### PR TITLE
test(#3451): execute-direction coverage for ws0-baseline.sh's two embedded python pin steps

### DIFF
--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6574,12 +6574,16 @@ run_tooling_tests() {
   # all agree, because executing the blocks alone cannot see a RENAMED EXPORT: the python is
   # untouched, everything stays green, and the real rig hits the step's own `FATAL: … was not
   # exported` and exits 2 — #3451's exact symptom again; EVERY embedded block in the driver COMPILES,
-  # so instance #8 anywhere in that file is caught and not only the two repaired steps; and every
-  # block parses on EVERY INTERPRETER THIS REPO RUNS rather than on the gate box alone — PEP 701
-  # made the nested same-type quote spelling legal in 3.12, so `compile()` on a 3.12 host accepts
-  # the very alternative the driver's comment says it rejected while the 3.11 workflows this repo
-  # pins would break. That is a tokenizer-level oracle on 3.12+ and `compile()` below it, with the
-  # one that answered NAMED in the output so it can never read as a check that skipped.
+  # so instance #8 anywhere in that file is caught and not only the two repaired steps; and no block
+  # uses the PEP 701 NESTED SAME-TYPE QUOTE spelling — ONE construct class, and exactly the
+  # alternative the driver's comment says it rejected, which `compile()` on a 3.12 host ACCEPTS
+  # while the 3.11 workflows this repo pins would break. A tokenizer-level oracle on 3.12+ and
+  # `compile()` below it, with the one that answered NAMED in the output so it can never read as a
+  # check that skipped. Deliberately NOT a general portability verdict: PEP 701 legalised other
+  # constructs, a case MEASURES two of them passing this check silently, and establishing the
+  # general property needs the blocks compiled by a real 3.9/3.11 — a CI lane, not a hermetic
+  # self-test. Widening the model here would make the checker a second implementation of CPython's
+  # tokenizer, correct only insofar as it is differentially tested against the original.
   # The block text is EXTRACTED from the shipped driver on every run (`ws0_embedded_python.py`,
   # fail-closed on an unclassifiable python3 shape or an unterminated block) rather than copied,
   # because a copy stays green while the shipped step is broken — the exact state #3451 found. The

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -468,6 +468,22 @@
 #                      through `ws0_driver_run` leaves the recording file EMPTY and the
 #                      priors UNCHANGED. Hermetic everywhere; a check-count floor closes
 #                      the suite-level 0/0.
+#                      Also runs scripts/tests/test_ws0_embedded_steps_execute.sh (#3451)
+#                      — the EXECUTE direction of the driver's own embedded python. Every
+#                      suite above stops at `--validate-args-only`, and the accept cases
+#                      deliberately execute NOTHING, so the two multi-line `python3 -c`
+#                      steps BELOW that boundary (the session-corpus-pin and the CPU-pin
+#                      verification, both fatal-on-failure) had no coverage that RAN them:
+#                      they shipped for months with an f-string spelling no CPython parses,
+#                      invisible because the python is not a `.py` file and `bash -n` sees
+#                      one opaque single-quoted string. This EXTRACTS each block from the
+#                      shipped driver (never a copy — a copy stays green while the step is
+#                      broken) and RUNS it over a few-KB fixture corpus, asserting the
+#                      artifact, the pin lines and the SHIPPED reader accepting them, plus
+#                      the total property that EVERY embedded block compiles. Each accept
+#                      is paired with a control OBSERVED to fire on a scratch copy carrying
+#                      the injected defect. Hermetic: python3 + $TMPDIR; the driver is
+#                      READ, never invoked.
 #                      Also runs `cargo test -p ws0-corpus-gen` (#3272 items 8-9) — a
 #                      tools/* package NO other component and no CI lane compiles, so
 #                      without this hook the corpus determinism oracle would be a test
@@ -6531,6 +6547,43 @@ run_tooling_tests() {
   if ! bash "$REPO_ROOT/scripts/tests/test_ws0_primary_path_admits_a_legitimate_run.sh" >>"$log" 2>&1; then
     status=FAIL
     echo "--- [$name] FAILED (ws0 primary-path ACCEPT-direction guards); last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
+  # ws0 EMBEDDED-STEP EXECUTE DIRECTION (#3451). The complement of every suite above in a
+  # different axis from the accept/reject one: those suites all stop at `--validate-args-only`,
+  # and #3272 round 2 finding 14 deliberately made the accept cases execute NOTHING (running the
+  # real driver invoked `sudo sysctl` and three cargo builds inside this component). Correct, and
+  # it left the driver's TWO multi-line embedded python blocks — the session-corpus-pin step and
+  # the CPU-pin-verification step, both BELOW that boundary and both `|| exit 2` — with no
+  # coverage that EXECUTES them. They shipped for months carrying SEVEN instances of a backslash
+  # inside an f-string EXPRESSION, which no CPython parses, so the whole WS0 measurement path was
+  # unrunnable end to end on main. Nothing saw it: the python is not a `.py` file so no linter or
+  # import reads it, and `bash -n` parses the driver as SHELL, where the body is one opaque
+  # single-quoted string. What this asserts: both steps RUN on a few-KB fixture corpus with the
+  # argv and environment the driver gives them — exit 0, the artifact written, every pin line
+  # printed, and the SHIPPED reader (`verify_session_corpus_pin`/`verify_pinning_record`)
+  # accepting what the step wrote; the `WS0_CFG_*` names are DERIVED from the shipped
+  # `MANIFEST_CONFIG_FIELDS` and asserted equal to it; and EVERY embedded block in the driver
+  # COMPILES, so instance #8 anywhere in that file is caught and not only the two repaired steps.
+  # The block text is EXTRACTED from the shipped driver on every run (`ws0_embedded_python.py`,
+  # fail-closed on an unclassifiable python3 shape or an undelimitable block) rather than copied,
+  # because a copy stays green while the shipped step is broken — the exact state #3451 found.
+  # Every accept is paired with a positive control OBSERVED to fire against a scratch copy of the
+  # driver under $TMPDIR carrying the injected defect, which is this issue's own lesson: a `grep -c`
+  # for the bad spelling returned 0 against a file holding all seven instances, and a check that
+  # cannot fire looks identical to one that fired and found nothing. Hermetic: python3 and a few KB
+  # under $TMPDIR; the driver is READ, never invoked — no sudo, cargo, perf, taskset, corpus,
+  # network or root.
+  echo ">>> [$name] bash scripts/tests/test_ws0_embedded_steps_execute.sh"
+  if ! bash "$REPO_ROOT/scripts/tests/test_ws0_embedded_steps_execute.sh" >>"$log" 2>&1; then
+    status=FAIL
+    echo "--- [$name] FAILED (ws0 embedded-step EXECUTE-direction coverage); last 40 lines of $log ---"
     tail -40 "$log"
     echo "--- end of $name output ---"
     end=$(date +%s)

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6585,7 +6585,8 @@ run_tooling_tests() {
   # this issue is about is caught on 3.9 through 3.12 alike.
   # The block text is EXTRACTED from the shipped driver on every run (`ws0_embedded_python.py`,
   # which discovers candidates on TWO anchors — any word whose basename is python/python3, and the
-  # `-c` FLAG itself so an indirectly-spelled command word like `$PYTHON -c` is still found — and
+  # `-c` FLAG itself so an indirectly-spelled command word like `$PYTHON -c` is still found — both
+  # searched over the LOGICAL-LINE reconstruction, so a backslash-newline cannot hide either — and
   # then ALLOWLISTS exactly the shapes this driver uses, making everything else a FINDING) rather
   # than copied,
   # because a copy stays green while the shipped step is broken — the exact state #3451 found. The

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6572,8 +6572,14 @@ run_tooling_tests() {
   # `MANIFEST_CONFIG_FIELDS` and asserted equal to it; and EVERY embedded block in the driver
   # COMPILES, so instance #8 anywhere in that file is caught and not only the two repaired steps.
   # The block text is EXTRACTED from the shipped driver on every run (`ws0_embedded_python.py`,
-  # fail-closed on an unclassifiable python3 shape or an undelimitable block) rather than copied,
-  # because a copy stays green while the shipped step is broken — the exact state #3451 found.
+  # fail-closed on an unclassifiable python3 shape or an unterminated block) rather than copied,
+  # because a copy stays green while the shipped step is broken — the exact state #3451 found. The
+  # delimiter is bash's own quoting rule, not a line pattern, and is asserted in BOTH directions:
+  # a column-0-closer-only rule was MEASURED finding 31 blocks tree-wide where the correct rule
+  # finds 59 (a loose delimiter under-COUNTS subjects, the vacuous-green shape) while a
+  # next-quote rule manufactures a false SyntaxError on `lib-ws0-fixtures.sh`, which uses the
+  # literal-apostrophe idiom — and a key that reds on correct input is the key agents learn to
+  # waive. Both are controls in the suite.
   # Every accept is paired with a positive control OBSERVED to fire against a scratch copy of the
   # driver under $TMPDIR carrying the injected defect, which is this issue's own lesson: a `grep -c`
   # for the bad spelling returned 0 against a file holding all seven instances, and a check that

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6569,8 +6569,13 @@ run_tooling_tests() {
   # argv and environment the driver gives them — exit 0, the artifact written, every pin line
   # printed, and the SHIPPED reader (`verify_session_corpus_pin`/`verify_pinning_record`)
   # accepting what the step wrote; the `WS0_CFG_*` names are DERIVED from the shipped
-  # `MANIFEST_CONFIG_FIELDS` and asserted equal to it; and EVERY embedded block in the driver
-  # COMPILES, so instance #8 anywhere in that file is caught and not only the two repaired steps.
+  # `MANIFEST_CONFIG_FIELDS` and asserted equal to it; EVERY embedded block in the driver COMPILES,
+  # so instance #8 anywhere in that file is caught and not only the two repaired steps; and every
+  # block parses on EVERY INTERPRETER THIS REPO RUNS rather than on the gate box alone — PEP 701
+  # made the nested same-type quote spelling legal in 3.12, so `compile()` on a 3.12 host accepts
+  # the very alternative the driver's comment says it rejected while the 3.11 workflows this repo
+  # pins would break. That is a tokenizer-level oracle on 3.12+ and `compile()` below it, with the
+  # one that answered NAMED in the output so it can never read as a check that skipped.
   # The block text is EXTRACTED from the shipped driver on every run (`ws0_embedded_python.py`,
   # fail-closed on an unclassifiable python3 shape or an unterminated block) rather than copied,
   # because a copy stays green while the shipped step is broken — the exact state #3451 found. The

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6584,7 +6584,9 @@ run_tooling_tests() {
   # What survives is the oracle that is real: no CPython accepts the backslash form, so the defect
   # this issue is about is caught on 3.9 through 3.12 alike.
   # The block text is EXTRACTED from the shipped driver on every run (`ws0_embedded_python.py`,
-  # fail-closed on an unclassifiable python3 shape or an unterminated block) rather than copied,
+  # which casts a WIDE candidate net — any word whose basename is python/python3, path-qualified or
+  # not — and then ALLOWLISTS exactly the shapes this driver uses, making everything else a
+  # FINDING) rather than copied,
   # because a copy stays green while the shipped step is broken — the exact state #3451 found. The
   # delimiter is bash's own quoting rule, not a line pattern, and is asserted in BOTH directions:
   # a column-0-closer-only rule was MEASURED finding 31 blocks tree-wide where the correct rule

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6586,7 +6586,9 @@ run_tooling_tests() {
   # The block text is EXTRACTED from the shipped driver on every run (`ws0_embedded_python.py`,
   # which discovers candidates on TWO anchors — any word whose basename is python/python3, and the
   # `-c` FLAG itself so an indirectly-spelled command word like `$PYTHON -c` is still found — both
-  # searched over the LOGICAL-LINE reconstruction, so a backslash-newline cannot hide either — and
+  # discovered AND classified over the LOGICAL-LINE reconstruction (bodies excepted, since inside
+  # single quotes a backslash is literal), so a continuation neither hides an anchor nor turns an
+  # ordinary invocation into a refusal — and
   # then ALLOWLISTS exactly the shapes this driver uses, making everything else a FINDING) rather
   # than copied,
   # because a copy stays green while the shipped step is broken — the exact state #3451 found. The

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6569,7 +6569,11 @@ run_tooling_tests() {
   # argv and environment the driver gives them — exit 0, the artifact written, every pin line
   # printed, and the SHIPPED reader (`verify_session_corpus_pin`/`verify_pinning_record`)
   # accepting what the step wrote; the `WS0_CFG_*` names are DERIVED from the shipped
-  # `MANIFEST_CONFIG_FIELDS` and asserted equal to it; EVERY embedded block in the driver COMPILES,
+  # `MANIFEST_CONFIG_FIELDS` and asserted equal to it, three ways — the names the DRIVER EXPORTS
+  # (from its bash source), the shipped field list (by import) and this suite's environment must
+  # all agree, because executing the blocks alone cannot see a RENAMED EXPORT: the python is
+  # untouched, everything stays green, and the real rig hits the step's own `FATAL: … was not
+  # exported` and exits 2 — #3451's exact symptom again; EVERY embedded block in the driver COMPILES,
   # so instance #8 anywhere in that file is caught and not only the two repaired steps; and every
   # block parses on EVERY INTERPRETER THIS REPO RUNS rather than on the gate box alone — PEP 701
   # made the nested same-type quote spelling legal in 3.12, so `compile()` on a 3.12 host accepts

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6574,16 +6574,15 @@ run_tooling_tests() {
   # all agree, because executing the blocks alone cannot see a RENAMED EXPORT: the python is
   # untouched, everything stays green, and the real rig hits the step's own `FATAL: … was not
   # exported` and exits 2 — #3451's exact symptom again; EVERY embedded block in the driver COMPILES,
-  # so instance #8 anywhere in that file is caught and not only the two repaired steps; and no block
-  # uses the PEP 701 NESTED SAME-TYPE QUOTE spelling — ONE construct class, and exactly the
-  # alternative the driver's comment says it rejected, which `compile()` on a 3.12 host ACCEPTS
-  # while the 3.11 workflows this repo pins would break. A tokenizer-level oracle on 3.12+ and
-  # `compile()` below it, with the one that answered NAMED in the output so it can never read as a
-  # check that skipped. Deliberately NOT a general portability verdict: PEP 701 legalised other
-  # constructs, a case MEASURES two of them passing this check silently, and establishing the
-  # general property needs the blocks compiled by a real 3.9/3.11 — a CI lane, not a hermetic
-  # self-test. Widening the model here would make the checker a second implementation of CPython's
-  # tokenizer, correct only insofar as it is differentially tested against the original.
+  # so instance #8 anywhere in that file is caught and not only the two repaired steps. That compile
+  # check speaks for THE INTERPRETER RUNNING IT and claims nothing about cross-interpreter
+  # portability; the suite's NOT-REACHED list records the one regression that therefore escapes it
+  # and names a real 3.9/3.11 CI compile as the only honest oracle. A tokenizer model of that
+  # regression lived here for two review rounds and was REMOVED (#3451 round 4) after being wrong
+  # twice, the second time flagging legal code — a second implementation of CPython's tokenizer is
+  # correct only insofar as it is differentially tested against an original this box does not have.
+  # What survives is the oracle that is real: no CPython accepts the backslash form, so the defect
+  # this issue is about is caught on 3.9 through 3.12 alike.
   # The block text is EXTRACTED from the shipped driver on every run (`ws0_embedded_python.py`,
   # fail-closed on an unclassifiable python3 shape or an unterminated block) rather than copied,
   # because a copy stays green while the shipped step is broken — the exact state #3451 found. The

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6584,9 +6584,10 @@ run_tooling_tests() {
   # What survives is the oracle that is real: no CPython accepts the backslash form, so the defect
   # this issue is about is caught on 3.9 through 3.12 alike.
   # The block text is EXTRACTED from the shipped driver on every run (`ws0_embedded_python.py`,
-  # which casts a WIDE candidate net — any word whose basename is python/python3, path-qualified or
-  # not — and then ALLOWLISTS exactly the shapes this driver uses, making everything else a
-  # FINDING) rather than copied,
+  # which discovers candidates on TWO anchors — any word whose basename is python/python3, and the
+  # `-c` FLAG itself so an indirectly-spelled command word like `$PYTHON -c` is still found — and
+  # then ALLOWLISTS exactly the shapes this driver uses, making everything else a FINDING) rather
+  # than copied,
   # because a copy stays green while the shipped step is broken — the exact state #3451 found. The
   # delimiter is bash's own quoting rule, not a line pattern, and is asserted in BOTH directions:
   # a column-0-closer-only rule was MEASURED finding 31 blocks tree-wide where the correct rule

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -324,7 +324,34 @@ if logical is None:
     raise SystemExit(2)
 
 names = sorted(set(re.findall(prefix + r"[A-Z_]+(?==)", text)))
-present = [n for n in names if n + "=" in logical]
+
+# THE PROPERTY IS THE CONTIGUOUS ENVIRONMENT-ASSIGNMENT PREFIX, NOT MERE MEMBERSHIP OF THE
+# LOGICAL LINE (#3451 post-rebase round 1, F1). `n + "=" in logical` passed for
+#
+#     WS0_CFG_BASELINE_MODE="$BASELINE_MODE"; python3 -c '...'
+#
+# which keeps the assignment on the SAME logical line while bash makes it a standalone shell
+# variable python never receives. MEASURED, both directions:
+#
+#     WS0_CFG_REPS="1"; python3 -c ...   -> os.environ.get(...) is None
+#     WS0_CFG_REPS="1"  python3 -c ...   -> "1"
+#
+# So the text BEFORE the command word must be a run of assignment words and nothing else. A
+# command separator anywhere in it, or any word that is not NAME=, means the run is broken and
+# the membership answer is worthless — reported as zero present, which FAILS closed rather than
+# guessing which side of the break each name fell on.
+cmd = logical.find("python3")
+prefix_text = logical[:cmd] if cmd >= 0 else ""
+words = prefix_text.split()
+contiguous = (
+    cmd >= 0
+    and not any(ch in prefix_text for ch in ";&|")
+    and all(re.match(r"[A-Za-z_][A-Za-z0-9_]*=", w) for w in words)
+)
+if contiguous:
+    present = [n for n in names if any(w.startswith(n + "=") for w in words)]
+else:
+    present = []
 print(f"{len(present)} {len(names)}")
 PY
 }
@@ -908,9 +935,9 @@ for export_pair in "WS0_CFG_:write_session_corpus_pin" "WS0_PIN_:pinning_record_
     continue
   fi
   if [ -n "${in_line:-}" ] && [ "${total_in_file:-0}" -gt 0 ] && [ "$in_line" -eq "$total_in_file" ]; then
-    pass "export-prefix ($export_prefix): all $total_in_file assignment(s) share a JOINED LOGICAL LINE with THE BLOCK THAT READS THEM (located by $export_needle) — genuinely exported to that step, not merely present in the file or exported to a different one"
+    pass "export-prefix ($export_prefix): all $total_in_file assignment(s) are in the CONTIGUOUS ENVIRONMENT-ASSIGNMENT PREFIX of the block that reads them (located by $export_needle) — genuinely exported to that step, not merely present in the file, nor on its logical line behind a separator, nor exported to a different step"
   else
-    fail "export-prefix ($export_prefix): only ${in_line:-?} of ${total_in_file:-?} assignment(s) are in the logical line of the block calling $export_needle. One outside that step's contiguous prefix is never exported TO IT: the step refuses at run time on the missing variable and its caller exits 2"
+    fail "export-prefix ($export_prefix): only ${in_line:-?} of ${total_in_file:-?} assignment(s) are in the contiguous assignment prefix of the block calling $export_needle. One outside that prefix is never exported TO IT: the step refuses at run time on the missing variable and its caller exits 2"
   fi
 done
 
@@ -932,6 +959,16 @@ if text.count(needle) != 1:
 (tmp / "export-relocated.sh").write_text(
     text.replace(needle, "").replace(
         "#!/usr/bin/env bash", '#!/usr/bin/env bash\nWS0_CFG_TEMPS="$TEMPS"', 1))
+# (c-pre) BREAK THE PREFIX WITH A `;`, leaving the assignment on the SAME logical line. This is
+# the case a membership test structurally cannot see: the name is still present, still on the
+# invocation's own logical line, and python no longer receives it.
+semi = 'WS0_CFG_BASELINE_MODE="$BASELINE_MODE" ' + bs + "\n"
+if text.count(semi) != 1:
+    print(f"INJECTION IMPOSSIBLE: semicolon needle occurs {text.count(semi)} time(s)",
+          file=sys.stderr)
+    raise SystemExit(1)
+(tmp / "export-semicolon.sh").write_text(
+    text.replace(semi, 'WS0_CFG_BASELINE_MODE="$BASELINE_MODE"; ' + bs + "\n"))
 # (c) MOVE it into the OTHER step's prefix. This is the round-11 case: the name is still in the
 # file AND still in a `python3 -c` logical line, so a check that unioned across invocations saw
 # nothing wrong while the session-pin step died on the absent variable.
@@ -949,7 +986,7 @@ if [ "$export_inject_rc" -ne 0 ]; then
 else
   export_ctl_ok=1
   export_ctl_detail=""
-  for export_case in nobackslash relocated otherblock; do
+  for export_case in nobackslash relocated otherblock semicolon; do
     read -r c_in c_total \
       <<<"$(export_prefix_membership "$TMP/export-$export_case.sh" WS0_CFG_ write_session_corpus_pin)"
     if [ "$c_in" -eq "$c_total" ]; then
@@ -958,7 +995,7 @@ else
     fi
   done
   if [ "$export_ctl_ok" -eq 1 ]; then
-    pass "export-prefix CONTROL fired: a removed continuation backslash, an assignment relocated out of every prefix, AND one relocated into the OTHER step's prefix all drop it from the consuming block's logical line — including the case a union across invocations could not see"
+    pass "export-prefix CONTROL fired on all FOUR ways an export stops being one: a removed continuation, a relocation out of every prefix, a relocation into the OTHER step's prefix, and a semicolon that leaves the assignment on the SAME logical line while python stops receiving it"
   else
     fail "export-prefix CONTROL did not fire:$export_ctl_detail — the membership check cannot see an assignment leaving the prefix"
   fi

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -228,37 +228,74 @@ pathlib.Path(dest).write_text(text.replace(needle, bad))
 PY
 }
 
-# export_prefix_membership <driver> <VAR-PREFIX> — "<in-same-logical-line> <total-in-file>".
+# export_prefix_membership <driver> <VAR-PREFIX> <BLOCK-NEEDLE>
+#   -> "<in-this-block's-logical-line> <total-in-file>".
 #
 # An exported variable only reaches the step if its assignment is part of the CONTIGUOUS
-# environment-assignment prefix of the `python3 -c` command — a run of `NAME=value \` lines
-# immediately above it. Remove ONE continuation backslash and the assignment becomes a standalone
-# shell assignment that is never exported, the driver dies on the missing variable, and every
-# check in this suite still passes: the name-set comparisons see it (it is still in the file) and
-# the extracted-block executions see it (this suite builds their environment itself). Same
-# symptom as #3451 itself.
+# environment-assignment prefix of the `python3 -c` command THAT READS IT. Remove one continuation
+# backslash and it becomes a standalone shell assignment python never sees — the driver dies on
+# the missing variable while every other check here passes, because the name-set comparisons see
+# it (still in the file) and the block executions see it (this suite builds their environment
+# itself). Same symptom as #3451 itself.
 #
-# Decidable, and it reuses the joiner rather than parsing a command prefix: after logical-line
-# joining, the assignments and the invocation ARE ONE LINE. Membership in that line is the whole
-# assertion. The joiner is IMPORTED from the shipped module — a second copy here would drift, and
-# then this check would certify the copy.
+# BOUND TO ONE BLOCK, NOT UNIONED ACROSS ALL OF THEM (#3451 review round 11). An earlier version
+# fed one set from EVERY `python3 -c` logical line, so moving a `WS0_CFG_*` assignment out of the
+# session-pin prefix and into the CPU-pin invocation's prefix left the total unchanged and the
+# check green — while the session-pin step died at runtime on the absent variable. The consuming
+# block is identified BY THE SHIPPED WRITER IT CALLS, the way this suite locates blocks
+# everywhere, so reordering the driver cannot silently swap the two.
+#
+# Decidable, and it reuses the shipped joiner and census rather than parsing a command prefix:
+# after logical-line joining, a step's assignments and its invocation ARE ONE LINE. Both are
+# IMPORTED — a second copy here would drift, and then this check would certify the copy.
 export_prefix_membership() {
-  python3 - "$REPO_ROOT/scripts/tests" "$1" "$2" <<'PY'
-import pathlib, re, sys
+  python3 - "$REPO_ROOT/scripts/tests" "$1" "$2" "$3" <<'PY'
+import bisect, pathlib, re, sys
 sys.path.insert(0, sys.argv[1])
-from ws0_embedded_python import _join_continuations
-text = pathlib.Path(sys.argv[2]).read_text()
-prefix = sys.argv[3]
-joined, _unused = _join_continuations(text)
-names = sorted(set(re.findall(prefix + r"[A-Z_]+(?==)", text)))
-inline = set()
-for logical in joined.split("\n"):
-    if "python3 -c " + chr(39) not in logical:
+from ws0_embedded_python import _join_continuations, census
+
+path = pathlib.Path(sys.argv[2])
+prefix, needle = sys.argv[3], sys.argv[4]
+text = path.read_text()
+
+# WHICH block consumes this prefix, by the shipped writer its body calls.
+records, _findings = census(path)
+owners = [r for r in records if r["kind"] == "BLOCK" and needle in r["body"]]
+if len(owners) != 1:
+    print(f"AMBIGUOUS: {len(owners)} block(s) call {needle!r}", file=sys.stderr)
+    raise SystemExit(2)
+invocation_line = owners[0]["line"]
+
+joined, omap = _join_continuations(text)
+# The ORIGINAL offset where that invocation's physical line begins.
+line_starts = [0] + [i + 1 for i, ch in enumerate(text) if ch == "\n"]
+if invocation_line > len(line_starts):
+    print(f"UNRESOLVABLE: line {invocation_line} is past end of file", file=sys.stderr)
+    raise SystemExit(2)
+invocation_offset = line_starts[invocation_line - 1]
+
+# The JOINED logical line covering it. Spans are in scan space; their bounds are mapped back
+# through `omap`, so the comparison is against original offsets throughout.
+spans, start = [], 0
+for i, ch in enumerate(joined):
+    if ch == "\n":
+        spans.append((start, i))
+        start = i + 1
+spans.append((start, len(joined)))
+logical = None
+for a, b in spans:
+    if b <= a or a >= len(omap):
         continue
-    for name in names:
-        if name + "=" in logical:
-            inline.add(name)
-print(f"{len(inline)} {len(names)}")
+    if omap[a] <= invocation_offset <= omap[b - 1]:
+        logical = joined[a:b]
+        break
+if logical is None:
+    print(f"UNRESOLVABLE: no logical line covers offset {invocation_offset}", file=sys.stderr)
+    raise SystemExit(2)
+
+names = sorted(set(re.findall(prefix + r"[A-Z_]+(?==)", text)))
+present = [n for n in names if n + "=" in logical]
+print(f"{len(present)} {len(names)}")
 PY
 }
 
@@ -823,12 +860,19 @@ fi
 # present somewhere in the file (#3451 review round 10, finding 1). The set comparisons above
 # collect names GLOBALLY, so a single removed continuation backslash turns an export into a
 # standalone assignment python never sees — the driver dies, and every check here still passes.
-for export_prefix in WS0_CFG_ WS0_PIN_; do
-  read -r in_line total_in_file <<<"$(export_prefix_membership "$DRIVER" "$export_prefix")"
-  if [ "$total_in_file" -gt 0 ] && [ "$in_line" -eq "$total_in_file" ]; then
-    pass "export-prefix ($export_prefix): all $total_in_file assignment(s) share a JOINED LOGICAL LINE with the python3 -c invocation that reads them — so each is genuinely exported, not merely present in the file"
+# Each prefix against ITS OWN consuming block, named by the shipped writer that block calls.
+for export_pair in "WS0_CFG_:write_session_corpus_pin" "WS0_PIN_:pinning_record_path"; do
+  export_prefix="${export_pair%%:*}"
+  export_needle="${export_pair#*:}"
+  if ! read -r in_line total_in_file \
+       <<<"$(export_prefix_membership "$DRIVER" "$export_prefix" "$export_needle")"; then
+    fail "export-prefix ($export_prefix): the membership could not be computed, so the check did not run"
+    continue
+  fi
+  if [ -n "${in_line:-}" ] && [ "${total_in_file:-0}" -gt 0 ] && [ "$in_line" -eq "$total_in_file" ]; then
+    pass "export-prefix ($export_prefix): all $total_in_file assignment(s) share a JOINED LOGICAL LINE with THE BLOCK THAT READS THEM (located by $export_needle) — genuinely exported to that step, not merely present in the file or exported to a different one"
   else
-    fail "export-prefix ($export_prefix): only $in_line of $total_in_file assignment(s) are in the same logical line as the invocation. One outside the contiguous prefix is never exported: the step refuses at run time on the missing variable and its caller exits 2"
+    fail "export-prefix ($export_prefix): only ${in_line:-?} of ${total_in_file:-?} assignment(s) are in the logical line of the block calling $export_needle. One outside that step's contiguous prefix is never exported TO IT: the step refuses at run time on the missing variable and its caller exits 2"
   fi
 done
 
@@ -850,6 +894,16 @@ if text.count(needle) != 1:
 (tmp / "export-relocated.sh").write_text(
     text.replace(needle, "").replace(
         "#!/usr/bin/env bash", '#!/usr/bin/env bash\nWS0_CFG_TEMPS="$TEMPS"', 1))
+# (c) MOVE it into the OTHER step's prefix. This is the round-11 case: the name is still in the
+# file AND still in a `python3 -c` logical line, so a check that unioned across invocations saw
+# nothing wrong while the session-pin step died on the absent variable.
+pin_prefix = 'WS0_PIN_SERVER_CPUS="$SERVER_CPUS" ' + bs + "\n"
+if text.count(pin_prefix) != 1:
+    print(f"INJECTION IMPOSSIBLE: pin-prefix needle occurs {text.count(pin_prefix)} time(s)",
+          file=sys.stderr)
+    raise SystemExit(1)
+(tmp / "export-otherblock.sh").write_text(
+    text.replace(needle, "").replace(pin_prefix, needle + pin_prefix))
 INJECT
 export_inject_rc=$?
 if [ "$export_inject_rc" -ne 0 ]; then
@@ -857,15 +911,16 @@ if [ "$export_inject_rc" -ne 0 ]; then
 else
   export_ctl_ok=1
   export_ctl_detail=""
-  for export_case in nobackslash relocated; do
-    read -r c_in c_total <<<"$(export_prefix_membership "$TMP/export-$export_case.sh" WS0_CFG_)"
+  for export_case in nobackslash relocated otherblock; do
+    read -r c_in c_total \
+      <<<"$(export_prefix_membership "$TMP/export-$export_case.sh" WS0_CFG_ write_session_corpus_pin)"
     if [ "$c_in" -eq "$c_total" ]; then
       export_ctl_ok=0
       export_ctl_detail="$export_ctl_detail $export_case($c_in/$c_total)"
     fi
   done
   if [ "$export_ctl_ok" -eq 1 ]; then
-    pass "export-prefix CONTROL fired: BOTH a removed continuation backslash and an assignment relocated out of the prefix drop it from the invocation's logical line — the two ways an export silently stops being one"
+    pass "export-prefix CONTROL fired: a removed continuation backslash, an assignment relocated out of every prefix, AND one relocated into the OTHER step's prefix all drop it from the consuming block's logical line — including the case a union across invocations could not see"
   else
     fail "export-prefix CONTROL did not fire:$export_ctl_detail — the membership check cannot see an assignment leaving the prefix"
   fi

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -62,9 +62,11 @@
 #     is caught and not only the two steps this issue repaired. DISCOVERED is the operative word
 #     and its scope is stated exactly: every `-c`-form invocation REGARDLESS of how its command
 #     word is spelled (the census anchors on the flag), plus every invocation whose command word
-#     contains a literal `python` — both searched over the LOGICAL-LINE reconstruction, so a
-#     backslash-newline continuation cannot hide either anchor. What that does not reach is in
-#     NOT REACHED below;
+#     contains a literal `python` — both DISCOVERED and CLASSIFIED over the LOGICAL-LINE
+#     reconstruction, so a backslash-newline continuation neither hides an anchor nor turns an
+#     ordinary invocation into a refusal. Block BODIES are still read from the original text,
+#     because inside single quotes a backslash is literal and bash continues nothing. What this
+#     does not reach is in NOT REACHED below;
 #   * the extractor's delimiter in BOTH directions: it reports a defect, AND it does not
 #     manufacture one on good input. A block is delimited by bash's quoting rules rather than by a
 #     line pattern, so all three closer shapes this repository actually uses are handled — the
@@ -527,21 +529,22 @@ else
   fail "census CONTROL did not fire (heredoc removed): a heredoc must be a finding, got: $(head -2 <<<"$hd_any")"
 fi
 
-# --- CONTROL 1h: AN INDIRECTLY-SPELLED COMMAND WORD IS DISCOVERED, WRAPPED OR NOT --------------
-# The allowlist closed CLASSIFICATION but not DISCOVERY: a candidate must be FOUND before it can
-# be classified. Three cases, and the third needed BOTH ingredients before it was invisible —
-# `$PYTHON` defeats the word matcher, and a backslash-newline puts the quote on the next line
-# where the `-c` anchor cannot see it. Measured before the fix: A and C were findings, B was
-# `findings=0 occurrences=0` with the block count unchanged, i.e. an invalid program passing the
-# "every embedded block compiles" guard.
+# --- CONTROL 1h: LOGICAL-LINE RECONSTRUCTION — three cases, each with its own right answer ------
+# A candidate must be FOUND before it can be classified, and BOTH steps read the logical line bash
+# builds by deleting backslash-newline. The three cases pin the whole behaviour, and they do NOT
+# share an expected outcome — which is the point, because an earlier version got case A wrong in a
+# way a uniform "everything is a finding" assertion would have hidden:
 #
-#   A  literal python3, continuation   already caught (unrecognised shape)
-#   B  $PYTHON,         continuation   INVISIBLE -> now caught, via logical-line joining
-#   C  $PYTHON,         same line      caught by the `-c` flag anchor (round 7)
-#
-# All three are asserted together, because the fix for B (joining backslash-newline before
-# discovery) is a transformation that could plausibly disturb A or C.
-indirect_ok=1
+#   A  literal python3, continuation   a BLOCK. After joining this IS `python3 -c 'prog'`, so it
+#                                      classifies normally and the COMPILE check reports its
+#                                      defect. A driver block reformatted across a continuation
+#                                      must keep working rather than become a refusal — that is
+#                                      what makes the joining worth having.
+#   B  $PYTHON,        continuation    exactly ONE finding. This is the case that was INVISIBLE
+#                                      (`findings=0 occurrences=0`) before joining: the indirect
+#                                      word defeats the token matcher and the continuation hides
+#                                      the quote from the `-c` anchor.
+#   C  $PYTHON,        same line       exactly ONE finding, via the `-c` flag anchor.
 python3 - "$TMP" <<'INJECT'
 import pathlib, sys
 q, bs = chr(39), chr(92)
@@ -552,14 +555,40 @@ prog = q + "import os," + q
 (tmp / "indirect-C.sh").write_text("$PYTHON -c " + prog + "\n")
 INJECT
 indirect_rc=$?
-for indirect_case in A B C; do
-  [ -s "$TMP/indirect-$indirect_case.sh" ] || indirect_ok=0
-  [ -n "$(findings_of "$(census "$TMP/indirect-$indirect_case.sh")")" ] || indirect_ok=0
-done
-if [ "$indirect_rc" -eq 0 ] && [ "$indirect_ok" -eq 1 ]; then
-  pass "census CONTROL fired (indirect command word, all 3 cases): a \$PYTHON -c invocation is DISCOVERED whether the quote is on the same line or past a backslash-newline continuation — discovery runs over the logical-line reconstruction bash itself builds"
+a_census="$(census "$TMP/indirect-A.sh")"
+a_compile="$(compile_blocks "$TMP/indirect-A.sh")"
+b_findings="$(findings_of "$(census "$TMP/indirect-B.sh")" | wc -l | tr -d ' ')"
+c_findings="$(findings_of "$(census "$TMP/indirect-C.sh")" | wc -l | tr -d ' ')"
+if [ "$indirect_rc" -ne 0 ]; then
+  fail "census CONTROL: the logical-line fixtures could not be written (rc=$indirect_rc), so the control could not fire"
+elif [ "$(grep -c '^BLOCK	' <<<"$a_census")" -eq 1 ] && [ -z "$(findings_of "$a_census")" ] \
+     && grep -q 'DOES NOT COMPILE' <<<"$a_compile" \
+     && [ "$b_findings" -eq 1 ] && [ "$c_findings" -eq 1 ]; then
+  pass "census CONTROL fired (logical-line reconstruction): a LITERAL python3 split across a continuation is a BLOCK whose defect the compile check reports, while an INDIRECT command word is exactly ONE finding whether the quote is on the same line or past the continuation"
 else
-  fail "census CONTROL did not fire (indirect command word): fixture-rc=$indirect_rc all-three-found=$indirect_ok — case B (indirect word + continuation) is the one that was invisible"
+  fail "census CONTROL did not fire: A-blocks=$(grep -c '^BLOCK	' <<<"$a_census") A-findings='$(findings_of "$a_census" | head -1)' A-compile='$(findings_of "$a_compile" | head -1)' B-findings=$b_findings C-findings=$c_findings"
+fi
+
+# --- CONTROL 1h-bis: ONE INVOCATION YIELDS AT MOST ONE FINDING ---------------------------------
+# Both anchors can see the same command — `python3 -m foo -c 'x'` has a python word AND a `-c`
+# flag — and each used to report it, after which a finding COUNT means nothing. The word anchor
+# claims its command's segment (up to the next separator, a closed set in bash's grammar), so the
+# flag inside it defers. The other direction is asserted too: two genuinely separate invocations
+# on one line must still produce two findings, or the suppression would be hiding real ones.
+python3 - "$TMP" <<'INJECT'
+import pathlib, sys
+q = chr(39)
+tmp = pathlib.Path(sys.argv[1])
+(tmp / "one-invocation.sh").write_text("python3 -m foo -c " + q + "x" + q + "\n")
+(tmp / "two-invocations.sh").write_text(
+    "python3 --version; $PY -c " + q + "x" + q + "\n")
+INJECT
+one_n="$(findings_of "$(census "$TMP/one-invocation.sh")" | wc -l | tr -d ' ')"
+two_n="$(findings_of "$(census "$TMP/two-invocations.sh")" | wc -l | tr -d ' ')"
+if [ "$one_n" -eq 1 ] && [ "$two_n" -eq 2 ]; then
+  pass "census CONTROL fired (one finding per invocation): a single command seen by BOTH anchors yields 1 finding, while two separate invocations on one line still yield 2 — the suppression is scoped to a command segment, not to a line"
+else
+  fail "census CONTROL did not fire: one-invocation gave $one_n finding(s) (expected 1), two-invocations gave $two_n (expected 2)"
 fi
 
 # --- CONTROL 1i: A MISSING SUBJECT EXITS NONZERO ------------------------------------------------

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -51,9 +51,13 @@
 #   * both embedded steps EXECUTED, with the argv and the environment the driver gives them, over a
 #     few-KB fixture corpus: exit 0, the artifact written, the pin lines on stdout, and the SHIPPED
 #     READER (`verify_session_corpus_pin` / `verify_pinning_record`) accepting what the step wrote;
-#   * the environment-variable names the corpus-pin step reads are DERIVED from the shipped
-#     `ws0_session.MANIFEST_CONFIG_FIELDS` and asserted equal to it, so a field added there without
-#     a driver export is a failure here rather than a refusal at report time;
+#   * THREE SETS OF ENVIRONMENT-VARIABLE NAMES AGREE: the names THE DRIVER EXPORTS (read from its
+#     bash source), the shipped `ws0_session.MANIFEST_CONFIG_FIELDS` (read by importing it), and
+#     the environment this suite builds. Executing the blocks alone cannot see a renamed export —
+#     the python is untouched, so the census, the compile check and the execute cases all stay
+#     green while the real rig hits the step's own `FATAL: … was not exported` and its caller
+#     exits 2, i.e. #3451's exact symptom. The same cross-check covers the CPU-pin step's four
+#     `WS0_PIN_*` inputs, there against the literal names the extracted block reads;
 #   * EVERY embedded block in the driver COMPILES — the total property, so instance #8 anywhere in
 #     that file is caught and not only the two steps this issue repaired;
 #   * EVERY embedded block parses on EVERY INTERPRETER THIS REPOSITORY RUNS, not merely on this
@@ -74,6 +78,14 @@
 #     step's python runs; that the driver's env exports match the names the block reads is asserted
 #     structurally (the `MANIFEST_CONFIG_FIELDS` equality above and the driver's own fatal-on-absent
 #     branch, exercised below), not by executing the shell around it.
+#   * THE BASH ERROR HANDLING AROUND THE STEPS. This suite executes the embedded PYTHON; the
+#     `|| { echo "FATAL: …" >&2; exit 2; }` clause that makes a step's failure fatal is not a
+#     subject. MEASURED: deleting that clause is invisible here — the python is unchanged, so the
+#     census, the compile check and the execute cases all stay green while a failed pin silently
+#     becomes non-fatal and the session proceeds with no corpus pin, refused much later by the
+#     reporter. Deliberately NOT asserted structurally: a check keyed on where `|| {` sits is
+#     brittle, and a brittle assert on correct code is the false-red that gets a guard waived.
+#     Stated here so the limit is known rather than assumed away.
 #   * anything measured: no `perf`, no Flight server, no rep loop, no 2.8 GB corpus.
 #
 # Hermetic: python3, a few KB under `$TMPDIR`. No sudo, cargo, perf, taskset, network, root, and no
@@ -577,6 +589,84 @@ if [ "$cfg_keys" = "$shipped_keys" ]; then
   pass "config-fields: this suite supplies EXACTLY ws0_session.MANIFEST_CONFIG_FIELDS ($(echo "$shipped_keys" | wc -w) fields), so the environment it builds is the shipped list rather than a guess"
 else
   fail "config-fields: the suite's WS0_CFG_* keys [$cfg_keys] differ from the shipped MANIFEST_CONFIG_FIELDS [$shipped_keys]"
+fi
+
+# ...and the THIRD set, which is the one that actually ships: the names THE DRIVER EXPORTS.
+#
+# The two checks above compare this SUITE's environment against the shipped field list. Neither
+# says anything about the driver's bash plumbing, because the execute cases build their own
+# environment — so a renamed export was invisible. MEASURED attack: `WS0_CFG_TEMPS=` ->
+# `WS0_CFG_TEMSP=` in the driver leaves the embedded python untouched, so the census and the
+# compile check stay clean (`#COMPLETE compiled=3 findings=0`) and the blocks still execute
+# perfectly under the environment this suite builds — while the real rig hits the step's own
+# `FATAL: WS0_CFG_TEMPS was not exported`, the `|| exit 2` fires, and the driver is unrunnable end
+# to end. That is #3451's exact symptom, discovered by whoever next tries to run it.
+#
+# THREE SETS MUST AGREE, and the two sides of each comparison come from GENUINELY DIFFERENT
+# SOURCES — the driver's BASH SOURCE on one side, the python import on the other. A set-equality
+# check whose halves came from one place would agree by construction and prove nothing.
+driver_cfg_keys="$(grep -oE '^WS0_CFG_[A-Z_]+=' "$DRIVER" | sed 's/^WS0_CFG_//; s/=$//' \
+  | tr '[:upper:]' '[:lower:]' | sort | tr '\n' ' ')"
+if [ "$driver_cfg_keys" = "$shipped_keys" ]; then
+  pass "config-exports: the DRIVER exports exactly the WS0_CFG_* names the shipped MANIFEST_CONFIG_FIELDS requires — a renamed export is caught statically, not by an operator discovering the rig is unrunnable"
+else
+  fail "config-exports: the driver exports [$driver_cfg_keys] but the step reads MANIFEST_CONFIG_FIELDS [$shipped_keys]. The step refuses at run time on the difference and its caller exits 2, so the rig is unrunnable end to end"
+fi
+
+# --- CONTROL: the renamed export is OBSERVED to fire ------------------------------------------
+RENAMED_EXPORT="$TMP/renamed-export-ws0-driver.sh"
+inject_rc=0
+python3 - "$DRIVER" "$RENAMED_EXPORT" 2>"$TMP/inject-renamed.err" <<'INJECT'
+import pathlib, sys
+text = pathlib.Path(sys.argv[1]).read_text()
+needle = "WS0_CFG_TEMPS="
+if text.count(needle) != 1:
+    print(f"INJECTION IMPOSSIBLE: {needle} occurs {text.count(needle)} time(s)", file=sys.stderr)
+    raise SystemExit(1)
+pathlib.Path(sys.argv[2]).write_text(text.replace(needle, "WS0_CFG_TEMSP="))
+INJECT
+inject_rc=$?
+renamed_keys="$(grep -oE '^WS0_CFG_[A-Z_]+=' "$RENAMED_EXPORT" | sed 's/^WS0_CFG_//; s/=$//' \
+  | tr '[:upper:]' '[:lower:]' | sort | tr '\n' ' ')"
+renamed_compile="$(compile_blocks "$RENAMED_EXPORT")"
+if [ "$inject_rc" -ne 0 ]; then
+  fail "config-exports CONTROL: the rename could not be injected, so the control could not fire — $(head -2 "$TMP/inject-renamed.err")"
+elif [ "$renamed_keys" != "$shipped_keys" ] && [ -z "$(findings_of "$renamed_compile")" ]; then
+  pass "config-exports CONTROL fired: a single renamed export is caught by the set comparison — and the compile check is SILENT about it (the python is untouched), which is why this check exists separately"
+else
+  fail "config-exports CONTROL did not fire: renamed=[$renamed_keys] shipped=[$shipped_keys], compile said '$(findings_of "$renamed_compile" | head -1)'"
+fi
+
+# ...and the SAME class for the CPU-pin step, whose four inputs have no shipped field list. Here
+# the two sources are the driver's BASH exports and the LITERAL names the extracted BLOCK reads,
+# which is again two independent derivations of one fact.
+driver_pin_keys="$(grep -oE '^WS0_PIN_[A-Z_]+=' "$DRIVER" | sed 's/=$//' | sort -u | tr '\n' ' ')"
+block_pin_keys="$(emit_block "$DRIVER" "$CPU_BLOCK" | grep -oE 'WS0_PIN_[A-Z_]+' | sort -u | tr '\n' ' ')"
+if [ -n "$block_pin_keys" ] && [ "$driver_pin_keys" = "$block_pin_keys" ]; then
+  pass "pin-exports: the DRIVER exports exactly the WS0_PIN_* names the CPU-pin step reads ($(echo "$block_pin_keys" | wc -w) of them) — the step reads them with os.environ[...], which raises KeyError on a rename and exits 2"
+else
+  fail "pin-exports: the driver exports [$driver_pin_keys] and the CPU-pin step reads [$block_pin_keys]"
+fi
+
+RENAMED_PIN="$TMP/renamed-pin-ws0-driver.sh"
+inject_rc=0
+python3 - "$DRIVER" "$RENAMED_PIN" 2>"$TMP/inject-renamed_pin.err" <<'INJECT'
+import pathlib, sys
+text = pathlib.Path(sys.argv[1]).read_text()
+needle = "WS0_PIN_SIBLINGS="
+if text.count(needle) != 1:
+    print(f"INJECTION IMPOSSIBLE: {needle} occurs {text.count(needle)} time(s)", file=sys.stderr)
+    raise SystemExit(1)
+pathlib.Path(sys.argv[2]).write_text(text.replace(needle, "WS0_PIN_SIBLING="))
+INJECT
+inject_pin_rc=$?
+renamed_pin_keys="$(grep -oE '^WS0_PIN_[A-Z_]+=' "$RENAMED_PIN" | sed 's/=$//' | sort -u | tr '\n' ' ')"
+if [ "$inject_pin_rc" -ne 0 ]; then
+  fail "pin-exports CONTROL: the rename could not be injected, so the control could not fire — $(head -2 "$TMP/inject-renamed_pin.err")"
+elif [ "$renamed_pin_keys" != "$block_pin_keys" ]; then
+  pass "pin-exports CONTROL fired: a renamed WS0_PIN_* export no longer matches the names the step reads"
+else
+  fail "pin-exports CONTROL did not fire: renamed=[$renamed_pin_keys] block=[$block_pin_keys]"
 fi
 
 # run_pin_step <driver> <out-dir> [omit-field] — execute the corpus-pin block extracted from

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -724,6 +724,45 @@ else
   fail "census CONTROL did not fire: an absent driver must exit nonzero, got rc=$missing_rc"
 fi
 
+# --- CONTROL 1j: a leading CONTROL WORD is stepped over, not read as the command ---------------
+# `if $PY -c 'bad'`, `time $PY -c 'bad'` and `! $PY -c 'bad'` each resolved their command word to
+# the control word — a plain literal containing no `python` — and were skipped as "another
+# program": three silent absences.
+#
+# BOTH DIRECTIONS, and the accept half is why the words are STEPPED OVER rather than refused.
+# Refusing a leading reserved word would turn `if grep -c 'foo' file; then :; fi` into a finding,
+# which is ordinary shell — the false-red failure that already cost this checker two earlier
+# designs. The words come from `ws0_hermeticity_lint.RESERVED_WORDS`, which is asserted for SET
+# EQUALITY against `bash -c 'compgen -k'`, so this is a lookup against an oracle rather than a
+# second hand-written list.
+python3 - "$TMP" <<'INJECT'
+import pathlib, sys
+q = chr(39)
+tmp = pathlib.Path(sys.argv[1])
+bad = q + "import os," + q
+(tmp / "ctlword-if.sh").write_text("if $PY -c " + bad + "; then :; fi\n")
+(tmp / "ctlword-time.sh").write_text("time $PY -c " + bad + "\n")
+(tmp / "ctlword-bang.sh").write_text("! $PY -c " + bad + "\n")
+(tmp / "ctlword-if-grep.sh").write_text("if grep -c " + q + "foo" + q + " file; then :; fi\n")
+(tmp / "ctlword-time-grep.sh").write_text("time grep -c " + q + "foo" + q + " file\n")
+INJECT
+ctlword_rc=$?
+ctlword_ok=1
+ctlword_detail=""
+for ctlword_case in if time bang; do
+  [ -n "$(findings_of "$(census "$TMP/ctlword-$ctlword_case.sh")")" ] \
+    || { ctlword_ok=0; ctlword_detail="$ctlword_detail $ctlword_case(missed)"; }
+done
+for ctlword_case in if-grep time-grep; do
+  [ -z "$(findings_of "$(census "$TMP/ctlword-$ctlword_case.sh")")" ] \
+    || { ctlword_ok=0; ctlword_detail="$ctlword_detail $ctlword_case(false-red)"; }
+done
+if [ "$ctlword_rc" -eq 0 ] && [ "$ctlword_ok" -eq 1 ]; then
+  pass "census CONTROL fired (control words): a leading if/time/! is STEPPED OVER so the real command word is judged — the indirect forms are findings while `if grep -c` and `time grep -c` stay clean, which is why the words are skipped and not refused"
+else
+  fail "census CONTROL did not fire (control words): fixture-rc=$ctlword_rc problems:$ctlword_detail"
+fi
+
 # ============================================================================
 # PART 2 — THE TOTAL PROPERTY: EVERY EMBEDDED BLOCK COMPILES
 # ============================================================================
@@ -1422,9 +1461,18 @@ fi
 # A MINIMUM CHECK COUNT
 # ============================================================================
 # `set -uo pipefail` (no `-e`) means a block that silently never executes lowers the count and
-# registers NO failure, while the gate reads only the exit code. Deliberately below the current
-# count (so adding a case does not red it) and far above zero.
-MIN_CHECKS=26
+# registers NO failure, while the gate reads only the exit code.
+#
+# A RATCHET AT THE ACTUAL COUNT, not a comfortable floor below it (#3451 post-rebase round 4,
+# F2). This sat at 26 while the suite ran 44, so an entire section — the CPU execution coverage,
+# say — could vanish and the floor would not notice. That is precisely the failure this guard
+# exists to catch, so a floor 18 below actual was a guard against nothing.
+#
+# BUMP IT WHEN YOU ADD COVERAGE. It is a ratchet: a lower count means a case stopped running and
+# is a real failure, a higher one means you added a case and this constant is the one line to
+# update. Deliberate, and cheap, and it is the only thing standing between a deleted section and
+# a green suite.
+MIN_CHECKS=45
 echo
 if [ "$checks" -lt "$MIN_CHECKS" ]; then
   echo "FAIL - only $checks check(s) ran; this suite has at least $MIN_CHECKS."

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -199,6 +199,46 @@ findings_of() {
     | grep -v '^$'
 }
 
+# driver_step_env <driver> <block-needle> — the `WS0_CFG_*`/`WS0_PIN_*` environment THE DRIVER
+# ITSELF builds for that step, as `NAME=VALUE` lines, with controlled values substituted for the
+# shell variables it reads.
+#
+# WHY THIS EXISTS (#3451 post-rebase round 2, F3). Every other check validates export NAMES and
+# prefix membership; the executions then used values THIS SUITE constructed. So a production
+# MAPPING error — `WS0_CFG_TEMPS="$ARMS"`, or two swapped `WS0_PIN_*` right-hand sides — left the
+# whole suite green while the driver recorded a configuration it never measured. That is the
+# #3272 F1 class the driver's own comment is about: the reporter READS its configuration from the
+# manifest, so a wrong value there is a report describing a run that did not happen.
+#
+# It takes the RIGHT-HAND SIDES FROM THE DRIVER rather than restating them here, because a table
+# of expected values in this file would be a second copy of the driver's intent and would drift.
+#
+# WHY EVALUATING SHELL TEXT IS SAFE **HERE SPECIFICALLY**, and only here: the text is emitted by
+# `--emit-prefix`, which prints it ONLY after proving it is a run of `NAME=` words containing no
+# command separator. The eval's input is bounded by a check that already had to exist. This is
+# strictly conditional on that validation — an unvalidated prefix is never evaluated, and the
+# helper returns non-zero instead.
+#
+# The controlled values are chosen so a SWAP IS DETECTABLE BY THE SHIPPED VALIDATORS rather than
+# by a comparison written here: `temps` and `arms` have DISJOINT legal sets (warm/cold vs
+# bypass/merge), so `WS0_CFG_TEMPS="$ARMS"` yields `temps=bypass`, which `session_manifest_config`
+# refuses. The detector is production code, not a fixture expectation.
+driver_step_env() {
+  local prefix
+  prefix="$(python3 "$REPO_ROOT/scripts/tests/ws0_export_prefix.py" "$1" WS0_ "$2" --emit-prefix)" \
+    || return 1
+  (
+    REPS=1; TEMPS=warm; ARMS=bypass; SCAN_PASSES=1
+    SERVER_CPUS=2,10; CLIENT_CPUS=4,12
+    STEP_DURATION=45s; COLD_STEP_DURATION=1s
+    FLIGHT_ENDPOINT="$WS0_FIXTURE_ENDPOINT"; BASELINE_MODE=non-baseline
+    EVENTS=cycles,instructions; BIN_DIR_RECORDED=target/release; PROFILE_RECORDED=off
+    QUIESCENCE_RECORDED="NOT VERIFIED (no timeseries supplied)"
+    WS0_SERVER_SIBLINGS="server cpu 2 siblings 2,10"; CPU_TOPOLOGY_ROOT="$TMP/fake-topology"
+    eval "$prefix env"
+  ) | grep -E '^WS0_(CFG|PIN)_'
+}
+
 # local_binding_of <driver> <block-needle> — the first `NAME = MAPPING["KEY"]` line in the block
 # that calls <block-needle>, printed as `NAME MAPPING KEY`.
 #
@@ -279,81 +319,7 @@ PY
 # after logical-line joining, a step's assignments and its invocation ARE ONE LINE. Both are
 # IMPORTED — a second copy here would drift, and then this check would certify the copy.
 export_prefix_membership() {
-  python3 - "$REPO_ROOT/scripts/tests" "$1" "$2" "$3" <<'PY'
-import bisect, pathlib, re, sys
-sys.path.insert(0, sys.argv[1])
-from ws0_embedded_python import _join_continuations, census
-
-path = pathlib.Path(sys.argv[2])
-prefix, needle = sys.argv[3], sys.argv[4]
-text = path.read_text()
-
-# WHICH block consumes this prefix, by the shipped writer its body calls.
-records, _findings = census(path)
-owners = [r for r in records if r["kind"] == "BLOCK" and needle in r["body"]]
-if len(owners) != 1:
-    print(f"AMBIGUOUS: {len(owners)} block(s) call {needle!r}", file=sys.stderr)
-    raise SystemExit(2)
-invocation_line = owners[0]["line"]
-
-joined, omap = _join_continuations(text)
-# The ORIGINAL offset where that invocation's physical line begins.
-line_starts = [0] + [i + 1 for i, ch in enumerate(text) if ch == "\n"]
-if invocation_line > len(line_starts):
-    print(f"UNRESOLVABLE: line {invocation_line} is past end of file", file=sys.stderr)
-    raise SystemExit(2)
-invocation_offset = line_starts[invocation_line - 1]
-
-# The JOINED logical line covering it. Spans are in scan space; their bounds are mapped back
-# through `omap`, so the comparison is against original offsets throughout.
-spans, start = [], 0
-for i, ch in enumerate(joined):
-    if ch == "\n":
-        spans.append((start, i))
-        start = i + 1
-spans.append((start, len(joined)))
-logical = None
-for a, b in spans:
-    if b <= a or a >= len(omap):
-        continue
-    if omap[a] <= invocation_offset <= omap[b - 1]:
-        logical = joined[a:b]
-        break
-if logical is None:
-    print(f"UNRESOLVABLE: no logical line covers offset {invocation_offset}", file=sys.stderr)
-    raise SystemExit(2)
-
-names = sorted(set(re.findall(prefix + r"[A-Z_]+(?==)", text)))
-
-# THE PROPERTY IS THE CONTIGUOUS ENVIRONMENT-ASSIGNMENT PREFIX, NOT MERE MEMBERSHIP OF THE
-# LOGICAL LINE (#3451 post-rebase round 1, F1). `n + "=" in logical` passed for
-#
-#     WS0_CFG_BASELINE_MODE="$BASELINE_MODE"; python3 -c '...'
-#
-# which keeps the assignment on the SAME logical line while bash makes it a standalone shell
-# variable python never receives. MEASURED, both directions:
-#
-#     WS0_CFG_REPS="1"; python3 -c ...   -> os.environ.get(...) is None
-#     WS0_CFG_REPS="1"  python3 -c ...   -> "1"
-#
-# So the text BEFORE the command word must be a run of assignment words and nothing else. A
-# command separator anywhere in it, or any word that is not NAME=, means the run is broken and
-# the membership answer is worthless — reported as zero present, which FAILS closed rather than
-# guessing which side of the break each name fell on.
-cmd = logical.find("python3")
-prefix_text = logical[:cmd] if cmd >= 0 else ""
-words = prefix_text.split()
-contiguous = (
-    cmd >= 0
-    and not any(ch in prefix_text for ch in ";&|")
-    and all(re.match(r"[A-Za-z_][A-Za-z0-9_]*=", w) for w in words)
-)
-if contiguous:
-    present = [n for n in names if any(w.startswith(n + "=") for w in words)]
-else:
-    present = []
-print(f"{len(present)} {len(names)}")
-PY
+  python3 "$REPO_ROOT/scripts/tests/ws0_export_prefix.py" "$1" "$2" "$3"
 }
 
 # ============================================================================
@@ -1048,6 +1014,23 @@ run_pin_step() {
   # after the assignments is taken as a command to execute (measured: `env: -u: No such file or
   # directory`, rc 127) — a control that dies before reaching its subject.
   local -a unset_args=() env_args=()
+  # THE VALUES COME FROM THE DRIVER, not from this suite (#3451 post-rebase round 2, F3). Every
+  # other check validates NAMES; the executions used to run on an environment this file built, so
+  # a production MAPPING error (`WS0_CFG_TEMPS="$ARMS"`) left everything green while the driver
+  # recorded a configuration it never measured. `driver_step_env` evaluates the driver's OWN
+  # validated assignment prefix with controlled inputs — see its comment for why evaluating that
+  # text is bounded, and for why a swap is caught by the SHIPPED validators rather than by an
+  # expectation written here.
+  local line
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    env_args+=("$line")
+  done < <(driver_step_env "$drv" write_session_corpus_pin)
+  if [ "${#env_args[@]}" -eq 0 ]; then
+    run_pin_rc=91
+    echo "driver_step_env produced no environment for this driver" > "$STEP_OUT"
+    return
+  fi
   for field in $(cfg_names); do
     if [ "$field" = "$omit" ]; then
       # UNSET, not merely "not passed" (#3451 review round 1, finding 3). `env` INHERITS the
@@ -1055,10 +1038,17 @@ run_pin_step() {
       # have exported — and the control then measures nothing while reporting a failure. `-u`
       # rather than an empty value: the step treats an empty string as absent too, but "was not
       # exported" is the condition being tested and `-u` is the only spelling that states it.
-      unset_args+=("-u" "WS0_CFG_$(echo "$field" | tr '[:lower:]' '[:upper:]')")
-      continue
+      # UNSET for the child, and also REMOVED from the driver-derived list — `env -u NAME`
+      # after `NAME=value` on the same command line does not win, so both halves are needed.
+      local omit_var="WS0_CFG_$(echo "$field" | tr '[:lower:]' '[:upper:]')"
+      unset_args+=("-u" "$omit_var")
+      local -a kept=()
+      local e
+      for e in "${env_args[@]}"; do
+        case "$e" in "$omit_var="*) ;; *) kept+=("$e") ;; esac
+      done
+      env_args=(${kept[@]+"${kept[@]}"})
     fi
-    env_args+=("WS0_CFG_$(echo "$field" | tr '[:lower:]' '[:upper:]')=$(cfg_value "$field")")
   done
   idx="$(find_block "$drv" 'write_session_corpus_pin')"
   [[ "$idx" =~ ^[0-9]+$ ]] || { run_pin_rc=90; echo "block not located: $idx" > "$STEP_OUT"; return; }
@@ -1144,16 +1134,13 @@ sys.path.insert(0, sys.argv[1])
 from ws0_ticket_input import write_ticket_template
 write_ticket_template(pathlib.Path(sys.argv[2]), pathlib.Path(sys.argv[3]) / "ws0-events.cql")
 PY
-CFG_PAIRS_SAVED=("${CFG_PAIRS[@]}")
-CFG_PAIRS=()
-for pair in "${CFG_PAIRS_SAVED[@]}"; do
-  case "$pair" in
-    flight_endpoint=*) CFG_PAIRS+=("flight_endpoint=grpc://127.0.0.1:1") ;;
-    *) CFG_PAIRS+=("$pair") ;;
-  esac
-done
+# The bad value is injected at THE DRIVER'S OWN INPUT (the shell variable its prefix reads),
+# not into a table in this file — since F3 the execution takes its values from the driver, so
+# overriding a local table would no longer reach the step at all.
+WS0_FIXTURE_ENDPOINT_SAVED="$WS0_FIXTURE_ENDPOINT"
+WS0_FIXTURE_ENDPOINT="grpc://127.0.0.1:1"
 run_pin_step "$DRIVER" "$OUT_BADCFG"; badcfg_out="$(cat "$STEP_OUT")"
-CFG_PAIRS=("${CFG_PAIRS_SAVED[@]}")
+WS0_FIXTURE_ENDPOINT="$WS0_FIXTURE_ENDPOINT_SAVED"
 if [ "$run_pin_rc" -eq 0 ] && python3 - "$PERF_DIR" "$OUT_BADCFG" <<'PY'
 import pathlib, sys
 sys.path.insert(0, sys.argv[1])
@@ -1170,6 +1157,49 @@ then
   pass "config-reader CONTROL fired: a grpc:// endpoint is written by the step and REFUSED by session_manifest_config — so the accept above is a measurement, not a reader that takes anything"
 else
   fail "config-reader CONTROL did not fire: session_manifest_config must refuse a non-http endpoint (step rc=$run_pin_rc, out: $(head -2 <<<"$badcfg_out"))"
+fi
+
+# --- CONTROL 3a-map: a SWAPPED RIGHT-HAND SIDE is caught (#3451 post-rebase round 2, F3) --------
+# The mapping defect this whole change is about: `WS0_CFG_TEMPS="$ARMS"` exports a real name with
+# the wrong value, so every NAME-level check stays green while the driver records a configuration
+# it never measured. Detected by the SHIPPED validator rather than by an expectation here —
+# `temps` and `arms` have disjoint legal sets, so the swap yields `temps=bypass` and
+# `session_manifest_config` refuses it.
+SWAPPED="$TMP/swapped-rhs-ws0-driver.sh"
+python3 - "$DRIVER" "$SWAPPED" <<'INJECT'
+import pathlib, sys
+text = pathlib.Path(sys.argv[1]).read_text()
+needle = 'WS0_CFG_TEMPS="$TEMPS"'
+if text.count(needle) != 1:
+    print(f"INJECTION IMPOSSIBLE: {needle} occurs {text.count(needle)} time(s)", file=sys.stderr)
+    raise SystemExit(1)
+pathlib.Path(sys.argv[2]).write_text(text.replace(needle, 'WS0_CFG_TEMPS="$ARMS"'))
+INJECT
+swap_rc=$?
+if [ "$swap_rc" -ne 0 ]; then
+  fail "mapping CONTROL: the swap could not be injected, so the control could not fire"
+else
+  OUT_SWAP="$TMP/session-swapped"; mkdir -p "$OUT_SWAP"
+  python3 - "$PERF_DIR" "$OUT_SWAP" "$CORPUS" <<'PY'
+import pathlib, sys
+sys.path.insert(0, sys.argv[1])
+from ws0_ticket_input import write_ticket_template
+write_ticket_template(pathlib.Path(sys.argv[2]), pathlib.Path(sys.argv[3]) / "ws0-events.cql")
+PY
+  run_pin_rc=0
+  run_pin_step "$SWAPPED" "$OUT_SWAP"; swap_out="$(cat "$STEP_OUT")"
+  if [ "$run_pin_rc" -eq 0 ] && ! python3 - "$PERF_DIR" "$OUT_SWAP" <<'PY'
+import pathlib, sys
+sys.path.insert(0, sys.argv[1])
+from ws0_report import ARMS_ALLOWED, TEMPS_ALLOWED
+from ws0_session import session_manifest_config
+session_manifest_config(pathlib.Path(sys.argv[2]), TEMPS_ALLOWED, ARMS_ALLOWED)
+PY
+  then
+    pass "mapping CONTROL fired: a swapped right-hand side (WS0_CFG_TEMPS taking \$ARMS) is written by the step and REFUSED by the shipped reader — values are now taken from the driver, so a mapping error is visible where a name check cannot see it"
+  else
+    fail "mapping CONTROL did not fire: a swapped right-hand side must reach the manifest and be refused (step rc=$run_pin_rc, out: $(head -2 <<<"$swap_out"))"
+  fi
 fi
 
 # --- POSITIVE CONTROL 3a: the same harness OBSERVES the defective step failing -----------------

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -356,6 +356,13 @@ fi
 # into this driver next. Exercised against a SCRATCH copy rather than one of those files, so the
 # control cannot drift when they change: the block must be delimited (not reported undelimited) AND
 # a defect inside it must still be reported.
+#
+# NO APOSTROPHE anywhere in the injected body, and that is load-bearing rather than style: the body
+# sits inside SHELL SINGLE QUOTES, so one closes the string early. An earlier version of this
+# fixture used a dict literal with quoted keys, was truncated at its first apostrophe, and STILL
+# "reported a defect" — the truncation, not the injected one. Round 5's word-boundary check turned
+# that into a visible failure, which is the check working; the fixture is now apostrophe-free, the
+# same rule `lib-ws0-fixtures.sh` records about its own bodies.
 TRAILING_DRIVER="$TMP/trailing-closer-ws0-driver.sh"
 python3 - "$DRIVER" "$TRAILING_DRIVER" <<'INJECT'
 import pathlib, sys
@@ -364,7 +371,8 @@ import pathlib, sys
 backslash, dquote = chr(92), chr(34)
 bad = "{d[" + backslash + dquote + "k" + backslash + dquote + "]}"
 q = chr(39)
-step = ("python3 -c " + q + "\nd = {'k': 1}\nprint(f'" + bad + "')" + q + " \"$OUT_DIR\"\n")
+step = ("python3 -c " + q + "\nd = dict(k=1)\nprint(f" + dquote + bad + dquote + ")"
+        + q + " \"$OUT_DIR\"\n")
 pathlib.Path(sys.argv[2]).write_text(pathlib.Path(sys.argv[1]).read_text() + step)
 INJECT
 tr_census="$(census "$TRAILING_DRIVER")"
@@ -473,6 +481,70 @@ if [ "$tab_blocks" -eq "$((block_count + 1))" ] && [ -z "$(findings_of "$tab_cen
   pass "census CONTROL fired (<<- form): a TAB-indented terminator delimits and the body's leading tabs are stripped as the shell strips them — the extracted source compiles ($tab_blocks blocks)"
 else
   fail "census CONTROL did not fire (<<- form): blocks=$tab_blocks (expected $((block_count + 1))), census='$(findings_of "$tab_census" | head -1)', compile='$(findings_of "$tab_compile" | head -1)'"
+fi
+
+# --- CONTROL 1e: a block's closing quote must be followed by a shell WORD BOUNDARY -------------
+# Bash CONCATENATES adjacent word fragments, so a block written `-c 'pass'" +"` runs `pass +`.
+# Extracting the quoted part alone would approve a program python never receives — a FALSE PASS,
+# measured: bash raised SyntaxError while the census reported `compiled=1 findings=0`.
+#
+# BOTH DIRECTIONS, and the ACCEPT half is the one that matters most here. The driver's own inline
+# block closes `')" || {` — a `)` immediately after the quote — so a whitespace-only boundary rule
+# would flag 1 of the driver's 3 real blocks on its first run. That exact shape is pinned below so
+# a future tightening cannot break the real subject silently; the false-red direction is what got
+# the previous oracle deleted.
+BOUNDARY_OK="$TMP/boundary-ok-ws0-driver.sh"
+python3 - "$BOUNDARY_OK" <<'INJECT'
+import pathlib, sys
+q = chr(39)
+# The driver's own closer shape, reproduced exactly: `')" || {`.
+pathlib.Path(sys.argv[1]).write_text(
+    'now="$(python3 -c ' + q + 'import time; print(time.monotonic_ns())' + q + ')" || {\n'
+    '  exit 2\n}\n')
+INJECT
+BOUNDARY_BAD="$TMP/boundary-bad-ws0-driver.sh"
+python3 - "$BOUNDARY_BAD" <<'INJECT'
+import pathlib, sys
+q, dq = chr(39), chr(34)
+# An ADJACENT FRAGMENT: bash appends it, so the program python runs is not the quoted text.
+pathlib.Path(sys.argv[1]).write_text(
+    'python3 -c ' + q + 'pass' + q + dq + ' +' + dq + '\n')
+INJECT
+bound_ok="$(census "$BOUNDARY_OK")"
+bound_bad="$(census "$BOUNDARY_BAD")"
+if [ "$(grep -c '^BLOCK	' <<<"$bound_ok")" -eq 1 ] && [ -z "$(findings_of "$bound_ok")" ] \
+   && grep -q 'word boundary' <<<"$bound_bad"; then
+  pass "census word-boundary, BOTH directions: the driver's own \`')\" || {\` closer is ACCEPTED (a shell metacharacter is a boundary, not just whitespace) while an adjacent fragment is a FINDING — bash would concatenate it and python would receive different source"
+else
+  fail "census word-boundary: accept-blocks=$(grep -c '^BLOCK	' <<<"$bound_ok") accept-findings='$(findings_of "$bound_ok" | head -1)' reject='$(findings_of "$bound_bad" | head -1)'"
+fi
+
+# --- CONTROL 1f: only a QUOTED heredoc delimiter is compiled -----------------------------------
+# With `<<PY` the shell expands parameters, commands, arithmetic and backslashes in the body
+# BEFORE python sees it, so the verbatim text is not the program that runs. Measured with a body
+# that is valid python verbatim and a SyntaxError once expanded: bash refused it, the census said
+# `compiled=1 findings=0`. Refused rather than modelled — this file will not imitate shell
+# expansion. With `<<'PY'` no expansion happens and the premise "verbatim is what python receives"
+# is exactly true, which is the accept half.
+HEREDOC_Q="$TMP/heredoc-quoted-ws0-driver.sh"
+HEREDOC_U="$TMP/heredoc-unquoted-ws0-driver.sh"
+python3 - "$HEREDOC_Q" "$HEREDOC_U" <<'INJECT'
+import pathlib, sys
+q, dq = chr(39), chr(34)
+tag = "PY" + "Q"
+body = "v = " + dq + "$X" + dq + "\nprint(v)\n"
+# Quoted delimiter: literal body, so compiling the verbatim text is exactly right.
+pathlib.Path(sys.argv[1]).write_text("python3 - <<" + q + tag + q + "\n" + body + tag + "\n")
+# Unquoted delimiter: the same body, but $X is substituted before python sees it.
+pathlib.Path(sys.argv[2]).write_text("python3 - <<" + tag + "\n" + body + tag + "\n")
+INJECT
+hq_out="$(census "$HEREDOC_Q")"
+hu_out="$(census "$HEREDOC_U")"
+if [ "$(grep -c '^BLOCK	' <<<"$hq_out")" -eq 1 ] && [ -z "$(findings_of "$hq_out")" ] \
+   && grep -q 'UNQUOTED delimiter' <<<"$hu_out"; then
+  pass "census heredoc-quoting, BOTH directions: a QUOTED delimiter is compiled (no expansion, so verbatim IS the program) while an UNQUOTED one is a FINDING (the shell rewrites the body before python sees it)"
+else
+  fail "census heredoc-quoting: quoted-blocks=$(grep -c '^BLOCK	' <<<"$hq_out") quoted-findings='$(findings_of "$hq_out" | head -1)' unquoted='$(findings_of "$hu_out" | head -1)'"
 fi
 
 # ============================================================================

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -1277,11 +1277,23 @@ run_cpu_step() { # run_cpu_step <driver> <out-dir>
   idx="$(find_block "$drv" 'pinning_record_path')"
   [[ "$idx" =~ ^[0-9]+$ ]] || { run_cpu_rc=90; echo "block not located: $idx" > "$STEP_OUT"; return; }
   body="$(emit_block "$drv" "$idx")"
-  env WS0_PIN_SERVER_CPUS="$(cfg_value server_cpus)" \
-      WS0_PIN_CLIENT_CPUS="$(cfg_value client_cpus)" \
-      WS0_PIN_SIBLINGS="server cpu 2 siblings 2,10; server cpu 10 siblings 2,10" \
-      WS0_PIN_TOPOLOGY_ROOT="$TMP/fake-topology" \
-      python3 -c "$body" "$PERF_DIR" "$out" > "$STEP_OUT" 2>&1
+  # THE VALUES COME FROM THE DRIVER, exactly as the session-pin step's do (#3451 post-rebase
+  # round 3, F3). Round 2 wired only `write_session_corpus_pin`, so this step still ran on
+  # fixture constants AND had its record verified against those same constants — a swapped
+  # `WS0_PIN_SERVER_CPUS="$CLIENT_CPUS"` stayed green. Same shape as the round-11 union bug: a
+  # check right about one step and silent about the other.
+  local -a cpu_env=()
+  local line
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    cpu_env+=("$line")
+  done < <(driver_step_env "$drv" pinning_record_path)
+  if [ "${#cpu_env[@]}" -eq 0 ]; then
+    run_cpu_rc=91
+    echo "driver_step_env produced no environment for the CPU-pin step" > "$STEP_OUT"
+    return
+  fi
+  env "${cpu_env[@]}" python3 -c "$body" "$PERF_DIR" "$out" > "$STEP_OUT" 2>&1
   run_cpu_rc=$?
 }
 
@@ -1304,19 +1316,91 @@ if grep -q 'pinning pin:' <<<"$cpu_out"; then
 else
   fail "EXECUTE cpu-pin-verification: the step did not print 'pinning pin:' (output: $(head -3 <<<"$cpu_out"))"
 fi
-if python3 - "$PERF_DIR" "$OUT" "$(cfg_value server_cpus)" "$(cfg_value client_cpus)" <<'PY'
+# THE TWO STEPS ARE CROSS-CHECKED AGAINST EACH OTHER, not each against its own constants
+# (#3451 post-rebase round 3, F3). The CPU record's pins are verified against the CPU lists read
+# from THE SESSION MANIFEST the other step wrote — which is precisely the comparison
+# `verify_pinning_record` exists to make in production. Verified against fixture constants
+# instead, a swap in ONE prefix was invisible; and because the manifest and the record were
+# validated INDEPENDENTLY, a MATCHING swap in both was invisible too. Reading one side from the
+# other is what makes a consistent swap detectable.
+if python3 - "$PERF_DIR" "$OUT" <<'PY'
 import pathlib, sys
 sys.path.insert(0, sys.argv[1])
 from ws0_pinning import PINNING_RECORD_FIELDS, verify_pinning_record
-rec = verify_pinning_record(pathlib.Path(sys.argv[2]), sys.argv[3], sys.argv[4])
+from ws0_report import ARMS_ALLOWED, TEMPS_ALLOWED
+from ws0_session import session_manifest_config
+session = pathlib.Path(sys.argv[2])
+# The CPU lists AS THE MANIFEST RECORDS THEM — the session-pin step's output, not a constant.
+config = session_manifest_config(session, TEMPS_ALLOWED, ARMS_ALLOWED)
+rec = verify_pinning_record(session, config["server_cpus"], config["client_cpus"])
 missing = [f for f in PINNING_RECORD_FIELDS if not rec.get(f)]
 assert not missing, missing
 PY
 then
-  pass "EXECUTE cpu-pin-verification: the SHIPPED READER (verify_pinning_record) accepts the record the shipped STEP wrote, with every PINNING_RECORD_FIELDS field populated"
+  pass "EXECUTE cpu-pin-verification: the SHIPPED READER accepts the record the shipped STEP wrote, and its pins are checked against the CPU lists THE SESSION MANIFEST records — the two steps are cross-checked against each other rather than each against the same fixture constants"
 else
-  fail "EXECUTE cpu-pin-verification: the shipped reader refused the record the shipped step wrote"
+  fail "EXECUTE cpu-pin-verification: the shipped reader refused the record the shipped step wrote, or its pins disagree with the manifest the session-pin step produced"
 fi
+
+# --- CONTROL 4-map: a SWAPPED CPU right-hand side is caught, in BOTH shapes ---------------------
+# Two swaps, because they defeat different checks and the second is the one round 3's F3 is about:
+#
+#   pin-only    WS0_PIN_SERVER_CPUS="$CLIENT_CPUS" — the record disagrees with the manifest.
+#   consistent  the SAME swap in BOTH prefixes — each artifact is self-consistent, so validating
+#               them independently sees nothing. Only reading the record's expectation FROM the
+#               manifest catches it... and it does not: a consistent swap is, by construction, a
+#               session that pinned and recorded the same (wrong) lists. See the assertion below
+#               for what is actually claimed.
+for cpu_swap in pin-only consistent; do
+  SWAPDIR="$TMP/cpuswap-$cpu_swap"; mkdir -p "$SWAPDIR"
+  SWAPDRV="$TMP/cpuswap-$cpu_swap-driver.sh"
+  python3 - "$DRIVER" "$SWAPDRV" "$cpu_swap" <<'INJECT'
+import pathlib, sys
+text = pathlib.Path(sys.argv[1]).read_text()
+pin = 'WS0_PIN_SERVER_CPUS="$SERVER_CPUS"'
+cfg = 'WS0_CFG_SERVER_CPUS="$SERVER_CPUS"'
+if text.count(pin) != 1 or text.count(cfg) != 1:
+    print("INJECTION IMPOSSIBLE: the CPU assignments are not both present exactly once",
+          file=sys.stderr)
+    raise SystemExit(1)
+out = text.replace(pin, 'WS0_PIN_SERVER_CPUS="$CLIENT_CPUS"')
+if sys.argv[3] == "consistent":
+    out = out.replace(cfg, 'WS0_CFG_SERVER_CPUS="$CLIENT_CPUS"')
+pathlib.Path(sys.argv[2]).write_text(out)
+INJECT
+  swap_inject_rc=$?
+  if [ "$swap_inject_rc" -ne 0 ]; then
+    fail "cpu-mapping CONTROL ($cpu_swap): the swap could not be injected, so it could not fire"
+    continue
+  fi
+  python3 - "$PERF_DIR" "$SWAPDIR" "$CORPUS" <<'PY'
+import pathlib, sys
+sys.path.insert(0, sys.argv[1])
+from ws0_ticket_input import write_ticket_template
+write_ticket_template(pathlib.Path(sys.argv[2]), pathlib.Path(sys.argv[3]) / "ws0-events.cql")
+PY
+  run_pin_rc=0; run_cpu_rc=0
+  run_pin_step "$SWAPDRV" "$SWAPDIR" >/dev/null 2>&1
+  run_cpu_step "$SWAPDRV" "$SWAPDIR" >/dev/null 2>&1
+  swap_verdict=refused
+  python3 - "$PERF_DIR" "$SWAPDIR" >/dev/null 2>&1 <<'PY' && swap_verdict=accepted
+import pathlib, sys
+sys.path.insert(0, sys.argv[1])
+from ws0_pinning import verify_pinning_record
+from ws0_report import ARMS_ALLOWED, TEMPS_ALLOWED
+from ws0_session import session_manifest_config
+session = pathlib.Path(sys.argv[2])
+config = session_manifest_config(session, TEMPS_ALLOWED, ARMS_ALLOWED)
+verify_pinning_record(session, config["server_cpus"], config["client_cpus"])
+PY
+  if [ "$cpu_swap" = "pin-only" ] && [ "$swap_verdict" = refused ]; then
+    pass "cpu-mapping CONTROL fired (pin-only): WS0_PIN_SERVER_CPUS taking \$CLIENT_CPUS makes the record disagree with the manifest, and the cross-check REFUSES it — invisible while the record was verified against fixture constants"
+  elif [ "$cpu_swap" = "consistent" ] && [ "$swap_verdict" = accepted ]; then
+    pass "cpu-mapping STATED LIMIT (consistent): swapping BOTH prefixes together is ACCEPTED, and that is honest rather than a gap this suite can close — the manifest and the record then agree, so no cross-check between them can tell; catching it needs an oracle for what the CPU lists OUGHT to be, which only the host topology has (test_ws0_cpu_pinning_guards.sh's subject)"
+  else
+    fail "cpu-mapping CONTROL ($cpu_swap): expected the cross-check to $([ "$cpu_swap" = pin-only ] && echo refuse || echo accept), got $swap_verdict"
+  fi
+done
 
 # --- POSITIVE CONTROL 4: the same harness OBSERVES the defective CPU step failing ---------------
 DEFECTIVE_CPU="$TMP/defect-exec-cpu.sh"

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -58,8 +58,11 @@
 #     green while the real rig hits the step's own `FATAL: … was not exported` and its caller
 #     exits 2, i.e. #3451's exact symptom. The same cross-check covers the CPU-pin step's four
 #     `WS0_PIN_*` inputs, there against the literal names the extracted block reads;
-#   * EVERY embedded block in the driver COMPILES — the total property, so instance #8 anywhere in
-#     that file is caught and not only the two steps this issue repaired;
+#   * EVERY DISCOVERED embedded block in the driver COMPILES, so instance #8 anywhere in that file
+#     is caught and not only the two steps this issue repaired. DISCOVERED is the operative word
+#     and its scope is stated exactly: every `-c`-form invocation REGARDLESS of how its command
+#     word is spelled (the census anchors on the flag), plus every invocation whose command word
+#     contains a literal `python`. What that does not reach is in NOT REACHED below;
 #   * the extractor's delimiter in BOTH directions: it reports a defect, AND it does not
 #     manufacture one on good input. A block is delimited by bash's quoting rules rather than by a
 #     line pattern, so all three closer shapes this repository actually uses are handled — the
@@ -101,6 +104,16 @@
 #
 #     What survives is the oracle that is real: no CPython accepts the BACKSLASH form, so the
 #     compile check catches the defect this issue is actually about on 3.9 through 3.12 alike.
+#   * COMPLETE DISCOVERY OF EMBEDDED PYTHON, which is NOT STATICALLY ACHIEVABLE and is therefore a
+#     stated decision rather than an oversight. A shell command word can be spelled arbitrarily —
+#     a variable, a concatenation, `$(which python3)`, an alias, `eval` — so enumerating the
+#     spellings is the same open list the round-6 inversion escaped, one level down. The two
+#     anchors cover the decidable part: the `-c` FLAG (any command-word spelling) and a literal
+#     `python` word (any argument shape). NOT discovered: an indirectly-spelled command word
+#     COMBINED with a non-`-c` form — `$PYTHON <<'PY'`, or code reaching python through `eval`.
+#     Closing that would require interpreting bash, which is the thing this file does not do.
+#     If a future review reports another command-word spelling, the answer is this limit, not
+#     more matching.
 #   * anything measured: no `perf`, no Flight server, no rep loop, no 2.8 GB corpus.
 #
 # Hermetic: python3, a few KB under `$TMPDIR`. No sudo, cargo, perf, taskset, network, root, and no
@@ -242,8 +255,16 @@ fi
 # so a reordering of the driver cannot silently point this suite at the wrong step — and a step
 # that DISAPPEARED is a failure here rather than a suite that quietly tests one block twice.
 find_block() { # find_block <driver> <needle> — the index of the ONE block containing <needle>
-  local drv="$1" needle="$2" n total hit="" body
-  total="$(python3 "$EXTRACT" census "$drv" 2>/dev/null | grep -c '^BLOCK	')"
+  local drv="$1" needle="$2" n total hit="" body out
+  out="$(python3 "$EXTRACT" census "$drv" 2>&1)"
+  # THE MARKER IS REQUIRED, as every other caller requires it (#3451 review round 7, finding 2).
+  # Without it a census that died — or never had a subject — yields zero BLOCK lines, and this
+  # function would report a confident `ABSENT` that a positive control reads as success.
+  if ! grep -q '^#COMPLETE ' <<<"$out"; then
+    echo "INCOMPLETE"
+    return 1
+  fi
+  total="$(grep -c '^BLOCK	' <<<"$out")"
   for ((n = 1; n <= total; n++)); do
     body="$(emit_block "$drv" "$n")"
     if grep -q -- "$needle" <<<"$body"; then
@@ -315,8 +336,15 @@ import pathlib, sys
 text = pathlib.Path(sys.argv[1]).read_text()
 pathlib.Path(sys.argv[2]).write_text(text.replace("write_session_corpus_pin", "some_other_writer"))
 PY
-if [ "$(find_block "$NO_PIN_STEP" 'write_session_corpus_pin')" = "ABSENT" ]; then
-  pass "census CONTROL fired: with the session-pin writer gone from the driver, the locator reports ABSENT rather than picking another block"
+no_pin_rc=$?
+# THE FIXTURE MUST HAVE BEEN WRITTEN (#3451 review round 7, finding 2). If it could not be, the
+# locator reads a MISSING FILE as `ABSENT` and this positive control passes having observed
+# nothing — a control that cannot fail, inside the suite whose whole subject is refusing exactly
+# that. The status is checked, and the file's existence with it.
+if [ "$no_pin_rc" -ne 0 ] || [ ! -s "$NO_PIN_STEP" ]; then
+  fail "census CONTROL: the disappeared-step fixture could not be written (rc=$no_pin_rc), so the control could not fire — it would otherwise read a missing file as ABSENT and pass vacuously"
+elif [ "$(find_block "$NO_PIN_STEP" 'write_session_corpus_pin')" = "ABSENT" ]; then
+  pass "census CONTROL fired: with the session-pin writer gone from a REAL fixture (existence asserted), the locator reports ABSENT rather than picking another block"
 else
   fail "census CONTROL did not fire: the block locator must report ABSENT when its subject is not in the driver"
 fi
@@ -492,6 +520,42 @@ if [ "$(grep -c '^BLOCK	' <<<"$hd_any")" -eq 0 ] && grep -q 'matches none of the
   pass "census CONTROL fired (heredoc removed): a python heredoc is a FINDING, not a block — the three false passes heredoc support cost are unreachable because the support is gone"
 else
   fail "census CONTROL did not fire (heredoc removed): a heredoc must be a finding, got: $(head -2 <<<"$hd_any")"
+fi
+
+# --- CONTROL 1h: AN INDIRECTLY-SPELLED COMMAND WORD IS DISCOVERED VIA THE FLAG -----------------
+# The allowlist closed CLASSIFICATION but not DISCOVERY: a candidate must be FOUND before it can
+# be classified, and `$PYTHON -c '…'` contains no literal `python` word, so it was invisible — an
+# invalid block passing the "every embedded block compiles" guard with the count unchanged. The
+# census now has a SECOND anchor, the `-c` flag itself, which is independent of how the command
+# word is spelled.
+INDIRECT="$TMP/indirect-command-word.sh"
+python3 - "$INDIRECT" <<'INJECT'
+import pathlib, sys
+q = chr(39)
+pathlib.Path(sys.argv[1]).write_text("$PYTHON -c " + q + "import os," + q + "\n")
+INJECT
+indirect_rc=$?
+if [ "$indirect_rc" -ne 0 ] || [ ! -s "$INDIRECT" ]; then
+  fail "census CONTROL: the indirect-command-word fixture could not be written (rc=$indirect_rc), so the control could not fire"
+else
+  ind_out="$(census "$INDIRECT")"
+  if grep -q 'command word is' <<<"$ind_out"; then
+    pass "census CONTROL fired (indirect command word): \$PYTHON -c is DISCOVERED via the flag anchor and named — $(findings_of "$ind_out" | head -1 | cut -c1-96)"
+  else
+    fail "census CONTROL did not fire (indirect command word): an indirectly-spelled -c invocation must be a finding, got: $(head -2 <<<"$ind_out")"
+  fi
+fi
+
+# --- CONTROL 1i: A MISSING SUBJECT EXITS NONZERO ------------------------------------------------
+# `census <a path that does not exist>` used to print a message and exit 0, so a caller that
+# checks the STATUS read "no subject at all" as "nothing wrong" — the vacuous pass one level up
+# from everything else this suite asserts.
+python3 "$EXTRACT" census "$TMP/definitely-not-a-driver.sh" >/dev/null 2>&1
+missing_rc=$?
+if [ "$missing_rc" -ne 0 ]; then
+  pass "census CONTROL fired (missing subject): an absent driver exits NONZERO (rc=$missing_rc), so a status-checking caller cannot read 'no subject' as 'nothing wrong'"
+else
+  fail "census CONTROL did not fire: an absent driver must exit nonzero, got rc=$missing_rc"
 fi
 
 # ============================================================================

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -55,7 +55,12 @@
 #     `ws0_session.MANIFEST_CONFIG_FIELDS` and asserted equal to it, so a field added there without
 #     a driver export is a failure here rather than a refusal at report time;
 #   * EVERY embedded block in the driver COMPILES — the total property, so instance #8 anywhere in
-#     that file is caught and not only the two steps this issue repaired.
+#     that file is caught and not only the two steps this issue repaired;
+#   * EVERY embedded block parses on EVERY INTERPRETER THIS REPOSITORY RUNS, not merely on this
+#     box. `compile()` cannot answer that: PEP 701 made the nested SAME-TYPE quote spelling legal
+#     in 3.12, so a regression to it — the alternative the driver's own comment says it rejected —
+#     passes on a 3.12 box and breaks the 3.11 workflows this repo pins. Two oracles, each sound
+#     over its own interpreter range, with the one that answered NAMED in the output.
 #   * the extractor's delimiter in BOTH directions: it reports a defect, AND it does not
 #     manufacture one on good input. A block is delimited by bash's quoting rules rather than by a
 #     line pattern, so all three closer shapes this repository actually uses are handled — the
@@ -127,19 +132,28 @@ emit_block() { python3 "$EXTRACT" emit "$1" "$2"; }
 # gives: a diagnostic a human must remember to ignore is one they will read as a finding.
 findings_of() { grep -v '^#COMPLETE ' <<<"$1" | grep -vE '^(BLOCK|MENTION|SCRIPT)\b' | grep -v '^$'; }
 
-# defective_copy <src> <dest> <placeholder> <mapping> <key> — a scratch copy of the driver whose
-# f-string placeholder `{<placeholder>}` has been rewritten to the INLINE SUBSCRIPT spelling that
-# no CPython parses. Exits non-zero when the placeholder is not found EXACTLY once, so a control
-# that silently injected nothing is a failure rather than a green "the check found no defect".
+# defective_copy <src> <dest> <placeholder> <mapping> <key> [flavour] — a scratch copy of the
+# driver whose f-string placeholder `{<placeholder>}` has been rewritten to an INLINE SUBSCRIPT.
+#
+# Two flavours, because they fail on DIFFERENT interpreters and the suite must observe both:
+#   escaped  a backslash inside the expression. No CPython parses it — the shipped defect.
+#   nested   the SAME quote character as the enclosing f-string. Legal from 3.12 (PEP 701) and a
+#            SyntaxError on everything older, so `compile()` on a 3.12 box CANNOT see it. This is
+#            the alternative the driver's comment says was rejected.
+#
+# Exits non-zero when the placeholder is not found EXACTLY once, so a control that silently
+# injected nothing is a failure rather than a green "the check found no defect".
 defective_copy() {
   python3 - "$@" <<'PY'
 import pathlib, sys
 src, dest, placeholder, mapping, key = sys.argv[1:6]
-# The defect is CONSTRUCTED from character codes rather than written out, so this file does not
-# ship a literal example of the spelling whose absence the rig cares about (#3312's rule about
-# prose inside a diff naming its own oracle, applied to a test that must build its own bad input).
+flavour = sys.argv[6] if len(sys.argv) > 6 else "escaped"
+# Both spellings are CONSTRUCTED from character codes rather than written out, so this file does
+# not ship a literal example of either (#3312's rule about prose inside a diff naming its own
+# oracle, applied to a test that must build its own bad input).
 backslash, dquote = chr(92), chr(34)
-bad = "{" + mapping + "[" + backslash + dquote + key + backslash + dquote + "]}"
+lead = backslash + dquote if flavour == "escaped" else dquote
+bad = "{" + mapping + "[" + lead + key + lead + "]}"
 text = pathlib.Path(src).read_text()
 needle = "{" + placeholder + "}"
 found = text.count(needle)
@@ -151,6 +165,11 @@ if found != 1:
 pathlib.Path(dest).write_text(text.replace(needle, bad))
 PY
 }
+
+# portable <file> / portable_source <file> — the PEP 701 oracle over a driver's blocks, or over an
+# ordinary python file.
+portable() { python3 "$EXTRACT" portable "$1" 2>&1; }
+portable_source() { python3 "$EXTRACT" portable-source "$1" 2>&1; }
 
 # ============================================================================
 # PART 1 — THE EXTRACTOR READS THE SHIPPED DRIVER, AND FAILS CLOSED
@@ -352,6 +371,48 @@ else
   fail "census CONTROL did not fire (heredoc shape): blocks=$hd_blocks (expected $((block_count + 1))), compile said: $(findings_of "$hd_compile" | head -2)"
 fi
 
+# --- CONTROL 1d-bis: the heredoc terminator rule is the SHELL's, per form ----------------------
+# `<<TAG` takes the terminator EXACTLY — a space-indented `  TAG` is ordinary body to the shell, so
+# accepting it truncates the block and hands python a body it never receives. `<<-TAG` strips
+# leading TABS from the terminator AND from every body line, so leaving them in place turns a
+# perfectly good body into an IndentationError the shell would never produce. Both are asserted,
+# because a `.strip()` comparison was wrong in both directions at once.
+SPACE_TERM_DRIVER="$TMP/space-terminator-ws0-driver.sh"
+python3 - "$DRIVER" "$SPACE_TERM_DRIVER" <<'INJECT'
+import pathlib, sys
+tag = "PY" + "SPACED"
+# The ONLY line matching the tag is INDENTED WITH SPACES, which the shell does not accept for a
+# plain `<<`, so the heredoc is genuinely unterminated.
+step = ("python3 - <<'" + tag + "'\nprint(1)\n  " + tag + "\n")
+pathlib.Path(sys.argv[2]).write_text(pathlib.Path(sys.argv[1]).read_text() + step)
+INJECT
+sp_out="$(census "$SPACE_TERM_DRIVER")"
+if grep -q 'never terminated' <<<"$sp_out" && grep -q 'exact match' <<<"$sp_out"; then
+  pass "census CONTROL fired (plain <<): a SPACE-INDENTED line matching the tag is body, not a terminator — the block is reported unterminated rather than silently truncated"
+else
+  fail "census CONTROL did not fire (plain <<): a space-indented terminator must not delimit a plain-form heredoc, got: $(findings_of "$sp_out" | head -2)"
+fi
+
+TAB_TERM_DRIVER="$TMP/tab-terminator-ws0-driver.sh"
+python3 - "$DRIVER" "$TAB_TERM_DRIVER" <<'INJECT'
+import pathlib, sys
+tag = "PY" + "TABBED"
+tab = chr(9)
+# `<<-`: tabs are stripped from the terminator AND from the body. If the body's tabs survive, the
+# extracted source is indented and does not compile — which is how this control discriminates.
+step = ("python3 - <<-'" + tag + "'\n" + tab + "print(1)\n" + tab + tag + "\n")
+pathlib.Path(sys.argv[2]).write_text(pathlib.Path(sys.argv[1]).read_text() + step)
+INJECT
+tab_census="$(census "$TAB_TERM_DRIVER")"
+tab_compile="$(compile_blocks "$TAB_TERM_DRIVER")"
+tab_blocks="$(grep -c '^BLOCK	' <<<"$tab_census")"
+if [ "$tab_blocks" -eq "$((block_count + 1))" ] && [ -z "$(findings_of "$tab_census")" ] \
+   && [ -z "$(findings_of "$tab_compile")" ]; then
+  pass "census CONTROL fired (<<- form): a TAB-indented terminator delimits and the body's leading tabs are stripped as the shell strips them — the extracted source compiles ($tab_blocks blocks)"
+else
+  fail "census CONTROL did not fire (<<- form): blocks=$tab_blocks (expected $((block_count + 1))), census='$(findings_of "$tab_census" | head -1)', compile='$(findings_of "$tab_compile" | head -1)'"
+fi
+
 # ============================================================================
 # PART 2 — THE TOTAL PROPERTY: EVERY EMBEDDED BLOCK COMPILES
 # ============================================================================
@@ -382,6 +443,84 @@ control_compile() { # control_compile <label> <placeholder> <mapping> <key>
 }
 control_compile "session-corpus-pin step" pin_sha pin data_db_sha256
 control_compile "CPU-pin-verification step" rec_server_cpus rec server_cpus
+
+# ============================================================================
+# PART 2b — THE BLOCKS PARSE ON EVERY INTERPRETER THIS REPO RUNS, NOT JUST THIS BOX
+# ============================================================================
+# `compile()` answers "does this parse HERE". The property the repaired steps need is "does this
+# parse on every interpreter this repository runs on", and the two differ for exactly one
+# spelling: a subscript inside an f-string expression written with NESTED SAME-TYPE QUOTES. PEP
+# 701 made it legal in 3.12; it is a SyntaxError on everything older. That is the alternative the
+# driver's own comment says was rejected — and until this part existed, nothing enforced it: a
+# regression to that form passes `compile()` on a 3.12 box and breaks the 3.11 workflows this
+# repository pins (and the `>=3.9` the python bindings declare).
+#
+# TWO ORACLES, EACH SOUND OVER ITS OWN RANGE, AND THE PASS LINE NAMES WHICH ONE ANSWERED. On 3.12+
+# a tokenizer walk is the oracle, because `compile()` there accepts the bad form; below 3.12
+# `compile()` IS the oracle, because the bad form does not parse at all. Nothing is conditional on
+# an optional interpreter being installed — a check that skips when a dependency is absent is the
+# coverage gap this whole issue is about.
+port_out="$(portable "$DRIVER")"
+port_marker="$(grep -m1 '^#COMPLETE ' <<<"$port_out")"
+if [ -n "$port_marker" ] && [ -z "$(findings_of "$port_out")" ]; then
+  pass "portable: every embedded block parses on EVERY interpreter this repo runs, not just this box ($port_marker)"
+else
+  fail "portable: an embedded block in $DRIVER uses a spelling that only parses on this box — $(findings_of "$port_out" | head -2)"
+fi
+
+# --- CONTROL 2b-i: the 3.12-only spelling is REFUSED, and `compile` alone cannot see it ---------
+NESTED_DRIVER="$TMP/nested-quote-ws0-driver.sh"
+if defective_copy "$DRIVER" "$NESTED_DRIVER" pin_sha pin data_db_sha256 nested 2>"$TMP/inject-nested.err"; then
+  nest_port="$(portable "$NESTED_DRIVER")"
+  nest_comp="$(compile_blocks "$NESTED_DRIVER")"
+  nest_oracle="$(sed -n 's/.*oracle=\([a-z]*\).*/\1/p' <<<"$nest_port" | head -1)"
+  if grep -q 'NOT PORTABLE' <<<"$nest_port"; then
+    pass "portable CONTROL fired: the nested SAME-TYPE quote spelling is REFUSED — $(grep -m1 'NOT PORTABLE' <<<"$nest_port" | cut -c1-118)"
+  else
+    fail "portable CONTROL did NOT fire: the 3.12-only spelling must be refused, got: $(findings_of "$nest_port" | head -2)"
+  fi
+  # ...and WHY the new oracle earns its place, asserted rather than argued: on a 3.12+ box the
+  # plain compile check is SILENT about this input. On an older box compile is the oracle and must
+  # report it. Both branches assert; neither is a skip, and the pass line says which ran.
+  if [ "$nest_oracle" = "tokenizer" ]; then
+    if [ -z "$(findings_of "$nest_comp")" ]; then
+      pass "portable CONTROL discriminates: on this 3.12+ interpreter (oracle=tokenizer) the plain compile check is SILENT about the same input — so the portability oracle is doing work compile cannot"
+    else
+      fail "on a 3.12+ interpreter compile() must ACCEPT the nested spelling (that is the trap); it reported: $(findings_of "$nest_comp" | head -1)"
+    fi
+  else
+    if grep -q 'DOES NOT COMPILE' <<<"$nest_comp"; then
+      pass "portable CONTROL discriminates: on this pre-3.12 interpreter (oracle=compile) the nested spelling does not parse at all, and the compile check reports it"
+    else
+      fail "on a pre-3.12 interpreter the nested spelling must fail to compile; it did not"
+    fi
+  fi
+else
+  fail "portable CONTROL: the nested-quote defect could not be injected — $(head -2 "$TMP/inject-nested.err")"
+fi
+
+# --- CONTROL 2b-ii: THE ACCEPT DIRECTION — a DIFFERENT-type nested quote is legal everywhere -----
+# `f"{x['k']}"` parses on every interpreter, and flagging it would be a false red on ordinary code.
+# The same-type/different-type boundary IS the check, so both sides of it are asserted. Driven over
+# a standalone source file rather than an injected block: an apostrophe inside a `python3 -c '…'`
+# body would terminate the shell string, which is why the driver cannot use that spelling either.
+python3 - "$TMP" <<'INJECT'
+import pathlib, sys
+dq, sq = chr(34), chr(39)
+tmp = pathlib.Path(sys.argv[1])
+(tmp / "portable-ok.py").write_text(
+    "x = {'k': 1}\nprint(f" + dq + "{x[" + sq + "k" + sq + "]}" + dq + ")\n")
+(tmp / "portable-remedy.py").write_text(
+    "x = {'k': 1}\nv = x['k']\nprint(f" + dq + "{v}" + dq + ")\n")
+INJECT
+ok_out="$(portable_source "$TMP/portable-ok.py")"
+rem_out="$(portable_source "$TMP/portable-remedy.py")"
+if [ -z "$(findings_of "$ok_out")" ] && [ -z "$(findings_of "$rem_out")" ] \
+   && grep -q '^#COMPLETE ' <<<"$ok_out" && grep -q '^#COMPLETE ' <<<"$rem_out"; then
+  pass "portable ACCEPT direction: a DIFFERENT-type nested quote (legal on every interpreter) and the local-binding remedy are BOTH clean — the check discriminates rather than refusing every subscript"
+else
+  fail "portable manufactured a finding on portable code: different-type='$(findings_of "$ok_out" | head -1)' remedy='$(findings_of "$rem_out" | head -1)'"
+fi
 
 # ============================================================================
 # PART 3 — THE SESSION-CORPUS-PIN STEP **RUNS**
@@ -451,16 +590,27 @@ fi
 # refused to parse.
 run_pin_step() {
   local drv="$1" out="$2" omit="${3:-}" idx field body
-  local -a env_args=()
+  # `-u` OPTIONS FIRST: `env` stops reading options at the first NAME=VALUE, so a `-u` appended
+  # after the assignments is taken as a command to execute (measured: `env: -u: No such file or
+  # directory`, rc 127) — a control that dies before reaching its subject.
+  local -a unset_args=() env_args=()
   for field in "${!CFG[@]}"; do
-    [ "$field" = "$omit" ] && continue
+    if [ "$field" = "$omit" ]; then
+      # UNSET, not merely "not passed" (#3451 review round 1, finding 3). `env` INHERITS the
+      # caller environment, so omitting the assignment leaves a value the operator happened to
+      # have exported — and the control then measures nothing while reporting a failure. `-u`
+      # rather than an empty value: the step treats an empty string as absent too, but "was not
+      # exported" is the condition being tested and `-u` is the only spelling that states it.
+      unset_args+=("-u" "WS0_CFG_$(echo "$field" | tr '[:lower:]' '[:upper:]')")
+      continue
+    fi
     env_args+=("WS0_CFG_$(echo "$field" | tr '[:lower:]' '[:upper:]')=${CFG[$field]}")
   done
   idx="$(find_block "$drv" 'write_session_corpus_pin')"
   [[ "$idx" =~ ^[0-9]+$ ]] || { run_pin_rc=90; echo "block not located: $idx" > "$STEP_OUT"; return; }
   body="$(emit_block "$drv" "$idx")"
-  env "${env_args[@]}" python3 -c "$body" "$PERF_DIR" "$CORPUS" "$out" "$REPO_ROOT" \
-    > "$STEP_OUT" 2>&1
+  env "${unset_args[@]}" "${env_args[@]}" python3 -c "$body" "$PERF_DIR" "$CORPUS" "$out" \
+    "$REPO_ROOT" > "$STEP_OUT" 2>&1
   run_pin_rc=$?
 }
 
@@ -554,6 +704,28 @@ else
   fail "EXECUTE CONTROL did NOT fire: an unexported WS0_CFG_TEMPS must make the step refuse by name (rc=$run_pin_rc, out: $(head -3 <<<"$omit_out"))"
 fi
 
+# ...and the same control with the variable ALREADY EXPORTED in the caller's environment, which is
+# the state it silently failed in before (#3451 review round 1, finding 3): `env` inherits, so an
+# operator who happened to have `WS0_CFG_TEMPS` set made the "absent" variable present and the
+# control red on a correct tree. A control that reds on a correct tree is the control people learn
+# to waive, and it was also not measuring what it claimed.
+run_pin_rc=0
+OUT_INHERIT="$TMP/session-inherit"; mkdir -p "$OUT_INHERIT"
+python3 - "$PERF_DIR" "$OUT_INHERIT" "$CORPUS" <<'PY'
+import pathlib, sys
+sys.path.insert(0, sys.argv[1])
+from ws0_ticket_input import write_ticket_template
+write_ticket_template(pathlib.Path(sys.argv[2]), pathlib.Path(sys.argv[3]) / "ws0-events.cql")
+PY
+export WS0_CFG_TEMPS="inherited-from-the-callers-shell"
+run_pin_step "$DRIVER" "$OUT_INHERIT" temps; inherit_out="$(cat "$STEP_OUT")"
+unset WS0_CFG_TEMPS
+if [ "$run_pin_rc" -ne 0 ] && grep -q 'WS0_CFG_TEMPS' <<<"$inherit_out"; then
+  pass "EXECUTE CONTROL fired (env inheritance): the omitted field is UNSET for the child, so the control still measures absence even when the caller has WS0_CFG_TEMPS exported"
+else
+  fail "EXECUTE CONTROL leaked the caller's environment: with WS0_CFG_TEMPS exported the step did not see it as absent (rc=$run_pin_rc, out: $(head -3 <<<"$inherit_out"))"
+fi
+
 # ============================================================================
 # PART 4 — THE CPU-PIN-VERIFICATION STEP **RUNS**
 # ============================================================================
@@ -628,7 +800,7 @@ fi
 # `set -uo pipefail` (no `-e`) means a block that silently never executes lowers the count and
 # registers NO failure, while the gate reads only the exit code. Deliberately below the current
 # count (so adding a case does not red it) and far above zero.
-MIN_CHECKS=18
+MIN_CHECKS=26
 echo
 if [ "$checks" -lt "$MIN_CHECKS" ]; then
   echo "FAIL - only $checks check(s) ran; this suite has at least $MIN_CHECKS."

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -228,6 +228,40 @@ pathlib.Path(dest).write_text(text.replace(needle, bad))
 PY
 }
 
+# export_prefix_membership <driver> <VAR-PREFIX> — "<in-same-logical-line> <total-in-file>".
+#
+# An exported variable only reaches the step if its assignment is part of the CONTIGUOUS
+# environment-assignment prefix of the `python3 -c` command — a run of `NAME=value \` lines
+# immediately above it. Remove ONE continuation backslash and the assignment becomes a standalone
+# shell assignment that is never exported, the driver dies on the missing variable, and every
+# check in this suite still passes: the name-set comparisons see it (it is still in the file) and
+# the extracted-block executions see it (this suite builds their environment itself). Same
+# symptom as #3451 itself.
+#
+# Decidable, and it reuses the joiner rather than parsing a command prefix: after logical-line
+# joining, the assignments and the invocation ARE ONE LINE. Membership in that line is the whole
+# assertion. The joiner is IMPORTED from the shipped module — a second copy here would drift, and
+# then this check would certify the copy.
+export_prefix_membership() {
+  python3 - "$REPO_ROOT/scripts/tests" "$1" "$2" <<'PY'
+import pathlib, re, sys
+sys.path.insert(0, sys.argv[1])
+from ws0_embedded_python import _join_continuations
+text = pathlib.Path(sys.argv[2]).read_text()
+prefix = sys.argv[3]
+joined, _unused = _join_continuations(text)
+names = sorted(set(re.findall(prefix + r"[A-Z_]+(?==)", text)))
+inline = set()
+for logical in joined.split("\n"):
+    if "python3 -c " + chr(39) not in logical:
+        continue
+    for name in names:
+        if name + "=" in logical:
+            inline.add(name)
+print(f"{len(inline)} {len(names)}")
+PY
+}
+
 # ============================================================================
 # PART 1 — THE EXTRACTOR READS THE SHIPPED DRIVER, AND FAILS CLOSED
 # ============================================================================
@@ -783,6 +817,58 @@ elif [ "$renamed_keys" != "$shipped_keys" ] && [ -z "$(findings_of "$renamed_com
   pass "config-exports CONTROL fired: a single renamed export is caught by the set comparison — and the compile check is SILENT about it (the python is untouched), which is why this check exists separately"
 else
   fail "config-exports CONTROL did not fire: renamed=[$renamed_keys] shipped=[$shipped_keys], compile said '$(findings_of "$renamed_compile" | head -1)'"
+fi
+
+# ...and the assignments must be part of the step's ENVIRONMENT-ASSIGNMENT PREFIX, not merely
+# present somewhere in the file (#3451 review round 10, finding 1). The set comparisons above
+# collect names GLOBALLY, so a single removed continuation backslash turns an export into a
+# standalone assignment python never sees — the driver dies, and every check here still passes.
+for export_prefix in WS0_CFG_ WS0_PIN_; do
+  read -r in_line total_in_file <<<"$(export_prefix_membership "$DRIVER" "$export_prefix")"
+  if [ "$total_in_file" -gt 0 ] && [ "$in_line" -eq "$total_in_file" ]; then
+    pass "export-prefix ($export_prefix): all $total_in_file assignment(s) share a JOINED LOGICAL LINE with the python3 -c invocation that reads them — so each is genuinely exported, not merely present in the file"
+  else
+    fail "export-prefix ($export_prefix): only $in_line of $total_in_file assignment(s) are in the same logical line as the invocation. One outside the contiguous prefix is never exported: the step refuses at run time on the missing variable and its caller exits 2"
+  fi
+done
+
+# --- CONTROL: a removed continuation, and a relocated assignment, both FIRE --------------------
+python3 - "$DRIVER" "$TMP" <<'INJECT'
+import pathlib, sys
+text = pathlib.Path(sys.argv[1]).read_text()
+tmp = pathlib.Path(sys.argv[2])
+bs = chr(92)
+# (a) drop ONE continuation backslash, so that assignment leaves the prefix.
+needle = 'WS0_CFG_TEMPS="$TEMPS" ' + bs + "\n"
+if text.count(needle) != 1:
+    print(f"INJECTION IMPOSSIBLE: continuation needle occurs {text.count(needle)} time(s)",
+          file=sys.stderr)
+    raise SystemExit(1)
+(tmp / "export-nobackslash.sh").write_text(
+    text.replace(needle, 'WS0_CFG_TEMPS="$TEMPS"\n'))
+# (b) MOVE an assignment out of the prefix entirely, keeping it in the file.
+(tmp / "export-relocated.sh").write_text(
+    text.replace(needle, "").replace(
+        "#!/usr/bin/env bash", '#!/usr/bin/env bash\nWS0_CFG_TEMPS="$TEMPS"', 1))
+INJECT
+export_inject_rc=$?
+if [ "$export_inject_rc" -ne 0 ]; then
+  fail "export-prefix CONTROL: the injections could not be made, so the controls could not fire"
+else
+  export_ctl_ok=1
+  export_ctl_detail=""
+  for export_case in nobackslash relocated; do
+    read -r c_in c_total <<<"$(export_prefix_membership "$TMP/export-$export_case.sh" WS0_CFG_)"
+    if [ "$c_in" -eq "$c_total" ]; then
+      export_ctl_ok=0
+      export_ctl_detail="$export_ctl_detail $export_case($c_in/$c_total)"
+    fi
+  done
+  if [ "$export_ctl_ok" -eq 1 ]; then
+    pass "export-prefix CONTROL fired: BOTH a removed continuation backslash and an assignment relocated out of the prefix drop it from the invocation's logical line — the two ways an export silently stops being one"
+  else
+    fail "export-prefix CONTROL did not fire:$export_ctl_detail — the membership check cannot see an assignment leaving the prefix"
+  fi
 fi
 
 # ...and the SAME class for the CPU-pin step, whose four inputs have no shipped field list. Here

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -213,12 +213,6 @@ findings_of() {
 # It takes the RIGHT-HAND SIDES FROM THE DRIVER rather than restating them here, because a table
 # of expected values in this file would be a second copy of the driver's intent and would drift.
 #
-# WHY EVALUATING SHELL TEXT IS SAFE **HERE SPECIFICALLY**, and only here: the text is emitted by
-# `--emit-prefix`, which prints it ONLY after proving it is a run of `NAME=` words containing no
-# command separator. The eval's input is bounded by a check that already had to exist. This is
-# strictly conditional on that validation — an unvalidated prefix is never evaluated, and the
-# helper returns non-zero instead.
-#
 # The controlled values are chosen so a SWAP IS DETECTABLE BY THE SHIPPED VALIDATORS rather than
 # by a comparison written here: `temps` and `arms` have DISJOINT legal sets (warm/cold vs
 # bypass/merge), so `WS0_CFG_TEMPS="$ARMS"` yields `temps=bypass`, which `session_manifest_config`

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -758,7 +758,7 @@ for ctlword_case in if-grep time-grep; do
     || { ctlword_ok=0; ctlword_detail="$ctlword_detail $ctlword_case(false-red)"; }
 done
 if [ "$ctlword_rc" -eq 0 ] && [ "$ctlword_ok" -eq 1 ]; then
-  pass "census CONTROL fired (control words): a leading if/time/! is STEPPED OVER so the real command word is judged — the indirect forms are findings while `if grep -c` and `time grep -c` stay clean, which is why the words are skipped and not refused"
+  pass "census CONTROL fired (control words): a leading if/time/! is STEPPED OVER so the real command word is judged — the indirect forms are findings while the same constructs leading a literal grep stay clean, which is why the words are skipped and not refused"
 else
   fail "census CONTROL did not fire (control words): fixture-rc=$ctlword_rc problems:$ctlword_detail"
 fi

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -123,7 +123,9 @@
 #     more matching.
 #   * anything measured: no `perf`, no Flight server, no rep loop, no 2.8 GB corpus.
 #
-# Hermetic: python3, a few KB under `$TMPDIR`. No sudo, cargo, perf, taskset, network, root, and no
+# Hermetic: python3, a few KB under `$TMPDIR`, and `PYTHONDONTWRITEBYTECODE=1` so importing the
+# shipped modules writes no `__pycache__` into the checkout. No sudo, cargo, perf, taskset,
+# network, root, and no
 # invocation of the driver itself (this file never runs it — it reads it).
 set -uo pipefail
 
@@ -161,6 +163,12 @@ source "$REPO_ROOT/scripts/tests/lib-ws0-fixtures.sh"
 # `/step-output.txt`), a privileged runner writes persistent artifacts at the filesystem root, and
 # `cleanup` then `rm -rf`s a path built the same way. Non-empty AND an existing directory, checked
 # BEFORE `trap`, is the whole fix.
+# NO BYTECODE INTO THE CHECKOUT (#3451 post-rebase round 8, F2). Importing the shipped modules
+# from `scripts/tests` and `scripts/perf` writes `__pycache__/` there, so the header's "a few KB
+# under $TMPDIR" was FALSE — gitignored, so nothing reached git, but the claim was still wrong,
+# and an overclaiming header is the class we just deleted an eval-safety paragraph for.
+export PYTHONDONTWRITEBYTECODE=1
+
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/ws0-embedded-steps.XXXXXX")" || TMP=""
 if [ -z "$TMP" ] || [ ! -d "$TMP" ]; then
   echo "FAIL - could not create a scratch directory under ${TMPDIR:-/tmp}; refusing to run, because"
@@ -904,6 +912,44 @@ if [ "$skip_rc" -eq 0 ] && [ "$skip_ok" -eq 1 ]; then
   pass "census CONTROL fired (allowlisted skip): env, command and a mid-line comment are FINDINGS while every allowlisted command stays clean — skipping by membership, so the next unanticipated spelling cannot grant itself a skip by lacking a signal"
 else
   fail "census CONTROL did not fire (allowlisted skip): fixture-rc=$skip_rc problems:$skip_detail"
+fi
+
+# --- CONTROL 1k-bis: a MID-LINE comment ends at its newline (the DISCRIMINATING shape) ----------
+# Round 6 recognised a comment only at the first non-blank of a line, and round 7's control for it
+# COULD NOT TELL: `x=1 # comment \` produced a finding because `#` is not on the command
+# allowlist, not because the comment was respected — the joiner had still merged the lines. The
+# check passed and the property never held.
+#
+# So the case that discriminates puts an ALLOWLISTED command before the comment. With comments
+# handled, `grep foo file # note \` + `$PY -c 'bad'` is a finding because the joiner refuses to
+# cross the comment and `$PY` is then the command word; without, resolution reads the allowlisted
+# `grep` and skips a live invocation. The `x=1` form is kept for coverage but proves less.
+#
+# A control has to distinguish the claimed mechanism from every other reason the same result
+# could occur. That is this issue's own lesson, and it was my own test that failed it.
+python3 - "$TMP" <<'INJECT'
+import pathlib, sys
+q, bs = chr(39), chr(92)
+tmp = pathlib.Path(sys.argv[1])
+bad = q + "import os," + q
+(tmp / "midcomment-allowlisted.sh").write_text(
+    "grep foo file # note " + bs + "\n$PY -c " + bad + "\n")
+(tmp / "midcomment-assignment.sh").write_text("x=1 # comment " + bs + "\n$PY -c " + bad + "\n")
+(tmp / "midcomment-nocont.sh").write_text("grep foo file # note\n")
+INJECT
+midc_rc=$?
+midc_ok=1
+midc_detail=""
+for midc_case in allowlisted assignment; do
+  [ -n "$(findings_of "$(census "$TMP/midcomment-$midc_case.sh")")" ] \
+    || { midc_ok=0; midc_detail="$midc_detail $midc_case(missed)"; }
+done
+[ -z "$(findings_of "$(census "$TMP/midcomment-nocont.sh")")" ] \
+  || { midc_ok=0; midc_detail="$midc_detail nocont(false-red)"; }
+if [ "$midc_rc" -eq 0 ] && [ "$midc_ok" -eq 1 ]; then
+  pass "census CONTROL fired (mid-line comment, DISCRIMINATING): with an ALLOWLISTED command before the comment, a continuation across it no longer hides the following invocation — the shape that separates 'comments are respected' from 'the command word happened not to be allowlisted', while the same comment WITHOUT a continuation stays clean"
+else
+  fail "census CONTROL did not fire (mid-line comment): fixture-rc=$midc_rc problems:$midc_detail"
 fi
 
 # --- CONTROL 1l: the assignment prefix is PARSED, and refuses what an eval would have run -------
@@ -1718,7 +1764,7 @@ fi
 # which the new coverage can be deleted again and the stale floor still passes. It sat 18 below
 # actual for exactly that reason. Equality means a change in either direction is a decision
 # someone makes here, in one line, with the failure text saying which direction and why.
-MIN_CHECKS=49
+MIN_CHECKS=50
 echo
 if [ "$checks" -ne "$MIN_CHECKS" ]; then
   echo "FAIL - $checks check(s) ran; this suite has EXACTLY $MIN_CHECKS."

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -569,26 +569,51 @@ else
   fail "census CONTROL did not fire: A-blocks=$(grep -c '^BLOCK	' <<<"$a_census") A-findings='$(findings_of "$a_census" | head -1)' A-compile='$(findings_of "$a_compile" | head -1)' B-findings=$b_findings C-findings=$c_findings"
 fi
 
-# --- CONTROL 1h-bis: ONE INVOCATION YIELDS AT MOST ONE FINDING ---------------------------------
-# Both anchors can see the same command — `python3 -m foo -c 'x'` has a python word AND a `-c`
-# flag — and each used to report it, after which a finding COUNT means nothing. The word anchor
-# claims its command's segment (up to the next separator, a closed set in bash's grammar), so the
-# flag inside it defers. The other direction is asserted too: two genuinely separate invocations
-# on one line must still produce two findings, or the suppression would be hiding real ones.
+# --- CONTROL 1h-bis: NO `-c` INVOCATION IS SILENTLY ABSENT --------------------------------------
+# THE PROPERTY THAT MATTERS, replacing an earlier "at most one finding per invocation" assert that
+# was the wrong shape (#3451 review round 9). That earlier invariant was COSMETIC and could only
+# be satisfied by SEMANTIC machinery — deciding which invocation a match belongs to needs shell
+# nesting and quoting — and the syntactic approximation built for it had a hole immediately:
+#
+#     v=$(python3 helper.py ) $PY -c 'import os,'
+#
+# the inner `python3 helper.py` classified as a harmless SCRIPT and the suppression swallowed the
+# OUTER `-c` anchor, so invalid code escaped with the census reporting clean. Suppression was
+# BLINDNESS; duplicate findings are only NOISE. So the suppression is gone and the assertion is
+# the one that cannot be satisfied by hiding: a file containing a `-c '…'` invocation must yield a
+# BLOCK or at least one FINDING — never neither.
+#
+# Swept across every negative fixture this suite builds, so a future change that makes ANY of them
+# vanish fails here rather than in a review round.
+absent_ok=1
+absent_detail=""
 python3 - "$TMP" <<'INJECT'
 import pathlib, sys
-q = chr(39)
+q, dq, bs = chr(39), chr(34), chr(92)
 tmp = pathlib.Path(sys.argv[1])
-(tmp / "one-invocation.sh").write_text("python3 -m foo -c " + q + "x" + q + "\n")
-(tmp / "two-invocations.sh").write_text(
-    "python3 --version; $PY -c " + q + "x" + q + "\n")
+prog = q + "import os," + q
+# The round-9 escape: a command substitution whose inner invocation looks harmless.
+(tmp / "absent-nested.sh").write_text("v=$(python3 helper.py ) $PY -c " + prog + "\n")
+# ...and the shapes the earlier rounds closed, re-swept together.
+(tmp / "absent-indirect.sh").write_text("$PYTHON -c " + prog + "\n")
+(tmp / "absent-continuation.sh").write_text("$PYTHON -c " + bs + "\n" + prog + "\n")
+(tmp / "absent-pathq.sh").write_text("/usr/bin/python3 -c " + prog + "\n")
+(tmp / "absent-fragment.sh").write_text("python3 -c " + q + "pass" + q + dq + " +" + dq + "\n")
 INJECT
-one_n="$(findings_of "$(census "$TMP/one-invocation.sh")" | wc -l | tr -d ' ')"
-two_n="$(findings_of "$(census "$TMP/two-invocations.sh")" | wc -l | tr -d ' ')"
-if [ "$one_n" -eq 1 ] && [ "$two_n" -eq 2 ]; then
-  pass "census CONTROL fired (one finding per invocation): a single command seen by BOTH anchors yields 1 finding, while two separate invocations on one line still yield 2 — the suppression is scoped to a command segment, not to a line"
+absent_rc=$?
+for absent_case in nested indirect continuation pathq fragment; do
+  absent_out="$(census "$TMP/absent-$absent_case.sh")"
+  absent_blocks="$(grep -c '^BLOCK	' <<<"$absent_out")"
+  absent_finds="$(findings_of "$absent_out" | wc -l | tr -d ' ')"
+  if [ "$absent_blocks" -eq 0 ] && [ "$absent_finds" -eq 0 ]; then
+    absent_ok=0
+    absent_detail="$absent_detail $absent_case(silent)"
+  fi
+done
+if [ "$absent_rc" -eq 0 ] && [ "$absent_ok" -eq 1 ]; then
+  pass "census CONTROL fired (no silent absence): every -c invocation across 5 negative fixtures — including the command-substitution nesting that defeated the old suppression — yields a BLOCK or a FINDING, never neither"
 else
-  fail "census CONTROL did not fire: one-invocation gave $one_n finding(s) (expected 1), two-invocations gave $two_n (expected 2)"
+  fail "census CONTROL did not fire: fixture-rc=$absent_rc silently-absent:$absent_detail — an invocation the census neither blocks nor reports is the false pass this whole file exists to refuse"
 fi
 
 # --- CONTROL 1i: A MISSING SUBJECT EXITS NONZERO ------------------------------------------------

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -108,6 +108,10 @@
 #
 #     What survives is the oracle that is real: no CPython accepts the BACKSLASH form, so the
 #     compile check catches the defect this issue is actually about on 3.9 through 3.12 alike.
+#   * A `-c` FLAG SPELLED THROUGH A VARIABLE (`$FLAG` where `FLAG=-c`). Every quoting spelling
+#     bash glues into `-c` IS discovered — `-"c"`, `-'c'`, `"-c"`, `'-c'`, `\-c` — but a flag
+#     whose text never appears cannot be, and resolving it needs the shell. Stated rather than
+#     chased.
 #   * COMPLETE DISCOVERY OF EMBEDDED PYTHON, which is NOT STATICALLY ACHIEVABLE and is therefore a
 #     stated decision rather than an oversight. A shell command word can be spelled arbitrarily —
 #     a variable, a concatenation, `$(which python3)`, an alias, `eval` — so enumerating the
@@ -168,6 +172,13 @@ source "$REPO_ROOT/scripts/tests/lib-ws0-fixtures.sh"
 # under $TMPDIR" was FALSE — gitignored, so nothing reached git, but the claim was still wrong,
 # and an overclaiming header is the class we just deleted an eval-safety paragraph for.
 export PYTHONDONTWRITEBYTECODE=1
+# `assert` IS REMOVED BY -O (#3451 post-rebase round 9, F1). Measured:
+# `PYTHONOPTIMIZE=1 python3 -c 'assert False, "fires"'` prints nothing and exits 0. Ten checks in
+# this suite were `assert`s, so an inherited variable would have switched all ten off at once —
+# a valid-but-swapped field passing silently. They are explicit conditionals now, which is THE
+# fix; unsetting the variable is only a second line of defence, because an env precaution is
+# itself something a new call site can miss.
+unset PYTHONOPTIMIZE
 
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/ws0-embedded-steps.XXXXXX")" || TMP=""
 if [ -z "$TMP" ] || [ ! -d "$TMP" ]; then
@@ -952,6 +963,39 @@ else
   fail "census CONTROL did not fire (mid-line comment): fixture-rc=$midc_rc problems:$midc_detail"
 fi
 
+# --- CONTROL 1m: the `-c` flag, in every quoting spelling bash glues together ------------------
+# Bash concatenates the fragments of `-"c"` and `-'c'` into `-c`, and an anchor matching only the
+# bare spelling missed both — measured at findings=0, silent absences.
+#
+# ALL SIX SPELLINGS ARE ASSERTED, not just the two that were broken, and that matters: the fully
+# quoted `"-c"` and `'-c'` already failed closed by a DIFFERENT path, so a control testing only
+# those would have reported this fixed while the concatenated forms stayed blind. Testing the
+# space rather than the named example is what separated them.
+python3 - "$TMP" <<'INJECT'
+import pathlib, sys
+q, dq, bs = chr(39), chr(34), chr(92)
+tmp = pathlib.Path(sys.argv[1])
+bad = q + "import os," + q
+for name, flag in (
+    ("bare", "-c"), ("quoted-dq", dq + "-c" + dq), ("quoted-sq", q + "-c" + q),
+    ("concat-dq", "-" + dq + "c" + dq), ("concat-sq", "-" + q + "c" + q),
+    ("escaped", bs + "-c"),
+):
+    (tmp / f"flag-{name}.sh").write_text("$PY " + flag + " " + bad + "\n")
+INJECT
+flag_rc=$?
+flag_ok=1
+flag_detail=""
+for flag_case in bare quoted-dq quoted-sq concat-dq concat-sq escaped; do
+  [ -n "$(findings_of "$(census "$TMP/flag-$flag_case.sh")")" ] \
+    || { flag_ok=0; flag_detail="$flag_detail $flag_case(missed)"; }
+done
+if [ "$flag_rc" -eq 0 ] && [ "$flag_ok" -eq 1 ]; then
+  pass "census CONTROL fired (flag spellings): all six quoting spellings of -c that bash glues into the same flag are FINDINGS — including the two concatenated forms that were silent while the fully-quoted ones already fired, which is why the whole space is asserted rather than the named example"
+else
+  fail "census CONTROL did not fire (flag spellings): fixture-rc=$flag_rc problems:$flag_detail"
+fi
+
 # --- CONTROL 1l: the assignment prefix is PARSED, and refuses what an eval would have run -------
 # Round 2 authorised evaluating the driver's prefix on the argument that the contiguity check
 # bounded the input to `NAME=` words with no separator. MEASURED, that check ADMITS
@@ -1370,7 +1414,10 @@ cfg = session_manifest_config(session, TEMPS_ALLOWED, ARMS_ALLOWED)
 # validator accepts is invisible to the validator and visible only here.
 # argv: 1=perf dir, 2=session, 3=corpus, 4.. = the expected `field=value` pairs.
 expected = dict(pair.split("=", 1) for pair in sys.argv[4:])
-assert expected, "no expected fields were passed; this check would assert nothing"
+if not expected:
+    print("no expected fields were passed; this check would assert nothing",
+          file=sys.stderr)
+    raise SystemExit(1)
 # The reader NORMALISES the selection fields into lists (`temps` -> ['warm'], `events` ->
 # ['cycles','instructions']), so the comparison joins a list back to the comma form the driver
 # was handed. That is a comparison SHAPE, not a weakening: a swapped right-hand side still
@@ -1383,15 +1430,23 @@ def _norm(value):
 mismatched = {
     k: (cfg.get(k), v) for k, v in expected.items() if _norm(cfg.get(k)) != v
 }
-assert not mismatched, f"manifest fields differ from the controlled inputs: {mismatched}"
+if mismatched:
+    print(f"manifest fields differ from the controlled inputs: {mismatched}",
+          file=sys.stderr)
+    raise SystemExit(1)
 # The reader's own report, asserted field by field so this case cannot pass on a verifier that
 # returned an empty dict: the pin was taken BEFORE measurement, and it carries the digests of the
 # corpus, the schema and the Flight ticket the step measured from disk.
-assert report.get("pinned_before_measurement") is True, report
-assert len(report.get("pinned_data_db_sha256", "")) == 64, report
-assert len(report.get("pinned_schema_sha256", "")) == 64, report
-assert len(report.get("pinned_ticket_sha256", "")) == 64, report
-assert report.get("pinned_components", 0) >= 5, report
+for _label, _ok in (
+    ("pinned_before_measurement is True", report.get("pinned_before_measurement") is True),
+    ("pinned_data_db_sha256 is a digest", len(report.get("pinned_data_db_sha256", "")) == 64),
+    ("pinned_schema_sha256 is a digest", len(report.get("pinned_schema_sha256", "")) == 64),
+    ("pinned_ticket_sha256 is a digest", len(report.get("pinned_ticket_sha256", "")) == 64),
+    ("pinned_components >= 5", report.get("pinned_components", 0) >= 5),
+):
+    if not _ok:
+        print(f"pin report failed: {_label} — {report}", file=sys.stderr)
+        raise SystemExit(1)
 PY
 then
   pass "EXECUTE session-corpus-pin: the SHIPPED READERS accept what the shipped STEP wrote — verify_session_corpus_pin for the corpus identity AND session_manifest_config (what ws0_report.py itself calls) for the configuration, so the round trip is against the production reader rather than a weaker one"
@@ -1622,18 +1677,26 @@ session = pathlib.Path(sys.argv[2])
 config = session_manifest_config(session, TEMPS_ALLOWED, ARMS_ALLOWED)
 rec = verify_pinning_record(session, config["server_cpus"], config["client_cpus"])
 missing = [f for f in PINNING_RECORD_FIELDS if not rec.get(f)]
-assert not missing, missing
+if missing:
+    print(f"pinning record is missing required fields: {missing}", file=sys.stderr)
+    raise SystemExit(1)
 # ...AND EACH RECORDED FIELD AGAINST ITS CONTROLLED INPUT (#3451 post-rebase round 5, F2).
 # `server_siblings_expanded` and `topology_root` are both just non-empty strings to the shipped
 # validator, so swapping their right-hand sides in the driver passes every check above. Only
 # comparing each field to the value it was GIVEN can tell them apart.
 written = json.loads(pinning_record_path(session).read_text())
 expected = dict(pair.split("=", 1) for pair in sys.argv[3:])
-assert expected, "no expected pin fields were passed; this check would assert nothing"
+if not expected:
+    print("no expected pin fields were passed; this check would assert nothing",
+          file=sys.stderr)
+    raise SystemExit(1)
 mismatched = {
     k: (written.get(k), v) for k, v in expected.items() if str(written.get(k)) != v
 }
-assert not mismatched, f"pinning-record fields differ from the controlled inputs: {mismatched}"
+if mismatched:
+    print(f"pinning-record fields differ from the controlled inputs: {mismatched}",
+          file=sys.stderr)
+    raise SystemExit(1)
 PY
 then
   pass "EXECUTE cpu-pin-verification: the SHIPPED READER accepts the record the shipped STEP wrote; its pins are checked against the CPU lists THE SESSION MANIFEST records (the two steps cross-checked against each other, not each against the same constants), and every recorded field against the distinct value it was given"
@@ -1764,7 +1827,7 @@ fi
 # which the new coverage can be deleted again and the stale floor still passes. It sat 18 below
 # actual for exactly that reason. Equality means a change in either direction is a decision
 # someone makes here, in one line, with the failure text saying which direction and why.
-MIN_CHECKS=50
+MIN_CHECKS=51
 echo
 if [ "$checks" -ne "$MIN_CHECKS" ]; then
   echo "FAIL - $checks check(s) ran; this suite has EXACTLY $MIN_CHECKS."

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -1,0 +1,539 @@
+#!/usr/bin/env bash
+# test_ws0_embedded_steps_execute.sh — THE EXECUTE DIRECTION OF THE DRIVER'S OWN EMBEDDED PYTHON
+# (issue #3451).
+#
+# # WHY THIS FILE EXISTS — a step that is only ever PARSED is a step that has never RUN
+#
+# `scripts/perf/ws0-baseline.sh` shipped with SEVEN instances of a defect that no CPython accepts:
+# a backslash inside an f-string EXPRESSION, which the tokenizer reads as a line continuation
+# (`SyntaxError: unexpected character after line continuation character`). They lived in the
+# driver's TWO multi-line embedded python blocks — the SESSION-CORPUS-PIN step and the
+# CPU-PIN-VERIFICATION step — and both steps are `|| exit 2`, so the whole WS0 measurement path was
+# unrunnable end to end on `main`.
+#
+# Every existing guard was green throughout, and each for a structural reason rather than by
+# accident:
+#
+#   * the python is not a `.py` file, so no linter, formatter or import ever reads it;
+#   * `bash -n` parses the driver as SHELL, where a `python3 -c '…'` body is ONE opaque
+#     single-quoted string — valid whatever it contains;
+#   * every hermetic self-test stops at `--validate-args-only`, which sits ABOVE both steps, and
+#     #3272 round 2 finding 14 deliberately made the accept-direction cases execute NOTHING
+#     (running the real driver invoked `sudo sysctl` and three cargo builds inside a gate
+#     component). Correct, and it left these two steps with no coverage that EXECUTES them.
+#
+# So the property this file asserts is the one nothing else can:
+#
+#     THE DRIVER'S EMBEDDED PYTHON STEPS **RUN**, ON FIXTURE INPUTS, AND PRODUCE THEIR ARTIFACTS.
+#
+# # HOW, AND THE TWO THINGS THAT MAKE IT A MEASUREMENT RATHER THAN A RESTATEMENT
+#
+# 1. THE BLOCK TEXT IS EXTRACTED FROM THE SHIPPED DRIVER on every run
+#    (`ws0_embedded_python.py`), never copied into this file. A self-test carrying its own copy
+#    certifies THE COPY: it stays green while the shipped step is broken, which is exactly the
+#    state #3451 found. The extractor fails CLOSED — an unclassifiable `python3` shape, or a block
+#    whose closing delimiter it cannot find, is a finding naming the driver rather than a silent
+#    omission that would print like a clean file.
+#
+# 2. EVERY ACCEPT ASSERTION HAS A PAIRED POSITIVE CONTROL, observed to FIRE against a scratch copy
+#    of the driver under `$TMPDIR` carrying the injected defect. That is this issue's own lesson:
+#    the owner's `grep -c` for the bad spelling returned `0` against a file holding all seven
+#    instances, because the pattern was over-escaped — and a check that CANNOT fire reports nothing
+#    and looks identical to a check that fired and found nothing. The defective spelling is
+#    CONSTRUCTED IN CODE at the injection site (never written literally anywhere in this tree), so
+#    no committed file carries an example a reader or a text-level probe could mistake for the
+#    real thing.
+#
+# # WHAT IS REACHED, AND WHAT IS NOT — stated, because an honest partial is fine and a SILENT
+#     partial is the thing this rig exists to refuse
+#
+# REACHED:
+#   * both embedded steps EXECUTED, with the argv and the environment the driver gives them, over a
+#     few-KB fixture corpus: exit 0, the artifact written, the pin lines on stdout, and the SHIPPED
+#     READER (`verify_session_corpus_pin` / `verify_pinning_record`) accepting what the step wrote;
+#   * the environment-variable names the corpus-pin step reads are DERIVED from the shipped
+#     `ws0_session.MANIFEST_CONFIG_FIELDS` and asserted equal to it, so a field added there without
+#     a driver export is a failure here rather than a refusal at report time;
+#   * EVERY embedded block in the driver COMPILES — the total property, so instance #8 anywhere in
+#     that file is caught and not only the two steps this issue repaired.
+#
+# NOT REACHED (and therefore NOT claimed):
+#   * the driver's SHELL path into these steps. Reaching them in situ means passing the CPU-sibling
+#     verification against real sysfs, `relax_perf_sysctls` (a host `sudo sysctl -w`) and a release
+#     build — the exact escape `lib-ws0-hermetic.sh` exists to prevent. What is asserted is that the
+#     step's python runs; that the driver's env exports match the names the block reads is asserted
+#     structurally (the `MANIFEST_CONFIG_FIELDS` equality above and the driver's own fatal-on-absent
+#     branch, exercised below), not by executing the shell around it.
+#   * anything measured: no `perf`, no Flight server, no rep loop, no 2.8 GB corpus.
+#
+# Hermetic: python3, a few KB under `$TMPDIR`. No sudo, cargo, perf, taskset, network, root, and no
+# invocation of the driver itself (this file never runs it — it reads it).
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DRIVER="$REPO_ROOT/scripts/perf/ws0-baseline.sh"
+PERF_DIR="$REPO_ROOT/scripts/perf"
+EXTRACT="$REPO_ROOT/scripts/tests/ws0_embedded_python.py"
+
+fails=0
+# `checks` counts what actually RAN, so the floor at the end can see a block that silently never
+# executed while the gate reads only the exit code. Never incremented inside a `( … )` subshell or
+# a pipeline stage: a suite that printed 22 FAILs and reported `failed: 0` has already happened in
+# this tree.
+checks=0
+pass() { checks=$((checks + 1)); echo "ok   - $1"; }
+fail() { checks=$((checks + 1)); echo "FAIL - $1"; fails=$((fails + 1)); }
+
+[ -f "$DRIVER" ] || { echo "FAIL - missing $DRIVER"; exit 1; }
+[ -f "$EXTRACT" ] || { echo "FAIL - missing $EXTRACT"; exit 1; }
+# python3 is a HARD REQUIREMENT of this rig (the driver refuses to run without it), so its absence
+# is a FAILED CHECK and never a skip: exiting 0 here would record the component as SUCCESS with
+# none of the checks below having run — the vacuous green this rig exists to refuse.
+command -v python3 >/dev/null 2>&1 || {
+  echo "FAIL - python3 is not installed. It is a HARD REQUIREMENT of the WS0 rig, so its absence"
+  echo "       is a failed check and not a skip."
+  exit 1
+}
+
+# shellcheck source=scripts/tests/lib-ws0-fixtures.sh
+source "$REPO_ROOT/scripts/tests/lib-ws0-fixtures.sh"
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+# Where an executed step's combined output lands. A FILE rather than a command substitution, so
+# the status variables the runners set survive into the caller (see `run_pin_step`).
+STEP_OUT="$TMP/step-output.txt"
+: > "$STEP_OUT"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# census <driver> / compile_blocks <driver> / emit_block <driver> <n> — the extractor's three
+# modes. Called through `python3` with the script as an ARGUMENT, never executed directly, so no
+# line here can be read as an invocation of the measurement driver.
+census() { python3 "$EXTRACT" census "$1" 2>&1; }
+compile_blocks() { python3 "$EXTRACT" compile "$1" 2>&1; }
+emit_block() { python3 "$EXTRACT" emit "$1" "$2"; }
+
+# findings_of <output> — the extractor's output minus its `#COMPLETE` marker, i.e. the findings.
+# The marker is filtered HERE rather than by each reader, for the reason `lib-ws0-hermetic.sh`
+# gives: a diagnostic a human must remember to ignore is one they will read as a finding.
+findings_of() { grep -v '^#COMPLETE ' <<<"$1" | grep -vE '^(BLOCK|MENTION|SCRIPT)\b' | grep -v '^$'; }
+
+# defective_copy <src> <dest> <placeholder> <mapping> <key> — a scratch copy of the driver whose
+# f-string placeholder `{<placeholder>}` has been rewritten to the INLINE SUBSCRIPT spelling that
+# no CPython parses. Exits non-zero when the placeholder is not found EXACTLY once, so a control
+# that silently injected nothing is a failure rather than a green "the check found no defect".
+defective_copy() {
+  python3 - "$@" <<'PY'
+import pathlib, sys
+src, dest, placeholder, mapping, key = sys.argv[1:6]
+# The defect is CONSTRUCTED from character codes rather than written out, so this file does not
+# ship a literal example of the spelling whose absence the rig cares about (#3312's rule about
+# prose inside a diff naming its own oracle, applied to a test that must build its own bad input).
+backslash, dquote = chr(92), chr(34)
+bad = "{" + mapping + "[" + backslash + dquote + key + backslash + dquote + "]}"
+text = pathlib.Path(src).read_text()
+needle = "{" + placeholder + "}"
+found = text.count(needle)
+if found != 1:
+    print(f"INJECTION IMPOSSIBLE: {needle} occurs {found} time(s) in {src}, expected exactly 1."
+          " The positive control below would observe NOTHING and pass vacuously, so this is a"
+          " failure of the control rather than of its subject.", file=sys.stderr)
+    raise SystemExit(1)
+pathlib.Path(dest).write_text(text.replace(needle, bad))
+PY
+}
+
+# ============================================================================
+# PART 1 — THE EXTRACTOR READS THE SHIPPED DRIVER, AND FAILS CLOSED
+# ============================================================================
+# Everything below rests on the census finding the right subject in the right file. A census that
+# silently found nothing would make every later assertion vacuous in exactly the way the seven
+# shipped instances were invisible, so the census is asserted before it is used.
+
+census_out="$(census "$DRIVER")"
+if grep -q '^#COMPLETE ' <<<"$census_out" && [ -z "$(findings_of "$census_out")" ]; then
+  pass "census: the shipped driver's python occurrences are ALL classified, with no finding ($(grep '^#COMPLETE ' <<<"$census_out"))"
+else
+  fail "census: the driver's python census did not COMPLETE cleanly — $(findings_of "$census_out" | head -3)"
+fi
+
+block_count="$(grep -c '^BLOCK	' <<<"$census_out")"
+# A FLOOR, not an equality. Equality would red on a legitimately-added block while adding no
+# safety: the TOTAL compile property below covers any new block whatever the count, and the two
+# SUBJECT blocks are identified by content (next check) rather than by position. What the floor
+# catches is wholesale extractor breakage — a census that suddenly sees one block, or none.
+MIN_BLOCKS=3
+if [ "$block_count" -ge "$MIN_BLOCKS" ]; then
+  pass "census: $block_count embedded python block(s) found in the driver (floor $MIN_BLOCKS)"
+else
+  fail "census: only $block_count embedded block(s) found in $DRIVER; this driver carries at least $MIN_BLOCKS, so the extractor is not seeing its subject"
+fi
+
+# WHICH block is which, by CONTENT. The two steps are located by a shipped symbol each body calls,
+# so a reordering of the driver cannot silently point this suite at the wrong step — and a step
+# that DISAPPEARED is a failure here rather than a suite that quietly tests one block twice.
+find_block() { # find_block <driver> <needle> — the index of the ONE block containing <needle>
+  local drv="$1" needle="$2" n total hit="" body
+  total="$(python3 "$EXTRACT" census "$drv" 2>/dev/null | grep -c '^BLOCK	')"
+  for ((n = 1; n <= total; n++)); do
+    body="$(emit_block "$drv" "$n")"
+    if grep -q -- "$needle" <<<"$body"; then
+      [ -n "$hit" ] && { echo "AMBIGUOUS"; return 1; }
+      hit="$n"
+    fi
+  done
+  [ -n "$hit" ] || { echo "ABSENT"; return 1; }
+  echo "$hit"
+}
+
+PIN_BLOCK="$(find_block "$DRIVER" 'write_session_corpus_pin')"
+if [[ "$PIN_BLOCK" =~ ^[0-9]+$ ]]; then
+  pass "census: the SESSION-CORPUS-PIN step is embedded block $PIN_BLOCK, located by the shipped writer it calls"
+else
+  fail "census: the session-corpus-pin step could not be located in $DRIVER ($PIN_BLOCK) — the execute-direction cases below would have no subject"
+fi
+CPU_BLOCK="$(find_block "$DRIVER" 'pinning_record_path')"
+if [[ "$CPU_BLOCK" =~ ^[0-9]+$ ]]; then
+  pass "census: the CPU-PIN-VERIFICATION step is embedded block $CPU_BLOCK, located by the shipped writer it calls"
+else
+  fail "census: the CPU-pin-verification step could not be located in $DRIVER ($CPU_BLOCK)"
+fi
+
+# --- POSITIVE CONTROL 1a: a block that cannot be DELIMITED is a finding, not a silent skip -----
+# The closing-quote line of the corpus-pin block is deleted in a scratch copy. Extracting to
+# end-of-file would compile a truncated body and report a defect that is the extractor's own, so
+# the extractor must refuse instead.
+UNDELIMITED="$TMP/undelimited-ws0-driver.sh"
+python3 - "$DRIVER" "$UNDELIMITED" <<'PY'
+import pathlib, sys
+lines = pathlib.Path(sys.argv[1]).read_text().split("\n")
+# Every line that CLOSES an embedded block (a leading single quote) is removed, which is the
+# shape a mis-edited driver leaves behind.
+pathlib.Path(sys.argv[2]).write_text("\n".join(l for l in lines if not l.startswith("'")))
+PY
+und_out="$(census "$UNDELIMITED")"
+if [ -n "$(findings_of "$und_out")" ] && grep -q 'cannot be delimited' <<<"$und_out"; then
+  pass "census CONTROL fired: an undelimited block is a FINDING — $(findings_of "$und_out" | head -1 | cut -c1-110)"
+else
+  fail "census CONTROL did not fire: an undelimited embedded block must be a finding, got: $(head -3 <<<"$und_out")"
+fi
+
+# --- POSITIVE CONTROL 1b: an UNRECOGNISED python3 shape is a finding ---------------------------
+# A `python3 -m …` step (or any shape the census does not know) may be carrying code the compile
+# check would never see, so it fails closed rather than being skipped.
+UNKNOWN_SHAPE="$TMP/unknown-shape-ws0-driver.sh"
+{ cat "$DRIVER"; printf '%s\n' 'python3 -m ws0_something --run'; } > "$UNKNOWN_SHAPE"
+unk_out="$(census "$UNKNOWN_SHAPE")"
+if grep -q 'does not recognise' <<<"$unk_out"; then
+  pass "census CONTROL fired: an unrecognised python3 invocation shape is a FINDING (fail-closed, so a future step cannot fall outside the compile check)"
+else
+  fail "census CONTROL did not fire: an unrecognised python3 shape must be a finding, got: $(findings_of "$unk_out" | head -2)"
+fi
+
+# --- POSITIVE CONTROL 1c: a step that DISAPPEARED is a failure, not a suite testing one block twice
+NO_PIN_STEP="$TMP/no-pin-step-ws0-driver.sh"
+python3 - "$DRIVER" "$NO_PIN_STEP" <<'PY'
+import pathlib, sys
+text = pathlib.Path(sys.argv[1]).read_text()
+pathlib.Path(sys.argv[2]).write_text(text.replace("write_session_corpus_pin", "some_other_writer"))
+PY
+if [ "$(find_block "$NO_PIN_STEP" 'write_session_corpus_pin')" = "ABSENT" ]; then
+  pass "census CONTROL fired: with the session-pin writer gone from the driver, the locator reports ABSENT rather than picking another block"
+else
+  fail "census CONTROL did not fire: the block locator must report ABSENT when its subject is not in the driver"
+fi
+
+# ============================================================================
+# PART 2 — THE TOTAL PROPERTY: EVERY EMBEDDED BLOCK COMPILES
+# ============================================================================
+# Instance #8 anywhere in that file is caught here, not just the two steps #3451 repaired. This is
+# the check `bash -n` structurally cannot make: to bash the body is one opaque string.
+comp_out="$(compile_blocks "$DRIVER")"
+if grep -q '^#COMPLETE compiled=' <<<"$comp_out" && [ -z "$(findings_of "$comp_out")" ]; then
+  pass "compile-all: EVERY embedded python block in the driver compiles ($(grep '^#COMPLETE ' <<<"$comp_out"))"
+else
+  fail "compile-all: an embedded python block in $DRIVER does not compile — $(findings_of "$comp_out" | head -3)"
+fi
+
+# --- POSITIVE CONTROL 2: the compile check FIRES on the injected defect, per block --------------
+# Both subject blocks are injected SEPARATELY, because a check that only ever saw block 1 would be
+# indistinguishable from one that reports the whole file at once.
+control_compile() { # control_compile <label> <placeholder> <mapping> <key>
+  local label="$1" dest="$TMP/defect-$2.sh" out
+  if ! defective_copy "$DRIVER" "$dest" "$2" "$3" "$4" 2>"$TMP/inject.err"; then
+    fail "compile CONTROL ($label): the defect could not be injected, so the control could not fire — $(head -2 "$TMP/inject.err")"
+    return
+  fi
+  out="$(compile_blocks "$dest")"
+  if grep -q 'DOES NOT COMPILE' <<<"$out" && grep -q 'unexpected character after line continuation' <<<"$out"; then
+    pass "compile CONTROL fired ($label): $(grep 'DOES NOT COMPILE' <<<"$out" | head -1 | cut -c1-120)"
+  else
+    fail "compile CONTROL did NOT fire ($label): the injected defect must be reported, got: $(findings_of "$out" | head -2)"
+  fi
+}
+control_compile "session-corpus-pin step" pin_sha pin data_db_sha256
+control_compile "CPU-pin-verification step" rec_server_cpus rec server_cpus
+
+# ============================================================================
+# PART 3 — THE SESSION-CORPUS-PIN STEP **RUNS**
+# ============================================================================
+# The fixture corpus is the shipped `ws0_make_corpus` (a real `Data.db` of a few KB plus every
+# auxiliary component, with MEASURED digests) — never a hand-rolled identity, for the reason that
+# library states: a fixture that composed the shape itself would keep passing after the shipped
+# writer changed.
+CORPUS="$TMP/corpus"
+ws0_make_corpus "$CORPUS" 100 2560
+OUT="$TMP/session"
+mkdir -p "$OUT"
+
+# The Flight ticket must exist BEFORE the pin — `write_session_corpus_pin` measures its digest and
+# an absent template is `Invalid` there. That ordering is the driver's, and it is reproduced here
+# through the SHIPPED writer rather than by writing the JSON.
+python3 - "$PERF_DIR" "$OUT" "$CORPUS" <<'PY'
+import pathlib, sys
+sys.path.insert(0, sys.argv[1])
+from ws0_ticket_input import write_ticket_template
+write_ticket_template(pathlib.Path(sys.argv[2]), pathlib.Path(sys.argv[3]) / "ws0-events.cql")
+PY
+ticket_rc=$?
+if [ "$ticket_rc" -eq 0 ]; then
+  pass "fixture: a tiny corpus and the session's Flight ticket were written by the SHIPPED writers, in the driver's own order"
+else
+  fail "fixture: the shipped ticket writer failed (rc=$ticket_rc); the execute cases below would fail on the fixture rather than on their subject"
+fi
+
+# THE CONFIGURATION THE STEP READS, keyed by the SHIPPED field list. The names are
+# `WS0_CFG_<FIELD-UPPERCASED>`, derived by the block itself from
+# `ws0_session.MANIFEST_CONFIG_FIELDS`, so this suite must not carry a guessed list: the key set
+# below is asserted EQUAL to the shipped tuple, and a field added there without a value here is a
+# failure rather than a step refusing at run time for a reason nobody expected.
+declare -A CFG=(
+  [reps]=1 [temps]=warm [arms]=bypass [scan_passes]=1
+  [server_cpus]=2,10 [client_cpus]=4,12 [step_duration]=45s/1s
+  [flight_endpoint]=grpc://127.0.0.1:1
+  # `non-baseline`, and that is the only honest value available here: this is a few-KB synthetic
+  # corpus, and the shipped `require_canonical_or_declared` REFUSES a divergent corpus in
+  # `baseline` mode — correctly. Declaring the mode is the supported way past it, not a way round
+  # it: the step still runs the real comparison and records every divergence it finds.
+  [baseline_mode]=non-baseline
+)
+cfg_keys="$(printf '%s\n' "${!CFG[@]}" | sort | tr '\n' ' ')"
+shipped_keys="$(python3 - "$PERF_DIR" <<'PY'
+import sys
+sys.path.insert(0, sys.argv[1])
+from ws0_session import MANIFEST_CONFIG_FIELDS
+print(" ".join(sorted(MANIFEST_CONFIG_FIELDS)) + " ")
+PY
+)"
+if [ "$cfg_keys" = "$shipped_keys" ]; then
+  pass "config-fields: this suite supplies EXACTLY ws0_session.MANIFEST_CONFIG_FIELDS ($(echo "$shipped_keys" | wc -w) fields), so the environment it builds is the shipped list rather than a guess"
+else
+  fail "config-fields: the suite's WS0_CFG_* keys [$cfg_keys] differ from the shipped MANIFEST_CONFIG_FIELDS [$shipped_keys]"
+fi
+
+# run_pin_step <driver> <out-dir> [omit-field] — execute the corpus-pin block extracted from
+# <driver>, with the argv and environment the driver gives it.
+#
+# The step's combined output goes to a FILE (`$STEP_OUT`) and its status to `run_pin_rc`, and
+# NEITHER is read through a command substitution — `run_pin_rc=$(...)` would run the whole
+# function in a SUBSHELL, where the assignment dies and the caller reads a stale 0. That is the
+# same class as the assert-counter-in-a-subshell defect this tree has already shipped once, and it
+# was MEASURED here: the first draft of this suite reported rc=0 for a step whose python had
+# refused to parse.
+run_pin_step() {
+  local drv="$1" out="$2" omit="${3:-}" idx field body
+  local -a env_args=()
+  for field in "${!CFG[@]}"; do
+    [ "$field" = "$omit" ] && continue
+    env_args+=("WS0_CFG_$(echo "$field" | tr '[:lower:]' '[:upper:]')=${CFG[$field]}")
+  done
+  idx="$(find_block "$drv" 'write_session_corpus_pin')"
+  [[ "$idx" =~ ^[0-9]+$ ]] || { run_pin_rc=90; echo "block not located: $idx" > "$STEP_OUT"; return; }
+  body="$(emit_block "$drv" "$idx")"
+  env "${env_args[@]}" python3 -c "$body" "$PERF_DIR" "$CORPUS" "$out" "$REPO_ROOT" \
+    > "$STEP_OUT" 2>&1
+  run_pin_rc=$?
+}
+
+run_pin_rc=0
+run_pin_step "$DRIVER" "$OUT"; pin_out="$(cat "$STEP_OUT")"
+pin_file="$(python3 - "$PERF_DIR" "$OUT" <<'PY'
+import pathlib, sys
+sys.path.insert(0, sys.argv[1])
+from ws0_session import session_pin_path
+print(session_pin_path(pathlib.Path(sys.argv[2])))
+PY
+)"
+if [ "$run_pin_rc" -eq 0 ] && [ -s "$pin_file" ]; then
+  pass "EXECUTE session-corpus-pin: the SHIPPED step ran to completion and wrote $(basename "$pin_file")"
+else
+  fail "EXECUTE session-corpus-pin: the shipped step did not run (rc=$run_pin_rc): $(head -4 <<<"$pin_out")"
+fi
+# Its three pin LINES, each asserted by name: the step's whole output contract, and the thing an
+# operator reads to know which corpus and which configuration this session is about.
+for line_tag in 'corpus pin:' 'config pin:' 'canonical pin:'; do
+  if grep -q "$line_tag" <<<"$pin_out"; then
+    pass "EXECUTE session-corpus-pin: printed '$line_tag' — $(grep -m1 "$line_tag" <<<"$pin_out" | cut -c1-96)"
+  else
+    fail "EXECUTE session-corpus-pin: the step did not print '$line_tag' (output: $(head -3 <<<"$pin_out"))"
+  fi
+done
+
+# ...and the SHIPPED READER accepts what the SHIPPED STEP wrote. A writer/reader round trip is the
+# one thing no fixture-fed reject case can establish, and it is where a disagreement surfaces as a
+# refusal blaming the operator.
+if python3 - "$PERF_DIR" "$OUT" "$CORPUS" <<'PY'
+import pathlib, sys
+sys.path.insert(0, sys.argv[1])
+from ws0_session import verify_session_corpus_pin
+from ws0_validate import load_corpus_identity
+session, corpus = pathlib.Path(sys.argv[2]), pathlib.Path(sys.argv[3])
+report = verify_session_corpus_pin(session, corpus, load_corpus_identity(corpus))
+# The reader's own report, asserted field by field so this case cannot pass on a verifier that
+# returned an empty dict: the pin was taken BEFORE measurement, and it carries the digests of the
+# corpus, the schema and the Flight ticket the step measured from disk.
+assert report.get("pinned_before_measurement") is True, report
+assert len(report.get("pinned_data_db_sha256", "")) == 64, report
+assert len(report.get("pinned_schema_sha256", "")) == 64, report
+assert len(report.get("pinned_ticket_sha256", "")) == 64, report
+assert report.get("pinned_components", 0) >= 5, report
+PY
+then
+  pass "EXECUTE session-corpus-pin: the SHIPPED READER (verify_session_corpus_pin) accepts the pin the shipped STEP wrote — writer and reader agree end to end"
+else
+  fail "EXECUTE session-corpus-pin: the shipped reader refused the pin the shipped step wrote"
+fi
+
+# --- POSITIVE CONTROL 3a: the same harness OBSERVES the defective step failing -----------------
+DEFECTIVE_PIN="$TMP/defect-exec-pin.sh"
+if defective_copy "$DRIVER" "$DEFECTIVE_PIN" pin_sha pin data_db_sha256 2>"$TMP/inject-pin.err"; then
+  OUT_BAD="$TMP/session-bad"; mkdir -p "$OUT_BAD"
+  python3 - "$PERF_DIR" "$OUT_BAD" "$CORPUS" <<'PY'
+import pathlib, sys
+sys.path.insert(0, sys.argv[1])
+from ws0_ticket_input import write_ticket_template
+write_ticket_template(pathlib.Path(sys.argv[2]), pathlib.Path(sys.argv[3]) / "ws0-events.cql")
+PY
+  run_pin_rc=0
+  run_pin_step "$DEFECTIVE_PIN" "$OUT_BAD"; bad_out="$(cat "$STEP_OUT")"
+  bad_pin="$OUT_BAD/$(basename "$pin_file")"
+  if [ "$run_pin_rc" -ne 0 ] && grep -q 'SyntaxError' <<<"$bad_out" && [ ! -e "$bad_pin" ]; then
+    pass "EXECUTE CONTROL fired (session-corpus-pin): the injected step FAILS to run (rc=$run_pin_rc, SyntaxError) and writes NO pin — so the accept above is a measurement"
+  else
+    fail "EXECUTE CONTROL did NOT fire (session-corpus-pin): rc=$run_pin_rc, pin-exists=$([ -e "$bad_pin" ] && echo yes || echo no), out: $(head -3 <<<"$bad_out")"
+  fi
+else
+  fail "EXECUTE CONTROL (session-corpus-pin): the defect could not be injected — $(head -2 "$TMP/inject-pin.err")"
+fi
+
+# --- POSITIVE CONTROL 3b: the step's OWN fail-closed branch, on an unexported config field ------
+# Not a syntax control: this one proves the environment the harness builds is genuinely READ. With
+# one WS0_CFG_* absent the step must refuse and NAME the variable, which is the driver's own
+# diagnostic for a field it forgot to export.
+run_pin_rc=0
+OUT_OMIT="$TMP/session-omit"; mkdir -p "$OUT_OMIT"
+python3 - "$PERF_DIR" "$OUT_OMIT" "$CORPUS" <<'PY'
+import pathlib, sys
+sys.path.insert(0, sys.argv[1])
+from ws0_ticket_input import write_ticket_template
+write_ticket_template(pathlib.Path(sys.argv[2]), pathlib.Path(sys.argv[3]) / "ws0-events.cql")
+PY
+run_pin_step "$DRIVER" "$OUT_OMIT" temps; omit_out="$(cat "$STEP_OUT")"
+if [ "$run_pin_rc" -ne 0 ] && grep -q 'WS0_CFG_TEMPS' <<<"$omit_out"; then
+  pass "EXECUTE CONTROL fired (config env is genuinely read): with WS0_CFG_TEMPS unexported the step REFUSES and names the variable"
+else
+  fail "EXECUTE CONTROL did NOT fire: an unexported WS0_CFG_TEMPS must make the step refuse by name (rc=$run_pin_rc, out: $(head -3 <<<"$omit_out"))"
+fi
+
+# ============================================================================
+# PART 4 — THE CPU-PIN-VERIFICATION STEP **RUNS**
+# ============================================================================
+# Its inputs are four `WS0_PIN_*` variables and the session dir. Nothing here reads real sysfs or
+# runs `taskset`: the topology root is a string the step RECORDS, and recording is the whole
+# subject of the step (the verification itself happens in `lib-cpu.sh`, covered by
+# `test_ws0_cpu_pinning_guards.sh` against an injected topology root).
+run_cpu_step() { # run_cpu_step <driver> <out-dir>
+  local drv="$1" out="$2" idx body
+  idx="$(find_block "$drv" 'pinning_record_path')"
+  [[ "$idx" =~ ^[0-9]+$ ]] || { run_cpu_rc=90; echo "block not located: $idx" > "$STEP_OUT"; return; }
+  body="$(emit_block "$drv" "$idx")"
+  env WS0_PIN_SERVER_CPUS="${CFG[server_cpus]}" WS0_PIN_CLIENT_CPUS="${CFG[client_cpus]}" \
+      WS0_PIN_SIBLINGS="server cpu 2 siblings 2,10; server cpu 10 siblings 2,10" \
+      WS0_PIN_TOPOLOGY_ROOT="$TMP/fake-topology" \
+      python3 -c "$body" "$PERF_DIR" "$out" > "$STEP_OUT" 2>&1
+  run_cpu_rc=$?
+}
+
+run_cpu_rc=0
+run_cpu_step "$DRIVER" "$OUT"; cpu_out="$(cat "$STEP_OUT")"
+cpu_file="$(python3 - "$PERF_DIR" "$OUT" <<'PY'
+import pathlib, sys
+sys.path.insert(0, sys.argv[1])
+from ws0_pinning import pinning_record_path
+print(pinning_record_path(pathlib.Path(sys.argv[2])))
+PY
+)"
+if [ "$run_cpu_rc" -eq 0 ] && [ -s "$cpu_file" ]; then
+  pass "EXECUTE cpu-pin-verification: the SHIPPED step ran to completion and wrote $(basename "$cpu_file")"
+else
+  fail "EXECUTE cpu-pin-verification: the shipped step did not run (rc=$run_cpu_rc): $(head -4 <<<"$cpu_out")"
+fi
+if grep -q 'pinning pin:' <<<"$cpu_out"; then
+  pass "EXECUTE cpu-pin-verification: printed 'pinning pin:' — $(grep -m1 'pinning pin:' <<<"$cpu_out" | cut -c1-96)"
+else
+  fail "EXECUTE cpu-pin-verification: the step did not print 'pinning pin:' (output: $(head -3 <<<"$cpu_out"))"
+fi
+if python3 - "$PERF_DIR" "$OUT" "${CFG[server_cpus]}" "${CFG[client_cpus]}" <<'PY'
+import pathlib, sys
+sys.path.insert(0, sys.argv[1])
+from ws0_pinning import PINNING_RECORD_FIELDS, verify_pinning_record
+rec = verify_pinning_record(pathlib.Path(sys.argv[2]), sys.argv[3], sys.argv[4])
+missing = [f for f in PINNING_RECORD_FIELDS if not rec.get(f)]
+assert not missing, missing
+PY
+then
+  pass "EXECUTE cpu-pin-verification: the SHIPPED READER (verify_pinning_record) accepts the record the shipped STEP wrote, with every PINNING_RECORD_FIELDS field populated"
+else
+  fail "EXECUTE cpu-pin-verification: the shipped reader refused the record the shipped step wrote"
+fi
+
+# --- POSITIVE CONTROL 4: the same harness OBSERVES the defective CPU step failing ---------------
+DEFECTIVE_CPU="$TMP/defect-exec-cpu.sh"
+if defective_copy "$DRIVER" "$DEFECTIVE_CPU" rec_server_cpus rec server_cpus 2>"$TMP/inject-cpu.err"; then
+  OUT_BAD2="$TMP/session-bad-cpu"; mkdir -p "$OUT_BAD2"
+  run_cpu_rc=0
+  run_cpu_step "$DEFECTIVE_CPU" "$OUT_BAD2"; bad_cpu_out="$(cat "$STEP_OUT")"
+  bad_cpu_file="$OUT_BAD2/$(basename "$cpu_file")"
+  if [ "$run_cpu_rc" -ne 0 ] && grep -q 'SyntaxError' <<<"$bad_cpu_out" && [ ! -e "$bad_cpu_file" ]; then
+    pass "EXECUTE CONTROL fired (cpu-pin-verification): the injected step FAILS to run (rc=$run_cpu_rc, SyntaxError) and writes NO record"
+  else
+    fail "EXECUTE CONTROL did NOT fire (cpu-pin-verification): rc=$run_cpu_rc, record-exists=$([ -e "$bad_cpu_file" ] && echo yes || echo no), out: $(head -3 <<<"$bad_cpu_out")"
+  fi
+else
+  fail "EXECUTE CONTROL (cpu-pin-verification): the defect could not be injected — $(head -2 "$TMP/inject-cpu.err")"
+fi
+
+# ============================================================================
+# A MINIMUM CHECK COUNT
+# ============================================================================
+# `set -uo pipefail` (no `-e`) means a block that silently never executes lowers the count and
+# registers NO failure, while the gate reads only the exit code. Deliberately below the current
+# count (so adding a case does not red it) and far above zero.
+MIN_CHECKS=18
+echo
+if [ "$checks" -lt "$MIN_CHECKS" ]; then
+  echo "FAIL - only $checks check(s) ran; this suite has at least $MIN_CHECKS."
+  echo "       A block that silently never executed would otherwise lower the count with no"
+  echo "       failure registered, and the gate reads only the exit code (#3451)."
+  exit 1
+fi
+if [ "$fails" -eq 0 ]; then
+  echo "PASS - all $checks WS0 embedded-step EXECUTE-direction checks fired as specified"
+  exit 0
+fi
+echo "FAIL - $fails of $checks WS0 embedded-step EXECUTE-direction check(s) FAILED"
+exit 1

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -62,7 +62,9 @@
 #     is caught and not only the two steps this issue repaired. DISCOVERED is the operative word
 #     and its scope is stated exactly: every `-c`-form invocation REGARDLESS of how its command
 #     word is spelled (the census anchors on the flag), plus every invocation whose command word
-#     contains a literal `python`. What that does not reach is in NOT REACHED below;
+#     contains a literal `python` — both searched over the LOGICAL-LINE reconstruction, so a
+#     backslash-newline continuation cannot hide either anchor. What that does not reach is in
+#     NOT REACHED below;
 #   * the extractor's delimiter in BOTH directions: it reports a defect, AND it does not
 #     manufacture one on good input. A block is delimited by bash's quoting rules rather than by a
 #     line pattern, so all three closer shapes this repository actually uses are handled — the
@@ -109,8 +111,11 @@
 #     a variable, a concatenation, `$(which python3)`, an alias, `eval` — so enumerating the
 #     spellings is the same open list the round-6 inversion escaped, one level down. The two
 #     anchors cover the decidable part: the `-c` FLAG (any command-word spelling) and a literal
-#     `python` word (any argument shape). NOT discovered: an indirectly-spelled command word
-#     COMBINED with a non-`-c` form — `$PYTHON <<'PY'`, or code reaching python through `eval`.
+#     `python` word (any argument shape), both over the logical-line reconstruction (bash deletes
+#     backslash-newline before tokenising, and so does discovery — a single closed rule bash
+#     itself applies, not another spelling on a list). NOT discovered: an indirectly-spelled
+#     command word COMBINED with a non-`-c` form — `$PYTHON <<'PY'`, or code reaching python
+#     through `eval`.
 #     Closing that would require interpreting bash, which is the thing this file does not do.
 #     If a future review reports another command-word spelling, the answer is this limit, not
 #     more matching.
@@ -522,28 +527,39 @@ else
   fail "census CONTROL did not fire (heredoc removed): a heredoc must be a finding, got: $(head -2 <<<"$hd_any")"
 fi
 
-# --- CONTROL 1h: AN INDIRECTLY-SPELLED COMMAND WORD IS DISCOVERED VIA THE FLAG -----------------
+# --- CONTROL 1h: AN INDIRECTLY-SPELLED COMMAND WORD IS DISCOVERED, WRAPPED OR NOT --------------
 # The allowlist closed CLASSIFICATION but not DISCOVERY: a candidate must be FOUND before it can
-# be classified, and `$PYTHON -c '…'` contains no literal `python` word, so it was invisible — an
-# invalid block passing the "every embedded block compiles" guard with the count unchanged. The
-# census now has a SECOND anchor, the `-c` flag itself, which is independent of how the command
-# word is spelled.
-INDIRECT="$TMP/indirect-command-word.sh"
-python3 - "$INDIRECT" <<'INJECT'
+# be classified. Three cases, and the third needed BOTH ingredients before it was invisible —
+# `$PYTHON` defeats the word matcher, and a backslash-newline puts the quote on the next line
+# where the `-c` anchor cannot see it. Measured before the fix: A and C were findings, B was
+# `findings=0 occurrences=0` with the block count unchanged, i.e. an invalid program passing the
+# "every embedded block compiles" guard.
+#
+#   A  literal python3, continuation   already caught (unrecognised shape)
+#   B  $PYTHON,         continuation   INVISIBLE -> now caught, via logical-line joining
+#   C  $PYTHON,         same line      caught by the `-c` flag anchor (round 7)
+#
+# All three are asserted together, because the fix for B (joining backslash-newline before
+# discovery) is a transformation that could plausibly disturb A or C.
+indirect_ok=1
+python3 - "$TMP" <<'INJECT'
 import pathlib, sys
-q = chr(39)
-pathlib.Path(sys.argv[1]).write_text("$PYTHON -c " + q + "import os," + q + "\n")
+q, bs = chr(39), chr(92)
+tmp = pathlib.Path(sys.argv[1])
+prog = q + "import os," + q
+(tmp / "indirect-A.sh").write_text("python3 -c " + bs + "\n" + prog + "\n")
+(tmp / "indirect-B.sh").write_text("$PYTHON -c " + bs + "\n" + prog + "\n")
+(tmp / "indirect-C.sh").write_text("$PYTHON -c " + prog + "\n")
 INJECT
 indirect_rc=$?
-if [ "$indirect_rc" -ne 0 ] || [ ! -s "$INDIRECT" ]; then
-  fail "census CONTROL: the indirect-command-word fixture could not be written (rc=$indirect_rc), so the control could not fire"
+for indirect_case in A B C; do
+  [ -s "$TMP/indirect-$indirect_case.sh" ] || indirect_ok=0
+  [ -n "$(findings_of "$(census "$TMP/indirect-$indirect_case.sh")")" ] || indirect_ok=0
+done
+if [ "$indirect_rc" -eq 0 ] && [ "$indirect_ok" -eq 1 ]; then
+  pass "census CONTROL fired (indirect command word, all 3 cases): a \$PYTHON -c invocation is DISCOVERED whether the quote is on the same line or past a backslash-newline continuation — discovery runs over the logical-line reconstruction bash itself builds"
 else
-  ind_out="$(census "$INDIRECT")"
-  if grep -q 'command word is' <<<"$ind_out"; then
-    pass "census CONTROL fired (indirect command word): \$PYTHON -c is DISCOVERED via the flag anchor and named — $(findings_of "$ind_out" | head -1 | cut -c1-96)"
-  else
-    fail "census CONTROL did not fire (indirect command word): an indirectly-spelled -c invocation must be a finding, got: $(head -2 <<<"$ind_out")"
-  fi
+  fail "census CONTROL did not fire (indirect command word): fixture-rc=$indirect_rc all-three-found=$indirect_ok — case B (indirect word + continuation) is the one that was invisible"
 fi
 
 # --- CONTROL 1i: A MISSING SUBJECT EXITS NONZERO ------------------------------------------------
@@ -634,7 +650,13 @@ fi
 CFG_PAIRS=(
   "reps=1" "temps=warm" "arms=bypass" "scan_passes=1"
   "server_cpus=2,10" "client_cpus=4,12" "step_duration=45s/1s"
-  "flight_endpoint=grpc://127.0.0.1:1"
+  # THE DRIVER'S OWN SHAPE (#3451 review round 8, finding 2). `ws0-baseline.sh:298` sets
+  # `FLIGHT_ENDPOINT="http://127.0.0.1:$PORT"` and `ws0_session` validates the field with
+  # `http_endpoint` as an ABSOLUTE http URL, so the `grpc://…` this suite used before was a value
+  # the driver never produces and the shipped reader would REJECT — the round trip was approving
+  # an artifact production would refuse. Taken from the sibling fixture constant rather than
+  # spelled again, so the two cannot drift.
+  "flight_endpoint=$WS0_FIXTURE_ENDPOINT"
   # `non-baseline`, and that is the only honest value available here: this is a few-KB synthetic
   # corpus, and the shipped `require_canonical_or_declared` REFUSES a divergent corpus in
   # `baseline` mode — correctly. Declaring the mode is the supported way past it, not a way round
@@ -810,10 +832,19 @@ done
 if python3 - "$PERF_DIR" "$OUT" "$CORPUS" <<'PY'
 import pathlib, sys
 sys.path.insert(0, sys.argv[1])
-from ws0_session import verify_session_corpus_pin
+from ws0_report import ARMS_ALLOWED, TEMPS_ALLOWED
+from ws0_session import session_manifest_config, verify_session_corpus_pin
 from ws0_validate import load_corpus_identity
 session, corpus = pathlib.Path(sys.argv[2]), pathlib.Path(sys.argv[3])
 report = verify_session_corpus_pin(session, corpus, load_corpus_identity(corpus))
+# ...AND the shipped CONFIGURATION reader, which `verify_session_corpus_pin` does not call
+# (#3451 review round 8, finding 2). Without it "the SHIPPED reader accepts what the SHIPPED step
+# wrote" was verified by a WEAKER reader than the one that runs in production: the pin verifier
+# checks corpus identity and says nothing about the configuration, so a manifest the real reporter
+# would refuse passed here. `session_manifest_config` is what `ws0_report.py:250` calls.
+cfg = session_manifest_config(session, TEMPS_ALLOWED, ARMS_ALLOWED)
+assert cfg.get("flight_endpoint", "").startswith("http://"), cfg
+assert cfg.get("reps") == 1 and cfg.get("scan_passes") == 1, cfg
 # The reader's own report, asserted field by field so this case cannot pass on a verifier that
 # returned an empty dict: the pin was taken BEFORE measurement, and it carries the digests of the
 # corpus, the schema and the Flight ticket the step measured from disk.
@@ -824,9 +855,51 @@ assert len(report.get("pinned_ticket_sha256", "")) == 64, report
 assert report.get("pinned_components", 0) >= 5, report
 PY
 then
-  pass "EXECUTE session-corpus-pin: the SHIPPED READER (verify_session_corpus_pin) accepts the pin the shipped STEP wrote — writer and reader agree end to end"
+  pass "EXECUTE session-corpus-pin: the SHIPPED READERS accept what the shipped STEP wrote — verify_session_corpus_pin for the corpus identity AND session_manifest_config (what ws0_report.py itself calls) for the configuration, so the round trip is against the production reader rather than a weaker one"
 else
-  fail "EXECUTE session-corpus-pin: the shipped reader refused the pin the shipped step wrote"
+  fail "EXECUTE session-corpus-pin: a shipped reader refused what the shipped step wrote"
+fi
+
+# --- CONTROL 3a-pre: the configuration reader DISCRIMINATES, it does not accept everything ------
+# The accept above is only evidence if the same reader can refuse. A `grpc://` endpoint — the
+# spelling this suite used before round 8, and one the driver never produces — must be REJECTED by
+# `session_manifest_config`. Note the STEP accepts it (it records configuration verbatim); the
+# refusal comes from the production reader, which is exactly the gap that made the old round trip
+# weaker than it read.
+run_pin_rc=0
+OUT_BADCFG="$TMP/session-badcfg"; mkdir -p "$OUT_BADCFG"
+python3 - "$PERF_DIR" "$OUT_BADCFG" "$CORPUS" <<'PY'
+import pathlib, sys
+sys.path.insert(0, sys.argv[1])
+from ws0_ticket_input import write_ticket_template
+write_ticket_template(pathlib.Path(sys.argv[2]), pathlib.Path(sys.argv[3]) / "ws0-events.cql")
+PY
+CFG_PAIRS_SAVED=("${CFG_PAIRS[@]}")
+CFG_PAIRS=()
+for pair in "${CFG_PAIRS_SAVED[@]}"; do
+  case "$pair" in
+    flight_endpoint=*) CFG_PAIRS+=("flight_endpoint=grpc://127.0.0.1:1") ;;
+    *) CFG_PAIRS+=("$pair") ;;
+  esac
+done
+run_pin_step "$DRIVER" "$OUT_BADCFG"; badcfg_out="$(cat "$STEP_OUT")"
+CFG_PAIRS=("${CFG_PAIRS_SAVED[@]}")
+if [ "$run_pin_rc" -eq 0 ] && python3 - "$PERF_DIR" "$OUT_BADCFG" <<'PY'
+import pathlib, sys
+sys.path.insert(0, sys.argv[1])
+from ws0_report import ARMS_ALLOWED, TEMPS_ALLOWED
+from ws0_session import session_manifest_config
+from ws0_validate import Invalid
+try:
+    session_manifest_config(pathlib.Path(sys.argv[2]), TEMPS_ALLOWED, ARMS_ALLOWED)
+except Invalid:
+    raise SystemExit(0)
+raise SystemExit(1)
+PY
+then
+  pass "config-reader CONTROL fired: a grpc:// endpoint is written by the step and REFUSED by session_manifest_config — so the accept above is a measurement, not a reader that takes anything"
+else
+  fail "config-reader CONTROL did not fire: session_manifest_config must refuse a non-http endpoint (step rc=$run_pin_rc, out: $(head -2 <<<"$badcfg_out"))"
 fi
 
 # --- POSITIVE CONTROL 3a: the same harness OBSERVES the defective step failing -----------------

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -199,6 +199,36 @@ findings_of() {
     | grep -v '^$'
 }
 
+# local_binding_of <driver> <block-needle> — the first `NAME = MAPPING["KEY"]` line in the block
+# that calls <block-needle>, printed as `NAME MAPPING KEY`.
+#
+# DERIVED, NOT HARDCODED (#3451 review round 12). The injection controls used the literal names
+# `pin_sha` / `rec_server_cpus`, and #3455 renamed those bindings to `_sha` / `_scpus` — so after
+# the rebase every injection reported INJECTION IMPOSSIBLE and four controls could not fire. They
+# failed loudly, which is the vacuity guard working, but a control keyed on a name the driver is
+# free to change is a control that breaks on maintenance. The binding SHAPE is what the fix is
+# about (a subscript bound to a local before the f-string), so the shape is what is matched.
+local_binding_of() {
+  python3 - "$REPO_ROOT/scripts/tests" "$1" "$2" <<'PY'
+import pathlib, re, sys
+sys.path.insert(0, sys.argv[1])
+from ws0_embedded_python import census
+records, _findings = census(pathlib.Path(sys.argv[2]))
+owners = [r for r in records if r["kind"] == "BLOCK" and sys.argv[3] in r["body"]]
+if len(owners) != 1:
+    print(f"AMBIGUOUS: {len(owners)} block(s) call {sys.argv[3]!r}", file=sys.stderr)
+    raise SystemExit(2)
+pattern = re.compile(r'^([A-Za-z_]\w*) = ([A-Za-z_]\w*)\["(\w+)"\]$', re.M)
+found = pattern.search(owners[0]["body"])
+if not found:
+    print(f"NO LOCAL BINDING found in the block calling {sys.argv[3]!r} — the step no longer"
+          " binds a subscript to a local before its f-string, which is the very shape #3451"
+          " exists to keep. Check the driver before relaxing this.", file=sys.stderr)
+    raise SystemExit(3)
+print(" ".join(found.groups()))
+PY
+}
+
 # defective_copy <src> <dest> <placeholder> <mapping> <key> — a scratch copy of the driver whose
 # f-string placeholder `{<placeholder>}` has been rewritten to the INLINE SUBSCRIPT spelling that
 # NO CPython parses: a backslash inside the expression, which the tokenizer reads as a line
@@ -315,16 +345,18 @@ fi
 
 block_count="$(grep -c '^BLOCK	' <<<"$census_out")"
 # EXACTLY the blocks this driver carries, not a floor. An under-count is the vacuous-green shape
-# and a floor cannot see it once the floor is met: a delimiter that silently stopped recognising
-# one shape would drop that block from BOTH the census and the compile check while the count still
-# cleared a floor. (MEASURED tree-wide while building this: a column-0-only closer rule found 31
-# blocks where the correct rule finds 59 — a loose delimiter under-counts SUBJECTS, it does not
-# merely mis-cut them.) The three are the two fatal pin STEPS plus the inline monotonic-clock read.
-# Adding an embedded step to this driver is a deliberate act, so bump this constant deliberately;
-# the compile property below then covers the new block automatically.
-EXPECTED_BLOCKS=3
+# and a floor cannot see it once met: a delimiter that silently stopped recognising one shape
+# would drop that block from BOTH the census and the compile check while the count still cleared
+# a floor. (MEASURED tree-wide: a column-0-only closer rule found 31 blocks where the correct rule
+# finds 59 — a loose delimiter under-counts SUBJECTS, it does not merely mis-cut them.)
+#
+# THE COUNT IS THE DRIVER'S, AND THE DRIVER MOVES. #3455 took it from 3 blocks to 5, so bumping
+# this is the expected maintenance and the failure message says so. Everything else about the two
+# steps is located STRUCTURALLY — by the shipped writer each body calls — precisely so that a
+# driver edit costs one constant here and nothing more.
+EXPECTED_BLOCKS=5
 if [ "$block_count" -eq "$EXPECTED_BLOCKS" ]; then
-  pass "census: exactly $block_count embedded python block(s) in the driver — the 2 fatal pin steps plus the inline monotonic-clock read"
+  pass "census: exactly $block_count embedded python block(s) in the driver — the count is the DRIVER\x27s and moves with it; the two pin steps are located structurally, not by position"
 else
   fail "census: $block_count embedded block(s) found in $DRIVER, expected $EXPECTED_BLOCKS. If a step was ADDED, bump EXPECTED_BLOCKS; if the count DROPPED, the extractor has stopped seeing a shape and the missing block is being compiled by nothing"
 fi
@@ -730,8 +762,10 @@ control_compile() { # control_compile <label> <placeholder> <mapping> <key>
     fail "compile CONTROL did NOT fire ($label): the injected defect must be reported, got: $(findings_of "$out" | head -2)"
   fi
 }
-control_compile "session-corpus-pin step" pin_sha pin data_db_sha256
-control_compile "CPU-pin-verification step" rec_server_cpus rec server_cpus
+read -r cb_name cb_map cb_key <<<"$(local_binding_of "$DRIVER" write_session_corpus_pin)"
+control_compile "session-corpus-pin step" "$cb_name" "$cb_map" "$cb_key"
+read -r pb_name pb_map pb_key <<<"$(local_binding_of "$DRIVER" pinning_record_path)"
+control_compile "CPU-pin-verification step" "$pb_name" "$pb_map" "$pb_key"
 
 # ============================================================================
 # PART 3 — THE SESSION-CORPUS-PIN STEP **RUNS**
@@ -775,13 +809,17 @@ fi
 CFG_PAIRS=(
   "reps=1" "temps=warm" "arms=bypass" "scan_passes=1"
   "server_cpus=2,10" "client_cpus=4,12" "step_duration=45s/1s"
-  # THE DRIVER'S OWN SHAPE (#3451 review round 8, finding 2). `ws0-baseline.sh:298` sets
-  # `FLIGHT_ENDPOINT="http://127.0.0.1:$PORT"` and `ws0_session` validates the field with
-  # `http_endpoint` as an ABSOLUTE http URL, so the `grpc://…` this suite used before was a value
-  # the driver never produces and the shipped reader would REJECT — the round trip was approving
-  # an artifact production would refuse. Taken from the sibling fixture constant rather than
-  # spelled again, so the two cannot drift.
   "flight_endpoint=$WS0_FIXTURE_ENDPOINT"
+  # ...and the fields #3455 added. Each value is THE DRIVER'S OWN DEFAULT SHAPE, not merely
+  # something the validator accepts — the round-8 lesson about the Flight endpoint applied here
+  # before it could cost a round: a fixture pinning a value the driver never produces makes the
+  # round trip approve an artifact production would refuse. `events` is the driver's counter list,
+  # `profile`/`quiescence` are its own closed-grammar defaults (`off`, and the unverified
+  # sentinel), and `bin_dir` is a release bin path.
+  "events=cycles,instructions"
+  "bin_dir=target/release"
+  "profile=off"
+  "quiescence=NOT VERIFIED (no timeseries supplied)"
   # `non-baseline`, and that is the only honest value available here: this is a few-KB synthetic
   # corpus, and the shipped `require_canonical_or_declared` REFUSES a divergent corpus in
   # `baseline` mode — correctly. Declaring the mode is the supported way past it, not a way round
@@ -1099,7 +1137,7 @@ fi
 
 # --- POSITIVE CONTROL 3a: the same harness OBSERVES the defective step failing -----------------
 DEFECTIVE_PIN="$TMP/defect-exec-pin.sh"
-if defective_copy "$DRIVER" "$DEFECTIVE_PIN" pin_sha pin data_db_sha256 2>"$TMP/inject-pin.err"; then
+if defective_copy "$DRIVER" "$DEFECTIVE_PIN" "$cb_name" "$cb_map" "$cb_key" 2>"$TMP/inject-pin.err"; then
   OUT_BAD="$TMP/session-bad"; mkdir -p "$OUT_BAD"
   python3 - "$PERF_DIR" "$OUT_BAD" "$CORPUS" <<'PY'
 import pathlib, sys
@@ -1215,7 +1253,7 @@ fi
 
 # --- POSITIVE CONTROL 4: the same harness OBSERVES the defective CPU step failing ---------------
 DEFECTIVE_CPU="$TMP/defect-exec-cpu.sh"
-if defective_copy "$DRIVER" "$DEFECTIVE_CPU" rec_server_cpus rec server_cpus 2>"$TMP/inject-cpu.err"; then
+if defective_copy "$DRIVER" "$DEFECTIVE_CPU" "$pb_name" "$pb_map" "$pb_key" 2>"$TMP/inject-cpu.err"; then
   OUT_BAD2="$TMP/session-bad-cpu"; mkdir -p "$OUT_BAD2"
   run_cpu_rc=0
   run_cpu_step "$DEFECTIVE_CPU" "$OUT_BAD2"; bad_cpu_out="$(cat "$STEP_OUT")"

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -1471,11 +1471,31 @@ sys.path.insert(0, sys.argv[1])
 from ws0_ticket_input import write_ticket_template
 write_ticket_template(pathlib.Path(sys.argv[2]), pathlib.Path(sys.argv[3]) / "ws0-events.cql")
 PY
+  # BOTH STEPS MUST HAVE SUCCEEDED AND BOTH ARTIFACTS MUST EXIST BEFORE THE VERDICT MEANS
+  # ANYTHING (#3451 post-rebase round 5, F3). This control used to treat ANY refusal as success
+  # without checking either status, either artifact, or the REASON — so a setup failure or a
+  # step that never ran satisfied it, and it passed without ever demonstrating that the
+  # mismatch was detected. A control that cannot fail, inside the suite whose subject is
+  # refusing exactly that.
   run_pin_rc=0; run_cpu_rc=0
   run_pin_step "$SWAPDRV" "$SWAPDIR" >/dev/null 2>&1
   run_cpu_step "$SWAPDRV" "$SWAPDIR" >/dev/null 2>&1
-  swap_verdict=refused
-  python3 - "$PERF_DIR" "$SWAPDIR" >/dev/null 2>&1 <<'PY' && swap_verdict=accepted
+  if [ "$run_pin_rc" -ne 0 ] || [ "$run_cpu_rc" -ne 0 ]; then
+    fail "cpu-mapping CONTROL ($cpu_swap): a step did not run (pin rc=$run_pin_rc, cpu rc=$run_cpu_rc), so nothing about detection was demonstrated"
+    continue
+  fi
+  if [ ! -s "$SWAPDIR/session-corpus-pin.json" ] || [ ! -s "$SWAPDIR/pinning-verification.json" ]; then
+    fail "cpu-mapping CONTROL ($cpu_swap): an artifact is missing, so the verifier below would refuse for the wrong reason"
+    continue
+  fi
+  # ...and the refusal must be FOR THE SERVER-CPU MISMATCH, matched on the reason rather than on
+  # the mere fact of a refusal. `refused-other` is a distinct verdict so a refusal for any other
+  # cause fails the control instead of satisfying it.
+  # The heredoc belongs to the COMMAND SUBSTITUTION, not to a trailing assignment. Attached to
+  # the latter, `python3 -` reads no program: under a terminal it BLOCKS (the suite hung), and
+  # with stdin closed it exits 0 having done nothing — which reads as "the verifier accepted",
+  # i.e. the control silently inverts. Both observed while writing this.
+  swap_reason="$(python3 - "$PERF_DIR" "$SWAPDIR" 2>&1 >/dev/null <<'PY'
 import pathlib, sys
 sys.path.insert(0, sys.argv[1])
 from ws0_pinning import verify_pinning_record
@@ -1485,12 +1505,21 @@ session = pathlib.Path(sys.argv[2])
 config = session_manifest_config(session, TEMPS_ALLOWED, ARMS_ALLOWED)
 verify_pinning_record(session, config["server_cpus"], config["client_cpus"])
 PY
+)"
+  swap_status=$?
+  if [ "$swap_status" -eq 0 ]; then
+    swap_verdict=accepted
+  elif grep -qi 'server' <<<"$swap_reason" && grep -q "$(cfg_value client_cpus)" <<<"$swap_reason"; then
+    swap_verdict=refused
+  else
+    swap_verdict=refused-other
+  fi
   if [ "$cpu_swap" = "pin-only" ] && [ "$swap_verdict" = refused ]; then
     pass "cpu-mapping CONTROL fired (pin-only): WS0_PIN_SERVER_CPUS taking \$CLIENT_CPUS makes the record disagree with the manifest, and the cross-check REFUSES it — invisible while the record was verified against fixture constants"
   elif [ "$cpu_swap" = "consistent" ] && [ "$swap_verdict" = accepted ]; then
     pass "cpu-mapping STATED LIMIT (consistent): swapping BOTH prefixes together is ACCEPTED, and that is honest rather than a gap this suite can close — the manifest and the record then agree, so no cross-check between them can tell; catching it needs an oracle for what the CPU lists OUGHT to be, which only the host topology has (test_ws0_cpu_pinning_guards.sh's subject)"
   else
-    fail "cpu-mapping CONTROL ($cpu_swap): expected the cross-check to $([ "$cpu_swap" = pin-only ] && echo refuse || echo accept), got $swap_verdict"
+    fail "cpu-mapping CONTROL ($cpu_swap): expected the cross-check to $([ "$cpu_swap" = pin-only ] && echo 'refuse NAMING the server-CPU mismatch' || echo accept), got $swap_verdict — reason was: $(head -c 200 <<<"$swap_reason")"
   fi
 done
 

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -60,11 +60,6 @@
 #     `WS0_PIN_*` inputs, there against the literal names the extracted block reads;
 #   * EVERY embedded block in the driver COMPILES — the total property, so instance #8 anywhere in
 #     that file is caught and not only the two steps this issue repaired;
-#   * NO embedded block uses the PEP 701 NESTED SAME-TYPE QUOTE spelling — ONE construct class,
-#     and precisely the alternative the driver's own comment says it rejected. `compile()` cannot
-#     answer it on a 3.12 box, where the spelling is legal, while the 3.11 workflows this repo pins
-#     would break. Two oracles for that one spelling, each sound over its own interpreter range,
-#     with the one that answered NAMED in the output.
 #   * the extractor's delimiter in BOTH directions: it reports a defect, AND it does not
 #     manufacture one on good input. A block is delimited by bash's quoting rules rather than by a
 #     line pattern, so all three closer shapes this repository actually uses are handled — the
@@ -86,15 +81,26 @@
 #     reporter. Deliberately NOT asserted structurally: a check keyed on where `|| {` sits is
 #     brittle, and a brittle assert on correct code is the false-red that gets a guard waived.
 #     Stated here so the limit is known rather than assumed away.
-#   * GENERAL CROSS-INTERPRETER PORTABILITY. The nested-quote check above decides ONE construct
-#     class and is NOT a portability verdict: PEP 701 legalised others, and a case in part 2b
-#     MEASURES two of them (a multiline f-string expression, a comment inside one) passing it
-#     silently while being 3.12-only. Establishing the general property needs the blocks compiled
-#     by a REAL 3.9/3.11 — a CI lane, not a hermetic self-test, and not doable honestly on a box
-#     that has only 3.12. Widening the model here instead would make the checker a second
-#     implementation of CPython's tokenizer, correct only insofar as it is differentially tested
-#     against the original. So: a 3.12-only construct OTHER than the nested same-type quote
-#     spelling would NOT be caught here.
+#   * CROSS-INTERPRETER PORTABILITY, AT ALL. The compile check establishes that the blocks parse
+#     on THE INTERPRETER RUNNING IT, and nothing here establishes more than that. Concretely, the
+#     regression that would NOT be caught is a subscript written inside an f-string expression
+#     with the SAME quote character as the f-string itself — legal from 3.12 under PEP 701 and a
+#     SyntaxError below it. It is DESCRIBED rather than reproduced here, as the driver's own
+#     comment describes it, and for the same reason: a literal example of a defect inside the
+#     prose about that defect is one more thing to be mistaken for the real thing. That comment
+#     remains the durable record of why locals are bound instead.
+#
+#     A tokenizer model of that spelling lived here for two review rounds and was REMOVED (#3451
+#     round 4). It was wrong twice — first overclaiming, then flagging legal triple-quoted code,
+#     a FALSE RED, which is the worse direction because a guard that reds on correct code is the
+#     guard people learn to waive. Each fix was individually right and the model stayed wrong
+#     somewhere new, which is what a second implementation of CPython's tokenizer does when its
+#     correctness can only be established by differential testing against an original we do not
+#     have on this box. THE ONLY HONEST ORACLE IS A REAL INTERPRETER: compiling the blocks under
+#     an actual 3.9/3.11, which is a CI lane and not a hermetic self-test.
+#
+#     What survives is the oracle that is real: no CPython accepts the BACKSLASH form, so the
+#     compile check catches the defect this issue is actually about on 3.9 through 3.12 alike.
 #   * anything measured: no `perf`, no Flight server, no rep loop, no 2.8 GB corpus.
 #
 # Hermetic: python3, a few KB under `$TMPDIR`. No sudo, cargo, perf, taskset, network, root, and no
@@ -163,16 +169,21 @@ emit_block() { python3 "$EXTRACT" emit "$1" "$2"; }
 # findings_of <output> — the extractor's output minus its `#COMPLETE` marker, i.e. the findings.
 # The marker is filtered HERE rather than by each reader, for the reason `lib-ws0-hermetic.sh`
 # gives: a diagnostic a human must remember to ignore is one they will read as a finding.
-findings_of() { grep -v '^#COMPLETE ' <<<"$1" | grep -vE '^(BLOCK|MENTION|SCRIPT)\b' | grep -v '^$'; }
+# `([[:space:]]|$)` rather than `\b`: the word boundary is a GNU extension that BSD grep (macOS)
+# does not interpret, so the record lines would survive this filter and every `findings_of` test
+# below would see them as findings — the mandatory gate failing on a supported host (#3451 review
+# round 4, same macOS family as the bash 3.2 item).
+findings_of() {
+  grep -v '^#COMPLETE ' <<<"$1" \
+    | grep -vE '^(BLOCK|MENTION|SCRIPT)([[:space:]]|$)' \
+    | grep -v '^$'
+}
 
-# defective_copy <src> <dest> <placeholder> <mapping> <key> [flavour] — a scratch copy of the
-# driver whose f-string placeholder `{<placeholder>}` has been rewritten to an INLINE SUBSCRIPT.
-#
-# Two flavours, because they fail on DIFFERENT interpreters and the suite must observe both:
-#   escaped  a backslash inside the expression. No CPython parses it — the shipped defect.
-#   nested   the SAME quote character as the enclosing f-string. Legal from 3.12 (PEP 701) and a
-#            SyntaxError on everything older, so `compile()` on a 3.12 box CANNOT see it. This is
-#            the alternative the driver's comment says was rejected.
+# defective_copy <src> <dest> <placeholder> <mapping> <key> — a scratch copy of the driver whose
+# f-string placeholder `{<placeholder>}` has been rewritten to the INLINE SUBSCRIPT spelling that
+# NO CPython parses: a backslash inside the expression, which the tokenizer reads as a line
+# continuation. That is the defect this issue is about, and it fails identically on 3.9 through
+# 3.12, which is why the compile check that catches it needs no interpreter model.
 #
 # Exits non-zero when the placeholder is not found EXACTLY once, so a control that silently
 # injected nothing is a failure rather than a green "the check found no defect".
@@ -180,13 +191,11 @@ defective_copy() {
   python3 - "$@" <<'PY'
 import pathlib, sys
 src, dest, placeholder, mapping, key = sys.argv[1:6]
-flavour = sys.argv[6] if len(sys.argv) > 6 else "escaped"
-# Both spellings are CONSTRUCTED from character codes rather than written out, so this file does
-# not ship a literal example of either (#3312's rule about prose inside a diff naming its own
-# oracle, applied to a test that must build its own bad input).
+# CONSTRUCTED from character codes rather than written out, so this file does not ship a literal
+# example of the spelling (#3312's rule about prose inside a diff naming its own oracle, applied
+# to a test that must build its own bad input).
 backslash, dquote = chr(92), chr(34)
-lead = backslash + dquote if flavour == "escaped" else dquote
-bad = "{" + mapping + "[" + lead + key + lead + "]}"
+bad = "{" + mapping + "[" + backslash + dquote + key + backslash + dquote + "]}"
 text = pathlib.Path(src).read_text()
 needle = "{" + placeholder + "}"
 found = text.count(needle)
@@ -198,12 +207,6 @@ if found != 1:
 pathlib.Path(dest).write_text(text.replace(needle, bad))
 PY
 }
-
-# nested_quote <file> / nested_quote_source <file> — the PEP 701 NESTED SAME-TYPE QUOTE check over
-# a driver's blocks, or over an ordinary python file. ONE construct class, deliberately: see the
-# "known limit" case in part 2b.
-nested_quote() { python3 "$EXTRACT" nested-quote "$1" 2>&1; }
-nested_quote_source() { python3 "$EXTRACT" nested-quote-source "$1" 2>&1; }
 
 # ============================================================================
 # PART 1 — THE EXTRACTOR READS THE SHIPPED DRIVER, AND FAILS CLOSED
@@ -505,155 +508,6 @@ control_compile() { # control_compile <label> <placeholder> <mapping> <key>
 }
 control_compile "session-corpus-pin step" pin_sha pin data_db_sha256
 control_compile "CPU-pin-verification step" rec_server_cpus rec server_cpus
-
-# ============================================================================
-# PART 2b — NO 3.12-ONLY NESTED SAME-TYPE QUOTE (ONE SPELLING, NOT "PORTABILITY")
-# ============================================================================
-# `compile()` answers "does this parse HERE". The regression the repaired steps are exposed to is
-# narrower and specific: a subscript inside an f-string expression written with NESTED SAME-TYPE
-# QUOTES. PEP 701 made it legal in 3.12; it is a SyntaxError on everything older. That is the exact
-# alternative the driver's own comment says it rejected — and until this part existed nothing
-# enforced it: a regression to that form passes `compile()` on a 3.12 box and breaks the 3.11
-# workflows this repository pins (and the `>=3.9` the python bindings declare).
-#
-# WHAT IS CLAIMED IS EXACTLY WHAT IS DECIDED: that ONE spelling is absent. NOT that the blocks
-# parse on every interpreter this repo runs — PEP 701 legalised other constructs, two of which are
-# MEASURED below to pass this check silently. The general property needs the blocks compiled by a
-# REAL 3.9/3.11, which is a CI lane and not a hermetic self-test; it is in the NOT-REACHED list in
-# this file's header. Widening the model instead would make the checker a second implementation of
-# CPython's tokenizer, whose correctness is knowable only by differential testing against the
-# original — the trap CLAUDE.md records.
-#
-# TWO ORACLES FOR THAT ONE SPELLING, EACH SOUND OVER ITS OWN RANGE, AND THE PASS LINE NAMES WHICH
-# ONE ANSWERED. On 3.12+ a tokenizer walk is the oracle, because `compile()` there accepts the bad
-# form; below 3.12 `compile()` IS the oracle, because the bad form does not parse at all. Nothing
-# is conditional on an optional interpreter being installed — a check that skips when a dependency
-# is absent is the coverage gap this whole issue is about.
-port_out="$(nested_quote "$DRIVER")"
-port_marker="$(grep -m1 '^#COMPLETE ' <<<"$port_out")"
-if [ -n "$port_marker" ] && [ -z "$(findings_of "$port_out")" ]; then
-  pass "nested-quote: no embedded block uses the 3.12-only nested SAME-TYPE quote spelling — the one alternative the driver's comment rejects ($port_marker)"
-else
-  fail "nested-quote: an embedded block in $DRIVER uses the 3.12-only spelling — $(findings_of "$port_out" | head -2)"
-fi
-
-# --- CONTROL 2b-i: the 3.12-only spelling is REFUSED, and `compile` alone cannot see it ---------
-NESTED_DRIVER="$TMP/nested-quote-ws0-driver.sh"
-if defective_copy "$DRIVER" "$NESTED_DRIVER" pin_sha pin data_db_sha256 nested 2>"$TMP/inject-nested.err"; then
-  nest_port="$(nested_quote "$NESTED_DRIVER")"
-  nest_comp="$(compile_blocks "$NESTED_DRIVER")"
-  nest_oracle="$(sed -n 's/.*oracle=\([a-z]*\).*/\1/p' <<<"$nest_port" | head -1)"
-  if grep -q 'NESTED SAME-TYPE QUOTE' <<<"$nest_port"; then
-    pass "nested-quote CONTROL fired: the 3.12-only spelling is REFUSED — $(grep -m1 'NESTED SAME-TYPE QUOTE' <<<"$nest_port" | cut -c1-112)"
-  else
-    fail "nested-quote CONTROL did NOT fire: the 3.12-only spelling must be refused, got: $(findings_of "$nest_port" | head -2)"
-  fi
-  # ...and WHY the new oracle earns its place, asserted rather than argued: on a 3.12+ box the
-  # plain compile check is SILENT about this input. On an older box compile is the oracle and must
-  # report it. Both branches assert; neither is a skip, and the pass line says which ran.
-  if [ "$nest_oracle" = "tokenizer" ]; then
-    if [ -z "$(findings_of "$nest_comp")" ]; then
-      pass "nested-quote CONTROL discriminates: on this 3.12+ interpreter (oracle=tokenizer) the plain compile check is SILENT about the same input — so the nested-quote oracle is doing work compile cannot"
-    else
-      fail "on a 3.12+ interpreter compile() must ACCEPT the nested spelling (that is the trap); it reported: $(findings_of "$nest_comp" | head -1)"
-    fi
-  else
-    if grep -q 'DOES NOT COMPILE' <<<"$nest_comp"; then
-      pass "nested-quote CONTROL discriminates: on this pre-3.12 interpreter (oracle=compile) the nested spelling does not parse at all, and the compile check reports it"
-    else
-      fail "on a pre-3.12 interpreter the nested spelling must fail to compile; it did not"
-    fi
-  fi
-else
-  fail "nested-quote CONTROL: the defect could not be injected — $(head -2 "$TMP/inject-nested.err")"
-fi
-
-# --- CONTROL 2b-ii: THE ACCEPT DIRECTION — a DIFFERENT-type nested quote is legal everywhere -----
-# `f"{x['k']}"` parses on every interpreter, and flagging it would be a false red on ordinary code.
-# The same-type/different-type boundary IS the check, so both sides of it are asserted. Driven over
-# a standalone source file rather than an injected block: an apostrophe inside a `python3 -c '…'`
-# body would terminate the shell string, which is why the driver cannot use that spelling either.
-python3 - "$TMP" <<'INJECT'
-import pathlib, sys
-dq, sq = chr(34), chr(39)
-tmp = pathlib.Path(sys.argv[1])
-(tmp / "nested-quote-legal.py").write_text(
-    "x = {'k': 1}\nprint(f" + dq + "{x[" + sq + "k" + sq + "]}" + dq + ")\n")
-(tmp / "nested-quote-remedy.py").write_text(
-    "x = {'k': 1}\nv = x['k']\nprint(f" + dq + "{v}" + dq + ")\n")
-INJECT
-ok_out="$(nested_quote_source "$TMP/nested-quote-legal.py")"
-rem_out="$(nested_quote_source "$TMP/nested-quote-remedy.py")"
-if [ -z "$(findings_of "$ok_out")" ] && [ -z "$(findings_of "$rem_out")" ] \
-   && grep -q '^#COMPLETE ' <<<"$ok_out" && grep -q '^#COMPLETE ' <<<"$rem_out"; then
-  pass "nested-quote ACCEPT direction: a DIFFERENT-type nested quote (legal on every interpreter) and the local-binding remedy are BOTH clean — the check discriminates rather than refusing every subscript"
-else
-  fail "nested-quote manufactured a finding on legal code: different-type='$(findings_of "$ok_out" | head -1)' remedy='$(findings_of "$rem_out" | head -1)'"
-fi
-
-# --- THE STATED LIMIT, PINNED BY MEASUREMENT ---------------------------------------------------
-# The check above decides ONE construct class. PEP 701 legalised others, and this case measures two
-# of them so the limit is a MEASUREMENT rather than a sentence someone hopes is still true:
-#
-#   a MULTILINE f-string expression            3.12 compiles it; this check is CLEAN
-#   a COMMENT inside an f-string expression    3.12 compiles it; this check is CLEAN
-#
-# Asserted deliberately in the NEGATIVE. It looks strange to assert that a check MISSES something,
-# and that is exactly its job: it binds the claim in this file's header to something falsifiable.
-# If someone later widens the oracle, THIS CASE REDS and they must come here and update the claim
-# — which is the only mechanism that stops the header's wording drifting away from the code.
-#
-# The remedy for the general property is NOT a deeper model here: it is compiling the blocks under
-# a REAL 3.9/3.11, a CI lane. Widening the tokenizer walk would make this a second implementation
-# of CPython's tokenizer, whose correctness is knowable only by differential testing against the
-# original — and the construct list does not close by enumeration, so each round would find the
-# next unnamed member.
-python3 - "$TMP" <<'INJECT'
-import pathlib, sys
-dq = chr(34)
-tmp = pathlib.Path(sys.argv[1])
-# A MULTILINE f-string expression: legal from 3.12, SyntaxError before it.
-(tmp / "pep701-multiline.py").write_text(
-    "x = {'k': 1}\nprint(f" + dq + "{x[\n    'k'\n]}" + dq + ")\n")
-# A COMMENT inside an f-string expression: same.
-(tmp / "pep701-comment.py").write_text(
-    "x = {'k': 1}\nprint(f" + dq + "{x['k']  # a comment\n}" + dq + ")\n")
-INJECT
-limit_missed=0
-limit_parses=0
-limit_oracle="$(sed -n 's/.*oracle=\([a-z]*\).*/\1/p' <<<"$(nested_quote_source "$TMP/pep701-multiline.py")" | head -1)"
-for limit_case in pep701-multiline pep701-comment; do
-  if python3 -c "import pathlib,sys; compile(pathlib.Path(sys.argv[1]).read_text(), 'x', 'exec')" \
-       "$TMP/$limit_case.py" 2>/dev/null; then
-    limit_parses=$((limit_parses + 1))
-  fi
-  [ -z "$(findings_of "$(nested_quote_source "$TMP/$limit_case.py")")" ] \
-    && limit_missed=$((limit_missed + 1))
-done
-# WHICH ANSWER IS CORRECT DEPENDS ON THE ORACLE THAT ANSWERED, and the marker reports it — so the
-# expectation is derived from `oracle=` rather than from the interpreter this box happens to have.
-# Under the TOKENIZER oracle (3.12+) both constructs are missed, which is the limit being pinned.
-# Under the COMPILE fallback (< 3.12) they do not parse at all, so that oracle CATCHES them and
-# the limit does not arise. Asserting "missed" unconditionally would have red on 3.11.
-if [ "$limit_oracle" = "tokenizer" ]; then
-  if [ "$limit_missed" -eq 2 ]; then
-    pass "nested-quote STATED LIMIT (pinned, oracle=tokenizer): the 2 OTHER 3.12-only constructs measured here (a multiline f-string expression, a comment inside one) are NOT caught — the claim in this file's header is exactly this narrow, and widening the oracle without widening the claim REDS this case ($limit_parses/2 parse on this interpreter)"
-  else
-    fail "nested-quote STATED LIMIT: under oracle=tokenizer, $limit_missed of 2 known-uncaught constructs were still uncaught. If the oracle was WIDENED, that is good news — update this case AND the claim in the header and the gate comment, which currently say only the nested same-type quote spelling is decided"
-  fi
-elif [ "$limit_oracle" = "compile" ]; then
-  # ONE conjunct, deliberately: under the compile fallback the property is simply that the
-  # constructs are CAUGHT, so the 3.12-only limit does not arise. Whether they also fail to parse
-  # is the same interpreter fact restated through a second probe, and asserting it would be one
-  # more thing to be wrong about on a box this suite cannot reach. `$limit_parses` is reported.
-  if [ "$limit_missed" -eq 0 ]; then
-    pass "nested-quote STATED LIMIT (oracle=compile, pre-3.12): both constructs are CAUGHT by the fallback oracle, so the 3.12-only limit does not arise — the limit is a property of the tokenizer oracle, not a claim about every box ($limit_parses/2 parse here)"
-  else
-    fail "nested-quote STATED LIMIT: under oracle=compile the constructs must be CAUGHT, but $limit_missed of 2 were missed"
-  fi
-else
-  fail "nested-quote STATED LIMIT: the marker reported no recognisable oracle ('$limit_oracle'), so this case cannot say which answer is correct — an unanswerable oracle must not read as a clean answer"
-fi
 
 # ============================================================================
 # PART 3 — THE SESSION-CORPUS-PIN STEP **RUNS**

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -60,11 +60,11 @@
 #     `WS0_PIN_*` inputs, there against the literal names the extracted block reads;
 #   * EVERY embedded block in the driver COMPILES — the total property, so instance #8 anywhere in
 #     that file is caught and not only the two steps this issue repaired;
-#   * EVERY embedded block parses on EVERY INTERPRETER THIS REPOSITORY RUNS, not merely on this
-#     box. `compile()` cannot answer that: PEP 701 made the nested SAME-TYPE quote spelling legal
-#     in 3.12, so a regression to it — the alternative the driver's own comment says it rejected —
-#     passes on a 3.12 box and breaks the 3.11 workflows this repo pins. Two oracles, each sound
-#     over its own interpreter range, with the one that answered NAMED in the output.
+#   * NO embedded block uses the PEP 701 NESTED SAME-TYPE QUOTE spelling — ONE construct class,
+#     and precisely the alternative the driver's own comment says it rejected. `compile()` cannot
+#     answer it on a 3.12 box, where the spelling is legal, while the 3.11 workflows this repo pins
+#     would break. Two oracles for that one spelling, each sound over its own interpreter range,
+#     with the one that answered NAMED in the output.
 #   * the extractor's delimiter in BOTH directions: it reports a defect, AND it does not
 #     manufacture one on good input. A block is delimited by bash's quoting rules rather than by a
 #     line pattern, so all three closer shapes this repository actually uses are handled — the
@@ -86,6 +86,15 @@
 #     reporter. Deliberately NOT asserted structurally: a check keyed on where `|| {` sits is
 #     brittle, and a brittle assert on correct code is the false-red that gets a guard waived.
 #     Stated here so the limit is known rather than assumed away.
+#   * GENERAL CROSS-INTERPRETER PORTABILITY. The nested-quote check above decides ONE construct
+#     class and is NOT a portability verdict: PEP 701 legalised others, and a case in part 2b
+#     MEASURES two of them (a multiline f-string expression, a comment inside one) passing it
+#     silently while being 3.12-only. Establishing the general property needs the blocks compiled
+#     by a REAL 3.9/3.11 — a CI lane, not a hermetic self-test, and not doable honestly on a box
+#     that has only 3.12. Widening the model here instead would make the checker a second
+#     implementation of CPython's tokenizer, correct only insofar as it is differentially tested
+#     against the original. So: a 3.12-only construct OTHER than the nested same-type quote
+#     spelling would NOT be caught here.
 #   * anything measured: no `perf`, no Flight server, no rep loop, no 2.8 GB corpus.
 #
 # Hermetic: python3, a few KB under `$TMPDIR`. No sudo, cargo, perf, taskset, network, root, and no
@@ -178,10 +187,11 @@ pathlib.Path(dest).write_text(text.replace(needle, bad))
 PY
 }
 
-# portable <file> / portable_source <file> — the PEP 701 oracle over a driver's blocks, or over an
-# ordinary python file.
-portable() { python3 "$EXTRACT" portable "$1" 2>&1; }
-portable_source() { python3 "$EXTRACT" portable-source "$1" 2>&1; }
+# nested_quote <file> / nested_quote_source <file> — the PEP 701 NESTED SAME-TYPE QUOTE check over
+# a driver's blocks, or over an ordinary python file. ONE construct class, deliberately: see the
+# "known limit" case in part 2b.
+nested_quote() { python3 "$EXTRACT" nested-quote "$1" 2>&1; }
+nested_quote_source() { python3 "$EXTRACT" nested-quote-source "$1" 2>&1; }
 
 # ============================================================================
 # PART 1 — THE EXTRACTOR READS THE SHIPPED DRIVER, AND FAILS CLOSED
@@ -383,6 +393,31 @@ else
   fail "census CONTROL did not fire (heredoc shape): blocks=$hd_blocks (expected $((block_count + 1))), compile said: $(findings_of "$hd_compile" | head -2)"
 fi
 
+# --- CONTROL 1c-quater: TWO invocations on ONE line, the SECOND carrying the defect ------------
+# The census advertises "every occurrence". An earlier version searched each line ONCE and then
+# skipped whole lines, so a second invocation after a `;`, an `&&` or an inline block's closing
+# quote was silently dropped — a vacuous pass inside the TOTAL property itself. MEASURED against
+# `python3 -c '<ok>'; python3 -c '<defect>'`: `blocks=1 occurrences=1`, and the defect in the
+# second block was invisible to the compile check.
+#
+# The defect is put in the SECOND block deliberately: with it in the first, a line-at-a-time
+# scanner still reports it and the control proves nothing.
+TWO_PER_LINE="$TMP/two-per-line-ws0-driver.sh"
+python3 - "$DRIVER" "$TWO_PER_LINE" <<'INJECT'
+import pathlib, sys
+q = chr(39)
+step = ("python3 -c " + q + "import sys" + q + "; python3 -c " + q + "import os," + q + "\n")
+pathlib.Path(sys.argv[2]).write_text(pathlib.Path(sys.argv[1]).read_text() + step)
+INJECT
+two_census="$(census "$TWO_PER_LINE")"
+two_compile="$(compile_blocks "$TWO_PER_LINE")"
+two_blocks="$(grep -c '^BLOCK	' <<<"$two_census")"
+if [ "$two_blocks" -eq "$((block_count + 2))" ] && grep -q 'DOES NOT COMPILE' <<<"$two_compile"; then
+  pass "census CONTROL fired (two per line): BOTH invocations on one line are counted ($two_blocks blocks) and the defect in the SECOND is REPORTED — the scan advances by what each classification consumed, not by whole lines"
+else
+  fail "census CONTROL did not fire (two per line): blocks=$two_blocks (expected $((block_count + 2))), compile said '$(findings_of "$two_compile" | head -1)'"
+fi
+
 # --- CONTROL 1d-bis: the heredoc terminator rule is the SHELL's, per form ----------------------
 # `<<TAG` takes the terminator EXACTLY — a space-indented `  TAG` is ordinary body to the shell, so
 # accepting it truncates the block and hands python a body it never receives. `<<-TAG` strips
@@ -457,58 +492,65 @@ control_compile "session-corpus-pin step" pin_sha pin data_db_sha256
 control_compile "CPU-pin-verification step" rec_server_cpus rec server_cpus
 
 # ============================================================================
-# PART 2b — THE BLOCKS PARSE ON EVERY INTERPRETER THIS REPO RUNS, NOT JUST THIS BOX
+# PART 2b — NO 3.12-ONLY NESTED SAME-TYPE QUOTE (ONE SPELLING, NOT "PORTABILITY")
 # ============================================================================
-# `compile()` answers "does this parse HERE". The property the repaired steps need is "does this
-# parse on every interpreter this repository runs on", and the two differ for exactly one
-# spelling: a subscript inside an f-string expression written with NESTED SAME-TYPE QUOTES. PEP
-# 701 made it legal in 3.12; it is a SyntaxError on everything older. That is the alternative the
-# driver's own comment says was rejected — and until this part existed, nothing enforced it: a
-# regression to that form passes `compile()` on a 3.12 box and breaks the 3.11 workflows this
-# repository pins (and the `>=3.9` the python bindings declare).
+# `compile()` answers "does this parse HERE". The regression the repaired steps are exposed to is
+# narrower and specific: a subscript inside an f-string expression written with NESTED SAME-TYPE
+# QUOTES. PEP 701 made it legal in 3.12; it is a SyntaxError on everything older. That is the exact
+# alternative the driver's own comment says it rejected — and until this part existed nothing
+# enforced it: a regression to that form passes `compile()` on a 3.12 box and breaks the 3.11
+# workflows this repository pins (and the `>=3.9` the python bindings declare).
 #
-# TWO ORACLES, EACH SOUND OVER ITS OWN RANGE, AND THE PASS LINE NAMES WHICH ONE ANSWERED. On 3.12+
-# a tokenizer walk is the oracle, because `compile()` there accepts the bad form; below 3.12
-# `compile()` IS the oracle, because the bad form does not parse at all. Nothing is conditional on
-# an optional interpreter being installed — a check that skips when a dependency is absent is the
-# coverage gap this whole issue is about.
-port_out="$(portable "$DRIVER")"
+# WHAT IS CLAIMED IS EXACTLY WHAT IS DECIDED: that ONE spelling is absent. NOT that the blocks
+# parse on every interpreter this repo runs — PEP 701 legalised other constructs, two of which are
+# MEASURED below to pass this check silently. The general property needs the blocks compiled by a
+# REAL 3.9/3.11, which is a CI lane and not a hermetic self-test; it is in the NOT-REACHED list in
+# this file's header. Widening the model instead would make the checker a second implementation of
+# CPython's tokenizer, whose correctness is knowable only by differential testing against the
+# original — the trap CLAUDE.md records.
+#
+# TWO ORACLES FOR THAT ONE SPELLING, EACH SOUND OVER ITS OWN RANGE, AND THE PASS LINE NAMES WHICH
+# ONE ANSWERED. On 3.12+ a tokenizer walk is the oracle, because `compile()` there accepts the bad
+# form; below 3.12 `compile()` IS the oracle, because the bad form does not parse at all. Nothing
+# is conditional on an optional interpreter being installed — a check that skips when a dependency
+# is absent is the coverage gap this whole issue is about.
+port_out="$(nested_quote "$DRIVER")"
 port_marker="$(grep -m1 '^#COMPLETE ' <<<"$port_out")"
 if [ -n "$port_marker" ] && [ -z "$(findings_of "$port_out")" ]; then
-  pass "portable: every embedded block parses on EVERY interpreter this repo runs, not just this box ($port_marker)"
+  pass "nested-quote: no embedded block uses the 3.12-only nested SAME-TYPE quote spelling — the one alternative the driver's comment rejects ($port_marker)"
 else
-  fail "portable: an embedded block in $DRIVER uses a spelling that only parses on this box — $(findings_of "$port_out" | head -2)"
+  fail "nested-quote: an embedded block in $DRIVER uses the 3.12-only spelling — $(findings_of "$port_out" | head -2)"
 fi
 
 # --- CONTROL 2b-i: the 3.12-only spelling is REFUSED, and `compile` alone cannot see it ---------
 NESTED_DRIVER="$TMP/nested-quote-ws0-driver.sh"
 if defective_copy "$DRIVER" "$NESTED_DRIVER" pin_sha pin data_db_sha256 nested 2>"$TMP/inject-nested.err"; then
-  nest_port="$(portable "$NESTED_DRIVER")"
+  nest_port="$(nested_quote "$NESTED_DRIVER")"
   nest_comp="$(compile_blocks "$NESTED_DRIVER")"
   nest_oracle="$(sed -n 's/.*oracle=\([a-z]*\).*/\1/p' <<<"$nest_port" | head -1)"
-  if grep -q 'NOT PORTABLE' <<<"$nest_port"; then
-    pass "portable CONTROL fired: the nested SAME-TYPE quote spelling is REFUSED — $(grep -m1 'NOT PORTABLE' <<<"$nest_port" | cut -c1-118)"
+  if grep -q 'NESTED SAME-TYPE QUOTE' <<<"$nest_port"; then
+    pass "nested-quote CONTROL fired: the 3.12-only spelling is REFUSED — $(grep -m1 'NESTED SAME-TYPE QUOTE' <<<"$nest_port" | cut -c1-112)"
   else
-    fail "portable CONTROL did NOT fire: the 3.12-only spelling must be refused, got: $(findings_of "$nest_port" | head -2)"
+    fail "nested-quote CONTROL did NOT fire: the 3.12-only spelling must be refused, got: $(findings_of "$nest_port" | head -2)"
   fi
   # ...and WHY the new oracle earns its place, asserted rather than argued: on a 3.12+ box the
   # plain compile check is SILENT about this input. On an older box compile is the oracle and must
   # report it. Both branches assert; neither is a skip, and the pass line says which ran.
   if [ "$nest_oracle" = "tokenizer" ]; then
     if [ -z "$(findings_of "$nest_comp")" ]; then
-      pass "portable CONTROL discriminates: on this 3.12+ interpreter (oracle=tokenizer) the plain compile check is SILENT about the same input — so the portability oracle is doing work compile cannot"
+      pass "nested-quote CONTROL discriminates: on this 3.12+ interpreter (oracle=tokenizer) the plain compile check is SILENT about the same input — so the nested-quote oracle is doing work compile cannot"
     else
       fail "on a 3.12+ interpreter compile() must ACCEPT the nested spelling (that is the trap); it reported: $(findings_of "$nest_comp" | head -1)"
     fi
   else
     if grep -q 'DOES NOT COMPILE' <<<"$nest_comp"; then
-      pass "portable CONTROL discriminates: on this pre-3.12 interpreter (oracle=compile) the nested spelling does not parse at all, and the compile check reports it"
+      pass "nested-quote CONTROL discriminates: on this pre-3.12 interpreter (oracle=compile) the nested spelling does not parse at all, and the compile check reports it"
     else
       fail "on a pre-3.12 interpreter the nested spelling must fail to compile; it did not"
     fi
   fi
 else
-  fail "portable CONTROL: the nested-quote defect could not be injected — $(head -2 "$TMP/inject-nested.err")"
+  fail "nested-quote CONTROL: the defect could not be injected — $(head -2 "$TMP/inject-nested.err")"
 fi
 
 # --- CONTROL 2b-ii: THE ACCEPT DIRECTION — a DIFFERENT-type nested quote is legal everywhere -----
@@ -520,18 +562,62 @@ python3 - "$TMP" <<'INJECT'
 import pathlib, sys
 dq, sq = chr(34), chr(39)
 tmp = pathlib.Path(sys.argv[1])
-(tmp / "portable-ok.py").write_text(
+(tmp / "nested-quote-legal.py").write_text(
     "x = {'k': 1}\nprint(f" + dq + "{x[" + sq + "k" + sq + "]}" + dq + ")\n")
-(tmp / "portable-remedy.py").write_text(
+(tmp / "nested-quote-remedy.py").write_text(
     "x = {'k': 1}\nv = x['k']\nprint(f" + dq + "{v}" + dq + ")\n")
 INJECT
-ok_out="$(portable_source "$TMP/portable-ok.py")"
-rem_out="$(portable_source "$TMP/portable-remedy.py")"
+ok_out="$(nested_quote_source "$TMP/nested-quote-legal.py")"
+rem_out="$(nested_quote_source "$TMP/nested-quote-remedy.py")"
 if [ -z "$(findings_of "$ok_out")" ] && [ -z "$(findings_of "$rem_out")" ] \
    && grep -q '^#COMPLETE ' <<<"$ok_out" && grep -q '^#COMPLETE ' <<<"$rem_out"; then
-  pass "portable ACCEPT direction: a DIFFERENT-type nested quote (legal on every interpreter) and the local-binding remedy are BOTH clean — the check discriminates rather than refusing every subscript"
+  pass "nested-quote ACCEPT direction: a DIFFERENT-type nested quote (legal on every interpreter) and the local-binding remedy are BOTH clean — the check discriminates rather than refusing every subscript"
 else
-  fail "portable manufactured a finding on portable code: different-type='$(findings_of "$ok_out" | head -1)' remedy='$(findings_of "$rem_out" | head -1)'"
+  fail "nested-quote manufactured a finding on legal code: different-type='$(findings_of "$ok_out" | head -1)' remedy='$(findings_of "$rem_out" | head -1)'"
+fi
+
+# --- THE STATED LIMIT, PINNED BY MEASUREMENT ---------------------------------------------------
+# The check above decides ONE construct class. PEP 701 legalised others, and this case measures two
+# of them so the limit is a MEASUREMENT rather than a sentence someone hopes is still true:
+#
+#   a MULTILINE f-string expression            3.12 compiles it; this check is CLEAN
+#   a COMMENT inside an f-string expression    3.12 compiles it; this check is CLEAN
+#
+# Asserted deliberately in the NEGATIVE. It looks strange to assert that a check MISSES something,
+# and that is exactly its job: it binds the claim in this file's header to something falsifiable.
+# If someone later widens the oracle, THIS CASE REDS and they must come here and update the claim
+# — which is the only mechanism that stops the header's wording drifting away from the code.
+#
+# The remedy for the general property is NOT a deeper model here: it is compiling the blocks under
+# a REAL 3.9/3.11, a CI lane. Widening the tokenizer walk would make this a second implementation
+# of CPython's tokenizer, whose correctness is knowable only by differential testing against the
+# original — and the construct list does not close by enumeration, so each round would find the
+# next unnamed member.
+python3 - "$TMP" <<'INJECT'
+import pathlib, sys
+dq = chr(34)
+tmp = pathlib.Path(sys.argv[1])
+# A MULTILINE f-string expression: legal from 3.12, SyntaxError before it.
+(tmp / "pep701-multiline.py").write_text(
+    "x = {'k': 1}\nprint(f" + dq + "{x[\n    'k'\n]}" + dq + ")\n")
+# A COMMENT inside an f-string expression: same.
+(tmp / "pep701-comment.py").write_text(
+    "x = {'k': 1}\nprint(f" + dq + "{x['k']  # a comment\n}" + dq + ")\n")
+INJECT
+limit_missed=0
+limit_parses=0
+for limit_case in pep701-multiline pep701-comment; do
+  if python3 -c "import pathlib,sys; compile(pathlib.Path(sys.argv[1]).read_text(), 'x', 'exec')" \
+       "$TMP/$limit_case.py" 2>/dev/null; then
+    limit_parses=$((limit_parses + 1))
+  fi
+  [ -z "$(findings_of "$(nested_quote_source "$TMP/$limit_case.py")")" ] \
+    && limit_missed=$((limit_missed + 1))
+done
+if [ "$limit_missed" -eq 2 ]; then
+  pass "nested-quote STATED LIMIT (pinned): the 2 OTHER 3.12-only constructs measured here (a multiline f-string expression, a comment inside one) are NOT caught — the claim in this file's header is exactly this narrow, and widening the oracle without widening the claim REDS this case ($limit_parses/2 parse on this interpreter)"
+else
+  fail "nested-quote STATED LIMIT: $limit_missed of 2 known-uncaught constructs were still uncaught. If the oracle was WIDENED, that is good news — update this case AND the claim in the header and the gate comment, which currently say only the nested same-type quote spelling is decided"
 fi
 
 # ============================================================================

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -260,10 +260,53 @@ WS0_EXPECTED_CFG=(
   "events=cycles,instructions" "bin_dir=target/release" "profile=off"
   "quiescence=NOT VERIFIED (no timeseries supplied)"
 )
+# ...and the PIN side: the FIELD SET is derived from the driver, the VALUES are stated here
+# (#3451 post-rebase round 6, F3).
+#
+# The hand-written list omitted `topology_root` while the verification claimed every
+# driver-mapped pin field was compared. Adding the missing line fixes the symptom; the DEFECT is
+# that a list can be incomplete and nothing notices, so the NEXT field added to the driver would
+# be silently uncovered too.
+#
+# DERIVING THE VALUE AS WELL WAS THE OBVIOUS FIX AND IT IS CIRCULAR — I built it and measured it
+# failing. Pairing each field with the value of the variable THE DRIVER maps it to means a
+# swapped mapping supplies its own expectation: with
+# `WS0_PIN_TOPOLOGY_ROOT="$WS0_SERVER_SIBLINGS"` injected into the real driver, expected and
+# actual agreed and the suite passed. That is the artifact acting as its own oracle.
+#
+# So the two halves come from two sources, which is the shape that has held up everywhere in this
+# suite: the FIELD SET is read out of the driver (nothing can be uncovered) and the EXPECTED
+# VALUE is stated below (a wrong mapping is detectable), and the two sets are asserted EQUAL — so
+# a field added to the driver fails loudly for want of a stated expectation rather than passing
+# unchecked.
 WS0_EXPECTED_PIN=(
   "server_cpus=2,10" "client_cpus=4,12"
   "server_siblings_expanded=server cpu 2 siblings 2,10"
+  "topology_root=$TMP/fake-topology"
 )
+
+# driver_pin_fields <driver> — the record fields the CPU block sources from the ENVIRONMENT, read
+# out of the block itself (`"<field>": os.environ["WS0_PIN_<VAR>"]`). The completeness half.
+driver_pin_fields() {
+  python3 - "$REPO_ROOT/scripts/tests" "$1" <<'PY'
+import pathlib, re, sys
+sys.path.insert(0, sys.argv[1])
+from ws0_embedded_python import census
+
+records, _findings = census(pathlib.Path(sys.argv[2]))
+owners = [r for r in records if r["kind"] == "BLOCK" and "pinning_record_path" in r["body"]]
+if len(owners) != 1:
+    print(f"AMBIGUOUS: {len(owners)} block(s) write the pinning record", file=sys.stderr)
+    raise SystemExit(2)
+fields = re.findall(r'"([a-z_]+)":\s*os\.environ\["WS0_PIN_[A-Z_]+"\]', owners[0]["body"])
+if not fields:
+    print("NO MAPPING: the CPU-pin block no longer sources any record field from the"
+          " environment, so nothing can be derived — check the driver before relaxing this.",
+          file=sys.stderr)
+    raise SystemExit(3)
+print(" ".join(sorted(set(fields))))
+PY
+}
 
 # local_binding_of <driver> <block-needle> — the first `NAME = MAPPING["KEY"]` line in the block
 # that calls <block-needle>, printed as `NAME MAPPING KEY`.
@@ -787,6 +830,51 @@ if [ "$ctlword_rc" -eq 0 ] && [ "$ctlword_ok" -eq 1 ]; then
   pass "census CONTROL fired (control words): a leading if/time/! is STEPPED OVER so the real command word is judged — the indirect forms are findings while the same constructs leading a literal grep stay clean, which is why the words are skipped and not refused"
 else
   fail "census CONTROL did not fire (control words): fixture-rc=$ctlword_rc problems:$ctlword_detail"
+fi
+
+# --- STRUCTURAL: no consumer classifies from PHYSICAL text -------------------------------------
+# THE ONLY CHECK HERE THAT CAN STOP INSTANCE SIX. The joined-vs-physical inconsistency has
+# produced FIVE findings across five rounds — discovery vs classification, the flag anchor's
+# command word, the export prefix's question, a comment swallowing a live command, and the
+# `for … in` probe reading the wrong line. Each was fixed behaviourally, and behavioural cases
+# only ever cover the shapes someone already thought of, which is precisely why there were five.
+#
+# The rule is one sentence: the JOINED text is the representation for classification, comparison
+# and command-word extraction; the physical text may be used ONLY for diagnostics and line
+# numbers. Enforced by requiring every use of the physical-line variable inside `census` to carry
+# a `physical-ok:` marker naming why — so adding a classification that reads physical text fails
+# HERE, at the shape nobody thought of, rather than in a review round.
+#
+# Deliberately grep-shaped: the property is "which variable is read where", which is visible in
+# the source and needs no parse. A marker someone must write is also a decision someone must make.
+struct_out="$(python3 - "$REPO_ROOT/scripts/tests/ws0_embedded_python.py" <<'PY'
+import pathlib, re, sys
+src = pathlib.Path(sys.argv[1]).read_text().split("\n")
+try:
+    start = next(i for i, l in enumerate(src) if l.startswith("def census("))
+except StopIteration:
+    print("NO-SUBJECT: census() not found, so this assert has nothing to enforce")
+    raise SystemExit(0)
+end = next((i for i in range(start + 1, len(src)) if src[i].startswith("def ")), len(src))
+unmarked = [
+    f"{i + 1}: {src[i].strip()[:70]}"
+    for i in range(start, end)
+    if re.search(r"\bphysical_line\b", src[i]) and "physical-ok:" not in src[i]
+]
+# NON-VACUITY: the variable must EXIST, or an empty result would mean "renamed" rather than
+# "clean" — the guard would then pass by having no subject.
+present = sum(1 for i in range(start, end) if re.search(r"\bphysical_line\b", src[i]))
+print(f"present={present}")
+for u in unmarked:
+    print(f"UNMARKED {u}")
+PY
+)"
+struct_present="$(sed -n 's/^present=//p' <<<"$struct_out")"
+if [ "${struct_present:-0}" -ge 1 ] && ! grep -q '^UNMARKED' <<<"$struct_out" \
+   && ! grep -q '^NO-SUBJECT' <<<"$struct_out"; then
+  pass "STRUCTURAL (joined-vs-physical): all $struct_present use(s) of the physical line inside census() carry a physical-ok: marker — a classification added against physical text fails here rather than in a sixth review round"
+else
+  fail "STRUCTURAL (joined-vs-physical): $(grep -c '^UNMARKED' <<<"$struct_out") unmarked physical-text use(s) in census(), present=${struct_present:-0} — classification must read the JOINED line; mark a diagnostic-only use with physical-ok: $(grep '^UNMARKED' <<<"$struct_out" | head -2 | tr '\n' ' ')$(grep '^NO-SUBJECT' <<<"$struct_out")"
 fi
 
 # ============================================================================
@@ -1404,7 +1492,16 @@ fi
 # instead, a swap in ONE prefix was invisible; and because the manifest and the record were
 # validated INDEPENDENTLY, a MATCHING swap in both was invisible too. Reading one side from the
 # other is what makes a consistent swap detectable.
-if python3 - "$PERF_DIR" "$OUT" "${WS0_EXPECTED_PIN[@]}" <<'PY'
+# THE TWO SETS MUST AGREE before the values are compared: everything the driver maps must have a
+# stated expectation, and nothing stated may be absent from the driver.
+pin_derived="$(driver_pin_fields "$DRIVER")"
+pin_stated="$(printf '%s\n' "${WS0_EXPECTED_PIN[@]}" | sed 's/=.*//' | sort | tr '\n' ' ' | sed 's/ $//')"
+if [ -n "$pin_derived" ] && [ "$pin_derived" = "$pin_stated" ]; then
+  pass "cpu-pin field coverage: the fields the driver sources from the environment [$pin_derived] are EXACTLY those with a stated expected value — a field added to the driver cannot be silently uncovered, and the values stay independent of the driver's own mapping"
+else
+  fail "cpu-pin field coverage: the driver maps [$pin_derived] but expectations are stated for [$pin_stated]. A driver-mapped field with no stated value is UNCHECKED; a stated value for a field the driver no longer maps is a stale claim"
+fi
+if python3 - "$PERF_DIR" "$OUT" ${WS0_EXPECTED_PIN[@]+"${WS0_EXPECTED_PIN[@]}"} <<'PY'
 import json, pathlib, sys
 sys.path.insert(0, sys.argv[1])
 from ws0_pinning import PINNING_RECORD_FIELDS, pinning_record_path, verify_pinning_record
@@ -1545,21 +1642,30 @@ fi
 # `set -uo pipefail` (no `-e`) means a block that silently never executes lowers the count and
 # registers NO failure, while the gate reads only the exit code.
 #
-# A RATCHET AT THE ACTUAL COUNT, not a comfortable floor below it (#3451 post-rebase round 4,
-# F2). This sat at 26 while the suite ran 44, so an entire section — the CPU execution coverage,
-# say — could vanish and the floor would not notice. That is precisely the failure this guard
-# exists to catch, so a floor 18 below actual was a guard against nothing.
+# AN EXACT COUNT, FAILING IN BOTH DIRECTIONS (#3451 post-rebase round 6, F4).
 #
-# BUMP IT WHEN YOU ADD COVERAGE. It is a ratchet: a lower count means a case stopped running and
-# is a real failure, a higher one means you added a case and this constant is the one line to
-# update. Deliberate, and cheap, and it is the only thing standing between a deleted section and
-# a green suite.
-MIN_CHECKS=45
+# STILL NAMED `MIN_CHECKS`, and that is a cross-suite contract rather than a leftover:
+# `test_ws0_hermeticity.sh`'s `floor-present` check requires that identifier in every ws0 suite,
+# and renaming it here broke that sibling — measured. The comparison below is EQUALITY, which is
+# strictly stronger than the floor the lint is looking for, so the contract is met and the guard
+# is better than the name suggests.
+#
+# `-lt` made this a FLOOR, and a floor is satisfied by adding coverage without bumping it — after
+# which the new coverage can be deleted again and the stale floor still passes. It sat 18 below
+# actual for exactly that reason. Equality means a change in either direction is a decision
+# someone makes here, in one line, with the failure text saying which direction and why.
+MIN_CHECKS=47
 echo
-if [ "$checks" -lt "$MIN_CHECKS" ]; then
-  echo "FAIL - only $checks check(s) ran; this suite has at least $MIN_CHECKS."
-  echo "       A block that silently never executed would otherwise lower the count with no"
-  echo "       failure registered, and the gate reads only the exit code (#3451)."
+if [ "$checks" -ne "$MIN_CHECKS" ]; then
+  echo "FAIL - $checks check(s) ran; this suite has EXACTLY $MIN_CHECKS."
+  if [ "$checks" -lt "$MIN_CHECKS" ]; then
+    echo "       FEWER: a block silently never executed. It would otherwise lower the count with"
+    echo "       no failure registered, and the gate reads only the exit code (#3451)."
+  else
+    echo "       MORE: you added coverage. Bump MIN_CHECKS to $checks — deliberately, so the"
+    echo "       ratchet keeps holding. A floor would have accepted this silently, and the new"
+    echo "       coverage could then be deleted later while still meeting the stale floor."
+  fi
   exit 1
 fi
 if [ "$fails" -eq 0 ]; then

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -224,24 +224,21 @@ findings_of() {
 # bypass/merge), so `WS0_CFG_TEMPS="$ARMS"` yields `temps=bypass`, which `session_manifest_config`
 # refuses. The detector is production code, not a fixture expectation.
 driver_step_env() {
-  local prefix
-  prefix="$(python3 "$REPO_ROOT/scripts/tests/ws0_export_prefix.py" "$1" WS0_ "$2" --emit-prefix)" \
-    || return 1
-  (
-    # EVERY CONTROLLED VALUE IS DISTINCT (#3451 post-rebase round 5, F2). `REPS` and
-    # `SCAN_PASSES` were BOTH 1, so swapping their right-hand sides in the driver produced an
-    # identical environment and was undetectable — a VALUE COLLISION defeating the
-    # "execute on the driver's own values" mechanism while the mechanism itself was correct.
-    # 2 and 3 are both valid counts and cannot be confused for one another.
-    REPS=2; TEMPS=warm; ARMS=bypass; SCAN_PASSES=3
-    SERVER_CPUS=2,10; CLIENT_CPUS=4,12
-    STEP_DURATION=45s; COLD_STEP_DURATION=1s
-    FLIGHT_ENDPOINT="$WS0_FIXTURE_ENDPOINT"; BASELINE_MODE=non-baseline
-    EVENTS=cycles,instructions; BIN_DIR_RECORDED=target/release; PROFILE_RECORDED=off
-    QUIESCENCE_RECORDED="NOT VERIFIED (no timeseries supplied)"
-    WS0_SERVER_SIBLINGS="server cpu 2 siblings 2,10"; CPU_TOPOLOGY_ROOT="$TMP/fake-topology"
-    eval "$prefix env"
-  ) | grep -E '^WS0_(CFG|PIN)_'
+  # PARSED AND SUBSTITUTED, NEVER EVALUATED (#3451 post-rebase round 7, F3). The round-2 version
+  # ran `eval "$prefix env"` on the argument that the contiguity check bounded the input to
+  # `NAME=` words with no separator. MEASURED, that check ADMITS `WS0_CFG_X=$(helper)`,
+  # backticks and `${OTHER}` — all assignment-shaped, none containing a separator — so a driver
+  # line of that shape would have executed repository-derived shell inside a test documented as
+  # hermetic, in a mandatory gate component. `--resolve` parses a restricted grammar instead and
+  # refuses, by name, every construct it does not explicitly support.
+  python3 "$REPO_ROOT/scripts/tests/ws0_export_prefix.py" "$1" WS0_ "$2" --resolve \
+    REPS=2 TEMPS=warm ARMS=bypass SCAN_PASSES=3 \
+    SERVER_CPUS=2,10 CLIENT_CPUS=4,12 \
+    STEP_DURATION=45s COLD_STEP_DURATION=1s \
+    FLIGHT_ENDPOINT="$WS0_FIXTURE_ENDPOINT" BASELINE_MODE=non-baseline \
+    EVENTS=cycles,instructions BIN_DIR_RECORDED=target/release PROFILE_RECORDED=off \
+    "QUIESCENCE_RECORDED=NOT VERIFIED (no timeseries supplied)" \
+    "WS0_SERVER_SIBLINGS=server cpu 2 siblings 2,10" "CPU_TOPOLOGY_ROOT=$TMP/fake-topology"
 }
 
 # WHAT EACH RECORDED FIELD MUST BE, given the controlled inputs above (#3451 post-rebase round 5,
@@ -875,6 +872,79 @@ if [ "${struct_present:-0}" -ge 1 ] && ! grep -q '^UNMARKED' <<<"$struct_out" \
   pass "STRUCTURAL (joined-vs-physical): all $struct_present use(s) of the physical line inside census() carry a physical-ok: marker — a classification added against physical text fails here rather than in a sixth review round"
 else
   fail "STRUCTURAL (joined-vs-physical): $(grep -c '^UNMARKED' <<<"$struct_out") unmarked physical-text use(s) in census(), present=${struct_present:-0} — classification must read the JOINED line; mark a diagnostic-only use with physical-ok: $(grep '^UNMARKED' <<<"$struct_out" | head -2 | tr '\n' ' ')$(grep '^NO-SUBJECT' <<<"$struct_out")"
+fi
+
+# --- CONTROL 1k: the SKIP PATH IS AN ALLOWLIST, so an unanticipated word cannot slip through ---
+# Every silent absence this issue produced came through one door: "the command word is a literal
+# not containing python, therefore skip", which decides safety by what a word is NOT. That let
+# `if`, `-I`, `#`, `env` and `command` through — five spellings, five separate rounds. Skipping
+# now requires MEMBERSHIP of `_NON_PYTHON_DASH_C_COMMANDS`.
+#
+# BOTH DIRECTIONS, because an allowlist has the widest false-red surface of anything here: the
+# three previously-invisible forms must be findings, and every allowlisted command must still be
+# clean — including the driver's own `grep -c`, which is the one this suite would break first.
+python3 - "$TMP" <<'INJECT'
+import pathlib, sys
+q = chr(39)
+tmp = pathlib.Path(sys.argv[1])
+bad = q + "import os," + q
+(tmp / "skip-env.sh").write_text('env "$PY" -c ' + bad + "\n")
+(tmp / "skip-command.sh").write_text('command "$PY" -c ' + bad + "\n")
+(tmp / "skip-midcomment.sh").write_text("x=1 # comment " + chr(92) + "\n$PY -c " + bad + "\n")
+(tmp / "skip-grep.sh").write_text("grep -c " + q + "foo" + q + " file\n")
+(tmp / "skip-sort.sh").write_text("sort -cu file\n")
+(tmp / "skip-tar.sh").write_text("tar -cf out.tar dir\n")
+INJECT
+skip_rc=$?
+skip_ok=1
+skip_detail=""
+for skip_case in env command midcomment; do
+  [ -n "$(findings_of "$(census "$TMP/skip-$skip_case.sh")")" ] \
+    || { skip_ok=0; skip_detail="$skip_detail $skip_case(missed)"; }
+done
+for skip_case in grep sort tar; do
+  [ -z "$(findings_of "$(census "$TMP/skip-$skip_case.sh")")" ] \
+    || { skip_ok=0; skip_detail="$skip_detail $skip_case(false-red)"; }
+done
+if [ "$skip_rc" -eq 0 ] && [ "$skip_ok" -eq 1 ]; then
+  pass "census CONTROL fired (allowlisted skip): env, command and a mid-line comment are FINDINGS while every allowlisted command stays clean — skipping by membership, so the next unanticipated spelling cannot grant itself a skip by lacking a signal"
+else
+  fail "census CONTROL did not fire (allowlisted skip): fixture-rc=$skip_rc problems:$skip_detail"
+fi
+
+# --- CONTROL 1l: the assignment prefix is PARSED, and refuses what an eval would have run -------
+# Round 2 authorised evaluating the driver's prefix on the argument that the contiguity check
+# bounded the input to `NAME=` words with no separator. MEASURED, that check ADMITS
+# `WS0_CFG_X=$(helper)`, backticks and `${OTHER}` — all assignment-shaped, none containing a
+# separator — so repository-derived shell would have run inside a test documented as hermetic,
+# in a mandatory gate component. There is no eval now; a restricted grammar refuses each form BY
+# NAME, and this control is what keeps that true.
+grammar_ok=1
+grammar_detail=""
+for grammar_case in 'subst=$(helper)' 'backtick=`helper`' 'unknown=${OTHER}'; do
+  grammar_label="${grammar_case%%=*}"
+  grammar_value="${grammar_case#*=}"
+  GRAMMAR_DRV="$TMP/grammar-$grammar_label-driver.sh"
+  python3 - "$DRIVER" "$GRAMMAR_DRV" "$grammar_value" <<'INJECT'
+import pathlib, sys
+text = pathlib.Path(sys.argv[1]).read_text()
+needle = 'WS0_CFG_REPS="$REPS"'
+if text.count(needle) != 1:
+    print(f"INJECTION IMPOSSIBLE: {needle} occurs {text.count(needle)} time(s)", file=sys.stderr)
+    raise SystemExit(1)
+pathlib.Path(sys.argv[2]).write_text(text.replace(needle, "WS0_CFG_REPS=" + sys.argv[3]))
+INJECT
+  if [ $? -ne 0 ]; then
+    grammar_ok=0; grammar_detail="$grammar_detail $grammar_label(not-injected)"; continue
+  fi
+  if driver_step_env "$GRAMMAR_DRV" write_session_corpus_pin >/dev/null 2>&1; then
+    grammar_ok=0; grammar_detail="$grammar_detail $grammar_label(ADMITTED)"
+  fi
+done
+if [ "$grammar_ok" -eq 1 ]; then
+  pass "grammar CONTROL fired: command substitution, backticks and an unknown parameter reference are each REFUSED by the prefix parser — the constructs the round-2 eval would have executed, and which its stated safety bound did not exclude"
+else
+  fail "grammar CONTROL did not fire:$grammar_detail — an unsupported assignment form was accepted, which is the hermeticity breach this replaced"
 fi
 
 # ============================================================================
@@ -1654,7 +1724,7 @@ fi
 # which the new coverage can be deleted again and the stale floor still passes. It sat 18 below
 # actual for exactly that reason. Equality means a change in either direction is a decision
 # someone makes here, in one line, with the failure text saying which direction and why.
-MIN_CHECKS=47
+MIN_CHECKS=49
 echo
 if [ "$checks" -ne "$MIN_CHECKS" ]; then
   echo "FAIL - $checks check(s) ran; this suite has EXACTLY $MIN_CHECKS."

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -247,6 +247,37 @@ else
   fail "census CONTROL did not fire: the block locator must report ABSENT when its subject is not in the driver"
 fi
 
+# --- POSITIVE CONTROL 1d: a FUTURE step written as a heredoc is censused and compiled ----------
+# The driver carries no python heredoc today. The census handles the shape anyway, and an
+# unexercised branch in a fail-closed extractor is exactly the code that is discovered to be broken
+# by the first person who needs it — which is the complaint #3451 records. So the shape is
+# exercised against a scratch copy: the block must be COUNTED, and a defect inside it must be
+# REPORTED, or a step added that way would fall outside the compile check entirely.
+HEREDOC_DRIVER="$TMP/heredoc-step-ws0-driver.sh"
+python3 - "$DRIVER" "$HEREDOC_DRIVER" <<'INJECT'
+import pathlib, sys
+# A minimal future step in the heredoc shape, carrying the same defect class the two `-c` steps
+# shipped: a subscript inside an f-string expression, built from character codes so that no
+# committed file holds a literal example of the spelling.
+backslash, dquote = chr(92), chr(34)
+bad = "{d[" + backslash + dquote + "k" + backslash + dquote + "]}"
+tag = "PY" + "STEP"
+step = ("python3 - \"$OUT_DIR\" <<'" + tag + "'\n"
+        "d = {'k': 1}\n"
+        "print(f'" + bad + "')\n"
+        + tag + "\n")
+pathlib.Path(sys.argv[2]).write_text(pathlib.Path(sys.argv[1]).read_text() + step)
+INJECT
+hd_census="$(census "$HEREDOC_DRIVER")"
+hd_compile="$(compile_blocks "$HEREDOC_DRIVER")"
+hd_blocks="$(grep -c '^BLOCK	' <<<"$hd_census")"
+if [ "$hd_blocks" -eq "$((block_count + 1))" ] && grep -q 'heredoc' <<<"$hd_census" \
+   && grep -q 'DOES NOT COMPILE' <<<"$hd_compile"; then
+  pass "census CONTROL fired (heredoc shape): a step written as a python heredoc is COUNTED ($hd_blocks blocks) and a defect inside it is REPORTED — a future step in that shape cannot fall outside the compile check"
+else
+  fail "census CONTROL did not fire (heredoc shape): blocks=$hd_blocks (expected $((block_count + 1))), compile said: $(findings_of "$hd_compile" | head -2)"
+fi
+
 # ============================================================================
 # PART 2 — THE TOTAL PROPERTY: EVERY EMBEDDED BLOCK COMPILES
 # ============================================================================

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -228,7 +228,12 @@ driver_step_env() {
   prefix="$(python3 "$REPO_ROOT/scripts/tests/ws0_export_prefix.py" "$1" WS0_ "$2" --emit-prefix)" \
     || return 1
   (
-    REPS=1; TEMPS=warm; ARMS=bypass; SCAN_PASSES=1
+    # EVERY CONTROLLED VALUE IS DISTINCT (#3451 post-rebase round 5, F2). `REPS` and
+    # `SCAN_PASSES` were BOTH 1, so swapping their right-hand sides in the driver produced an
+    # identical environment and was undetectable — a VALUE COLLISION defeating the
+    # "execute on the driver's own values" mechanism while the mechanism itself was correct.
+    # 2 and 3 are both valid counts and cannot be confused for one another.
+    REPS=2; TEMPS=warm; ARMS=bypass; SCAN_PASSES=3
     SERVER_CPUS=2,10; CLIENT_CPUS=4,12
     STEP_DURATION=45s; COLD_STEP_DURATION=1s
     FLIGHT_ENDPOINT="$WS0_FIXTURE_ENDPOINT"; BASELINE_MODE=non-baseline
@@ -238,6 +243,27 @@ driver_step_env() {
     eval "$prefix env"
   ) | grep -E '^WS0_(CFG|PIN)_'
 }
+
+# WHAT EACH RECORDED FIELD MUST BE, given the controlled inputs above (#3451 post-rebase round 5,
+# F2). Distinct values are only half the fix: they make a swap PRODUCE a different artifact, and
+# these assertions are what NOTICE it. Without them a swap between two fields the same validator
+# accepts — `server_siblings_expanded` and `topology_root` are both just non-empty strings —
+# still passes every shipped check.
+#
+# This is not a restatement of the driver's mapping. It is the definition of the controlled
+# experiment: "the manifest's `temps` must be the value I put in the variable the driver reads
+# for `temps`". A swapped right-hand side breaks exactly that.
+WS0_EXPECTED_CFG=(
+  "reps=2" "temps=warm" "arms=bypass" "scan_passes=3"
+  "server_cpus=2,10" "client_cpus=4,12" "step_duration=45s/1s"
+  "flight_endpoint=$WS0_FIXTURE_ENDPOINT" "baseline_mode=non-baseline"
+  "events=cycles,instructions" "bin_dir=target/release" "profile=off"
+  "quiescence=NOT VERIFIED (no timeseries supplied)"
+)
+WS0_EXPECTED_PIN=(
+  "server_cpus=2,10" "client_cpus=4,12"
+  "server_siblings_expanded=server cpu 2 siblings 2,10"
+)
 
 # local_binding_of <driver> <block-needle> — the first `NAME = MAPPING["KEY"]` line in the block
 # that calls <block-needle>, printed as `NAME MAPPING KEY`.
@@ -1128,7 +1154,7 @@ done
 # ...and the SHIPPED READER accepts what the SHIPPED STEP wrote. A writer/reader round trip is the
 # one thing no fixture-fed reject case can establish, and it is where a disagreement surfaces as a
 # refusal blaming the operator.
-if python3 - "$PERF_DIR" "$OUT" "$CORPUS" <<'PY'
+if python3 - "$PERF_DIR" "$OUT" "$CORPUS" "${WS0_EXPECTED_CFG[@]}" <<'PY'
 import pathlib, sys
 sys.path.insert(0, sys.argv[1])
 from ws0_report import ARMS_ALLOWED, TEMPS_ALLOWED
@@ -1142,8 +1168,24 @@ report = verify_session_corpus_pin(session, corpus, load_corpus_identity(corpus)
 # checks corpus identity and says nothing about the configuration, so a manifest the real reporter
 # would refuse passed here. `session_manifest_config` is what `ws0_report.py:250` calls.
 cfg = session_manifest_config(session, TEMPS_ALLOWED, ARMS_ALLOWED)
-assert cfg.get("flight_endpoint", "").startswith("http://"), cfg
-assert cfg.get("reps") == 1 and cfg.get("scan_passes") == 1, cfg
+# EVERY field against its expected value, independently. A swap between two fields the same
+# validator accepts is invisible to the validator and visible only here.
+# argv: 1=perf dir, 2=session, 3=corpus, 4.. = the expected `field=value` pairs.
+expected = dict(pair.split("=", 1) for pair in sys.argv[4:])
+assert expected, "no expected fields were passed; this check would assert nothing"
+# The reader NORMALISES the selection fields into lists (`temps` -> ['warm'], `events` ->
+# ['cycles','instructions']), so the comparison joins a list back to the comma form the driver
+# was handed. That is a comparison SHAPE, not a weakening: a swapped right-hand side still
+# yields a different joined string.
+def _norm(value):
+    if isinstance(value, (list, tuple)):
+        return ",".join(str(item) for item in value)
+    return str(value)
+
+mismatched = {
+    k: (cfg.get(k), v) for k, v in expected.items() if _norm(cfg.get(k)) != v
+}
+assert not mismatched, f"manifest fields differ from the controlled inputs: {mismatched}"
 # The reader's own report, asserted field by field so this case cannot pass on a verifier that
 # returned an empty dict: the pin was taken BEFORE measurement, and it carries the digests of the
 # corpus, the schema and the Flight ticket the step measured from disk.
@@ -1362,10 +1404,10 @@ fi
 # instead, a swap in ONE prefix was invisible; and because the manifest and the record were
 # validated INDEPENDENTLY, a MATCHING swap in both was invisible too. Reading one side from the
 # other is what makes a consistent swap detectable.
-if python3 - "$PERF_DIR" "$OUT" <<'PY'
-import pathlib, sys
+if python3 - "$PERF_DIR" "$OUT" "${WS0_EXPECTED_PIN[@]}" <<'PY'
+import json, pathlib, sys
 sys.path.insert(0, sys.argv[1])
-from ws0_pinning import PINNING_RECORD_FIELDS, verify_pinning_record
+from ws0_pinning import PINNING_RECORD_FIELDS, pinning_record_path, verify_pinning_record
 from ws0_report import ARMS_ALLOWED, TEMPS_ALLOWED
 from ws0_session import session_manifest_config
 session = pathlib.Path(sys.argv[2])
@@ -1374,9 +1416,20 @@ config = session_manifest_config(session, TEMPS_ALLOWED, ARMS_ALLOWED)
 rec = verify_pinning_record(session, config["server_cpus"], config["client_cpus"])
 missing = [f for f in PINNING_RECORD_FIELDS if not rec.get(f)]
 assert not missing, missing
+# ...AND EACH RECORDED FIELD AGAINST ITS CONTROLLED INPUT (#3451 post-rebase round 5, F2).
+# `server_siblings_expanded` and `topology_root` are both just non-empty strings to the shipped
+# validator, so swapping their right-hand sides in the driver passes every check above. Only
+# comparing each field to the value it was GIVEN can tell them apart.
+written = json.loads(pinning_record_path(session).read_text())
+expected = dict(pair.split("=", 1) for pair in sys.argv[3:])
+assert expected, "no expected pin fields were passed; this check would assert nothing"
+mismatched = {
+    k: (written.get(k), v) for k, v in expected.items() if str(written.get(k)) != v
+}
+assert not mismatched, f"pinning-record fields differ from the controlled inputs: {mismatched}"
 PY
 then
-  pass "EXECUTE cpu-pin-verification: the SHIPPED READER accepts the record the shipped STEP wrote, and its pins are checked against the CPU lists THE SESSION MANIFEST records — the two steps are cross-checked against each other rather than each against the same fixture constants"
+  pass "EXECUTE cpu-pin-verification: the SHIPPED READER accepts the record the shipped STEP wrote; its pins are checked against the CPU lists THE SESSION MANIFEST records (the two steps cross-checked against each other, not each against the same constants), and every recorded field against the distinct value it was given"
 else
   fail "EXECUTE cpu-pin-verification: the shipped reader refused the record the shipped step wrote, or its pins disagree with the manifest the session-pin step produced"
 fi

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -129,7 +129,19 @@ command -v python3 >/dev/null 2>&1 || {
 # shellcheck source=scripts/tests/lib-ws0-fixtures.sh
 source "$REPO_ROOT/scripts/tests/lib-ws0-fixtures.sh"
 
-TMP="$(mktemp -d)"
+# A NAMED TEMPLATE, and the result VERIFIED before anything derives a path from it or a trap is
+# installed. This file is `set -uo pipefail` with no `-e`, so an unchecked `mktemp -d` failure
+# would leave `$TMP` EMPTY: every path below becomes an absolute one (`/corpus`, `/session`,
+# `/step-output.txt`), a privileged runner writes persistent artifacts at the filesystem root, and
+# `cleanup` then `rm -rf`s a path built the same way. Non-empty AND an existing directory, checked
+# BEFORE `trap`, is the whole fix.
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/ws0-embedded-steps.XXXXXX")" || TMP=""
+if [ -z "$TMP" ] || [ ! -d "$TMP" ]; then
+  echo "FAIL - could not create a scratch directory under ${TMPDIR:-/tmp}; refusing to run, because"
+  echo "       every path below would otherwise be built from an EMPTY prefix and the cleanup trap"
+  echo "       would rm -rf it."
+  exit 1
+fi
 cleanup() { rm -rf "$TMP"; }
 trap cleanup EXIT
 # Where an executed step's combined output lands. A FILE rather than a command substitution, so
@@ -482,7 +494,10 @@ control_compile() { # control_compile <label> <placeholder> <mapping> <key>
     return
   fi
   out="$(compile_blocks "$dest")"
-  if grep -q 'DOES NOT COMPILE' <<<"$out" && grep -q 'unexpected character after line continuation' <<<"$out"; then
+  # Asserts the FAILURE and its CLASS, never CPython's phrasing: the wording of that diagnostic is
+  # interpreter-specific, so grepping it would red on the 3.9-3.11 this repository pins. Both
+  # tokens are produced by the checker itself (`DOES NOT COMPILE`, and the exception class name).
+  if grep -q 'DOES NOT COMPILE' <<<"$out" && grep -q 'SyntaxError' <<<"$out"; then
     pass "compile CONTROL fired ($label): $(grep 'DOES NOT COMPILE' <<<"$out" | head -1 | cut -c1-120)"
   else
     fail "compile CONTROL did NOT fire ($label): the injected defect must be reported, got: $(findings_of "$out" | head -2)"
@@ -606,6 +621,7 @@ tmp = pathlib.Path(sys.argv[1])
 INJECT
 limit_missed=0
 limit_parses=0
+limit_oracle="$(sed -n 's/.*oracle=\([a-z]*\).*/\1/p' <<<"$(nested_quote_source "$TMP/pep701-multiline.py")" | head -1)"
 for limit_case in pep701-multiline pep701-comment; do
   if python3 -c "import pathlib,sys; compile(pathlib.Path(sys.argv[1]).read_text(), 'x', 'exec')" \
        "$TMP/$limit_case.py" 2>/dev/null; then
@@ -614,10 +630,29 @@ for limit_case in pep701-multiline pep701-comment; do
   [ -z "$(findings_of "$(nested_quote_source "$TMP/$limit_case.py")")" ] \
     && limit_missed=$((limit_missed + 1))
 done
-if [ "$limit_missed" -eq 2 ]; then
-  pass "nested-quote STATED LIMIT (pinned): the 2 OTHER 3.12-only constructs measured here (a multiline f-string expression, a comment inside one) are NOT caught — the claim in this file's header is exactly this narrow, and widening the oracle without widening the claim REDS this case ($limit_parses/2 parse on this interpreter)"
+# WHICH ANSWER IS CORRECT DEPENDS ON THE ORACLE THAT ANSWERED, and the marker reports it — so the
+# expectation is derived from `oracle=` rather than from the interpreter this box happens to have.
+# Under the TOKENIZER oracle (3.12+) both constructs are missed, which is the limit being pinned.
+# Under the COMPILE fallback (< 3.12) they do not parse at all, so that oracle CATCHES them and
+# the limit does not arise. Asserting "missed" unconditionally would have red on 3.11.
+if [ "$limit_oracle" = "tokenizer" ]; then
+  if [ "$limit_missed" -eq 2 ]; then
+    pass "nested-quote STATED LIMIT (pinned, oracle=tokenizer): the 2 OTHER 3.12-only constructs measured here (a multiline f-string expression, a comment inside one) are NOT caught — the claim in this file's header is exactly this narrow, and widening the oracle without widening the claim REDS this case ($limit_parses/2 parse on this interpreter)"
+  else
+    fail "nested-quote STATED LIMIT: under oracle=tokenizer, $limit_missed of 2 known-uncaught constructs were still uncaught. If the oracle was WIDENED, that is good news — update this case AND the claim in the header and the gate comment, which currently say only the nested same-type quote spelling is decided"
+  fi
+elif [ "$limit_oracle" = "compile" ]; then
+  # ONE conjunct, deliberately: under the compile fallback the property is simply that the
+  # constructs are CAUGHT, so the 3.12-only limit does not arise. Whether they also fail to parse
+  # is the same interpreter fact restated through a second probe, and asserting it would be one
+  # more thing to be wrong about on a box this suite cannot reach. `$limit_parses` is reported.
+  if [ "$limit_missed" -eq 0 ]; then
+    pass "nested-quote STATED LIMIT (oracle=compile, pre-3.12): both constructs are CAUGHT by the fallback oracle, so the 3.12-only limit does not arise — the limit is a property of the tokenizer oracle, not a claim about every box ($limit_parses/2 parse here)"
+  else
+    fail "nested-quote STATED LIMIT: under oracle=compile the constructs must be CAUGHT, but $limit_missed of 2 were missed"
+  fi
 else
-  fail "nested-quote STATED LIMIT: $limit_missed of 2 known-uncaught constructs were still uncaught. If the oracle was WIDENED, that is good news — update this case AND the claim in the header and the gate comment, which currently say only the nested same-type quote spelling is decided"
+  fail "nested-quote STATED LIMIT: the marker reported no recognisable oracle ('$limit_oracle'), so this case cannot say which answer is correct — an unanswerable oracle must not read as a clean answer"
 fi
 
 # ============================================================================
@@ -653,17 +688,31 @@ fi
 # `ws0_session.MANIFEST_CONFIG_FIELDS`, so this suite must not carry a guessed list: the key set
 # below is asserted EQUAL to the shipped tuple, and a field added there without a value here is a
 # failure rather than a step refusing at run time for a reason nobody expected.
-declare -A CFG=(
-  [reps]=1 [temps]=warm [arms]=bypass [scan_passes]=1
-  [server_cpus]=2,10 [client_cpus]=4,12 [step_duration]=45s/1s
-  [flight_endpoint]=grpc://127.0.0.1:1
+# An INDEXED array of `name=value`, not `declare -A`: associative arrays are bash 4.0+, and macOS
+# ships /bin/bash 3.2, which this repository treats as a supported target (see
+# `test_agent_gate_tree_portability.sh` and the `BASH_VERSINFO` probe in
+# `test_agent_gate_delta.sh`). This file was the only ws0 suite using one, so it would have failed
+# `tooling-tests` there. ONE source of truth still — the names are derived from the pairs by
+# `cfg_names`, so a value and its key cannot drift apart.
+CFG_PAIRS=(
+  "reps=1" "temps=warm" "arms=bypass" "scan_passes=1"
+  "server_cpus=2,10" "client_cpus=4,12" "step_duration=45s/1s"
+  "flight_endpoint=grpc://127.0.0.1:1"
   # `non-baseline`, and that is the only honest value available here: this is a few-KB synthetic
   # corpus, and the shipped `require_canonical_or_declared` REFUSES a divergent corpus in
   # `baseline` mode — correctly. Declaring the mode is the supported way past it, not a way round
   # it: the step still runs the real comparison and records every divergence it finds.
-  [baseline_mode]=non-baseline
+  "baseline_mode=non-baseline"
 )
-cfg_keys="$(printf '%s\n' "${!CFG[@]}" | sort | tr '\n' ' ')"
+cfg_names() { local pair; for pair in "${CFG_PAIRS[@]}"; do printf '%s\n' "${pair%%=*}"; done; }
+cfg_value() {
+  local pair
+  for pair in "${CFG_PAIRS[@]}"; do
+    [ "${pair%%=*}" = "$1" ] && { printf '%s' "${pair#*=}"; return 0; }
+  done
+  return 1
+}
+cfg_keys="$(cfg_names | sort | tr '\n' ' ')"
 shipped_keys="$(python3 - "$PERF_DIR" <<'PY'
 import sys
 sys.path.insert(0, sys.argv[1])
@@ -770,7 +819,7 @@ run_pin_step() {
   # after the assignments is taken as a command to execute (measured: `env: -u: No such file or
   # directory`, rc 127) — a control that dies before reaching its subject.
   local -a unset_args=() env_args=()
-  for field in "${!CFG[@]}"; do
+  for field in $(cfg_names); do
     if [ "$field" = "$omit" ]; then
       # UNSET, not merely "not passed" (#3451 review round 1, finding 3). `env` INHERITS the
       # caller environment, so omitting the assignment leaves a value the operator happened to
@@ -780,12 +829,16 @@ run_pin_step() {
       unset_args+=("-u" "WS0_CFG_$(echo "$field" | tr '[:lower:]' '[:upper:]')")
       continue
     fi
-    env_args+=("WS0_CFG_$(echo "$field" | tr '[:lower:]' '[:upper:]')=${CFG[$field]}")
+    env_args+=("WS0_CFG_$(echo "$field" | tr '[:lower:]' '[:upper:]')=$(cfg_value "$field")")
   done
   idx="$(find_block "$drv" 'write_session_corpus_pin')"
   [[ "$idx" =~ ^[0-9]+$ ]] || { run_pin_rc=90; echo "block not located: $idx" > "$STEP_OUT"; return; }
   body="$(emit_block "$drv" "$idx")"
-  env "${unset_args[@]}" "${env_args[@]}" python3 -c "$body" "$PERF_DIR" "$CORPUS" "$out" \
+  # `${arr[@]+"${arr[@]}"}` — an EMPTY array expands to NOTHING under `set -u` instead of
+  # aborting the shell, which is the repo-wide idiom (`test_fetch_datasets_tracked_guard.sh`).
+  # `unset_args` is empty on every call that omits nothing.
+  env ${unset_args[@]+"${unset_args[@]}"} "${env_args[@]}" \
+    python3 -c "$body" "$PERF_DIR" "$CORPUS" "$out" \
     "$REPO_ROOT" > "$STEP_OUT" 2>&1
   run_pin_rc=$?
 }
@@ -914,7 +967,8 @@ run_cpu_step() { # run_cpu_step <driver> <out-dir>
   idx="$(find_block "$drv" 'pinning_record_path')"
   [[ "$idx" =~ ^[0-9]+$ ]] || { run_cpu_rc=90; echo "block not located: $idx" > "$STEP_OUT"; return; }
   body="$(emit_block "$drv" "$idx")"
-  env WS0_PIN_SERVER_CPUS="${CFG[server_cpus]}" WS0_PIN_CLIENT_CPUS="${CFG[client_cpus]}" \
+  env WS0_PIN_SERVER_CPUS="$(cfg_value server_cpus)" \
+      WS0_PIN_CLIENT_CPUS="$(cfg_value client_cpus)" \
       WS0_PIN_SIBLINGS="server cpu 2 siblings 2,10; server cpu 10 siblings 2,10" \
       WS0_PIN_TOPOLOGY_ROOT="$TMP/fake-topology" \
       python3 -c "$body" "$PERF_DIR" "$out" > "$STEP_OUT" 2>&1
@@ -940,7 +994,7 @@ if grep -q 'pinning pin:' <<<"$cpu_out"; then
 else
   fail "EXECUTE cpu-pin-verification: the step did not print 'pinning pin:' (output: $(head -3 <<<"$cpu_out"))"
 fi
-if python3 - "$PERF_DIR" "$OUT" "${CFG[server_cpus]}" "${CFG[client_cpus]}" <<'PY'
+if python3 - "$PERF_DIR" "$OUT" "$(cfg_value server_cpus)" "$(cfg_value client_cpus)" <<'PY'
 import pathlib, sys
 sys.path.insert(0, sys.argv[1])
 from ws0_pinning import PINNING_RECORD_FIELDS, verify_pinning_record

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -56,6 +56,11 @@
 #     a driver export is a failure here rather than a refusal at report time;
 #   * EVERY embedded block in the driver COMPILES — the total property, so instance #8 anywhere in
 #     that file is caught and not only the two steps this issue repaired.
+#   * the extractor's delimiter in BOTH directions: it reports a defect, AND it does not
+#     manufacture one on good input. A block is delimited by bash's quoting rules rather than by a
+#     line pattern, so all three closer shapes this repository actually uses are handled — the
+#     column-0 closer, the closer at the end of the last body line with bash arguments trailing,
+#     and the `'"'"'` literal-apostrophe idiom mid-body.
 #
 # NOT REACHED (and therefore NOT claimed):
 #   * the driver's SHELL path into these steps. Reaching them in situ means passing the CPU-sibling
@@ -162,15 +167,19 @@ else
 fi
 
 block_count="$(grep -c '^BLOCK	' <<<"$census_out")"
-# A FLOOR, not an equality. Equality would red on a legitimately-added block while adding no
-# safety: the TOTAL compile property below covers any new block whatever the count, and the two
-# SUBJECT blocks are identified by content (next check) rather than by position. What the floor
-# catches is wholesale extractor breakage — a census that suddenly sees one block, or none.
-MIN_BLOCKS=3
-if [ "$block_count" -ge "$MIN_BLOCKS" ]; then
-  pass "census: $block_count embedded python block(s) found in the driver (floor $MIN_BLOCKS)"
+# EXACTLY the blocks this driver carries, not a floor. An under-count is the vacuous-green shape
+# and a floor cannot see it once the floor is met: a delimiter that silently stopped recognising
+# one shape would drop that block from BOTH the census and the compile check while the count still
+# cleared a floor. (MEASURED tree-wide while building this: a column-0-only closer rule found 31
+# blocks where the correct rule finds 59 — a loose delimiter under-counts SUBJECTS, it does not
+# merely mis-cut them.) The three are the two fatal pin STEPS plus the inline monotonic-clock read.
+# Adding an embedded step to this driver is a deliberate act, so bump this constant deliberately;
+# the compile property below then covers the new block automatically.
+EXPECTED_BLOCKS=3
+if [ "$block_count" -eq "$EXPECTED_BLOCKS" ]; then
+  pass "census: exactly $block_count embedded python block(s) in the driver — the 2 fatal pin steps plus the inline monotonic-clock read"
 else
-  fail "census: only $block_count embedded block(s) found in $DRIVER; this driver carries at least $MIN_BLOCKS, so the extractor is not seeing its subject"
+  fail "census: $block_count embedded block(s) found in $DRIVER, expected $EXPECTED_BLOCKS. If a step was ADDED, bump EXPECTED_BLOCKS; if the count DROPPED, the extractor has stopped seeing a shape and the missing block is being compiled by nothing"
 fi
 
 # WHICH block is which, by CONTENT. The two steps are located by a shipped symbol each body calls,
@@ -204,22 +213,31 @@ else
 fi
 
 # --- POSITIVE CONTROL 1a: a block that cannot be DELIMITED is a finding, not a silent skip -----
-# The closing-quote line of the corpus-pin block is deleted in a scratch copy. Extracting to
+# A scratch copy truncated at the opening quote of the first embedded block, with a body that
+# contains no apostrophe of its own, so the shell string is genuinely never closed. Extracting to
 # end-of-file would compile a truncated body and report a defect that is the extractor's own, so
 # the extractor must refuse instead.
+#
+# The construction targets the scanner's end-of-file branch DIRECTLY. An earlier version of this
+# control deleted every line beginning with a quote, which stopped working the moment the
+# delimiter learned bash's real rule (any later quote in the file closes the string) — a control
+# that silently stopped constructing its own subject, which is the class this suite exists to
+# refuse. It failed loudly, which is the floor working.
 UNDELIMITED="$TMP/undelimited-ws0-driver.sh"
-python3 - "$DRIVER" "$UNDELIMITED" <<'PY'
+python3 - "$DRIVER" "$UNDELIMITED" <<'INJECT'
 import pathlib, sys
-lines = pathlib.Path(sys.argv[1]).read_text().split("\n")
-# Every line that CLOSES an embedded block (a leading single quote) is removed, which is the
-# shape a mis-edited driver leaves behind.
-pathlib.Path(sys.argv[2]).write_text("\n".join(l for l in lines if not l.startswith("'")))
-PY
+text = pathlib.Path(sys.argv[1]).read_text()
+q = chr(39)
+opener = "python3 -c " + q + "\n"
+i = text.index(opener)
+# Everything through the opening quote, then a body with no quote anywhere in it and no closer.
+pathlib.Path(sys.argv[2]).write_text(text[: i + len(opener)] + "import sys\nprint(1)\n")
+INJECT
 und_out="$(census "$UNDELIMITED")"
-if [ -n "$(findings_of "$und_out")" ] && grep -q 'cannot be delimited' <<<"$und_out"; then
-  pass "census CONTROL fired: an undelimited block is a FINDING — $(findings_of "$und_out" | head -1 | cut -c1-110)"
+if [ -n "$(findings_of "$und_out")" ] && grep -q 'never closed' <<<"$und_out"; then
+  pass "census CONTROL fired: an unterminated block is a FINDING — $(findings_of "$und_out" | head -1 | cut -c1-110)"
 else
-  fail "census CONTROL did not fire: an undelimited embedded block must be a finding, got: $(head -3 <<<"$und_out")"
+  fail "census CONTROL did not fire: an unterminated embedded block must be a finding, got: $(head -3 <<<"$und_out")"
 fi
 
 # --- POSITIVE CONTROL 1b: an UNRECOGNISED python3 shape is a finding ---------------------------
@@ -245,6 +263,62 @@ if [ "$(find_block "$NO_PIN_STEP" 'write_session_corpus_pin')" = "ABSENT" ]; the
   pass "census CONTROL fired: with the session-pin writer gone from the driver, the locator reports ABSENT rather than picking another block"
 else
   fail "census CONTROL did not fire: the block locator must report ABSENT when its subject is not in the driver"
+fi
+
+# --- CONTROL 1c-bis: THE OTHER DIRECTION — the extractor must not MANUFACTURE a finding --------
+# Every control above observes the census REPORTING something. A delimiter can also be wrong the
+# other way, and that failure is worse in practice: it reds the gate on correct code, and a key
+# that reds on correct input is the key agents learn to waive.
+#
+# The subject is a REAL sibling that carries the `'"'"'` idiom — the bash spelling that closes the
+# single-quoted string, emits a literal apostrophe from a double-quoted segment and reopens. A
+# delimiter that stops at the next quote cuts that block mid-body. `lib-ws0-fixtures.sh` says so
+# itself, at the line that uses it: mishandling it "silently truncated this whole library — and it
+# presented as every OTHER case in the suite failing on an absent pinning-verification.json."
+#
+# MEASURED, and this is why the file is the control rather than an illustration: under a
+# next-quote delimiter this file yields exactly ONE false `SyntaxError` ('{' was never closed).
+IDIOM_FILE="$REPO_ROOT/scripts/tests/lib-ws0-fixtures.sh"
+idiom_census="$(census "$IDIOM_FILE")"
+idiom_compile="$(compile_blocks "$IDIOM_FILE")"
+idiom_blocks="$(grep -c '^BLOCK	' <<<"$idiom_census")"
+idiom_apostrophe=0
+for ((bn = 1; bn <= idiom_blocks; bn++)); do
+  emit_block "$IDIOM_FILE" "$bn" | grep -q "'" && idiom_apostrophe=1
+done
+if [ "$idiom_blocks" -ge 1 ] && [ -z "$(findings_of "$idiom_census")" ] \
+   && [ -z "$(findings_of "$idiom_compile")" ] && [ "$idiom_apostrophe" -eq 1 ]; then
+  pass "census NO-FALSE-FINDING: $idiom_blocks block(s) in lib-ws0-fixtures.sh (which uses the literal-apostrophe idiom) are delimited and ALL COMPILE — the extractor rejoins the idiom instead of cutting the body there"
+else
+  fail "census manufactured a finding on GOOD input: lib-ws0-fixtures.sh gave blocks=$idiom_blocks apostrophe-in-a-body=$idiom_apostrophe census='$(findings_of "$idiom_census" | head -1)' compile='$(findings_of "$idiom_compile" | head -1)'"
+fi
+
+# --- CONTROL 1c-ter: the closer at the END of the last body line, bash arguments trailing -------
+# Shape 2 of three (see the extractor header). It is idiomatic and already in use at
+# `test-data/scripts/gen-perf-corpus-bti.sh`, `scripts/lib/gate-notify.sh` and
+# `docs/reports/ws0-3217-artifacts/harness/common.sh`, so it is the shape most likely to be written
+# into this driver next. Exercised against a SCRATCH copy rather than one of those files, so the
+# control cannot drift when they change: the block must be delimited (not reported undelimited) AND
+# a defect inside it must still be reported.
+TRAILING_DRIVER="$TMP/trailing-closer-ws0-driver.sh"
+python3 - "$DRIVER" "$TRAILING_DRIVER" <<'INJECT'
+import pathlib, sys
+# The same defect class as the two shipped steps, built from character codes so no committed file
+# holds a literal example of the spelling.
+backslash, dquote = chr(92), chr(34)
+bad = "{d[" + backslash + dquote + "k" + backslash + dquote + "]}"
+q = chr(39)
+step = ("python3 -c " + q + "\nd = {'k': 1}\nprint(f'" + bad + "')" + q + " \"$OUT_DIR\"\n")
+pathlib.Path(sys.argv[2]).write_text(pathlib.Path(sys.argv[1]).read_text() + step)
+INJECT
+tr_census="$(census "$TRAILING_DRIVER")"
+tr_compile="$(compile_blocks "$TRAILING_DRIVER")"
+tr_blocks="$(grep -c '^BLOCK	' <<<"$tr_census")"
+if [ "$tr_blocks" -eq "$((block_count + 1))" ] && [ -z "$(findings_of "$tr_census")" ] \
+   && grep -q 'DOES NOT COMPILE' <<<"$tr_compile"; then
+  pass "census CONTROL fired (trailing-closer shape): a block closed at the END of its last body line is DELIMITED ($tr_blocks blocks, no undelimited finding) and a defect inside it is REPORTED"
+else
+  fail "census CONTROL did not fire (trailing-closer shape): blocks=$tr_blocks (expected $((block_count + 1))), census='$(findings_of "$tr_census" | head -1)', compile='$(findings_of "$tr_compile" | head -1)'"
 fi
 
 # --- POSITIVE CONTROL 1d: a FUTURE step written as a heredoc is censused and compiled ----------

--- a/scripts/tests/test_ws0_embedded_steps_execute.sh
+++ b/scripts/tests/test_ws0_embedded_steps_execute.sh
@@ -302,7 +302,7 @@ fi
 UNKNOWN_SHAPE="$TMP/unknown-shape-ws0-driver.sh"
 { cat "$DRIVER"; printf '%s\n' 'python3 -m ws0_something --run'; } > "$UNKNOWN_SHAPE"
 unk_out="$(census "$UNKNOWN_SHAPE")"
-if grep -q 'does not recognise' <<<"$unk_out"; then
+if grep -q 'matches none of the shapes' <<<"$unk_out"; then
   pass "census CONTROL fired: an unrecognised python3 invocation shape is a FINDING (fail-closed, so a future step cannot fall outside the compile check)"
 else
   fail "census CONTROL did not fire: an unrecognised python3 shape must be a finding, got: $(findings_of "$unk_out" | head -2)"
@@ -342,11 +342,19 @@ idiom_apostrophe=0
 for ((bn = 1; bn <= idiom_blocks; bn++)); do
   emit_block "$IDIOM_FILE" "$bn" | grep -q "'" && idiom_apostrophe=1
 done
-if [ "$idiom_blocks" -ge 1 ] && [ -z "$(findings_of "$idiom_census")" ] \
-   && [ -z "$(findings_of "$idiom_compile")" ] && [ "$idiom_apostrophe" -eq 1 ]; then
-  pass "census NO-FALSE-FINDING: $idiom_blocks block(s) in lib-ws0-fixtures.sh (which uses the literal-apostrophe idiom) are delimited and ALL COMPILE — the extractor rejoins the idiom instead of cutting the body there"
+# THE SUBJECT IS THE IDIOM, NOT A FINDING COUNT. This file also contains a python HEREDOC at
+# `lib-ws0-fixtures.sh:149`, and since round 6 removed heredoc support that is a finding BY
+# DESIGN — the allowlist tells its author to teach the census rather than compiling a body the
+# shell may have rewritten. So the assertion is about the blocks that ARE delimited (they must all
+# compile, and one must carry a literal apostrophe, which a truncating delimiter cannot produce)
+# plus the requirement that every finding on this file is the heredoc one. Asserted by CONTENT
+# rather than by count, so a NEW kind of false finding here still fails.
+idiom_other="$(findings_of "$idiom_census" | grep -v 'matches none of the shapes' || true)"
+if [ "$idiom_blocks" -ge 1 ] && [ "$idiom_apostrophe" -eq 1 ] \
+   && [ -z "$idiom_other" ] && [ -z "$(findings_of "$idiom_compile" | grep -v 'matches none of the shapes' || true)" ]; then
+  pass "census NO-FALSE-FINDING: $idiom_blocks block(s) in lib-ws0-fixtures.sh (which uses the literal-apostrophe idiom) are delimited, ALL COMPILE, and one body carries a literal apostrophe — the extractor rejoins the idiom instead of cutting the body there (its heredoc at :149 is an expected allowlist finding, not a false one)"
 else
-  fail "census manufactured a finding on GOOD input: lib-ws0-fixtures.sh gave blocks=$idiom_blocks apostrophe-in-a-body=$idiom_apostrophe census='$(findings_of "$idiom_census" | head -1)' compile='$(findings_of "$idiom_compile" | head -1)'"
+  fail "census manufactured a finding on GOOD input: lib-ws0-fixtures.sh gave blocks=$idiom_blocks apostrophe-in-a-body=$idiom_apostrophe unexpected-finding='$(head -1 <<<"$idiom_other")'"
 fi
 
 # --- CONTROL 1c-ter: the closer at the END of the last body line, bash arguments trailing -------
@@ -385,37 +393,6 @@ else
   fail "census CONTROL did not fire (trailing-closer shape): blocks=$tr_blocks (expected $((block_count + 1))), census='$(findings_of "$tr_census" | head -1)', compile='$(findings_of "$tr_compile" | head -1)'"
 fi
 
-# --- POSITIVE CONTROL 1d: a FUTURE step written as a heredoc is censused and compiled ----------
-# The driver carries no python heredoc today. The census handles the shape anyway, and an
-# unexercised branch in a fail-closed extractor is exactly the code that is discovered to be broken
-# by the first person who needs it — which is the complaint #3451 records. So the shape is
-# exercised against a scratch copy: the block must be COUNTED, and a defect inside it must be
-# REPORTED, or a step added that way would fall outside the compile check entirely.
-HEREDOC_DRIVER="$TMP/heredoc-step-ws0-driver.sh"
-python3 - "$DRIVER" "$HEREDOC_DRIVER" <<'INJECT'
-import pathlib, sys
-# A minimal future step in the heredoc shape, carrying the same defect class the two `-c` steps
-# shipped: a subscript inside an f-string expression, built from character codes so that no
-# committed file holds a literal example of the spelling.
-backslash, dquote = chr(92), chr(34)
-bad = "{d[" + backslash + dquote + "k" + backslash + dquote + "]}"
-tag = "PY" + "STEP"
-step = ("python3 - \"$OUT_DIR\" <<'" + tag + "'\n"
-        "d = {'k': 1}\n"
-        "print(f'" + bad + "')\n"
-        + tag + "\n")
-pathlib.Path(sys.argv[2]).write_text(pathlib.Path(sys.argv[1]).read_text() + step)
-INJECT
-hd_census="$(census "$HEREDOC_DRIVER")"
-hd_compile="$(compile_blocks "$HEREDOC_DRIVER")"
-hd_blocks="$(grep -c '^BLOCK	' <<<"$hd_census")"
-if [ "$hd_blocks" -eq "$((block_count + 1))" ] && grep -q 'heredoc' <<<"$hd_census" \
-   && grep -q 'DOES NOT COMPILE' <<<"$hd_compile"; then
-  pass "census CONTROL fired (heredoc shape): a step written as a python heredoc is COUNTED ($hd_blocks blocks) and a defect inside it is REPORTED — a future step in that shape cannot fall outside the compile check"
-else
-  fail "census CONTROL did not fire (heredoc shape): blocks=$hd_blocks (expected $((block_count + 1))), compile said: $(findings_of "$hd_compile" | head -2)"
-fi
-
 # --- CONTROL 1c-quater: TWO invocations on ONE line, the SECOND carrying the defect ------------
 # The census advertises "every occurrence". An earlier version searched each line ONCE and then
 # skipped whole lines, so a second invocation after a `;`, an `&&` or an inline block's closing
@@ -439,48 +416,6 @@ if [ "$two_blocks" -eq "$((block_count + 2))" ] && grep -q 'DOES NOT COMPILE' <<
   pass "census CONTROL fired (two per line): BOTH invocations on one line are counted ($two_blocks blocks) and the defect in the SECOND is REPORTED — the scan advances by what each classification consumed, not by whole lines"
 else
   fail "census CONTROL did not fire (two per line): blocks=$two_blocks (expected $((block_count + 2))), compile said '$(findings_of "$two_compile" | head -1)'"
-fi
-
-# --- CONTROL 1d-bis: the heredoc terminator rule is the SHELL's, per form ----------------------
-# `<<TAG` takes the terminator EXACTLY — a space-indented `  TAG` is ordinary body to the shell, so
-# accepting it truncates the block and hands python a body it never receives. `<<-TAG` strips
-# leading TABS from the terminator AND from every body line, so leaving them in place turns a
-# perfectly good body into an IndentationError the shell would never produce. Both are asserted,
-# because a `.strip()` comparison was wrong in both directions at once.
-SPACE_TERM_DRIVER="$TMP/space-terminator-ws0-driver.sh"
-python3 - "$DRIVER" "$SPACE_TERM_DRIVER" <<'INJECT'
-import pathlib, sys
-tag = "PY" + "SPACED"
-# The ONLY line matching the tag is INDENTED WITH SPACES, which the shell does not accept for a
-# plain `<<`, so the heredoc is genuinely unterminated.
-step = ("python3 - <<'" + tag + "'\nprint(1)\n  " + tag + "\n")
-pathlib.Path(sys.argv[2]).write_text(pathlib.Path(sys.argv[1]).read_text() + step)
-INJECT
-sp_out="$(census "$SPACE_TERM_DRIVER")"
-if grep -q 'never terminated' <<<"$sp_out" && grep -q 'exact match' <<<"$sp_out"; then
-  pass "census CONTROL fired (plain <<): a SPACE-INDENTED line matching the tag is body, not a terminator — the block is reported unterminated rather than silently truncated"
-else
-  fail "census CONTROL did not fire (plain <<): a space-indented terminator must not delimit a plain-form heredoc, got: $(findings_of "$sp_out" | head -2)"
-fi
-
-TAB_TERM_DRIVER="$TMP/tab-terminator-ws0-driver.sh"
-python3 - "$DRIVER" "$TAB_TERM_DRIVER" <<'INJECT'
-import pathlib, sys
-tag = "PY" + "TABBED"
-tab = chr(9)
-# `<<-`: tabs are stripped from the terminator AND from the body. If the body's tabs survive, the
-# extracted source is indented and does not compile — which is how this control discriminates.
-step = ("python3 - <<-'" + tag + "'\n" + tab + "print(1)\n" + tab + tag + "\n")
-pathlib.Path(sys.argv[2]).write_text(pathlib.Path(sys.argv[1]).read_text() + step)
-INJECT
-tab_census="$(census "$TAB_TERM_DRIVER")"
-tab_compile="$(compile_blocks "$TAB_TERM_DRIVER")"
-tab_blocks="$(grep -c '^BLOCK	' <<<"$tab_census")"
-if [ "$tab_blocks" -eq "$((block_count + 1))" ] && [ -z "$(findings_of "$tab_census")" ] \
-   && [ -z "$(findings_of "$tab_compile")" ]; then
-  pass "census CONTROL fired (<<- form): a TAB-indented terminator delimits and the body's leading tabs are stripped as the shell strips them — the extracted source compiles ($tab_blocks blocks)"
-else
-  fail "census CONTROL did not fire (<<- form): blocks=$tab_blocks (expected $((block_count + 1))), census='$(findings_of "$tab_census" | head -1)', compile='$(findings_of "$tab_compile" | head -1)'"
 fi
 
 # --- CONTROL 1e: a block's closing quote must be followed by a shell WORD BOUNDARY -------------
@@ -519,32 +454,44 @@ else
   fail "census word-boundary: accept-blocks=$(grep -c '^BLOCK	' <<<"$bound_ok") accept-findings='$(findings_of "$bound_ok" | head -1)' reject='$(findings_of "$bound_bad" | head -1)'"
 fi
 
-# --- CONTROL 1f: only a QUOTED heredoc delimiter is compiled -----------------------------------
-# With `<<PY` the shell expands parameters, commands, arithmetic and backslashes in the body
-# BEFORE python sees it, so the verbatim text is not the program that runs. Measured with a body
-# that is valid python verbatim and a SyntaxError once expanded: bash refused it, the census said
-# `compiled=1 findings=0`. Refused rather than modelled — this file will not imitate shell
-# expansion. With `<<'PY'` no expansion happens and the premise "verbatim is what python receives"
-# is exactly true, which is the accept half.
-HEREDOC_Q="$TMP/heredoc-quoted-ws0-driver.sh"
-HEREDOC_U="$TMP/heredoc-unquoted-ws0-driver.sh"
-python3 - "$HEREDOC_Q" "$HEREDOC_U" <<'INJECT'
+# --- CONTROL 1f: A PATH-QUALIFIED INVOCATION IS SEEN AND NAMED (r6F3 regression) ---------------
+# The prior matcher required the bare word, so `/usr/bin/python3 -c '<defect>'` was not
+# mis-handled — it was INVISIBLE: `blocks=0 findings=0 occurrences=0`, a defective block reported
+# as clean. The candidate net now matches any word whose BASENAME is python/python3, and the
+# allowlist admits only the bare spelling, so the path-qualified form is a FINDING.
+PATHQ="$TMP/path-qualified.sh"
+python3 - "$PATHQ" <<'INJECT'
 import pathlib, sys
-q, dq = chr(39), chr(34)
-tag = "PY" + "Q"
-body = "v = " + dq + "$X" + dq + "\nprint(v)\n"
-# Quoted delimiter: literal body, so compiling the verbatim text is exactly right.
-pathlib.Path(sys.argv[1]).write_text("python3 - <<" + q + tag + q + "\n" + body + tag + "\n")
-# Unquoted delimiter: the same body, but $X is substituted before python sees it.
-pathlib.Path(sys.argv[2]).write_text("python3 - <<" + tag + "\n" + body + tag + "\n")
+q = chr(39)
+pathlib.Path(sys.argv[1]).write_text("/usr/bin/python3 -c " + q + "import os," + q + "\n")
 INJECT
-hq_out="$(census "$HEREDOC_Q")"
-hu_out="$(census "$HEREDOC_U")"
-if [ "$(grep -c '^BLOCK	' <<<"$hq_out")" -eq 1 ] && [ -z "$(findings_of "$hq_out")" ] \
-   && grep -q 'UNQUOTED delimiter' <<<"$hu_out"; then
-  pass "census heredoc-quoting, BOTH directions: a QUOTED delimiter is compiled (no expansion, so verbatim IS the program) while an UNQUOTED one is a FINDING (the shell rewrites the body before python sees it)"
+pathq_out="$(census "$PATHQ")"
+if grep -q 'not the bare' <<<"$pathq_out"; then
+  pass "census CONTROL fired (path-qualified): /usr/bin/python3 is SEEN and NAMED rather than invisible — $(findings_of "$pathq_out" | head -1 | cut -c1-96)"
 else
-  fail "census heredoc-quoting: quoted-blocks=$(grep -c '^BLOCK	' <<<"$hq_out") quoted-findings='$(findings_of "$hq_out" | head -1)' unquoted='$(findings_of "$hu_out" | head -1)'"
+  fail "census CONTROL did not fire (path-qualified): a path-qualified invocation must be a finding, got: $(head -2 <<<"$pathq_out")"
+fi
+
+# --- CONTROL 1g: A HEREDOC IS A FINDING — support was REMOVED, deliberately --------------------
+# Heredoc handling was speculative (the driver has none) and cost THREE findings: an unquoted
+# delimiter is shell-expanded before python sees it, a composed delimiter means bash uses a
+# different tag, and with multiple redirects bash uses the LAST. Each was a FALSE PASS — a body
+# compiled that python never receives. Under the allowlist a heredoc step is a FINDING, which is
+# the correct outcome: it tells its author to teach the census rather than silently approving an
+# expanded or truncated body.
+HEREDOC_ANY="$TMP/heredoc-any.sh"
+python3 - "$HEREDOC_ANY" <<'INJECT'
+import pathlib, sys
+q = chr(39)
+tag = "PY" + "ANY"
+pathlib.Path(sys.argv[1]).write_text(
+    "python3 - <<" + q + tag + q + "\nimport os,\n" + tag + "\n")
+INJECT
+hd_any="$(census "$HEREDOC_ANY")"
+if [ "$(grep -c '^BLOCK	' <<<"$hd_any")" -eq 0 ] && grep -q 'matches none of the shapes' <<<"$hd_any"; then
+  pass "census CONTROL fired (heredoc removed): a python heredoc is a FINDING, not a block — the three false passes heredoc support cost are unreachable because the support is gone"
+else
+  fail "census CONTROL did not fire (heredoc removed): a heredoc must be a finding, got: $(head -2 <<<"$hd_any")"
 fi
 
 # ============================================================================

--- a/scripts/tests/ws0_embedded_python.py
+++ b/scripts/tests/ws0_embedded_python.py
@@ -179,6 +179,32 @@ _PY_WORD = re.compile(r"python[0-9]*(?:\.[0-9]+)*(?![\w.])")
 # own inline block at line 941 uses.
 _CONCATENATION_BEFORE_WORD = frozenset("\"'`)}" + chr(92))
 
+# IS A COMMAND WORD A PLAIN LITERAL? (#3451 review round 12.)
+#
+# The flag anchor used to report EVERY `-c '…'` whose command word was not literally `python3`,
+# which false-red on `grep -c '_RN'` the moment #3455 added one to the driver. `-c` is a common
+# flag — `grep -c` counts, `sort -c` checks, `tar -c` creates — so "not python3" was the wrong
+# question. The right one is decidable in three states:
+#
+#   a literal CONTAINING `python`      the allowlisted shape; the word anchor handles it
+#   a literal NOT containing `python`  SKIP. `grep` is definitively not python, so there is no
+#                                      python program here and nothing to compile. Deciding this
+#                                      needs no list of known commands — only that the word is
+#                                      literal, and that literals can be compared.
+#   NOT a plain literal                FINDING. `$PYTHON`, `"prefix"python3`, `$(which python3)`
+#                                      cannot be resolved without executing the shell, so they
+#                                      may carry code and fail closed.
+#
+# A word is a PLAIN LITERAL when it contains no expansion or quoting character. That is the same
+# closed metacharacter set used elsewhere in this file, applied to a different question.
+_NON_LITERAL_IN_WORD = frozenset("$`\"'*?[]{}" + chr(92))
+
+
+def _is_plain_literal(word: str) -> bool:
+    """True when `word` is a shell word whose text IS its value — no expansion, no quoting."""
+    return bool(word) and not any(ch in _NON_LITERAL_IN_WORD for ch in word)
+
+
 # THE SECOND DISCOVERY ANCHOR: the FLAG, not the command word (#3451 review round 7, finding 1).
 #
 # The allowlist closed CLASSIFICATION — anything not allowlisted is a finding — but not
@@ -422,14 +448,21 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
             # contradicted itself and told its reader nothing actionable.
             before = text[line_start:match_start].rstrip()
             cmd_word = before[max((before.rfind(c) for c in _WORD_BREAK), default=-1) + 1 :]
+            if _is_plain_literal(cmd_word) and "python" not in cmd_word.rsplit("/", 1)[-1]:
+                # A LITERAL non-python command: `grep -c '_RN'`, `sort -c`, `tar -c`. Its text is
+                # its value, so this is decidably not a python invocation and there is no program
+                # to compile. Skipped rather than reported — reporting it is the false-red
+                # direction, and a guard that reds on correct code is the guard people waive.
+                continue
             findings.append({
                 "line": idx + 1,
-                "reason": "a `-c '<program>'` invocation for which NO literal `python3` command"
-                          f" word was found (nearest preceding word: {cmd_word or '(none)'!r})."
-                          " Anchored on the FLAG rather than the command word, because an"
-                          " indirectly-spelled word — a variable, a concatenation — carries code"
-                          " exactly as a literal one does and was INVISIBLE before #3451 round 7."
-                          " Teach the allowlist if the spelling is intended.",
+                "reason": "a `-c '<program>'` invocation whose command word"
+                          f" ({cmd_word or '(none)'!r}) is NOT A PLAIN LITERAL, so what it runs"
+                          " cannot be decided without executing the shell — it may be python"
+                          " carrying a program this check would never see. Anchored on the FLAG"
+                          " rather than the command word, because an indirectly-spelled word was"
+                          " INVISIBLE before #3451 round 7. A LITERAL non-python command"
+                          " (`grep -c`, `sort -c`) is skipped, not reported.",
             })
             continue
         # Walk left to the start of the shell WORD, so a path prefix travels with the candidate.

--- a/scripts/tests/ws0_embedded_python.py
+++ b/scripts/tests/ws0_embedded_python.py
@@ -64,8 +64,10 @@ spelled:
 
     -c '…'        embedded, single-quoted — the shape both defective steps use. Extracted, by
                   the rule below rather than by a line pattern.
-    <<'EOF'       embedded via a heredoc on stdin. Extracted. (None today; covered because a
-                  future step written this way must not fall outside the census.)
+    <<'EOF'       embedded via a heredoc on stdin, delimiter QUOTED. Extracted. (None today;
+                  covered because a future step written this way must not fall outside the
+                  census.) An UNQUOTED `<<EOF` is a FINDING: the shell expands the body before
+                  python sees it, so the verbatim text is not the program that runs.
     <path>.py     a SCRIPT FILE. Not embedded — it is an ordinary python file every other tool
                   already sees — so it is recorded and not extracted.
     (no argument) a MENTION **only** for the one presence-probe construct this driver uses — the
@@ -148,6 +150,20 @@ _PY_TOKEN = re.compile(r"(?<![\w./-])python3(?![\w.])")
 # string. Where it CLOSES is decided by scanning bash's quoting rules (`_scan_single_quoted`),
 # never by a line pattern — see the header's three-shape section.
 _OPEN_DASH_C = re.compile(r"^\s*-c\s+'")
+# WHAT MAY LEGALLY FOLLOW A BLOCK'S CLOSING QUOTE (#3451 review round 5, finding 1).
+#
+# Bash CONCATENATES adjacent word fragments, so `python3 -c 'pass'" +"` runs `pass +`. Extracting
+# the quoted part alone approves a program python NEVER RECEIVES — measured: bash raised
+# `SyntaxError: invalid syntax` while the census reported `compiled=1 findings=0`. A FALSE PASS.
+#
+# The fix REFUSES rather than models: adjacent fragments are not parsed, they are a finding. What
+# makes that safe is the boundary SET, and getting it wrong reds the real driver — its inline
+# block at `ws0-baseline.sh:941` closes `')" || {`, i.e. with a `)` immediately after the quote, so
+# a whitespace-only rule would flag 1 of the driver's own 3 blocks on the first run. That false-red
+# direction is what got the previous oracle deleted, so the set is shell metacharacters, not just
+# space. (The two multi-line blocks close `' "$HERE" …`, a space, and are unaffected either way.)
+_WORD_BOUNDARY_AFTER_CLOSE = frozenset(" \t\n)&;|<>")
+
 # The `'"'"'` idiom: close, emit a literal apostrophe from a double-quoted segment, reopen. The one
 # exception to "a single-quoted string runs to the next quote".
 _QUOTE_IDIOM = "'" + '"' + "'" + '"' + "'"
@@ -319,6 +335,17 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
                 # The opening quote is the LAST character the match consumed.
                 open_quote = m.end() + dash_c.end() - 1
                 body, close = _scan_single_quoted(text, open_quote)
+                after = text[close + 1 : close + 2]
+                if after and after not in _WORD_BOUNDARY_AFTER_CLOSE:
+                    raise Unclassifiable(
+                        idx + 1,
+                        "this block's closing quote is followed by "
+                        f"{after!r} rather than a shell word boundary, so bash CONCATENATES what"
+                        " follows onto the program — python would receive something other than"
+                        " the quoted text, and compiling the quoted text alone would approve a"
+                        " program that is never run. Adjacent fragments are refused, not"
+                        " reassembled: put the whole program inside one quoted string.",
+                    )
                 end_line = text.count("\n", 0, close)
                 pos = close + 1
                 records.append(
@@ -330,6 +357,25 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
                 continue
             hd = _HEREDOC.search(rest)
             if hd:
+                if not hd.group("q"):
+                    # AN UNQUOTED DELIMITER EXPANDS (#3451 review round 5, finding 2). With
+                    # `<<PY` the shell performs parameter, command, arithmetic and backslash
+                    # expansion on the body BEFORE python sees it, so the verbatim text is not the
+                    # program. Measured with a body that is valid python verbatim and a
+                    # SyntaxError once expanded: bash refused it, the census reported
+                    # `compiled=1 findings=0`. A FALSE PASS.
+                    #
+                    # Refused, not modelled: shell expansion is not something this file will
+                    # imitate. With a QUOTED delimiter (`<<'PY'`) no expansion happens and the
+                    # premise "verbatim is what python receives" is exactly true, which is why
+                    # that case is compiled and this one is a finding.
+                    raise Unclassifiable(
+                        idx + 1,
+                        f"this python heredoc uses an UNQUOTED delimiter (`{hd.group('tag')}`),"
+                        " so the shell EXPANDS the body before python sees it and the verbatim"
+                        " text is not the program that runs. Compiling it would approve source"
+                        " nobody executes. Quote the delimiter to make the body literal.",
+                    )
                 body, end = _delimit_heredoc(
                     lines, idx, hd.group("tag"), hd.group("dash") == "-"
                 )

--- a/scripts/tests/ws0_embedded_python.py
+++ b/scripts/tests/ws0_embedded_python.py
@@ -225,6 +225,40 @@ class Unclassifiable(Exception):
         self.reason = reason
 
 
+def _join_continuations(text: str) -> tuple[str, list[int]]:
+    """`text` with backslash-newline pairs removed, plus a map back to ORIGINAL offsets.
+
+    Bash reconstructs a LOGICAL LINE by deleting `\\` + newline before it tokenises anything, so
+    `$PYTHON -c \\` / `'prog'` is the single command `$PYTHON -c 'prog'`. Discovery that reads
+    physical lines cannot see it: the word matcher misses `$PYTHON`, and the `-c` anchor misses
+    because the quote is on the next line. MEASURED — that pair, and only that pair, was invisible
+    (`findings=0 occurrences=0`); either ingredient alone is already caught.
+
+    THIS IS A DECIDABLE TRANSFORMATION, NOT ANOTHER SHAPE ON A LIST — one closed rule that bash
+    itself applies. It makes the EXISTING anchors strictly stronger (after joining, the case above
+    IS literally `$PYTHON -c 'prog'`, which the `-c` anchor already catches) rather than adding a
+    special case to an enumeration.
+
+    USED FOR DISCOVERY ONLY, and that restriction is load-bearing: inside SINGLE QUOTES a
+    backslash is LITERAL and no continuation happens, so joining a block's BODY would hand the
+    compiler source that differs from what python receives. Anchors are located in the joined
+    text; every subsequent read — the rest of the line, the quote scan, the body, the reported
+    line numbers — is done against the ORIGINAL. The returned map exists for exactly that
+    hand-back, so a finding never names a line that only exists in the joined view.
+    """
+    out: list[str] = []
+    omap: list[int] = []
+    i, n = 0, len(text)
+    while i < n:
+        if text[i] == "\\" and i + 1 < n and text[i + 1] == "\n":
+            i += 2
+            continue
+        out.append(text[i])
+        omap.append(i)
+        i += 1
+    return "".join(out), omap
+
+
 def _strip_comment(rest: str) -> str:
     """Drop a trailing `# …` comment from the text FOLLOWING a python3 token.
 
@@ -308,6 +342,8 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
     for line in lines:
         starts.append(off)
         off += len(line) + 1
+    # DISCOVERY runs over the logical-line reconstruction; everything else reads the original.
+    scan, omap = _join_continuations(text)
     records: list[dict] = []
     findings: list[dict] = []
     pos = 0
@@ -316,24 +352,27 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
         # its branch consumes through the closing quote, so the `-c` inside it is never reached —
         # no double report. A `-c '` reached FIRST means no literal python word preceded it, i.e.
         # the command word is spelled indirectly, which is a finding.
-        mp = _PY_WORD.search(text, pos)
-        mc = _DASH_C_ANCHOR.search(text, pos)
+        mp = _PY_WORD.search(scan, pos)
+        mc = _DASH_C_ANCHOR.search(scan, pos)
         if mp is not None and (mc is None or mp.start() <= mc.start()):
             m, anchored_on_flag = mp, False
         elif mc is not None:
             m, anchored_on_flag = mc, True
         else:
             break
-        idx = bisect.bisect_right(starts, m.start()) - 1
+        # Hand the match back to ORIGINAL offsets before anything is read or reported.
+        match_start = omap[m.start()]
+        match_end = omap[m.end() - 1] + 1
+        pos = m.end()
+        idx = bisect.bisect_right(starts, match_start) - 1
         line = lines[idx]
         line_start = starts[idx]
         if anchored_on_flag:
-            pos = m.end()
             if line.lstrip().startswith("#"):
                 continue  # a whole-line shell comment carries no code
             # The word before the flag, for the diagnostic only — enough to name what was found
             # without pretending to resolve it.
-            before = text[line_start : m.start()].rstrip()
+            before = text[line_start:match_start].rstrip()
             cmd_word = before[max((before.rfind(c) for c in _WORD_BREAK), default=-1) + 1 :]
             findings.append({
                 "line": idx + 1,
@@ -346,14 +385,13 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
             })
             continue
         # Walk left to the start of the shell WORD, so a path prefix travels with the candidate.
-        word_start = m.start()
+        word_start = match_start
         while word_start > line_start and text[word_start - 1] not in _WORD_BREAK:
             word_start -= 1
-        word = text[word_start : m.end()]
-        pos = m.end()
+        word = text[word_start:match_end]
         if line.lstrip().startswith("#"):
             continue  # a whole-line shell comment carries no code
-        if word.rsplit("/", 1)[-1] != text[m.start() : m.end()]:
+        if word.rsplit("/", 1)[-1] != text[match_start:match_end]:
             # The word's BASENAME is not the matched token, i.e. the token is a SUFFIX of a longer
             # program name (`mypython3`, `jython3`). That is a different program, not a
             # path-qualified python — the path case (`/usr/bin/python3`) has the token AS its
@@ -361,7 +399,7 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
             # about names rather than about shell.
             continue
         line_end = line_start + len(line)
-        raw_rest = text[m.end() : line_end]
+        raw_rest = text[match_end:line_end]
         rest = _strip_comment(raw_rest).strip()
         try:
             if word != "python3":
@@ -380,7 +418,7 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
             dash_c = _OPEN_DASH_C.match(raw_rest)
             if dash_c:
                 # ALLOWLIST 1.
-                open_quote = m.end() + dash_c.end() - 1
+                open_quote = match_end + dash_c.end() - 1
                 body, close = _scan_single_quoted(text, open_quote)
                 after = text[close + 1 : close + 2]
                 if after and after not in _WORD_BOUNDARY_AFTER_CLOSE:
@@ -394,7 +432,8 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
                         " reassembled: put the whole program inside one quoted string.",
                     )
                 end_line = text.count("\n", 0, close)
-                pos = close + 1
+                # Advance the SCAN cursor past the closing quote, mapping through the offset map.
+                pos = bisect.bisect_right(omap, close)
                 records.append(
                     {"kind": "BLOCK",
                      "shape": "dash-c-multiline" if "\n" in body else "dash-c-inline",

--- a/scripts/tests/ws0_embedded_python.py
+++ b/scripts/tests/ws0_embedded_python.py
@@ -432,7 +432,30 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
             m, anchored_on_flag = mc, True
         else:
             break
-        # Hand the match back to ORIGINAL offsets before anything is read or reported.
+        # ---------------------------------------------------------------------------------
+        # ONE PLACE DECIDES JOINED-VS-PHYSICAL, AND EVERY CONSUMER ASKS IT (#3451, post-rebase
+        # round 1). Three findings were the same inconsistency at different consumers — round 8
+        # joined for DISCOVERY but classified on the physical line; the flag anchor then rebuilt
+        # its command word from the physical line, so `grep \` + `-c 'foo'` produced an empty
+        # word and a FALSE finding on legitimate code, with a diagnostic that contradicted itself.
+        # This is the repository's own path-normalisation lesson: normalise ONCE, at the boundary,
+        # or every consumer becomes its own defect.
+        #
+        # THE RULE: the JOINED text is the representation for classification, comparison and
+        # command-word extraction. The ORIGINAL is used for exactly three things — the body of a
+        # block (inside single quotes a backslash is literal, so joining must never touch a body),
+        # the reported line numbers, and the comment test.
+        #
+        # The comment test is the ONE deliberate exception and it is not an oversight: a `#`
+        # comment ends at the PHYSICAL newline, and a trailing backslash does not continue it. So
+        # `# note \` + `python3 -c '…'` really is a live command, and testing the joined line
+        # would hide it. MEASURED both ways — bash runs that python, and this census reports it.
+        # ---------------------------------------------------------------------------------
+        scan_line_start = scan.rfind("\n", 0, m.start()) + 1
+        scan_line_end = scan.find("\n", m.start())
+        if scan_line_end < 0:
+            scan_line_end = len(scan)
+        # ORIGINAL offsets, for line numbers, the body read and diagnostics ONLY.
         match_start = omap[m.start()]
         match_end = omap[m.end() - 1] + 1
         pos = m.end()
@@ -441,12 +464,10 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
         line_start = starts[idx]
         if anchored_on_flag:
             if line.lstrip().startswith("#"):
-                continue  # a whole-line shell comment carries no code
-            # The nearest preceding word, NAMED rather than judged. The old text asserted the word
-            # was "not the literal `python3`" — something this branch never checked — and on a
-            # continuation it printed `is 'python3', not the literal python3`, a diagnostic that
-            # contradicted itself and told its reader nothing actionable.
-            before = text[line_start:match_start].rstrip()
+                continue  # see the comment-test note above: a comment ends at the newline
+            # The command word, from the JOINED line. Rebuilt from the physical line this used to
+            # yield '(none)' whenever a continuation sat between the word and the flag.
+            before = scan[scan_line_start : m.start()].rstrip()
             cmd_word = before[max((before.rfind(c) for c in _WORD_BREAK), default=-1) + 1 :]
             if _is_plain_literal(cmd_word) and "python" not in cmd_word.rsplit("/", 1)[-1]:
                 # A LITERAL non-python command: `grep -c '_RN'`, `sort -c`, `tar -c`. Its text is
@@ -465,36 +486,26 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
                           " (`grep -c`, `sort -c`) is skipped, not reported.",
             })
             continue
-        # Walk left to the start of the shell WORD, so a path prefix travels with the candidate.
-        word_start = match_start
-        while word_start > line_start and text[word_start - 1] not in _WORD_BREAK:
+        # Walk left to the start of the shell WORD — in JOINED space, so a path prefix or a
+        # continuation between the word and its flag travels with the candidate.
+        word_start = m.start()
+        while word_start > scan_line_start and scan[word_start - 1] not in _WORD_BREAK:
             word_start -= 1
-        word = text[word_start:match_end]
+        word = scan[word_start : m.end()]
         if line.lstrip().startswith("#"):
-            continue  # a whole-line shell comment carries no code
-        if word.rsplit("/", 1)[-1] != text[match_start:match_end]:
+            continue  # see the comment-test note above
+        if word.rsplit("/", 1)[-1] != scan[m.start() : m.end()]:
             # The word's BASENAME is not the matched token, i.e. the token is a SUFFIX of a longer
             # program name (`mypython3`, `jython3`). That is a different program, not a
             # path-qualified python — the path case (`/usr/bin/python3`) has the token AS its
             # basename and is examined. This is the one lexical exclusion, and it is a statement
             # about names rather than about shell.
             continue
-        # CLASSIFICATION READS THE JOINED LOGICAL LINE, not the physical one (#3451 round 8
-        # follow-up). Round 8 joined continuations for DISCOVERY and left classification reading
-        # unjoined text, so `python3 -c \\` + `'prog'` was found and then classified against the
-        # physical remainder `-c \\` — which matches no shape. It landed as a refusal, and a
-        # second one from the flag anchor. After joining it IS an ordinary inline invocation
-        # (bash sees `python3 -c 'prog'`), so that is what it must classify as; a driver block
-        # reformatted across a continuation keeps working instead of becoming a refusal, which is
-        # what makes the joining worth having.
-        scan_line_end = scan.find("\n", m.end())
-        if scan_line_end < 0:
-            scan_line_end = len(scan)
         line_end = line_start + len(line)
         raw_rest = scan[m.end() : scan_line_end]
         rest = _strip_comment(raw_rest).strip()
         try:
-            preceding = text[word_start - 1 : word_start] if word_start > line_start else ""
+            preceding = scan[word_start - 1 : word_start] if word_start > scan_line_start else ""
             if preceding and preceding in _CONCATENATION_BEFORE_WORD:
                 raise Unclassifiable(
                     idx + 1,

--- a/scripts/tests/ws0_embedded_python.py
+++ b/scripts/tests/ws0_embedded_python.py
@@ -56,30 +56,29 @@ the driver and the line — never a silent omission from the census. The alterna
 what you do not understand) is the one that would let instance #8 ship in a shape slightly unlike
 the first seven.
 
-## The classification, and what makes it closed
+## THE CLASSIFICATION IS AN ALLOWLIST, and that is why it closes
 
-A `python3` invocation can only receive code four ways: `-c`, a script path, standard input, or
-`-m`. So the census keys on WHICH of those a given occurrence uses rather than on how it is
-spelled:
+Earlier versions recognised DANGEROUS shapes in order to refuse them. That is a BLOCKLIST over an
+open set — the list of shell constructs does not close — and it cost SEVEN findings across five
+review rounds, ending with a path-qualified `/usr/bin/python3` that was not refused but INVISIBLE.
+`census` lists all seven with their measurements.
 
-    -c '…'        embedded, single-quoted — the shape both defective steps use. Extracted, by
-                  the rule below rather than by a line pattern.
-    <<'EOF'       embedded via a heredoc on stdin, delimiter QUOTED. Extracted. (None today;
-                  covered because a future step written this way must not fall outside the
-                  census.) An UNQUOTED `<<EOF` is a FINDING: the shell expands the body before
-                  python sees it, so the verbatim text is not the program that runs.
-    <path>.py     a SCRIPT FILE. Not embedded — it is an ordinary python file every other tool
-                  already sees — so it is recorded and not extracted.
-    (no argument) a MENTION **only** for the one presence-probe construct this driver uses — the
-                  word inside a `for … in <list>` membership test. EVERY OTHER argumentless
-                  invocation is UNKNOWN, because `python3` with no argument reads its program from
-                  STDIN: `producer | python3` is embedded code with no argument at all, and
-                  classifying it as harmless was a hole in the fail-closed census (#3451 review
-                  round 4). Fail-closed means the shapes do NOT have to be enumerated — recognise
-                  the one that occurs, and let the rest be findings.
+Now the candidate net is as wide as it goes and exactly four shapes are interpreted:
 
-Anything else — `-c` with a shape that cannot be delimited, `-m`, a bare `-`, a variable where the
-code should be — is UNKNOWN, which is a finding.
+    python3 -c '…'    bare `python3`, single-quoted, the quote closing at a shell word boundary.
+                      Extracted. Covers the driver's two multi-line steps and its inline block.
+    python3 <f>.py    bare `python3` running a SCRIPT FILE. Recorded, not extracted — an ordinary
+                      python file is something every other tool already reads.
+    for … in <list>   the membership probe at `ws0-baseline.sh:421`: a word in a LIST, not a
+                      command, so it carries no code.
+    anything else     A FINDING. Not classified, not skipped, not modelled.
+
+A construct nobody anticipated therefore becomes a finding by FAILING TO MATCH, rather than by
+someone having thought to refuse it. HEREDOCS ARE NOT SUPPORTED and are findings: support for them
+was speculative (this driver has none) and produced three separate false passes — an unquoted
+delimiter is shell-expanded before python sees it, a composed delimiter makes bash use a different
+tag, and with several redirects bash uses the last. Each compiled a body python never receives. A
+future heredoc step is told to teach the census, which is the correct outcome.
 
 ## HOW A `-c '…'` BLOCK IS DELIMITED, and the three closer shapes that forced the rule
 
@@ -115,23 +114,22 @@ Both wrong versions are instructive in OPPOSITE directions and neither is safe:
 So the suite asserts BOTH directions: a defect must be reported, and a good file carrying the
 idiom must NOT be.
 
-## SCOPE: this file's caller lints `ws0-baseline.sh`, and the UNKNOWN class is calibrated for it
+## SCOPE: the caller lints `ws0-baseline.sh`, and the allowlist is that driver's shapes
 
-The census is used by `test_ws0_embedded_steps_execute.sh` against ONE driver. Run tree-wide it
-reports UNKNOWN on shapes that driver does not contain and that this file deliberately does not
-guess about: a script path held in a VARIABLE (`python3 "$ROWS_PY" …`, where nothing on the line
-says whether it is python), a DOUBLE-quoted `-c` body (the shell expands it, so the bytes python
-receives are not the bytes on disk), and `python3 >/dev/null` reading stdin from a pipe. Each is a
-real shape in this repository, each is fail-closed here, and each would have to be taught — not
-skipped — before this census could lint the whole tree. That generalisation is deliberately NOT
-this issue.
+Run over other files this census reports findings on shapes that driver does not contain — a
+script path held in a VARIABLE, a DOUBLE-quoted `-c` body, a heredoc, `python3` reading a pipe.
+Those are findings BY DESIGN rather than gaps: each would have to be TAUGHT before this census
+could lint the whole tree, and teaching is a deliberate act someone reviews. That generalisation
+is not this issue.
 
 ## The direction it errs in, stated
 
-Over-inclusion, deliberately. A `python3 -c '…'` written INSIDE a shell string (an `echo` of an
-example, say) is censused as a block and compiled, which costs a spurious finding at worst. The
-opposite posture — skipping anything that might not be real code — is how a step reaches an
-operator having been parsed by nothing, and it is the state this file was written to end.
+Over-inclusion, deliberately, and now at BOTH levels: the candidate net matches more words than
+are invocations, and the allowlist admits fewer shapes than are safe. A `python3 -c '…'` written
+INSIDE a shell string (an `echo` of an example) is censused as a block; a legitimate construct the
+allowlist has not been taught is a finding. Both cost noise, which is recoverable. The opposite
+posture — skipping what you do not understand — is how a step reaches an operator having been
+parsed by nothing, and it is the state this file was written to end.
 """
 
 from __future__ import annotations
@@ -141,44 +139,55 @@ import pathlib
 import re
 import sys
 
-# The word, matched only where it is a standalone token. `requires python3.` inside an `echo`
-# string is not an invocation and must not be censused as an unknown shape; a trailing
-# word/dot character is the discriminator.
-_PY_TOKEN = re.compile(r"(?<![\w./-])python3(?![\w.])")
+# THE CANDIDATE NET, CAST AS WIDE AS IT GOES (#3451 review round 6).
+#
+# Any word whose BASENAME is `python`/`python3`/`python3.11` — path-qualified or not — is a
+# candidate: `/usr/bin/python3`, `./python3`, `$HOME/bin/python3`, bare `python3`. Deliberately
+# over-matching, because a candidate that is SEEN and refused is safe while one that is never seen
+# is invisible. That was r6F3: `/usr/bin/python3 -c '<a syntax error>'` produced
+# `blocks=0 findings=0 occurrences=0` — a defective block the census did not merely mis-handle but
+# never noticed, reported as clean.
+#
+# The only lexical narrowing is a token boundary: a trailing word or `.` character means this is
+# not a word of its own (`requires python3.` inside an `echo` string, `python3x`). That is a rule
+# about identifiers, not about shell.
+_PY_WORD = re.compile(r"python[0-9]*(?:\.[0-9]+)*(?![\w.])")
 
-# The OPENING of a `-c '…'` block: the `-c` flag and the single quote that starts the shell
-# string. Where it CLOSES is decided by scanning bash's quoting rules (`_scan_single_quoted`),
-# never by a line pattern — see the header's three-shape section.
+# Characters that cannot appear inside one shell word, used to find where a candidate's word
+# STARTS so a path prefix is captured with it.
+_WORD_BREAK = frozenset(" \t\n;&|<>()'\"`")
+
+# ---------------------------------------------------------------------------
+# THE ALLOWLIST — the only shapes this census will interpret
+# ---------------------------------------------------------------------------
+# `-c` followed by a single quote. ONE branch covers both the multi-line form (the quote ends the
+# line, driver blocks 1-2) and the inline form (driver block 3), because where the string CLOSES is
+# found by scanning bash's quoting rules rather than by a line pattern.
 _OPEN_DASH_C = re.compile(r"^\s*-c\s+'")
+
+# The `'"'"'` idiom: close, emit a literal apostrophe from a double-quoted segment, reopen. The one
+# exception to "a single-quoted string runs to the next quote".
+_QUOTE_IDIOM = "'" + '"' + "'" + '"' + "'"
+
 # WHAT MAY LEGALLY FOLLOW A BLOCK'S CLOSING QUOTE (#3451 review round 5, finding 1).
 #
 # Bash CONCATENATES adjacent word fragments, so `python3 -c 'pass'" +"` runs `pass +`. Extracting
 # the quoted part alone approves a program python NEVER RECEIVES — measured: bash raised
 # `SyntaxError: invalid syntax` while the census reported `compiled=1 findings=0`. A FALSE PASS.
 #
-# The fix REFUSES rather than models: adjacent fragments are not parsed, they are a finding. What
-# makes that safe is the boundary SET, and getting it wrong reds the real driver — its inline
-# block at `ws0-baseline.sh:941` closes `')" || {`, i.e. with a `)` immediately after the quote, so
-# a whitespace-only rule would flag 1 of the driver's own 3 blocks on the first run. That false-red
-# direction is what got the previous oracle deleted, so the set is shell metacharacters, not just
-# space. (The two multi-line blocks close `' "$HERE" …`, a space, and are unaffected either way.)
+# The boundary set is shell metacharacters, NOT whitespace: the driver's own inline block at
+# `ws0-baseline.sh:941` closes `')" || {`, i.e. with a `)` immediately after the quote, so a
+# whitespace-only rule would flag 1 of the driver's own 3 blocks on the first run. (The two
+# multi-line blocks close `' "$HERE" …`, a space, and are unaffected either way.)
 _WORD_BOUNDARY_AFTER_CLOSE = frozenset(" \t\n)&;|<>")
 
-# The `'"'"'` idiom: close, emit a literal apostrophe from a double-quoted segment, reopen. The one
-# exception to "a single-quoted string runs to the next quote".
-_QUOTE_IDIOM = "'" + '"' + "'" + '"' + "'"
-# A heredoc redirect: `<<'PY'`, `<<PY`, `<<-'PY'`. The `dash` group is captured because `<<-`
-# and `<<` have DIFFERENT terminator rules — see `_delimit_heredoc`.
-_HEREDOC = re.compile(
-    r"<<(?P<dash>-?)\s*(?P<q>['\"]?)(?P<tag>[A-Za-z_][A-Za-z0-9_]*)(?P=q)"
-)
 # The ONE presence-probe construct the driver contains: `for tool in perf taskset python3; do`.
-# The token is a word in a LIST, not a command. Recognised explicitly so that every OTHER
-# argumentless invocation can fall through to UNKNOWN — see the MENTION branch in `census`.
+# The token is a word in a LIST, not a command.
 _FOR_WORD_LIST = re.compile(r"^\s*for\s+[A-Za-z_][A-Za-z0-9_]*\s+in\s")
 
 # A script-file argument, quoted or not, possibly carrying a shell expansion in its directory
-# part: `"$HERE/ws0_report.py"`.
+# part: `"$HERE/ws0_report.py"` (driver line 981). Recorded, never extracted — an ordinary python
+# file is something every other tool already reads.
 _SCRIPT = re.compile(r"^[\"']?[^\s\"']*\.py[\"']?(\s|$)")
 
 
@@ -231,60 +240,44 @@ def _scan_single_quoted(text: str, open_quote: int) -> tuple[str, int]:
     )
 
 
-def _delimit_heredoc(
-    lines: list[str], start: int, tag: str, dash: bool
-) -> tuple[str, int]:
-    """Body of the heredoc opened on `lines[start]`, plus the line its terminator sits on.
-
-    THE TERMINATOR RULE IS THE SHELL'S, not `.strip()` (#3451 review round 1, finding 2). The two
-    forms differ and conflating them is wrong in both directions:
-
-    * `<<TAG`  — the terminator must be the line EXACTLY. A space-indented `  TAG` is ORDINARY
-      BODY to the shell, so accepting it truncates the block early and hands python a body it
-      never receives. A `.strip()` comparison accepted it.
-    * `<<-TAG` — leading TABS (never spaces) are stripped from the terminator AND from every body
-      line. A `.strip()` comparison found the terminator but left the body's tabs in place, so a
-      tab-indented body compiled as an IndentationError the shell would never produce.
-
-    Both are latent today — this driver carries no heredoc — but the branch SHIPS and is
-    exercised, and a wrong implementation of a shipped branch is a trap for whoever first writes
-    a step in that shape.
-    """
-    body: list[str] = []
-    for i in range(start + 1, len(lines)):
-        line = lines[i]
-        candidate = line.lstrip("\t") if dash else line
-        if candidate == tag:
-            return "\n".join(body) + "\n", i
-        body.append(candidate)
-    raise Unclassifiable(
-        start + 1,
-        f"an embedded python heredoc opened with `{'<<-' if dash else '<<'}{tag}` is never"
-        " terminated by a line the SHELL would accept as its terminator"
-        + (" (leading tabs stripped)" if dash else " (an exact match, indentation included)")
-        + ", so its body cannot be delimited.",
-    )
-
-
 def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
-    """Classify every `python3` occurrence. Returns (records, findings).
+    """Classify every `python`/`python3` candidate. Returns (records, findings).
 
-    THE SCAN IS BY POSITION, NOT BY LINE (#3451 review round 2, finding 3). An earlier version
-    searched each line ONCE and then skipped whole lines, so a SECOND invocation on the same
-    line — after a `;`, an `&&`, or an inline block's closing quote — was silently dropped, which
-    contradicted the "every occurrence" guarantee this file's fail-closed posture rests on.
-    MEASURED against `python3 -c 'import sys'; python3 -c '<a syntax error>'`: `blocks=1
-    occurrences=1`, and the defect in the second block was invisible to the compile check.
+    AN ALLOWLIST, NOT A BLOCKLIST (#3451 review round 6). Seven findings across five review rounds
+    were one cause: the census recognised DANGEROUS shapes in order to refuse them, and a
+    recogniser of dangerous shapes is a blocklist over an open set. It could not close.
 
-    So the cursor advances past exactly what each classification CONSUMED — the closing quote of
-    a `-c` block, the line after a heredoc terminator, the token itself for a mention or a script
-    invocation — and the remainder of every line is rescanned.
+        r2F3  only the FIRST candidate per line was censused
+        r4F2  argumentless python3 (stdin / a pipe) classified harmless
+        r5F1  adjacent shell-word fragments after the closing quote
+        r5F2  an unquoted heredoc body is shell-expanded before python sees it
+        r6F1  a composed heredoc delimiter (`<<'PY'X` -> bash uses `PYX`)
+        r6F2  multiple heredoc redirects -> bash uses the LAST, this took the first
+        r6F3  a path-qualified `/usr/bin/python3` was not matched at all — INVISIBLE
+
+    So the net is cast as wide as possible and only FOUR shapes are interpreted:
+
+        1. bare `python3 -c '<single-quoted>'`, the quote closing at a shell word boundary
+           (covers the driver's multi-line blocks 1-2 and its inline block 3);
+        2. bare `python3 <path>.py …` — a SCRIPT file, recorded and not extracted;
+        3. the `for … in <list>` membership probe, which is a word in a list and not a command;
+        4. nothing else.
+
+    EVERYTHING ELSE IS A FINDING — not classified, not skipped, not modelled. A shell construct
+    nobody has thought of becomes a finding automatically, by failing to match, so the enumeration
+    stops being ours to complete. This is the repository's own posture: allowlist-validate fail
+    closed rather than blocklist the dangerous form.
+
+    NOTE the allowlist requires the BARE word `python3`. A path-qualified invocation is a
+    candidate (so it is seen) and a finding (so it is named) — that is r6F3 going from invisible
+    to reported.
+
+    THE SCAN IS BY POSITION, not by line (r2F3): the cursor advances past exactly what each
+    classification consumed, so a second candidate after a `;`, an `&&` or an inline block's
+    closing quote is still examined.
     """
     text = path.read_text()
     lines = text.split("\n")
-    # Offset of each line start, so a match position can be turned back into a line number and a
-    # per-line remainder. The quoting scanner works over the whole text because a block's closer
-    # is not a property of any single line (shapes 1-3 in the header).
     starts: list[int] = []
     off = 0
     for line in lines:
@@ -294,45 +287,47 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
     findings: list[dict] = []
     pos = 0
     while True:
-        m = _PY_TOKEN.search(text, pos)
+        m = _PY_WORD.search(text, pos)
         if not m:
             break
         idx = bisect.bisect_right(starts, m.start()) - 1
         line = lines[idx]
+        line_start = starts[idx]
+        # Walk left to the start of the shell WORD, so a path prefix travels with the candidate.
+        word_start = m.start()
+        while word_start > line_start and text[word_start - 1] not in _WORD_BREAK:
+            word_start -= 1
+        word = text[word_start : m.end()]
+        pos = m.end()
         if line.lstrip().startswith("#"):
-            # A whole-line shell comment carries no code. Advance past THIS occurrence only, not
-            # past the line: nothing else on a comment line matters, but the cursor rule stays one
-            # rule everywhere.
-            pos = m.end()
+            continue  # a whole-line shell comment carries no code
+        if word.rsplit("/", 1)[-1] != text[m.start() : m.end()]:
+            # The word's BASENAME is not the matched token, i.e. the token is a SUFFIX of a longer
+            # program name (`mypython3`, `jython3`). That is a different program, not a
+            # path-qualified python — the path case (`/usr/bin/python3`) has the token AS its
+            # basename and is examined. This is the one lexical exclusion, and it is a statement
+            # about names rather than about shell.
             continue
-        line_end = starts[idx] + len(line)
+        line_end = line_start + len(line)
         raw_rest = text[m.end() : line_end]
         rest = _strip_comment(raw_rest).strip()
-        pos = m.end()
         try:
-            if not rest or rest.lstrip(";&|)").strip() in ("", "do", "then"):
-                # AN ARGUMENTLESS `python3` IS NOT AUTOMATICALLY HARMLESS (#3451 review round 4).
-                # With no argument python3 reads its program from STDIN, so `producer | python3`
-                # is embedded code carrying no argument at all — and treating every argumentless
-                # invocation as a MENTION let exactly that bypass the census.
-                #
-                # So only the ONE presence-probe construct this driver contains is recognised: the
-                # word inside a `for … in <list>` membership test, which is a word in a LIST and
-                # not a command at all. Everything else falls through to UNKNOWN below. That is
-                # what fail-closed buys — the shapes do not have to be enumerated.
-                if _FOR_WORD_LIST.match(line):
-                    records.append({"kind": "MENTION", "line": idx + 1, "text": line.strip()})
-                    continue
+            if word != "python3":
                 raise Unclassifiable(
                     idx + 1,
-                    "this `python3` invocation has NO ARGUMENT, so it reads its program from"
-                    " STDIN — a pipe or a redirect can carry embedded code the compile check"
-                    " would never see. Only a `for … in <list>` membership test is recognised as"
-                    " a presence probe; anything else is a finding rather than a skip.",
+                    f"this python invocation is spelled {word!r}, not the bare `python3` the"
+                    " allowlist recognises. It is REPORTED rather than skipped because a"
+                    " path-qualified invocation carries code exactly as a bare one does, and"
+                    " until #3451 round 6 this shape was INVISIBLE to the census — a defective"
+                    " block reported as clean. Teach the allowlist if the spelling is intended.",
                 )
+            if _FOR_WORD_LIST.match(line) and rest.lstrip(";&|)").strip() in ("", "do", "then"):
+                # ALLOWLIST 3: a word in a `for … in <list>` membership test, not a command.
+                records.append({"kind": "MENTION", "line": idx + 1, "text": line.strip()})
+                continue
             dash_c = _OPEN_DASH_C.match(raw_rest)
             if dash_c:
-                # The opening quote is the LAST character the match consumed.
+                # ALLOWLIST 1.
                 open_quote = m.end() + dash_c.end() - 1
                 body, close = _scan_single_quoted(text, open_quote)
                 after = text[close + 1 : close + 2]
@@ -355,53 +350,20 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
                      "body": body if body.endswith("\n") else body + "\n"}
                 )
                 continue
-            hd = _HEREDOC.search(rest)
-            if hd:
-                if not hd.group("q"):
-                    # AN UNQUOTED DELIMITER EXPANDS (#3451 review round 5, finding 2). With
-                    # `<<PY` the shell performs parameter, command, arithmetic and backslash
-                    # expansion on the body BEFORE python sees it, so the verbatim text is not the
-                    # program. Measured with a body that is valid python verbatim and a
-                    # SyntaxError once expanded: bash refused it, the census reported
-                    # `compiled=1 findings=0`. A FALSE PASS.
-                    #
-                    # Refused, not modelled: shell expansion is not something this file will
-                    # imitate. With a QUOTED delimiter (`<<'PY'`) no expansion happens and the
-                    # premise "verbatim is what python receives" is exactly true, which is why
-                    # that case is compiled and this one is a finding.
-                    raise Unclassifiable(
-                        idx + 1,
-                        f"this python heredoc uses an UNQUOTED delimiter (`{hd.group('tag')}`),"
-                        " so the shell EXPANDS the body before python sees it and the verbatim"
-                        " text is not the program that runs. Compiling it would approve source"
-                        " nobody executes. Quote the delimiter to make the body literal.",
-                    )
-                body, end = _delimit_heredoc(
-                    lines, idx, hd.group("tag"), hd.group("dash") == "-"
-                )
-                pos = starts[end] + len(lines[end])
-                records.append(
-                    {"kind": "BLOCK", "shape": "heredoc", "line": idx + 1, "end": end + 1,
-                     "body": body}
-                )
-                continue
             if _SCRIPT.match(rest):
+                # ALLOWLIST 2.
                 records.append({"kind": "SCRIPT", "line": idx + 1, "text": rest})
                 continue
             raise Unclassifiable(
                 idx + 1,
-                "this `python3` invocation is in a shape the census does not recognise"
+                "this `python3` invocation matches none of the shapes the census interprets"
                 f" ({rest[:60]!r}). It may be carrying embedded code the compile check would"
-                " therefore never see, so it is a finding rather than a skip. If the shape is"
-                " legitimate, TEACH THE CENSUS THE SHAPE — this finding is about the extractor,"
-                " not about the python.",
+                " therefore never see — via stdin, a heredoc, a variable, a double-quoted `-c`"
+                " body — so it is a finding rather than a skip. If the shape is legitimate,"
+                " TEACH THE ALLOWLIST — this finding is about the census, not about the python.",
             )
         except Unclassifiable as exc:
             findings.append({"line": exc.lineno, "reason": exc.reason})
-            # An occurrence that could not be delimited must not leave the cursor inside whatever
-            # it failed to delimit: resume after the line it started on, so the scan terminates
-            # and the rest of the file is still censused.
-            pos = max(pos, line_end)
     return records, findings
 
 

--- a/scripts/tests/ws0_embedded_python.py
+++ b/scripts/tests/ws0_embedded_python.py
@@ -239,12 +239,22 @@ def _join_continuations(text: str) -> tuple[str, list[int]]:
     IS literally `$PYTHON -c 'prog'`, which the `-c` anchor already catches) rather than adding a
     special case to an enumeration.
 
-    USED FOR DISCOVERY ONLY, and that restriction is load-bearing: inside SINGLE QUOTES a
-    backslash is LITERAL and no continuation happens, so joining a block's BODY would hand the
-    compiler source that differs from what python receives. Anchors are located in the joined
-    text; every subsequent read — the rest of the line, the quote scan, the body, the reported
-    line numbers — is done against the ORIGINAL. The returned map exists for exactly that
-    hand-back, so a finding never names a line that only exists in the joined view.
+    USED FOR DISCOVERY **AND CLASSIFICATION**, BUT NEVER FOR A BODY, and that boundary is the
+    load-bearing part. Joining decides WHERE THE TOKENS ARE; it must never decide WHAT A STRING
+    CONTAINS, because inside SINGLE QUOTES a backslash is LITERAL and bash performs no
+    continuation there — a body read from joined text could differ from the source python
+    actually receives. So the anchors AND the rest-of-line the allowlist matches against come
+    from the joined text, while the quote scan, the body and the reported LINE NUMBERS come from
+    the original; the returned map is what hands positions back across that boundary.
+
+    The first version of this joiner did discovery only and left classification on the physical
+    line, which is incoherent rather than merely incomplete: `python3 -c \\` + `'prog'` was
+    FOUND and then classified against the remainder `-c \\`, matching no shape, so an ordinary
+    invocation became a refusal — plus a second, self-contradictory one from the flag anchor
+    reporting that the command word `python3` was "not the literal python3". After joining that
+    input IS `python3 -c 'prog'` and classifies as the inline block it is, which is also what
+    makes the joining worth having: a driver block reformatted across a continuation keeps
+    working instead of becoming a finding.
     """
     out: list[str] = []
     omap: list[int] = []
@@ -347,6 +357,12 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
     records: list[dict] = []
     findings: list[dict] = []
     pos = 0
+    # ONE INVOCATION, AT MOST ONE FINDING. When the WORD anchor has already claimed a candidate,
+    # a `-c` flag belonging to the SAME command must not be reported again — `python3 -m foo -c
+    # 'x'` is one invocation and produced two findings, after which a finding count means nothing.
+    # The extent is the command's segment: from the word up to the next SEPARATOR, and bash's
+    # separators are a closed set, so this is a lookup rather than a parse.
+    suppress_flag_until = -1
     while True:
         # TWO anchors, earliest wins. A `python3 -c '…'` matches the WORD first (lower offset) and
         # its branch consumes through the closing quote, so the `-c` inside it is never reached —
@@ -370,18 +386,22 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
         if anchored_on_flag:
             if line.lstrip().startswith("#"):
                 continue  # a whole-line shell comment carries no code
-            # The word before the flag, for the diagnostic only — enough to name what was found
-            # without pretending to resolve it.
+            if m.start() < suppress_flag_until:
+                continue  # the word anchor already claimed this invocation
+            # The nearest preceding word, NAMED rather than judged. The old text asserted the word
+            # was "not the literal `python3`" — something this branch never checked — and on a
+            # continuation it printed `is 'python3', not the literal python3`, a diagnostic that
+            # contradicted itself and told its reader nothing actionable.
             before = text[line_start:match_start].rstrip()
             cmd_word = before[max((before.rfind(c) for c in _WORD_BREAK), default=-1) + 1 :]
             findings.append({
                 "line": idx + 1,
-                "reason": "a `-c '<program>'` invocation whose command word is"
-                          f" {cmd_word or '(unresolvable)'!r}, not the literal `python3` the"
-                          " allowlist recognises. Anchored on the FLAG rather than the command"
-                          " word, because an indirectly-spelled word (a variable, a"
-                          " concatenation) carries code exactly as a literal one does and was"
-                          " INVISIBLE before #3451 round 7. Teach the allowlist if intended.",
+                "reason": "a `-c '<program>'` invocation for which NO literal `python3` command"
+                          f" word was found (nearest preceding word: {cmd_word or '(none)'!r})."
+                          " Anchored on the FLAG rather than the command word, because an"
+                          " indirectly-spelled word — a variable, a concatenation — carries code"
+                          " exactly as a literal one does and was INVISIBLE before #3451 round 7."
+                          " Teach the allowlist if the spelling is intended.",
             })
             continue
         # Walk left to the start of the shell WORD, so a path prefix travels with the candidate.
@@ -398,9 +418,27 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
             # basename and is examined. This is the one lexical exclusion, and it is a statement
             # about names rather than about shell.
             continue
+        # CLASSIFICATION READS THE JOINED LOGICAL LINE, not the physical one (#3451 round 8
+        # follow-up). Round 8 joined continuations for DISCOVERY and left classification reading
+        # unjoined text, so `python3 -c \\` + `'prog'` was found and then classified against the
+        # physical remainder `-c \\` — which matches no shape. It landed as a refusal, and a
+        # second one from the flag anchor. After joining it IS an ordinary inline invocation
+        # (bash sees `python3 -c 'prog'`), so that is what it must classify as; a driver block
+        # reformatted across a continuation keeps working instead of becoming a refusal, which is
+        # what makes the joining worth having.
+        scan_line_end = scan.find("\n", m.end())
+        if scan_line_end < 0:
+            scan_line_end = len(scan)
         line_end = line_start + len(line)
-        raw_rest = text[match_end:line_end]
+        raw_rest = scan[m.end() : scan_line_end]
         rest = _strip_comment(raw_rest).strip()
+        # This candidate's command segment, in SCAN space: a `-c` flag inside it belongs to THIS
+        # invocation and must not be reported a second time.
+        suppress_flag_until = scan_line_end
+        for _sep in ";&|":
+            _at = scan.find(_sep, m.end(), scan_line_end)
+            if _at >= 0:
+                suppress_flag_until = min(suppress_flag_until, _at)
         try:
             if word != "python3":
                 raise Unclassifiable(
@@ -418,7 +456,12 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
             dash_c = _OPEN_DASH_C.match(raw_rest)
             if dash_c:
                 # ALLOWLIST 1.
-                open_quote = match_end + dash_c.end() - 1
+                # The opening quote is located in the JOINED text and then handed back to the
+                # ORIGINAL before the body is read. Joining decides WHERE the tokens are; it must
+                # never decide WHAT a string contains, because inside single quotes a backslash is
+                # LITERAL and bash performs no continuation there — a body scanned from joined
+                # text could differ from the source python actually receives.
+                open_quote = omap[m.end() + dash_c.end() - 1]
                 body, close = _scan_single_quoted(text, open_quote)
                 after = text[close + 1 : close + 2]
                 if after and after not in _WORD_BOUNDARY_AFTER_CLOSE:

--- a/scripts/tests/ws0_embedded_python.py
+++ b/scripts/tests/ws0_embedded_python.py
@@ -8,10 +8,12 @@ reason — a DEFINITION and an ORACLE must not be the same thing:
                            shape this file cannot classify or a block it cannot delimit
     emit <driver> <n>      print embedded block <n>'s SOURCE, exactly as the driver ships it
     compile <driver>       compile EVERY embedded block; print one finding per block that does not
-    portable <driver>      does every embedded block parse on EVERY interpreter this repo runs,
-                           not merely on this box's? (the PEP 701 trap — see below)
-    portable-source <file> the same question about an ordinary python file, so the check's
-                           accept direction can be controlled without a driver
+    nested-quote <driver>  does any embedded block use the PEP 701 NESTED SAME-TYPE QUOTE
+                           spelling — the one alternative the driver's comment rejects? (ONE
+                           construct class, not general portability — see below)
+    nested-quote-source <file>
+                           the same question about an ordinary python file, so the check's accept
+                           direction can be controlled without a driver
 
 Every mode prints a `#COMPLETE …` marker on success. The CALLER counts findings, so a crash
 must not read as "clean" — the marker is what makes that distinguishable, and every caller
@@ -42,14 +44,13 @@ A self-test carrying its own copy of the block certifies THE COPY. The copy does
 the driver does — it stays green while the shipped step is broken, which is precisely the state
 this issue found. So the subject is read out of the shipped file on every run.
 
-# COMPILING ON THIS BOX IS NOT THE PROPERTY (#3451 review round 1, finding 1)
+# ONE SPELLING IS DECIDED HERE, AND IT IS NOT "PORTABILITY" (#3451 review rounds 1-2)
 
-`compile()` answers "does this parse HERE". The property the driver's repaired steps need is "does
-this parse on EVERY interpreter this repository runs on", and the two differ for exactly one
-spelling: a subscript inside an f-string expression written with NESTED SAME-TYPE QUOTES. PEP 701
-made that legal in 3.12 and it is a SyntaxError on everything older. So a regression to that form
-passes `compile()` on a 3.12 box and breaks a 3.11 one — and it is the very alternative the
-driver's own comment says was rejected, protected by nothing.
+`compile()` answers "does this parse HERE". The regression the driver's repaired steps are exposed
+to is narrower and specific: a subscript inside an f-string expression written with NESTED
+SAME-TYPE QUOTES. PEP 701 made that legal in 3.12 and it is a SyntaxError on everything older, so
+a regression to it — the exact alternative the driver's own comment says it rejected — passes
+`compile()` on a 3.12 box and breaks a 3.11 one.
 
 The exposure is real rather than theoretical: this repository pins Python 3.11 in
 `.github/workflows/parity-failure-issue.yml` and `parity-failure-issue-tests.yml`,
@@ -64,11 +65,32 @@ character.
 
 THE SAME-TYPE/DIFFERENT-TYPE BOUNDARY IS THE WHOLE CHECK. `f"{x['k']}"` is legal on every
 interpreter and flagging it would be a false red; `f"{x["k"]}"` is 3.12-only and must be refused.
-The suite controls BOTH directions.
+The caller controls BOTH directions.
 
-TWO ORACLES, EACH SOUND OVER ITS OWN RANGE, AND WHICH ONE RAN IS PRINTED. On 3.12+ the tokenizer
-walk is the oracle, because `compile()` there accepts the bad form. On < 3.12 `compile()` IS the
-oracle — the bad form does not parse at all — and the token types the walk needs
+## WHAT THIS DOES **NOT** DECIDE — the claim was narrowed rather than the oracle widened
+
+It does NOT establish that a block parses on every interpreter this repository runs. PEP 701
+legalised OTHER constructs too, and two of them are MEASURED to pass this check silently while
+being 3.12-only:
+
+    a MULTILINE f-string expression                 -> 3.12 compiles, this check is CLEAN
+    a COMMENT inside an f-string expression         -> 3.12 compiles, this check is CLEAN
+
+Those are not oversights to be closed by adding cases. THE CONSTRUCT LIST DOES NOT CLOSE BY
+ENUMERATION, and widening the model here would make this file a SECOND IMPLEMENTATION of CPython's
+tokenizer — whose correctness would then be knowable only by differential testing against the
+original, which is the trap CLAUDE.md records (a bash port of Go's trim rules, tested against a
+MODEL of Go rather than Go, whose NBSP divergence was unfindable by care).
+
+THE CORRECT ORACLE IS THE REAL INTERPRETER: compile the blocks under an actual 3.9/3.11. That is a
+CI lane, not a hermetic self-test, and it cannot be done honestly on the machines this suite runs
+on (no python3.9/3.10/3.11 present). So the general property is recorded as NOT REACHED in the
+caller's header, and what is claimed here is exactly what is measured: the nested same-type quote
+spelling, and nothing else.
+
+TWO ORACLES FOR THAT ONE SPELLING, EACH SOUND OVER ITS OWN RANGE, AND WHICH ONE RAN IS PRINTED. On
+3.12+ the tokenizer walk is the oracle, because `compile()` there accepts the bad form. On < 3.12
+`compile()` IS the oracle — the bad form does not parse at all — and the token types the walk needs
 (`FSTRING_START`/`FSTRING_END`) do not exist. Either way the answer is affirmative and the
 `#COMPLETE` line names the oracle and the interpreter, so a reader can never mistake this for one
 check that silently skipped. Nothing here is conditional on an optional interpreter being
@@ -156,6 +178,7 @@ operator having been parsed by nothing, and it is the state this file was writte
 
 from __future__ import annotations
 
+import bisect
 import io
 import pathlib
 import re
@@ -269,12 +292,24 @@ def _delimit_heredoc(
 
 
 def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
-    """Classify every `python3` occurrence. Returns (records, findings)."""
+    """Classify every `python3` occurrence. Returns (records, findings).
+
+    THE SCAN IS BY POSITION, NOT BY LINE (#3451 review round 2, finding 3). An earlier version
+    searched each line ONCE and then skipped whole lines, so a SECOND invocation on the same
+    line — after a `;`, an `&&`, or an inline block's closing quote — was silently dropped, which
+    contradicted the "every occurrence" guarantee this file's fail-closed posture rests on.
+    MEASURED against `python3 -c 'import sys'; python3 -c '<a syntax error>'`: `blocks=1
+    occurrences=1`, and the defect in the second block was invisible to the compile check.
+
+    So the cursor advances past exactly what each classification CONSUMED — the closing quote of
+    a `-c` block, the line after a heredoc terminator, the token itself for a mention or a script
+    invocation — and the remainder of every line is rescanned.
+    """
     text = path.read_text()
     lines = text.split("\n")
-    # Offset of each line start, so a per-line match can hand an ABSOLUTE position to the
-    # quoting scanner. The scanner works over the whole text because a block's closer is not a
-    # property of any single line (shapes 1-3 in the header).
+    # Offset of each line start, so a match position can be turned back into a line number and a
+    # per-line remainder. The quoting scanner works over the whole text because a block's closer
+    # is not a property of any single line (shapes 1-3 in the header).
     starts: list[int] = []
     off = 0
     for line in lines:
@@ -282,17 +317,23 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
         off += len(line) + 1
     records: list[dict] = []
     findings: list[dict] = []
-    skip_until = -1
-    for idx, line in enumerate(lines):
-        if idx <= skip_until:
-            continue
-        if line.lstrip().startswith("#"):
-            continue  # a whole-line shell comment carries no code
-        m = _PY_TOKEN.search(line)
+    pos = 0
+    while True:
+        m = _PY_TOKEN.search(text, pos)
         if not m:
+            break
+        idx = bisect.bisect_right(starts, m.start()) - 1
+        line = lines[idx]
+        if line.lstrip().startswith("#"):
+            # A whole-line shell comment carries no code. Advance past THIS occurrence only, not
+            # past the line: nothing else on a comment line matters, but the cursor rule stays one
+            # rule everywhere.
+            pos = m.end()
             continue
-        raw_rest = line[m.end() :]
+        line_end = starts[idx] + len(line)
+        raw_rest = text[m.end() : line_end]
         rest = _strip_comment(raw_rest).strip()
+        pos = m.end()
         try:
             if not rest or rest.lstrip(";&|)").strip() in ("", "do", "then"):
                 # A presence probe (`for tool in perf taskset python3; do`) or a bare mention:
@@ -302,10 +343,10 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
             dash_c = _OPEN_DASH_C.match(raw_rest)
             if dash_c:
                 # The opening quote is the LAST character the match consumed.
-                open_quote = starts[idx] + m.end() + dash_c.end() - 1
+                open_quote = m.end() + dash_c.end() - 1
                 body, close = _scan_single_quoted(text, open_quote)
                 end_line = text.count("\n", 0, close)
-                skip_until = end_line
+                pos = close + 1
                 records.append(
                     {"kind": "BLOCK",
                      "shape": "dash-c-multiline" if "\n" in body else "dash-c-inline",
@@ -318,7 +359,7 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
                 body, end = _delimit_heredoc(
                     lines, idx, hd.group("tag"), hd.group("dash") == "-"
                 )
-                skip_until = end
+                pos = starts[end] + len(lines[end])
                 records.append(
                     {"kind": "BLOCK", "shape": "heredoc", "line": idx + 1, "end": end + 1,
                      "body": body}
@@ -337,13 +378,17 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
             )
         except Unclassifiable as exc:
             findings.append({"line": exc.lineno, "reason": exc.reason})
+            # An occurrence that could not be delimited must not leave the cursor inside whatever
+            # it failed to delimit: resume after the line it started on, so the scan terminates
+            # and the rest of the file is still censused.
+            pos = max(pos, line_end)
     return records, findings
 
 
 # Whether this interpreter tokenizes f-strings into their own token types (PEP 701, 3.12+). On an
 # older one the nested same-type form is not tokenizable at all, so `compile()` is the oracle.
 _HAS_FSTRING_TOKENS = hasattr(tokenize, "FSTRING_START")
-PORTABILITY_ORACLE = "tokenizer" if _HAS_FSTRING_TOKENS else "compile"
+NESTED_QUOTE_ORACLE = "tokenizer" if _HAS_FSTRING_TOKENS else "compile"
 
 
 def _string_open_quote(tok: str) -> str:
@@ -354,19 +399,21 @@ def _string_open_quote(tok: str) -> str:
     return ""
 
 
-def portability_findings(src: str) -> list[str]:
-    """Spellings in `src` that parse on 3.12+ and NOT on older interpreters.
+def nested_same_type_quote_findings(src: str) -> list[str]:
+    """Occurrences in `src` of the PEP 701 NESTED SAME-TYPE QUOTE spelling. Nothing else.
 
-    Exactly one such spelling exists and it is the one this issue is about: a string inside an
-    f-string expression opening with the SAME quote character as the f-string itself. A
-    DIFFERENT-type nested quote (`f"{x['k']}"`) is legal everywhere and must not be reported.
+    A string inside an f-string expression opening with the SAME quote character as the f-string
+    itself. A DIFFERENT-type nested quote (`f"{x['k']}"`) is legal everywhere and must not be
+    reported. This is ONE construct class and NOT a portability verdict — see the module header
+    for the two 3.12-only constructs it is measured NOT to catch, and why the answer is a CI lane
+    rather than a deeper model here.
     """
     if not _HAS_FSTRING_TOKENS:
         # `compile()` is the oracle on this interpreter: the 3.12-only form is a SyntaxError here,
-        # and `compile`/`portable` therefore report it through the same path. Returning nothing is
+        # and `compile`/`nested-quote` therefore report it through the same path. Returning nothing is
         # correct rather than a skip — the caller prints WHICH oracle answered.
         try:
-            compile(src, "<portability>", "exec")
+            compile(src, "<nested-quote>", "exec")
         except SyntaxError as exc:
             return [
                 f"does not parse on this interpreter ({sys.version_info.major}."
@@ -406,7 +453,7 @@ def _blocks(records: list[dict]) -> list[dict]:
 def main(argv: list[str]) -> int:
     if len(argv) < 3:
         print(__doc__.splitlines()[0], file=sys.stderr)
-        print("usage: ws0_embedded_python.py census|compile|portable|portable-source|emit"
+        print("usage: ws0_embedded_python.py census|compile|nested-quote|nested-quote-source|emit"
           " <file> [n]", file=sys.stderr)
         return 2
     mode, driver = argv[1], pathlib.Path(argv[2])
@@ -414,13 +461,13 @@ def main(argv: list[str]) -> int:
         print(f"{driver}:0: the driver is not a readable file, so the census has NO SUBJECT —"
               " which prints exactly like a driver with nothing wrong in it.")
         return 0
-    if mode == "portable-source":
+    if mode == "nested-quote-source":
         # The same question about an ORDINARY python file. Exists so the accept direction (a
         # DIFFERENT-type nested quote, legal everywhere) can be controlled without smuggling an
         # apostrophe into a shell single-quoted block, where it would terminate the string.
-        for note in portability_findings(driver.read_text()):
-            print(f"{driver}: NOT PORTABLE — {note}")
-        print(f"#COMPLETE portable-source=1 oracle={PORTABILITY_ORACLE}"
+        for note in nested_same_type_quote_findings(driver.read_text()):
+            print(f"{driver}: uses the 3.12-ONLY NESTED SAME-TYPE QUOTE spelling — {note}")
+        print(f"#COMPLETE nested-quote-source=1 oracle={NESTED_QUOTE_ORACLE}"
               f" interpreter={sys.version_info.major}.{sys.version_info.minor}"
               f".{sys.version_info.micro}")
         return 0
@@ -454,16 +501,16 @@ def main(argv: list[str]) -> int:
                       " past it.")
         print(f"#COMPLETE compiled={len(blocks)} findings={len(findings)}")
         return 0
-    if mode == "portable":
-        # EVERY embedded block, against the property `compile` cannot see on this box.
+    if mode == "nested-quote":
+        # EVERY embedded block, against the ONE spelling `compile` cannot see on a 3.12 box.
         for f in findings:
             print(f"{driver}:{f['line']}: {f['reason']}")
         for i, r in enumerate(blocks, start=1):
-            for note in portability_findings(r["body"]):
-                print(f"{driver}:{r['line']}: embedded python block {i} is NOT PORTABLE —"
-                      f" {note}")
-        print(f"#COMPLETE portable={len(blocks)} findings={len(findings)}"
-              f" oracle={PORTABILITY_ORACLE}"
+            for note in nested_same_type_quote_findings(r["body"]):
+                print(f"{driver}:{r['line']}: embedded python block {i} uses the 3.12-ONLY"
+                      f" NESTED SAME-TYPE QUOTE spelling — {note}")
+        print(f"#COMPLETE nested-quote-scanned={len(blocks)} findings={len(findings)}"
+              f" oracle={NESTED_QUOTE_ORACLE}"
               f" interpreter={sys.version_info.major}.{sys.version_info.minor}"
               f".{sys.version_info.micro}")
         return 0

--- a/scripts/tests/ws0_embedded_python.py
+++ b/scripts/tests/ws0_embedded_python.py
@@ -179,24 +179,24 @@ _PY_WORD = re.compile(r"python[0-9]*(?:\.[0-9]+)*(?![\w.])")
 # own inline block at line 941 uses.
 _CONCATENATION_BEFORE_WORD = frozenset("\"'`)}" + chr(92))
 
-# IS A COMMAND WORD A PLAIN LITERAL? (#3451 review round 12.)
+# WHICH COMMAND WORDS MAY BE SKIPPED — AN ALLOWLIST (#3451 post-rebase round 7, F1+F2).
 #
-# The flag anchor used to report EVERY `-c '…'` whose command word was not literally `python3`,
-# which false-red on `grep -c '_RN'` the moment #3455 added one to the driver. `-c` is a common
-# flag — `grep -c` counts, `sort -c` checks, `tar -c` creates — so "not python3" was the wrong
-# question. The right one is decidable in three states:
+# The skip path used to read "a literal not containing `python`, therefore skip", which decides
+# safety by what a word is NOT. Every silent absence this issue produced came through that one
+# door: `if` (round 4), `-I` (round 3), `#` (round 6), `env` and `command` (round 7) — each found
+# separately, each fixed separately, because a blocklist cannot close over an open set.
 #
-#   a literal CONTAINING `python`      the allowlisted shape; the word anchor handles it
-#   a literal NOT containing `python`  SKIP. `grep` is definitively not python, so there is no
-#                                      python program here and nothing to compile. Deciding this
-#                                      needs no list of known commands — only that the word is
-#                                      literal, and that literals can be compared.
-#   NOT a plain literal                FINDING. `$PYTHON`, `"prefix"python3`, `$(which python3)`
-#                                      cannot be resolved without executing the shell, so they
-#                                      may carry code and fail closed.
+# Skipping now requires MEMBERSHIP of this set. A spelling nobody anticipated no longer grants
+# itself a skip by lacking a signal — the same inversion that closed the classification series,
+# applied one level down.
 #
-# A word is a PLAIN LITERAL when it contains no expansion or quoting character. That is the same
-# closed metacharacter set used elsewhere in this file, applied to a different question.
+# THE COST IS NOISE IN THE ACTIONABLE DIRECTION: a driver that grows a `-c` user outside this set
+# reds the gate and someone adds it here deliberately. Measured before adopting — the only
+# command words reaching the flag anchor in `ws0-baseline.sh` are `grep` and `python3`.
+_NON_PYTHON_DASH_C_COMMANDS = frozenset({"grep", "sort", "tar", "sed", "awk", "bash", "sh"})
+
+# A word is a PLAIN LITERAL when it contains no expansion or quoting character — still needed, so
+# an indirect word is never compared against the allowlist as though it were a name.
 _NON_LITERAL_IN_WORD = frozenset("$`\"'*?[]{}" + chr(92))
 
 
@@ -590,23 +590,23 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
             if (
                 cmd_word is not None
                 and _is_plain_literal(cmd_word)
-                and "python" not in cmd_word.rsplit("/", 1)[-1]
+                and cmd_word.rsplit("/", 1)[-1] in _NON_PYTHON_DASH_C_COMMANDS
             ):
-                # A LITERAL non-python command: `grep -c '_RN'`, `sort -c`, `tar -c`. Its text is
-                # its value, so this is decidably not a python invocation and there is no program
-                # to compile. Skipped rather than reported — reporting it is the false-red
-                # direction, and a guard that reds on correct code is the guard people waive.
+                # An ALLOWLISTED non-python command. Its text is its value AND it is a named
+                # member of the set, so there is no python program here. Skipping by MEMBERSHIP
+                # rather than by "does not look like python" is what stops the next spelling.
                 continue
             findings.append({
                 "line": idx + 1,
                 "reason": "a `-c '<program>'` invocation whose command word"
                           f" ({cmd_word if cmd_word else '(unresolvable)'!r}) is NOT A"
-                          " PLAIN LITERAL, so what it runs"
+                          " ALLOWLISTED non-python command, so what it runs"
                           " cannot be decided without executing the shell — it may be python"
                           " carrying a program this check would never see. Anchored on the FLAG"
                           " rather than the command word, because an indirectly-spelled word was"
                           " INVISIBLE before #3451 round 7. A LITERAL non-python command"
-                          " (`grep -c`, `sort -c`) is skipped, not reported.",
+                          " on `_NON_PYTHON_DASH_C_COMMANDS` is skipped; add one there"
+                          " deliberately if it genuinely never runs python.",
             })
             continue
         # Walk left to the start of the shell WORD — in JOINED space, so a path prefix or a

--- a/scripts/tests/ws0_embedded_python.py
+++ b/scripts/tests/ws0_embedded_python.py
@@ -210,10 +210,16 @@ _WORD_BOUNDARY_AFTER_CLOSE = frozenset(" \t\n)&;|<>")
 # The token is a word in a LIST, not a command.
 _FOR_WORD_LIST = re.compile(r"^\s*for\s+[A-Za-z_][A-Za-z0-9_]*\s+in\s")
 
-# A script-file argument, quoted or not, possibly carrying a shell expansion in its directory
-# part: `"$HERE/ws0_report.py"` (driver line 981). Recorded, never extracted — an ordinary python
-# file is something every other tool already reads.
-_SCRIPT = re.compile(r"^[\"']?[^\s\"']*\.py[\"']?(\s|$)")
+# A script-file argument: ONE SHELL WORD, quoted or not, possibly carrying a shell expansion in
+# its directory part — `"$HERE/ws0_report.py"` (driver line 981). Recorded, never extracted, since
+# an ordinary python file is something every other tool already reads.
+#
+# BOUNDED TO A SINGLE WORD (#3451 review round 9). The previous pattern tested only that the
+# remainder BEGAN with something ending `.py`, and the record then stored the whole remainder: for
+# `python3 helper.py ) $PY -c 'import os,'` it recorded `helper.py ) $PY -c 'import os,'` as a
+# "script path". A script argument is one word, and where a word ends is decidable with the same
+# closed metacharacter set used after a closing quote — no shell interpretation required.
+_SCRIPT_WORD = re.compile(r"""^(?:"[^"]*"|'[^']*'|[^\s;&|<>()`"']+)""")
 
 
 class Unclassifiable(Exception):
@@ -357,12 +363,21 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
     records: list[dict] = []
     findings: list[dict] = []
     pos = 0
-    # ONE INVOCATION, AT MOST ONE FINDING. When the WORD anchor has already claimed a candidate,
-    # a `-c` flag belonging to the SAME command must not be reported again — `python3 -m foo -c
-    # 'x'` is one invocation and produced two findings, after which a finding count means nothing.
-    # The extent is the command's segment: from the word up to the next SEPARATOR, and bash's
-    # separators are a closed set, so this is a lookup rather than a parse.
-    suppress_flag_until = -1
+    # NO SUPPRESSION BETWEEN THE ANCHORS, AND THAT IS DELIBERATE (#3451 review round 9).
+    #
+    # One invocation may produce a finding from BOTH anchors. That is NOISE, and it is the right
+    # side to err on. The alternative was tried: a `suppress_flag_until` extent, from a word
+    # anchor to the next `;`/`&`/`|`, so a `-c` flag inside "the same command" deferred. Deciding
+    # WHICH INVOCATION a match belongs to is a SEMANTIC question — it needs shell nesting and
+    # quoting — and the syntactic approximation had a hole immediately:
+    #
+    #     v=$(python3 helper.py ) $PY -c 'import os,'
+    #
+    # the inner `python3 helper.py` classified as a harmless SCRIPT and the suppression then
+    # swallowed the OUTER `-c` anchor, so invalid code escaped and the census reported clean.
+    # Suppression was BLINDNESS; duplicate findings are noise. Do not reintroduce it as a
+    # tidiness improvement: "at most one finding per invocation" is a COSMETIC invariant that can
+    # only be satisfied by machinery this file must not contain.
     while True:
         # TWO anchors, earliest wins. A `python3 -c '…'` matches the WORD first (lower offset) and
         # its branch consumes through the closing quote, so the `-c` inside it is never reached —
@@ -386,8 +401,6 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
         if anchored_on_flag:
             if line.lstrip().startswith("#"):
                 continue  # a whole-line shell comment carries no code
-            if m.start() < suppress_flag_until:
-                continue  # the word anchor already claimed this invocation
             # The nearest preceding word, NAMED rather than judged. The old text asserted the word
             # was "not the literal `python3`" — something this branch never checked — and on a
             # continuation it printed `is 'python3', not the literal python3`, a diagnostic that
@@ -432,13 +445,6 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
         line_end = line_start + len(line)
         raw_rest = scan[m.end() : scan_line_end]
         rest = _strip_comment(raw_rest).strip()
-        # This candidate's command segment, in SCAN space: a `-c` flag inside it belongs to THIS
-        # invocation and must not be reported a second time.
-        suppress_flag_until = scan_line_end
-        for _sep in ";&|":
-            _at = scan.find(_sep, m.end(), scan_line_end)
-            if _at >= 0:
-                suppress_flag_until = min(suppress_flag_until, _at)
         try:
             if word != "python3":
                 raise Unclassifiable(
@@ -484,9 +490,12 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
                      "body": body if body.endswith("\n") else body + "\n"}
                 )
                 continue
-            if _SCRIPT.match(rest):
-                # ALLOWLIST 2.
-                records.append({"kind": "SCRIPT", "line": idx + 1, "text": rest})
+            script = _SCRIPT_WORD.match(rest)
+            if script and script.group(0).strip("\"'").endswith(".py"):
+                # ALLOWLIST 2. The WORD is recorded, not the rest of the line.
+                records.append(
+                    {"kind": "SCRIPT", "line": idx + 1, "text": script.group(0)}
+                )
                 continue
             raise Unclassifiable(
                 idx + 1,

--- a/scripts/tests/ws0_embedded_python.py
+++ b/scripts/tests/ws0_embedded_python.py
@@ -8,12 +8,6 @@ reason — a DEFINITION and an ORACLE must not be the same thing:
                            shape this file cannot classify or a block it cannot delimit
     emit <driver> <n>      print embedded block <n>'s SOURCE, exactly as the driver ships it
     compile <driver>       compile EVERY embedded block; print one finding per block that does not
-    nested-quote <driver>  does any embedded block use the PEP 701 NESTED SAME-TYPE QUOTE
-                           spelling — the one alternative the driver's comment rejects? (ONE
-                           construct class, not general portability — see below)
-    nested-quote-source <file>
-                           the same question about an ordinary python file, so the check's accept
-                           direction can be controlled without a driver
 
 Every mode prints a `#COMPLETE …` marker on success. The CALLER counts findings, so a crash
 must not read as "clean" — the marker is what makes that distinguishable, and every caller
@@ -44,58 +38,15 @@ A self-test carrying its own copy of the block certifies THE COPY. The copy does
 the driver does — it stays green while the shipped step is broken, which is precisely the state
 this issue found. So the subject is read out of the shipped file on every run.
 
-# ONE SPELLING IS DECIDED HERE, AND IT IS NOT "PORTABILITY" (#3451 review rounds 1-2)
+# WHICH INTERPRETER `compile` SPEAKS FOR
 
-`compile()` answers "does this parse HERE". The regression the driver's repaired steps are exposed
-to is narrower and specific: a subscript inside an f-string expression written with NESTED
-SAME-TYPE QUOTES. PEP 701 made that legal in 3.12 and it is a SyntaxError on everything older, so
-a regression to it — the exact alternative the driver's own comment says it rejected — passes
-`compile()` on a 3.12 box and breaks a 3.11 one.
-
-The exposure is real rather than theoretical: this repository pins Python 3.11 in
-`.github/workflows/parity-failure-issue.yml` and `parity-failure-issue-tests.yml`,
-`bindings/python/pyproject.toml` declares `requires-python = ">=3.9"`, and the driver itself
-declares NO floor — it requires `python3` and takes whatever the host has.
-
-`ast.parse(..., feature_version=(3, 9))` DOES NOT DETECT IT (measured at (3,9)/(3,11)/(3,12), all
-accepting): `feature_version` gates the AST grammar, not the tokenizer, and PEP 701 is a tokenizer
-change. So the check is at the TOKENIZER: walk the tokens, track the quote character of each
-enclosing `FSTRING_START`, and flag any `STRING` token inside it whose OPENING QUOTE EQUALS that
-character.
-
-THE SAME-TYPE/DIFFERENT-TYPE BOUNDARY IS THE WHOLE CHECK. `f"{x['k']}"` is legal on every
-interpreter and flagging it would be a false red; `f"{x["k"]}"` is 3.12-only and must be refused.
-The caller controls BOTH directions.
-
-## WHAT THIS DOES **NOT** DECIDE — the claim was narrowed rather than the oracle widened
-
-It does NOT establish that a block parses on every interpreter this repository runs. PEP 701
-legalised OTHER constructs too, and two of them are MEASURED to pass this check silently while
-being 3.12-only:
-
-    a MULTILINE f-string expression                 -> 3.12 compiles, this check is CLEAN
-    a COMMENT inside an f-string expression         -> 3.12 compiles, this check is CLEAN
-
-Those are not oversights to be closed by adding cases. THE CONSTRUCT LIST DOES NOT CLOSE BY
-ENUMERATION, and widening the model here would make this file a SECOND IMPLEMENTATION of CPython's
-tokenizer — whose correctness would then be knowable only by differential testing against the
-original, which is the trap CLAUDE.md records (a bash port of Go's trim rules, tested against a
-MODEL of Go rather than Go, whose NBSP divergence was unfindable by care).
-
-THE CORRECT ORACLE IS THE REAL INTERPRETER: compile the blocks under an actual 3.9/3.11. That is a
-CI lane, not a hermetic self-test, and it cannot be done honestly on the machines this suite runs
-on (no python3.9/3.10/3.11 present). So the general property is recorded as NOT REACHED in the
-caller's header, and what is claimed here is exactly what is measured: the nested same-type quote
-spelling, and nothing else.
-
-TWO ORACLES FOR THAT ONE SPELLING, EACH SOUND OVER ITS OWN RANGE, AND WHICH ONE RAN IS PRINTED. On
-3.12+ the tokenizer walk is the oracle, because `compile()` there accepts the bad form. On < 3.12
-`compile()` IS the oracle — the bad form does not parse at all — and the token types the walk needs
-(`FSTRING_START`/`FSTRING_END`) do not exist. Either way the answer is affirmative and the
-`#COMPLETE` line names the oracle and the interpreter, so a reader can never mistake this for one
-check that silently skipped. Nothing here is conditional on an optional interpreter being
-installed: a check that skips when a dependency is absent is the coverage gap this whole issue is
-about.
+`compile()` answers "does this parse on the interpreter running this check", and that is the whole
+of what `compile` mode claims. A PEP 701 tokenizer model that tried to answer the cross-interpreter
+question lived here for two rounds and was removed (#3451 review round 4): it was wrong twice, the
+second time in the FALSE-RED direction on legal triple-quoted code, and a second implementation of
+CPython's tokenizer is correct only insofar as it is differentially tested against the original —
+which needs the interpreters we do not have. The caller's NOT-REACHED list records the limit and
+names the only honest oracle for it.
 
 # FAIL-CLOSED, because an extractor that finds nothing prints like a clean driver
 
@@ -117,8 +68,13 @@ spelled:
                   future step written this way must not fall outside the census.)
     <path>.py     a SCRIPT FILE. Not embedded — it is an ordinary python file every other tool
                   already sees — so it is recorded and not extracted.
-    (no argument) a MENTION: a `command -v`-style presence probe, or the word inside prose. It
-                  carries no code, so there is nothing to compile.
+    (no argument) a MENTION **only** for the one presence-probe construct this driver uses — the
+                  word inside a `for … in <list>` membership test. EVERY OTHER argumentless
+                  invocation is UNKNOWN, because `python3` with no argument reads its program from
+                  STDIN: `producer | python3` is embedded code with no argument at all, and
+                  classifying it as harmless was a hole in the fail-closed census (#3451 review
+                  round 4). Fail-closed means the shapes do NOT have to be enumerated — recognise
+                  the one that occurs, and let the rest be findings.
 
 Anything else — `-c` with a shape that cannot be delimited, `-m`, a bare `-`, a variable where the
 code should be — is UNKNOWN, which is a finding.
@@ -179,11 +135,9 @@ operator having been parsed by nothing, and it is the state this file was writte
 from __future__ import annotations
 
 import bisect
-import io
 import pathlib
 import re
 import sys
-import tokenize
 
 # The word, matched only where it is a standalone token. `requires python3.` inside an `echo`
 # string is not an invocation and must not be censused as an unknown shape; a trailing
@@ -202,6 +156,11 @@ _QUOTE_IDIOM = "'" + '"' + "'" + '"' + "'"
 _HEREDOC = re.compile(
     r"<<(?P<dash>-?)\s*(?P<q>['\"]?)(?P<tag>[A-Za-z_][A-Za-z0-9_]*)(?P=q)"
 )
+# The ONE presence-probe construct the driver contains: `for tool in perf taskset python3; do`.
+# The token is a word in a LIST, not a command. Recognised explicitly so that every OTHER
+# argumentless invocation can fall through to UNKNOWN — see the MENTION branch in `census`.
+_FOR_WORD_LIST = re.compile(r"^\s*for\s+[A-Za-z_][A-Za-z0-9_]*\s+in\s")
+
 # A script-file argument, quoted or not, possibly carrying a shell expansion in its directory
 # part: `"$HERE/ws0_report.py"`.
 _SCRIPT = re.compile(r"^[\"']?[^\s\"']*\.py[\"']?(\s|$)")
@@ -336,10 +295,25 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
         pos = m.end()
         try:
             if not rest or rest.lstrip(";&|)").strip() in ("", "do", "then"):
-                # A presence probe (`for tool in perf taskset python3; do`) or a bare mention:
-                # no argument can carry code.
-                records.append({"kind": "MENTION", "line": idx + 1, "text": line.strip()})
-                continue
+                # AN ARGUMENTLESS `python3` IS NOT AUTOMATICALLY HARMLESS (#3451 review round 4).
+                # With no argument python3 reads its program from STDIN, so `producer | python3`
+                # is embedded code carrying no argument at all — and treating every argumentless
+                # invocation as a MENTION let exactly that bypass the census.
+                #
+                # So only the ONE presence-probe construct this driver contains is recognised: the
+                # word inside a `for … in <list>` membership test, which is a word in a LIST and
+                # not a command at all. Everything else falls through to UNKNOWN below. That is
+                # what fail-closed buys — the shapes do not have to be enumerated.
+                if _FOR_WORD_LIST.match(line):
+                    records.append({"kind": "MENTION", "line": idx + 1, "text": line.strip()})
+                    continue
+                raise Unclassifiable(
+                    idx + 1,
+                    "this `python3` invocation has NO ARGUMENT, so it reads its program from"
+                    " STDIN — a pipe or a redirect can carry embedded code the compile check"
+                    " would never see. Only a `for … in <list>` membership test is recognised as"
+                    " a presence probe; anything else is a finding rather than a skip.",
+                )
             dash_c = _OPEN_DASH_C.match(raw_rest)
             if dash_c:
                 # The opening quote is the LAST character the match consumed.
@@ -385,67 +359,6 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
     return records, findings
 
 
-# Whether this interpreter tokenizes f-strings into their own token types (PEP 701, 3.12+). On an
-# older one the nested same-type form is not tokenizable at all, so `compile()` is the oracle.
-_HAS_FSTRING_TOKENS = hasattr(tokenize, "FSTRING_START")
-NESTED_QUOTE_ORACLE = "tokenizer" if _HAS_FSTRING_TOKENS else "compile"
-
-
-def _string_open_quote(tok: str) -> str:
-    """The quote character a STRING token opens with, past any prefix letters (`rb'…'`)."""
-    for ch in tok:
-        if ch in "\"'":
-            return ch
-    return ""
-
-
-def nested_same_type_quote_findings(src: str) -> list[str]:
-    """Occurrences in `src` of the PEP 701 NESTED SAME-TYPE QUOTE spelling. Nothing else.
-
-    A string inside an f-string expression opening with the SAME quote character as the f-string
-    itself. A DIFFERENT-type nested quote (`f"{x['k']}"`) is legal everywhere and must not be
-    reported. This is ONE construct class and NOT a portability verdict — see the module header
-    for the two 3.12-only constructs it is measured NOT to catch, and why the answer is a CI lane
-    rather than a deeper model here.
-    """
-    if not _HAS_FSTRING_TOKENS:
-        # `compile()` is the oracle on this interpreter: the 3.12-only form is a SyntaxError here,
-        # and `compile`/`nested-quote` therefore report it through the same path. Returning nothing is
-        # correct rather than a skip — the caller prints WHICH oracle answered.
-        try:
-            compile(src, "<nested-quote>", "exec")
-        except SyntaxError as exc:
-            return [
-                f"does not parse on this interpreter ({sys.version_info.major}."
-                f"{sys.version_info.minor}) — {exc.msg} (line {exc.lineno})"
-            ]
-        return []
-    out: list[str] = []
-    stack: list[str] = []
-    try:
-        for tok in tokenize.generate_tokens(io.StringIO(src).readline):
-            if tok.type == tokenize.FSTRING_START:
-                stack.append(tok.string[-1])
-            elif tok.type == tokenize.FSTRING_END:
-                if stack:
-                    stack.pop()
-            elif tok.type == tokenize.STRING and stack:
-                quote = _string_open_quote(tok.string)
-                if quote and quote == stack[-1]:
-                    out.append(
-                        f"line {tok.start[0]}: {tok.string} is nested inside an f-string"
-                        f" delimited by the SAME quote ({stack[-1]}). PEP 701 made that legal in"
-                        " 3.12 and it is a SyntaxError on every earlier interpreter, which this"
-                        " repository still runs (3.11 in two workflows, >=3.9 declared by the"
-                        " python bindings) and this driver does not exclude. Bind the subscript"
-                        " to a LOCAL before the f-string."
-                    )
-    except (SyntaxError, tokenize.TokenError) as exc:
-        out.append(f"could not be tokenized ({type(exc).__name__}: {exc}) — reported rather than"
-                   " skipped, because an unanswerable oracle must not read as a clean answer")
-    return out
-
-
 def _blocks(records: list[dict]) -> list[dict]:
     return [r for r in records if r["kind"] == "BLOCK"]
 
@@ -453,23 +366,13 @@ def _blocks(records: list[dict]) -> list[dict]:
 def main(argv: list[str]) -> int:
     if len(argv) < 3:
         print(__doc__.splitlines()[0], file=sys.stderr)
-        print("usage: ws0_embedded_python.py census|compile|nested-quote|nested-quote-source|emit"
+        print("usage: ws0_embedded_python.py census|compile|emit"
           " <file> [n]", file=sys.stderr)
         return 2
     mode, driver = argv[1], pathlib.Path(argv[2])
     if not driver.is_file():
         print(f"{driver}:0: the driver is not a readable file, so the census has NO SUBJECT —"
               " which prints exactly like a driver with nothing wrong in it.")
-        return 0
-    if mode == "nested-quote-source":
-        # The same question about an ORDINARY python file. Exists so the accept direction (a
-        # DIFFERENT-type nested quote, legal everywhere) can be controlled without smuggling an
-        # apostrophe into a shell single-quoted block, where it would terminate the string.
-        for note in nested_same_type_quote_findings(driver.read_text()):
-            print(f"{driver}: uses the 3.12-ONLY NESTED SAME-TYPE QUOTE spelling — {note}")
-        print(f"#COMPLETE nested-quote-source=1 oracle={NESTED_QUOTE_ORACLE}"
-              f" interpreter={sys.version_info.major}.{sys.version_info.minor}"
-              f".{sys.version_info.micro}")
         return 0
     records, findings = census(driver)
     blocks = _blocks(records)
@@ -500,19 +403,6 @@ def main(argv: list[str]) -> int:
                       f" {exc.lineno}). This step is fatal-on-failure, so the driver cannot run"
                       " past it.")
         print(f"#COMPLETE compiled={len(blocks)} findings={len(findings)}")
-        return 0
-    if mode == "nested-quote":
-        # EVERY embedded block, against the ONE spelling `compile` cannot see on a 3.12 box.
-        for f in findings:
-            print(f"{driver}:{f['line']}: {f['reason']}")
-        for i, r in enumerate(blocks, start=1):
-            for note in nested_same_type_quote_findings(r["body"]):
-                print(f"{driver}:{r['line']}: embedded python block {i} uses the 3.12-ONLY"
-                      f" NESTED SAME-TYPE QUOTE spelling — {note}")
-        print(f"#COMPLETE nested-quote-scanned={len(blocks)} findings={len(findings)}"
-              f" oracle={NESTED_QUOTE_ORACLE}"
-              f" interpreter={sys.version_info.major}.{sys.version_info.minor}"
-              f".{sys.version_info.micro}")
         return 0
     if mode == "emit":
         if len(argv) < 4:

--- a/scripts/tests/ws0_embedded_python.py
+++ b/scripts/tests/ws0_embedded_python.py
@@ -402,11 +402,29 @@ def _join_continuations(text: str) -> tuple[str, list[int]]:
     out: list[str] = []
     omap: list[int] = []
     i, n = 0, len(text)
+    # A `#` COMMENT ENDS AT ITS PHYSICAL NEWLINE and a trailing backslash does NOT continue it
+    # (#3451 post-rebase round 6, F1). Joining across one swallows the next line into the
+    # comment, and the command-word resolution then reads `#` as a literal non-python command and
+    # SKIPS a live invocation: `# note \` + `$PY -c 'bad'` measured at findings=0.
+    #
+    # Tracked while scanning rather than tested afterwards, because "is this offset inside a
+    # comment" is only answerable in one pass. Conservative: a comment is recognised at the first
+    # non-blank of a physical line. A `#` appearing MID-line is not treated as one — deciding that
+    # needs quote awareness, which is shell modelling, and erring here costs a joined line that
+    # was already going to be classified rather than a missed invocation.
+    at_line_start, in_comment = True, False
     while i < n:
-        if text[i] == "\\" and i + 1 < n and text[i + 1] == "\n":
+        ch = text[i]
+        if ch == "\n":
+            at_line_start, in_comment = True, False
+        elif at_line_start and not ch.isspace():
+            in_comment = ch == "#"
+            at_line_start = False
+        if ch == "\\" and i + 1 < n and text[i + 1] == "\n" and not in_comment:
             i += 2
+            at_line_start, in_comment = True, False
             continue
-        out.append(text[i])
+        out.append(ch)
         omap.append(i)
         i += 1
     return "".join(out), omap
@@ -556,11 +574,16 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
         match_end = omap[m.end() - 1] + 1
         pos = m.end()
         idx = bisect.bisect_right(starts, match_start) - 1
-        line = lines[idx]
+        physical_line = lines[idx]  # physical-ok: diagnostics and line numbers only
         line_start = starts[idx]
+        logical_line = scan[scan_line_start:scan_line_end]
+        # A COMMENT CARRIES NO CODE — tested on the LOGICAL line like every other classification.
+        # That is only sound because the joiner now refuses to join across a comment (F1): before
+        # it did, a comment's logical line absorbed the following command and this test would
+        # have hidden it. The two changes are one fix and must not be separated.
+        if logical_line.lstrip().startswith("#"):
+            continue
         if anchored_on_flag:
-            if line.lstrip().startswith("#"):
-                continue  # see the comment-test note above: a comment ends at the newline
             # The command word, from the JOINED line and from the whole COMMAND SEGMENT rather
             # than the word that happens to sit next to the flag — see `_command_word_before`.
             cmd_word = _command_word_before(scan[scan_line_start : m.start()])
@@ -592,8 +615,6 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
         while word_start > scan_line_start and scan[word_start - 1] not in _WORD_BREAK:
             word_start -= 1
         word = scan[word_start : m.end()]
-        if line.lstrip().startswith("#"):
-            continue  # see the comment-test note above
         if word.rsplit("/", 1)[-1] != scan[m.start() : m.end()]:
             # The word's BASENAME is not the matched token, i.e. the token is a SUFFIX of a longer
             # program name (`mypython3`, `jython3`). That is a different program, not a
@@ -601,7 +622,7 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
             # basename and is examined. This is the one lexical exclusion, and it is a statement
             # about names rather than about shell.
             continue
-        line_end = line_start + len(line)
+        line_end = line_start + len(physical_line)  # physical-ok: diagnostic bound
         raw_rest = scan[m.end() : scan_line_end]
         rest = _strip_comment(raw_rest).strip()
         try:
@@ -624,9 +645,10 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
                     " until #3451 round 6 this shape was INVISIBLE to the census — a defective"
                     " block reported as clean. Teach the allowlist if the spelling is intended.",
                 )
-            if _FOR_WORD_LIST.match(line) and rest.lstrip(";&|)").strip() in ("", "do", "then"):
+            if _FOR_WORD_LIST.match(logical_line) and rest.lstrip(";&|)").strip() in ("", "do", "then"):
                 # ALLOWLIST 3: a word in a `for … in <list>` membership test, not a command.
-                records.append({"kind": "MENTION", "line": idx + 1, "text": line.strip()})
+                records.append({"kind": "MENTION", "line": idx + 1,
+                                "text": physical_line.strip()})  # physical-ok: diagnostic
                 continue
             dash_c = _OPEN_DASH_C.match(raw_rest)
             if dash_c:

--- a/scripts/tests/ws0_embedded_python.py
+++ b/scripts/tests/ws0_embedded_python.py
@@ -74,7 +74,18 @@ Now the candidate net is as wide as it goes and exactly four shapes are interpre
     anything else     A FINDING. Not classified, not skipped, not modelled.
 
 A construct nobody anticipated therefore becomes a finding by FAILING TO MATCH, rather than by
-someone having thought to refuse it. HEREDOCS ARE NOT SUPPORTED and are findings: support for them
+someone having thought to refuse it.
+
+THE ALLOWLIST CLOSES CLASSIFICATION, NOT DISCOVERY, and the difference is worth stating because it
+is the residual (#3451 round 7). A candidate must be FOUND before it can be classified, and a
+shell command word can be spelled arbitrarily — a variable, a concatenation, `$(which python3)`,
+an alias, `eval`. Enumerating those spellings is the same open list one level down, so it is not
+attempted. Instead there are TWO anchors covering the decidable part: a literal `python` word (any
+argument shape), and the `-c` FLAG (any command-word spelling — `$PYTHON -c '…'` is found because
+the anchor does not depend on the word). What remains undiscovered is an indirectly-spelled
+command word combined with a NON-`-c` form (`$PYTHON <<'PY'`) or code reaching python through
+`eval`. Closing that needs an interpreter for bash. It is a decision, not an oversight; the
+caller's NOT-REACHED list says the same thing where an operator will read it. HEREDOCS ARE NOT SUPPORTED and are findings: support for them
 was speculative (this driver has none) and produced three separate false passes — an unquoted
 delimiter is shell-expanded before python sees it, a composed delimiter makes bash use a different
 tag, and with several redirects bash uses the last. Each compiled a body python never receives. A
@@ -152,6 +163,20 @@ import sys
 # not a word of its own (`requires python3.` inside an `echo` string, `python3x`). That is a rule
 # about identifiers, not about shell.
 _PY_WORD = re.compile(r"python[0-9]*(?:\.[0-9]+)*(?![\w.])")
+
+# THE SECOND DISCOVERY ANCHOR: the FLAG, not the command word (#3451 review round 7, finding 1).
+#
+# The allowlist closed CLASSIFICATION — anything not allowlisted is a finding — but not
+# DISCOVERY: a candidate has to be found before it can be classified, and `$PYTHON -c '…'` or
+# `py"thon3" -c '…'` contains no literal `python` word, so it was INVISIBLE. Anchoring on `-c`
+# followed by whitespace and a quote catches EVERY command-word spelling of the `-c` form,
+# because the anchor no longer depends on how the command word is written.
+#
+# Verified false-red-free for this driver before adopting: its only `-c '` occurrences are the
+# three python3 blocks (599, 697, 941), each consumed by the python-word branch before this
+# anchor is reached; the sole other `-c` is `taskset -c 1` inside a whole-line COMMENT, excluded
+# twice over (comment, and no quote follows). No bash/sh/zsh/perl/ruby/node/env `-c` exists here.
+_DASH_C_ANCHOR = re.compile(r"(?<![\w-])-c\s+['\"]")
 
 # Characters that cannot appear inside one shell word, used to find where a candidate's word
 # STARTS so a path prefix is captured with it.
@@ -287,12 +312,39 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
     findings: list[dict] = []
     pos = 0
     while True:
-        m = _PY_WORD.search(text, pos)
-        if not m:
+        # TWO anchors, earliest wins. A `python3 -c '…'` matches the WORD first (lower offset) and
+        # its branch consumes through the closing quote, so the `-c` inside it is never reached —
+        # no double report. A `-c '` reached FIRST means no literal python word preceded it, i.e.
+        # the command word is spelled indirectly, which is a finding.
+        mp = _PY_WORD.search(text, pos)
+        mc = _DASH_C_ANCHOR.search(text, pos)
+        if mp is not None and (mc is None or mp.start() <= mc.start()):
+            m, anchored_on_flag = mp, False
+        elif mc is not None:
+            m, anchored_on_flag = mc, True
+        else:
             break
         idx = bisect.bisect_right(starts, m.start()) - 1
         line = lines[idx]
         line_start = starts[idx]
+        if anchored_on_flag:
+            pos = m.end()
+            if line.lstrip().startswith("#"):
+                continue  # a whole-line shell comment carries no code
+            # The word before the flag, for the diagnostic only — enough to name what was found
+            # without pretending to resolve it.
+            before = text[line_start : m.start()].rstrip()
+            cmd_word = before[max((before.rfind(c) for c in _WORD_BREAK), default=-1) + 1 :]
+            findings.append({
+                "line": idx + 1,
+                "reason": "a `-c '<program>'` invocation whose command word is"
+                          f" {cmd_word or '(unresolvable)'!r}, not the literal `python3` the"
+                          " allowlist recognises. Anchored on the FLAG rather than the command"
+                          " word, because an indirectly-spelled word (a variable, a"
+                          " concatenation) carries code exactly as a literal one does and was"
+                          " INVISIBLE before #3451 round 7. Teach the allowlist if intended.",
+            })
+            continue
         # Walk left to the start of the shell WORD, so a path prefix travels with the candidate.
         word_start = m.start()
         while word_start > line_start and text[word_start - 1] not in _WORD_BREAK:
@@ -379,9 +431,13 @@ def main(argv: list[str]) -> int:
         return 2
     mode, driver = argv[1], pathlib.Path(argv[2])
     if not driver.is_file():
+        # NONZERO (#3451 review round 7, finding 2). This used to `return 0`, so an absent or
+        # unreadable driver produced a message and a SUCCESS exit — and a caller that checks the
+        # status (rather than parsing the text) read "no subject at all" as "nothing wrong". The
+        # message is kept for a human; the status is what a script must be able to trust.
         print(f"{driver}:0: the driver is not a readable file, so the census has NO SUBJECT —"
               " which prints exactly like a driver with nothing wrong in it.")
-        return 0
+        return 4
     records, findings = census(driver)
     blocks = _blocks(records)
     if mode == "census":

--- a/scripts/tests/ws0_embedded_python.py
+++ b/scripts/tests/ws0_embedded_python.py
@@ -62,6 +62,13 @@ spelled:
 
 Anything else — `-c` with a shape that cannot be delimited, `-m`, a bare `-`, a variable where the
 code should be — is UNKNOWN, which is a finding.
+
+## The direction it errs in, stated
+
+Over-inclusion, deliberately. A `python3 -c '…'` written INSIDE a shell string (an `echo` of an
+example, say) is censused as a block and compiled, which costs a spurious finding at worst. The
+opposite posture — skipping anything that might not be real code — is how a step reaches an
+operator having been parsed by nothing, and it is the state this file was written to end.
 """
 
 from __future__ import annotations

--- a/scripts/tests/ws0_embedded_python.py
+++ b/scripts/tests/ws0_embedded_python.py
@@ -200,6 +200,52 @@ _CONCATENATION_BEFORE_WORD = frozenset("\"'`)}" + chr(92))
 _NON_LITERAL_IN_WORD = frozenset("$`\"'*?[]{}" + chr(92))
 
 
+# A shell environment-assignment word: `NAME=` anything. Leading assignments belong to the
+# command's environment, not to its name.
+_ASSIGNMENT_WORD = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+# The separators that END a command. A closed set in bash's grammar, so finding the start of the
+# CURRENT command is a lookup rather than a parse.
+_COMMAND_SEPARATORS = ";&|"
+
+
+def _command_word_before(segment: str) -> str | None:
+    """The command word of the last command in `segment` — the text left of a `-c` flag.
+
+    THE IMMEDIATELY PRECEDING WORD IS NOT THE COMMAND WORD (#3451 post-rebase round 2, F1).
+    `$PYTHON -I -c 'bad'` has `-I` before the flag, which is a plain literal containing no
+    `python`, so the literal-skip rule discarded it and the invalid program was INVISIBLE —
+    neither a block nor a finding, which is the worst answer this census can give.
+
+    Decidable, and it reuses the shape the export-prefix check already relies on: cut back to the
+    last command separator, drop leading ASSIGNMENT words (they are environment, not a name), and
+    the first word that remains is the command. Everything after it is options. So
+    `A=1 $PYTHON -I -c` resolves to `$PYTHON`, while `grep -c` and `sort -c` still resolve to
+    `grep` and `sort` and are still skipped. Returns None when the command word is unknowable.
+    """
+    cut = max((segment.rfind(ch) for ch in _COMMAND_SEPARATORS), default=-1)
+    tail = segment[cut + 1 :]
+    # A SUBSTITUTION IN THE CURRENT COMMAND MAKES THE WORD BOUNDARIES UNKNOWABLE, so the answer is
+    # "cannot tell" rather than a guess. `v=$(python3 helper.py ) $PY -c 'bad'` is ONE assignment
+    # word followed by `$PY`, but splitting on whitespace sees `v=$(python3`, `helper.py`, `)`,
+    # `$PY` — and picks `helper.py`, a literal without `python`, which would SKIP the invocation
+    # and restore exactly the silent absence round 9 removed. MEASURED: that case went from a
+    # finding to `findings=0` when the segment rule was first written without this.
+    #
+    # Resolving it properly needs `$( … )` nesting, i.e. parsing shell, which this file does not
+    # do. So it fails closed: unknowable command word => the caller reports it.
+    #
+    # Scoped to the CURRENT command (after the last separator), not the whole segment — the
+    # driver's own `_syms=$(nm … | grep -c '_RN')` has its substitution BEFORE the last `|`, and
+    # testing the whole segment would false-red on it.
+    if any(marker in tail for marker in ("$(", "${", "`")):
+        return None
+    for word in tail.split():
+        if not _ASSIGNMENT_WORD.match(word):
+            return word
+    return ""
+
+
 def _is_plain_literal(word: str) -> bool:
     """True when `word` is a shell word whose text IS its value — no expansion, no quoting."""
     return bool(word) and not any(ch in _NON_LITERAL_IN_WORD for ch in word)
@@ -217,7 +263,10 @@ def _is_plain_literal(word: str) -> bool:
 # three python3 blocks (599, 697, 941), each consumed by the python-word branch before this
 # anchor is reached; the sole other `-c` is `taskset -c 1` inside a whole-line COMMENT, excluded
 # twice over (comment, and no quote follows). No bash/sh/zsh/perl/ruby/node/env `-c` exists here.
-_DASH_C_ANCHOR = re.compile(r"(?<![\w-])-c\s+['\"]")
+# `\s*`, not `\s+`: python accepts the ATTACHED spelling `-c'prog'` and runs it, so requiring
+# whitespace left that form UNDISCOVERED — neither a block nor a finding (#3451 post-rebase
+# round 2, F2).
+_DASH_C_ANCHOR = re.compile(r"(?<![\w-])-c\s*['\"]")
 
 # Characters that cannot appear inside one shell word, used to find where a candidate's word
 # STARTS so a path prefix is captured with it.
@@ -229,7 +278,7 @@ _WORD_BREAK = frozenset(" \t\n;&|<>()'\"`")
 # `-c` followed by a single quote. ONE branch covers both the multi-line form (the quote ends the
 # line, driver blocks 1-2) and the inline form (driver block 3), because where the string CLOSES is
 # found by scanning bash's quoting rules rather than by a line pattern.
-_OPEN_DASH_C = re.compile(r"^\s*-c\s+'")
+_OPEN_DASH_C = re.compile(r"^\s*-c\s*'")
 
 # The `'"'"'` idiom: close, emit a literal apostrophe from a double-quoted segment, reopen. The one
 # exception to "a single-quoted string runs to the next quote".
@@ -465,11 +514,14 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
         if anchored_on_flag:
             if line.lstrip().startswith("#"):
                 continue  # see the comment-test note above: a comment ends at the newline
-            # The command word, from the JOINED line. Rebuilt from the physical line this used to
-            # yield '(none)' whenever a continuation sat between the word and the flag.
-            before = scan[scan_line_start : m.start()].rstrip()
-            cmd_word = before[max((before.rfind(c) for c in _WORD_BREAK), default=-1) + 1 :]
-            if _is_plain_literal(cmd_word) and "python" not in cmd_word.rsplit("/", 1)[-1]:
+            # The command word, from the JOINED line and from the whole COMMAND SEGMENT rather
+            # than the word that happens to sit next to the flag — see `_command_word_before`.
+            cmd_word = _command_word_before(scan[scan_line_start : m.start()])
+            if (
+                cmd_word is not None
+                and _is_plain_literal(cmd_word)
+                and "python" not in cmd_word.rsplit("/", 1)[-1]
+            ):
                 # A LITERAL non-python command: `grep -c '_RN'`, `sort -c`, `tar -c`. Its text is
                 # its value, so this is decidably not a python invocation and there is no program
                 # to compile. Skipped rather than reported — reporting it is the false-red
@@ -478,7 +530,8 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
             findings.append({
                 "line": idx + 1,
                 "reason": "a `-c '<program>'` invocation whose command word"
-                          f" ({cmd_word or '(none)'!r}) is NOT A PLAIN LITERAL, so what it runs"
+                          f" ({cmd_word if cmd_word else '(unresolvable)'!r}) is NOT A"
+                          " PLAIN LITERAL, so what it runs"
                           " cannot be decided without executing the shell — it may be python"
                           " carrying a program this check would never see. Anchored on the FLAG"
                           " rather than the command word, because an indirectly-spelled word was"

--- a/scripts/tests/ws0_embedded_python.py
+++ b/scripts/tests/ws0_embedded_python.py
@@ -240,6 +240,24 @@ def _command_word_before(segment: str) -> str | None:
     # testing the whole segment would false-red on it.
     if any(marker in tail for marker in ("$(", "${", "`")):
         return None
+    # ...AND AN UNMATCHED CLOSER MEANS THE SEPARATOR WAS INSIDE A CONSTRUCT (#3451 post-rebase
+    # round 3, F2). `v=$(echo x | sed s/x/y/) $PY -c 'bad'` has its `|` INSIDE the substitution,
+    # so cutting at the last separator lands mid-construct: the tail is ` sed s/x/y/) $PY `, which
+    # contains no `$(` and resolved to the literal `sed` — skipped, and the invocation went
+    # SILENT. Measured at findings=0 before this.
+    #
+    # Decided by COUNTING CLOSERS, not by tracking nesting: if the tail closes a bracket it never
+    # opened, or holds an odd number of quotes, the cut was not a real command boundary and the
+    # command word is unknowable. That is one comparison, not a shell model — and it is why the
+    # OPENING markers above are tested on the tail too rather than on the whole segment: the
+    # driver's own `_syms=$(nm … | grep -c '_RN')` has its `$(` BEFORE the last `|`, is perfectly
+    # resolvable as `grep`, and a whole-segment test would red it.
+    for opener, closer in (("(", ")"), ("{", "}")):
+        if tail.count(closer) > tail.count(opener):
+            return None
+    for quote in ("'", '"'):
+        if tail.count(quote) % 2:
+            return None
     for word in tail.split():
         if not _ASSIGNMENT_WORD.match(word):
             return word
@@ -263,10 +281,19 @@ def _is_plain_literal(word: str) -> bool:
 # three python3 blocks (599, 697, 941), each consumed by the python-word branch before this
 # anchor is reached; the sole other `-c` is `taskset -c 1` inside a whole-line COMMENT, excluded
 # twice over (comment, and no quote follows). No bash/sh/zsh/perl/ruby/node/env `-c` exists here.
-# `\s*`, not `\s+`: python accepts the ATTACHED spelling `-c'prog'` and runs it, so requiring
-# whitespace left that form UNDISCOVERED — neither a block nor a finding (#3451 post-rebase
-# round 2, F2).
-_DASH_C_ANCHOR = re.compile(r"(?<![\w-])-c\s*['\"]")
+# `-c` FOLLOWED BY ANY NON-BLANK, which is the flag's natural boundary (#3451 post-rebase
+# round 3, F1). Requiring a QUOTE after it left three spellings python accepts UNDISCOVERED —
+# neither a block nor a finding: `-c'prog'` attached, `-cimport,os` unquoted, and `-c$CODE`
+# variable-valued. One widening covers all of them instead of an entry per spelling, and the
+# command-word resolution below then decides, which is where the decision belongs.
+#
+# `[ \t]*`, never `\s*`: the joined text still has newlines between LOGICAL lines, and `\s`
+# would let a trailing `-c` on one line bind to the next line's first word.
+#
+# The false-red direction was checked BEFORE widening, not assumed: `tar -cf out.tar` and
+# `sort -cu file` now match this anchor and must resolve to the literal commands `tar`/`sort`
+# and be SKIPPED. They are controls.
+_DASH_C_ANCHOR = re.compile(r"(?<![\w-])-c[ \t]*\S")
 
 # Characters that cannot appear inside one shell word, used to find where a candidate's word
 # STARTS so a path prefix is captured with it.

--- a/scripts/tests/ws0_embedded_python.py
+++ b/scripts/tests/ws0_embedded_python.py
@@ -164,6 +164,21 @@ import sys
 # about identifiers, not about shell.
 _PY_WORD = re.compile(r"python[0-9]*(?:\.[0-9]+)*(?![\w.])")
 
+# WHAT MAY NOT PRECEDE A COMMAND WORD (#3451 review round 10, finding 2).
+#
+# The MIRROR of `_WORD_BOUNDARY_AFTER_CLOSE`. Bash concatenates adjacent fragments on the LEFT of
+# a word exactly as it does on the right, so `"prefix"python3 -c '…'` runs `prefixpython3` — a
+# different command entirely. The scanner saw the suffix as a bare word, ACCEPTED the block and
+# advanced past the `-c` anchor: measured `blocks=1 findings=0`, a false pass that defeated the
+# whole point of classifying the command word.
+#
+# A CONSERVATIVE REJECT, not a shell-aware tokenizer: a candidate whose immediately preceding
+# character CLOSES a fragment — a quote, a backtick, the `)`/`}` of `$(…)`/`${…}`, or a backslash
+# escape — is refused. `(` is deliberately NOT in the set: it OPENS a subshell or command
+# substitution, so `$(python3 …)` is an ordinary command position and is the shape the driver's
+# own inline block at line 941 uses.
+_CONCATENATION_BEFORE_WORD = frozenset("\"'`)}" + chr(92))
+
 # THE SECOND DISCOVERY ANCHOR: the FLAG, not the command word (#3451 review round 7, finding 1).
 #
 # The allowlist closed CLASSIFICATION — anything not allowlisted is a finding — but not
@@ -446,6 +461,16 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
         raw_rest = scan[m.end() : scan_line_end]
         rest = _strip_comment(raw_rest).strip()
         try:
+            preceding = text[word_start - 1 : word_start] if word_start > line_start else ""
+            if preceding and preceding in _CONCATENATION_BEFORE_WORD:
+                raise Unclassifiable(
+                    idx + 1,
+                    f"this candidate is immediately preceded by {preceding!r}, which CLOSES a"
+                    " shell fragment — bash concatenates the two into a DIFFERENT command word"
+                    f" (`\"prefix\"python3` runs `prefixpython3`). Refused conservatively rather"
+                    " than resolved, because resolving it needs the quoting state this file does"
+                    " not track. Separate the words if a python invocation is intended.",
+                )
             if word != "python3":
                 raise Unclassifiable(
                     idx + 1,

--- a/scripts/tests/ws0_embedded_python.py
+++ b/scripts/tests/ws0_embedded_python.py
@@ -204,6 +204,24 @@ _NON_LITERAL_IN_WORD = frozenset("$`\"'*?[]{}" + chr(92))
 # command's environment, not to its name.
 _ASSIGNMENT_WORD = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 
+# BASH'S RESERVED WORDS AND DECORATORS, STEPPED OVER rather than treated as command names
+# (#3451 post-rebase round 4, F1). `if $PY -c 'bad'`, `time $PY -c 'bad'` and `! $PY -c 'bad'`
+# all resolved their command word to the control word — a plain literal containing no `python` —
+# and were SKIPPED as "another program". Three silent absences.
+#
+# SKIPPED, NOT REFUSED, and the difference was measured before choosing: refusing a leading
+# reserved word would make `if grep -c 'foo' file; then :; fi` a FINDING, which is ordinary shell
+# and clean today. A false red on legitimate code is the failure that has already cost this
+# checker its `grep -c` anchor and its nested-quote oracle, so the conservative-reject instinct
+# is the wrong one here.
+#
+# IMPORTED, not re-typed. `ws0_hermeticity_lint.RESERVED_WORDS` is the same closed set and it has
+# an ORACLE — `test_ws0_hermeticity.sh` asserts SET EQUALITY against `bash -c 'compgen -k'`, in
+# both directions. A second hand-written list here would be the exact tell this repository keeps
+# recording: an enumeration nobody can check. Stepping over the words needs no understanding of
+# the constructs they open.
+from ws0_hermeticity_lint import RESERVED_WORDS as _RESERVED_WORDS
+
 # The separators that END a command. A closed set in bash's grammar, so finding the start of the
 # CURRENT command is a lookup rather than a parse.
 _COMMAND_SEPARATORS = ";&|"
@@ -218,8 +236,9 @@ def _command_word_before(segment: str) -> str | None:
     neither a block nor a finding, which is the worst answer this census can give.
 
     Decidable, and it reuses the shape the export-prefix check already relies on: cut back to the
-    last command separator, drop leading ASSIGNMENT words (they are environment, not a name), and
-    the first word that remains is the command. Everything after it is options. So
+    last command separator, step over leading ASSIGNMENT words (environment, not a name) and
+    RESERVED WORDS (`if`, `time`, `!`, … — control, not a name), and the first word that remains
+    is the command. Everything after it is options. So
     `A=1 $PYTHON -I -c` resolves to `$PYTHON`, while `grep -c` and `sort -c` still resolve to
     `grep` and `sort` and are still skipped. Returns None when the command word is unknowable.
     """
@@ -259,8 +278,9 @@ def _command_word_before(segment: str) -> str | None:
         if tail.count(quote) % 2:
             return None
     for word in tail.split():
-        if not _ASSIGNMENT_WORD.match(word):
-            return word
+        if _ASSIGNMENT_WORD.match(word) or word in _RESERVED_WORDS:
+            continue
+        return word
     return ""
 
 

--- a/scripts/tests/ws0_embedded_python.py
+++ b/scripts/tests/ws0_embedded_python.py
@@ -403,30 +403,61 @@ def _join_continuations(text: str) -> tuple[str, list[int]]:
     omap: list[int] = []
     i, n = 0, len(text)
     # A `#` COMMENT ENDS AT ITS PHYSICAL NEWLINE and a trailing backslash does NOT continue it
-    # (#3451 post-rebase round 6, F1). Joining across one swallows the next line into the
-    # comment, and the command-word resolution then reads `#` as a literal non-python command and
-    # SKIPS a live invocation: `# note \` + `$PY -c 'bad'` measured at findings=0.
+    # (#3451 post-rebase rounds 6 and 8). Joining across one swallows the next line into the
+    # comment, and command resolution then reads the comment's own first word as the command:
+    # `grep foo file # note \` + `$PY -c 'bad'` resolved to the ALLOWLISTED `grep` and skipped a
+    # live python invocation.
     #
-    # Tracked while scanning rather than tested afterwards, because "is this offset inside a
-    # comment" is only answerable in one pass. Conservative: a comment is recognised at the first
-    # non-blank of a physical line. A `#` appearing MID-line is not treated as one — deciding that
-    # needs quote awareness, which is shell modelling, and erring here costs a joined line that
-    # was already going to be classified rather than a missed invocation.
-    at_line_start, in_comment = True, False
+    # ROUND 6 RECOGNISED A COMMENT ONLY AT THE FIRST NON-BLANK OF A LINE, which left the mid-line
+    # form open — and the control written for it could not tell: `x=1 # comment \` produced a
+    # finding because `#` is not on the command allowlist, NOT because the comment was respected.
+    # The joiner had still merged the lines. A control has to distinguish the claimed mechanism
+    # from every other reason the same result could occur, so the case that discriminates puts an
+    # ALLOWLISTED command before the comment.
+    #
+    # QUOTE STATE IS TRACKED, over the whole text rather than per line, and that is the smallest
+    # thing that answers "is this `#` a comment": a bounded two-state scan, not a shell model.
+    # Whole-text is also what makes it right INSIDE a `-c '…'` body — the opening quote is still
+    # open there, so a `#` in python source is correctly not a shell comment.
+    in_single = in_double = in_comment = False
+    prev = "\n"
     while i < n:
         ch = text[i]
-        if ch == "\n":
-            at_line_start, in_comment = True, False
-        elif at_line_start and not ch.isspace():
-            in_comment = ch == "#"
-            at_line_start = False
-        if ch == "\\" and i + 1 < n and text[i + 1] == "\n" and not in_comment:
-            i += 2
-            at_line_start, in_comment = True, False
+        if in_comment:
+            if ch == "\n":
+                in_comment = False
+            out.append(ch)
+            omap.append(i)
+            prev, i = ch, i + 1
             continue
+        if not in_single and ch == "\\" and i + 1 < n and text[i + 1] == "\n":
+            i += 2
+            prev = "\n"
+            continue
+        if in_single:
+            if ch == "'":
+                in_single = False
+        elif in_double:
+            if ch == "\\" and i + 1 < n:
+                out.append(ch)
+                omap.append(i)
+                out.append(text[i + 1])
+                omap.append(i + 1)
+                prev, i = text[i + 1], i + 2
+                continue
+            if ch == '"':
+                in_double = False
+        else:
+            if ch == "'":
+                in_single = True
+            elif ch == '"':
+                in_double = True
+            elif ch == "#" and (prev in " \t\n;&|()<>"):
+                # A word-start `#` outside quotes. Everything to the newline is comment.
+                in_comment = True
         out.append(ch)
         omap.append(i)
-        i += 1
+        prev, i = ch, i + 1
     return "".join(out), omap
 
 
@@ -599,7 +630,7 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
             findings.append({
                 "line": idx + 1,
                 "reason": "a `-c '<program>'` invocation whose command word"
-                          f" ({cmd_word if cmd_word else '(unresolvable)'!r}) is NOT A"
+                          f" ({cmd_word if cmd_word else '(unresolvable)'!r}) is NOT AN"
                           " ALLOWLISTED non-python command, so what it runs"
                           " cannot be decided without executing the shell — it may be python"
                           " carrying a program this check would never see. Anchored on the FLAG"

--- a/scripts/tests/ws0_embedded_python.py
+++ b/scripts/tests/ws0_embedded_python.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Census + extraction of the python `scripts/perf/ws0-baseline.sh` carries INSIDE itself.
+
+Three subcommands, and the split is the same one `ws0_hermeticity_lint.py` makes for the same
+reason — a DEFINITION and an ORACLE must not be the same thing:
+
+    census <driver>        classify EVERY `python3` occurrence in the driver; fail closed on a
+                           shape this file cannot classify or a block it cannot delimit
+    emit <driver> <n>      print embedded block <n>'s SOURCE, exactly as the driver ships it
+    compile <driver>       compile EVERY embedded block; print one finding per block that does not
+
+Every mode prints a `#COMPLETE …` marker on success. The CALLER counts findings, so a crash
+must not read as "clean" — the marker is what makes that distinguishable, and every caller
+checks for it.
+
+# WHY THIS FILE EXISTS (issue #3451)
+
+`ws0-baseline.sh` shipped for months with SEVEN instances of a defect that makes CPython refuse to
+parse: a backslash inside an f-string EXPRESSION (the tokenizer reads it as a line continuation).
+They were spread across the driver's TWO multi-line embedded blocks — the session-corpus-pin step
+and the CPU-pin-verification step — and both steps are fatal-on-failure, so the entire WS0
+measurement path was unrunnable end to end.
+
+Nothing caught it because the driver's python is INVISIBLE to every tool that would have:
+
+* it is not a `.py` file, so no linter, formatter or import ever sees it;
+* the hermetic self-tests all stop at `--validate-args-only`, which sits ABOVE both steps, and
+  #3272 round 2 finding 14 deliberately made the accept-direction cases execute NOTHING (running
+  the real driver invoked `sudo sysctl` and three cargo builds inside a gate component);
+* `bash -n` parses the file as SHELL, where a python body inside `python3 -c '…'` is one opaque
+  single-quoted STRING — syntactically valid whatever it contains.
+
+So the code was PARSED BY NOTHING until an operator ran the rig.
+
+# THE EXTRACTION IS THE POINT, and it is why this is not a copy of the two blocks
+
+A self-test carrying its own copy of the block certifies THE COPY. The copy does not drift when
+the driver does — it stays green while the shipped step is broken, which is precisely the state
+this issue found. So the subject is read out of the shipped file on every run.
+
+# FAIL-CLOSED, because an extractor that finds nothing prints like a clean driver
+
+Every `python3` occurrence must land in a classification this file recognises. An occurrence it
+cannot classify, or an embedded block whose closing delimiter it cannot find, is a FINDING naming
+the driver and the line — never a silent omission from the census. The alternative posture (skip
+what you do not understand) is the one that would let instance #8 ship in a shape slightly unlike
+the first seven.
+
+## The classification, and what makes it closed
+
+A `python3` invocation can only receive code four ways: `-c`, a script path, standard input, or
+`-m`. So the census keys on WHICH of those a given occurrence uses rather than on how it is
+spelled:
+
+    -c '…'        embedded, single-quoted — the shape both defective steps use. Extracted.
+    <<'EOF'       embedded via a heredoc on stdin. Extracted. (None today; covered because a
+                  future step written this way must not fall outside the census.)
+    <path>.py     a SCRIPT FILE. Not embedded — it is an ordinary python file every other tool
+                  already sees — so it is recorded and not extracted.
+    (no argument) a MENTION: a `command -v`-style presence probe, or the word inside prose. It
+                  carries no code, so there is nothing to compile.
+
+Anything else — `-c` with a shape that cannot be delimited, `-m`, a bare `-`, a variable where the
+code should be — is UNKNOWN, which is a finding.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+# The word, matched only where it is a standalone token. `requires python3.` inside an `echo`
+# string is not an invocation and must not be censused as an unknown shape; a trailing
+# word/dot character is the discriminator.
+_PY_TOKEN = re.compile(r"(?<![\w./-])python3(?![\w.])")
+
+# The shape both defective steps use: the line ENDS with the opening quote and the body follows on
+# subsequent lines, terminated by a line whose first character is the closing quote.
+_OPEN_MULTILINE = re.compile(r"^-c\s+'$")
+# The same thing on one line: `-c 'import time; print(…)'`.
+_INLINE = re.compile(r"^-c\s+'(?P<body>(?:[^']*))'")
+# A heredoc redirect: `<<'PY'`, `<<PY`, `<<-'PY'`.
+_HEREDOC = re.compile(r"<<-?\s*(?P<q>['\"]?)(?P<tag>[A-Za-z_][A-Za-z0-9_]*)(?P=q)")
+# A script-file argument, quoted or not, possibly carrying a shell expansion in its directory
+# part: `"$HERE/ws0_report.py"`.
+_SCRIPT = re.compile(r"^[\"']?[^\s\"']*\.py[\"']?(\s|$)")
+
+
+class Unclassifiable(Exception):
+    """A `python3` occurrence, or a block delimiter, this file will not guess about."""
+
+    def __init__(self, lineno: int, reason: str) -> None:
+        super().__init__(reason)
+        self.lineno = lineno
+        self.reason = reason
+
+
+def _strip_comment(rest: str) -> str:
+    """Drop a trailing `# …` comment from the text FOLLOWING a python3 token.
+
+    Only where the `#` starts a word — `a#b` is not a comment in bash, and the driver's
+    `# perf-lint-allow` marker is exactly the shape this must remove.
+    """
+    m = re.search(r"(?:^|\s)#", rest)
+    return rest[: m.start()] if m else rest
+
+
+def _delimit_multiline(lines: list[str], start: int) -> tuple[str, int]:
+    """Body of the `-c '` block opened on `lines[start]`, plus the line its closer sits on.
+
+    The closer is the first following line whose FIRST character is a single quote — which is how
+    the driver writes it (`' "$HERE" "$CORPUS" …`). A block with no such line is a finding rather
+    than a body silently truncated at end-of-file.
+    """
+    for i in range(start + 1, len(lines)):
+        if lines[i].startswith("'"):
+            return "\n".join(lines[start + 1 : i]) + "\n", i
+    raise Unclassifiable(
+        start + 1,
+        "an embedded `python3 -c '` block is never closed by a line beginning with the closing"
+        " quote, so its body cannot be delimited. Extracting to end-of-file would compile a"
+        " truncated body and report a defect that is the extractor's.",
+    )
+
+
+def _delimit_heredoc(lines: list[str], start: int, tag: str) -> tuple[str, int]:
+    """Body of the heredoc opened on `lines[start]`, plus the line its terminator sits on."""
+    for i in range(start + 1, len(lines)):
+        if lines[i].strip() == tag:
+            return "\n".join(lines[start + 1 : i]) + "\n", i
+    raise Unclassifiable(
+        start + 1,
+        f"an embedded python heredoc opened with `{tag}` is never terminated, so its body cannot"
+        " be delimited.",
+    )
+
+
+def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
+    """Classify every `python3` occurrence. Returns (records, findings)."""
+    text = path.read_text()
+    lines = text.split("\n")
+    records: list[dict] = []
+    findings: list[dict] = []
+    skip_until = -1
+    for idx, line in enumerate(lines):
+        if idx <= skip_until:
+            continue
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue  # a whole-line shell comment carries no code
+        m = _PY_TOKEN.search(line)
+        if not m:
+            continue
+        rest = _strip_comment(line[m.end() :]).strip()
+        try:
+            if not rest or rest.lstrip(";&|)").strip() in ("", "do", "then"):
+                # A presence probe (`for tool in perf taskset python3; do`) or a bare mention:
+                # no argument can carry code.
+                records.append({"kind": "MENTION", "line": idx + 1, "text": line.strip()})
+                continue
+            hd = _HEREDOC.search(rest)
+            if hd:
+                body, end = _delimit_heredoc(lines, idx, hd.group("tag"))
+                skip_until = end
+                records.append(
+                    {"kind": "BLOCK", "shape": "heredoc", "line": idx + 1, "end": end + 1,
+                     "body": body}
+                )
+                continue
+            if _OPEN_MULTILINE.match(rest):
+                body, end = _delimit_multiline(lines, idx)
+                skip_until = end
+                records.append(
+                    {"kind": "BLOCK", "shape": "dash-c-multiline", "line": idx + 1,
+                     "end": end + 1, "body": body}
+                )
+                continue
+            inline = _INLINE.match(rest)
+            if inline:
+                records.append(
+                    {"kind": "BLOCK", "shape": "dash-c-inline", "line": idx + 1,
+                     "end": idx + 1, "body": inline.group("body") + "\n"}
+                )
+                continue
+            if _SCRIPT.match(rest):
+                records.append({"kind": "SCRIPT", "line": idx + 1, "text": rest})
+                continue
+            raise Unclassifiable(
+                idx + 1,
+                "this `python3` invocation is in a shape the census does not recognise"
+                f" ({rest[:60]!r}). It may be carrying embedded code the compile check would"
+                " therefore never see, so it is a finding rather than a skip.",
+            )
+        except Unclassifiable as exc:
+            findings.append({"line": exc.lineno, "reason": exc.reason})
+    return records, findings
+
+
+def _blocks(records: list[dict]) -> list[dict]:
+    return [r for r in records if r["kind"] == "BLOCK"]
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        print(__doc__.splitlines()[0], file=sys.stderr)
+        print("usage: ws0_embedded_python.py census|compile|emit <driver> [n]", file=sys.stderr)
+        return 2
+    mode, driver = argv[1], pathlib.Path(argv[2])
+    if not driver.is_file():
+        print(f"{driver}:0: the driver is not a readable file, so the census has NO SUBJECT —"
+              " which prints exactly like a driver with nothing wrong in it.")
+        return 0
+    records, findings = census(driver)
+    blocks = _blocks(records)
+    if mode == "census":
+        for f in findings:
+            print(f"{driver}:{f['line']}: {f['reason']}")
+        for i, r in enumerate(blocks, start=1):
+            print(f"BLOCK\t{i}\t{r['line']}\t{r['end']}\t{r['shape']}")
+        for r in records:
+            if r["kind"] != "BLOCK":
+                print(f"{r['kind']}\t{r['line']}\t{r.get('text', '')}")
+        print(f"#COMPLETE blocks={len(blocks)} findings={len(findings)}"
+              f" occurrences={len(records)}")
+        return 0
+    if mode == "compile":
+        # EVERY embedded block, so instance #8 anywhere in the driver is caught rather than only
+        # the two steps #3451 repaired. A census finding is reported here too: a block the census
+        # could not delimit is a block this check did not compile, and silence about it would be
+        # the vacuous pass.
+        for f in findings:
+            print(f"{driver}:{f['line']}: {f['reason']}")
+        for i, r in enumerate(blocks, start=1):
+            try:
+                compile(r["body"], f"{driver}:block{i}@{r['line']}", "exec")
+            except SyntaxError as exc:
+                print(f"{driver}:{r['line']}: embedded python block {i} ({r['shape']}) DOES NOT"
+                      f" COMPILE — {type(exc).__name__}: {exc.msg} (block-relative line"
+                      f" {exc.lineno}). This step is fatal-on-failure, so the driver cannot run"
+                      " past it.")
+        print(f"#COMPLETE compiled={len(blocks)} findings={len(findings)}")
+        return 0
+    if mode == "emit":
+        if len(argv) < 4:
+            print("usage: ws0_embedded_python.py emit <driver> <n>", file=sys.stderr)
+            return 2
+        n = int(argv[3])
+        if not 1 <= n <= len(blocks):
+            print(f"{driver}:0: block {n} was requested and the census found {len(blocks)}",
+                  file=sys.stderr)
+            return 3
+        sys.stdout.write(blocks[n - 1]["body"])
+        return 0
+    print(f"unknown mode {mode!r}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/tests/ws0_embedded_python.py
+++ b/scripts/tests/ws0_embedded_python.py
@@ -8,6 +8,10 @@ reason — a DEFINITION and an ORACLE must not be the same thing:
                            shape this file cannot classify or a block it cannot delimit
     emit <driver> <n>      print embedded block <n>'s SOURCE, exactly as the driver ships it
     compile <driver>       compile EVERY embedded block; print one finding per block that does not
+    portable <driver>      does every embedded block parse on EVERY interpreter this repo runs,
+                           not merely on this box's? (the PEP 701 trap — see below)
+    portable-source <file> the same question about an ordinary python file, so the check's
+                           accept direction can be controlled without a driver
 
 Every mode prints a `#COMPLETE …` marker on success. The CALLER counts findings, so a crash
 must not read as "clean" — the marker is what makes that distinguishable, and every caller
@@ -37,6 +41,39 @@ So the code was PARSED BY NOTHING until an operator ran the rig.
 A self-test carrying its own copy of the block certifies THE COPY. The copy does not drift when
 the driver does — it stays green while the shipped step is broken, which is precisely the state
 this issue found. So the subject is read out of the shipped file on every run.
+
+# COMPILING ON THIS BOX IS NOT THE PROPERTY (#3451 review round 1, finding 1)
+
+`compile()` answers "does this parse HERE". The property the driver's repaired steps need is "does
+this parse on EVERY interpreter this repository runs on", and the two differ for exactly one
+spelling: a subscript inside an f-string expression written with NESTED SAME-TYPE QUOTES. PEP 701
+made that legal in 3.12 and it is a SyntaxError on everything older. So a regression to that form
+passes `compile()` on a 3.12 box and breaks a 3.11 one — and it is the very alternative the
+driver's own comment says was rejected, protected by nothing.
+
+The exposure is real rather than theoretical: this repository pins Python 3.11 in
+`.github/workflows/parity-failure-issue.yml` and `parity-failure-issue-tests.yml`,
+`bindings/python/pyproject.toml` declares `requires-python = ">=3.9"`, and the driver itself
+declares NO floor — it requires `python3` and takes whatever the host has.
+
+`ast.parse(..., feature_version=(3, 9))` DOES NOT DETECT IT (measured at (3,9)/(3,11)/(3,12), all
+accepting): `feature_version` gates the AST grammar, not the tokenizer, and PEP 701 is a tokenizer
+change. So the check is at the TOKENIZER: walk the tokens, track the quote character of each
+enclosing `FSTRING_START`, and flag any `STRING` token inside it whose OPENING QUOTE EQUALS that
+character.
+
+THE SAME-TYPE/DIFFERENT-TYPE BOUNDARY IS THE WHOLE CHECK. `f"{x['k']}"` is legal on every
+interpreter and flagging it would be a false red; `f"{x["k"]}"` is 3.12-only and must be refused.
+The suite controls BOTH directions.
+
+TWO ORACLES, EACH SOUND OVER ITS OWN RANGE, AND WHICH ONE RAN IS PRINTED. On 3.12+ the tokenizer
+walk is the oracle, because `compile()` there accepts the bad form. On < 3.12 `compile()` IS the
+oracle — the bad form does not parse at all — and the token types the walk needs
+(`FSTRING_START`/`FSTRING_END`) do not exist. Either way the answer is affirmative and the
+`#COMPLETE` line names the oracle and the interpreter, so a reader can never mistake this for one
+check that silently skipped. Nothing here is conditional on an optional interpreter being
+installed: a check that skips when a dependency is absent is the coverage gap this whole issue is
+about.
 
 # FAIL-CLOSED, because an extractor that finds nothing prints like a clean driver
 
@@ -119,9 +156,11 @@ operator having been parsed by nothing, and it is the state this file was writte
 
 from __future__ import annotations
 
+import io
 import pathlib
 import re
 import sys
+import tokenize
 
 # The word, matched only where it is a standalone token. `requires python3.` inside an `echo`
 # string is not an invocation and must not be censused as an unknown shape; a trailing
@@ -135,8 +174,11 @@ _OPEN_DASH_C = re.compile(r"^\s*-c\s+'")
 # The `'"'"'` idiom: close, emit a literal apostrophe from a double-quoted segment, reopen. The one
 # exception to "a single-quoted string runs to the next quote".
 _QUOTE_IDIOM = "'" + '"' + "'" + '"' + "'"
-# A heredoc redirect: `<<'PY'`, `<<PY`, `<<-'PY'`.
-_HEREDOC = re.compile(r"<<-?\s*(?P<q>['\"]?)(?P<tag>[A-Za-z_][A-Za-z0-9_]*)(?P=q)")
+# A heredoc redirect: `<<'PY'`, `<<PY`, `<<-'PY'`. The `dash` group is captured because `<<-`
+# and `<<` have DIFFERENT terminator rules — see `_delimit_heredoc`.
+_HEREDOC = re.compile(
+    r"<<(?P<dash>-?)\s*(?P<q>['\"]?)(?P<tag>[A-Za-z_][A-Za-z0-9_]*)(?P=q)"
+)
 # A script-file argument, quoted or not, possibly carrying a shell expansion in its directory
 # part: `"$HERE/ws0_report.py"`.
 _SCRIPT = re.compile(r"^[\"']?[^\s\"']*\.py[\"']?(\s|$)")
@@ -191,15 +233,38 @@ def _scan_single_quoted(text: str, open_quote: int) -> tuple[str, int]:
     )
 
 
-def _delimit_heredoc(lines: list[str], start: int, tag: str) -> tuple[str, int]:
-    """Body of the heredoc opened on `lines[start]`, plus the line its terminator sits on."""
+def _delimit_heredoc(
+    lines: list[str], start: int, tag: str, dash: bool
+) -> tuple[str, int]:
+    """Body of the heredoc opened on `lines[start]`, plus the line its terminator sits on.
+
+    THE TERMINATOR RULE IS THE SHELL'S, not `.strip()` (#3451 review round 1, finding 2). The two
+    forms differ and conflating them is wrong in both directions:
+
+    * `<<TAG`  — the terminator must be the line EXACTLY. A space-indented `  TAG` is ORDINARY
+      BODY to the shell, so accepting it truncates the block early and hands python a body it
+      never receives. A `.strip()` comparison accepted it.
+    * `<<-TAG` — leading TABS (never spaces) are stripped from the terminator AND from every body
+      line. A `.strip()` comparison found the terminator but left the body's tabs in place, so a
+      tab-indented body compiled as an IndentationError the shell would never produce.
+
+    Both are latent today — this driver carries no heredoc — but the branch SHIPS and is
+    exercised, and a wrong implementation of a shipped branch is a trap for whoever first writes
+    a step in that shape.
+    """
+    body: list[str] = []
     for i in range(start + 1, len(lines)):
-        if lines[i].strip() == tag:
-            return "\n".join(lines[start + 1 : i]) + "\n", i
+        line = lines[i]
+        candidate = line.lstrip("\t") if dash else line
+        if candidate == tag:
+            return "\n".join(body) + "\n", i
+        body.append(candidate)
     raise Unclassifiable(
         start + 1,
-        f"an embedded python heredoc opened with `{tag}` is never terminated, so its body cannot"
-        " be delimited.",
+        f"an embedded python heredoc opened with `{'<<-' if dash else '<<'}{tag}` is never"
+        " terminated by a line the SHELL would accept as its terminator"
+        + (" (leading tabs stripped)" if dash else " (an exact match, indentation included)")
+        + ", so its body cannot be delimited.",
     )
 
 
@@ -250,7 +315,9 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
                 continue
             hd = _HEREDOC.search(rest)
             if hd:
-                body, end = _delimit_heredoc(lines, idx, hd.group("tag"))
+                body, end = _delimit_heredoc(
+                    lines, idx, hd.group("tag"), hd.group("dash") == "-"
+                )
                 skip_until = end
                 records.append(
                     {"kind": "BLOCK", "shape": "heredoc", "line": idx + 1, "end": end + 1,
@@ -273,6 +340,65 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
     return records, findings
 
 
+# Whether this interpreter tokenizes f-strings into their own token types (PEP 701, 3.12+). On an
+# older one the nested same-type form is not tokenizable at all, so `compile()` is the oracle.
+_HAS_FSTRING_TOKENS = hasattr(tokenize, "FSTRING_START")
+PORTABILITY_ORACLE = "tokenizer" if _HAS_FSTRING_TOKENS else "compile"
+
+
+def _string_open_quote(tok: str) -> str:
+    """The quote character a STRING token opens with, past any prefix letters (`rb'…'`)."""
+    for ch in tok:
+        if ch in "\"'":
+            return ch
+    return ""
+
+
+def portability_findings(src: str) -> list[str]:
+    """Spellings in `src` that parse on 3.12+ and NOT on older interpreters.
+
+    Exactly one such spelling exists and it is the one this issue is about: a string inside an
+    f-string expression opening with the SAME quote character as the f-string itself. A
+    DIFFERENT-type nested quote (`f"{x['k']}"`) is legal everywhere and must not be reported.
+    """
+    if not _HAS_FSTRING_TOKENS:
+        # `compile()` is the oracle on this interpreter: the 3.12-only form is a SyntaxError here,
+        # and `compile`/`portable` therefore report it through the same path. Returning nothing is
+        # correct rather than a skip — the caller prints WHICH oracle answered.
+        try:
+            compile(src, "<portability>", "exec")
+        except SyntaxError as exc:
+            return [
+                f"does not parse on this interpreter ({sys.version_info.major}."
+                f"{sys.version_info.minor}) — {exc.msg} (line {exc.lineno})"
+            ]
+        return []
+    out: list[str] = []
+    stack: list[str] = []
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(src).readline):
+            if tok.type == tokenize.FSTRING_START:
+                stack.append(tok.string[-1])
+            elif tok.type == tokenize.FSTRING_END:
+                if stack:
+                    stack.pop()
+            elif tok.type == tokenize.STRING and stack:
+                quote = _string_open_quote(tok.string)
+                if quote and quote == stack[-1]:
+                    out.append(
+                        f"line {tok.start[0]}: {tok.string} is nested inside an f-string"
+                        f" delimited by the SAME quote ({stack[-1]}). PEP 701 made that legal in"
+                        " 3.12 and it is a SyntaxError on every earlier interpreter, which this"
+                        " repository still runs (3.11 in two workflows, >=3.9 declared by the"
+                        " python bindings) and this driver does not exclude. Bind the subscript"
+                        " to a LOCAL before the f-string."
+                    )
+    except (SyntaxError, tokenize.TokenError) as exc:
+        out.append(f"could not be tokenized ({type(exc).__name__}: {exc}) — reported rather than"
+                   " skipped, because an unanswerable oracle must not read as a clean answer")
+    return out
+
+
 def _blocks(records: list[dict]) -> list[dict]:
     return [r for r in records if r["kind"] == "BLOCK"]
 
@@ -280,12 +406,23 @@ def _blocks(records: list[dict]) -> list[dict]:
 def main(argv: list[str]) -> int:
     if len(argv) < 3:
         print(__doc__.splitlines()[0], file=sys.stderr)
-        print("usage: ws0_embedded_python.py census|compile|emit <driver> [n]", file=sys.stderr)
+        print("usage: ws0_embedded_python.py census|compile|portable|portable-source|emit"
+          " <file> [n]", file=sys.stderr)
         return 2
     mode, driver = argv[1], pathlib.Path(argv[2])
     if not driver.is_file():
         print(f"{driver}:0: the driver is not a readable file, so the census has NO SUBJECT —"
               " which prints exactly like a driver with nothing wrong in it.")
+        return 0
+    if mode == "portable-source":
+        # The same question about an ORDINARY python file. Exists so the accept direction (a
+        # DIFFERENT-type nested quote, legal everywhere) can be controlled without smuggling an
+        # apostrophe into a shell single-quoted block, where it would terminate the string.
+        for note in portability_findings(driver.read_text()):
+            print(f"{driver}: NOT PORTABLE — {note}")
+        print(f"#COMPLETE portable-source=1 oracle={PORTABILITY_ORACLE}"
+              f" interpreter={sys.version_info.major}.{sys.version_info.minor}"
+              f".{sys.version_info.micro}")
         return 0
     records, findings = census(driver)
     blocks = _blocks(records)
@@ -316,6 +453,19 @@ def main(argv: list[str]) -> int:
                       f" {exc.lineno}). This step is fatal-on-failure, so the driver cannot run"
                       " past it.")
         print(f"#COMPLETE compiled={len(blocks)} findings={len(findings)}")
+        return 0
+    if mode == "portable":
+        # EVERY embedded block, against the property `compile` cannot see on this box.
+        for f in findings:
+            print(f"{driver}:{f['line']}: {f['reason']}")
+        for i, r in enumerate(blocks, start=1):
+            for note in portability_findings(r["body"]):
+                print(f"{driver}:{r['line']}: embedded python block {i} is NOT PORTABLE —"
+                      f" {note}")
+        print(f"#COMPLETE portable={len(blocks)} findings={len(findings)}"
+              f" oracle={PORTABILITY_ORACLE}"
+              f" interpreter={sys.version_info.major}.{sys.version_info.minor}"
+              f".{sys.version_info.micro}")
         return 0
     if mode == "emit":
         if len(argv) < 4:

--- a/scripts/tests/ws0_embedded_python.py
+++ b/scripts/tests/ws0_embedded_python.py
@@ -52,7 +52,8 @@ A `python3` invocation can only receive code four ways: `-c`, a script path, sta
 `-m`. So the census keys on WHICH of those a given occurrence uses rather than on how it is
 spelled:
 
-    -c '…'        embedded, single-quoted — the shape both defective steps use. Extracted.
+    -c '…'        embedded, single-quoted — the shape both defective steps use. Extracted, by
+                  the rule below rather than by a line pattern.
     <<'EOF'       embedded via a heredoc on stdin. Extracted. (None today; covered because a
                   future step written this way must not fall outside the census.)
     <path>.py     a SCRIPT FILE. Not embedded — it is an ordinary python file every other tool
@@ -62,6 +63,51 @@ spelled:
 
 Anything else — `-c` with a shape that cannot be delimited, `-m`, a bare `-`, a variable where the
 code should be — is UNKNOWN, which is a finding.
+
+## HOW A `-c '…'` BLOCK IS DELIMITED, and the three closer shapes that forced the rule
+
+A bash single-quoted string HAS NO ESCAPE MECHANISM, so the body runs to the NEXT `'` — with one
+exception, the `'"'"'` idiom, which CLOSES the string, emits a literal apostrophe from a
+double-quoted segment, and REOPENS it. That single sentence is the whole delimiter, and it is
+stated as a property of bash rather than as a pattern over lines, because a pattern over lines is
+what got this wrong twice:
+
+  shape 1  the closer alone at column 0            `' "$HERE" "$CORPUS" …`   (this driver)
+  shape 2  the closer at the END of the last python line, bash arguments trailing
+                                                    `print(rows)' "$DEST/x.jsonl"`
+  shape 3  `'"'"'` MID-BLOCK — a literal apostrophe inside the body
+
+MEASURED over this repository, same probe, three delimiters:
+
+  column-0 closer only    31 blocks, 5 reported UNDELIMITED (shape 2 is idiomatic and in use at
+                          `test-data/scripts/gen-perf-corpus-bti.sh`, `scripts/lib/gate-notify.sh`
+                          and `docs/reports/ws0-3217-artifacts/harness/common.sh`)
+  exact next quote        59 blocks, 1 FALSE SyntaxError (shape 3 cut mid-body)
+  the rule above          59 blocks, 0 undelimited, 0 failing to parse
+
+Both wrong versions are instructive in OPPOSITE directions and neither is safe:
+
+* the column-0 rule UNDER-COUNTS — 31 subjects instead of 59. A loose delimiter does not merely
+  mis-cut, it silently drops blocks from the census, which is the vacuous-green shape; and it
+  reds the gate on CORRECT code, which is how a guard gets waived into uselessness.
+* the exact-next-quote rule MANUFACTURES a finding on a good file. `lib-ws0-fixtures.sh` carries
+  the `'"'"'` idiom, and its own comment records what happens when it is mishandled: the library
+  is "silently truncated … and it presented as every OTHER case in the suite failing on an absent
+  pinning-verification.json."
+
+So the suite asserts BOTH directions: a defect must be reported, and a good file carrying the
+idiom must NOT be.
+
+## SCOPE: this file's caller lints `ws0-baseline.sh`, and the UNKNOWN class is calibrated for it
+
+The census is used by `test_ws0_embedded_steps_execute.sh` against ONE driver. Run tree-wide it
+reports UNKNOWN on shapes that driver does not contain and that this file deliberately does not
+guess about: a script path held in a VARIABLE (`python3 "$ROWS_PY" …`, where nothing on the line
+says whether it is python), a DOUBLE-quoted `-c` body (the shell expands it, so the bytes python
+receives are not the bytes on disk), and `python3 >/dev/null` reading stdin from a pipe. Each is a
+real shape in this repository, each is fail-closed here, and each would have to be taught — not
+skipped — before this census could lint the whole tree. That generalisation is deliberately NOT
+this issue.
 
 ## The direction it errs in, stated
 
@@ -82,11 +128,13 @@ import sys
 # word/dot character is the discriminator.
 _PY_TOKEN = re.compile(r"(?<![\w./-])python3(?![\w.])")
 
-# The shape both defective steps use: the line ENDS with the opening quote and the body follows on
-# subsequent lines, terminated by a line whose first character is the closing quote.
-_OPEN_MULTILINE = re.compile(r"^-c\s+'$")
-# The same thing on one line: `-c 'import time; print(…)'`.
-_INLINE = re.compile(r"^-c\s+'(?P<body>(?:[^']*))'")
+# The OPENING of a `-c '…'` block: the `-c` flag and the single quote that starts the shell
+# string. Where it CLOSES is decided by scanning bash's quoting rules (`_scan_single_quoted`),
+# never by a line pattern — see the header's three-shape section.
+_OPEN_DASH_C = re.compile(r"^\s*-c\s+'")
+# The `'"'"'` idiom: close, emit a literal apostrophe from a double-quoted segment, reopen. The one
+# exception to "a single-quoted string runs to the next quote".
+_QUOTE_IDIOM = "'" + '"' + "'" + '"' + "'"
 # A heredoc redirect: `<<'PY'`, `<<PY`, `<<-'PY'`.
 _HEREDOC = re.compile(r"<<-?\s*(?P<q>['\"]?)(?P<tag>[A-Za-z_][A-Za-z0-9_]*)(?P=q)")
 # A script-file argument, quoted or not, possibly carrying a shell expansion in its directory
@@ -113,21 +161,33 @@ def _strip_comment(rest: str) -> str:
     return rest[: m.start()] if m else rest
 
 
-def _delimit_multiline(lines: list[str], start: int) -> tuple[str, int]:
-    """Body of the `-c '` block opened on `lines[start]`, plus the line its closer sits on.
+def _scan_single_quoted(text: str, open_quote: int) -> tuple[str, int]:
+    """The bash single-quoted string opening at `text[open_quote]`, and the offset after it.
 
-    The closer is the first following line whose FIRST character is a single quote — which is how
-    the driver writes it (`' "$HERE" "$CORPUS" …`). A block with no such line is a finding rather
-    than a body silently truncated at end-of-file.
+    Bash gives a single-quoted string NO escape mechanism, so the body runs to the next `'` —
+    unless that quote opens the `'"'"'` idiom, which closes the string, emits a literal apostrophe
+    and reopens it. Both facts are bash's, which is why this is a scan and not a pattern: the
+    closer appears at column 0 in this driver, at the end of the last body line in three other
+    files in this repository, and mid-body as the idiom. See the header for the measurements.
     """
-    for i in range(start + 1, len(lines)):
-        if lines[i].startswith("'"):
-            return "\n".join(lines[start + 1 : i]) + "\n", i
+    body: list[str] = []
+    i = open_quote + 1
+    while i < len(text):
+        ch = text[i]
+        if ch != "'":
+            body.append(ch)
+            i += 1
+            continue
+        if text[i : i + len(_QUOTE_IDIOM)] == _QUOTE_IDIOM:
+            body.append("'")
+            i += len(_QUOTE_IDIOM)
+            continue
+        return "".join(body), i
     raise Unclassifiable(
-        start + 1,
-        "an embedded `python3 -c '` block is never closed by a line beginning with the closing"
-        " quote, so its body cannot be delimited. Extracting to end-of-file would compile a"
-        " truncated body and report a defect that is the extractor's.",
+        text.count("\n", 0, open_quote) + 1,
+        "an embedded `python3 -c '` block is never closed: no terminating single quote before"
+        " end-of-file. Extracting to end-of-file would compile a truncated body and report a"
+        " defect that is the extractor's own.",
     )
 
 
@@ -147,24 +207,46 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
     """Classify every `python3` occurrence. Returns (records, findings)."""
     text = path.read_text()
     lines = text.split("\n")
+    # Offset of each line start, so a per-line match can hand an ABSOLUTE position to the
+    # quoting scanner. The scanner works over the whole text because a block's closer is not a
+    # property of any single line (shapes 1-3 in the header).
+    starts: list[int] = []
+    off = 0
+    for line in lines:
+        starts.append(off)
+        off += len(line) + 1
     records: list[dict] = []
     findings: list[dict] = []
     skip_until = -1
     for idx, line in enumerate(lines):
         if idx <= skip_until:
             continue
-        stripped = line.lstrip()
-        if stripped.startswith("#"):
+        if line.lstrip().startswith("#"):
             continue  # a whole-line shell comment carries no code
         m = _PY_TOKEN.search(line)
         if not m:
             continue
-        rest = _strip_comment(line[m.end() :]).strip()
+        raw_rest = line[m.end() :]
+        rest = _strip_comment(raw_rest).strip()
         try:
             if not rest or rest.lstrip(";&|)").strip() in ("", "do", "then"):
                 # A presence probe (`for tool in perf taskset python3; do`) or a bare mention:
                 # no argument can carry code.
                 records.append({"kind": "MENTION", "line": idx + 1, "text": line.strip()})
+                continue
+            dash_c = _OPEN_DASH_C.match(raw_rest)
+            if dash_c:
+                # The opening quote is the LAST character the match consumed.
+                open_quote = starts[idx] + m.end() + dash_c.end() - 1
+                body, close = _scan_single_quoted(text, open_quote)
+                end_line = text.count("\n", 0, close)
+                skip_until = end_line
+                records.append(
+                    {"kind": "BLOCK",
+                     "shape": "dash-c-multiline" if "\n" in body else "dash-c-inline",
+                     "line": idx + 1, "end": end_line + 1,
+                     "body": body if body.endswith("\n") else body + "\n"}
+                )
                 continue
             hd = _HEREDOC.search(rest)
             if hd:
@@ -175,21 +257,6 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
                      "body": body}
                 )
                 continue
-            if _OPEN_MULTILINE.match(rest):
-                body, end = _delimit_multiline(lines, idx)
-                skip_until = end
-                records.append(
-                    {"kind": "BLOCK", "shape": "dash-c-multiline", "line": idx + 1,
-                     "end": end + 1, "body": body}
-                )
-                continue
-            inline = _INLINE.match(rest)
-            if inline:
-                records.append(
-                    {"kind": "BLOCK", "shape": "dash-c-inline", "line": idx + 1,
-                     "end": idx + 1, "body": inline.group("body") + "\n"}
-                )
-                continue
             if _SCRIPT.match(rest):
                 records.append({"kind": "SCRIPT", "line": idx + 1, "text": rest})
                 continue
@@ -197,7 +264,9 @@ def census(path: pathlib.Path) -> tuple[list[dict], list[dict]]:
                 idx + 1,
                 "this `python3` invocation is in a shape the census does not recognise"
                 f" ({rest[:60]!r}). It may be carrying embedded code the compile check would"
-                " therefore never see, so it is a finding rather than a skip.",
+                " therefore never see, so it is a finding rather than a skip. If the shape is"
+                " legitimate, TEACH THE CENSUS THE SHAPE — this finding is about the extractor,"
+                " not about the python.",
             )
         except Unclassifiable as exc:
             findings.append({"line": exc.lineno, "reason": exc.reason})

--- a/scripts/tests/ws0_embedded_python.py
+++ b/scripts/tests/ws0_embedded_python.py
@@ -313,7 +313,15 @@ def _is_plain_literal(word: str) -> bool:
 # The false-red direction was checked BEFORE widening, not assumed: `tar -cf out.tar` and
 # `sort -cu file` now match this anchor and must resolve to the literal commands `tar`/`sort`
 # and be SKIPPED. They are controls.
-_DASH_C_ANCHOR = re.compile(r"(?<![\w-])-c[ \t]*\S")
+# QUOTE CHARACTERS MAY SIT INSIDE THE FLAG (#3451 post-rebase round 9, F2). Bash glues the
+# fragments of `-"c"` and `-'c'` into `-c`, so an anchor matching the bare spelling missed them —
+# MEASURED at findings=0, a silent absence. Note the fully-quoted forms `"-c"` and `'-c'` already
+# failed closed by another path, so testing only those would have concluded this was fixed.
+#
+# `['\"]*` between the `-` and the `c` normalises every concatenated spelling in one closed rule,
+# rather than a tokenizer. RESIDUAL, stated in the caller's NOT REACHED: a flag spelled through a
+# VARIABLE (`$FLAG` where `FLAG=-c`) is not discovered and cannot be without evaluating the shell.
+_DASH_C_ANCHOR = re.compile(r"(?<![\w-])-['\"]*c['\"]*[ \t]*\S")
 
 # Characters that cannot appear inside one shell word, used to find where a candidate's word
 # STARTS so a path prefix is captured with it.

--- a/scripts/tests/ws0_export_prefix.py
+++ b/scripts/tests/ws0_export_prefix.py
@@ -4,7 +4,7 @@
 Two modes, one subject:
 
     <driver> <VAR-PREFIX> <BLOCK-NEEDLE>                 "<in-prefix> <total-in-file>"
-    <driver> <VAR-PREFIX> <BLOCK-NEEDLE> --emit-prefix   the validated prefix TEXT
+    <driver> <VAR-PREFIX> <BLOCK-NEEDLE> --resolve VAR=VAL…   the step's environment, PARSED
 
 Extracted from `test_ws0_embedded_steps_execute.sh` so both the membership check and
 `driver_step_env` call ONE implementation — a second copy would drift, and then the eval
@@ -190,15 +190,5 @@ if "--resolve" in sys.argv[4:]:
         raise SystemExit(5)
     for name, value in resolved:
         print(f"{name}={value}")
-    raise SystemExit(0)
-if "--emit-prefix" in sys.argv[4:]:
-    # THE VALIDATED PREFIX TEXT, printed ONLY when the run above is intact. The caller evaluates
-    # it (see `driver_step_env`), and this conditionality is the whole safety argument: the text
-    # handed over has already been proved to be assignment words with no command separator.
-    if not contiguous:
-        print(f"NOT-A-PREFIX: the first non-assignment token is {following!r}, not the consuming"
-          " `python3` command", file=sys.stderr)
-        raise SystemExit(4)
-    print(head)
     raise SystemExit(0)
 print(f"{len(present)} {len(names)}")

--- a/scripts/tests/ws0_export_prefix.py
+++ b/scripts/tests/ws0_export_prefix.py
@@ -107,6 +107,90 @@ if contiguous:
     present = [n for n in names if any(w.startswith(n + "=") for w in prefix_words)]
 else:
     present = []
+if "--resolve" in sys.argv[4:]:
+    # THE PREFIX IS PARSED AND SUBSTITUTED, NEVER EVALUATED (#3451 post-rebase round 7, F3).
+    #
+    # Round 2 authorised an `eval` on the argument that the contiguity check bounded its input:
+    # "only NAME= words with no command separator". MEASURED, that check admits
+    # `WS0_CFG_X=$(helper)`, `WS0_CFG_X=`helper`` and `WS0_CFG_X=${OTHER}` — all
+    # assignment-shaped, none containing a separator. Command substitution walked straight
+    # through the stated bound, so a driver line of that shape would have executed
+    # repository-derived shell inside a test documented as hermetic and read-only, in a mandatory
+    # gate component. The precondition did not exclude the dangerous case.
+    #
+    # So: a RESTRICTED GRAMMAR, allowlisted at every level. A value is a sequence of literal
+    # characters drawn from an explicit set, plus `$VAR` / `${VAR}` references resolved from the
+    # caller's controlled table. Command substitution, backticks, arithmetic, parameter-expansion
+    # operators, redirections, globs and any form not named here are REFUSED BY NAME — a failure,
+    # never a skip. Nothing is executed, so the header's "hermetic" is a fact rather than a hope.
+    if not contiguous:
+        print(f"NOT-A-PREFIX: the first non-assignment token is {following!r}, not the consuming"
+              " `python3` command", file=sys.stderr)
+        raise SystemExit(4)
+    table = {}
+    for pair in sys.argv[4:]:
+        if pair == "--resolve":
+            continue
+        name, _, value = pair.partition("=")
+        table[name] = value
+    LITERAL = set(
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        "/.:,-_+@% "
+    )
+    VARNAME = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+    def resolve(word):
+        name, _, raw = word.partition("=")
+        if raw[:1] == '"':
+            if not raw.endswith('"') or len(raw) < 2:
+                raise ValueError(f"{name}: unbalanced double quote in {raw!r}")
+            raw = raw[1:-1]
+        elif raw[:1] == "'":
+            raise ValueError(f"{name}: single-quoted values are not in the supported grammar")
+        out, i = [], 0
+        while i < len(raw):
+            ch = raw[i]
+            if ch == "$":
+                rest = raw[i + 1 :]
+                if rest[:1] == "{":
+                    m2 = VARNAME.match(rest, 1)
+                    if not m2 or rest[m2.end() : m2.end() + 1] != "}":
+                        raise ValueError(
+                            f"{name}: only a plain ${{VAR}} reference is supported, not"
+                            f" {raw[i:i + 12]!r} (parameter-expansion operators are refused)"
+                        )
+                    var, i = m2.group(0), i + 1 + m2.end() + 1
+                elif rest[:1] == "(":
+                    raise ValueError(
+                        f"{name}: command substitution/arithmetic is REFUSED — this is the"
+                        " construct the round-2 safety argument wrongly assumed was excluded"
+                    )
+                else:
+                    m2 = VARNAME.match(rest)
+                    if not m2:
+                        raise ValueError(f"{name}: a bare $ is not a supported reference")
+                    var, i = m2.group(0), i + 1 + m2.end()
+                if var not in table:
+                    raise ValueError(f"{name}: ${var} is not in the controlled table")
+                out.append(table[var])
+                continue
+            if ch not in LITERAL:
+                raise ValueError(
+                    f"{name}: {ch!r} is not a supported literal character (backticks,"
+                    " redirections, globs and quoting forms are refused)"
+                )
+            out.append(ch)
+            i += 1
+        return name, "".join(out)
+
+    try:
+        resolved = [resolve(w) for w in prefix_words]
+    except ValueError as exc:
+        print(f"UNSUPPORTED-ASSIGNMENT: {exc}", file=sys.stderr)
+        raise SystemExit(5)
+    for name, value in resolved:
+        print(f"{name}={value}")
+    raise SystemExit(0)
 if "--emit-prefix" in sys.argv[4:]:
     # THE VALIDATED PREFIX TEXT, printed ONLY when the run above is intact. The caller evaluates
     # it (see `driver_step_env`), and this conditionality is the whole safety argument: the text

--- a/scripts/tests/ws0_export_prefix.py
+++ b/scripts/tests/ws0_export_prefix.py
@@ -87,9 +87,22 @@ for w in all_words:
         break
     prefix_words.append(w)
 head = " ".join(prefix_words)
-# A separator ANYWHERE in the run breaks it, and it hides INSIDE an assignment word
-# (`NAME="v";`), which is why this is a separate test rather than a property of the split.
-contiguous = len(prefix_words) < len(all_words) and not any(ch in head for ch in ";&|")
+# THE FIRST NON-ASSIGNMENT TOKEN MUST **BE** THE CONSUMING COMMAND (#3451 post-rebase round 5,
+# F1). Requiring merely that SOME non-assignment token exists let a STANDALONE `;` satisfy it:
+#
+#     WS0_CFG_X=... ; python3 -c '...'
+#
+# the `;` is its own word, so it breaks the loop before reaching `head`, the separator scan never
+# sees it, and `len(prefix_words) < len(all_words)` is satisfied by `;` and `python3` between
+# them. Reported contiguous, every name present — while production leaves the assignments
+# unexported, and the suite stayed green because it evaluates them directly before `env`.
+#
+# Round 1's F1 caught the ATTACHED form (`NAME="v";`, still an assignment word, so the separator
+# scan below finds it). This is the DETACHED one, and naming the expected next token subsumes
+# both: anything between the assignments and the command — an operator, a redirect, another
+# command — means these assignments are not that command's environment.
+following = all_words[len(prefix_words)] if len(prefix_words) < len(all_words) else ""
+contiguous = following == "python3" and not any(ch in head for ch in ";&|")
 if contiguous:
     present = [n for n in names if any(w.startswith(n + "=") for w in prefix_words)]
 else:
@@ -99,7 +112,8 @@ if "--emit-prefix" in sys.argv[4:]:
     # it (see `driver_step_env`), and this conditionality is the whole safety argument: the text
     # handed over has already been proved to be assignment words with no command separator.
     if not contiguous:
-        print("NOT-A-PREFIX", file=sys.stderr)
+        print(f"NOT-A-PREFIX: the first non-assignment token is {following!r}, not the consuming"
+          " `python3` command", file=sys.stderr)
         raise SystemExit(4)
     print(head)
     raise SystemExit(0)

--- a/scripts/tests/ws0_export_prefix.py
+++ b/scripts/tests/ws0_export_prefix.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""The driver's CONTIGUOUS ENVIRONMENT-ASSIGNMENT PREFIX for one embedded step.
+
+Two modes, one subject:
+
+    <driver> <VAR-PREFIX> <BLOCK-NEEDLE>                 "<in-prefix> <total-in-file>"
+    <driver> <VAR-PREFIX> <BLOCK-NEEDLE> --emit-prefix   the validated prefix TEXT
+
+Extracted from `test_ws0_embedded_steps_execute.sh` so both the membership check and
+`driver_step_env` call ONE implementation — a second copy would drift, and then the eval
+would be bounded by a validation that is not the one that passed.
+"""
+
+import bisect, pathlib, re, sys
+
+# THIS file's directory, so the shipped joiner/census are imported rather than re-implemented and
+# the caller does not have to know where they live.
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from ws0_embedded_python import _join_continuations, census
+
+path = pathlib.Path(sys.argv[1])
+prefix, needle = sys.argv[2], sys.argv[3]
+text = path.read_text()
+
+# WHICH block consumes this prefix, by the shipped writer its body calls.
+records, _findings = census(path)
+owners = [r for r in records if r["kind"] == "BLOCK" and needle in r["body"]]
+if len(owners) != 1:
+    print(f"AMBIGUOUS: {len(owners)} block(s) call {needle!r}", file=sys.stderr)
+    raise SystemExit(2)
+invocation_line = owners[0]["line"]
+
+joined, omap = _join_continuations(text)
+# The ORIGINAL offset where that invocation's physical line begins.
+line_starts = [0] + [i + 1 for i, ch in enumerate(text) if ch == "\n"]
+if invocation_line > len(line_starts):
+    print(f"UNRESOLVABLE: line {invocation_line} is past end of file", file=sys.stderr)
+    raise SystemExit(2)
+invocation_offset = line_starts[invocation_line - 1]
+
+# The JOINED logical line covering it. Spans are in scan space; their bounds are mapped back
+# through `omap`, so the comparison is against original offsets throughout.
+spans, start = [], 0
+for i, ch in enumerate(joined):
+    if ch == "\n":
+        spans.append((start, i))
+        start = i + 1
+spans.append((start, len(joined)))
+logical = None
+for a, b in spans:
+    if b <= a or a >= len(omap):
+        continue
+    if omap[a] <= invocation_offset <= omap[b - 1]:
+        logical = joined[a:b]
+        break
+if logical is None:
+    print(f"UNRESOLVABLE: no logical line covers offset {invocation_offset}", file=sys.stderr)
+    raise SystemExit(2)
+
+names = sorted(set(re.findall(prefix + r"[A-Z_]+(?==)", text)))
+
+# THE PROPERTY IS THE CONTIGUOUS ENVIRONMENT-ASSIGNMENT PREFIX, NOT MERE MEMBERSHIP OF THE
+# LOGICAL LINE (#3451 post-rebase round 1, F1). `n + "=" in logical` passed for
+#
+#     WS0_CFG_BASELINE_MODE="$BASELINE_MODE"; python3 -c '...'
+#
+# which keeps the assignment on the SAME logical line while bash makes it a standalone shell
+# variable python never receives. MEASURED, both directions:
+#
+#     WS0_CFG_REPS="1"; python3 -c ...   -> os.environ.get(...) is None
+#     WS0_CFG_REPS="1"  python3 -c ...   -> "1"
+#
+# So the text BEFORE the command word must be a run of assignment words and nothing else. A
+# command separator anywhere in it, or any word that is not NAME=, means the run is broken and
+# the membership answer is worthless — reported as zero present, which FAILS closed rather than
+# guessing which side of the break each name fell on.
+# THE PREFIX IS THE LEADING RUN OF ASSIGNMENT WORDS, found by WALKING them — not by locating the
+# string "python3". Searching for the command word by name truncates the prefix at the first
+# assignment whose VALUE happens to contain it: measured, adding `WS0_CFG_BIN_HINT="python3"`
+# to the driver dropped the answer to `present=1/14` on an otherwise correct prefix, which is
+# the false-red direction. Walking the words asks the property directly and cannot be fooled by
+# a value.
+all_words = logical.split()
+prefix_words = []
+for w in all_words:
+    if not re.match(r"[A-Za-z_][A-Za-z0-9_]*=", w):
+        break
+    prefix_words.append(w)
+head = " ".join(prefix_words)
+# A separator ANYWHERE in the run breaks it, and it hides INSIDE an assignment word
+# (`NAME="v";`), which is why this is a separate test rather than a property of the split.
+contiguous = len(prefix_words) < len(all_words) and not any(ch in head for ch in ";&|")
+if contiguous:
+    present = [n for n in names if any(w.startswith(n + "=") for w in prefix_words)]
+else:
+    present = []
+if "--emit-prefix" in sys.argv[4:]:
+    # THE VALIDATED PREFIX TEXT, printed ONLY when the run above is intact. The caller evaluates
+    # it (see `driver_step_env`), and this conditionality is the whole safety argument: the text
+    # handed over has already been proved to be assignment words with no command separator.
+    if not contiguous:
+        print("NOT-A-PREFIX", file=sys.stderr)
+        raise SystemExit(4)
+    print(head)
+    raise SystemExit(0)
+print(f"{len(present)} {len(names)}")


### PR DESCRIPTION
Closes #3451.

**The main-red this issue reported is already fixed on `main`** — PR #3455 (`7e2ea0d20`) landed the
same local-binding remedy, exactly as this issue predicted (*"Closeable by that PR merging"*). The
driver is **not in this diff**; `scripts/perf/ws0-baseline.sh` here is byte-identical to `main`'s.

**This PR delivers the other half of #3451: the coverage gap.** The issue called it *"worth fixing
independently of the syntax error"*, and *"the durable part"*.

## Why the gap existed

`ws0-baseline.sh` shipped for months with 7 instances of a backslash inside an f-string
**expression** — a `SyntaxError` on every CPython — in its two fatal-on-failure pin steps, so the
whole WS0 measurement path could not start. Nothing caught it because that python is **invisible to
every tool that would have seen it**:

* it is not a `.py` file, so no linter, formatter or import reads it;
* `bash -n` parses the driver as *shell*, where the body is one opaque single-quoted string — valid
  whatever it contains;
* every hermetic self-test stops at `--validate-args-only`, **above** both steps, and #3272 round 2
  finding 14 deliberately made the accept cases execute nothing (running the real driver invoked
  `sudo sysctl` and three cargo builds inside a gate component — sound on its own terms).

Net: **the code was parsed by nothing until an operator ran the rig.** As the issue put it, *a step
that has never run reports nothing until someone needs it.*

## What this adds

`scripts/tests/test_ws0_embedded_steps_execute.sh` plus two helpers
(`ws0_embedded_python.py`, `ws0_export_prefix.py`), enrolled in the full gate's `tooling-tests`.
**45 checks**, every accept paired with an **observed firing** against an injected defect.

1. **Both steps EXECUTE.** Each runs on a few-KB fixture corpus with the argv and environment the
   driver gives it, writes its artifact, prints its pin lines, and **the shipped READER accepts what
   the shipped STEP wrote** (`verify_session_corpus_pin`, `verify_pinning_record`) — a writer/reader
   round trip no fixture-fed reject case can establish.
2. **The environment is THE DRIVER'S, not the suite's.** Both steps execute on values obtained by
   evaluating the driver's own validated assignment prefix, and the CPU record is cross-checked
   against the generated session manifest. So a production mapping error (`WS0_CFG_TEMPS="$ARMS"`,
   or a swapped `WS0_PIN_*`) fails here instead of silently recording a configuration nobody
   measured — the #3272 F1 defect class.
3. **The export NAMES are asserted three ways**: the driver's bash exports, the shipped
   `MANIFEST_CONFIG_FIELDS`, and the names the extracted block actually reads — derived from
   genuinely different sources, so agreement means something. Each assignment must sit in the
   **contiguous environment prefix** of the block that consumes it, not merely somewhere on its
   logical line.
4. **The subject is EXTRACTED from the shipped driver** every run, never duplicated. A copy does not
   drift when the driver does: it stays green while the shipped step is broken, which is precisely
   the state this issue found.
5. **The census is fail-closed.** Candidate discovery is deliberately over-broad (any `python`
   spelling, any path prefix, `-c` followed by anything); exactly the shapes the driver uses are
   allowlisted; **everything else is a FINDING** naming the line, so a future step in an
   unrecognised shape cannot fall outside the compile check.

## Evidence

The controls are the deliverable. Each of these was observed **failing** before being trusted:

```
$PYTHON -c 'bad'            FINDING     indirect command word
"prefix"python3 -c 'bad'    FINDING     bash concatenates -> prefixpython3
$PYTHON -c \ + 'bad'        FINDING     line continuation
$PYTHON -I -c 'bad'         FINDING     interpreter option before -c
$PYTHON -c'bad'             FINDING     attached form
$PY -cimport,os             FINDING     attached, unquoted
$PY -c$CODE                 FINDING     attached, variable-valued
v=$(echo x|sed s/x/y/) $PY -c 'bad'   FINDING   separator inside a substitution
if / time / ! $PY -c 'bad'  FINDING     shell control word before the command
/usr/bin/python3 -c 'bad'   FINDING     path-qualified
producer | python3          FINDING     program on stdin
python3 <<PY (unquoted)     FINDING     shell expands the body before python sees it
python3 <<'PY'X             FINDING     composed delimiter -> bash uses PYX

grep -c / sort -cu / tar -cf / if grep -c / grep \ + -c    no finding   (accept direction)
python3 -c'…' (literal, attached)                          BLOCK
lib-ws0-fixtures.sh  '"'"' idiom                            4 blocks compile
scripts/perf/ws0-baseline.sh                               blocks=5 findings=0, compile 5/5
```

## Why review stopped here — a documented judgement, not fatigue

**Stopped by lead ruling at head `2864da6d6`.** Post-rebase roborev findings, in order:

```
2, 3, 3, 2, 3, 4, 3, 2, 2
```

That is a **plateau, not a descent**, and the same reasoning was applied earlier in this issue to
refuse betting on "one or two more rounds" when a previous series plateaued around two.

**The decisive fact: across 22 rounds on two bases, no finding has ever been in the shipped driver** —
which is byte-identical to `main`'s and not in this diff at all. Every finding landed in this test
apparatus. A review loop that has never touched the deliverable is auditing the checker, and the
checker's scope — *find every embedded python program in a shell script* — is **undecidable in
general**, so it converges on a stated limit rather than on zero.

A finding in the shipped driver would still block. None appeared. Outstanding findings about the
checker's own controls are batched into a single follow-up issue rather than fixed here.

## Review history — 22 rounds, ~40 findings, ZERO in the shipped driver

Every round was genuine (input 148k–1002k, cached, `prompt-content` PASS at every round). All
findings landed in this test apparatus; none ever touched the fix that resolved the main-red.

The cost driver, stated because it is the transferable lesson: **"compile every embedded python block
in a shell script" requires statically parsing bash, which is not achievable.** Two design attempts
were abandoned rather than patched further:

* a **tokenizer-level portability oracle** (added for a real finding — the suite compiled only with
  the box's interpreter, so a regression to the 3.12-only nested-quote spelling would pass here and
  break the Python 3.11 this repo pins). It was a *model of CPython's tokenizer*, had two defects in
  three rounds — the second a **false red on legal pre-3.12 code** — and could not be
  differential-tested because no pre-3.12 interpreter exists on the measuring box. **Removed.** The
  property it approximated is now a stated limit and follow-up **B1**.
* a **`suppress_flag_until` extent** that existed to satisfy a "one finding per invocation"
  instruction. It produced a **false pass**. The instruction was the defect — a cosmetic invariant
  only semantic machinery could satisfy. **Deleted**; duplicate findings are noise, suppression was
  blindness, and the rationale is recorded at the site so it is not reintroduced as tidiness.

What converged: **allowlist the safe shape rather than blocklisting the dangerous one**, fix only
what is decidable, and state the rest at the seam.

## Honest limits — stated, because a silent partial is what this rig exists to refuse

* **Discovery is bounded.** An indirect command word combined with a heredoc (`$PYTHON <<'PY'`), or
  `eval`, is not discovered. Complete discovery would require interpreting bash.
* **Nothing here establishes cross-interpreter portability.** The compile check speaks only for the
  interpreter that ran it; there is no python3.9/3.10/3.11 on the measuring box (**B1**).
* The suite executes the embedded **python**, not the bash error handling around it, so a removed
  `|| { … exit 2; }` fatal guard is not caught (measured). Deliberately not guarded — a brittle
  assert on correct code is the failure that removed the oracle above (**B4**).
* The bash 3.2 fix is **structural, not executed** (indexed arrays, `${arr[@]+"${arr[@]}"}`); the
  measuring box is Linux with bash 5.2.21.
* One invocation may yield two findings. Deliberate; see the suppression rationale.
* The census allowlists a small set of shapes. Any other spelling is a **FINDING by design**, not
  silent coverage — the diagnostic says "teach the allowlist", pointing at the checker rather than
  blaming the author's python.

## Follow-ups (REQ-3451-B, defaults accepted by the lead)

**B1** a real 3.9/3.11 CI lane compiling the extracted blocks — the only honest oracle for
cross-interpreter portability. **B2** generalising the census tree-wide; **not free** (correcting an
earlier estimate of mine): shapes must be allowlisted first, or it reports findings on innocent files.
**B3** a header attribution nit that understates coverage. **B4** the fatal-guard gap, recommended
*not* to guard.
