### PR TITLE
gate(#3522): execute cqlite-ffi-common + cqlite-node tests in the gate of record, and mechanize the workspace test-execution census

### DIFF
--- a/.github/ci-gating-tiers.yml
+++ b/.github/ci-gating-tiers.yml
@@ -122,7 +122,7 @@ exempt:
     reason: Feature-matrix build lane; the merge-gating minimal-features build runs in the local gate.
     issue: "#2910"
   - workflow: ci.yml
-    reason: Broad opt-in lane (ci:broad); its merge-gating content is covered by the local agent gate.
+    reason: "Broad opt-in lane; exempt because it is ci:broad-label-gated and does not run on an unlabelled PR at all — NOT because the local agent gate is a superset of it. It is not: ci.yml executes `cargo test -p cqlite-core --features delta-scan --lib`, and the local gate only COMPILES those tests (feature-iso-delta-scan is `--lib --no-run`). Audited in #3522."
     issue: "#2910"
   - workflow: compaction-parity.yml
     reason: Byte-parity lane whose merge-gating half is the local gate's compaction-byte-parity component.
@@ -149,7 +149,7 @@ exempt:
     reason: Docker-backed live-cell parity lane; not merge-gating today.
     issue: "#2910"
   - workflow: node-ci.yml
-    reason: Node binding lane; the merge-gating half is the local gate's node-bindings component.
+    reason: "Node binding lane; the merge-gating half is the local gate's node-bindings component, which since #3522 runs the WHOLE jest suite (it ran 1 of 27 files before), plus binding-rust-tests for cqlite-node's Rust unit tests, which ran nowhere. The multi-platform build matrix is release coverage, not merge-gating."
     issue: "#2910"
   - workflow: observability-gate.yml
     reason: Observability correctness plus label-gated overhead bench; overhead is advisory.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ ad-hoc cargo runs never count. `scripts/agent-gate.sh --list` shows the componen
 
 | Mode | Command | Use |
 |------|---------|-----|
-| **Full** — the gate of record | `scripts/agent-gate.sh` | ONCE per issue, immediately pre-merge, inside `flow-closer`. fmt, clippy `-D warnings`, core/integration/write/CLI tests, `oom-audit` (SKIP-aware structural no-unbounded-materialization audit, #2012), `pub-surface` (cqlite-core crate-root declaration-consistency guard, #1712), minimal-features build, the **feature-matrix lanes** (#1699: `flight-tests` EXECUTES cqlite-flight's UNIT suite (`--lib --bins`) and prints a run-time census naming the 42 integration targets it does NOT run, why, and who does (#3384); `legacy-heuristics` builds AND RUNS the feature's gated tests at its own feature set; `feature-iso-parquet`/`feature-iso-delta-scan` compile `parquet` and `delta-scan` in MUTUAL isolation, each without the other, never `--all-features`), the **binding lanes** (#3522: `binding-rust-tests` EXECUTES `cqlite-ffi-common` (ALL targets) and `cqlite-node` (`--lib`), whose Rust tests previously ran NOWHERE, and never SKIPs — it needs nothing beyond cargo; `node-bindings` runs the WHOLE jest suite, not 1 of 27 files), smoke. Emits `AGENT-GATE SUMMARY`. |
+| **Full** — the gate of record | `scripts/agent-gate.sh` | ONCE per issue, immediately pre-merge, inside `flow-closer`. fmt, clippy `-D warnings`, core/integration/write/CLI tests **at the TARGET granularity each component names, NEVER whole packages** (#3522: `cli-tests` runs 35 of 45 `--test` targets and passes no `--lib`/`--bins`, so `cqlite-cli`'s 255 lib/bin unit tests execute nowhere; `integration-tests` COMPILES `cqlite-integration-tests` (`--no-run`) then runs 6 named targets, leaving its lib's 206 tests and 13 bins unexecuted — per-member record: `scripts/tests/workspace-test-disposition.txt`), `oom-audit` (SKIP-aware structural no-unbounded-materialization audit, #2012), `pub-surface` (cqlite-core crate-root declaration-consistency guard, #1712), minimal-features build, the **feature-matrix lanes** (#1699: `flight-tests` EXECUTES cqlite-flight's UNIT suite (`--lib --bins`) and prints a run-time census naming the 42 integration targets it does NOT run, why, and who does (#3384); `legacy-heuristics` builds AND RUNS the feature's gated tests at its own feature set; `feature-iso-parquet`/`feature-iso-delta-scan` compile `parquet` and `delta-scan` in MUTUAL isolation, each without the other, never `--all-features`), the **binding lanes** (#3522: `binding-rust-tests` EXECUTES `cqlite-ffi-common` (ALL targets) and `cqlite-node` (`--lib`), whose Rust tests previously ran NOWHERE, and never SKIPs — it needs nothing beyond cargo; `node-bindings` runs the WHOLE jest suite, not 1 of 27 files), smoke. Emits `AGENT-GATE SUMMARY`. |
 | **Lite** (#1821, ~1–5 min) | `scripts/agent-gate.sh --lite` | EVERY fix round. file-size + fmt + scoped clippy + blast-radius tests (touched package `--lib` + diff's new `--test` targets, mapped from `git diff origin/main...HEAD`; defaults to `cqlite-core --lib` when no rust package is in the diff). Emits a DISTINCT `AGENT-GATE LITE SUMMARY` (MODE: lite) — can NEVER be pasted as the full SUMMARY. |
 | **Delta** (#1892) | `scripts/agent-gate.sh --delta <anchor-sha> --anchor-run-id <id>` (or `--anchor-summary-file <path>`) | Re-certify a post-full-PASS polish round whose diff is ONLY executable tests/docs (rust test code, python/node binding tests against an already-built module, `scripts/tests/*.sh`, `*.md`; #2081). FAILs CLOSED on anything else (src, scripts, workflows, `Cargo.*`, config, test-data, unbuilt node module) — never builds, never passes vacuously. Emits a DISTINCT `AGENT-GATE DELTA SUMMARY` naming the anchor + a `delta-executors:` line; record BOTH it AND the anchor's full SUMMARY in the PR. NOT the gate of record. |
 
@@ -106,7 +106,11 @@ execute NOWHERE** — not locally, not in CI — because their module-level
 `#![cfg(feature = "observability-testing")]` is off in every lane that runs them (#3375), a gap #2910's tier
 aggregation cannot see because the tier *runs* and silently executes 0 tests. So when you add a feature flag,
 ask which lane **executes** it, not which lane compiles it; if the answer is none, the feature is uncovered
-however green the gate looks. `experimental` is the remaining known instance (#3373).
+however green the gate looks. `experimental` is **one** remaining instance (#3373) and NOT the only one: in `cqlite-core` the
+crate-level-gated integration targets for `delta-scan` (13) and `observability-testing` (14) are named
+by no `--test` in the gate and execute ZERO tests at `core-tests`' feature set, as do 3 of the 5
+`dhat-heap` ones; the `delta_scan` module's own 39 lib tests run in no gate component either
+(`feature-iso-delta-scan` is `--lib --no-run`), only in the `required`-exempt `ci.yml` (#3522 audit).
 **AND THE SAME REASONING RUNS AT PACKAGE GRANULARITY, WHICH IS WHERE IT WAS COSTLIEST (#3522).**
 `cargo clippy --workspace --all-targets` compiles EVERY workspace member on every full gate, so a
 whole CRATE can be built by every run and execute nothing — and it reads as covered precisely
@@ -127,7 +131,10 @@ convention THROWS. A false rationale in a gate log is worse than none, because i
 next person looking.) The durable question is the same one shape up: for each workspace member, **which component
 EXECUTES it** — recorded, member by member, in `scripts/tests/workspace-test-disposition.txt`
 (`EXECUTED`/`PARTIAL`/`NOT-EXECUTED`, a closed label set enforced under `tooling-tests`), so a new
-crate cannot join the unexecuted set unannounced. That census records completeness and labeling, **not
+crate cannot join the unexecuted set unannounced. Each record also carries a CLASS — `silent` (no
+committed doctrine claims it is covered) vs `contradicts-doctrine` (doctrine says it is and it is not)
+— coupled to the label (`EXECUTED` ⇔ `no-gap`), because a gap our own doctrine denies is a false
+certification and not a backlog item. That census records completeness and labeling, **not
 truth** — deliberately, on #1716's precedent.
 Two corollaries the lanes are built on. **Derive, never curate**: both executing lanes compute their subject
 set from committed source at run time — `legacy-heuristics` its `--test` targets (from cargo metadata plus a
@@ -270,7 +277,15 @@ bindings/node/   # Node.js bindings (napi-rs) — Phase 3 complete
 test-data/       # Real Cassandra 5.0 SSTables for testing
 tools/           # 7 crates, each with a RECORDED disposition in one of THREE
                  #   categories, pinned by the gate guard
-                 #   scripts/tests/test_tools_crate_disposition.sh (#1716):
+                 #   scripts/tests/test_tools_crate_disposition.sh (#1716).
+                 #   These labels say whether something INVOKES the crate —
+                 #   usually its BINARY — and NOT whether its TESTS execute
+                 #   (#3522). Of the WIRED four only ws0-corpus-gen's tests run
+                 #   in the gate (tooling-tests); cassandra-parity (25+9),
+                 #   sstabledump-validator (17+2) and flight-loadgen (21) have
+                 #   tests that execute NOWHERE, as does MIXED format-validator
+                 #   (8). Per-member record, with the label AND the class:
+                 #   scripts/tests/workspace-test-disposition.txt.
                  #   WIRED   — cassandra-parity, flight-loadgen,
                  #             sstabledump-validator, ws0-corpus-gen.
                  #   UNWIRED — nothing runs them AND nothing depends on them:
@@ -306,9 +321,11 @@ compiled by every workspace build" was false). The `tools/` crates are compiled 
 `-D warnings` no matter their disposition.
 
 **Their unit tests, though, run ONLY when your diff touches their package (#1716).** No CI job and
-no gate component runs workspace-wide tests, so an untouched `tools/` crate's tests never execute —
-but `--lite`'s blast-radius maps a touched path to its package and runs that package's `--lib`
-tests. Consequence, found the hard way on #1716: editing only `tools/format-validator/README.md`
+no gate component runs workspace-wide tests, so an untouched `tools/` crate's tests execute only
+where something names its package explicitly — `ws0-corpus-gen` under the gate's `tooling-tests`, and
+`cassandra-parity` in the path-filtered, `required`-exempt `cassandra-parity.yml`; for every other
+`tools/` crate they never execute (#3522). But `--lite`'s blast-radius maps a touched path to its
+package and runs that package's `--lib` tests. Consequence, found the hard way on #1716: editing only `tools/format-validator/README.md`
 made `--lite` run that crate's tests **for the first time**, and one failed —
 `test_hex_dump_formatting` asserted an unseparated `"48656c6c6f"` against a `hexdump -C`-style
 formatter that emits `48 65 6c 6c 6f`, an expectation that could never hold for any input. **Expect

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,11 +106,12 @@ execute NOWHERE** — not locally, not in CI — because their module-level
 `#![cfg(feature = "observability-testing")]` is off in every lane that runs them (#3375), a gap #2910's tier
 aggregation cannot see because the tier *runs* and silently executes 0 tests. So when you add a feature flag,
 ask which lane **executes** it, not which lane compiles it; if the answer is none, the feature is uncovered
-however green the gate looks. `experimental` is **one** remaining instance (#3373) and NOT the only one: in `cqlite-core` the
-crate-level-gated integration targets for `delta-scan` (13) and `observability-testing` (14) are named
-by no `--test` in the gate and execute ZERO tests at `core-tests`' feature set, as do 3 of the 5
-`dhat-heap` ones; the `delta_scan` module's own 39 lib tests run in no gate component either
-(`feature-iso-delta-scan` is `--lib --no-run`), only in the `required`-exempt `ci.yml` (#3522 audit).
+however green the gate looks. `experimental` is **one** remaining instance (#3373) and NOT the only
+one: in `cqlite-core` the crate-level-gated integration targets for `delta-scan` (13) and
+`observability-testing` (14) are named by no `--test` in the gate and execute ZERO tests at
+`core-tests`' feature set, as do 3 of the 5 `dhat-heap` ones; the `delta_scan` module's own 39 lib
+tests run in no gate component either (`feature-iso-delta-scan` is `--lib --no-run`), only in the
+`required`-exempt `ci.yml` (#3522 audit).
 **AND THE SAME REASONING RUNS AT PACKAGE GRANULARITY, WHICH IS WHERE IT WAS COSTLIEST (#3522).**
 `cargo clippy --workspace --all-targets` compiles EVERY workspace member on every full gate, so a
 whole CRATE can be built by every run and execute nothing — and it reads as covered precisely
@@ -325,8 +326,9 @@ no gate component runs workspace-wide tests, so an untouched `tools/` crate's te
 where something names its package explicitly — `ws0-corpus-gen` under the gate's `tooling-tests`, and
 `cassandra-parity` in the path-filtered, `required`-exempt `cassandra-parity.yml`; for every other
 `tools/` crate they never execute (#3522). But `--lite`'s blast-radius maps a touched path to its
-package and runs that package's `--lib` tests. Consequence, found the hard way on #1716: editing only `tools/format-validator/README.md`
-made `--lite` run that crate's tests **for the first time**, and one failed —
+package and runs that package's `--lib` tests. Consequence, found the hard way on #1716: editing
+only `tools/format-validator/README.md` made `--lite` run that crate's tests **for the first time**,
+and one failed —
 `test_hex_dump_formatting` asserted an unseparated `"48656c6c6f"` against a `hexdump -C`-style
 formatter that emits `48 65 6c 6c 6f`, an expectation that could never hold for any input. **Expect
 latent failures the first time you touch a long-unwired crate**; they are pre-existing, not yours,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ ad-hoc cargo runs never count. `scripts/agent-gate.sh --list` shows the componen
 
 | Mode | Command | Use |
 |------|---------|-----|
-| **Full** — the gate of record | `scripts/agent-gate.sh` | ONCE per issue, immediately pre-merge, inside `flow-closer`. fmt, clippy `-D warnings`, core/integration/write/CLI tests, `oom-audit` (SKIP-aware structural no-unbounded-materialization audit, #2012), `pub-surface` (cqlite-core crate-root declaration-consistency guard, #1712), minimal-features build, the **feature-matrix lanes** (#1699: `flight-tests` EXECUTES cqlite-flight's UNIT suite (`--lib --bins`) and prints a run-time census naming the 42 integration targets it does NOT run, why, and who does (#3384); `legacy-heuristics` builds AND RUNS the feature's gated tests at its own feature set; `feature-iso-parquet`/`feature-iso-delta-scan` compile `parquet` and `delta-scan` in MUTUAL isolation, each without the other, never `--all-features`), smoke. Emits `AGENT-GATE SUMMARY`. |
+| **Full** — the gate of record | `scripts/agent-gate.sh` | ONCE per issue, immediately pre-merge, inside `flow-closer`. fmt, clippy `-D warnings`, core/integration/write/CLI tests, `oom-audit` (SKIP-aware structural no-unbounded-materialization audit, #2012), `pub-surface` (cqlite-core crate-root declaration-consistency guard, #1712), minimal-features build, the **feature-matrix lanes** (#1699: `flight-tests` EXECUTES cqlite-flight's UNIT suite (`--lib --bins`) and prints a run-time census naming the 42 integration targets it does NOT run, why, and who does (#3384); `legacy-heuristics` builds AND RUNS the feature's gated tests at its own feature set; `feature-iso-parquet`/`feature-iso-delta-scan` compile `parquet` and `delta-scan` in MUTUAL isolation, each without the other, never `--all-features`), the **binding lanes** (#3522: `binding-rust-tests` EXECUTES `cqlite-ffi-common` (ALL targets) and `cqlite-node` (`--lib`), whose Rust tests previously ran NOWHERE, and never SKIPs — it needs nothing beyond cargo; `node-bindings` runs the WHOLE jest suite, not 1 of 27 files), smoke. Emits `AGENT-GATE SUMMARY`. |
 | **Lite** (#1821, ~1–5 min) | `scripts/agent-gate.sh --lite` | EVERY fix round. file-size + fmt + scoped clippy + blast-radius tests (touched package `--lib` + diff's new `--test` targets, mapped from `git diff origin/main...HEAD`; defaults to `cqlite-core --lib` when no rust package is in the diff). Emits a DISTINCT `AGENT-GATE LITE SUMMARY` (MODE: lite) — can NEVER be pasted as the full SUMMARY. |
 | **Delta** (#1892) | `scripts/agent-gate.sh --delta <anchor-sha> --anchor-run-id <id>` (or `--anchor-summary-file <path>`) | Re-certify a post-full-PASS polish round whose diff is ONLY executable tests/docs (rust test code, python/node binding tests against an already-built module, `scripts/tests/*.sh`, `*.md`; #2081). FAILs CLOSED on anything else (src, scripts, workflows, `Cargo.*`, config, test-data, unbuilt node module) — never builds, never passes vacuously. Emits a DISTINCT `AGENT-GATE DELTA SUMMARY` naming the anchor + a `delta-executors:` line; record BOTH it AND the anchor's full SUMMARY in the PR. NOT the gate of record. |
 
@@ -107,6 +107,25 @@ execute NOWHERE** — not locally, not in CI — because their module-level
 aggregation cannot see because the tier *runs* and silently executes 0 tests. So when you add a feature flag,
 ask which lane **executes** it, not which lane compiles it; if the answer is none, the feature is uncovered
 however green the gate looks. `experimental` is the remaining known instance (#3373).
+**AND THE SAME REASONING RUNS AT PACKAGE GRANULARITY, WHICH IS WHERE IT WAS COSTLIEST (#3522).**
+`cargo clippy --workspace --all-targets` compiles EVERY workspace member on every full gate, so a
+whole CRATE can be built by every run and execute nothing — and it reads as covered precisely
+because the workspace builds clean. Measured: `cqlite-ffi-common` appeared **zero times** in
+`scripts/**` and `.github/workflows/**` (37 unit tests + `tests/dependency_boundary.rs` +
+`tests/error_contract_table.rs`, executed by nothing anywhere), and `cqlite-node`'s 53 Rust unit
+tests were in the same hole because `node-bindings` runs jest against the BUILT ARTIFACT and never
+`cargo test`. Both now run in `binding-rust-tests`. Two design rules came out of it. **A
+never-SKIPping lane must not be folded into a SKIP-aware one**: `node-bindings` correctly SKIPs
+without node/npm, and putting cqlite-node's *Rust* tests behind that SKIP would be a coverage hole
+wearing a SKIP's clothes — so the Rust lane depends on nothing beyond cargo and never SKIPs. **And
+enrolling a lane in `DATASET_COMPONENTS` is not enough to stop a corpus-dependent suite skipping**:
+the widened `node-bindings` also exports `CQLITE_REQUIRE_FIXTURES=1` on the full gate, because
+without it 7 of the 27 jest suites `describe.skip` SILENTLY and jest reports an all-skipped suite as
+PASSED. The durable question is the same one shape up: for each workspace member, **which component
+EXECUTES it** — recorded, member by member, in `scripts/tests/workspace-test-disposition.txt`
+(`EXECUTED`/`PARTIAL`/`NOT-EXECUTED`, a closed label set enforced under `tooling-tests`), so a new
+crate cannot join the unexecuted set unannounced. That census records completeness and labeling, **not
+truth** — deliberately, on #1716's precedent.
 Two corollaries the lanes are built on. **Derive, never curate**: both executing lanes compute their subject
 set from committed source at run time — `legacy-heuristics` its `--test` targets (from cargo metadata plus a
 module closure, so a manifest-gated or directory-style target is not missed) and its allowed-zero set, and
@@ -128,7 +147,10 @@ incomplete source set is permissive everywhere, an unevaluated one is merely una
 proves nothing. `scripts/tests/test_agent_gate_feature_matrix_lanes.sh` (opt-in) plants each lane's
 incident-class break in a throwaway `git worktree` and requires the lane to red **and** to NAME the planted
 symbol — a bare red is not evidence either, since an unrelated breakage produces an identical exit code and
-SUMMARY line.
+SUMMARY line. `scripts/tests/test_agent_gate_binding_rust_lanes.sh` does the same for the #3522 binding
+lanes, and adds the case the failing-assertion plants cannot reach: one that cfg's a unit suite OUT, so it
+compiles, runs **zero** tests and exits 0 — the only plant that exercises the non-zero-count half of
+`check_unittest_targets_ran`.
 
 **Required invocation — summary-file redirect, never raw stdout (issues #1175/#2079), full AND lite:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,9 +119,12 @@ never-SKIPping lane must not be folded into a SKIP-aware one**: `node-bindings` 
 without node/npm, and putting cqlite-node's *Rust* tests behind that SKIP would be a coverage hole
 wearing a SKIP's clothes — so the Rust lane depends on nothing beyond cargo and never SKIPs. **And
 enrolling a lane in `DATASET_COMPONENTS` is not enough to stop a corpus-dependent suite skipping**:
-the widened `node-bindings` also exports `CQLITE_REQUIRE_FIXTURES=1` on the full gate, because
-without it 7 of the 27 jest suites `describe.skip` SILENTLY and jest reports an all-skipped suite as
-PASSED. The durable question is the same one shape up: for each workspace member, **which component
+the widened `node-bindings` also exports `CQLITE_REQUIRE_FIXTURES=1` on the full gate, which buys ONE
+named setup failure instead of 14 separate `beforeAll` throws and closes `parity.test.js`'s `test.skip`
+placeholder — the one corpus-conditional path in that suite that would pass silently. (An earlier draft
+of this paragraph said those suites `describe.skip`; **measured, none does** — the repo's Node
+convention THROWS. A false rationale in a gate log is worse than none, because it is what stops the
+next person looking.) The durable question is the same one shape up: for each workspace member, **which component
 EXECUTES it** — recorded, member by member, in `scripts/tests/workspace-test-disposition.txt`
 (`EXECUTED`/`PARTIAL`/`NOT-EXECUTED`, a closed label set enforced under `tooling-tests`), so a new
 crate cannot join the unexecuted set unannounced. That census records completeness and labeling, **not

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6210,25 +6210,60 @@ EOF
   # of the component log — because a lane that omits coverage silently is
   # indistinguishable from one that covers it, and "the log a reviewer actually reads"
   # is both of those. Not a comment: a comment is not read on a run.
-  local ffi_ids="" ffi_expect_n=0 ffi_skip="" _tn _tid _trf _troff _trfl
-  local -a ffi_expect=()
-  while IFS=$'\t' read -r _tn _tid _trf; do
-    [ -n "$_tn" ] || continue
-    ffi_ids="$ffi_ids $_tid"
-    _troff=""
-    for _trfl in ${_trf//,/ }; do
-      case "$ffi_enabled" in *" $_trfl "*) ;; *) _troff="$_trfl"; break ;; esac
-    done
-    if [ -n "$_troff" ]; then
-      # cargo SILENTLY skips a required-features target it cannot enable, printing no
-      # banner at all — so demanding an observation for it would red a healthy lane.
-      # Excluded from the expectation and DECLARED, never dropped quietly.
-      ffi_skip="$ffi_skip $_tid(required-features[$_trf]:off[$_troff])"
-    else
-      ffi_expect+=("$_tid")
-      ffi_expect_n=$((ffi_expect_n + 1))
-    fi
-  done <<< "$ffi_targets"
+  # Partition a package's DERIVED integration targets into the ones cargo can actually
+  # run at this lane's feature set and the ones it will SILENTLY skip for an unmet
+  # `required-features` (cargo prints no banner at all for those, so demanding an
+  # observation would red a healthy lane — they are excluded and DECLARED, never dropped
+  # quietly). Prints ONE tab-separated line: <runner-ids> TAB <target-names> TAB
+  # <skip-reasons>.
+  #
+  # SHARED by both packages deliberately. The cqlite-ffi-common half and the cqlite-node
+  # half are the SAME logic, and a near-copy is how one of them silently stops matching
+  # cargo's behaviour — the drift this whole component exists to prevent.
+  _brt_partition_targets() { # <target-meta> <enabled-set>
+    local meta="$1" enabled="$2"
+    local ids="" names="" skip="" tn tid trf troff trfl
+    while IFS=$'\t' read -r tn tid trf; do
+      [ -n "$tn" ] || continue
+      troff=""
+      for trfl in ${trf//,/ }; do
+        case "$enabled" in *" $trfl "*) ;; *) troff="$trfl"; break ;; esac
+      done
+      if [ -n "$troff" ]; then
+        skip="$skip $tid(required-features[$trf]:off[$troff])"
+      else
+        ids="$ids $tid"; names="$names $tn"
+      fi
+    done <<< "$meta"
+    printf '%s\t%s\t%s\n' "${ids# }" "${names# }" "${skip# }"
+  }
+
+  local ffi_ids="" ffi_names="" ffi_skip="" ffi_expect_n=0
+  local node_ids="" node_names="" node_skip="" node_expect_n=0
+  local -a ffi_expect=() node_expect=() node_test_args=()
+  local _t
+  IFS=$'\t' read -r ffi_ids ffi_names ffi_skip <<< "$(_brt_partition_targets "$ffi_targets" "$ffi_enabled")"
+  IFS=$'\t' read -r node_ids node_names node_skip <<< "$(_brt_partition_targets "$node_targets" "$node_enabled")"
+  for _t in $ffi_ids; do ffi_expect+=("$_t"); done
+  ffi_expect_n=${#ffi_expect[@]}
+  for _t in $node_ids; do node_expect+=("$_t"); done
+  node_expect_n=${#node_expect[@]}
+  # THE EXECUTION HALF, and the reason it exists (roborev round 1, B1). An earlier cut of
+  # this lane COUNTED cqlite-node's integration targets, PRINTED them in the census and
+  # ran `--lib` only — so the day someone added `bindings/node/tests/foo.rs` the lane
+  # would have counted it, announced it, and left it UNEXECUTED while both this
+  # component and the disposition census stayed green. That is issue #3522's own defect
+  # reproduced inside the fix for #3522, which makes it the most serious shape this
+  # component could have carried.
+  #
+  # Fixed by EXECUTING them, not by failing closed on a non-zero count: refusing would
+  # red the gate on the CORRECT act of adding a test, and a lane that reds on correct
+  # input is the lane agents learn to waive (CLAUDE.md). `--lib` alone does not select
+  # integration targets, so each runnable one is named explicitly. cqlite-node declares
+  # ZERO today, so this expands to nothing and the command is byte-identical to before —
+  # and it becomes correct the moment that stops being true, which is the entire point of
+  # deriving the set instead of listing it.
+  for _t in $node_names; do node_test_args+=(--test "$_t"); done
 
   local -a census=()
   census+=("cargo test --no-fail-fast -p cqlite-ffi-common            (ALL targets: lib + every integration target)")
@@ -6248,14 +6283,17 @@ EOF
   census+=("     half IS fully covered, by the python-bindings component.")
   census+=("  2. cqlite-node's JavaScript suite. Owned by the node-bindings component, which builds")
   census+=("     the napi artifact and runs jest against it. This lane never builds that artifact.")
-  census+=("  3. cqlite-node integration (test) targets: it declares $node_targets_n — a DERIVED count")
-  census+=("     from cargo metadata, not an assumption. At $node_targets_n there is nothing to omit; if")
-  census+=("     that number ever rises without this lane running them, this line is the alarm.")
+  census+=("  3. NOTHING, on the cqlite-node integration half — it is EXECUTED, not omitted. The")
+  census+=("     count is DERIVED from cargo metadata ($node_targets_n declared, $node_expect_n runnable here) and")
+  census+=("     every runnable one is passed to cargo as an explicit --test, so a target added")
+  census+=("     tomorrow is RUN, not merely counted (roborev B1: counting-without-running would be")
+  census+=("     #3522's own defect reproduced inside the fix for #3522).")
   census+=("  4. Feature-gated bodies at features this lane leaves OFF (declared-minus-enabled,")
   census+=("     derived): cqlite-ffi-common ->${ffi_off:- <none: this crate declares no features>};")
   census+=("     cqlite-node ->${node_off:- <none>}. 'observability' is off ON PURPOSE — building the")
   census+=("     OTel stack is a cost this gate declines (#1844 excludes it from clippy likewise).")
-  [ -n "$ffi_skip" ] && census+=("  5. cqlite-ffi-common targets cargo cannot run at this feature set:$ffi_skip")
+  [ -n "$ffi_skip" ]  && census+=("  5. cqlite-ffi-common targets cargo cannot run at this feature set:$ffi_skip")
+  [ -n "$node_skip" ] && census+=("  6. cqlite-node targets cargo cannot run at this feature set:$node_skip")
   census+=("SCOPE OF THE #3522 AUDIT, recorded so it is not re-litigated: this component closes TWO")
   census+=("     of the ten gaps that audit found. The other eight are RECORDED, not silently fixed,")
   census+=("     in scripts/tests/workspace-test-disposition.txt (enforced by")
@@ -6315,9 +6353,30 @@ EOF
   # libpython at link time, which is a property of pyo3, not of cdylib.
   if env CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT" \
       cargo test --no-fail-fast -p cqlite-node \
-      ${node_feature_args[@]+"${node_feature_args[@]}"} --lib > "$node_log" 2>&1; then
+      ${node_feature_args[@]+"${node_feature_args[@]}"} --lib \
+      ${node_test_args[@]+"${node_test_args[@]}"} > "$node_log" 2>&1; then
     if ! check_unittest_targets_ran "$name/cqlite-node" "$node_log" "${node_unit_srcs[@]}" 2>>"$verdict_log"; then
       status=FAIL
+    fi
+    # The SAME two guards the cqlite-ffi-common half gets, on the same terms — so the
+    # integration targets this lane now EXECUTES are also observed to have run and to
+    # have run a non-zero number of tests.
+    if [ "$node_expect_n" -gt 0 ]; then
+      if ! check_test_targets_observed "$name/cqlite-node" "$node_log" "${node_expect[@]}" 2>>"$verdict_log"; then
+        status=FAIL
+      else
+        echo "$name/cqlite-node: integration targets OK — all $node_expect_n derived target(s) produced a 'Running' banner: $node_ids" >> "$verdict_log"
+      fi
+      if ! check_no_unexpected_zero_tests "$name/cqlite-node" "$node_log" 2>>"$verdict_log"; then
+        status=FAIL
+      fi
+    else
+      # NOT a skipped check: zero is the DERIVED, correct answer for a cdylib with no
+      # tests/ directory. Stated affirmatively in the verdict log so a reader can tell
+      # "there was nothing to observe" from "the observation did not happen" — and
+      # check_no_unexpected_zero_tests is deliberately NOT called, because with `--lib`
+      # only it would have an EMPTY subject set and report OK having measured nothing.
+      echo "$name/cqlite-node: 0 integration targets declared (DERIVED from cargo metadata) — nothing for the observation guard to judge, which is the correct answer for this package today, not a check that was skipped. The moment it declares one, the derived --test list executes it and both guards apply." >> "$verdict_log"
     fi
   else
     status=FAIL

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6621,11 +6621,11 @@ run_binding_rust_tests() {
   local ffi_enabled="" node_enabled=""
   if ! ffi_enabled=$(_resolved_package_features cqlite-ffi-common ${ffi_feature_args[@]+"${ffi_feature_args[@]}"}); then
     _brt_derivation_fail "cqlite-ffi-common's enabled feature set" \
-      "'cargo tree -p cqlite-ffi-common' emitted no line for the package (a cargo failure or an offline registry)."
+      "'cargo tree -p cqlite-ffi-common' failed, produced no output, emitted no line for the package (a cargo failure or an offline registry), or its feature-extraction/normalisation pipeline failed. Enumerated rather than asserting ONE cause: the E1 fix gave that helper two further failure modes, and a message naming only the package-line case would send the reader to the wrong remedy (roborev F2's class)."
   fi
   if ! node_enabled=$(_resolved_package_features cqlite-node ${node_feature_args[@]+"${node_feature_args[@]}"}); then
     _brt_derivation_fail "cqlite-node's enabled feature set" \
-      "'cargo tree -p cqlite-node --features write-support' emitted no line for the package."
+      "'cargo tree -p cqlite-node --features write-support' failed, produced no output, emitted no line for the package, or its feature-extraction/normalisation pipeline failed (see the cqlite-ffi-common note above: three failure modes, none asserted)."
   fi
 
   # cqlite-ffi-common's integration targets. This package HAS them, so an empty result
@@ -6885,13 +6885,24 @@ EOF
       if ! check_no_unexpected_zero_tests "$name/cqlite-node" "$node_log" 2>>"$verdict_log"; then
         status=FAIL
       fi
-    else
-      # NOT a skipped check: zero is the DERIVED, correct answer for a cdylib with no
-      # tests/ directory. Stated affirmatively in the verdict log so a reader can tell
-      # "there was nothing to observe" from "the observation did not happen" — and
-      # check_no_unexpected_zero_tests is deliberately NOT called, because with `--lib`
-      # only it would have an EMPTY subject set and report OK having measured nothing.
+    elif [ "$node_targets_n" -eq 0 ]; then
+      # NOT a skipped check: zero DECLARED is the derived, correct answer for a cdylib with no
+      # tests/ directory. Stated affirmatively in the verdict log so a reader can tell "there
+      # was nothing to observe" from "the observation did not happen" — and
+      # check_no_unexpected_zero_tests is deliberately NOT called, because with `--lib` only it
+      # would have an EMPTY subject set and report OK having measured nothing.
       echo "$name/cqlite-node: 0 integration targets declared (DERIVED from cargo metadata) — nothing for the observation guard to judge, which is the correct answer for this package today, not a check that was skipped. The moment it declares one, the derived --test list executes it and both guards apply." >> "$verdict_log"
+    else
+      # DECLARED BUT NONE RUNNABLE — a DIFFERENT cause with a DIFFERENT remedy, and it used to
+      # be reported as the branch above (roborev round 5, F2). This is the WRONG-CAUSE variant
+      # my own round-4 sweep named and did not act on: the branch keyed on `node_expect_n == 0`
+      # while its message asserted `node_targets_n == 0`, so with targets declared but all
+      # excluded by unmet required-features the verdict log CONTRADICTED the census printed
+      # moments earlier and falsely promised that a future target would execute.
+      #
+      # RULE, now applied rather than merely observed: a branch whose message asserts a CAUSE
+      # must be reachable ONLY from that cause. Two conditions, two branches, two messages.
+      echo "$name/cqlite-node: $node_targets_n integration target(s) DECLARED but NONE runnable at this lane's feature set, so there is nothing for the observation guard to judge — and, unlike the zero-declared case, this means DECLARED COVERAGE IS NOT BEING EXECUTED HERE. cargo skips such a target SILENTLY (no banner at all), so no guard can see it; the census above declares the same gap. Skipped:$node_skip" >> "$verdict_log"
     fi
   else
     status=FAIL

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -5869,7 +5869,23 @@ run_node_bindings() {
   fi
   # Strict-fixture mode on the FULL gate only, honouring the documented #2078 opt-out.
   # See the scope note above for why enrollment in DATASET_COMPONENTS is not enough.
+  # ENFORCED WITH `env -u`, NOT MERELY BY OMITTING THE ASSIGNMENT (roborev round 1, B2;
+  # the same lesson is already recorded on the bti-multiclustering lane, which cites it
+  # as "plain `env` INHERITS an exported value, and exporting CQLITE_REQUIRE_FIXTURES=1
+  # is routine"). Both variables are strict-mode triggers for this suite —
+  # `bindings/node/__test__/setup.js` ORs them (`CQLITE_REQUIRE_FIXTURES` ||
+  # `CQLITE_PARITY_REQUIRE_DATASETS`), and `abort-safety.test.js` reads both to turn a
+  # skip into a hard failure. So an inherited export would make `--only` or the
+  # documented #2078 opt-out FAIL while the census line printed below claims fixtures are
+  # optional: an opt-out that the SUMMARY reports as TAKEN but that does not let the gate
+  # finish, which is exactly what #2078's own per-lane-veto note forbids.
+  #
+  # The mode is decided by THIS SCRIPT's own state (`$ONLY`/`$LITE`/the opt-out) and the
+  # inherited variables are then unset — never the reverse. Deriving the mode FROM the
+  # inherited variables would let the ambient environment redefine what the gate
+  # certifies.
   local require_fixtures=0 fixture_note
+  local -a fixture_env=()
   if [ -z "$ONLY" ] && [ "$LITE" -eq 0 ] && [ "${AGENT_GATE_ALLOW_MISSING_FIXTURES:-0}" != 1 ]; then
     require_fixtures=1
     fixture_note="CQLITE_REQUIRE_FIXTURES=1 — an absent corpus fails ONCE, by name, in setup.js instead of as 14 separate beforeAll throws, and parity.test.js's test.skip placeholder (the one corpus-conditional path that would pass silently) cannot fire"
@@ -5877,6 +5893,11 @@ run_node_bindings() {
     fixture_note="CQLITE_REQUIRE_FIXTURES unset (AGENT_GATE_ALLOW_MISSING_FIXTURES=1) — with a corpus absent the 14 dataset-gated suites would THROW individually and parity.test.js would test.skip, so this run does NOT validate that half"
   else
     fixture_note="CQLITE_REQUIRE_FIXTURES unset (--only/--lite probe run) — with a corpus absent the 14 dataset-gated suites would THROW individually and parity.test.js would test.skip"
+  fi
+  if [ "$require_fixtures" = 1 ]; then
+    fixture_env=(CQLITE_REQUIRE_FIXTURES=1)
+  else
+    fixture_env=(-u CQLITE_REQUIRE_FIXTURES -u CQLITE_PARITY_REQUIRE_DATASETS)
   fi
 
   local -a census=()
@@ -5910,7 +5931,11 @@ run_node_bindings() {
   # agents learn to waive. Same rule as `_package_test_targets` preferring cargo
   # metadata over parsing `[[test]]` stanzas.
   local list_file="$LOG_DIR/$name.listtests.txt" suite_n=""
-  if ! CQLITE_LIST_FILE="$list_file" bash -c '
+  # Both strict-mode variables are unset here UNCONDITIONALLY, in every mode: listing
+  # tests needs no corpus, so an inherited strict flag could only turn a healthy
+  # enumeration into a failure. STEP 2 below is where the mode actually applies.
+  if ! env -u CQLITE_REQUIRE_FIXTURES -u CQLITE_PARITY_REQUIRE_DATASETS \
+       CQLITE_LIST_FILE="$list_file" bash -c '
       set -euo pipefail
       cd "'"$REPO_ROOT"'/bindings/node"
       if [ -f package-lock.json ]; then npm ci; else npm install; fi
@@ -5957,12 +5982,15 @@ run_node_bindings() {
   echo "derived suite set: $suite_n *.test.js file(s) (oracle: npx jest --listTests)" >> "$log"
 
   # STEP 2 — run them.
-  if CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT" \
-     RUN_SLOW_TESTS="${RUN_SLOW_TESTS:-0}" \
-     CQLITE_REQUIRE_FIXTURES_ARG="$require_fixtures" bash -c '
+  # `env "${fixture_env[@]}"` FIRST, because `env`'s -u options must precede any
+  # NAME=VALUE assignments. In strict mode that array IS the assignment; otherwise it is
+  # the pair of -u unsets, so the in-script conditional export this replaced (which could
+  # only ADD the variable, never remove an inherited one) is gone.
+  if env "${fixture_env[@]}" \
+     CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT" \
+     RUN_SLOW_TESTS="${RUN_SLOW_TESTS:-0}" bash -c '
       set -euo pipefail
       cd "'"$REPO_ROOT"'/bindings/node"
-      if [ "$CQLITE_REQUIRE_FIXTURES_ARG" = 1 ]; then export CQLITE_REQUIRE_FIXTURES=1; fi
       npm test' >>"$log" 2>&1; then
     # A green `npm test` is NOT sufficient: jest reports a suite whose every describe
     # was skipped as PASSED, so the exit code alone cannot distinguish 27 suites of

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -5456,6 +5456,131 @@ check_jest_suites_ran() {
 }
 export -f check_jest_suites_ran
 
+# check_jest_per_suite_passed <label> <json-file> <reconciled-set-file>
+#
+# THE PER-SUITE half of the jest affirmative measurement (issue #3522, roborev round 5 F1).
+#
+# WHY THE AGGREGATE CHECK IS NOT ENOUGH, and this is #3522's own defect at suite granularity.
+# check_jest_suites_ran requires `Tests: N passed` with N > 0 — ONE passed test across the
+# WHOLE run. Jest reports a file whose every test is individually skipped as a PASSED suite,
+# so one suite can execute ZERO assertions while its 26 siblings satisfy the aggregate and the
+# component still goes green. The original bug this issue exists for was a whole CRATE's tests
+# not executing behind a green gate; that is the same thing one level down.
+#
+# It is the COMPLEMENT of the two-oracle reconciliation, not a replacement: the reconciliation
+# proves the right FILES are present and were run, this proves each of them did WORK. Neither
+# implies the other, and a suite can pass both file-level checks while asserting nothing.
+#
+# The subject set is the RECONCILED set (the file the reconciliation validated), never the
+# JSON's own suite list — that would be self-referential in exactly the way D1 fixed. The JSON
+# list is cross-checked AGAINST it in both directions instead.
+#
+# NO EXEMPTION LIST, and that is a MEASURED result rather than an assumption (F1's design
+# trap). The two RUN_SLOW_TESTS opt-in tests are per-TEST skips inside suites that retain
+# other passing tests — measured at RUN_SLOW_TESTS=0: publish.test.js 31 passed / 1 skipped,
+# streaming.test.js 22 passed / 1 skipped, and ZERO suites with no passed test. So the
+# per-suite requirement holds on a correct tree with no excusals at all. If a suite ever
+# becomes legitimately all-skipped this guard REDS, and the remedy is to declare it BY NAME
+# WITH ITS REASON in the census — never to add a silent entry to an exemption list, which is
+# the curation this component exists not to have.
+check_jest_per_suite_passed() {
+  local label="$1" json="$2" expected_file="$3"
+  if [ ! -r "$json" ]; then
+    echo "$label: FAIL-CLOSED — jest's --json report is missing or unreadable at '$json', so no PER-SUITE measurement could be taken. The aggregate 'Tests: N passed' check alone cannot see an all-skipped suite (issue #3522, roborev F1)" >&2
+    return 1
+  fi
+  if [ ! -r "$expected_file" ]; then
+    echo "$label: FAIL-CLOSED — the reconciled suite set '$expected_file' is missing or unreadable, so this guard has no SUBJECT. A guard with an empty subject set reports OK having measured nothing (issue #3522)" >&2
+    return 1
+  fi
+  # jq FIRST, then python3, then a FAILED derivation — the same chain and the same direction as
+  # every other metadata helper here. A single-parser guard is a false red on a host that has
+  # only the other one, and this gate treats macOS as a first-class host.
+  local counts=""
+  if command -v jq >/dev/null 2>&1; then
+    counts=$(jq -r '.testResults[]? | [ (.name | sub("^.*/__test__/"; "")), ([ .assertionResults[]? | select(.status == "passed") ] | length) ] | @tsv' "$json") || counts="__PARSE_FAILED__"
+  elif command -v python3 >/dev/null 2>&1; then
+    counts=$(python3 -c '
+import json, sys
+with open(sys.argv[1]) as fh:
+    d = json.load(fh)
+for r in d.get("testResults") or []:
+    n = r.get("name") or ""
+    i = n.find("/__test__/")
+    rel = n[i + len("/__test__/"):] if i >= 0 else n
+    p = sum(1 for a in (r.get("assertionResults") or []) if a.get("status") == "passed")
+    print("%s\t%d" % (rel, p))
+' "$json") || counts="__PARSE_FAILED__"
+  else
+    echo "$label: FAIL-CLOSED — neither jq nor python3 is available to read jest's --json report, so the PER-SUITE measurement cannot be taken. An unparseable oracle is not a pass (issue #3522, roborev F1)" >&2
+    return 1
+  fi
+  if [ "$counts" = "__PARSE_FAILED__" ]; then
+    echo "$label: FAIL-CLOSED — could not parse jest's --json report at '$json'. The PARSE failed, not the tests; an unmeasurable per-suite result is never a pass (issue #3522, roborev F1)" >&2
+    return 1
+  fi
+  if [ -z "$counts" ]; then
+    echo "$label: FAIL-CLOSED — jest's --json report at '$json' yielded NO per-suite records. A guard that judged zero suites has measured nothing (issue #3522, roborev F1)" >&2
+    return 1
+  fi
+
+  # No `declare -A`: this gate supports stock macOS /bin/bash 3.2, where associative arrays do
+  # not exist (the same constraint check_unittest_targets_ran records). A TAB-delimited list
+  # plus an exact-field awk lookup is 3.2-safe, and jest's suite paths contain no tabs.
+  local bad="" missing="" extra="" seen_n=0 min_n="" min_name="" suite passed
+  while IFS= read -r suite; do
+    [ -n "$suite" ] || continue
+    passed=$(printf '%s\n' "$counts" | awk -F'\t' -v s="$suite" '$1 == s { print $2; exit }')
+    if [ -z "$passed" ]; then
+      missing="$missing $suite"
+      continue
+    fi
+    case "$passed" in
+      ''|*[!0-9]*)
+        echo "$label: FAIL-CLOSED — non-numeric passed-count '$passed' for suite '$suite' in jest's --json report. The parse is broken, which is never a pass (issue #3522, roborev F1)" >&2
+        return 1 ;;
+    esac
+    seen_n=$((seen_n + 1))
+    if [ "$passed" -eq 0 ]; then
+      bad="$bad $suite"
+    fi
+    if [ -z "$min_n" ] || [ "$passed" -lt "$min_n" ]; then
+      min_n="$passed"; min_name="$suite"
+    fi
+  done < "$expected_file"
+
+  # The reverse direction: a suite jest reported that the reconciled set does not contain. The
+  # reconciliation should already have caught this, so reaching it here means the two
+  # measurements disagree — reported separately because its remedy is different.
+  local jsuite
+  while IFS=$'\t' read -r jsuite passed; do
+    [ -n "$jsuite" ] || continue
+    grep -qxF -- "$jsuite" "$expected_file" || extra="$extra $jsuite"
+  done <<EOF
+$counts
+EOF
+
+  if [ -n "$missing" ]; then
+    echo "$label: FAIL-CLOSED — reconciled suite(s)$missing appear in NO per-suite record of jest's --json report, so whether they executed anything is UNKNOWN. The reconciliation proved the files are present and listed; this guard is what proves they did work, and it could not judge these (issue #3522, roborev F1)" >&2
+    return 1
+  fi
+  if [ -n "$extra" ]; then
+    echo "$label: FAIL-CLOSED — jest's --json report names suite(s)$extra that are NOT in the reconciled set, so the run and the reconciliation disagree about what the suite IS. Distinct from the case above: check the reconciliation's own two oracles rather than the per-suite results (issue #3522, roborev F1)" >&2
+    return 1
+  fi
+  if [ -n "$bad" ]; then
+    echo "$label: FAIL-CLOSED — suite(s)$bad executed ZERO passing tests. Jest reports a file whose every test is individually skipped as a PASSED suite, and the aggregate 'Tests: N passed' check is satisfied by the OTHER suites — so this coverage would have vacated silently. If a suite is LEGITIMATELY all-skipped it must be DECLARED BY NAME WITH ITS REASON in this component's census, never excused silently (issue #3522, roborev F1)" >&2
+    return 1
+  fi
+  if [ "$seen_n" -eq 0 ]; then
+    echo "$label: FAIL-CLOSED — judged ZERO suites against the reconciled set; a guard that measured nothing must never report OK (issue #3522, roborev F1)" >&2
+    return 1
+  fi
+  echo "$label: per-suite results OK — all $seen_n reconciled suite(s) executed >=1 passing test (leanest: $min_name with $min_n). Affirmative and PER-SUITE: the aggregate 'Tests: N passed' check cannot see one all-skipped suite among its passing siblings (issue #3522, roborev F1)" >&2
+  return 0
+}
+export -f check_jest_per_suite_passed
+
 # _package_test_targets <package>: print one TAB-separated line per declared
 # INTEGRATION (`test`) target of that workspace package — `<name>\t<required-features
 # comma-joined, empty when none>` (issue #1699, roborev round-2 finding 2).
@@ -6111,6 +6236,12 @@ run_node_bindings() {
   # absolute prefix (jest resolves rootDir from its config; this script uses $REPO_ROOT).
   local jest_set="$LOG_DIR/$name.suites-jest.txt"
   local disk_set="$LOG_DIR/$name.suites-disk.txt"
+  # Jest's machine-readable PER-SUITE report (roborev round 5, F1). Written under $LOG_DIR, so
+  # it is unique per run and a stale report from a previous run can never be read as this
+  # run's. Removed first anyway, so a jest that fails to write it is caught by the guard's
+  # unreadable-input branch rather than by silently reusing whatever was there.
+  local suite_json="$LOG_DIR/$name.jest-report.json"
+  rm -f "$suite_json"
   local only_disk only_jest
   # STATUS CHECKED, and the reason is CAUSE ATTRIBUTION, not just hygiene (roborev round 4, E1
   # class sweep). A truncated `jest_set` makes the reconciliation below report "ON DISK but NOT
@@ -6263,16 +6394,32 @@ run_node_bindings() {
   # NAME=VALUE assignments. In strict mode that array IS the assignment; otherwise it is
   # the pair of -u unsets, so the in-script conditional export this replaced (which could
   # only ADD the variable, never remove an inherited one) is gone.
+  # `npm test -- --json --outputFile=…` rather than a retyped jest command: `npm test` stays the
+  # derived answer to "what is this suite" (it runs `pretest` and passes `--expose-gc`), and the
+  # extra args after `--` reach jest. MEASURED: the human `Test Suites:`/`Tests:` summary the
+  # aggregate guard parses is STILL emitted alongside the JSON file, so both guards keep their
+  # inputs.
   if env "${fixture_env[@]}" \
      CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT" \
+     CQLITE_JEST_JSON="$suite_json" \
      RUN_SLOW_TESTS="${RUN_SLOW_TESTS:-0}" bash -c '
       set -euo pipefail
       cd "'"$REPO_ROOT"'/bindings/node"
-      npm test' >>"$log" 2>&1; then
+      npm test -- --json --outputFile="$CQLITE_JEST_JSON"' >>"$log" 2>&1; then
     # A green `npm test` is NOT sufficient: jest reports a suite whose every describe
     # was skipped as PASSED, so the exit code alone cannot distinguish 27 suites of
     # assertions from 27 suites of nothing.
-    if check_jest_suites_ran "$name" "$log" "$suite_n" 2>>"$log"; then
+    # BOTH halves are required and neither implies the other (roborev round 5, F1):
+    # check_jest_suites_ran judges the FILE SET and the aggregate counts;
+    # check_jest_per_suite_passed judges whether EACH reconciled suite did any work. A suite
+    # whose every test is individually skipped is reported by jest as a PASSED suite and
+    # satisfies the aggregate via its siblings, so only the per-suite guard can see it.
+    # ANDed without short-circuiting, so one run reports BOTH verdicts rather than revealing
+    # them serially across re-runs.
+    local _agg_ok=0 _per_ok=0
+    check_jest_suites_ran "$name" "$log" "$suite_n" 2>>"$log" && _agg_ok=1
+    check_jest_per_suite_passed "$name" "$suite_json" "$disk_set" 2>>"$log" && _per_ok=1
+    if [ "$_agg_ok" -eq 1 ] && [ "$_per_ok" -eq 1 ]; then
       status=PASS
     else
       status=FAIL
@@ -10922,6 +11069,26 @@ run_tooling_tests() {
      ! bash "$REPO_ROOT/scripts/tests/test_tools_crate_disposition_selftest.sh" >>"$log" 2>&1; then
     status=FAIL
     echo "--- [$name] FAILED (tools/ crate disposition census #1716); last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
+  # node-bindings jest guard self-test (#3522, roborev E1 + F1): hermetic, no node/npm/cargo/
+  # network/datasets — synthetic jest summaries and synthetic --json reports, with both guards
+  # sourced OUT OF THE REAL GATE SCRIPT rather than copied. Its load-bearing case is the one
+  # that cannot be produced by running the real suite: ONE passing suite plus ONE all-skipped
+  # suite. Jest reports the all-skipped file as a PASSED suite and the aggregate
+  # `Tests: N passed` is satisfied by its sibling, so the file-set guard ACCEPTS it (asserted
+  # here, so the case provably still discriminates) and only the per-suite guard rejects it.
+  # A failure FAILs the component.
+  echo ">>> [$name] bash scripts/tests/test_agent_gate_jest_guards.sh"
+  if ! bash "$REPO_ROOT/scripts/tests/test_agent_gate_jest_guards.sh" >>"$log" 2>&1; then
+    status=FAIL
+    echo "--- [$name] FAILED (node-bindings jest guard self-test #3522); last 40 lines of $log ---"
     tail -40 "$log"
     echo "--- end of $name output ---"
     end=$(date +%s)

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6086,6 +6086,36 @@ run_node_bindings() {
   echo ">>> [$name] $status ($((end - start))s)"
 }
 
+# Partition a package's DERIVED integration targets into the ones cargo can actually
+# run at this lane's feature set and the ones it will SILENTLY skip for an unmet
+# `required-features` (cargo prints no banner at all for those, so demanding an
+# observation would red a healthy lane — they are excluded and DECLARED, never dropped
+# quietly). Prints ONE tab-separated line: <runner-ids> TAB <target-names> TAB
+# <skip-reasons>.
+#
+# SHARED by both packages deliberately. The cqlite-ffi-common half and the cqlite-node
+# half are the SAME logic, and a near-copy is how one of them silently stops matching
+# cargo's behaviour — the drift this whole component exists to prevent.
+_brt_partition_targets() { # <target-meta> <enabled-set>
+  local meta="$1" enabled="$2"
+  local ids="" names="" skip="" tn tid trf troff trfl
+  while IFS=$'\t' read -r tn tid trf; do
+    [ -n "$tn" ] || continue
+    troff=""
+    for trfl in ${trf//,/ }; do
+      case "$enabled" in *" $trfl "*) ;; *) troff="$trfl"; break ;; esac
+    done
+    if [ -n "$troff" ]; then
+      skip="$skip $tid(required-features[$trf]:off[$troff])"
+    else
+      ids="$ids $tid"; names="$names $tn"
+    fi
+  done <<< "$meta"
+  # \037 = ASCII US. See this function's header: TAB here silently dropped an empty
+  # LEADING field, which is the C3 defect.
+  printf '%s\037%s\037%s\n' "${ids# }" "${names# }" "${skip# }"
+}
+
 # _package_declared_features <package>: print every feature NAME the package's own
 # manifest declares, one per line (possibly none), from cargo metadata. Exit 1 = the
 # derivation failed (no jq/python3, a metadata failure, or no such package) — never a
@@ -6335,40 +6365,14 @@ EOF
   # of the component log — because a lane that omits coverage silently is
   # indistinguishable from one that covers it, and "the log a reviewer actually reads"
   # is both of those. Not a comment: a comment is not read on a run.
-  # Partition a package's DERIVED integration targets into the ones cargo can actually
-  # run at this lane's feature set and the ones it will SILENTLY skip for an unmet
-  # `required-features` (cargo prints no banner at all for those, so demanding an
-  # observation would red a healthy lane — they are excluded and DECLARED, never dropped
-  # quietly). Prints ONE tab-separated line: <runner-ids> TAB <target-names> TAB
-  # <skip-reasons>.
-  #
-  # SHARED by both packages deliberately. The cqlite-ffi-common half and the cqlite-node
-  # half are the SAME logic, and a near-copy is how one of them silently stops matching
-  # cargo's behaviour — the drift this whole component exists to prevent.
-  _brt_partition_targets() { # <target-meta> <enabled-set>
-    local meta="$1" enabled="$2"
-    local ids="" names="" skip="" tn tid trf troff trfl
-    while IFS=$'\t' read -r tn tid trf; do
-      [ -n "$tn" ] || continue
-      troff=""
-      for trfl in ${trf//,/ }; do
-        case "$enabled" in *" $trfl "*) ;; *) troff="$trfl"; break ;; esac
-      done
-      if [ -n "$troff" ]; then
-        skip="$skip $tid(required-features[$trf]:off[$troff])"
-      else
-        ids="$ids $tid"; names="$names $tn"
-      fi
-    done <<< "$meta"
-    printf '%s\t%s\t%s\n' "${ids# }" "${names# }" "${skip# }"
-  }
-
   local ffi_ids="" ffi_names="" ffi_skip="" ffi_expect_n=0
   local node_ids="" node_names="" node_skip="" node_expect_n=0
   local -a ffi_expect=() node_expect=() node_test_args=()
   local _t
-  IFS=$'\t' read -r ffi_ids ffi_names ffi_skip <<< "$(_brt_partition_targets "$ffi_targets" "$ffi_enabled")"
-  IFS=$'\t' read -r node_ids node_names node_skip <<< "$(_brt_partition_targets "$node_targets" "$node_enabled")"
+  # IFS=US, matching the helper's delimiter. NOT tab — see the helper's own header for the
+  # leading-empty-field collapse that cost this a round.
+  IFS=$'\037' read -r ffi_ids ffi_names ffi_skip <<< "$(_brt_partition_targets "$ffi_targets" "$ffi_enabled")"
+  IFS=$'\037' read -r node_ids node_names node_skip <<< "$(_brt_partition_targets "$node_targets" "$node_enabled")"
   for _t in $ffi_ids; do ffi_expect+=("$_t"); done
   ffi_expect_n=${#ffi_expect[@]}
   for _t in $node_ids; do node_expect+=("$_t"); done
@@ -10676,6 +10680,27 @@ run_tooling_tests() {
      ! bash "$REPO_ROOT/scripts/tests/test_tools_crate_disposition_selftest.sh" >>"$log" 2>&1; then
     status=FAIL
     echo "--- [$name] FAILED (tools/ crate disposition census #1716); last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
+  # binding-rust-tests target-partition self-test (#3522, roborev C3): hermetic, no cargo /
+  # network / datasets. Drives _brt_partition_targets — sourced OUT OF THE REAL GATE SCRIPT,
+  # never a copy — over synthetic metadata, including the case that cost a review round: when
+  # EVERY declared integration target requires a disabled feature, the runnable fields are
+  # empty and the empty LEADING field must survive the caller's `read`. A TAB delimiter
+  # silently dropped it, so the skip text was misread as the runnable ids and the census would
+  # have announced unrunnable targets as EXECUTED. That case is unreachable by running the
+  # lane (cqlite-node declares zero integration targets today), which is precisely why it
+  # needs a test. A failure FAILs the component.
+  echo ">>> [$name] bash scripts/tests/test_agent_gate_binding_partition.sh"
+  if ! bash "$REPO_ROOT/scripts/tests/test_agent_gate_binding_partition.sh" >>"$log" 2>&1; then
+    status=FAIL
+    echo "--- [$name] FAILED (binding-rust-tests target-partition self-test #3522); last 40 lines of $log ---"
     tail -40 "$log"
     echo "--- end of $name output ---"
     end=$(date +%s)

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -5783,6 +5783,35 @@ run_python_bindings() {
   echo ">>> [$name] $status ($((end - start))s)"
 }
 
+# _node_bindings_corpus_present: does CQLITE_DATASETS_ROOT hold a corpus the node jest
+# suite will consider USABLE? (issue #3522, roborev round 2 C2.)
+#
+# A DELIBERATE, BOUNDED MIRROR of ONE line of the consumer:
+# `bindings/node/__test__/setup.js`'s
+#   DATASETS_AVAILABLE = fs.existsSync(SSTABLES_DIR) && hasDataDbFile(TEST_BASIC_DIR)
+# Named here with that file:line so the pair stays findable, because it IS a second
+# implementation and this repo's rule is to say so rather than let it drift silently. It is
+# used for ONE decision only — whether to SKIP under the #2078 opt-out — never to decide
+# what the suite runs, so a divergence costs at most an unnecessary SKIP in a mode that
+# already declares fixtures missing. That is the lenient direction on purpose.
+#
+# `[ -f "$f" ]` per candidate rather than `find -type f`, matching setup.js's
+# `statSync().isFile()`: it FOLLOWS a symlink and tests that the TARGET is a regular file. A
+# bare `-type f` would miss a symlinked Data.db, and `-xtype f` is unavailable on macOS's
+# BSD find, which this gate treats as a first-class host.
+_node_bindings_corpus_present() {
+  local root="${CQLITE_DATASETS_ROOT:-}" f
+  [ -n "$root" ] || return 1
+  [ -d "$root/sstables" ] || return 1
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    [ -f "$f" ] && return 0
+  done <<EOF
+$(find -H "$root/sstables/test_basic" -name '*-Data.db' -print 2>/dev/null)
+EOF
+  return 1
+}
+
 # node-bindings: build the napi-rs native module and run the WHOLE jest suite
 # against it. Symmetric to run_python_bindings and SKIP-aware: if there is no
 # node/npm on PATH the component records SKIP (loudly, never silently PASS) so a
@@ -5865,6 +5894,41 @@ run_node_bindings() {
   if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
     status=SKIP
     echo ">>> [$name] SKIP (no node/npm on PATH)"
+    record_result "$name" "$status" 0
+    return 0
+  fi
+  # #2078 OPT-OUT REGRESSION, FIXED BY SKIPPING (roborev round 2, C2). Widening this
+  # component to the whole jest suite made `AGENT_GATE_ALLOW_MISSING_FIXTURES=1` + no corpus
+  # FAIL where it used to PASS: the old scope was `write-readback-content` alone, which
+  # self-generates its SSTables. `env -u`'ing the strict variables (correct for B2, and kept)
+  # does NOT help here, because the suites do not gate on them — `helpers.js`'s
+  # `skipIfNoDatasets()` throws on `!global.DATASETS_AVAILABLE` and never consults
+  # `REQUIRE_FIXTURES` at all. So 14 suites throw whenever the corpus is absent, opt-out or
+  # not.
+  #
+  # That is precisely what the flight-tests header warns about in its own words: "an opt-out
+  # that the SUMMARY reports as taken did not, in fact, let the gate finish". The block would
+  # print `missing-fixtures: OPT-OUT` and the gate would die anyway; an opt-out's value is
+  # that it is BOTH visible AND effective.
+  #
+  # A SKIP, not a corpus-free subset. Running "just the suites that need no corpus" would
+  # reintroduce exactly the curation D2 removed, and nothing DERIVES which suites need a
+  # corpus without running them. A declared SKIP matches this component's existing
+  # SKIP-aware shape for a missing toolchain, and it names the coverage it is giving up.
+  #
+  # Checked BEFORE `npm ci` so the opt-out costs nothing. `--only`/`--lite` are unaffected:
+  # this branch keys on the opt-out alone, and under `--only` without it the component still
+  # runs (a probe, never a verdict).
+  if [ "${AGENT_GATE_ALLOW_MISSING_FIXTURES:-0}" = 1 ] && ! _node_bindings_corpus_present; then
+    status=SKIP
+    echo ">>> [$name] SKIP (AGENT_GATE_ALLOW_MISSING_FIXTURES=1 and no usable corpus at CQLITE_DATASETS_ROOT='${CQLITE_DATASETS_ROOT:-<unset>}')"
+    echo ">>> [$name]   NOT VALIDATED by this run: the 14 dataset-gated jest suites. helpers.js's"
+    echo ">>> [$name]   skipIfNoDatasets() THROWS on an absent corpus and never consults the strict-mode"
+    echo ">>> [$name]   env vars, so they cannot be run leniently — the honest options are SKIP or FAIL,"
+    echo ">>> [$name]   and FAIL would make the documented #2078 opt-out ineffective (roborev C2)."
+    echo ">>> [$name]   The corpus-free half (incl. the #1231 write-readback content proof) is ALSO"
+    echo ">>> [$name]   skipped: nothing derives which suites need a corpus without running them, and"
+    echo ">>> [$name]   curating that list is what D2 removed."
     record_result "$name" "$status" 0
     return 0
   fi

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -134,12 +134,26 @@
 #                      The full pytest run includes the #1231 Python write→read
 #                      content proof (test_write_readback_content.py), so a core
 #                      write-format regression reds a binding content test.
-#   node-bindings      napi build + the #1231 Node write→read content proof
-#                      (npx jest write-readback-content) in bindings/node; SKIPs
-#                      (never silently PASSes) if node/npm is unavailable. Scoped
-#                      to the content proof (not full `npm test`) so it stays
-#                      fast and corpus-free while still failing closed on a Node
-#                      write-path regression (#1255).
+#   node-bindings      napi build + the WHOLE jest suite (`npm test`) in
+#                      bindings/node; SKIPs (never silently PASSes) if node/npm is
+#                      unavailable. WIDENED from 1 of 27 jest files to all of them
+#                      (#3522, superseding the #1255 narrowing): node-ci.yml is
+#                      `required`-EXEMPT on the stated grounds that this component is
+#                      the merge-gating half, which was true of one file. Measured
+#                      before widening: the slow half (npm ci + the release-unwind
+#                      napi build) is already paid here, and the full suite adds
+#                      ~15-35s — 504 tests / 27 suites, green on two consecutive runs.
+#                      Now IN DATASET_COMPONENTS (7 suites read CQLITE_DATASETS_ROOT)
+#                      and the FULL gate exports CQLITE_REQUIRE_FIXTURES=1, so an
+#                      absent corpus THROWS instead of letting those suites silently
+#                      describe.skip; --only/--lite stay lenient and the #2078 opt-out
+#                      is honoured, with the mode PRINTED. check_jest_suites_ran is
+#                      the affirmative guard: the reported suite total must equal the
+#                      count of __test__/*.test.js DERIVED FROM DISK, no suite may be
+#                      failed or skipped, and the passed-test count must be non-zero
+#                      (jest reports an all-skipped suite as PASSED). cqlite-node's
+#                      RUST unit tests are binding-rust-tests' subject, deliberately
+#                      NOT behind this component's SKIP.
 #   binding-rust-tests EXECUTES the RUST test suites of the two binding-side crates no
 #                      other component runs (#3522): `cargo test -p cqlite-ffi-common`
 #                      (ALL targets — lib + tests/dependency_boundary.rs +
@@ -5305,6 +5319,81 @@ check_unittest_targets_ran() {
 }
 export -f check_unittest_targets_ran
 
+# check_jest_suites_ran <label> <logfile> <expected-suite-count>
+#
+# The jest ANALOGUE of check_unittest_targets_ran (issue #3522). A green `npm test`
+# exit is not evidence that anything ran: jest reports a suite whose every `describe`
+# was skipped as PASSED, so a corpus-less box (or a `describe.skip` someone left in)
+# produces `Test Suites: 27 passed, 27 total` over zero real assertions — the vacuous
+# green this whole issue exists to remove, arriving through the widened lane's own
+# plumbing.
+#
+# AFFIRMATIVE, in three directions, all parsed from jest's OWN summary:
+#   * the reported TOTAL suite count must equal <expected-suite-count>, which the
+#     caller DERIVES from the `__test__/*.test.js` files on disk — so a suite file that
+#     jest never picked up (a testPathIgnorePatterns edit, a rename, a filter left on
+#     the command line) FAILs instead of shrinking the lane silently;
+#   * no suite may be reported failed or skipped; and
+#   * the PASSED test count must be NON-ZERO.
+# A positive verdict PRINTS the counts, so a pasted log shows the check RAN and on what.
+#
+# Fail-closed on an unreadable/unparseable log for the same reason as its siblings: a
+# guard that consumed nothing has measured nothing and must never report OK. In
+# particular an ABSENT `Test Suites:` line is a FAIL, never "no problems found" — that
+# is the shape where the absence of a bad signal is read as a positive verdict.
+check_jest_suites_ran() {
+  local label="$1" logfile="$2" expected="$3"
+  case "$expected" in
+    ''|*[!0-9]*)
+      echo "$label: FAIL-CLOSED — check_jest_suites_ran was called with a non-numeric expected suite count ('$expected'); a guard whose subject size is unknown has no subject (issue #3522)" >&2
+      return 1 ;;
+  esac
+  if [ "$expected" -eq 0 ]; then
+    echo "$label: FAIL-CLOSED — check_jest_suites_ran was called expecting ZERO suites; a guard with an empty subject set would report OK having measured nothing (issue #3522)" >&2
+    return 1
+  fi
+  local _parse_src
+  _parse_src=$(_ansi_stripped_log "$logfile" 2>/dev/null) || _parse_src=""
+  if [ -z "$_parse_src" ] || [ ! -r "$_parse_src" ]; then
+    echo "$label: FAIL-CLOSED — could not prepare '$logfile' for parsing (resolved to '${_parse_src:-<empty>}'), so this guard parsed NOTHING (issue #3522)" >&2
+    return 1
+  fi
+  # The LAST summary block, so a nested/retried run cannot leave an older line in play.
+  local suites tests
+  suites=$(grep -E '^Test Suites:' "$_parse_src" | tail -1)
+  tests=$(grep -E '^Tests:' "$_parse_src" | tail -1)
+  if [ -z "$suites" ] || [ -z "$tests" ]; then
+    echo "$label: FAIL-CLOSED — no parseable jest summary in '$logfile' (Test Suites: '${suites:-<absent>}', Tests: '${tests:-<absent>}'). jest ran to a successful exit, so a summary must exist: a truncated log, a changed jest output format, or a run that never started. A guard that judged nothing must never report OK (issue #3522)" >&2
+    return 1
+  fi
+  # `<n> total` / `<n> passed` / `<n> failed` / `<n> skipped`, read by name rather than
+  # by position — jest omits a category entirely when its count is zero, so a
+  # positional parse would silently misread every line whose shape it did not expect.
+  local s_total s_failed s_skipped t_passed
+  s_total=$(printf '%s' "$suites" | sed -nE 's/.*[^0-9]([0-9]+) total.*/\1/p')
+  s_failed=$(printf '%s' "$suites" | sed -nE 's/.*[^0-9]([0-9]+) failed.*/\1/p')
+  s_skipped=$(printf '%s' "$suites" | sed -nE 's/.*[^0-9]([0-9]+) skipped.*/\1/p')
+  t_passed=$(printf '%s' "$tests" | sed -nE 's/.*[^0-9]([0-9]+) passed.*/\1/p')
+  : "${s_failed:=0}" "${s_skipped:=0}" "${t_passed:=0}"
+  case "$s_total" in
+    ''|*[!0-9]*)
+      echo "$label: FAIL-CLOSED — could not read a suite TOTAL out of jest's summary line ('$suites'). The parse is broken, which is never a pass (issue #3522)" >&2
+      return 1 ;;
+  esac
+  local bad=""
+  [ "$s_total" -eq "$expected" ] || bad="$bad jest ran $s_total suite(s) but $expected '*.test.js' file(s) exist on disk — a suite file was not picked up (a filter, a rename, or testPathIgnorePatterns);"
+  [ "$s_failed" -eq 0 ] || bad="$bad $s_failed suite(s) FAILED;"
+  [ "$s_skipped" -eq 0 ] || bad="$bad $s_skipped suite(s) were SKIPPED — a skipped suite is reported by jest as neither passed nor failed and would otherwise pass unnoticed;"
+  [ "$t_passed" -gt 0 ] || bad="$bad ZERO tests PASSED — jest reports an all-skipped suite as passing, so a green exit over no assertions is exactly the vacuous result this guard exists to catch;"
+  if [ -n "$bad" ]; then
+    echo "$label: FAIL-CLOSED —$bad (issue #3522; jest summary was: '$suites' / '$tests')" >&2
+    return 1
+  fi
+  echo "$label: jest suites OK — $s_total/$expected suite(s) ran (0 failed, 0 skipped) and $t_passed test(s) PASSED (affirmative measurement, parsed from jest's own summary)" >&2
+  return 0
+}
+export -f check_jest_suites_ran
+
 # _package_test_targets <package>: print one TAB-separated line per declared
 # INTEGRATION (`test`) target of that workspace package — `<name>\t<required-features
 # comma-joined, empty when none>` (issue #1699, roborev round-2 finding 2).
@@ -5679,20 +5768,57 @@ run_python_bindings() {
   echo ">>> [$name] $status ($((end - start))s)"
 }
 
-# node-bindings: build the napi-rs native module and run the #1231 Node
-# write→read CONTENT proof. Symmetric to run_python_bindings and SKIP-aware:
-# if there is no node/npm on PATH the component records SKIP (loudly, never
-# silently PASS) so a missing toolchain can't mask a real Node write-path
-# regression. Anything else (install/build/test failure) is a hard FAIL.
+# node-bindings: build the napi-rs native module and run the WHOLE jest suite
+# against it. Symmetric to run_python_bindings and SKIP-aware: if there is no
+# node/npm on PATH the component records SKIP (loudly, never silently PASS) so a
+# missing toolchain can't mask a real Node regression. Anything else
+# (install/build/test failure) is a hard FAIL.
 #
-# Scope (#1255): we run the content proof specifically (npx jest
-# write-readback-content) rather than the full `npm test`. The full Node suite
-# pulls in corpus-dependent parity/smoke tests and a slow `--release` napi
-# build; scoping to the content proof keeps the gate fast and reliable while
-# guaranteeing the load-bearing #1231 test executes fail-closed. The content
-# test self-generates its SSTables, so it needs no fixture corpus (hence
-# node-bindings is NOT in DATASET_COMPONENTS); CQLITE_DATASETS_ROOT is still
-# exported defensively for any test that reads it.
+# SCOPE — WIDENED FROM ONE FILE TO THE WHOLE SUITE (issue #3522; supersedes the
+# #1255 narrowing). This component used to run `npx jest write-readback-content`,
+# i.e. ONE of the 27 jest suites, guaranteeing only the #1231 write→read content
+# proof. The other 26 executed nowhere that gates a merge: node-ci.yml's PR lane is
+# path-filtered to bindings/node/** (a cqlite-core-only diff does not trigger it) and
+# is `required`-EXEMPT, and the full `npm test` there is label/schedule gated — while
+# .github/ci-gating-tiers.yml justifies that exemption with "the merge-gating half is
+# the local gate's node-bindings component". That claim was true of 1 file in 27.
+# Among the 26 were shared-vectors.test.js (the cross-binding SHA-256 EXACT oracles,
+# whose whole value is that Python, Node and Rust agree byte-for-byte) and
+# prepared.test.js (export-surface named-set assertions).
+#
+# The #1255 rationale for narrowing was cost + corpus dependence, and it was
+# re-MEASURED rather than re-argued: the slow half (`npm ci` + the
+# `--profile release-unwind` napi build) is paid by this component ALREADY, and the
+# full suite adds ~15–35s on top of it — 504 passing tests across 27/27 suites, green
+# on two consecutive runs. That is not a cost worth 26 suites of blindness.
+#
+# THE CORPUS HALF IS NOW HONOURED, NOT AVOIDED. 7 of the suite's files read
+# CQLITE_DATASETS_ROOT, so node-bindings IS now in DATASET_COMPONENTS (it was NOT
+# before, and that comment was correct then and would be a stale rationale now).
+# Enrollment alone is not enough: without CQLITE_REQUIRE_FIXTURES=1 the suite's
+# setup.js leaves DATASETS_AVAILABLE=false and the corpus-dependent describes
+# `describe.skip` SILENTLY — a green run over zero real assertions, which is #3220's
+# rule and this issue's own thesis in one. So the FULL gate exports
+# CQLITE_REQUIRE_FIXTURES=1, making an absent corpus throw. `--only`/`--lite` stay
+# lenient (they are probes; `--only` cannot be a verdict — it exits 3 on success),
+# and the documented #2078 opt-out AGENT_GATE_ALLOW_MISSING_FIXTURES=1 is honoured,
+# the same split flight-tests uses. Which mode was taken is PRINTED, never implicit.
+#
+# AFFIRMATIVE MEASUREMENT, not a green exit code (the same rule as the Rust lanes).
+# jest reports a suite whose every describe was skipped as PASSED, so `npm test`
+# exiting 0 does not establish that anything ran. check_jest_suites_ran requires the
+# reported total to equal the count of `__test__/*.test.js` files DERIVED FROM DISK,
+# requires no suite to have failed or been skipped, and requires a non-zero count of
+# PASSED tests.
+#
+# RUN_SLOW_TESTS is forwarded exactly as python-bindings forwards it (default 0). Two
+# tests opt into it (publish.test.js's `npm pack --dry-run`, streaming.test.js's
+# `memory stays bounded for large result sets`); the census names them.
+#
+# `npm test`, NOT `npx jest`: the package's own test script is the derived answer to
+# "what is this suite", it runs the `pretest` loader generation, and it passes
+# `--expose-gc`, which the memory tests need. A retyped jest invocation here would
+# drift from the package the moment either changes.
 run_node_bindings() {
   local name=node-bindings
   if [ -n "$ONLY" ] && ! grep -qw "$name" <<<"${ONLY//,/ }"; then
@@ -5707,16 +5833,94 @@ run_node_bindings() {
     record_result "$name" "$status" 0
     return 0
   fi
-  echo ">>> [$name] npm ci + npm run build + jest write-readback-content (#1231)"
-  if CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT" bash -c '
+  # The expected suite count, DERIVED FROM DISK at run time so a new
+  # `__test__/*.test.js` is covered with no gate edit — the property the old
+  # single-file filter could never have. A failed derivation is a FAIL naming the
+  # derivation, never a guard with no subject.
+  local test_dir="$REPO_ROOT/bindings/node/__test__" suite_n=""
+  if [ ! -d "$test_dir" ] || [ ! -r "$test_dir" ]; then
+    status=FAIL
+    {
+      echo "[$name] FAIL-CLOSED: bindings/node/__test__ is missing or unreadable, so the"
+      echo "        expected jest suite count cannot be DERIVED and the affirmative guard"
+      echo "        would have no subject (issue #3522)."
+    } | tee "$log"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+  # `find`, not a glob: a glob's meaning depends on ambient shell options this script
+  # never sets (nullglob/failglob), both reachable through BASHOPTS.
+  suite_n=$(find -H "$test_dir" -maxdepth 1 -type f -name '*.test.js' 2>/dev/null | grep -c . || true)
+  case "$suite_n" in
+    ''|*[!0-9]*) suite_n=0 ;;
+  esac
+  if [ "$suite_n" -eq 0 ]; then
+    status=FAIL
+    {
+      echo "[$name] FAIL-CLOSED: found 0 '*.test.js' files under bindings/node/__test__."
+      echo "        The COUNT failed (or the suite vanished), and a guard expecting zero"
+      echo "        suites would report OK having measured nothing (issue #3522)."
+    } | tee "$log"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
+  # Strict-fixture mode on the FULL gate only, honouring the documented #2078 opt-out.
+  # See the scope note above for why enrollment in DATASET_COMPONENTS is not enough.
+  local require_fixtures=0 fixture_note
+  if [ -z "$ONLY" ] && [ "$LITE" -eq 0 ] && [ "${AGENT_GATE_ALLOW_MISSING_FIXTURES:-0}" != 1 ]; then
+    require_fixtures=1
+    fixture_note="CQLITE_REQUIRE_FIXTURES=1 (an absent corpus THROWS; the corpus-dependent suites cannot silently describe.skip)"
+  elif [ "${AGENT_GATE_ALLOW_MISSING_FIXTURES:-0}" = 1 ]; then
+    fixture_note="CQLITE_REQUIRE_FIXTURES unset (AGENT_GATE_ALLOW_MISSING_FIXTURES=1) — corpus-dependent suites MAY silently skip, so this run does NOT validate them"
+  else
+    fixture_note="CQLITE_REQUIRE_FIXTURES unset (--only/--lite probe run) — corpus-dependent suites MAY silently skip"
+  fi
+
+  local -a census=()
+  census+=("npm ci + npm run build + npm test — the WHOLE jest suite ($suite_n files, derived from disk), #3522")
+  census+=("  supersedes the #1255 narrowing to 1 of 27 files; node-ci.yml is required-EXEMPT on the")
+  census+=("  grounds that THIS component is the merge-gating half, which was true of 1 file in 27.")
+  census+=("  fixtures: $fixture_note")
+  census+=("  RUN_SLOW_TESTS=${RUN_SLOW_TESTS:-0} — 2 tests opt in (publish.test.js 'npm pack --dry-run';")
+  census+=("       streaming.test.js 'memory stays bounded for large result sets'). At 0 they skip;")
+  census+=("       that is the suite's OWN gate, identical to python-bindings' convention.")
+  census+=("  NOT RUN HERE: cqlite-node's RUST unit tests — that is binding-rust-tests' subject,")
+  census+=("       deliberately a separate component because THIS one SKIPs without node/npm and a")
+  census+=("       Rust suite behind that SKIP would be a coverage hole wearing a SKIP's clothes.")
+  local cl
+  for cl in "${census[@]}"; do echo ">>> [$name] $cl"; done
+  {
+    echo "==== [$name] COVERAGE CENSUS (issue #3522) ===="
+    for cl in "${census[@]}"; do echo "$cl"; done
+    echo "==== end census ===="
+  } > "$log"
+
+  if CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT" \
+     RUN_SLOW_TESTS="${RUN_SLOW_TESTS:-0}" \
+     CQLITE_REQUIRE_FIXTURES_ARG="$require_fixtures" bash -c '
       set -euo pipefail
       cd "'"$REPO_ROOT"'/bindings/node"
       if [ -f package-lock.json ]; then npm ci; else npm install; fi
       npm run build
-      npx jest write-readback-content' >"$log" 2>&1; then
-    status=PASS
+      if [ "$CQLITE_REQUIRE_FIXTURES_ARG" = 1 ]; then export CQLITE_REQUIRE_FIXTURES=1; fi
+      npm test' >>"$log" 2>&1; then
+    # A green `npm test` is NOT sufficient: jest reports a suite whose every describe
+    # was skipped as PASSED, so the exit code alone cannot distinguish 27 suites of
+    # assertions from 27 suites of nothing.
+    if check_jest_suites_ran "$name" "$log" "$suite_n" 2>>"$log"; then
+      status=PASS
+    else
+      status=FAIL
+    fi
   else
     status=FAIL
+  fi
+  if [ "$status" = FAIL ]; then
     echo "--- [$name] FAILED; last 40 lines of $log ---"
     tail -40 "$log"
     echo "--- end of $name output ---"
@@ -11652,7 +11856,7 @@ run_file_size
 #     assertions with hardcoded vectors — it reads no CQLITE_DATASETS_ROOT and no
 #     Data.db — so guarding it just made `--only format-compat` falsely fail the
 #     preflight when datasets are absent.
-DATASET_COMPONENTS="core-tests tombstones-scan scan-offload-guard work-counters-guard memory-budget integration-tests write-tests cli-tests python-bindings smoke flight-tests legacy-heuristics"
+DATASET_COMPONENTS="core-tests tombstones-scan scan-offload-guard work-counters-guard memory-budget integration-tests write-tests cli-tests python-bindings node-bindings smoke flight-tests legacy-heuristics"
 
 # selected_needs_datasets: true iff at least one SELECTED component reads datasets.
 # With no --only, every component runs, so it's always true. With --only, it's true

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -251,6 +251,11 @@
 #                      datasets.
 #                      SKIP-aware (loud): SKIPs only when cqlite-core is absent.
 #   tooling-tests      shell-tooling regression tests (fast, no datasets/network):
+#                      scripts/tests/test_workspace_test_disposition.sh (+ its
+#                      self-test): the PACKAGE-granular #3522 census — every cargo
+#                      workspace member carries a recorded EXECUTED/PARTIAL/
+#                      NOT-EXECUTED disposition, so a crate that is compiled by every
+#                      gate run and executes nothing cannot arrive unnoticed;
 #                      scripts/tests/test_tools_crate_disposition.sh (+ its
 #                      selftest) — #1716/AK5: every crate under tools/ must be
 #                      EXPLICITLY classified WIRED / UNWIRED / MIXED, and every
@@ -10435,6 +10440,33 @@ run_tooling_tests() {
      ! bash "$REPO_ROOT/scripts/tests/test_tools_crate_disposition_selftest.sh" >>"$log" 2>&1; then
     status=FAIL
     echo "--- [$name] FAILED (tools/ crate disposition census #1716); last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
+  # Workspace test-execution disposition census (#3522). The PACKAGE-granular sibling
+  # of the tools/ census above: every cargo workspace member must be recorded in
+  # scripts/tests/workspace-test-disposition.txt as EXECUTED / PARTIAL / NOT-EXECUTED
+  # (a CLOSED label set) with a detail naming the gate component, or what is omitted
+  # and why. The defect it exists for: `cargo clippy --workspace --all-targets`
+  # compiles every member on every full gate, so a crate can be BUILT by every run and
+  # EXECUTE NOTHING — which is how cqlite-ffi-common (52 tests) and cqlite-node's 53
+  # Rust unit tests sat unexecuted for months while reading as covered. `members`
+  # globs `tools/*` and `bindings/*`, so a new crate otherwise joins with no statement
+  # of whether anything runs its tests. Like the tools/ census it is DELIBERATELY
+  # SMALL: it checks a disposition was RECORDED and LABELED, never that the record is
+  # TRUE (see its header for why #1716 removed the truth-verifying variant). It needs
+  # `cargo metadata` — a failed derivation is a FAIL naming the derivation, never a
+  # skip that greens. A failure FAILs the component.
+  echo ">>> [$name] bash scripts/tests/test_workspace_test_disposition.sh; bash scripts/tests/test_workspace_test_disposition_selftest.sh"
+  if ! bash "$REPO_ROOT/scripts/tests/test_workspace_test_disposition.sh" >>"$log" 2>&1 ||
+     ! bash "$REPO_ROOT/scripts/tests/test_workspace_test_disposition_selftest.sh" >>"$log" 2>&1; then
+    status=FAIL
+    echo "--- [$name] FAILED (workspace test-execution disposition census #3522); last 40 lines of $log ---"
     tail -40 "$log"
     echo "--- end of $name output ---"
     end=$(date +%s)

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -5387,17 +5387,61 @@ check_jest_suites_ran() {
   # `<n> total` / `<n> passed` / `<n> failed` / `<n> skipped`, read by name rather than
   # by position — jest omits a category entirely when its count is zero, so a
   # positional parse would silently misread every line whose shape it did not expect.
-  local s_total s_failed s_skipped t_passed
+  # THE `:=0` DEFAULTS ARE THE PERMISSIVE BRANCH, so they get a CROSS-CHECK (roborev round 4,
+  # E1 class sweep). jest OMITS a category entirely when its count is zero, so "no match" and
+  # "the parse broke" produce the SAME empty string — and `sed -n` exits 0 either way, so no
+  # status check can separate them. Defaulting to 0 therefore silently converts a broken parse
+  # into "nothing failed, nothing was skipped", which is the vacuous direction in the two
+  # fields whose whole job is to report trouble.
+  #
+  # Two guards instead, both affirmative:
+  #   (a) CLOSED GRAMMAR — every `<N> <word>` pair on the line must name a category this parser
+  #       knows. An unrecognised one FAILs naming it, rather than being silently dropped from
+  #       the reconciliation below (a new jest category would otherwise make the sum wrong and
+  #       be reported as a parse break, i.e. the right red with the wrong cause).
+  #   (b) SUM RECONCILIATION — the recognised parts must add up to the reported total. A sed
+  #       that half-worked cannot satisfy this, so a broken parse can no longer look like zeros.
+  # (a) is checked FIRST, so (b) can never red on a category the parser simply does not know.
+  local s_total s_failed s_skipped s_passed s_pending s_todo t_passed
+  local _unknown _pair _n _w _sum
+  _unknown=$(printf '%s' "$suites" | sed -E 's/^Test Suites:[[:space:]]*//' | tr ',' '\n' \
+    | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e '/^$/d' \
+    | awk '{ if ($1 ~ /^[0-9]+$/ && $2 != "passed" && $2 != "failed" && $2 != "skipped" && $2 != "total" && $2 != "pending" && $2 != "todo") print $2 }' \
+    | sort -u | tr '\n' ' ') || _unknown="__PARSE_FAILED__"
+  if [ "$_unknown" = "__PARSE_FAILED__" ]; then
+    echo "$label: FAIL-CLOSED — could not tokenise jest's suite summary line ('$suites') to validate its categories. An unmeasurable parse is never a pass (issue #3522, roborev E1)" >&2
+    return 1
+  fi
+  _unknown=$(printf '%s' "$_unknown" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+  if [ -n "$_unknown" ]; then
+    echo "$label: FAIL-CLOSED — jest's suite summary line names category/categories this guard does not recognise: $_unknown ('$suites'). The closed grammar is deliberate: an unrecognised category would be dropped from the sum reconciliation below and reported as a broken parse, i.e. the right red with the wrong cause. Teach this guard the category, then re-run (issue #3522, roborev E1)" >&2
+    return 1
+  fi
   s_total=$(printf '%s' "$suites" | sed -nE 's/.*[^0-9]([0-9]+) total.*/\1/p')
   s_failed=$(printf '%s' "$suites" | sed -nE 's/.*[^0-9]([0-9]+) failed.*/\1/p')
   s_skipped=$(printf '%s' "$suites" | sed -nE 's/.*[^0-9]([0-9]+) skipped.*/\1/p')
+  s_passed=$(printf '%s' "$suites" | sed -nE 's/.*[^0-9]([0-9]+) passed.*/\1/p')
+  s_pending=$(printf '%s' "$suites" | sed -nE 's/.*[^0-9]([0-9]+) pending.*/\1/p')
+  s_todo=$(printf '%s' "$suites" | sed -nE 's/.*[^0-9]([0-9]+) todo.*/\1/p')
   t_passed=$(printf '%s' "$tests" | sed -nE 's/.*[^0-9]([0-9]+) passed.*/\1/p')
-  : "${s_failed:=0}" "${s_skipped:=0}" "${t_passed:=0}"
+  : "${s_failed:=0}" "${s_skipped:=0}" "${s_passed:=0}" "${s_pending:=0}" "${s_todo:=0}" "${t_passed:=0}"
   case "$s_total" in
     ''|*[!0-9]*)
       echo "$label: FAIL-CLOSED — could not read a suite TOTAL out of jest's summary line ('$suites'). The parse is broken, which is never a pass (issue #3522)" >&2
       return 1 ;;
   esac
+  for _n in "$s_failed" "$s_skipped" "$s_passed" "$s_pending" "$s_todo" "$t_passed"; do
+    case "$_n" in
+      ''|*[!0-9]*)
+        echo "$label: FAIL-CLOSED — a suite/test count parsed out of jest's summary is not a number ('$_n'; suites='$suites', tests='$tests'). The parse is broken, which is never a pass (issue #3522, roborev E1)" >&2
+        return 1 ;;
+    esac
+  done
+  _sum=$((s_passed + s_failed + s_skipped + s_pending + s_todo))
+  if [ "$_sum" -ne "$s_total" ]; then
+    echo "$label: FAIL-CLOSED — jest's suite categories do not add up: passed=$s_passed failed=$s_failed skipped=$s_skipped pending=$s_pending todo=$s_todo sums to $_sum but the line reports $s_total total ('$suites'). The parse is broken; the categories above default to 0 when absent, so without this reconciliation a half-working parse would read as 'nothing failed, nothing skipped' (issue #3522, roborev E1)" >&2
+    return 1
+  fi
   local bad=""
   [ "$s_total" -eq "$expected" ] || bad="$bad jest ran $s_total suite(s) but $expected '*.test.js' file(s) exist on disk — a suite file was not picked up (a filter, a rename, or testPathIgnorePatterns);"
   [ "$s_failed" -eq 0 ] || bad="$bad $s_failed suite(s) FAILED;"
@@ -6068,7 +6112,24 @@ run_node_bindings() {
   local jest_set="$LOG_DIR/$name.suites-jest.txt"
   local disk_set="$LOG_DIR/$name.suites-disk.txt"
   local only_disk only_jest
-  sed -n 's#.*/__test__/##p' "$list_file" | grep '\.test\.js$' | sort -u > "$jest_set"
+  # STATUS CHECKED, and the reason is CAUSE ATTRIBUTION, not just hygiene (roborev round 4, E1
+  # class sweep). A truncated `jest_set` makes the reconciliation below report "ON DISK but NOT
+  # LISTED BY JEST — a silent config exclusion" and send the reader to jest.config.js, when in
+  # fact the normalisation pipeline failed. That is the "verdict is right, remedy is useless"
+  # defect the flight lane's fixture preflight records; a distinct named cause is the fix.
+  if ! sed -n 's#.*/__test__/##p' "$list_file" | grep '\.test\.js$' | sort -u > "$jest_set"; then
+    status=FAIL
+    {
+      echo "[$name] FAIL-CLOSED: could not normalise jest's --listTests output into a comparable"
+      echo "        suite set (the sed/grep/sort pipeline failed on $list_file). This is a PARSE"
+      echo "        failure, NOT a config exclusion — do not go looking at jest.config.js"
+      echo "        (issue #3522, roborev E1)."
+    } | tee -a "$log"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
 
   # ORACLE B — an INDEPENDENT recursive filesystem inventory. `find`, not a glob: a glob's
   # meaning depends on ambient shell options this script never sets and cannot control
@@ -6094,8 +6155,22 @@ run_node_bindings() {
   # silently split into two entries by the line-based sort/comm below, inflating the
   # inventory and producing a nonsense reconciliation. Refuse rather than mis-measure.
   local _nb_nuls _nb_lines
-  find -H "$_nb_test_dir" -type d -name node_modules -prune -o -type f -name '*.test.js' -print0 2>/dev/null \
-    | tr '\0' '\n' | sed -n 's#.*/__test__/##p' | sort -u > "$disk_set"
+  # Same treatment, same reason, opposite direction: a truncated `disk_set` would be reported
+  # as "LISTED BY JEST but NOT FOUND ON DISK" and send the reader to testMatch, when the
+  # inventory pipeline is what failed.
+  if ! find -H "$_nb_test_dir" -type d -name node_modules -prune -o -type f -name '*.test.js' -print0 2>/dev/null \
+    | tr '\0' '\n' | sed -n 's#.*/__test__/##p' | sort -u > "$disk_set"; then
+    status=FAIL
+    {
+      echo "[$name] FAIL-CLOSED: the independent suite inventory pipeline failed (find/tr/sed/sort"
+      echo "        over $_nb_test_dir). This is an INVENTORY failure, NOT jest running something"
+      echo "        outside __test__/ — do not go looking at testMatch (issue #3522, roborev E1)."
+    } | tee -a "$log"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
   _nb_nuls=$(find -H "$_nb_test_dir" -type d -name node_modules -prune -o -type f -name '*.test.js' -print0 2>/dev/null | tr -dc '\0' | wc -c | tr -d ' ')
   _nb_lines=$(grep -c . "$disk_set" || true)
   case "$_nb_nuls$_nb_lines" in
@@ -6426,7 +6501,15 @@ run_binding_rust_tests() {
     _brt_derivation_fail "cqlite-node's integration (test) target census" \
       "cargo metadata, its parser, or the package lookup failed — so this lane cannot state whether it is leaving any integration target un-run."
   else
+    # `|| true` swallows grep's legitimate 1-on-zero-matches, so the STATUS cannot be the
+    # guard — the VALUE must be (roborev round 4, E1 class sweep). Without the numeric check a
+    # failed grep yields the empty string, and `[ "" -eq 0 ]` later is a bash error rather than
+    # a named cause. Same shape as py_test_n's check below.
     node_targets_n=$(printf '%s' "$node_targets" | grep -c . || true)
+    case "$node_targets_n" in
+      ''|*[!0-9]*) _brt_derivation_fail "the count of cqlite-node's integration (test) targets" \
+                     "the count came back non-numeric ('$node_targets_n'), so the census cannot state whether this lane leaves any target un-run." ;;
+    esac
   fi
 
   # The declared-minus-enabled feature sets: what this lane leaves OFF, derived.
@@ -7114,10 +7197,27 @@ _resolved_package_features() {
   # awk EXIT STATUS carries the answer, so an empty feature field cannot be read as an absent
   # package.
   printf '%s\n' "$raw" | awk -F'|' -v pat="^$pkg v" '$1 ~ pat { found = 1 } END { exit found ? 0 : 1 }' || return 1
+  # `|| return 1` ON THE EXTRACTION PIPELINE (roborev round 4, E1 — the THIRD defect in this
+  # helper and the SECOND of this exact shape). This script runs `set -uo pipefail` WITHOUT
+  # `errexit`, so a failed awk/tr/sed/sort does NOT abort: it yields a partial or empty
+  # `feats` and the function returns SUCCESS. Callers then treat an empty enabled set as a
+  # measurement, and every `required-features` target silently becomes "excused" — the
+  # permissive direction, in the one value whose job is to say what is enabled.
+  #
+  # The `|| return 1` that used to be here caught this by accident: it was attached to the old
+  # single pipeline whose result was then rejected by `[ -n "$feats" ]`. #3522 correctly moved
+  # the presence oracle to the PACKAGE LINE (a featureless package is a real answer), and in
+  # doing so removed the only status check on the extraction. The old code caught it for the
+  # wrong reason; the new code did not catch it at all.
   feats=$(printf '%s\n' "$raw" \
     | awk -F'|' -v pat="^$pkg v" '$1 ~ pat {print $2}' \
-    | tr ',' '\n' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e '/^$/d' | sort -u)
-  printf ' %s ' "$(printf '%s' "$feats" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
+    | tr ',' '\n' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e '/^$/d' | sort -u) || return 1
+  # The NORMALIZATION pipeline needs the same treatment, and it cannot be checked inline
+  # inside the `printf` argument — a command substitution's failure there is discarded
+  # entirely. Captured into a variable first, status checked, then emitted.
+  local norm
+  norm=$(printf '%s' "$feats" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//') || return 1
+  printf ' %s ' "$norm"
 }
 
 # flight-tests: EXECUTE cqlite-flight's UNIT test suite locally (issue #1699).

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -143,16 +143,23 @@
 #                      before widening: the slow half (npm ci + the release-unwind
 #                      napi build) is already paid here, and the full suite adds
 #                      ~15-35s — 504 tests / 27 suites, green on two consecutive runs.
-#                      Now IN DATASET_COMPONENTS (7 suites read CQLITE_DATASETS_ROOT)
-#                      and the FULL gate exports CQLITE_REQUIRE_FIXTURES=1, so an
-#                      absent corpus THROWS instead of letting those suites silently
-#                      describe.skip; --only/--lite stay lenient and the #2078 opt-out
-#                      is honoured, with the mode PRINTED. check_jest_suites_ran is
+#                      Now IN DATASET_COMPONENTS: 14 of the suite files gate on dataset
+#                      availability (measured), and the FULL gate exports
+#                      CQLITE_REQUIRE_FIXTURES=1 — which buys ONE clean, named setup
+#                      failure in setup.js instead of 14 separate beforeAll THROWS, and
+#                      closes parity.test.js's `test.skip` placeholder, the one
+#                      corpus-conditional path that WOULD pass silently. It is NOT
+#                      protection against `describe.skip`: no *.test.js uses it (the
+#                      repo's Node convention is skipIfNoDatasets(), which THROWS).
+#                      --only/--lite stay lenient and the #2078 opt-out is honoured,
+#                      with the mode PRINTED. check_jest_suites_ran is
 #                      the affirmative guard: the reported suite total must equal the
 #                      set DERIVED FROM JEST ITSELF (`npx jest --listTests`, never a
 #                      find over testMatch), no suite may be failed or skipped, and the
-#                      passed-test count must be non-zero
-#                      (jest reports an all-skipped suite as PASSED). cqlite-node's
+#                      passed-test count must be non-zero (a suite whose every TEST is
+#                      `test.skip`ped is reported as a PASSED suite — the suite-level
+#                      `skipped` count only catches a whole file being skipped, which is
+#                      why the two are separate directions). cqlite-node's
 #                      RUST unit tests are binding-rust-tests' subject, deliberately
 #                      NOT behind this component's SKIP.
 #   binding-rust-tests EXECUTES the RUST test suites of the two binding-side crates no
@@ -5327,12 +5334,13 @@ export -f check_unittest_targets_ran
 
 # check_jest_suites_ran <label> <logfile> <expected-suite-count>
 #
-# The jest ANALOGUE of check_unittest_targets_ran (issue #3522). A green `npm test`
-# exit is not evidence that anything ran: jest reports a suite whose every `describe`
-# was skipped as PASSED, so a corpus-less box (or a `describe.skip` someone left in)
-# produces `Test Suites: 27 passed, 27 total` over zero real assertions — the vacuous
-# green this whole issue exists to remove, arriving through the widened lane's own
-# plumbing.
+# The jest ANALOGUE of check_unittest_targets_ran (issue #3522). A green `npm test` exit
+# is not evidence that anything ran: a suite whose every TEST is `test.skip`ped is
+# reported as a PASSED suite, so `Test Suites: 27 passed, 27 total` is reachable over
+# zero real assertions — the vacuous green this whole issue exists to remove, arriving
+# through the widened lane's own plumbing. (Jest's suite-level `skipped` count is a
+# DIFFERENT and weaker signal: it catches a whole FILE being skipped, not a file whose
+# every test was. That is why the two are separate directions below rather than one.)
 #
 # AFFIRMATIVE, in three directions, all parsed from jest's OWN summary:
 #   * the reported TOTAL suite count must equal <expected-suite-count>, which the
@@ -5390,7 +5398,7 @@ check_jest_suites_ran() {
   [ "$s_total" -eq "$expected" ] || bad="$bad jest ran $s_total suite(s) but $expected '*.test.js' file(s) exist on disk — a suite file was not picked up (a filter, a rename, or testPathIgnorePatterns);"
   [ "$s_failed" -eq 0 ] || bad="$bad $s_failed suite(s) FAILED;"
   [ "$s_skipped" -eq 0 ] || bad="$bad $s_skipped suite(s) were SKIPPED — a skipped suite is reported by jest as neither passed nor failed and would otherwise pass unnoticed;"
-  [ "$t_passed" -gt 0 ] || bad="$bad ZERO tests PASSED — jest reports an all-skipped suite as passing, so a green exit over no assertions is exactly the vacuous result this guard exists to catch;"
+  [ "$t_passed" -gt 0 ] || bad="$bad ZERO tests PASSED — a suite whose every test is test.skip'd is still reported as a PASSED suite, so a green exit over no assertions is exactly the vacuous result this guard exists to catch (and the suite-level skipped count above cannot see it);"
   if [ -n "$bad" ]; then
     echo "$label: FAIL-CLOSED —$bad (issue #3522; jest summary was: '$suites' / '$tests')" >&2
     return 1
@@ -5798,17 +5806,33 @@ run_python_bindings() {
 # full suite adds ~15–35s on top of it — 504 passing tests across 27/27 suites, green
 # on two consecutive runs. That is not a cost worth 26 suites of blindness.
 #
-# THE CORPUS HALF IS NOW HONOURED, NOT AVOIDED. 7 of the suite's files read
-# CQLITE_DATASETS_ROOT, so node-bindings IS now in DATASET_COMPONENTS (it was NOT
-# before, and that comment was correct then and would be a stale rationale now).
-# Enrollment alone is not enough: without CQLITE_REQUIRE_FIXTURES=1 the suite's
-# setup.js leaves DATASETS_AVAILABLE=false and the corpus-dependent describes
-# `describe.skip` SILENTLY — a green run over zero real assertions, which is #3220's
-# rule and this issue's own thesis in one. So the FULL gate exports
-# CQLITE_REQUIRE_FIXTURES=1, making an absent corpus throw. `--only`/`--lite` stay
-# lenient (they are probes; `--only` cannot be a verdict — it exits 3 on success),
-# and the documented #2078 opt-out AGENT_GATE_ALLOW_MISSING_FIXTURES=1 is honoured,
-# the same split flight-tests uses. Which mode was taken is PRINTED, never implicit.
+# THE CORPUS HALF IS NOW HONOURED, NOT AVOIDED — AND THE REASON IS NOT THE ONE THIS
+# COMMENT FIRST GAVE (roborev/rust-reviewer round 1, B4). 14 of the suite's files gate on
+# dataset availability, so node-bindings IS now in DATASET_COMPONENTS (it was NOT before,
+# and that comment was correct then and would be a stale rationale now).
+#
+# The FULL gate additionally exports CQLITE_REQUIRE_FIXTURES=1. What that buys, MEASURED:
+#   * ONE clean, named setup failure (setup.js's `No SSTable fixtures found: …` throw)
+#     instead of 14 separate `beforeAll` THROWS from `skipIfNoDatasets()`; and
+#   * it closes `parity.test.js:70`'s `test.skip` placeholder — the ONE
+#     corpus-conditional path in the whole suite that would otherwise pass SILENTLY.
+#
+# WHAT IT IS **NOT**, stated because the first version of this comment claimed it and the
+# claim was false in three ways. There is no `describe.skip` anywhere in
+# `bindings/node/__test__/*.test.js` — the only occurrence of that string is inside a
+# COMMENT in dataset-guard.test.js. The repo's Node convention is the OPPOSITE of
+# skipping: `helpers.js`'s `skipIfNoDatasets()` THROWS, and `result.test.js` says so
+# outright ("per the repo's Node test convention it THROWS (never skips) … so a
+# misconfigured CI run fails loudly rather than passing silently"). The earlier text also
+# said "7 suites"; the measured number is 14.
+#
+# Why the correction matters more than the wording: a maintainer reading the old
+# rationale would conclude that CQLITE_REQUIRE_FIXTURES=1 is the only thing standing
+# between this gate and a silent all-skip, and could then delete the
+# AGENT_GATE_ALLOW_MISSING_FIXTURES split — or check_jest_suites_ran's `s_skipped`
+# branch — as redundant, reasoning from a mechanism the suite never had. A FALSE
+# rationale in a gate log is worse than none, because it is what stops the next person
+# looking. Same class as the stale #1255 comment this change already fixed.
 #
 # AFFIRMATIVE MEASUREMENT, not a green exit code (the same rule as the Rust lanes).
 # jest reports a suite whose every describe was skipped as PASSED, so `npm test`
@@ -5848,11 +5872,11 @@ run_node_bindings() {
   local require_fixtures=0 fixture_note
   if [ -z "$ONLY" ] && [ "$LITE" -eq 0 ] && [ "${AGENT_GATE_ALLOW_MISSING_FIXTURES:-0}" != 1 ]; then
     require_fixtures=1
-    fixture_note="CQLITE_REQUIRE_FIXTURES=1 (an absent corpus THROWS; the corpus-dependent suites cannot silently describe.skip)"
+    fixture_note="CQLITE_REQUIRE_FIXTURES=1 — an absent corpus fails ONCE, by name, in setup.js instead of as 14 separate beforeAll throws, and parity.test.js's test.skip placeholder (the one corpus-conditional path that would pass silently) cannot fire"
   elif [ "${AGENT_GATE_ALLOW_MISSING_FIXTURES:-0}" = 1 ]; then
-    fixture_note="CQLITE_REQUIRE_FIXTURES unset (AGENT_GATE_ALLOW_MISSING_FIXTURES=1) — corpus-dependent suites MAY silently skip, so this run does NOT validate them"
+    fixture_note="CQLITE_REQUIRE_FIXTURES unset (AGENT_GATE_ALLOW_MISSING_FIXTURES=1) — with a corpus absent the 14 dataset-gated suites would THROW individually and parity.test.js would test.skip, so this run does NOT validate that half"
   else
-    fixture_note="CQLITE_REQUIRE_FIXTURES unset (--only/--lite probe run) — corpus-dependent suites MAY silently skip"
+    fixture_note="CQLITE_REQUIRE_FIXTURES unset (--only/--lite probe run) — with a corpus absent the 14 dataset-gated suites would THROW individually and parity.test.js would test.skip"
   fi
 
   local -a census=()

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -154,9 +154,12 @@
 #                      --only/--lite stay lenient and the #2078 opt-out is honoured,
 #                      with the mode PRINTED. check_jest_suites_ran is
 #                      the affirmative guard: the reported suite total must equal the
-#                      set DERIVED FROM JEST ITSELF (`./node_modules/.bin/jest
-#                      --listTests`, never a
-#                      find over testMatch), no suite may be failed or skipped, and the
+#                      RECONCILED set of TWO INDEPENDENT oracles — a recursive `find` over
+#                      __test__/ and `./node_modules/.bin/jest --listTests` — whose
+#                      symmetric difference must be EMPTY, FAILing with the specific paths
+#                      and two distinct remedies otherwise (#3522 D1: jest's list alone was
+#                      SELF-REFERENTIAL, since a config exclusion shrinks the expectation and
+#                      the run together). No suite may be failed or skipped, and the
 #                      passed-test count must be non-zero (a suite whose every TEST is
 #                      `test.skip`ped is reported as a PASSED suite — the suite-level
 #                      `skipped` count only catches a whole file being skipped, which is
@@ -5867,13 +5870,18 @@ EOF
 # AFFIRMATIVE MEASUREMENT, not a green exit code (the same rule as the Rust lanes).
 # jest reports a suite whose every describe was skipped as PASSED, so `npm test`
 # exiting 0 does not establish that anything ran. check_jest_suites_ran requires the
-# reported total to equal the suite set DERIVED FROM JEST ITSELF
-# (`./node_modules/.bin/jest --listTests`), requires no suite to have failed or been skipped, and requires a
-# non-zero count of PASSED tests. The oracle is jest and not a `find`, for the same
-# reason `_package_test_targets` uses cargo metadata rather than parsing `[[test]]`
-# stanzas: a find would re-implement this package's RECURSIVE `testMatch` plus jest's
-# default ignore patterns, and it would agree at 27 today while silently undercounting
-# the day someone adds a subdirectory — a false red on healthy code.
+# reported total to equal the RECONCILED suite set of TWO INDEPENDENT oracles — a recursive
+# `find` over `__test__/` and `./node_modules/.bin/jest --listTests` — requires no suite to
+# have failed or been skipped, and requires a non-zero count of PASSED tests.
+#
+# TWO oracles, because either alone is blind in a different way (#3522 D1). jest's list is
+# the only thing that knows what will ACTUALLY run (its `testMatch` is recursive and it
+# applies ignore patterns a `find` cannot reproduce), but using it as the EXPECTATION too is
+# self-referential: a config narrowing shrinks the expectation and the run TOGETHER and the
+# guard passes while "every committed suite ran" is false. The independent inventory supplies
+# the expectation; jest supplies what runs; a non-empty symmetric difference is a FAIL naming
+# the paths, in two distinct directions with two distinct remedies (a silent config
+# exclusion, vs jest running something outside `__test__/`).
 #
 # RUN_SLOW_TESTS is forwarded exactly as python-bindings forwards it (default 0). Two
 # tests opt into it (publish.test.js's `npm pack --dry-run`, streaming.test.js's
@@ -5992,17 +6000,36 @@ run_node_bindings() {
     echo "==== end census ===="
   } > "$log"
 
-  # STEP 1 — install, build, and DERIVE the suite set FROM JEST ITSELF.
+  # STEP 1 — install, build, and DERIVE the suite set FROM TWO INDEPENDENT ORACLES.
   #
-  # `./node_modules/.bin/jest --listTests` (0.9s) is the oracle, deliberately NOT a `find` over
-  # `__test__/*.test.js`. A find would be a SECOND IMPLEMENTATION of this package's
-  # `testMatch` (`**/__test__/**/*.test.js` — RECURSIVE) plus jest's default
-  # `testPathIgnorePatterns`, and its correctness would only be knowable by
-  # differential testing against the original. Measured: a `-maxdepth 1` find agrees at
-  # 27 TODAY and would silently UNDERCOUNT the day someone adds a subdirectory — turning
-  # the affirmative guard below into a false red on healthy code, which is the verdict
-  # agents learn to waive. Same rule as `_package_test_targets` preferring cargo
-  # metadata over parsing `[[test]]` stanzas.
+  # WHY TWO, AND WHY ONE WAS NOT ENOUGH (roborev round 3, D1). `jest --listTests` is the
+  # right oracle for the ACTUAL set — it applies this package's `testMatch`
+  # (`**/__test__/**/*.test.js`, RECURSIVE) and jest's ignore patterns, which a
+  # `find -maxdepth 1` cannot reproduce (it agrees at 27 today and would silently
+  # UNDERCOUNT the day a subdirectory appears, false-redding healthy code). That argument
+  # stands and is why the find below is RECURSIVE and is NOT used to select what runs.
+  #
+  # But using it as the EXPECTED count too made the guard SELF-REFERENTIAL: the expectation
+  # and the run both flow from jest's configuration, so a `testMatch` narrowing or an added
+  # ignore pattern shrinks BOTH TOGETHER and the guard passes while its stated contract
+  # ("every committed suite ran") is violated. That is #3522's own defect class one level
+  # up — the same shape as a CQLite-written/CQLite-read round-trip being invariant to a
+  # uniform framing error, and the same shape as `clippy --all-targets` "covering" a crate
+  # it only compiles. A measurement whose subject and whose oracle share a source cannot
+  # detect a change that moves both.
+  #
+  # So: an INDEPENDENT recursive filesystem inventory is taken, RECONCILED against jest's
+  # list, and any disagreement FAILs naming the specific paths — in two DISTINCT
+  # directions, because they have different remedies:
+  #   * on disk but NOT listed by jest  -> a silent CONFIG EXCLUSION (the defect found);
+  #   * listed by jest but NOT on disk  -> jest is running something outside __test__, or
+  #                                        this inventory is wrong.
+  # Only the RECONCILED set becomes the expectation the run summary is checked against.
+  #
+  # `find`, NOT `git ls-files`, deliberately: jest enumerates the DISK, so a
+  # committed-files inventory would red on a new-but-uncommitted test file — a false red on
+  # correct work, which is the verdict agents learn to waive. Both oracles must answer the
+  # same question ("what is on disk"); only one of them may consult jest's config.
   local list_file="$LOG_DIR/$name.listtests.txt" suite_n=""
   # Both strict-mode variables are unset here UNCONDITIONALLY, in every mode: listing
   # tests needs no corpus, so an inherited strict flag could only turn a healthy
@@ -6035,24 +6062,126 @@ run_node_bindings() {
     echo ">>> [$name] $status ($((end - start))s)"
     return 0
   fi
-  suite_n=$(grep -c '\.test\.js$' "$list_file" || true)
-  case "$suite_n" in
-    ''|*[!0-9]*) suite_n=0 ;;
-  esac
-  if [ "$suite_n" -eq 0 ]; then
+  # ORACLE A — jest's own list, normalised. Both sides are reduced to their path RELATIVE
+  # TO `__test__/`, so the comparison cannot be broken by a symlinked or differently-spelled
+  # absolute prefix (jest resolves rootDir from its config; this script uses $REPO_ROOT).
+  local jest_set="$LOG_DIR/$name.suites-jest.txt"
+  local disk_set="$LOG_DIR/$name.suites-disk.txt"
+  local only_disk only_jest
+  sed -n 's#.*/__test__/##p' "$list_file" | grep '\.test\.js$' | sort -u > "$jest_set"
+
+  # ORACLE B — an INDEPENDENT recursive filesystem inventory. `find`, not a glob: a glob's
+  # meaning depends on ambient shell options this script never sets and cannot control
+  # (`nullglob` empties an unmatched pattern, `failglob` makes it an error), both reachable
+  # through BASHOPTS — the round-34 lesson. `node_modules` is pruned to match jest's default
+  # ignore, which is the ONE piece of jest behaviour this inventory deliberately mirrors:
+  # without it the two oracles would disagree on vendored fixtures forever and the
+  # reconciliation would be a permanent red.
+  local _nb_test_dir="$REPO_ROOT/bindings/node/__test__"
+  if [ ! -d "$_nb_test_dir" ] || [ ! -r "$_nb_test_dir" ]; then
     status=FAIL
     {
-      echo "[$name] FAIL-CLOSED: './node_modules/.bin/jest --listTests' named ZERO *.test.js suites."
-      echo "        The DERIVATION failed (or the suite vanished), and a guard expecting zero"
-      echo "        suites would report OK having measured nothing (issue #3522)."
+      echo "[$name] FAIL-CLOSED: $_nb_test_dir is missing or unreadable, so the INDEPENDENT"
+      echo "        inventory half of the suite reconciliation cannot be taken. With only jest's"
+      echo "        own list the guard would be self-referential (issue #3522, roborev D1)."
     } | tee -a "$log"
     end=$(date +%s)
     record_result "$name" "$status" "$((end - start))"
     echo ">>> [$name] $status ($((end - start))s)"
     return 0
   fi
-  echo ">>> [$name] derived suite set: $suite_n *.test.js file(s) (oracle: ./node_modules/.bin/jest --listTests, not a find over testMatch)"
-  echo "derived suite set: $suite_n *.test.js file(s) (oracle: ./node_modules/.bin/jest --listTests)" >> "$log"
+  # `-print0` and a NUL-vs-line count assert: a filename containing a newline would be
+  # silently split into two entries by the line-based sort/comm below, inflating the
+  # inventory and producing a nonsense reconciliation. Refuse rather than mis-measure.
+  local _nb_nuls _nb_lines
+  find -H "$_nb_test_dir" -type d -name node_modules -prune -o -type f -name '*.test.js' -print0 2>/dev/null \
+    | tr '\0' '\n' | sed -n 's#.*/__test__/##p' | sort -u > "$disk_set"
+  _nb_nuls=$(find -H "$_nb_test_dir" -type d -name node_modules -prune -o -type f -name '*.test.js' -print0 2>/dev/null | tr -dc '\0' | wc -c | tr -d ' ')
+  _nb_lines=$(grep -c . "$disk_set" || true)
+  case "$_nb_nuls$_nb_lines" in
+    ''|*[!0-9]*) _nb_nuls=-1 ;;
+  esac
+  if [ "$_nb_nuls" != "$_nb_lines" ]; then
+    status=FAIL
+    {
+      echo "[$name] FAIL-CLOSED: the independent suite inventory counted $_nb_nuls NUL-delimited"
+      echo "        entries but $_nb_lines line(s) after conversion — a test filename contains a"
+      echo "        newline (or the count itself failed), so the line-based reconciliation below"
+      echo "        would mis-measure. Refusing rather than comparing garbage (issue #3522)."
+    } | tee -a "$log"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
+  # RECONCILE. `comm`'s exit status is CHECKED: an unchecked `$(comm …)` yields the EMPTY
+  # STRING when comm FAILS, and "empty symmetric difference" is exactly this check's PASS
+  # condition — so a comm failure would silently certify the two oracles as agreeing. Never
+  # let a permissive verdict rest on the absence of output that a failure also produces.
+  only_disk=$(comm -23 "$disk_set" "$jest_set"); [ $? -eq 0 ] || only_disk="__COMM_FAILED__"
+  only_jest=$(comm -13 "$disk_set" "$jest_set"); [ $? -eq 0 ] || only_jest="__COMM_FAILED__"
+  if [ "$only_disk" = "__COMM_FAILED__" ] || [ "$only_jest" = "__COMM_FAILED__" ]; then
+    status=FAIL
+    {
+      echo "[$name] FAIL-CLOSED: could not compare the two suite oracles (comm failed). An"
+      echo "        unmeasurable reconciliation is not a pass (issue #3522, roborev D1)."
+    } | tee -a "$log"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+  if [ -n "$only_disk" ] || [ -n "$only_jest" ]; then
+    status=FAIL
+    {
+      echo "[$name] FAIL-CLOSED: the two suite oracles DISAGREE (issue #3522, roborev D1)."
+      if [ -n "$only_disk" ]; then
+        echo "        ON DISK but NOT LISTED BY JEST — a SILENT CONFIG EXCLUSION. These committed"
+        echo "        suites would never run, and using jest's own list as the expectation would"
+        echo "        have hidden it (expectation and run shrink together):"
+        printf '%s\n' "$only_disk" | sed 's#^#          __test__/#'
+        echo "        REMEDY: check jest.config.js's testMatch / testPathIgnorePatterns, or any"
+        echo "        filter on the jest command line. If the exclusion is INTENDED, it must be"
+        echo "        declared here deliberately, not inferred from a shrinking count."
+      fi
+      if [ -n "$only_jest" ]; then
+        echo "        LISTED BY JEST but NOT FOUND ON DISK under __test__/ — jest is running"
+        echo "        something this inventory does not see (a testMatch reaching outside"
+        echo "        __test__/, a roots/rootDir change), or this inventory is wrong:"
+        printf '%s\n' "$only_jest" | sed 's#^#          #'
+        echo "        REMEDY: a DIFFERENT one from the case above — widen the inventory to match"
+        echo "        what the suite actually is, or narrow testMatch back."
+      fi
+    } | tee -a "$log"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
+  # Only the RECONCILED set becomes the expectation. Counted from the INVENTORY, not from
+  # jest's list — they are now proven identical, and taking it from the independent side
+  # keeps the guard's subject anchored to the filesystem rather than to jest's config.
+  suite_n=$(grep -c . "$disk_set" || true)
+  case "$suite_n" in
+    ''|*[!0-9]*) suite_n=0 ;;
+  esac
+  if [ "$suite_n" -eq 0 ]; then
+    status=FAIL
+    {
+      echo "[$name] FAIL-CLOSED: the reconciled suite set is EMPTY — no *.test.js found on disk"
+      echo "        under bindings/node/__test__ AND none listed by jest. The DERIVATION failed"
+      echo "        (or the suite vanished), and a guard expecting zero suites would report OK"
+      echo "        having measured nothing (issue #3522)."
+    } | tee -a "$log"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+  echo ">>> [$name] suite set RECONCILED: $suite_n *.test.js file(s) — two INDEPENDENT oracles agree (recursive find over __test__/ vs ./node_modules/.bin/jest --listTests); neither alone could detect a config exclusion (#3522 D1)"
+  echo "suite set RECONCILED: $suite_n *.test.js file(s) — independent recursive find over __test__/ AGREES with ./node_modules/.bin/jest --listTests (symmetric difference empty)" >> "$log"
 
   # STEP 2 — run them.
   # `env "${fixture_env[@]}"` FIRST, because `env`'s -u options must precede any

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6070,6 +6070,14 @@ run_binding_rust_tests() {
   local log="$LOG_DIR/$name.log"
   local ffi_log="$LOG_DIR/$name.cqlite-ffi-common.log"
   local node_log="$LOG_DIR/$name.cqlite-node.log"
+  # A THIRD file, for the guards' own verdicts — they must NOT be appended to the cargo
+  # log a LATER guard parses. check_unittest_targets_ran's success line contains the
+  # literal `Running unittests`, and check_no_unexpected_zero_tests keys on exactly that
+  # token: writing one guard's verdict into the other's input makes the two guards'
+  # ORDER load-bearing, which is the kind of coupling that decays into a vacuous pass.
+  # Concatenated LAST into the component log, so the FAIL branch's `tail -40` shows the
+  # verdicts (the informative half of a guard failure) rather than trailing cargo output.
+  local verdict_log="$LOG_DIR/$name.guards.log"
   local start end status
   start=$(date +%s)
 
@@ -6080,7 +6088,10 @@ run_binding_rust_tests() {
 
   # --- one place to report a failed DERIVATION -------------------------------
   # Every derivation below is fatal in the same way and for the same reason, so they
-  # report through one helper rather than five near-copies that could drift apart.
+  # report through one helper rather than five near-copies that could drift apart. It is
+  # defined here (so it reads `$name`/`$log`/`$_derivation_failed` by bash's dynamic
+  # scoping and takes no plumbing arguments) and therefore lands in the GLOBAL function
+  # namespace; the `_brt_` prefix is what keeps that from colliding with anything else.
   local _derivation_failed=0
   _brt_derivation_fail() { # <what> <why...>
     local what="$1"; shift
@@ -6096,6 +6107,7 @@ run_binding_rust_tests() {
   }
 
   : > "$log"
+  : > "$verdict_log"
 
   # NOTE the empty-but-successful case: cqlite-ffi-common declares no features at all, so
   # this legitimately returns the EMPTY SET. That is a measurement, and treating it as a
@@ -6255,7 +6267,7 @@ EOF
     echo "==== [$name] COVERAGE CENSUS (issue #3522) ===="
     for cl in "${census[@]}"; do echo "$cl"; done
     echo "enabled features (cargo tree -p, package-scoped): cqlite-ffi-common [$ffi_enabled] cqlite-node [$node_enabled]"
-    echo "per-package cargo logs: $ffi_log , $node_log"
+    echo "per-package cargo logs: $ffi_log , $node_log ; guard verdicts: $verdict_log"
     echo "==== end census ===="
   } > "$log"
 
@@ -6271,25 +6283,25 @@ EOF
       ${ffi_feature_args[@]+"${ffi_feature_args[@]}"} > "$ffi_log" 2>&1; then
     # Three affirmative guards, ANDed. Order matters only for readability; each writes
     # its own verdict to the log, so a pasted log shows which ones RAN and on what.
-    if ! check_unittest_targets_ran "$name/cqlite-ffi-common" "$ffi_log" "${ffi_unit_srcs[@]}" 2>>"$ffi_log"; then
+    if ! check_unittest_targets_ran "$name/cqlite-ffi-common" "$ffi_log" "${ffi_unit_srcs[@]}" 2>>"$verdict_log"; then
       status=FAIL
     fi
     if [ "$ffi_expect_n" -gt 0 ]; then
-      if ! check_test_targets_observed "$name/cqlite-ffi-common" "$ffi_log" "${ffi_expect[@]}" 2>>"$ffi_log"; then
+      if ! check_test_targets_observed "$name/cqlite-ffi-common" "$ffi_log" "${ffi_expect[@]}" 2>>"$verdict_log"; then
         status=FAIL
       else
-        echo "$name/cqlite-ffi-common: integration targets OK — all $ffi_expect_n derived target(s) produced a 'Running' banner:${ffi_ids}" >> "$ffi_log"
+        echo "$name/cqlite-ffi-common: integration targets OK — all $ffi_expect_n derived target(s) produced a 'Running' banner:${ffi_ids}" >> "$verdict_log"
       fi
     else
       # Unreachable while this package declares runnable targets (the derivation above
       # FAILs on zero), but stated rather than left implicit: an expectation set that
       # emptied itself would be a guard with no subject.
-      echo "$name/cqlite-ffi-common: FAIL-CLOSED — every declared integration target was excused by an unmet required-feature, leaving the observation guard with NO subject (issue #3522)." >> "$ffi_log"
+      echo "$name/cqlite-ffi-common: FAIL-CLOSED — every declared integration target was excused by an unmet required-feature, leaving the observation guard with NO subject (issue #3522)." >> "$verdict_log"
       status=FAIL
     fi
     # EMPTY allowed-zero list, deliberately: no cqlite-ffi-common integration target is
     # permitted to run zero tests, so a cfg change that empties one FAILs here.
-    if ! check_no_unexpected_zero_tests "$name/cqlite-ffi-common" "$ffi_log" 2>>"$ffi_log"; then
+    if ! check_no_unexpected_zero_tests "$name/cqlite-ffi-common" "$ffi_log" 2>>"$verdict_log"; then
       status=FAIL
     fi
   else
@@ -6304,14 +6316,14 @@ EOF
   if env CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT" \
       cargo test --no-fail-fast -p cqlite-node \
       ${node_feature_args[@]+"${node_feature_args[@]}"} --lib > "$node_log" 2>&1; then
-    if ! check_unittest_targets_ran "$name/cqlite-node" "$node_log" "${node_unit_srcs[@]}" 2>>"$node_log"; then
+    if ! check_unittest_targets_ran "$name/cqlite-node" "$node_log" "${node_unit_srcs[@]}" 2>>"$verdict_log"; then
       status=FAIL
     fi
   else
     status=FAIL
   fi
 
-  cat "$ffi_log" "$node_log" >> "$log" 2>/dev/null
+  cat "$ffi_log" "$node_log" "$verdict_log" >> "$log" 2>/dev/null
   if [ "$status" = FAIL ]; then
     echo "--- [$name] FAILED; last 40 lines of $log ---"
     tail -40 "$log"

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -5328,6 +5328,88 @@ for p in d["packages"]:
   printf '%s\n' "$out"
 }
 
+# _package_integration_target_ids <package>: print one TAB-separated line per declared
+# INTEGRATION (`test`) target — `<name>\t<runner-id>\t<required-features comma-joined>`
+# — and, UNLIKE _package_test_targets, treat "this package declares none" as a REAL
+# ANSWER rather than a failed derivation (issue #3522).
+#
+# Two reasons it is not just another caller of _package_test_targets.
+#
+#  1. ZERO IS A FACT HERE. _package_test_targets fails closed on an empty result
+#     because every one of its callers' packages declares integration targets, so
+#     emptiness there can only be a broken derivation. cqlite-node declares NONE, and
+#     the binding-rust-tests census must state that as a DERIVED fact ("this package
+#     has no integration targets") rather than as an assumption or a FAIL. Emptiness
+#     and failure are therefore distinguished by an explicit PRESENCE check on the
+#     package itself: a package cargo does not know about is a FAILED derivation
+#     (return 1); a package it knows about that declares no test target prints nothing
+#     and returns 0.
+#
+#  2. THE RUNNER ID. cargo's `Running tests/<path>.rs` banner — the string every
+#     observation guard here keys on — carries the target's path RELATIVE TO tests/,
+#     which equals the target NAME for a file-style target (`tests/foo.rs` -> `foo`)
+#     but NOT for a directory-style one (`tests/foo/main.rs` -> `foo/main`, name
+#     `foo`). Deriving the id from cargo's own `src_path` makes the guard's expectation
+#     agree with cargo's output BY CONSTRUCTION, so adding a directory-style target
+#     cannot turn a healthy lane red. A target mapped outside tests/ by an explicit
+#     `[[test]] path = "..."` yields its package-relative path, which is the second
+#     spelling check_no_unexpected_zero_tests already recognises.
+#
+# Same parser chain and same direction as its neighbours: jq, else python3, else a
+# FAILED derivation. Never a fallback to a partial or empty census.
+_package_integration_target_ids() {
+  local pkg="$1"
+  local meta present out
+  meta=$(cargo metadata --format-version 1 --no-deps 2>/dev/null) || return 1
+  [ -n "$meta" ] || return 1
+  if command -v jq >/dev/null 2>&1; then
+    # PRESENCE first: without it, an unknown/renamed package would print nothing and
+    # be reported as "declares no integration targets" — a false all-clear about a
+    # package the lane cannot see at all.
+    present=$(printf '%s' "$meta" | jq -r --arg n "$pkg" '[.packages[] | select(.name == $n)] | length') || return 1
+    [ "$present" = 1 ] || return 1
+    out=$(printf '%s' "$meta" | jq -r --arg n "$pkg" \
+      '.packages[] | select(.name == $n)
+       | ((.manifest_path // "") | split("/") | .[0:-1] | join("/")) as $root
+       | .targets[]
+       | select(.kind | index("test"))
+       | ((.src_path // "")) as $sp
+       | (if ($root != "" and ($sp | startswith($root + "/")))
+          then ($sp | ltrimstr($root + "/")) else $sp end) as $rel
+       | (if ($rel | startswith("tests/")) then ($rel | ltrimstr("tests/")) else $rel end) as $rel2
+       | (if ($rel2 | endswith(".rs")) then ($rel2 | .[0:-3]) else $rel2 end) as $id
+       | [.name, $id, ((."required-features" // []) | join(","))] | @tsv') || return 1
+  elif command -v python3 >/dev/null 2>&1; then
+    out=$(printf '%s' "$meta" | python3 -c '
+import json, os, sys
+pkg = sys.argv[1]
+d = json.load(sys.stdin)
+pkgs = [p for p in d.get("packages", []) if p.get("name") == pkg]
+if len(pkgs) != 1:
+    sys.exit(1)
+p = pkgs[0]
+root = os.path.dirname(p.get("manifest_path", ""))
+for t in p.get("targets", []):
+    if "test" not in (t.get("kind") or []):
+        continue
+    sp = t.get("src_path") or ""
+    rel = sp[len(root) + 1:] if root and sp.startswith(root + os.sep) else sp
+    if rel.startswith("tests/"):
+        rel = rel[len("tests/"):]
+    if rel.endswith(".rs"):
+        rel = rel[:-3]
+    print("%s\t%s\t%s" % (t["name"], rel, ",".join(t.get("required-features") or [])))
+' "$pkg") || return 1
+  else
+    return 1
+  fi
+  # NO `[ -n "$out" ] || return 1` HERE, DELIBERATELY — that is the one line that
+  # distinguishes this helper from _package_test_targets. See reason 1 above.
+  printf '%s' "$out"
+  [ -n "$out" ] && printf '\n'
+  return 0
+}
+
 # THE FLAKE-QUARANTINE PLUMBING IS RETIRED, DELIBERATELY (issues #3383/#3384).
 #
 # It used to live here: `FLIGHT_FLAKE_SKIPS`, a curated `<target>:<issue>` list that
@@ -5989,9 +6071,23 @@ run_flight_query_semantics_oracle() {
 # contract, and here it described the exact defect the code was changed to remove. The measured
 # reason for the change is in the body comment below.
 #
-# Emptiness is impossible for a real package (`default` is always in the set), so an empty result
-# is a failed derivation, and the caller must treat it as one rather than as "no features
-# enabled".
+# THE PRESENCE ORACLE IS THE PACKAGE LINE, NOT A NON-EMPTY FEATURE LIST (issue #3522, and this
+# header used to say the opposite). It read: "Emptiness is impossible for a real package
+# (`default` is always in the set), so an empty result is a failed derivation." That is FALSE,
+# and it was falsified by measurement on the first package that has no `[features]` table at
+# all: `cargo tree -p cqlite-ffi-common … -f '{p}|{f}'` prints
+# `cqlite-ffi-common v0.16.1 (…)|` — the package line is THERE, the feature field is EMPTY,
+# because cargo's `{f}` prints the ENABLED features and an implicit `default = []` enables
+# none. Under the old rule that healthy resolve returned FAILURE, so any lane covering such a
+# package would have failed closed forever on a correct tree — the false-red shape that teaches
+# agents to waive a lane.
+#
+# The fix keeps the fail-closed DIRECTION and makes the signal PRECISE: the derivation has
+# failed IFF cargo emitted no line for the package (a cargo failure, an offline registry, a
+# renamed package). A package that IS in the resolve with no features enabled returns the EMPTY
+# SET with success — which is a measurement, not an absence of one. Callers whose packages do
+# have features are unaffected (cqlite-flight resolves to `default test-util`, cqlite-core to
+# nine), and their failure branch now fires on the condition it always meant to name.
 _resolved_package_features() {
   # PACKAGE-SCOPED resolve, via `cargo tree -p` — NOT `cargo metadata` (roborev round-6
   # finding, Medium). `cargo metadata` resolves the ENTIRE workspace and unions features
@@ -6024,11 +6120,19 @@ _resolved_package_features() {
   # A failed resolve returns non-zero and the caller FAILs the lane naming the census, so
   # "could not measure" never becomes "nothing to report".
   local pkg="$1"; shift
-  local feats
-  feats=$(cargo tree -p "$pkg" "$@" -e features,normal,build,dev --prefix none -f '{p}|{f}' 2>/dev/null \
+  local raw feats
+  # The resolve is captured ONCE and interrogated twice, so the presence check and the feature
+  # extraction can never describe two different cargo runs.
+  raw=$(cargo tree -p "$pkg" "$@" -e features,normal,build,dev --prefix none -f '{p}|{f}' 2>/dev/null) || return 1
+  [ -n "$raw" ] || return 1
+  # PRESENCE: at least one line for this package. This — not the feature count — is what
+  # distinguishes "cargo could not resolve it" from "it enables nothing" (see the header). The
+  # awk EXIT STATUS carries the answer, so an empty feature field cannot be read as an absent
+  # package.
+  printf '%s\n' "$raw" | awk -F'|' -v pat="^$pkg v" '$1 ~ pat { found = 1 } END { exit found ? 0 : 1 }' || return 1
+  feats=$(printf '%s\n' "$raw" \
     | awk -F'|' -v pat="^$pkg v" '$1 ~ pat {print $2}' \
-    | tr ',' '\n' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e '/^$/d' | sort -u) || return 1
-  [ -n "$feats" ] || return 1
+    | tr ',' '\n' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e '/^$/d' | sort -u)
   printf ' %s ' "$(printf '%s' "$feats" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
 }
 

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -140,6 +140,33 @@
 #                      to the content proof (not full `npm test`) so it stays
 #                      fast and corpus-free while still failing closed on a Node
 #                      write-path regression (#1255).
+#   binding-rust-tests EXECUTES the RUST test suites of the two binding-side crates no
+#                      other component runs (#3522): `cargo test -p cqlite-ffi-common`
+#                      (ALL targets — lib + tests/dependency_boundary.rs +
+#                      tests/error_contract_table.rs) and `cargo test -p cqlite-node
+#                      --features write-support --lib`. Before it, BOTH executed
+#                      NOWHERE — not locally, not in CI: clippy --all-targets COMPILED
+#                      them and nothing RAN them, so an inverted assertion in either
+#                      could merge with every check green. Compiling is not covering
+#                      (#1699), and that holds at PACKAGE granularity too.
+#                      DELIBERATELY NOT folded into node-bindings: that component SKIPs
+#                      when node/npm is absent, and putting cqlite-node's RUST tests
+#                      behind that SKIP would be a coverage hole wearing a SKIP's
+#                      clothes. This one needs nothing beyond cargo and NEVER SKIPs.
+#                      Every subject set (integration targets + their runner ids,
+#                      unittest targets, enabled/declared features) is DERIVED from
+#                      cargo at run time, so a new tests/*.rs is covered with no gate
+#                      edit; a failed derivation FAILs naming the derivation. Guards are
+#                      affirmative, not exit-code-shaped: check_unittest_targets_ran
+#                      per package, check_test_targets_observed over the derived
+#                      integration set, and check_no_unexpected_zero_tests with an EMPTY
+#                      allowed-zero list. Prints a COVERAGE CENSUS on stdout and at the
+#                      head of its log naming what it does NOT run (cqlite-py's Rust
+#                      tests — structurally unlinkable; the jest suite — node-bindings'
+#                      subject; cqlite-node's derived integration-target count; the
+#                      features left off). Needs NO fixtures (verified: neither crate's
+#                      sources reference CQLITE_DATASETS_ROOT), so NOT in
+#                      DATASET_COMPONENTS.
 #   parity-report      cassandra-parity report --check: FAILs (naming
 #                      docs/reports/cassandra-test-parity.md) when the committed
 #                      derived report drifts from a fresh render of
@@ -2272,7 +2299,7 @@ _python_build_verify_venv() {
   return 3
 }
 
-COMPONENTS=(file-size fmt clippy roborev-lints core-tests tombstones-scan scan-offload-guard work-counters-guard byte-budget-guard arrow-parity-guard memory-budget integration-tests format-compat write-tests cli-tests compaction-byte-parity bti-multiclustering query-semantics-oracle flight-query-semantics-oracle flight-tests legacy-heuristics feature-iso-parquet feature-iso-delta-scan python-bindings node-bindings delivery-telemetry oom-audit parity-report operator-metrics-doc kit-dashboard-drift binding-unwind-profile pub-surface tooling-tests minimal-build smoke)
+COMPONENTS=(file-size fmt clippy roborev-lints core-tests tombstones-scan scan-offload-guard work-counters-guard byte-budget-guard arrow-parity-guard memory-budget integration-tests format-compat write-tests cli-tests compaction-byte-parity bti-multiclustering query-semantics-oracle flight-query-semantics-oracle flight-tests legacy-heuristics feature-iso-parquet feature-iso-delta-scan python-bindings node-bindings binding-rust-tests delivery-telemetry oom-audit parity-report operator-metrics-doc kit-dashboard-drift binding-unwind-profile pub-surface tooling-tests minimal-build smoke)
 
 # _component_lane <name> (issues #1737, #2657): SINGLE SOURCE OF TRUTH for the
 # MAIN-vs-SIDE lane split. Defined early (before the arg-parse dispatch) so the
@@ -2287,6 +2314,11 @@ COMPONENTS=(file-size fmt clippy roborev-lints core-tests tombstones-scan scan-o
 _component_lane() {
   case "$1" in
     python-bindings|node-bindings) printf side ;;
+    # binding-rust-tests builds cqlite-ffi-common (a cqlite-core dependent with
+    # default-features = false) and cqlite-node (cqlite-core + parquet + cli-helpers +
+    # write-support) — class (a) of the SIDE rationale: a feature set that DIVERGES from
+    # MAIN's, so sharing MAIN's target dir would thrash it (#2657/#3522).
+    binding-rust-tests) printf side ;;
     parity-report|delivery-telemetry|binding-unwind-profile|smoke|memory-budget) printf side ;;
     # #1699 feature-matrix lanes. All four build cqlite-core at a feature set that
     # DIVERGES from MAIN's (cqlite-flight's arrow flavour; default+legacy-heuristics;
@@ -5685,6 +5717,367 @@ run_node_bindings() {
     status=PASS
   else
     status=FAIL
+    echo "--- [$name] FAILED; last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+  fi
+  end=$(date +%s)
+  record_result "$name" "$status" "$((end - start))"
+  echo ">>> [$name] $status ($((end - start))s)"
+}
+
+# _package_declared_features <package>: print every feature NAME the package's own
+# manifest declares, one per line (possibly none), from cargo metadata. Exit 1 = the
+# derivation failed (no jq/python3, a metadata failure, or no such package) — never a
+# silent empty list, which would let a lane report "nothing is turned off" about a
+# package it could not read (issue #3522).
+#
+# Its consumer is the binding-rust-tests census: subtracting the RESOLVED enabled set
+# (_resolved_package_features) from this DECLARED set is how the lane states, as a
+# derived fact rather than a curated sentence, which of a binding crate's features it
+# leaves off — and therefore which `#[cfg(feature = ...)]` test bodies it does not run.
+_package_declared_features() {
+  local pkg="$1"
+  local meta present out
+  meta=$(cargo metadata --format-version 1 --no-deps 2>/dev/null) || return 1
+  [ -n "$meta" ] || return 1
+  if command -v jq >/dev/null 2>&1; then
+    present=$(printf '%s' "$meta" | jq -r --arg n "$pkg" '[.packages[] | select(.name == $n)] | length') || return 1
+    [ "$present" = 1 ] || return 1
+    out=$(printf '%s' "$meta" | jq -r --arg n "$pkg" \
+      '.packages[] | select(.name == $n) | (.features // {}) | keys[]') || return 1
+  elif command -v python3 >/dev/null 2>&1; then
+    out=$(printf '%s' "$meta" | python3 -c '
+import json, sys
+pkg = sys.argv[1]
+d = json.load(sys.stdin)
+pkgs = [p for p in d.get("packages", []) if p.get("name") == pkg]
+if len(pkgs) != 1:
+    sys.exit(1)
+for f in sorted((pkgs[0].get("features") or {}).keys()):
+    print(f)
+' "$pkg") || return 1
+  else
+    return 1
+  fi
+  # Emptiness is a legitimate answer here (cqlite-ffi-common declares no features at
+  # all), for the same reason and with the same presence check as
+  # _package_integration_target_ids.
+  printf '%s' "$out"
+  [ -n "$out" ] && printf '\n'
+  return 0
+}
+
+# binding-rust-tests: EXECUTE the RUST test suites of the two binding-side crates that
+# no other gate component runs — cqlite-ffi-common (whole package) and cqlite-node
+# (--lib) (issue #3522).
+#
+# THE DEFECT IT EXISTS FOR. Compiling is not covering, and #1699 established that at
+# FEATURE granularity. The same reasoning holds at PACKAGE granularity, and two crates
+# were sitting in exactly that hole: `cqlite-ffi-common` appeared ZERO times in
+# scripts/** and .github/workflows/**, so its 37 unit tests and its two integration
+# targets (tests/dependency_boundary.rs, tests/error_contract_table.rs) were reached
+# only by clippy's `--all-targets` compile and executed NOWHERE — not locally, not in
+# CI. `cqlite-node`'s 53 Rust unit tests were in the same position: node-bindings runs
+# jest against the BUILT ARTIFACT and never `cargo test`. An inverted assertion in
+# either could be committed, merged and released with every check green.
+#
+# WHY THIS IS A SEPARATE COMPONENT AND NOT PART OF node-bindings. node-bindings SKIPs
+# when node/npm is absent — correctly, since without them it can build nothing. Putting
+# cqlite-node's RUST tests behind that SKIP would mean a box with no npm silently stops
+# executing them: a coverage hole wearing a SKIP's clothes, which is this issue's own
+# defect class re-created by the fix. This component therefore depends on NOTHING beyond
+# cargo and NEVER SKIPs. The same argument keeps cqlite-ffi-common out of
+# python-bindings.
+#
+# FEATURE SETS, chosen and stated rather than defaulted into:
+#   * cqlite-ffi-common — none. The crate declares NO `[features]` table (derived and
+#     printed on every run), so there is no other set to choose.
+#   * cqlite-node — `--features write-support`, because that is what the SHIPPED
+#     artifact is built with (`npm run build` = `napi build … --features write-support`),
+#     so this lane runs the Rust half at the feature set the product actually ships. It
+#     costs nothing: cqlite-node's cqlite-core dependency already takes default features,
+#     which include write-support, so the flag adds no compilation. `observability` is
+#     deliberately NOT enabled — building the OTel stack is a cost this gate declines on
+#     purpose (#1844 excludes that stack from clippy for the same reason) — and the
+#     census DECLARES that, with the un-enabled feature set DERIVED, not listed by hand.
+#
+# AFFIRMATIVE MEASUREMENT, not a green exit code. A suite whose modules are cfg'd out
+# compiles, runs 0 tests and exits 0. Three guards, all over cargo's own output:
+#   * check_unittest_targets_ran   — per package, each selected `--lib` target must be
+#                                    OBSERVED and must have run a NON-ZERO count.
+#   * check_test_targets_observed  — every DERIVED cqlite-ffi-common integration target
+#                                    must have produced a `Running` banner (this is the
+#                                    guard that makes `dependency_boundary.rs` running in
+#                                    the gate of record a checkable fact, not a hope).
+#   * check_no_unexpected_zero_tests — with an EMPTY allowed-zero list, so any
+#                                    integration target that runs zero tests FAILs.
+# The two packages write to SEPARATE log files, deliberately: both print
+# `Running unittests src/lib.rs`, and check_unittest_targets_ran keys on that path, so a
+# single shared log would let one package's unit run satisfy the guard for the other.
+#
+# DERIVE, NEVER CURATE. Every subject set — integration targets, their runner ids,
+# unittest targets, enabled features, declared features — comes from `cargo metadata` /
+# `cargo tree` at run time, so a new `tests/*.rs` in either crate is covered with no gate
+# edit. A FAILED derivation is a FAIL NAMING THE DERIVATION, never a fallback to "nothing
+# to run": a silently empty subject set is the vacuous green this component was created
+# to remove.
+#
+# NOT IN DATASET_COMPONENTS, verified rather than assumed: neither `cqlite-ffi-common/`
+# nor `bindings/node/src/` contains any reference to `CQLITE_DATASETS_ROOT` or `test-data`
+# (measured; the jest suite does read the corpus, but that is node-bindings' subject, not
+# this lane's). The root is still exported defensively.
+run_binding_rust_tests() {
+  local name=binding-rust-tests
+  if [ -n "$ONLY" ] && ! grep -qw "$name" <<<"${ONLY//,/ }"; then
+    return 0
+  fi
+  local log="$LOG_DIR/$name.log"
+  local ffi_log="$LOG_DIR/$name.cqlite-ffi-common.log"
+  local node_log="$LOG_DIR/$name.cqlite-node.log"
+  local start end status
+  start=$(date +%s)
+
+  # Declared ONCE and consumed by BOTH the cargo invocation and the enabled-set
+  # derivation, so the two can never describe different builds.
+  local -a ffi_feature_args=()
+  local -a node_feature_args=(--features write-support)
+
+  # --- one place to report a failed DERIVATION -------------------------------
+  # Every derivation below is fatal in the same way and for the same reason, so they
+  # report through one helper rather than five near-copies that could drift apart.
+  local _derivation_failed=0
+  _brt_derivation_fail() { # <what> <why...>
+    local what="$1"; shift
+    {
+      echo "[$name] FAIL-CLOSED: could not derive $what."
+      echo "        $*"
+      echo "        The DERIVATION failed, not the tests. This component's subject sets are"
+      echo "        derived from cargo at run time so a new test target is covered with no gate"
+      echo "        edit; an underived (or silently empty) subject set is the vacuous green"
+      echo "        issue #3522 exists to remove, so it FAILs naming the derivation."
+    } >> "$log"
+    _derivation_failed=1
+  }
+
+  : > "$log"
+
+  # NOTE the empty-but-successful case: cqlite-ffi-common declares no features at all, so
+  # this legitimately returns the EMPTY SET. That is a measurement, and treating it as a
+  # failure is exactly the false red #3522 corrected in _resolved_package_features.
+  local ffi_enabled="" node_enabled=""
+  if ! ffi_enabled=$(_resolved_package_features cqlite-ffi-common ${ffi_feature_args[@]+"${ffi_feature_args[@]}"}); then
+    _brt_derivation_fail "cqlite-ffi-common's enabled feature set" \
+      "'cargo tree -p cqlite-ffi-common' emitted no line for the package (a cargo failure or an offline registry)."
+  fi
+  if ! node_enabled=$(_resolved_package_features cqlite-node ${node_feature_args[@]+"${node_feature_args[@]}"}); then
+    _brt_derivation_fail "cqlite-node's enabled feature set" \
+      "'cargo tree -p cqlite-node --features write-support' emitted no line for the package."
+  fi
+
+  # cqlite-ffi-common's integration targets. This package HAS them, so an empty result
+  # is a broken derivation and is reported as one.
+  local ffi_targets=""
+  if ! ffi_targets=$(_package_integration_target_ids cqlite-ffi-common); then
+    _brt_derivation_fail "cqlite-ffi-common's integration (test) targets" \
+      "cargo metadata, its parser, or the package lookup failed."
+  elif [ -z "$ffi_targets" ]; then
+    _brt_derivation_fail "cqlite-ffi-common's integration (test) targets" \
+      "the census counted ZERO, but this package declares tests/dependency_boundary.rs and tests/error_contract_table.rs. A zero here is a broken count, and 'no targets to observe' would silently retire the guard that proves dependency_boundary.rs runs."
+  fi
+
+  # cqlite-node's integration targets. Zero is the EXPECTED, DERIVED answer here (the
+  # crate is a cdylib with no tests/ directory) — which is why this uses the
+  # zero-tolerant helper. The census states the number it measured; it does not assume
+  # it.
+  local node_targets="" node_targets_n=0
+  if ! node_targets=$(_package_integration_target_ids cqlite-node); then
+    _brt_derivation_fail "cqlite-node's integration (test) target census" \
+      "cargo metadata, its parser, or the package lookup failed — so this lane cannot state whether it is leaving any integration target un-run."
+  else
+    node_targets_n=$(printf '%s' "$node_targets" | grep -c . || true)
+  fi
+
+  # The declared-minus-enabled feature sets: what this lane leaves OFF, derived.
+  local ffi_declared node_declared ffi_off="" node_off="" _f
+  if ! ffi_declared=$(_package_declared_features cqlite-ffi-common); then
+    _brt_derivation_fail "cqlite-ffi-common's declared feature list" "cargo metadata or its parser failed."
+  fi
+  if ! node_declared=$(_package_declared_features cqlite-node); then
+    _brt_derivation_fail "cqlite-node's declared feature list" "cargo metadata or its parser failed."
+  fi
+  for _f in $ffi_declared; do
+    case "$ffi_enabled" in *" $_f "*) ;; *) ffi_off="$ffi_off $_f" ;; esac
+  done
+  for _f in $node_declared; do
+    case "$node_enabled" in *" $_f "*) ;; *) node_off="$node_off $_f" ;; esac
+  done
+
+  # The unittest subject sets. `lib,cdylib,bin` rather than `lib,bin`: cqlite-node's
+  # library target has kind `cdylib` (it is a napi module), and a `lib,bin` filter
+  # returns NOTHING for it — which _package_unittest_srcs correctly reports as a failed
+  # derivation, and which a lane that shrugged at would turn into a guard with no
+  # subject.
+  local -a ffi_unit_srcs=() node_unit_srcs=()
+  local _us
+  while IFS= read -r _us; do [ -n "$_us" ] && ffi_unit_srcs+=("$_us"); done <<EOF
+$(_package_unittest_srcs cqlite-ffi-common lib "$ffi_enabled")
+EOF
+  while IFS= read -r _us; do [ -n "$_us" ] && node_unit_srcs+=("$_us"); done <<EOF
+$(_package_unittest_srcs cqlite-node lib,cdylib,bin "$node_enabled")
+EOF
+  [ "${#ffi_unit_srcs[@]}" -gt 0 ] || _brt_derivation_fail "cqlite-ffi-common's lib unittest target(s)" \
+    "cargo metadata returned none, so the zero-test guard would have no subject."
+  [ "${#node_unit_srcs[@]}" -gt 0 ] || _brt_derivation_fail "cqlite-node's lib unittest target(s)" \
+    "cargo metadata returned none (note its library target's kind is 'cdylib', not 'lib'), so the zero-test guard would have no subject."
+
+  # The count of Rust #[test] fns in bindings/python/src, for the census's cqlite-py
+  # clause. GREP-COUNTED, and the census says so: this counts `#[test]` ATTRIBUTES in
+  # committed source, which is a proxy for "test functions" and not a cargo-derived
+  # figure — cargo cannot give one, because the target cannot be built (that is the
+  # whole point of the clause). Fail-closed on an unreadable subject or a non-numeric
+  # result: a census that quietly reports "0 unrun tests" is a false all-clear.
+  local py_src="$REPO_ROOT/bindings/python/src" py_test_n=""
+  if [ ! -d "$py_src" ] || [ ! -r "$py_src" ]; then
+    _brt_derivation_fail "the count of Rust #[test] fns under bindings/python/src" \
+      "the directory is missing or unreadable, so the census cannot state the size of the gap it reports."
+  else
+    py_test_n=$(grep -rhoE --include='*.rs' '^[[:space:]]*#\[test\]' "$py_src" 2>/dev/null | grep -c . || true)
+    case "$py_test_n" in
+      ''|*[!0-9]*) _brt_derivation_fail "the count of Rust #[test] fns under bindings/python/src" \
+                     "the count came back non-numeric ('$py_test_n')." ;;
+    esac
+  fi
+
+  if [ "$_derivation_failed" -ne 0 ]; then
+    status=FAIL
+    cat "$log"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
+  # ---- THE CENSUS -----------------------------------------------------------
+  # Built ONCE and emitted TWICE — as `>>>` lines on the gate's stdout and at the HEAD
+  # of the component log — because a lane that omits coverage silently is
+  # indistinguishable from one that covers it, and "the log a reviewer actually reads"
+  # is both of those. Not a comment: a comment is not read on a run.
+  local ffi_ids="" ffi_expect_n=0 ffi_skip="" _tn _tid _trf _troff _trfl
+  local -a ffi_expect=()
+  while IFS=$'\t' read -r _tn _tid _trf; do
+    [ -n "$_tn" ] || continue
+    ffi_ids="$ffi_ids $_tid"
+    _troff=""
+    for _trfl in ${_trf//,/ }; do
+      case "$ffi_enabled" in *" $_trfl "*) ;; *) _troff="$_trfl"; break ;; esac
+    done
+    if [ -n "$_troff" ]; then
+      # cargo SILENTLY skips a required-features target it cannot enable, printing no
+      # banner at all — so demanding an observation for it would red a healthy lane.
+      # Excluded from the expectation and DECLARED, never dropped quietly.
+      ffi_skip="$ffi_skip $_tid(required-features[$_trf]:off[$_troff])"
+    else
+      ffi_expect+=("$_tid")
+      ffi_expect_n=$((ffi_expect_n + 1))
+    fi
+  done <<< "$ffi_targets"
+
+  local -a census=()
+  census+=("cargo test --no-fail-fast -p cqlite-ffi-common            (ALL targets: lib + every integration target)")
+  census+=("cargo test --no-fail-fast -p cqlite-node --features write-support --lib")
+  census+=("WHY THIS LANE EXISTS: before it, BOTH crates' Rust tests executed NOWHERE — not in")
+  census+=("     this gate, not in CI. clippy --all-targets COMPILED them and nothing RAN them.")
+  census+=("     Compiling is not covering (#1699), and that holds at PACKAGE granularity too.")
+  census+=("SUBJECTS (all DERIVED from cargo at run time, never hard-coded):")
+  census+=("  cqlite-ffi-common: unittest target(s) [${ffi_unit_srcs[*]}]; $ffi_expect_n integration target(s) [${ffi_ids# }]")
+  census+=("  cqlite-node:       unittest target(s) [${node_unit_srcs[*]}]; $node_targets_n integration target(s)")
+  census+=("COVERAGE CENSUS — WHAT THIS LANE DOES NOT RUN:")
+  census+=("  1. cqlite-py's Rust #[test] fns ($py_test_n occurrences of '#[test]' under")
+  census+=("     bindings/python/src, grep-counted from committed source — cargo cannot count them,")
+  census+=("     because the target cannot be built). 'cargo test -p cqlite-py' is STRUCTURALLY")
+  census+=("     IMPOSSIBLE, not merely unwired: a pyo3 cdylib's test harness cannot link libpython.")
+  census+=("     Already documented in this script (search: 'cannot link libpython'). The pytest")
+  census+=("     half IS fully covered, by the python-bindings component.")
+  census+=("  2. cqlite-node's JavaScript suite. Owned by the node-bindings component, which builds")
+  census+=("     the napi artifact and runs jest against it. This lane never builds that artifact.")
+  census+=("  3. cqlite-node integration (test) targets: it declares $node_targets_n — a DERIVED count")
+  census+=("     from cargo metadata, not an assumption. At $node_targets_n there is nothing to omit; if")
+  census+=("     that number ever rises without this lane running them, this line is the alarm.")
+  census+=("  4. Feature-gated bodies at features this lane leaves OFF (declared-minus-enabled,")
+  census+=("     derived): cqlite-ffi-common ->${ffi_off:- <none: this crate declares no features>};")
+  census+=("     cqlite-node ->${node_off:- <none>}. 'observability' is off ON PURPOSE — building the")
+  census+=("     OTel stack is a cost this gate declines (#1844 excludes it from clippy likewise).")
+  [ -n "$ffi_skip" ] && census+=("  5. cqlite-ffi-common targets cargo cannot run at this feature set:$ffi_skip")
+  census+=("SCOPE OF THE #3522 AUDIT, recorded so it is not re-litigated: this component closes TWO")
+  census+=("     of the ten gaps that audit found. The other eight are RECORDED, not silently fixed,")
+  census+=("     in scripts/tests/workspace-test-disposition.txt (enforced by")
+  census+=("     scripts/tests/test_workspace_test_disposition.sh under the tooling-tests component).")
+  local cl
+  for cl in "${census[@]}"; do echo ">>> [$name] $cl"; done
+  echo ">>> [$name] enabled features (cargo tree -p, package-scoped): cqlite-ffi-common [$ffi_enabled] cqlite-node [$node_enabled]"
+  {
+    echo "==== [$name] COVERAGE CENSUS (issue #3522) ===="
+    for cl in "${census[@]}"; do echo "$cl"; done
+    echo "enabled features (cargo tree -p, package-scoped): cqlite-ffi-common [$ffi_enabled] cqlite-node [$node_enabled]"
+    echo "per-package cargo logs: $ffi_log , $node_log"
+    echo "==== end census ===="
+  } > "$log"
+
+  # --no-fail-fast for the reason flight-tests and legacy-heuristics carry it: cargo
+  # test stops after the first failing test BINARY, and a lane whose purpose is to
+  # surface never-executed rot must surface ALL of it in one run rather than as a serial
+  # reveal.
+  status=PASS
+
+  # ---- cqlite-ffi-common: whole package -------------------------------------
+  if env CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT" \
+      cargo test --no-fail-fast -p cqlite-ffi-common \
+      ${ffi_feature_args[@]+"${ffi_feature_args[@]}"} > "$ffi_log" 2>&1; then
+    # Three affirmative guards, ANDed. Order matters only for readability; each writes
+    # its own verdict to the log, so a pasted log shows which ones RAN and on what.
+    if ! check_unittest_targets_ran "$name/cqlite-ffi-common" "$ffi_log" "${ffi_unit_srcs[@]}" 2>>"$ffi_log"; then
+      status=FAIL
+    fi
+    if [ "$ffi_expect_n" -gt 0 ]; then
+      if ! check_test_targets_observed "$name/cqlite-ffi-common" "$ffi_log" "${ffi_expect[@]}" 2>>"$ffi_log"; then
+        status=FAIL
+      else
+        echo "$name/cqlite-ffi-common: integration targets OK — all $ffi_expect_n derived target(s) produced a 'Running' banner:${ffi_ids}" >> "$ffi_log"
+      fi
+    else
+      # Unreachable while this package declares runnable targets (the derivation above
+      # FAILs on zero), but stated rather than left implicit: an expectation set that
+      # emptied itself would be a guard with no subject.
+      echo "$name/cqlite-ffi-common: FAIL-CLOSED — every declared integration target was excused by an unmet required-feature, leaving the observation guard with NO subject (issue #3522)." >> "$ffi_log"
+      status=FAIL
+    fi
+    # EMPTY allowed-zero list, deliberately: no cqlite-ffi-common integration target is
+    # permitted to run zero tests, so a cfg change that empties one FAILs here.
+    if ! check_no_unexpected_zero_tests "$name/cqlite-ffi-common" "$ffi_log" 2>>"$ffi_log"; then
+      status=FAIL
+    fi
+  else
+    status=FAIL
+  fi
+
+  # ---- cqlite-node: --lib ---------------------------------------------------
+  # Yes, a `crate-type = ["cdylib"]` package: `cargo test --lib` compiles the library as
+  # a TEST harness binary, which links fine (measured: 53 tests). This is NOT the
+  # cqlite-py situation — that one fails because a pyo3 extension's harness needs
+  # libpython at link time, which is a property of pyo3, not of cdylib.
+  if env CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT" \
+      cargo test --no-fail-fast -p cqlite-node \
+      ${node_feature_args[@]+"${node_feature_args[@]}"} --lib > "$node_log" 2>&1; then
+    if ! check_unittest_targets_ran "$name/cqlite-node" "$node_log" "${node_unit_srcs[@]}" 2>>"$node_log"; then
+      status=FAIL
+    fi
+  else
+    status=FAIL
+  fi
+
+  cat "$ffi_log" "$node_log" >> "$log" 2>/dev/null
+  if [ "$status" = FAIL ]; then
     echo "--- [$name] FAILED; last 40 lines of $log ---"
     tail -40 "$log"
     echo "--- end of $name output ---"
@@ -11681,6 +12074,7 @@ dispatch_component() {
     feature-iso-delta-scan) run_component feature-iso-delta-scan run_feature_iso delta-scan ;;
     python-bindings) run_python_bindings ;;
     node-bindings) run_node_bindings ;;
+    binding-rust-tests) run_binding_rust_tests ;;
     delivery-telemetry) run_delivery_telemetry ;;
     oom-audit) run_oom_audit ;;
     parity-report) run_parity_report ;;

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -5456,6 +5456,68 @@ check_jest_suites_ran() {
 }
 export -f check_jest_suites_ran
 
+# NB_TEST_ANCHOR — the ONE path anchor every node-suite normalisation uses (issue #3522,
+# roborev round 6 G1). Referenced by _jest_json_suite_counts's two implementations AND by the
+# two `sed` normalisations in run_node_bindings, so the four cannot drift.
+#
+# WHY IT IS THREE COMPONENTS AND NOT `/__test__/`. The short anchor was AMBIGUOUS, and the two
+# implementations resolved the ambiguity DIFFERENTLY: jq's `sub("^.*/__test__/"; "")` is greedy
+# (strips at the LAST occurrence) and so is `sed 's#.*/__test__/##'`, while python's
+# `n.find("/__test__/")` took the FIRST. On a python3-only host whose CHECKOUT PATH itself
+# contains a `__test__` directory, every suite is then reported missing and extra at once — a
+# FALSE RED on a correct tree, which is the direction that teaches agents to waive a lane. It is
+# latent wherever jq exists, so no run on a jq-equipped box can see it.
+#
+# Fixed by removing the ambiguity rather than picking a side: the anchor now names three path
+# components, which cannot plausibly recur inside a checkout prefix, AND every implementation
+# uses LAST-occurrence semantics on it. Same rule, same anchor, four places.
+NB_TEST_ANCHOR='/bindings/node/__test__/'
+
+# _jest_json_suite_counts <json-file> — print `<suite-path-relative-to-__test__>\t<passed-count>`
+# per suite from a jest `--json` report.
+#
+# SPLIT INTO TWO NAMED IMPLEMENTATIONS ON PURPOSE. CLAUDE.md records the rule this defect broke:
+# "a port is a second implementation, and a second implementation's correctness is only knowable
+# by differential testing against the original" (#3283 — a bash port of Go's exclusion logic
+# whose NBSP divergence was unfindable by care, because it was tested against a MODEL of the
+# original rather than the original). A jq branch and a python3 branch are exactly that, and
+# they had diverged. Naming them separately is what lets a self-test drive BOTH over one fixture
+# set and assert byte-identical output — differential testing against the original, not against
+# a model of it. It is NOT a test seam (#3312): the dispatcher's behaviour is unchanged and
+# nothing selects an implementation by variable.
+_jest_json_suite_counts_jq() { # <json-file>
+  jq -r --arg a "$NB_TEST_ANCHOR" '
+    .testResults[]?
+    | [ (.name | if index($a) then sub("^.*" + $a; "") else . end),
+        ([ .assertionResults[]? | select(.status == "passed") ] | length) ]
+    | @tsv' "$1"
+}
+_jest_json_suite_counts_py() { # <json-file>
+  python3 -c '
+import json, sys
+path, anchor = sys.argv[1], sys.argv[2]
+with open(path) as fh:
+    d = json.load(fh)
+for r in d.get("testResults") or []:
+    n = r.get("name") or ""
+    # rfind: LAST occurrence, matching jq'"'"'s greedy `^.*` and sed'"'"'s greedy `.*` (G1).
+    i = n.rfind(anchor)
+    rel = n[i + len(anchor):] if i >= 0 else n
+    p = sum(1 for a in (r.get("assertionResults") or []) if a.get("status") == "passed")
+    print("%s\t%d" % (rel, p))
+' "$1" "$NB_TEST_ANCHOR"
+}
+_jest_json_suite_counts() { # <json-file>
+  if command -v jq >/dev/null 2>&1; then
+    _jest_json_suite_counts_jq "$1"
+  elif command -v python3 >/dev/null 2>&1; then
+    _jest_json_suite_counts_py "$1"
+  else
+    printf '__PARSE_NO_TOOL__'
+    return 0
+  fi
+}
+
 # check_jest_per_suite_passed <label> <json-file> <reconciled-set-file>
 #
 # THE PER-SUITE half of the jest affirmative measurement (issue #3522, roborev round 5 F1).
@@ -5493,25 +5555,12 @@ check_jest_per_suite_passed() {
     echo "$label: FAIL-CLOSED — the reconciled suite set '$expected_file' is missing or unreadable, so this guard has no SUBJECT. A guard with an empty subject set reports OK having measured nothing (issue #3522)" >&2
     return 1
   fi
-  # jq FIRST, then python3, then a FAILED derivation — the same chain and the same direction as
-  # every other metadata helper here. A single-parser guard is a false red on a host that has
-  # only the other one, and this gate treats macOS as a first-class host.
+  # The parse is DELEGATED to _jest_json_suite_counts, whose two implementations are
+  # differentially tested against each other over a shared fixture set
+  # (scripts/tests/test_agent_gate_parser_parity.sh). See its header for why that matters.
   local counts=""
-  if command -v jq >/dev/null 2>&1; then
-    counts=$(jq -r '.testResults[]? | [ (.name | sub("^.*/__test__/"; "")), ([ .assertionResults[]? | select(.status == "passed") ] | length) ] | @tsv' "$json") || counts="__PARSE_FAILED__"
-  elif command -v python3 >/dev/null 2>&1; then
-    counts=$(python3 -c '
-import json, sys
-with open(sys.argv[1]) as fh:
-    d = json.load(fh)
-for r in d.get("testResults") or []:
-    n = r.get("name") or ""
-    i = n.find("/__test__/")
-    rel = n[i + len("/__test__/"):] if i >= 0 else n
-    p = sum(1 for a in (r.get("assertionResults") or []) if a.get("status") == "passed")
-    print("%s\t%d" % (rel, p))
-' "$json") || counts="__PARSE_FAILED__"
-  else
+  counts=$(_jest_json_suite_counts "$json") || counts="__PARSE_FAILED__"
+  if [ "$counts" = "__PARSE_NO_TOOL__" ]; then
     echo "$label: FAIL-CLOSED — neither jq nor python3 is available to read jest's --json report, so the PER-SUITE measurement cannot be taken. An unparseable oracle is not a pass (issue #3522, roborev F1)" >&2
     return 1
   fi
@@ -5665,49 +5714,67 @@ for p in d["packages"]:
 #
 # Same parser chain and same direction as its neighbours: jq, else python3, else a
 # FAILED derivation. Never a fallback to a partial or empty census.
-_package_integration_target_ids() {
-  local pkg="$1"
-  local meta present out
-  meta=$(cargo metadata --format-version 1 --no-deps 2>/dev/null) || return 1
-  [ -n "$meta" ] || return 1
-  if command -v jq >/dev/null 2>&1; then
-    # PRESENCE first: without it, an unknown/renamed package would print nothing and
-    # be reported as "declares no integration targets" — a false all-clear about a
-    # package the lane cannot see at all.
-    present=$(printf '%s' "$meta" | jq -r --arg n "$pkg" '[.packages[] | select(.name == $n)] | length') || return 1
-    [ "$present" = 1 ] || return 1
-    out=$(printf '%s' "$meta" | jq -r --arg n "$pkg" \
-      '.packages[] | select(.name == $n)
-       | ((.manifest_path // "") | split("/") | .[0:-1] | join("/")) as $root
-       | .targets[]
-       | select(.kind | index("test"))
-       | ((.src_path // "")) as $sp
-       | (if ($root != "" and ($sp | startswith($root + "/")))
-          then ($sp | ltrimstr($root + "/")) else $sp end) as $rel
-       | (if ($rel | startswith("tests/")) then ($rel | ltrimstr("tests/")) else $rel end) as $rel2
-       | (if ($rel2 | endswith(".rs")) then ($rel2 | .[0:-3]) else $rel2 end) as $id
-       | [.name, $id, ((."required-features" // []) | join(","))] | @tsv') || return 1
-  elif command -v python3 >/dev/null 2>&1; then
-    out=$(printf '%s' "$meta" | python3 -c '
-import json, os, sys
+# SPLIT INTO NAMED IMPLEMENTATIONS (issue #3522, roborev round 6 G1 sweep) for the reason on
+# _jest_json_suite_counts: a jq branch and a python3 branch are two implementations of one
+# transformation, and "correctness only knowable by differential testing against the original"
+# applies to every such pair, not only to the one that was found divergent. Naming them is what
+# lets scripts/tests/test_agent_gate_parser_parity.sh drive BOTH over one fixture set and assert
+# byte-identical output. Each takes the metadata JSON as an ARGUMENT rather than calling cargo,
+# which is what makes a fixture possible at all.
+_package_integration_target_ids_jq() { # <meta-json> <pkg>
+  local meta="$1" pkg="$2" present
+  # PRESENCE first: without it, an unknown/renamed package would print nothing and be
+  # reported as "declares no integration targets" — a false all-clear about a package the
+  # lane cannot see at all.
+  present=$(printf '%s' "$meta" | jq -r --arg n "$pkg" '[.packages[] | select(.name == $n)] | length') || return 1
+  [ "$present" = 1 ] || return 1
+  printf '%s' "$meta" | jq -r --arg n "$pkg" \
+    '.packages[] | select(.name == $n)
+     | ((.manifest_path // "") | split("/") | .[0:-1] | join("/")) as $root
+     | (.targets // [])[]
+     | select((.kind // []) | index("test"))
+     | ((.src_path // "")) as $sp
+     | (if ($root != "" and ($sp | startswith($root + "/")))
+        then ($sp | ltrimstr($root + "/")) else $sp end) as $rel
+     | (if ($rel | startswith("tests/")) then ($rel | ltrimstr("tests/")) else $rel end) as $rel2
+     | (if ($rel2 | endswith(".rs")) then ($rel2 | .[0:-3]) else $rel2 end) as $id
+     | [.name, $id, (((."required-features" // [])) | join(","))] | @tsv'
+}
+_package_integration_target_ids_py() { # <meta-json> <pkg>
+  printf '%s' "$1" | python3 -c '
+import json, sys
 pkg = sys.argv[1]
 d = json.load(sys.stdin)
 pkgs = [p for p in d.get("packages", []) if p.get("name") == pkg]
 if len(pkgs) != 1:
     sys.exit(1)
 p = pkgs[0]
-root = os.path.dirname(p.get("manifest_path", ""))
-for t in p.get("targets", []):
+mp = p.get("manifest_path", "") or ""
+# `/`-split dirname, matching jq exactly. os.path.dirname was the previous form and is
+# platform-dependent; cargo metadata paths are always `/`-separated, and using os.sep here
+# would be a second rule the jq branch does not share (G1 sweep).
+root = mp.rsplit("/", 1)[0] if "/" in mp else ""
+for t in p.get("targets", []) or []:
     if "test" not in (t.get("kind") or []):
         continue
     sp = t.get("src_path") or ""
-    rel = sp[len(root) + 1:] if root and sp.startswith(root + os.sep) else sp
+    rel = sp[len(root) + 1:] if root and sp.startswith(root + "/") else sp
     if rel.startswith("tests/"):
         rel = rel[len("tests/"):]
     if rel.endswith(".rs"):
         rel = rel[:-3]
-    print("%s\t%s\t%s" % (t["name"], rel, ",".join(t.get("required-features") or [])))
-' "$pkg") || return 1
+    print("%s\t%s\t%s" % (t.get("name") or "", rel, ",".join(t.get("required-features") or [])))
+' "$2"
+}
+_package_integration_target_ids() {
+  local pkg="$1"
+  local meta out
+  meta=$(cargo metadata --format-version 1 --no-deps 2>/dev/null) || return 1
+  [ -n "$meta" ] || return 1
+  if command -v jq >/dev/null 2>&1; then
+    out=$(_package_integration_target_ids_jq "$meta" "$pkg") || return 1
+  elif command -v python3 >/dev/null 2>&1; then
+    out=$(_package_integration_target_ids_py "$meta" "$pkg") || return 1
   else
     return 1
   fi
@@ -6248,7 +6315,9 @@ run_node_bindings() {
   # LISTED BY JEST — a silent config exclusion" and send the reader to jest.config.js, when in
   # fact the normalisation pipeline failed. That is the "verdict is right, remedy is useless"
   # defect the flight lane's fixture preflight records; a distinct named cause is the fix.
-  if ! sed -n 's#.*/__test__/##p' "$list_file" | grep '\.test\.js$' | sort -u > "$jest_set"; then
+  # Same anchor and same LAST-occurrence rule as _jest_json_suite_counts (G1): four
+  # normalisations, one definition, so they cannot resolve an ambiguity differently again.
+  if ! sed -n "s#.*${NB_TEST_ANCHOR}##p" "$list_file" | grep '\.test\.js$' | sort -u > "$jest_set"; then
     status=FAIL
     {
       echo "[$name] FAIL-CLOSED: could not normalise jest's --listTests output into a comparable"
@@ -6290,7 +6359,7 @@ run_node_bindings() {
   # as "LISTED BY JEST but NOT FOUND ON DISK" and send the reader to testMatch, when the
   # inventory pipeline is what failed.
   if ! find -H "$_nb_test_dir" -type d -name node_modules -prune -o -type f -name '*.test.js' -print0 2>/dev/null \
-    | tr '\0' '\n' | sed -n 's#.*/__test__/##p' | sort -u > "$disk_set"; then
+    | tr '\0' '\n' | sed -n "s#.*${NB_TEST_ANCHOR}##p" | sort -u > "$disk_set"; then
     status=FAIL
     {
       echo "[$name] FAIL-CLOSED: the independent suite inventory pipeline failed (find/tr/sed/sort"
@@ -6477,27 +6546,36 @@ _brt_partition_targets() { # <target-meta> <enabled-set>
 # (_resolved_package_features) from this DECLARED set is how the lane states, as a
 # derived fact rather than a curated sentence, which of a binding crate's features it
 # leaves off — and therefore which `#[cfg(feature = ...)]` test bodies it does not run.
-_package_declared_features() {
-  local pkg="$1"
-  local meta present out
-  meta=$(cargo metadata --format-version 1 --no-deps 2>/dev/null) || return 1
-  [ -n "$meta" ] || return 1
-  if command -v jq >/dev/null 2>&1; then
-    present=$(printf '%s' "$meta" | jq -r --arg n "$pkg" '[.packages[] | select(.name == $n)] | length') || return 1
-    [ "$present" = 1 ] || return 1
-    out=$(printf '%s' "$meta" | jq -r --arg n "$pkg" \
-      '.packages[] | select(.name == $n) | (.features // {}) | keys[]') || return 1
-  elif command -v python3 >/dev/null 2>&1; then
-    out=$(printf '%s' "$meta" | python3 -c '
+_package_declared_features_jq() { # <meta-json> <pkg>
+  local meta="$1" pkg="$2" present
+  present=$(printf '%s' "$meta" | jq -r --arg n "$pkg" '[.packages[] | select(.name == $n)] | length') || return 1
+  [ "$present" = 1 ] || return 1
+  printf '%s' "$meta" | jq -r --arg n "$pkg" \
+    '.packages[] | select(.name == $n) | (.features // {}) | keys[]'
+}
+_package_declared_features_py() { # <meta-json> <pkg>
+  printf '%s' "$1" | python3 -c '
 import json, sys
 pkg = sys.argv[1]
 d = json.load(sys.stdin)
 pkgs = [p for p in d.get("packages", []) if p.get("name") == pkg]
 if len(pkgs) != 1:
     sys.exit(1)
+# jq'"'"'s `keys` sorts by unicode codepoint; python'"'"'s sorted() on str does the same, so the two
+# orderings agree. Asserted by differential test rather than assumed (G1 sweep).
 for f in sorted((pkgs[0].get("features") or {}).keys()):
     print(f)
-' "$pkg") || return 1
+' "$2"
+}
+_package_declared_features() {
+  local pkg="$1"
+  local meta out
+  meta=$(cargo metadata --format-version 1 --no-deps 2>/dev/null) || return 1
+  [ -n "$meta" ] || return 1
+  if command -v jq >/dev/null 2>&1; then
+    out=$(_package_declared_features_jq "$meta" "$pkg") || return 1
+  elif command -v python3 >/dev/null 2>&1; then
+    out=$(_package_declared_features_py "$meta" "$pkg") || return 1
   else
     return 1
   fi
@@ -11080,6 +11158,29 @@ run_tooling_tests() {
      ! bash "$REPO_ROOT/scripts/tests/test_tools_crate_disposition_selftest.sh" >>"$log" 2>&1; then
     status=FAIL
     echo "--- [$name] FAILED (tools/ crate disposition census #1716); last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
+  # jq/python3 PARSER PARITY differential test (#3522, roborev G1): drives BOTH branches of
+  # every parser pair this lane added over ONE fixture set and requires byte-identical output
+  # AND identical exit status. The defect it exists for: _jest_json_suite_counts's jq branch
+  # stripped at the LAST `/__test__/` and its python3 branch at the FIRST, so on a python3-only
+  # host whose checkout path contains a `__test__` directory every suite was reported missing
+  # and extra at once — a FALSE RED on a correct tree, latent on every box that has jq. Per
+  # CLAUDE.md's #3283 rule, a port's correctness is only knowable by differential testing
+  # against the ORIGINAL, which is what this does rather than re-deriving expected output.
+  # It EXITS 2 (reported, not silently passed) when only one of jq/python3 is present, since a
+  # parity claim over a comparison that never ran is a vacuous green — so the component treats
+  # a non-zero exit as FAIL and an UNMEASURED run is visible rather than green.
+  echo ">>> [$name] bash scripts/tests/test_agent_gate_parser_parity.sh"
+  if ! bash "$REPO_ROOT/scripts/tests/test_agent_gate_parser_parity.sh" >>"$log" 2>&1; then
+    status=FAIL
+    echo "--- [$name] FAILED (jq/python3 parser parity #3522); last 40 lines of $log ---"
     tail -40 "$log"
     echo "--- end of $name output ---"
     end=$(date +%s)

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6315,7 +6315,20 @@ run_binding_rust_tests() {
     case "$node_enabled" in *" $_f "*) ;; *) node_off="$node_off $_f" ;; esac
   done
 
-  # The unittest subject sets. `lib,cdylib,bin` rather than `lib,bin`: cqlite-node's
+  # The unittest subject sets.
+  #
+  # cqlite-ffi-common: `lib,bin`, NOT `lib` (roborev round 3, D2). The invocation is an
+  # UNFILTERED `cargo test -p cqlite-ffi-common`, and cargo's default selection includes
+  # package BINARY unit targets — so deriving only `lib` made the affirmative guard's subject
+  # set NARROWER THAN WHAT ACTUALLY RUNS: a bin added later could execute zero tests and
+  # never be checked. That is the same property the rest of this lane is built on (an
+  # affirmative measurement must cover the whole subject), failing in miniature. The package
+  # has no bin today, so this is a no-op now and correct the moment that changes — which is
+  # the entire point of deriving rather than listing. Deliberately NOT fixed by naming the
+  # derived targets on the cargo command line: that would make the invocation a curated list
+  # again, which is the thing this component exists not to be.
+  #
+  # cqlite-node: `lib,cdylib,bin` rather than `lib,bin`:
   # library target has kind `cdylib` (it is a napi module), and a `lib,bin` filter
   # returns NOTHING for it — which _package_unittest_srcs correctly reports as a failed
   # derivation, and which a lane that shrugged at would turn into a guard with no
@@ -6323,7 +6336,7 @@ run_binding_rust_tests() {
   local -a ffi_unit_srcs=() node_unit_srcs=()
   local _us
   while IFS= read -r _us; do [ -n "$_us" ] && ffi_unit_srcs+=("$_us"); done <<EOF
-$(_package_unittest_srcs cqlite-ffi-common lib "$ffi_enabled")
+$(_package_unittest_srcs cqlite-ffi-common lib,bin "$ffi_enabled")
 EOF
   while IFS= read -r _us; do [ -n "$_us" ] && node_unit_srcs+=("$_us"); done <<EOF
 $(_package_unittest_srcs cqlite-node lib,cdylib,bin "$node_enabled")

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -154,7 +154,8 @@
 #                      --only/--lite stay lenient and the #2078 opt-out is honoured,
 #                      with the mode PRINTED. check_jest_suites_ran is
 #                      the affirmative guard: the reported suite total must equal the
-#                      set DERIVED FROM JEST ITSELF (`npx jest --listTests`, never a
+#                      set DERIVED FROM JEST ITSELF (`./node_modules/.bin/jest
+#                      --listTests`, never a
 #                      find over testMatch), no suite may be failed or skipped, and the
 #                      passed-test count must be non-zero (a suite whose every TEST is
 #                      `test.skip`ped is reported as a PASSED suite — the suite-level
@@ -5837,8 +5838,8 @@ run_python_bindings() {
 # AFFIRMATIVE MEASUREMENT, not a green exit code (the same rule as the Rust lanes).
 # jest reports a suite whose every describe was skipped as PASSED, so `npm test`
 # exiting 0 does not establish that anything ran. check_jest_suites_ran requires the
-# reported total to equal the suite set DERIVED FROM JEST ITSELF (`npx jest
-# --listTests`), requires no suite to have failed or been skipped, and requires a
+# reported total to equal the suite set DERIVED FROM JEST ITSELF
+# (`./node_modules/.bin/jest --listTests`), requires no suite to have failed or been skipped, and requires a
 # non-zero count of PASSED tests. The oracle is jest and not a `find`, for the same
 # reason `_package_test_targets` uses cargo metadata rather than parsing `[[test]]`
 # stanzas: a find would re-implement this package's RECURSIVE `testMatch` plus jest's
@@ -5867,6 +5868,14 @@ run_node_bindings() {
     record_result "$name" "$status" 0
     return 0
   fi
+  # `npx` is DELIBERATELY NOT in that predicate, and the suite-derivation below
+  # deliberately does not use it (roborev round 1, B7). An earlier cut ran
+  # `npx jest --listTests`, so on a host with node+npm but no `npx` shim a MISSING
+  # TOOLCHAIN became a hard FAIL — contradicting this component's own "SKIPs, never
+  # silently PASSes" contract. The fix is not to widen the predicate but to stop needing
+  # the shim: `./node_modules/.bin/jest` is what `npm ci` has just installed, it is the
+  # same binary, and it removes a network-capable `npx` package resolution from the gate
+  # path entirely.
   # Strict-fixture mode on the FULL gate only, honouring the documented #2078 opt-out.
   # See the scope note above for why enrollment in DATASET_COMPONENTS is not enough.
   # ENFORCED WITH `env -u`, NOT MERELY BY OMITTING THE ASSIGNMENT (roborev round 1, B2;
@@ -5921,7 +5930,7 @@ run_node_bindings() {
 
   # STEP 1 — install, build, and DERIVE the suite set FROM JEST ITSELF.
   #
-  # `npx jest --listTests` (0.9s) is the oracle, deliberately NOT a `find` over
+  # `./node_modules/.bin/jest --listTests` (0.9s) is the oracle, deliberately NOT a `find` over
   # `__test__/*.test.js`. A find would be a SECOND IMPLEMENTATION of this package's
   # `testMatch` (`**/__test__/**/*.test.js` — RECURSIVE) plus jest's default
   # `testPathIgnorePatterns`, and its correctness would only be knowable by
@@ -5940,7 +5949,7 @@ run_node_bindings() {
       cd "'"$REPO_ROOT"'/bindings/node"
       if [ -f package-lock.json ]; then npm ci; else npm install; fi
       npm run build
-      npx jest --listTests > "$CQLITE_LIST_FILE"' >>"$log" 2>&1; then
+      ./node_modules/.bin/jest --listTests > "$CQLITE_LIST_FILE"' >>"$log" 2>&1; then
     status=FAIL
     echo "--- [$name] FAILED (npm ci / npm run build / jest --listTests); last 40 lines of $log ---"
     tail -40 "$log"
@@ -5953,7 +5962,7 @@ run_node_bindings() {
   if [ ! -r "$list_file" ]; then
     status=FAIL
     {
-      echo "[$name] FAIL-CLOSED: 'npx jest --listTests' left no readable list at $list_file,"
+      echo "[$name] FAIL-CLOSED: './node_modules/.bin/jest --listTests' left no readable list at $list_file,"
       echo "        so the expected suite count could not be DERIVED and the affirmative guard"
       echo "        would have no subject (issue #3522)."
     } | tee -a "$log"
@@ -5969,7 +5978,7 @@ run_node_bindings() {
   if [ "$suite_n" -eq 0 ]; then
     status=FAIL
     {
-      echo "[$name] FAIL-CLOSED: 'npx jest --listTests' named ZERO *.test.js suites."
+      echo "[$name] FAIL-CLOSED: './node_modules/.bin/jest --listTests' named ZERO *.test.js suites."
       echo "        The DERIVATION failed (or the suite vanished), and a guard expecting zero"
       echo "        suites would report OK having measured nothing (issue #3522)."
     } | tee -a "$log"
@@ -5978,8 +5987,8 @@ run_node_bindings() {
     echo ">>> [$name] $status ($((end - start))s)"
     return 0
   fi
-  echo ">>> [$name] derived suite set: $suite_n *.test.js file(s) (oracle: npx jest --listTests, not a find over testMatch)"
-  echo "derived suite set: $suite_n *.test.js file(s) (oracle: npx jest --listTests)" >> "$log"
+  echo ">>> [$name] derived suite set: $suite_n *.test.js file(s) (oracle: ./node_modules/.bin/jest --listTests, not a find over testMatch)"
+  echo "derived suite set: $suite_n *.test.js file(s) (oracle: ./node_modules/.bin/jest --listTests)" >> "$log"
 
   # STEP 2 — run them.
   # `env "${fixture_env[@]}"` FIRST, because `env`'s -u options must precede any
@@ -6335,11 +6344,25 @@ EOF
   census+=("     half IS fully covered, by the python-bindings component.")
   census+=("  2. cqlite-node's JavaScript suite. Owned by the node-bindings component, which builds")
   census+=("     the napi artifact and runs jest against it. This lane never builds that artifact.")
-  census+=("  3. NOTHING, on the cqlite-node integration half — it is EXECUTED, not omitted. The")
-  census+=("     count is DERIVED from cargo metadata ($node_targets_n declared, $node_expect_n runnable here) and")
-  census+=("     every runnable one is passed to cargo as an explicit --test, so a target added")
-  census+=("     tomorrow is RUN, not merely counted (roborev B1: counting-without-running would be")
-  census+=("     #3522's own defect reproduced inside the fix for #3522).")
+  # BRANCHED ON THE DERIVED NUMBER (roborev round 1, B5). This clause used to be emitted
+  # unconditionally and read "it declares $node_targets_n — at $node_targets_n there is nothing to
+  # omit; if that number ever rises without this lane running them, this line is the
+  # alarm". At a non-zero value that is a SELF-CONTRADICTING sentence in the one output
+  # whose entire job is to declare omissions, with the alarm sounding the all-clear. A
+  # census sentence must be true at EVERY value of the number it quotes.
+  if [ "$node_targets_n" -eq 0 ]; then
+    census+=("  3. cqlite-node declares 0 integration (test) targets — DERIVED from cargo metadata,")
+    census+=("     not assumed. Nothing to run and nothing to omit. Should it ever declare one, the")
+    census+=("     derived --test list below EXECUTES it with no gate edit.")
+  elif [ "$node_expect_n" -eq "$node_targets_n" ]; then
+    census+=("  3. NOTHING on the cqlite-node integration half: all $node_targets_n declared target(s) are")
+    census+=("     EXECUTED, each passed to cargo as an explicit --test (DERIVED, never listed).")
+  else
+    census+=("  3. NOT RUN: $((node_targets_n - node_expect_n)) of cqlite-node's $node_targets_n declared integration target(s) —")
+    census+=("     cargo cannot enable their required-features at this lane's feature set, so it would")
+    census+=("     skip them SILENTLY (no banner at all). Each is named under 6. below. The other")
+    census+=("     $node_expect_n are EXECUTED as explicit --test targets.")
+  fi
   census+=("  4. Feature-gated bodies at features this lane leaves OFF (declared-minus-enabled,")
   census+=("     derived): cqlite-ffi-common ->${ffi_off:- <none: this crate declares no features>};")
   census+=("     cqlite-node ->${node_off:- <none>}. 'observability' is off ON PURPOSE — building the")

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -149,8 +149,9 @@
 #                      describe.skip; --only/--lite stay lenient and the #2078 opt-out
 #                      is honoured, with the mode PRINTED. check_jest_suites_ran is
 #                      the affirmative guard: the reported suite total must equal the
-#                      count of __test__/*.test.js DERIVED FROM DISK, no suite may be
-#                      failed or skipped, and the passed-test count must be non-zero
+#                      set DERIVED FROM JEST ITSELF (`npx jest --listTests`, never a
+#                      find over testMatch), no suite may be failed or skipped, and the
+#                      passed-test count must be non-zero
 #                      (jest reports an all-skipped suite as PASSED). cqlite-node's
 #                      RUST unit tests are binding-rust-tests' subject, deliberately
 #                      NOT behind this component's SKIP.
@@ -5812,9 +5813,13 @@ run_python_bindings() {
 # AFFIRMATIVE MEASUREMENT, not a green exit code (the same rule as the Rust lanes).
 # jest reports a suite whose every describe was skipped as PASSED, so `npm test`
 # exiting 0 does not establish that anything ran. check_jest_suites_ran requires the
-# reported total to equal the count of `__test__/*.test.js` files DERIVED FROM DISK,
-# requires no suite to have failed or been skipped, and requires a non-zero count of
-# PASSED tests.
+# reported total to equal the suite set DERIVED FROM JEST ITSELF (`npx jest
+# --listTests`), requires no suite to have failed or been skipped, and requires a
+# non-zero count of PASSED tests. The oracle is jest and not a `find`, for the same
+# reason `_package_test_targets` uses cargo metadata rather than parsing `[[test]]`
+# stanzas: a find would re-implement this package's RECURSIVE `testMatch` plus jest's
+# default ignore patterns, and it would agree at 27 today while silently undercounting
+# the day someone adds a subdirectory — a false red on healthy code.
 #
 # RUN_SLOW_TESTS is forwarded exactly as python-bindings forwards it (default 0). Two
 # tests opt into it (publish.test.js's `npm pack --dry-run`, streaming.test.js's
@@ -5838,42 +5843,6 @@ run_node_bindings() {
     record_result "$name" "$status" 0
     return 0
   fi
-  # The expected suite count, DERIVED FROM DISK at run time so a new
-  # `__test__/*.test.js` is covered with no gate edit — the property the old
-  # single-file filter could never have. A failed derivation is a FAIL naming the
-  # derivation, never a guard with no subject.
-  local test_dir="$REPO_ROOT/bindings/node/__test__" suite_n=""
-  if [ ! -d "$test_dir" ] || [ ! -r "$test_dir" ]; then
-    status=FAIL
-    {
-      echo "[$name] FAIL-CLOSED: bindings/node/__test__ is missing or unreadable, so the"
-      echo "        expected jest suite count cannot be DERIVED and the affirmative guard"
-      echo "        would have no subject (issue #3522)."
-    } | tee "$log"
-    end=$(date +%s)
-    record_result "$name" "$status" "$((end - start))"
-    echo ">>> [$name] $status ($((end - start))s)"
-    return 0
-  fi
-  # `find`, not a glob: a glob's meaning depends on ambient shell options this script
-  # never sets (nullglob/failglob), both reachable through BASHOPTS.
-  suite_n=$(find -H "$test_dir" -maxdepth 1 -type f -name '*.test.js' 2>/dev/null | grep -c . || true)
-  case "$suite_n" in
-    ''|*[!0-9]*) suite_n=0 ;;
-  esac
-  if [ "$suite_n" -eq 0 ]; then
-    status=FAIL
-    {
-      echo "[$name] FAIL-CLOSED: found 0 '*.test.js' files under bindings/node/__test__."
-      echo "        The COUNT failed (or the suite vanished), and a guard expecting zero"
-      echo "        suites would report OK having measured nothing (issue #3522)."
-    } | tee "$log"
-    end=$(date +%s)
-    record_result "$name" "$status" "$((end - start))"
-    echo ">>> [$name] $status ($((end - start))s)"
-    return 0
-  fi
-
   # Strict-fixture mode on the FULL gate only, honouring the documented #2078 opt-out.
   # See the scope note above for why enrollment in DATASET_COMPONENTS is not enough.
   local require_fixtures=0 fixture_note
@@ -5887,7 +5856,7 @@ run_node_bindings() {
   fi
 
   local -a census=()
-  census+=("npm ci + npm run build + npm test — the WHOLE jest suite ($suite_n files, derived from disk), #3522")
+  census+=("npm ci + npm run build + npm test — the WHOLE jest suite, #3522")
   census+=("  supersedes the #1255 narrowing to 1 of 27 files; node-ci.yml is required-EXEMPT on the")
   census+=("  grounds that THIS component is the merge-gating half, which was true of 1 file in 27.")
   census+=("  fixtures: $fixture_note")
@@ -5905,13 +5874,70 @@ run_node_bindings() {
     echo "==== end census ===="
   } > "$log"
 
+  # STEP 1 — install, build, and DERIVE the suite set FROM JEST ITSELF.
+  #
+  # `npx jest --listTests` (0.9s) is the oracle, deliberately NOT a `find` over
+  # `__test__/*.test.js`. A find would be a SECOND IMPLEMENTATION of this package's
+  # `testMatch` (`**/__test__/**/*.test.js` — RECURSIVE) plus jest's default
+  # `testPathIgnorePatterns`, and its correctness would only be knowable by
+  # differential testing against the original. Measured: a `-maxdepth 1` find agrees at
+  # 27 TODAY and would silently UNDERCOUNT the day someone adds a subdirectory — turning
+  # the affirmative guard below into a false red on healthy code, which is the verdict
+  # agents learn to waive. Same rule as `_package_test_targets` preferring cargo
+  # metadata over parsing `[[test]]` stanzas.
+  local list_file="$LOG_DIR/$name.listtests.txt" suite_n=""
+  if ! CQLITE_LIST_FILE="$list_file" bash -c '
+      set -euo pipefail
+      cd "'"$REPO_ROOT"'/bindings/node"
+      if [ -f package-lock.json ]; then npm ci; else npm install; fi
+      npm run build
+      npx jest --listTests > "$CQLITE_LIST_FILE"' >>"$log" 2>&1; then
+    status=FAIL
+    echo "--- [$name] FAILED (npm ci / npm run build / jest --listTests); last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+  if [ ! -r "$list_file" ]; then
+    status=FAIL
+    {
+      echo "[$name] FAIL-CLOSED: 'npx jest --listTests' left no readable list at $list_file,"
+      echo "        so the expected suite count could not be DERIVED and the affirmative guard"
+      echo "        would have no subject (issue #3522)."
+    } | tee -a "$log"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+  suite_n=$(grep -c '\.test\.js$' "$list_file" || true)
+  case "$suite_n" in
+    ''|*[!0-9]*) suite_n=0 ;;
+  esac
+  if [ "$suite_n" -eq 0 ]; then
+    status=FAIL
+    {
+      echo "[$name] FAIL-CLOSED: 'npx jest --listTests' named ZERO *.test.js suites."
+      echo "        The DERIVATION failed (or the suite vanished), and a guard expecting zero"
+      echo "        suites would report OK having measured nothing (issue #3522)."
+    } | tee -a "$log"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+  echo ">>> [$name] derived suite set: $suite_n *.test.js file(s) (oracle: npx jest --listTests, not a find over testMatch)"
+  echo "derived suite set: $suite_n *.test.js file(s) (oracle: npx jest --listTests)" >> "$log"
+
+  # STEP 2 — run them.
   if CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT" \
      RUN_SLOW_TESTS="${RUN_SLOW_TESTS:-0}" \
      CQLITE_REQUIRE_FIXTURES_ARG="$require_fixtures" bash -c '
       set -euo pipefail
       cd "'"$REPO_ROOT"'/bindings/node"
-      if [ -f package-lock.json ]; then npm ci; else npm install; fi
-      npm run build
       if [ "$CQLITE_REQUIRE_FIXTURES_ARG" = 1 ]; then export CQLITE_REQUIRE_FIXTURES=1; fi
       npm test' >>"$log" 2>&1; then
     # A green `npm test` is NOT sufficient: jest reports a suite whose every describe

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -12676,10 +12676,42 @@ DATASET_COMPONENTS="core-tests tombstones-scan scan-offload-guard work-counters-
 # With no --only, every component runs, so it's always true. With --only, it's true
 # only when the selection intersects DATASET_COMPONENTS — so e.g. `--only
 # tooling-tests` or `--only fmt` skips the (dataset-requiring) preflight entirely.
+# _component_will_skip_for_toolchain <component> — true when a SKIP-AWARE component is going to
+# SKIP anyway because its toolchain is absent (issue #3522, roborev round 7 H2).
+#
+# THE DEFECT IT EXISTS FOR. Enrolling node-bindings in DATASET_COMPONENTS (correct — 14 of its
+# jest suites read the corpus) meant `--only node-bindings` on a fixture-less host exited during
+# the GLOBAL DATASET PREFLIGHT, before the component could perform its documented
+# node/npm-missing SKIP. A widening that made the component stricter thereby made a documented
+# escape hatch UNREACHABLE — the same family as C2, where the same widening had made the #2078
+# opt-out ineffective.
+#
+# The ORDERING is the fix, not an exclusion list: a component that is going to SKIP for a
+# missing toolchain should never have been subject to a FIXTURE requirement in the first place.
+# Fixtures are an input to work that will not happen.
+#
+# Deliberately NARROW. It answers only "is this component's TOOLCHAIN absent", never "should
+# this component run" — the corpus question stays with the preflight, and a component whose
+# toolchain IS present is still fully subject to it. Each entry mirrors that component's OWN
+# SKIP predicate, and the two must be changed together; there is no way to derive one from the
+# other in shell, so this is a recorded pairing, like the census guards elsewhere in this file.
+_component_will_skip_for_toolchain() {
+  case "$1" in
+    node-bindings)   ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1 ;;
+    python-bindings) ! command -v python3 >/dev/null 2>&1 ;;
+    *) return 1 ;;
+  esac
+}
+
 selected_needs_datasets() {
   [ -z "$ONLY" ] && return 0
   local sel comp
   for sel in ${ONLY//,/ }; do
+    # A component that will SKIP for a missing toolchain contributes NO dataset requirement:
+    # it is not going to read a fixture, so demanding one would fail the run before its
+    # documented SKIP could be reported (H2). Checked per SELECTED component, so a selection
+    # mixing a skipping component with a real dataset consumer still requires the corpus.
+    _component_will_skip_for_toolchain "$sel" && continue
     for comp in $DATASET_COMPONENTS; do
       [ "$sel" = "$comp" ] && return 0
     done

--- a/scripts/tests/test_agent_gate_binding_partition.sh
+++ b/scripts/tests/test_agent_gate_binding_partition.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Self-test for _brt_partition_targets, the binding-rust-tests lane's integration-target
+# partitioner (issue #3522, roborev round 2 C3).
+#
+# WHAT IT COVERS AND WHY IT EXISTS. The helper splits a package's DERIVED integration
+# targets into the ones cargo can run at the lane's feature set and the ones it will
+# SILENTLY skip for an unmet `required-features`. Its output is read back with a single
+# `read` into three variables, and that read is where C3 lived: with a TAB delimiter, an
+# EMPTY LEADING FIELD is silently dropped (tab is IFS whitespace, so runs collapse and
+# leading/trailing separators are stripped). The consequence was not cosmetic — the skip
+# field would be misread as the runnable ids, the census would announce unrunnable targets
+# as EXECUTED, and the observation guard would then fail on an impossible runner id.
+#
+# That case is UNREACHABLE TODAY (cqlite-node declares zero integration targets and
+# cqlite-ffi-common's two require no features), which is exactly why it needs a test: the
+# helper's entire purpose is to be correct the moment that stops being true, so its
+# correctness cannot be established by running the lane.
+#
+# Needs NO cargo, NO network and NO datasets: the helper reads only its two arguments, so
+# every case is synthetic metadata. Deterministic and fast.
+# FAILS CLOSED: an unsourceable helper is a FAIL, never a skip.
+set -uo pipefail
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+GATE="$SCRIPT_DIR/../agent-gate.sh"
+[ -r "$GATE" ] || { echo "FAIL: cannot read $GATE" >&2; exit 1; }
+
+# Source ONLY the function under test, out of the real gate script — never a copy. A copy
+# would pass while the shipped helper rotted, which is the drift this whole issue is about.
+helper_src=$(sed -n '/^_brt_partition_targets() {/,/^}$/p' "$GATE")
+[ -n "$helper_src" ] || { echo "FAIL: could not extract _brt_partition_targets from $GATE — the function was renamed or reshaped; this self-test must not pass having tested nothing" >&2; exit 1; }
+eval "$helper_src" || { echo "FAIL: extracted _brt_partition_targets does not parse" >&2; exit 1; }
+
+PASS=0; FAIL=0
+ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+TAB=$(printf '\t')
+
+# check <name> <meta> <enabled> <want-ids> <want-names> <want-skip-substring-or-EMPTY>
+#
+# Reads the helper's output exactly as the production caller does — same IFS, same single
+# `read` — so a delimiter regression fails HERE rather than in the lane.
+check() {
+  local name="$1" meta="$2" enabled="$3" wid="$4" wnm="$5" wsk="$6"
+  local gid gnm gsk
+  IFS=$'\037' read -r gid gnm gsk <<< "$(_brt_partition_targets "$meta" "$enabled")"
+  local errs=""
+  [ "$gid" = "$wid" ] || errs="$errs ids=[$gid] want=[$wid];"
+  [ "$gnm" = "$wnm" ] || errs="$errs names=[$gnm] want=[$wnm];"
+  if [ -z "$wsk" ]; then
+    [ -z "$gsk" ] || errs="$errs skip=[$gsk] want empty;"
+  else
+    case "$gsk" in *"$wsk"*) ;; *) errs="$errs skip=[$gsk] want to contain [$wsk];" ;; esac
+  fi
+  if [ -z "$errs" ]; then ok "$name"; else bad "$name —$errs"; fi
+}
+
+# 1) The shape in production today: two targets, no required-features, all runnable.
+check "two unconditional targets are all runnable" \
+  "dependency_boundary${TAB}dependency_boundary${TAB}
+error_contract_table${TAB}error_contract_table${TAB}" \
+  "  " "dependency_boundary error_contract_table" "dependency_boundary error_contract_table" ""
+
+# 2) THE C3 CASE: every declared target requires a DISABLED feature, so the runnable
+#    fields are BOTH empty and the empty LEADING field must survive the read. With the old
+#    TAB delimiter this returned ids=<the skip text>, which the census then printed as
+#    executed targets.
+check "all targets gated off -> empty ids AND empty names, skip populated (C3)" \
+  "gated_a${TAB}gated_a${TAB}observability
+gated_b${TAB}gated_b${TAB}observability" \
+  " default write-support " "" "" "gated_a(required-features[observability]:off[observability])"
+
+# 3) A single gated target, same property with one record.
+check "one gated target -> empty ids, empty names" \
+  "only_gated${TAB}only_gated${TAB}dhat-heap" \
+  " default " "" "" "only_gated(required-features[dhat-heap]:off[dhat-heap])"
+
+# 4) MIXED: the runnable and skipped halves must not contaminate each other.
+check "mixed runnable + gated partitions correctly" \
+  "runs${TAB}runs${TAB}
+gated${TAB}gated${TAB}parquet" \
+  " default " "runs" "runs" "gated(required-features[parquet]:off[parquet])"
+
+# 5) A target whose required-features ARE enabled counts as runnable.
+check "required-features that are all enabled -> runnable" \
+  "needs_ws${TAB}needs_ws${TAB}write-support" \
+  " default write-support " "needs_ws" "needs_ws" ""
+
+# 6) Multiple required-features, only one missing, is still skipped — and the diagnostic
+#    names the SPECIFIC missing one rather than the whole list.
+check "partially-satisfied required-features -> skipped, naming the missing feature" \
+  "multi${TAB}multi${TAB}write-support,observability" \
+  " default write-support " "" "" "off[observability]"
+
+# 7) EMPTY metadata (the zero-integration-target package, i.e. cqlite-node today) yields
+#    three empty fields and NOT an error — zero is a derived fact, not a failure.
+check "empty metadata -> three empty fields" "" " default " "" "" ""
+
+# 8) The RUNNER ID may differ from the target NAME (a directory-style target maps to
+#    `<name>/main`). Both fields must be carried independently — conflating them is what
+#    _package_integration_target_ids exists to prevent.
+check "runner id distinct from target name is preserved in both fields" \
+  "dirstyle${TAB}dirstyle/main${TAB}" \
+  " default " "dirstyle/main" "dirstyle" ""
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_agent_gate_binding_partition.sh
+++ b/scripts/tests/test_agent_gate_binding_partition.sh
@@ -37,10 +37,19 @@ bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
 
 TAB=$(printf '\t')
 
-# check <name> <meta> <enabled> <want-ids> <want-names> <want-skip-substring-or-EMPTY>
+# check <name> <meta> <enabled> <want-ids> <want-names> <want-skip>
 #
 # Reads the helper's output exactly as the production caller does — same IFS, same single
 # `read` — so a delimiter regression fails HERE rather than in the lane.
+#
+# ALL THREE FIELDS ARE COMPARED EXACTLY (roborev round 6, G2). The skip field used to be a
+# SUBSTRING check, and the two-target case asserted only `gated_a` — so a regression that
+# DROPPED `gated_b` entirely still passed. A substring check over a multi-item field almost
+# never discriminates: it can only detect that something is present, never that nothing else
+# went missing, and "the skip census is complete" is the whole property that field carries.
+#
+# The cost is that every expectation must be spelled in full, which is the point: the
+# expectation is now a specification of the output rather than a hint about it.
 check() {
   local name="$1" meta="$2" enabled="$3" wid="$4" wnm="$5" wsk="$6"
   local gid gnm gsk
@@ -48,11 +57,7 @@ check() {
   local errs=""
   [ "$gid" = "$wid" ] || errs="$errs ids=[$gid] want=[$wid];"
   [ "$gnm" = "$wnm" ] || errs="$errs names=[$gnm] want=[$wnm];"
-  if [ -z "$wsk" ]; then
-    [ -z "$gsk" ] || errs="$errs skip=[$gsk] want empty;"
-  else
-    case "$gsk" in *"$wsk"*) ;; *) errs="$errs skip=[$gsk] want to contain [$wsk];" ;; esac
-  fi
+  [ "$gsk" = "$wsk" ] || errs="$errs skip=[$gsk] want=[$wsk];"
   if [ -z "$errs" ]; then ok "$name"; else bad "$name —$errs"; fi
 }
 
@@ -66,10 +71,10 @@ error_contract_table${TAB}error_contract_table${TAB}" \
 #    fields are BOTH empty and the empty LEADING field must survive the read. With the old
 #    TAB delimiter this returned ids=<the skip text>, which the census then printed as
 #    executed targets.
-check "all targets gated off -> empty ids AND empty names, skip populated (C3)" \
+check "all targets gated off -> empty ids AND names, and BOTH skips listed exactly (C3+G2)" \
   "gated_a${TAB}gated_a${TAB}observability
 gated_b${TAB}gated_b${TAB}observability" \
-  " default write-support " "" "" "gated_a(required-features[observability]:off[observability])"
+  " default write-support " "" "" "gated_a(required-features[observability]:off[observability]) gated_b(required-features[observability]:off[observability])"
 
 # 3) A single gated target, same property with one record.
 check "one gated target -> empty ids, empty names" \
@@ -89,9 +94,19 @@ check "required-features that are all enabled -> runnable" \
 
 # 6) Multiple required-features, only one missing, is still skipped — and the diagnostic
 #    names the SPECIFIC missing one rather than the whole list.
-check "partially-satisfied required-features -> skipped, naming the missing feature" \
+check "partially-satisfied required-features -> skipped; FULL reason compared, not a substring" \
   "multi${TAB}multi${TAB}write-support,observability" \
-  " default write-support " "" "" "off[observability]"
+  " default write-support " "" "" "multi(required-features[write-support,observability]:off[observability])"
+
+# 6b) THREE gated targets, all three required in the skip census. This is the case the old
+#     substring assertion provably could not catch: it asserted only the FIRST entry, so a
+#     regression dropping any later one passed. With an exact comparison, dropping `gated_c`
+#     changes the field and the case fails.
+check "three gated targets -> ALL THREE listed in the skip census, in order (G2)" \
+  "g_a${TAB}g_a${TAB}parquet
+g_b${TAB}g_b${TAB}parquet
+g_c${TAB}g_c${TAB}parquet" \
+  " default " "" "" "g_a(required-features[parquet]:off[parquet]) g_b(required-features[parquet]:off[parquet]) g_c(required-features[parquet]:off[parquet])"
 
 # 7) EMPTY metadata (the zero-integration-target package, i.e. cqlite-node today) yields
 #    three empty fields and NOT an error — zero is a derived fact, not a failure.

--- a/scripts/tests/test_agent_gate_binding_rust_lanes.sh
+++ b/scripts/tests/test_agent_gate_binding_rust_lanes.sh
@@ -396,15 +396,34 @@ unplant() {
 # harness either BLOCKS INDEFINITELY or -- at EOF -- silently reports FIRED-UNATTRIBUTED. A
 # failure that depends on an ambient shell option this harness never sets and cannot control
 # is the same class agent-gate.sh's own round-34 "`find`, not a glob" comment records.
-# `[ -f ]` per candidate means an unmatched pattern is skipped explicitly instead of being
-# handed to grep as a filename or as nothing at all.
+# THE FIRST FIX OF THIS WAS INCOMPLETE, AND THAT IS THE POINT (roborev round 4, E2). B6
+# replaced the INLINE unquoted glob at the call site with this function — and left the SAME
+# glob inside the function. `[ -f "$f" ]` per candidate handles `nullglob` (the pattern
+# expands to nothing, the body is skipped) but CANNOT handle `failglob`: with that option the
+# shell ABORTS AT THE `for` LINE, before any guard in the body can run, so an unattributed
+# Node failure would terminate the harness instead of producing its diagnostic summary.
+# "Fixed one site, missed its sibling" is the pattern agent-gate.sh's own round 35->38 comment
+# records as its fifth instance; this is ours.
+#
+# A bounded `find` instead, which is what the round-34 comment prescribes: its meaning does
+# not depend on ambient shell options this harness never sets and cannot control
+# (`nullglob`/`failglob`, both reachable through BASHOPTS). `-maxdepth 1` because the subject
+# is SIBLING files in one directory, not a tree. The find's status is deliberately not fatal:
+# no sibling logs is a legitimate state (node-bindings writes only one log), and the caller
+# already treats "marker not found" as UNATTRIBUTED, which is the fail-closed direction.
 _marker_in_sibling_logs() {
-  local marker="$1" complog="${2:-}" f
+  local marker="$1" complog="${2:-}" dir base f
   [ -n "$complog" ] || return 1
-  for f in "${complog%.log}".*.log; do
+  dir=$(dirname -- "$complog") || return 1
+  base=$(basename -- "${complog%.log}") || return 1
+  [ -d "$dir" ] || return 1
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
     [ -f "$f" ] || continue
-    grep -qF -- "$marker" "$f" && return 0
-  done
+    if grep -qF -- "$marker" "$f"; then return 0; fi
+  done <<EOF
+$(find -H "$dir" -maxdepth 1 -type f -name "$base.*.log" -print 2>/dev/null)
+EOF
   return 1
 }
 

--- a/scripts/tests/test_agent_gate_binding_rust_lanes.sh
+++ b/scripts/tests/test_agent_gate_binding_rust_lanes.sh
@@ -1,0 +1,472 @@
+#!/usr/bin/env bash
+#
+# test_agent_gate_binding_rust_lanes.sh — planted-break observation harness for the
+# binding-side gate lanes of issue #3522: the NEW `binding-rust-tests` component and
+# the WIDENED `node-bindings` component.
+#
+# WHAT THIS ANSWERS, and why nothing else does.
+# `--list` proves a lane is REGISTERED. A green SUMMARY line proves a lane RAN and
+# found nothing. Neither proves the lane CAN FAIL — and #3522 exists precisely because
+# two crates were compiled by every gate run while executing nothing, a state that is
+# indistinguishable from coverage unless you make the lane red on demand. This harness
+# is the affirmative evidence that each lane fires on the incident class it was built
+# for (issue #3522 AC3).
+#
+# BOTH DIRECTIONS, ALWAYS. Per case it runs the real component on a CLEAN tree
+# (expecting the lane's PASS) and then on a tree carrying ONE planted break (expecting
+# the lane's FAIL). A harness that only ever plants breaks passes just as happily
+# against a lane that fails unconditionally, so a lane that reds in BOTH directions is
+# reported as a HARNESS FAILURE, never as a successful observation.
+#
+# ATTRIBUTED, NOT MERELY RED. A lane that broke for an unrelated reason produces the
+# same exit code and the same SUMMARY line as one that detected the plant, so a bare
+# red is not evidence either. Each planted run's output must NAME the planted symbol.
+#
+# THE ZERO-TEST CASE IS THE ONE THE OTHERS CANNOT COVER. Three of the plants are
+# failing assertions; those prove the lane EXECUTES rather than merely compiles. The
+# fourth (`zero-tests`) cfg's a unit suite OUT, so it compiles clean, runs zero tests
+# and exits 0 — the vacuous green this whole issue is about. Only that case exercises
+# check_unittest_targets_ran's non-zero-count half, and a plain failing assertion would
+# pass over it silently.
+#
+# THE REAL COMPONENT, NEVER A RETYPED COMMAND. Each direction runs
+# `bash scripts/agent-gate.sh --only <lane>`. Retyping the lane's cargo invocation here
+# would prove that a cargo command works; it would prove nothing about the gate
+# component, which is the subject. `--only` is a PARTIAL run (it can never be a verdict
+# — it exits 3 on success for exactly that reason) and is deliberately lenient about
+# fixtures, which is what makes it usable as a probe.
+#
+# ISOLATION. Every mutation happens in a throwaway `git worktree add --detach` copy,
+# never the live checkout. #2926 makes a mid-run tree mutation a gate FAIL, so a harness
+# that edited the tree its own gate was running in would be the very defect it exists to
+# catch. That isolation is VERIFIED, not asserted: the live checkout's status AND HEAD
+# are captured at start and re-compared before the summary and again in cleanup. It also
+# REFUSES to run from a dirty checkout — the worktree is created from committed HEAD, so
+# uncommitted changes would be silently excluded and a PASS would describe code other
+# than the code in front of you.
+#
+# OPT-IN, NOT A GATE COMPONENT. It performs real compiles (and, for the node case, a
+# release-unwind napi build plus `npm ci`); taxing every full gate to re-prove a static
+# property is disproportionate. It is deliberately absent from COMPONENTS /
+# LITE_COMPONENTS / DELTA_COMPONENTS.
+#
+# Usage:
+#   bash scripts/tests/test_agent_gate_binding_rust_lanes.sh              # all cases
+#   bash scripts/tests/test_agent_gate_binding_rust_lanes.sh <case> ...   # subset
+#
+# Cases: ffi-integration ffi-error-contract node-rust-unit zero-tests node-jest
+#
+# Exit: 0 = every selected case observed to fire AND to stay clean; 1 = a case did not
+# fire, a clean baseline could not be established, or the live checkout was mutated;
+# 2 = usage / precondition refusal (unknown case, non-absolute CQLITE_DATASETS_ROOT,
+# DIRTY live checkout); 3 = a SUBSET run in which everything selected fired (a partial
+# observation, never the full AC3 evidence).
+
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "not a git checkout" >&2; exit 1; }
+cd "$REPO_ROOT" || exit 1
+
+ALL_CASES=(ffi-integration ffi-error-contract node-rust-unit zero-tests node-jest)
+
+SUBSET=0
+if [ "$#" -gt 0 ]; then
+  SUBSET=1
+  CASES=("$@")
+  for c in "${CASES[@]}"; do
+    case " ${ALL_CASES[*]} " in
+      *" $c "*) ;;
+      *) echo "unknown case: $c (known: ${ALL_CASES[*]})" >&2; exit 2 ;;
+    esac
+  done
+else
+  CASES=("${ALL_CASES[@]}")
+fi
+
+# The corpus root. binding-rust-tests needs NONE (neither crate's sources reference
+# CQLITE_DATASETS_ROOT — that is why it is not in DATASET_COMPONENTS), but node-bindings
+# IS a DATASET_COMPONENT now, and although `--only` runs it leniently its corpus-reading
+# suites would then skip and the observation would be over less code than the full gate
+# runs. So the node case requires a real corpus; the Rust cases do not.
+DATASETS="${CQLITE_DATASETS_ROOT:-}"
+_needs_datasets=0
+for _c in ${CASES[@]+"${CASES[@]}"}; do
+  case "$_c" in node-jest) _needs_datasets=1 ;; esac
+done
+if [ "$_needs_datasets" -eq 1 ] && [ -z "$DATASETS" ]; then
+  echo "CQLITE_DATASETS_ROOT is not set, and the selected cases include node-jest," >&2
+  echo "whose suite reads the corpus. Export the absolute root printed by:" >&2
+  echo "  bash test-data/scripts/fetch-datasets.sh" >&2
+  echo "Or select only the Rust cases, which need no corpus." >&2
+  exit 2
+fi
+# A root is VALIDATED whenever one is present, even by a run that does not read it: an
+# exported relative root is a fail-closed error everywhere else in this repo (#3148) and
+# must not become acceptable just because this run ignores it.
+case "${DATASETS:-/}" in
+  /*) ;;
+  *) echo "CQLITE_DATASETS_ROOT must be ABSOLUTE (got: $DATASETS)" >&2; exit 2 ;;
+esac
+
+# THE SUBJECT MUST BE THE CODE IN FRONT OF YOU. The throwaway worktree is created from
+# committed HEAD, so any UNCOMMITTED change is silently EXCLUDED from every run — the
+# harness would then report a successful observation of code that is not the code being
+# reviewed. Refuse rather than mislead; the remedy is a commit, not a flag. The COMMIT is
+# captured alongside the status because `git status --porcelain` alone cannot see a HEAD
+# move: a clean commit, checkout, reset or branch switch during this multi-minute run
+# leaves the status IDENTICAL while the code under observation changes.
+LIVE_HEAD_BEFORE=$(git -C "$REPO_ROOT" rev-parse HEAD) || {
+  echo "HARNESS FAILURE: could not read the live checkout's HEAD, so the" >&2
+  echo "  never-mutate-the-live-checkout invariant is unverifiable from the start." >&2
+  exit 2
+}
+LIVE_STATUS_BEFORE=$(git -C "$REPO_ROOT" status --porcelain) || {
+  echo "FATAL: could not read the live checkout's git status" >&2; exit 1; }
+if [ -n "$LIVE_STATUS_BEFORE" ]; then
+  {
+    echo "REFUSING TO RUN: the live checkout is DIRTY."
+    echo
+    echo "  This harness observes the lanes against a throwaway worktree created from"
+    echo "  committed HEAD ($(git -C "$REPO_ROOT" rev-parse --short HEAD)), so uncommitted"
+    echo "  changes are NOT part of any run. A PASS here would describe HEAD, not the"
+    echo "  working tree you are looking at — an observation about the wrong code."
+    echo
+    echo "  Commit (or stash) first, then re-run. There is deliberately no override:"
+    echo "  the only thing an override could buy is a green about code nobody changed."
+    echo
+    echo "  dirty paths:"
+    printf '%s\n' "$LIVE_STATUS_BEFORE" | sed 's/^/    /'
+  } >&2
+  exit 2
+fi
+
+LIVE_TREE_VIOLATED=0
+assert_live_checkout_untouched() {
+  local phase="$1" now now_head
+  now=$(git -C "$REPO_ROOT" status --porcelain 2>/dev/null) || {
+    echo "HARNESS FAILURE ($phase): could not re-read the live checkout's git status," >&2
+    echo "  so the never-mutate-the-live-checkout invariant is UNVERIFIABLE here." >&2
+    LIVE_TREE_VIOLATED=1; return 1; }
+  now_head=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null) || {
+    echo "HARNESS FAILURE ($phase): could not re-read the live checkout's HEAD," >&2
+    echo "  so the invariant is UNVERIFIABLE here (unreadable is never treated as unchanged)." >&2
+    LIVE_TREE_VIOLATED=1; return 1; }
+  if [ "$now_head" != "$LIVE_HEAD_BEFORE" ]; then
+    {
+      echo "HARNESS FAILURE ($phase): the live checkout's HEAD MOVED during the run"
+      echo "  ($LIVE_HEAD_BEFORE -> $now_head). The observation above was made against the"
+      echo "  OLD commit, so reporting it as this HEAD's would be a STALE certification"
+      echo "  indistinguishable from a fresh one."
+    } >&2
+    LIVE_TREE_VIOLATED=1; return 1
+  fi
+  if [ "$now" != "$LIVE_STATUS_BEFORE" ]; then
+    {
+      echo "HARNESS FAILURE ($phase): the LIVE CHECKOUT changed during the run."
+      echo "  Every plant must land in the throwaway worktree; a mutated live tree means"
+      echo "  one escaped isolation (and #2926 makes a mid-run tree mutation a gate FAIL)."
+      printf '%s\n' "$now" | sed 's/^/    /'
+    } >&2
+    LIVE_TREE_VIOLATED=1; return 1
+  fi
+  return 0
+}
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/brl-3522-XXXXXX") || exit 1
+TREE="$WORK/tree"
+# PRIVATE (under $WORK, itself an mktemp -d), never a predictable shared path: two
+# harnesses at once would corrupt each other's incremental state, and on a multi-user
+# host a pre-created fixed path would let another user supply the compiled artifacts
+# this harness then EXECUTES. Still SHARED between the clean and planted runs of one
+# invocation, which is what keeps the observation affordable.
+TARGET="$WORK/target"
+
+cleanup() {
+  local rc=$?
+  # A SIGNAL FORCES A NON-ZERO VERDICT. `cleanup` inherits `$?`, and on a signal
+  # delivered BETWEEN commands `$?` is ZERO — so an INTERRUPTED observation would exit
+  # successfully, which is this issue's own defect class inside its own harness.
+  local sig="${1:-}"
+  case "$sig" in
+    INT)  rc=130 ;;
+    TERM) rc=143 ;;
+  esac
+  [ -n "$sig" ] && echo "FATAL: observation ABORTED by SIG$sig — this run is NOT evidence (rc=$rc)" >&2
+  assert_live_checkout_untouched "cleanup" || rc=1
+  if [ -d "$TREE" ]; then
+    git -C "$REPO_ROOT" worktree remove --force "$TREE" >/dev/null 2>&1 || rm -rf "$TREE"
+  fi
+  git -C "$REPO_ROOT" worktree prune >/dev/null 2>&1
+  rm -rf "$WORK"
+  exit "$rc"
+}
+trap 'cleanup' EXIT
+trap 'cleanup INT' INT
+trap 'cleanup TERM' TERM
+
+echo "==== #3522 BINDING-LANE OBSERVATION ===="
+echo "repo:      $REPO_ROOT"
+echo "head:      $LIVE_HEAD_BEFORE"
+echo "cases:     ${CASES[*]}"
+[ "$SUBSET" -eq 1 ] && echo "mode:      SUBSET (partial observation — not the full AC3 evidence)"
+echo "worktree:  $TREE (throwaway; the live checkout is never mutated)"
+echo "target:    $TARGET"
+echo "datasets:  ${DATASETS:-<unset; no dataset-consuming case selected>}"
+echo
+
+# `$LIVE_HEAD_BEFORE`, not `HEAD`: the copy must be the exact commit whose observation
+# this run reports. `HEAD` is re-resolved at this moment and would silently follow a
+# concurrent commit.
+git worktree add --detach "$TREE" "$LIVE_HEAD_BEFORE" >/dev/null 2>&1 || {
+  echo "FATAL: could not create the throwaway worktree" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Plants. Each is a lane's INCIDENT CLASS, not a syntax error: a syntax error fires any
+# lane that compiles anything and so distinguishes nothing.
+# ---------------------------------------------------------------------------
+
+# The lane each case observes.
+lane_ffi_integration=binding-rust-tests
+lane_ffi_error_contract=binding-rust-tests
+lane_node_rust_unit=binding-rust-tests
+lane_zero_tests=binding-rust-tests
+lane_node_jest=node-bindings
+
+# (a) An inverted assertion in cqlite-ffi-common's dependency_boundary integration
+# target — the specific target #3522's AC names, because it is the one that measures the
+# binding crates' dependency closure and it had never executed anywhere.
+plant_ffi_integration() {
+  cat >> "$TREE/cqlite-ffi-common/tests/dependency_boundary.rs" <<'EOF'
+
+// #3522 PLANTED BREAK (binding-lane observation harness) — reverted by the harness.
+#[test]
+fn brl_3522_planted_dependency_boundary_break() {
+    assert_eq!(1 + 1, 3, "#3522 planted break in the dependency_boundary target");
+}
+EOF
+}
+plant_marker_ffi_integration='brl_3522_planted_dependency_boundary_break'
+plant_desc_ffi_integration='a failing #[test] appended to cqlite-ffi-common/tests/dependency_boundary.rs — the integration target #3522 AC names; firing proves the lane EXECUTES it (before #3522 nothing did, anywhere)'
+
+# (b) The same for the OTHER integration target, so the observation covers the derived
+# target SET rather than one member of it.
+plant_ffi_error_contract() {
+  cat >> "$TREE/cqlite-ffi-common/tests/error_contract_table.rs" <<'EOF'
+
+// #3522 PLANTED BREAK (binding-lane observation harness) — reverted by the harness.
+#[test]
+fn brl_3522_planted_error_contract_break() {
+    assert_eq!(1 + 1, 3, "#3522 planted break in the error_contract_table target");
+}
+EOF
+}
+plant_marker_ffi_error_contract='brl_3522_planted_error_contract_break'
+plant_desc_ffi_error_contract='a failing #[test] appended to cqlite-ffi-common/tests/error_contract_table.rs — the second derived integration target, so the observation covers the SET and not one member of it'
+
+# (c) A failing unit test in cqlite-node's Rust half. The gate names neither the module
+# nor the test, so firing proves reach beyond anything hard-coded — and it lands in the
+# `--lib` binary of a `crate-type = ["cdylib"]` package, which is the linkability
+# question this component's design turned on.
+plant_node_rust_unit() {
+  cat >> "$TREE/bindings/node/src/value_tests.rs" <<'EOF'
+
+// #3522 PLANTED BREAK (binding-lane observation harness) — reverted by the harness.
+#[test]
+fn brl_3522_planted_node_value_break() {
+    assert_eq!(1 + 1, 3, "#3522 planted break in cqlite-node's Rust unit suite");
+}
+EOF
+}
+plant_marker_node_rust_unit='brl_3522_planted_node_value_break'
+plant_desc_node_rust_unit='a failing #[test] appended to bindings/node/src/value_tests.rs — cqlite-node is crate-type = ["cdylib"], so this also observes that the --lib harness genuinely links and runs'
+
+# (d) THE ZERO-TEST CASE. cfg the whole cqlite-node unit suite OUT behind a feature that
+# does not exist. The crate still COMPILES, the `--lib` harness still runs, it executes
+# ZERO tests and cargo exits 0 — the vacuous green. Only check_unittest_targets_ran's
+# non-zero-count half can see this; the three failing-assertion plants above cannot, so
+# without this case that half of the guard would be unobserved.
+#
+# The marker is the unittest target PATH, because that is what the guard names in its
+# diagnostic ("src/lib.rs(ran 0 tests: ...)"). A `#[cfg]` on the mod declarations is used
+# rather than deleting the files, so the plant is a realistic cfg accident rather than a
+# structural edit.
+plant_zero_tests() {
+  python3 - "$TREE/bindings/node/src/lib.rs" <<'PY'
+import re, sys
+p = sys.argv[1]
+s = open(p).read()
+# Neutralise every `#[cfg(test)]` in the crate root so the unit suite compiles out while
+# the crate itself still builds — the exact shape of a cfg accident.
+s2 = s.replace('#[cfg(test)]', '#[cfg(all(test, feature = "brl-3522-nonexistent-feature"))]')
+assert s2 != s, "no #[cfg(test)] found in bindings/node/src/lib.rs to neutralise"
+open(p, 'w').write(s2)
+PY
+}
+plant_marker_zero_tests='ran 0 tests'
+plant_desc_zero_tests='every #[cfg(test)] in bindings/node/src/lib.rs re-gated on a nonexistent feature — the crate COMPILES, the --lib harness RUNS, it executes ZERO tests and cargo exits 0. The vacuous green; only check_unittest_targets_ran'"'"'s non-zero-count half sees it, which no failing-assertion plant exercises'
+
+# (e) A failing assertion in a jest suite the OLD node-bindings scope did not run.
+# shared-vectors.test.js is chosen deliberately: it carries the cross-binding SHA-256
+# exact oracles, whose entire value is that Python, Node and Rust agree byte-for-byte,
+# and before #3522 it executed in no merge-gating lane. Firing proves the widening is
+# real and not just a changed comment.
+plant_node_jest() {
+  cat >> "$TREE/bindings/node/__test__/shared-vectors.test.js" <<'EOF'
+
+// #3522 PLANTED BREAK (binding-lane observation harness) — reverted by the harness.
+test('brl_3522_planted_shared_vectors_break', () => {
+  expect(1 + 1).toBe(3);
+});
+EOF
+}
+plant_marker_node_jest='brl_3522_planted_shared_vectors_break'
+plant_desc_node_jest='a failing test appended to bindings/node/__test__/shared-vectors.test.js — one of the 26 suites the pre-#3522 `npx jest write-readback-content` scope never ran, and the one carrying the cross-binding SHA-256 exact oracles'
+
+# One uniform revert for every plant: restore tracked files, delete untracked ones.
+# `clean -fd` without -x deliberately spares the gitignored build output.
+unplant() {
+  git -C "$TREE" checkout -- . >/dev/null 2>&1
+  git -C "$TREE" clean -fdq >/dev/null 2>&1
+  local residue
+  residue=$(git -C "$TREE" status --porcelain)
+  if [ -n "$residue" ]; then
+    echo "  HARNESS ERROR: the throwaway tree did not revert cleanly:" >&2
+    printf '%s\n' "$residue" >&2
+    return 1
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# One direction of one case.
+#
+# `--only` exit codes are load-bearing and NOT the usual 0/1: a PARTIAL run that found
+# nothing exits 3 (the gate refuses to let a partial run be scripted into a green
+# claim), and a PARTIAL run with a failed component exits 1. So the CLEAN expectation is
+# 3, not 0. The exit code alone is not trusted either — the component's own SUMMARY line
+# is parsed and both must agree.
+# ---------------------------------------------------------------------------
+RC=0
+STATUS=""
+COMPONENT_LOG=""
+LAST_LOG=""
+run_direction() { # <case> <lane> <tag>
+  local cse=$1 lane=$2 tag=$3
+  local sf="$WORK/summary-$cse-$tag.txt" lg="$WORK/gate-$cse-$tag.log"
+  local t0 t1
+  t0=$(date +%s)
+  ( cd "$TREE" && env \
+      AGENT_GATE_SUMMARY_FILE="$sf" \
+      CARGO_TARGET_DIR="$TARGET" \
+      CQLITE_DATASETS_ROOT="${DATASETS:-}" \
+      bash scripts/agent-gate.sh --only "$lane" >"$lg" 2>&1 )
+  RC=$?
+  t1=$(date +%s)
+  STATUS=$(sed -n "s/^${lane}:[[:space:]]*\([A-Z][A-Z-]*\).*/\1/p" "$sf" 2>/dev/null | tail -1)
+  # The gate's per-component log, named by the SUMMARY's own `logs:` line. Used for
+  # ATTRIBUTION; the harness's captured stdout is the fallback, since the FAIL branch
+  # tails only 40 lines of the component log into it.
+  COMPONENT_LOG=""
+  local logdir
+  logdir=$(sed -n 's/^logs: //p' "$sf" 2>/dev/null | tail -1)
+  [ -n "$logdir" ] && [ -f "$logdir/$lane.log" ] && COMPONENT_LOG="$logdir/$lane.log"
+  [ -n "$STATUS" ] || STATUS="<no ${lane} line in the summary>"
+  printf '  %-7s exit=%s  summary says "%s: %s"  (%ss)\n' "$tag" "$RC" "$lane" "$STATUS" "$((t1 - t0))"
+  LAST_LOG="$lg"
+}
+
+RESULTS=()
+FAILED=0
+START=$(date +%s)
+
+for cse in "${CASES[@]}"; do
+  fn="${cse//-/_}"
+  lane_var="lane_${fn}"; lane="${!lane_var}"
+  desc_var="plant_desc_${fn}"
+  echo "---- $cse (lane: $lane) ----"
+  echo "  plant: ${!desc_var}"
+
+  unplant || { RESULTS+=("$cse|HARNESS-ERROR|tree would not revert before the clean run"); FAILED=1; continue; }
+
+  run_direction "$cse" "$lane" clean
+  clean_rc=$RC clean_status=$STATUS
+
+  "plant_${fn}" || { RESULTS+=("$cse|HARNESS-ERROR|the plant itself failed to apply"); FAILED=1; unplant; continue; }
+  run_direction "$cse" "$lane" planted
+  planted_rc=$RC planted_status=$STATUS
+  planted_log=$LAST_LOG
+  planted_component_log=$COMPONENT_LOG
+
+  unplant || { RESULTS+=("$cse|HARNESS-ERROR|tree would not revert after the planted run"); FAILED=1; continue; }
+
+  clean_ok=0;   [ "$clean_rc" = 3 ]   && [ "$clean_status" = PASS ] && clean_ok=1
+  planted_ok=0; [ "$planted_rc" = 1 ] && [ "$planted_status" = FAIL ] && planted_ok=1
+
+  marker_var="plant_marker_${fn}"
+  marker="${!marker_var}"
+  attributed=0
+  if [ "$planted_ok" = 1 ]; then
+    # The per-package sibling logs too: binding-rust-tests writes each package's cargo
+    # output to `<component>.<package>.log` (they cannot share one file — both print
+    # `Running unittests src/lib.rs`, which the unittest guard keys on).
+    if { [ -n "$planted_component_log" ] && grep -qF "$marker" "$planted_component_log"; } \
+       || grep -qF "$marker" "$planted_log" \
+       || { [ -n "$planted_component_log" ] && grep -qF -- "$marker" "${planted_component_log%.log}".*.log 2>/dev/null; }; then
+      attributed=1
+    fi
+  fi
+
+  if [ "$clean_ok" = 1 ] && [ "$planted_ok" = 1 ] && [ "$attributed" = 1 ]; then
+    RESULTS+=("$cse|FIRED|clean=PASS(exit 3), planted=FAIL(exit 1) naming '$marker'")
+    echo "  => FIRED: silent on the clean tree, red on the planted break, and the red NAMES"
+    echo "     the planted symbol ('$marker') — so the red is this plant's, not an unrelated one."
+  elif [ "$clean_ok" = 1 ] && [ "$planted_ok" = 1 ]; then
+    RESULTS+=("$cse|FIRED-UNATTRIBUTED|the lane red'd but its output never names '$marker'")
+    echo "  => FIRED, BUT UNATTRIBUTED: the lane went red and never named the planted symbol"
+    echo "     ('$marker'), so the red cannot be shown to be this plant's. Not an observation."
+    FAILED=1
+  elif [ "$clean_ok" = 0 ] && [ "$planted_ok" = 1 ]; then
+    RESULTS+=("$cse|HARNESS-FAILURE|clean direction did not pass (exit $clean_rc, status $clean_status) — red in both directions proves nothing")
+    echo "  => HARNESS FAILURE: the lane was already red on the CLEAN tree, so its red on the"
+    echo "     planted break is not evidence of anything. Fix the baseline, do not adjust the plant."
+    FAILED=1
+  elif [ "$clean_ok" = 1 ]; then
+    RESULTS+=("$cse|DID-NOT-FIRE|clean=PASS but the planted break produced exit $planted_rc, status $planted_status")
+    echo "  => DID NOT FIRE: the planted break did not red the lane. This is a REAL FINDING about"
+    echo "     the lane, not a harness knob — do not adjust the plant until it fires."
+    echo "     planted-run log: $planted_log (last 30 lines)"
+    tail -30 "$planted_log" | sed 's/^/       /'
+    FAILED=1
+  else
+    RESULTS+=("$cse|HARNESS-FAILURE|clean exit $clean_rc/$clean_status, planted exit $planted_rc/$planted_status — neither direction behaved as specified")
+    echo "  => HARNESS FAILURE: neither direction behaved as specified."
+    FAILED=1
+  fi
+  echo
+done
+
+# MEASURED before any verdict is printed: a success accompanied by a mutated live
+# checkout is not a success.
+assert_live_checkout_untouched "pre-summary" || FAILED=1
+
+END=$(date +%s)
+echo "==== #3522 OBSERVATION SUMMARY ===="
+# The CAPTURED commit, never a fresh `git rev-parse HEAD` at emit time: re-reading HEAD
+# here would attribute this run's evidence to a commit it never examined.
+echo "observed-commit: $LIVE_HEAD_BEFORE (captured at start; the throwaway copy was made from THIS sha)"
+echo "live-tree: $([ "$LIVE_TREE_VIOLATED" -eq 0 ] && echo "UNCHANGED (verified: git status --porcelain AND HEAD identical to start)" || echo "MUTATED — HARNESS FAILURE")"
+echo "elapsed:  $((END - START))s"
+[ "$SUBSET" -eq 1 ] && echo "mode:     SUBSET (${CASES[*]}) — a partial observation, NOT the full AC3 evidence"
+for r in "${RESULTS[@]}"; do
+  printf '%-22s %-18s %s\n' "${r%%|*}" "$(echo "$r" | cut -d'|' -f2)" "$(echo "$r" | cut -d'|' -f3-)"
+done
+if [ "$FAILED" -ne 0 ]; then
+  echo "RESULT: FAIL (a case did not fire, its clean baseline was not established, or the live checkout was mutated)"
+  exit 1
+fi
+if [ "$SUBSET" -eq 1 ]; then
+  echo "RESULT: PARTIAL (every SELECTED case fired; run with no arguments for the full observation)"
+  exit 3
+fi
+echo "RESULT: PASS (all ${#ALL_CASES[@]} cases observed to fire on a planted break and stay silent on a clean tree)"
+exit 0

--- a/scripts/tests/test_agent_gate_binding_rust_lanes.sh
+++ b/scripts/tests/test_agent_gate_binding_rust_lanes.sh
@@ -291,19 +291,57 @@ plant_desc_node_rust_unit='a failing #[test] appended to bindings/node/src/value
 # rather than deleting the files, so the plant is a realistic cfg accident rather than a
 # structural edit.
 plant_zero_tests() {
-  python3 - "$TREE/bindings/node/src/lib.rs" <<'PY'
-import re, sys
-p = sys.argv[1]
-s = open(p).read()
-# Neutralise every `#[cfg(test)]` in the crate root so the unit suite compiles out while
-# the crate itself still builds — the exact shape of a cfg accident.
-s2 = s.replace('#[cfg(test)]', '#[cfg(all(test, feature = "brl-3522-nonexistent-feature"))]')
-assert s2 != s, "no #[cfg(test)] found in bindings/node/src/lib.rs to neutralise"
-open(p, 'w').write(s2)
-PY
+  python3 - "$TREE/bindings/node/src" <<'ZEROPLANT'
+import os, re, sys
+
+src = sys.argv[1]
+
+# SWEEP THE CLASS, NOT THE INSTANCE (roborev round 1, B3). The first cut of this plant
+# edited `bindings/node/src/lib.rs`, which contains NO `#[cfg(test)]` at all -- the only
+# occurrence of that string there is PROSE inside a comment -- so the plant could never
+# apply and the case reported HARNESS-ERROR. The obvious repair (name the sibling files
+# that DO carry it) is the SAME staleness bug one level down, and it was already wrong on
+# arrival: two independent reviews produced two DIFFERENT file lists, one of them
+# incomplete. So the set is DERIVED here, at plant time, from the committed source.
+targets = []
+for name in sorted(os.listdir(src)):
+    if not name.endswith(".rs"):
+        continue
+    path = os.path.join(src, name)
+    with open(path) as fh:
+        text = fh.read()
+    # The ATTRIBUTE, at the start of a line (modulo indentation) -- not the bare string,
+    # which appears in prose. Every real `#[cfg(test)]` in this crate is on its own line.
+    if re.search(r'^[ \t]*#\[cfg\(test\)\]', text, re.M):
+        targets.append(path)
+
+# FAIL LOUDLY on an empty derivation -- never a silent no-op plant. An empty subject set
+# here means the crate stopped using `#[cfg(test)]` (or the pattern stopped matching), and
+# a plant that quietly applies to nothing turns this case into the vacuous green the whole
+# harness exists to detect. The harness treats a failed plant as HARNESS-ERROR, not as a
+# lane finding, which is the correct attribution.
+assert targets, "no file under bindings/node/src carries a line-initial #[cfg(test)] to neutralise"
+
+# `#[cfg(any())]`, NOT `#[cfg(feature = "does-not-exist")]`. An unknown feature name trips
+# rustc's `unexpected_cfgs` lint, and under `-D warnings` that reds the case via a COMPILE
+# FAILURE instead of via the zero-test guard -- the right colour by the wrong mechanism,
+# proving nothing about the guard this case exists to observe. `any()` is unconditionally
+# false and lint-clean.
+n = 0
+for path in targets:
+    with open(path) as fh:
+        text = fh.read()
+    new, k = re.subn(r'(?m)^([ \t]*)#\[cfg\(test\)\]', r'\1#[cfg(any())]', text)
+    assert k, path
+    with open(path, "w") as fh:
+        fh.write(new)
+    n += k
+print("zero-tests plant: neutralised %d #[cfg(test)] attribute(s) across %d file(s): %s"
+      % (n, len(targets), " ".join(os.path.basename(t) for t in targets)))
+ZEROPLANT
 }
 plant_marker_zero_tests='ran 0 tests'
-plant_desc_zero_tests='every #[cfg(test)] in bindings/node/src/lib.rs re-gated on a nonexistent feature — the crate COMPILES, the --lib harness RUNS, it executes ZERO tests and cargo exits 0. The vacuous green; only check_unittest_targets_ran'"'"'s non-zero-count half sees it, which no failing-assertion plant exercises'
+plant_desc_zero_tests='every line-initial #[cfg(test)] under bindings/node/src (file set DERIVED at plant time, never listed) rewritten to #[cfg(any())] — the crate COMPILES clean, the --lib harness RUNS, it executes ZERO tests and cargo exits 0. The vacuous green; only check_unittest_targets_ran'"'"'s non-zero-COUNT half sees it, which no failing-assertion plant exercises. #[cfg(any())] rather than an unknown feature name, so it cannot red via the unexpected_cfgs lint under -D warnings instead of via the guard'
 
 # (e) A failing assertion in a jest suite the OLD node-bindings scope did not run.
 # shared-vectors.test.js is chosen deliberately: it carries the cross-binding SHA-256
@@ -346,6 +384,30 @@ unplant() {
 # 3, not 0. The exit code alone is not trusted either — the component's own SUMMARY line
 # is parsed and both must agree.
 # ---------------------------------------------------------------------------
+# _marker_in_sibling_logs <marker> <component-log> — search the component's SIBLING logs
+# (binding-rust-tests writes each package's cargo output to `<component>.<pkg>.log` and its
+# guard verdicts to `<component>.guards.log`; they cannot share one file, because both
+# packages print `Running unittests src/lib.rs` and the unittest guard keys on that path).
+#
+# ITERATED, NOT PASSED AS AN UNQUOTED GLOB (roborev round 1, B6). This used to be
+# `grep -qF -- "$marker" "${log%.log}".*.log 2>/dev/null`, which relies on bash's DEFAULT
+# no-`nullglob` failure mode: bash honours `BASHOPTS` from the environment at startup, so
+# `BASHOPTS=nullglob bash ...` expands the pattern to NOTHING, grep then reads STDIN, and the
+# harness either BLOCKS INDEFINITELY or -- at EOF -- silently reports FIRED-UNATTRIBUTED. A
+# failure that depends on an ambient shell option this harness never sets and cannot control
+# is the same class agent-gate.sh's own round-34 "`find`, not a glob" comment records.
+# `[ -f ]` per candidate means an unmatched pattern is skipped explicitly instead of being
+# handed to grep as a filename or as nothing at all.
+_marker_in_sibling_logs() {
+  local marker="$1" complog="${2:-}" f
+  [ -n "$complog" ] || return 1
+  for f in "${complog%.log}".*.log; do
+    [ -f "$f" ] || continue
+    grep -qF -- "$marker" "$f" && return 0
+  done
+  return 1
+}
+
 RC=0
 STATUS=""
 COMPONENT_LOG=""
@@ -411,7 +473,7 @@ for cse in "${CASES[@]}"; do
     # `Running unittests src/lib.rs`, which the unittest guard keys on).
     if { [ -n "$planted_component_log" ] && grep -qF "$marker" "$planted_component_log"; } \
        || grep -qF "$marker" "$planted_log" \
-       || { [ -n "$planted_component_log" ] && grep -qF -- "$marker" "${planted_component_log%.log}".*.log 2>/dev/null; }; then
+       || _marker_in_sibling_logs "$marker" "$planted_component_log"; then
       attributed=1
     fi
   fi

--- a/scripts/tests/test_agent_gate_jest_guards.sh
+++ b/scripts/tests/test_agent_gate_jest_guards.sh
@@ -22,7 +22,14 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 GATE="$SCRIPT_DIR/../agent-gate.sh"
 [ -r "$GATE" ] || { echo "FAIL: cannot read $GATE" >&2; exit 1; }
 
-for fn in _ansi_stripped_log check_jest_suites_ran check_jest_per_suite_passed; do
+# NB_TEST_ANCHOR is a top-level assignment, not a function, and check_jest_per_suite_passed
+# DELEGATES its parse to _jest_json_suite_counts (the G1 extraction) — so both must be sourced
+# too, or every case fails with `command not found`. Sourcing the dependency explicitly rather
+# than duplicating the parser keeps this test driving the SHIPPED code.
+eval "$(sed -n '/^NB_TEST_ANCHOR=/p' "$GATE")"
+[ -n "${NB_TEST_ANCHOR:-}" ] || { echo "FAIL: could not extract NB_TEST_ANCHOR from $GATE" >&2; exit 1; }
+for fn in _ansi_stripped_log _jest_json_suite_counts_jq _jest_json_suite_counts_py \
+          _jest_json_suite_counts check_jest_suites_ran check_jest_per_suite_passed; do
   src=$(sed -n "/^$fn() {/,/^}$/p" "$GATE")
   [ -n "$src" ] || { echo "FAIL: could not extract $fn from $GATE — renamed or reshaped; this self-test must not pass having tested nothing" >&2; exit 1; }
   eval "$src" || { echo "FAIL: extracted $fn does not parse" >&2; exit 1; }
@@ -60,16 +67,27 @@ mk_json() {
 }
 mk_set() { local out="$1"; shift; printf '%s\n' "$@" > "$out"; }
 
-# expect_per_suite <name> <PASS|FAIL> <needle> <json> <set>
+# expect_per_suite <name> <PASS|FAIL> <comma-separated-needles> <json> <set>
+#
+# EVERY needle must be named, not just one (roborev round 6, G2). A single-substring check over
+# a message that lists MULTIPLE offenders can only establish that something was reported — never
+# that nothing was omitted. So a regression that reported only the FIRST empty suite would have
+# passed the all-empty case below, which is the same defect G2 found in the partition self-test.
+# Needles are comma-separated because the interesting cases are inherently multi-item.
 expect_per_suite() {
-  local nm="$1" want="$2" needle="$3" j="$4" e="$5" rc out
+  local nm="$1" want="$2" needles="$3" j="$4" e="$5" rc out n missing=""
   out=$(check_jest_per_suite_passed L "$j" "$e" 2>&1); rc=$?
   if [ "$want" = PASS ]; then
     [ "$rc" -eq 0 ] && ok "$nm" || bad "$nm — expected PASS, got $rc: $out"
     return
   fi
   if [ "$rc" -eq 0 ]; then bad "$nm — expected FAIL but the guard PASSED: $out"; return; fi
-  case "$out" in *"$needle"*) ok "$nm" ;; *) bad "$nm — failed but never named '$needle': $out" ;; esac
+  local IFS=,
+  for n in $needles; do
+    case "$out" in *"$n"*) ;; *) missing="$missing $n" ;; esac
+  done
+  unset IFS
+  if [ -z "$missing" ]; then ok "$nm"; else bad "$nm — failed but never named:$missing (got: $out)"; fi
 }
 
 # ---- check_jest_per_suite_passed ------------------------------------------------
@@ -94,7 +112,19 @@ mk_json "$WORK/good.json" "a.test.js:5:0" "b.test.js:2:1"
 expect_per_suite "every suite with >=1 passing test is ACCEPTED" PASS "" "$WORK/good.json" "$WORK/set2"
 
 mk_json "$WORK/allzero.json" "a.test.js:0:1" "b.test.js:0:1"
-expect_per_suite "ALL suites empty is REJECTED" FAIL "a.test.js" "$WORK/allzero.json" "$WORK/set2"
+expect_per_suite "ALL suites empty is REJECTED, naming EVERY one (G2)" FAIL "a.test.js,b.test.js" \
+  "$WORK/allzero.json" "$WORK/set2"
+
+# THREE empty suites: the case a first-offender-only regression would pass.
+mk_set "$WORK/set3" a.test.js b.test.js c.test.js
+mk_json "$WORK/zero3.json" "a.test.js:0:1" "b.test.js:0:1" "c.test.js:0:1"
+expect_per_suite "three empty suites -> ALL THREE named (G2)" FAIL "a.test.js,b.test.js,c.test.js" \
+  "$WORK/zero3.json" "$WORK/set3"
+
+# Two suites MISSING from the report: likewise both must be named.
+mk_json "$WORK/onlyA.json" "a.test.js:1:0"
+expect_per_suite "two suites absent from the report -> BOTH named (G2)" FAIL "b.test.js,c.test.js" \
+  "$WORK/onlyA.json" "$WORK/set3"
 
 mk_json "$WORK/one.json" "a.test.js:5:0"
 expect_per_suite "a reconciled suite ABSENT from the report is REJECTED (unjudged, not passed)" \

--- a/scripts/tests/test_agent_gate_jest_guards.sh
+++ b/scripts/tests/test_agent_gate_jest_guards.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Self-test for the node-bindings jest guards (issue #3522, roborev rounds 4 E1 + 5 F1):
+#   check_jest_suites_ran        — the FILE-SET / aggregate half
+#   check_jest_per_suite_passed  — the PER-SUITE half
+#
+# WHY BOTH ARE TESTED HERE, TOGETHER. They are complements, and the reason F1 existed is that
+# the aggregate one was mistaken for sufficient: jest reports a file whose every test is
+# individually skipped as a PASSED suite, so one suite can execute ZERO assertions while its
+# siblings satisfy `Tests: N passed`. The DISCRIMINATING case is therefore one passing suite
+# PLUS one all-skipped suite — a fixture that the aggregate guard accepts and the per-suite
+# guard must reject. That case is the whole point of this file, and it is the case that cannot
+# be produced by running the real suite, because the real suite has no all-skipped file
+# (measured: 27 suites, zero with no passing test).
+#
+# Hermetic: synthetic jest summaries and synthetic --json reports. No node, no npm, no cargo, no
+# network, no datasets. Functions are sourced OUT OF THE REAL GATE SCRIPT, never copied — a copy
+# would pass while the shipped guard rotted, which is the drift this whole issue is about.
+# FAILS CLOSED: an unextractable guard is a FAIL, never a skip.
+set -uo pipefail
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+GATE="$SCRIPT_DIR/../agent-gate.sh"
+[ -r "$GATE" ] || { echo "FAIL: cannot read $GATE" >&2; exit 1; }
+
+for fn in _ansi_stripped_log check_jest_suites_ran check_jest_per_suite_passed; do
+  src=$(sed -n "/^$fn() {/,/^}$/p" "$GATE")
+  [ -n "$src" ] || { echo "FAIL: could not extract $fn from $GATE — renamed or reshaped; this self-test must not pass having tested nothing" >&2; exit 1; }
+  eval "$src" || { echo "FAIL: extracted $fn does not parse" >&2; exit 1; }
+done
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/jestguards.XXXXXX") || exit 1
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0; FAIL=0
+ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+# ---- helpers -------------------------------------------------------------------
+# mk_json <file> <suite:passed:skipped> ... — a minimal jest --json report.
+mk_json() {
+  local out="$1"; shift
+  local first=1 spec name p s i
+  { printf '{"testResults":['
+    for spec in "$@"; do
+      name="${spec%%:*}"; p="${spec#*:}"; s="${p#*:}"; p="${p%%:*}"
+      [ "$first" -eq 1 ] || printf ','
+      first=0
+      printf '{"name":"/repo/bindings/node/__test__/%s","status":"passed","assertionResults":[' "$name"
+      i=0
+      while [ "$i" -lt "$p" ]; do [ "$i" -eq 0 ] || printf ','; printf '{"status":"passed"}'; i=$((i + 1)); done
+      local j=0
+      while [ "$j" -lt "$s" ]; do
+        if [ "$p" -gt 0 ] || [ "$j" -gt 0 ]; then printf ','; fi
+        printf '{"status":"pending"}'; j=$((j + 1))
+      done
+      printf ']}'
+    done
+    printf ']}'
+  } > "$out"
+}
+mk_set() { local out="$1"; shift; printf '%s\n' "$@" > "$out"; }
+
+# expect_per_suite <name> <PASS|FAIL> <needle> <json> <set>
+expect_per_suite() {
+  local nm="$1" want="$2" needle="$3" j="$4" e="$5" rc out
+  out=$(check_jest_per_suite_passed L "$j" "$e" 2>&1); rc=$?
+  if [ "$want" = PASS ]; then
+    [ "$rc" -eq 0 ] && ok "$nm" || bad "$nm — expected PASS, got $rc: $out"
+    return
+  fi
+  if [ "$rc" -eq 0 ]; then bad "$nm — expected FAIL but the guard PASSED: $out"; return; fi
+  case "$out" in *"$needle"*) ok "$nm" ;; *) bad "$nm — failed but never named '$needle': $out" ;; esac
+}
+
+# ---- check_jest_per_suite_passed ------------------------------------------------
+mk_set "$WORK/set2" a.test.js b.test.js
+
+# THE DISCRIMINATING CASE (F1). One suite with passing tests, one with ONLY skipped tests.
+# The aggregate guard accepts this; the per-suite guard must reject it, naming the empty suite.
+mk_json "$WORK/mixed.json" "a.test.js:5:0" "b.test.js:0:3"
+expect_per_suite "one passing suite + one ALL-SKIPPED suite is REJECTED, naming it (F1)" \
+  FAIL "b.test.js" "$WORK/mixed.json" "$WORK/set2"
+
+# And the aggregate guard on the SAME shape ACCEPTS it — the proof that the per-suite guard is
+# not redundant. Jest reports the all-skipped file as a passed suite, so the summary is green.
+printf 'Test Suites: 2 passed, 2 total\nTests:       3 skipped, 5 passed, 8 total\n' > "$WORK/mixed.log"
+if check_jest_suites_ran L "$WORK/mixed.log" 2 >/dev/null 2>&1; then
+  ok "the AGGREGATE guard accepts that same shape — so the per-suite guard is not redundant (F1)"
+else
+  bad "the aggregate guard rejected the mixed shape; the discriminating case no longer discriminates, so this self-test proves nothing about F1"
+fi
+
+mk_json "$WORK/good.json" "a.test.js:5:0" "b.test.js:2:1"
+expect_per_suite "every suite with >=1 passing test is ACCEPTED" PASS "" "$WORK/good.json" "$WORK/set2"
+
+mk_json "$WORK/allzero.json" "a.test.js:0:1" "b.test.js:0:1"
+expect_per_suite "ALL suites empty is REJECTED" FAIL "a.test.js" "$WORK/allzero.json" "$WORK/set2"
+
+mk_json "$WORK/one.json" "a.test.js:5:0"
+expect_per_suite "a reconciled suite ABSENT from the report is REJECTED (unjudged, not passed)" \
+  FAIL "b.test.js" "$WORK/one.json" "$WORK/set2"
+
+mk_json "$WORK/three.json" "a.test.js:1:0" "b.test.js:1:0" "c.test.js:1:0"
+expect_per_suite "a reported suite NOT in the reconciled set is REJECTED, distinctly" \
+  FAIL "c.test.js" "$WORK/three.json" "$WORK/set2"
+
+printf 'not json at all\n' > "$WORK/broken.json"
+expect_per_suite "an unparseable report is REJECTED" FAIL "FAIL-CLOSED" "$WORK/broken.json" "$WORK/set2"
+
+expect_per_suite "a MISSING report is REJECTED" FAIL "missing or unreadable" "$WORK/absent.json" "$WORK/set2"
+
+mk_set "$WORK/empty.set"
+expect_per_suite "an EMPTY reconciled set is REJECTED (a guard with no subject)" \
+  FAIL "FAIL-CLOSED" "$WORK/good.json" "$WORK/empty.set"
+
+printf '{"testResults":[]}' > "$WORK/norecords.json"
+expect_per_suite "a report with NO per-suite records is REJECTED" FAIL "NO per-suite records" \
+  "$WORK/norecords.json" "$WORK/set2"
+
+# ---- check_jest_suites_ran (round 4 E1: closed grammar + sum reconciliation) ----
+agg() { # <name> <PASS|FAIL> <needle> <suites-line> <tests-line> <expected>
+  local nm="$1" want="$2" needle="$3" rc out
+  printf '%s\n%s\n' "$4" "$5" > "$WORK/agg.log"
+  out=$(check_jest_suites_ran L "$WORK/agg.log" "$6" 2>&1); rc=$?
+  if [ "$want" = PASS ]; then
+    [ "$rc" -eq 0 ] && ok "$nm" || bad "$nm — expected PASS, got $rc: $out"
+    return
+  fi
+  if [ "$rc" -eq 0 ]; then bad "$nm — expected FAIL but PASSED: $out"; return; fi
+  case "$out" in *"$needle"*) ok "$nm" ;; *) bad "$nm — failed but never named '$needle': $out" ;; esac
+}
+agg "aggregate: the real 27/27 shape is ACCEPTED" PASS "" \
+  'Test Suites: 27 passed, 27 total' 'Tests:       2 skipped, 504 passed, 506 total' 27
+agg "aggregate: a SKIPPED suite is REJECTED" FAIL "were SKIPPED" \
+  'Test Suites: 1 skipped, 26 passed, 27 total' 'Tests:       504 passed, 506 total' 27
+agg "aggregate: categories that do NOT sum to total are REJECTED (E1)" FAIL "do not add up" \
+  'Test Suites: 20 passed, 27 total' 'Tests:       504 passed, 506 total' 27
+agg "aggregate: an UNRECOGNISED category is REJECTED first, by name (E1 closed grammar)" FAIL "obsolete" \
+  'Test Suites: 3 obsolete, 24 passed, 27 total' 'Tests:       504 passed, 506 total' 27
+agg "aggregate: a suite-count mismatch vs the reconciled set is REJECTED" FAIL "but 28" \
+  'Test Suites: 27 passed, 27 total' 'Tests:       504 passed, 506 total' 28
+agg "aggregate: ZERO passing tests overall is REJECTED" FAIL "ZERO tests PASSED" \
+  'Test Suites: 27 passed, 27 total' 'Tests:       506 skipped, 506 total' 27
+agg "aggregate: an absent jest summary is REJECTED" FAIL "no parseable jest summary" \
+  'nothing useful here' 'nor here' 27
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_agent_gate_parser_parity.sh
+++ b/scripts/tests/test_agent_gate_parser_parity.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Differential parity test for the jq/python3 parser PAIRS this lane added
+# (issue #3522, roborev round 6 G1).
+#
+# WHAT IT ANSWERS. Several helpers here parse the same input two ways — a jq program and a
+# python3 program — because a host may have only one of them. That makes each pair TWO
+# IMPLEMENTATIONS OF ONE TRANSFORMATION, and CLAUDE.md records the rule such a pair breaks:
+# "a port is a second implementation, and a second implementation's correctness is only
+# knowable by differential testing against the ORIGINAL" (#3283 — a bash port of Go's
+# exclusion logic whose NBSP divergence was unfindable by care, because it was tested against
+# a MODEL of the original rather than the original).
+#
+# G1 was exactly that: `_jest_json_suite_counts`'s jq branch stripped at the LAST `/__test__/`
+# (greedy `^.*`) and its python3 branch at the FIRST (`str.find`). On a python3-only host whose
+# CHECKOUT PATH contains a `__test__` directory, every suite was reported missing AND extra —
+# a FALSE RED on a correct tree, latent on every box that has jq, so no run here could see it.
+#
+# So this test does not re-derive what the parsers should output. It drives BOTH branches over
+# ONE fixture set and asserts BYTE-IDENTICAL output. That is differential testing against the
+# original rather than against a model of it, and it is the only check that can catch a
+# divergence nobody thought to predict.
+#
+# EACH FIXTURE IS ADVERSARIAL ON PURPOSE, and the G1 fixture is the case that was actually
+# wrong: a checkout prefix containing `__test__`. A fixture set that only contains healthy
+# input would agree under both the broken and the fixed code and would prove nothing.
+#
+# REQUIRES BOTH TOOLS, and SAYS SO rather than asserting parity it could not measure: with only
+# one of jq/python3 present the affected pairs are reported UNMEASURED and the run exits 2. A
+# green over an unexercised comparison is the vacuous pass this whole issue exists to remove.
+set -uo pipefail
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+GATE="$SCRIPT_DIR/../agent-gate.sh"
+[ -r "$GATE" ] || { echo "FAIL: cannot read $GATE" >&2; exit 1; }
+
+have_jq=0; have_py=0
+command -v jq >/dev/null 2>&1 && have_jq=1
+command -v python3 >/dev/null 2>&1 && have_py=1
+if [ "$have_jq" -ne 1 ] || [ "$have_py" -ne 1 ]; then
+  echo "UNMEASURED: this test needs BOTH jq and python3 to compare the two branches" >&2
+  echo "  (jq present=$have_jq, python3 present=$have_py). Reporting UNMEASURED rather than" >&2
+  echo "  PASS: a parity claim over a comparison that never ran is a vacuous green." >&2
+  exit 2
+fi
+
+# Source the anchor and every named implementation OUT OF THE REAL GATE SCRIPT — never a copy,
+# which would pass while the shipped parser rotted.
+eval "$(sed -n '/^NB_TEST_ANCHOR=/p' "$GATE")"
+[ -n "${NB_TEST_ANCHOR:-}" ] || { echo "FAIL: could not extract NB_TEST_ANCHOR from $GATE" >&2; exit 1; }
+for fn in _jest_json_suite_counts_jq _jest_json_suite_counts_py \
+          _package_integration_target_ids_jq _package_integration_target_ids_py \
+          _package_declared_features_jq _package_declared_features_py; do
+  src=$(sed -n "/^$fn() {/,/^}$/p" "$GATE")
+  [ -n "$src" ] || { echo "FAIL: could not extract $fn from $GATE — renamed or reshaped; this test must not pass having compared nothing" >&2; exit 1; }
+  eval "$src" || { echo "FAIL: extracted $fn does not parse" >&2; exit 1; }
+done
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/parserparity.XXXXXX") || exit 1
+trap 'rm -rf "$WORK"' EXIT
+PASS=0; FAIL=0
+ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+# cmp_pair <name> <jq-fn> <py-fn> <args...> — run both, require byte-identical stdout AND the
+# same exit status. Status matters as much as output: one branch failing while the other
+# succeeds is a divergence even when the successful one's output looks right.
+cmp_pair() {
+  local nm="$1" fjq="$2" fpy="$3"; shift 3
+  local o1 o2 r1 r2
+  o1=$("$fjq" "$@" 2>/dev/null); r1=$?
+  o2=$("$fpy" "$@" 2>/dev/null); r2=$?
+  if [ "$r1" -ne "$r2" ]; then
+    bad "$nm — EXIT STATUS diverges: jq=$r1 python3=$r2"
+    return
+  fi
+  if [ "$o1" != "$o2" ]; then
+    bad "$nm — OUTPUT diverges:
+--- jq ---
+$o1
+--- python3 ---
+$o2"
+    return
+  fi
+  ok "$nm (both branches identical; exit=$r1)"
+}
+
+# ---------------------------------------------------------------------------
+# PAIR 1 — _jest_json_suite_counts. THE G1 CASE IS FIRST.
+# ---------------------------------------------------------------------------
+# A checkout prefix that itself contains a `__test__` directory. VERIFIED to discriminate: the
+# pre-fix pair returned `value.test.js` (jq) vs
+# `proj/bindings/node/__test__/value.test.js` (python3) on this exact input.
+cat > "$WORK/prefix.json" <<'JSON'
+{"testResults":[
+ {"name":"/home/dev/__test__/proj/bindings/node/__test__/value.test.js","assertionResults":[{"status":"passed"},{"status":"pending"}]},
+ {"name":"/repo/bindings/node/__test__/sub/deep.test.js","assertionResults":[{"status":"passed"},{"status":"passed"}]},
+ {"name":"/repo/bindings/node/__test__/a.test.js","assertionResults":[]}
+]}
+JSON
+cmp_pair "jest counts: __test__ INSIDE the checkout prefix (the G1 case)" \
+  _jest_json_suite_counts_jq _jest_json_suite_counts_py "$WORK/prefix.json"
+
+# The anchor appearing TWICE in its full three-component form — the residual ambiguity the
+# longer anchor makes implausible but does not make impossible. Both must resolve it the same
+# way (last occurrence), whatever that way is.
+cat > "$WORK/twice.json" <<'JSON'
+{"testResults":[
+ {"name":"/x/bindings/node/__test__/y/bindings/node/__test__/z.test.js","assertionResults":[{"status":"passed"}]}
+]}
+JSON
+cmp_pair "jest counts: the full anchor occurring TWICE" \
+  _jest_json_suite_counts_jq _jest_json_suite_counts_py "$WORK/twice.json"
+
+# No anchor at all — both must fall back identically rather than one emitting a bare basename.
+cat > "$WORK/noanchor.json" <<'JSON'
+{"testResults":[{"name":"/somewhere/else/odd.test.js","assertionResults":[{"status":"passed"}]}]}
+JSON
+cmp_pair "jest counts: NO anchor in the path (identical fallback)" \
+  _jest_json_suite_counts_jq _jest_json_suite_counts_py "$WORK/noanchor.json"
+
+# Every assertion status jest emits, so the passed-count filter is compared over the whole
+# vocabulary rather than just passed/pending.
+cat > "$WORK/statuses.json" <<'JSON'
+{"testResults":[{"name":"/r/bindings/node/__test__/s.test.js","assertionResults":[
+ {"status":"passed"},{"status":"failed"},{"status":"pending"},{"status":"skipped"},
+ {"status":"todo"},{"status":"disabled"},{"status":"focused"}]}]}
+JSON
+cmp_pair "jest counts: all assertion statuses" \
+  _jest_json_suite_counts_jq _jest_json_suite_counts_py "$WORK/statuses.json"
+
+# Structural edge cases: absent assertionResults, absent testResults, empty testResults.
+printf '{"testResults":[{"name":"/r/bindings/node/__test__/n.test.js"}]}' > "$WORK/noassert.json"
+cmp_pair "jest counts: assertionResults ABSENT" \
+  _jest_json_suite_counts_jq _jest_json_suite_counts_py "$WORK/noassert.json"
+printf '{"testResults":[]}' > "$WORK/empty.json"
+cmp_pair "jest counts: testResults EMPTY" \
+  _jest_json_suite_counts_jq _jest_json_suite_counts_py "$WORK/empty.json"
+printf '{}' > "$WORK/bare.json"
+cmp_pair "jest counts: testResults ABSENT" \
+  _jest_json_suite_counts_jq _jest_json_suite_counts_py "$WORK/bare.json"
+
+# A path with a SPACE, which this repo tracks under docs/ and which a tab-delimited format
+# must carry unchanged.
+cat > "$WORK/space.json" <<'JSON'
+{"testResults":[{"name":"/r/bindings/node/__test__/has space.test.js","assertionResults":[{"status":"passed"}]}]}
+JSON
+cmp_pair "jest counts: a suite path containing a SPACE" \
+  _jest_json_suite_counts_jq _jest_json_suite_counts_py "$WORK/space.json"
+
+# ---------------------------------------------------------------------------
+# PAIR 2 — _package_integration_target_ids
+# ---------------------------------------------------------------------------
+META_BASIC='{"packages":[{"name":"p","manifest_path":"/w/p/Cargo.toml","features":{"b":[],"a":[],"default":[]},"targets":[
+ {"name":"lib_t","kind":["lib"],"src_path":"/w/p/src/lib.rs"},
+ {"name":"file_t","kind":["test"],"src_path":"/w/p/tests/file_t.rs","required-features":[]},
+ {"name":"dir_t","kind":["test"],"src_path":"/w/p/tests/dir_t/main.rs","required-features":["x","y"]},
+ {"name":"outside_t","kind":["test"],"src_path":"/w/p/other/outside_t.rs"},
+ {"name":"abs_t","kind":["test"],"src_path":"/elsewhere/abs_t.rs"}
+]}]}'
+cmp_pair "target ids: file/dir/outside/absolute src_path shapes" \
+  _package_integration_target_ids_jq _package_integration_target_ids_py "$META_BASIC" p
+
+cmp_pair "target ids: package NOT PRESENT (both must fail identically)" \
+  _package_integration_target_ids_jq _package_integration_target_ids_py "$META_BASIC" nosuch
+
+META_DUP='{"packages":[{"name":"p","manifest_path":"/w/p/Cargo.toml","targets":[]},{"name":"p","manifest_path":"/w/q/Cargo.toml","targets":[]}]}'
+cmp_pair "target ids: package name appearing TWICE (ambiguous — both must refuse)" \
+  _package_integration_target_ids_jq _package_integration_target_ids_py "$META_DUP" p
+
+META_NOTARGETS='{"packages":[{"name":"p","manifest_path":"/w/p/Cargo.toml","targets":[{"name":"l","kind":["cdylib"],"src_path":"/w/p/src/lib.rs"}]}]}'
+cmp_pair "target ids: NO test targets (zero is a real answer, not a failure)" \
+  _package_integration_target_ids_jq _package_integration_target_ids_py "$META_NOTARGETS" p
+
+META_MISSINGFIELDS='{"packages":[{"name":"p","manifest_path":"/w/p/Cargo.toml","targets":[{"name":"t","kind":["test"]}]}]}'
+cmp_pair "target ids: src_path ABSENT" \
+  _package_integration_target_ids_jq _package_integration_target_ids_py "$META_MISSINGFIELDS" p
+
+META_NOMANIFEST='{"packages":[{"name":"p","targets":[{"name":"t","kind":["test"],"src_path":"/w/p/tests/t.rs"}]}]}'
+cmp_pair "target ids: manifest_path ABSENT (empty root)" \
+  _package_integration_target_ids_jq _package_integration_target_ids_py "$META_NOMANIFEST" p
+
+META_MULTIKIND='{"packages":[{"name":"p","manifest_path":"/w/p/Cargo.toml","targets":[{"name":"t","kind":["test","bench"],"src_path":"/w/p/tests/t.rs"}]}]}'
+cmp_pair "target ids: multi-kind target including test" \
+  _package_integration_target_ids_jq _package_integration_target_ids_py "$META_MULTIKIND" p
+
+# ---------------------------------------------------------------------------
+# PAIR 3 — _package_declared_features. Ordering is the thing at risk: jq's `keys` sorts by
+# unicode codepoint and python's sorted() on str does too, but that is asserted here, not
+# assumed, and the fixture is deliberately out of order and mixed-case.
+# ---------------------------------------------------------------------------
+META_FEATS='{"packages":[{"name":"p","manifest_path":"/w/p/Cargo.toml","features":{"zeta":[],"Alpha":[],"beta":[],"_under":[],"a-dash":[],"10num":[]},"targets":[]}]}'
+cmp_pair "declared features: ORDERING over mixed case/punctuation/digits" \
+  _package_declared_features_jq _package_declared_features_py "$META_FEATS" p
+cmp_pair "declared features: package NOT PRESENT (both must fail identically)" \
+  _package_declared_features_jq _package_declared_features_py "$META_FEATS" nosuch
+META_NOFEATS='{"packages":[{"name":"p","manifest_path":"/w/p/Cargo.toml","targets":[]}]}'
+cmp_pair "declared features: features table ABSENT (empty is a real answer)" \
+  _package_declared_features_jq _package_declared_features_py "$META_NOFEATS" p
+
+# ---------------------------------------------------------------------------
+# The REAL workspace, as a final control: fixtures only cover shapes someone thought of.
+# ---------------------------------------------------------------------------
+if command -v cargo >/dev/null 2>&1; then
+  REAL_META=$(cargo metadata --format-version 1 --no-deps --manifest-path "$SCRIPT_DIR/../../Cargo.toml" 2>/dev/null)
+  if [ -n "$REAL_META" ]; then
+    for pkg in cqlite-ffi-common cqlite-node cqlite-core cqlite-cli cqlite-flight; do
+      cmp_pair "REAL metadata: target ids for $pkg" \
+        _package_integration_target_ids_jq _package_integration_target_ids_py "$REAL_META" "$pkg"
+      cmp_pair "REAL metadata: declared features for $pkg" \
+        _package_declared_features_jq _package_declared_features_py "$REAL_META" "$pkg"
+    done
+  else
+    echo "note: cargo metadata unavailable; the real-workspace control did not run (fixtures only)" >&2
+  fi
+else
+  echo "note: cargo absent; the real-workspace control did not run (fixtures only)" >&2
+fi
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_agent_gate_parser_parity.sh
+++ b/scripts/tests/test_agent_gate_parser_parity.sh
@@ -24,24 +24,52 @@
 # wrong: a checkout prefix containing `__test__`. A fixture set that only contains healthy
 # input would agree under both the broken and the fixed code and would prove nothing.
 #
-# REQUIRES BOTH TOOLS, and SAYS SO rather than asserting parity it could not measure: with only
-# one of jq/python3 present the affected pairs are reported UNMEASURED and the run exits 2. A
-# green over an unexercised comparison is the vacuous pass this whole issue exists to remove.
+# DEGRADES, IT DOES NOT DEMAND (roborev round 7, H1). With both tools it compares them. With
+# ONE it still exercises that one against every fixture via PROPERTY checks — invariants of the
+# transformation rather than golden output — and DECLARES, per fixture and in the summary, that
+# the differential half did not run. It never requires both tools, because the production
+# parsers do not: demanding them turned a valid python3-only host into a mandatory-component
+# FAILURE, which is the same false-red class G1 fixed, reintroduced by G1's own test.
+# The counts are reported separately and affirmatively, so "0 divergences found" can never be
+# read off a run that performed 0 comparisons.
 set -uo pipefail
 
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 GATE="$SCRIPT_DIR/../agent-gate.sh"
 [ -r "$GATE" ] || { echo "FAIL: cannot read $GATE" >&2; exit 1; }
 
+# TOOL AVAILABILITY, AND WHY THIS IS NOT "REQUIRE BOTH" (roborev round 7, H1).
+#
+# The first cut of this file demanded BOTH jq and python3 and exited non-zero otherwise. That
+# made the MANDATORY tooling-tests component FAIL on a valid python3-only host — because the
+# UNUSED jq implementation could not be compared. The production parsers support either tool
+# INDEPENDENTLY, so the harness had invented a provisioning requirement the shipped code does
+# not have. The irony is the lesson and it is recorded here deliberately: G1 fixed a false red
+# that hit python3-only hosts, and the fix introduced a HARD FAIL on single-tool hosts — same
+# population, worse outcome, in the guard built to make the gate trustworthy. "A lane that reds
+# on correct input is the lane agents learn to waive" (CLAUDE.md) applies to self-tests too.
+#
+# So the work is split in two, and what ran is DECLARED either way:
+#   * PROPERTY checks run against EVERY AVAILABLE implementation, always. They assert
+#     invariants of the transformation rather than golden output, so a single-tool host gets
+#     REAL COVERAGE rather than a skip — and they are not a weaker consolation prize: the
+#     "normalised suite path must not still contain the anchor" property CATCHES THE ACTUAL G1
+#     DEFECT on its own, with one tool.
+#   * The DIFFERENTIAL comparison runs only when both tools exist, because comparing one
+#     implementation against itself is not a comparison.
+# NEITHER tool present is a FAIL: nothing can be tested, and the production parsers would fail
+# on that host too.
 have_jq=0; have_py=0
 command -v jq >/dev/null 2>&1 && have_jq=1
 command -v python3 >/dev/null 2>&1 && have_py=1
-if [ "$have_jq" -ne 1 ] || [ "$have_py" -ne 1 ]; then
-  echo "UNMEASURED: this test needs BOTH jq and python3 to compare the two branches" >&2
-  echo "  (jq present=$have_jq, python3 present=$have_py). Reporting UNMEASURED rather than" >&2
-  echo "  PASS: a parity claim over a comparison that never ran is a vacuous green." >&2
-  exit 2
+if [ "$have_jq" -ne 1 ] && [ "$have_py" -ne 1 ]; then
+  echo "FAIL: neither jq nor python3 is present, so NO parser implementation can be exercised." >&2
+  echo "  This is a hard failure rather than a skip: the production parsers need one of the two," >&2
+  echo "  so a host with neither cannot run the lane this test covers either." >&2
+  exit 1
 fi
+DIFFERENTIAL=0
+[ "$have_jq" -eq 1 ] && [ "$have_py" -eq 1 ] && DIFFERENTIAL=1
 
 # Source the anchor and every named implementation OUT OF THE REAL GATE SCRIPT — never a copy,
 # which would pass while the shipped parser rotted.
@@ -58,15 +86,106 @@ done
 WORK=$(mktemp -d "${TMPDIR:-/tmp}/parserparity.XXXXXX") || exit 1
 trap 'rm -rf "$WORK"' EXIT
 PASS=0; FAIL=0
+DIFF_N=0     # differential comparisons actually PERFORMED
+PROP_N=0     # property checks actually PERFORMED
+SKIPPED_N=0  # differential comparisons NOT performed for want of a tool
 ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
 bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+skipped() { printf 'skip - %s\n' "$1"; SKIPPED_N=$((SKIPPED_N + 1)); }
+
+echo "tools: jq=$have_jq python3=$have_py -> differential comparison $([ "$DIFFERENTIAL" -eq 1 ] && echo ENABLED || echo 'DISABLED (only one implementation is runnable here)')"
+echo
+
+# ---------------------------------------------------------------------------
+# PROPERTY CHECKS — invariants of the transformation, asserted against every AVAILABLE
+# implementation. Not golden output: a golden would re-derive the transformation, which is the
+# very thing differential testing exists to avoid. These are the checks that give a SINGLE-TOOL
+# host real coverage.
+# ---------------------------------------------------------------------------
+# prop_jest <impl-fn> <label> <json>
+prop_jest() {
+  local fn="$1" lbl="$2" j="$3" out line nf errs=""
+  out=$("$fn" "$j" 2>/dev/null) || { bad "$lbl — implementation exited non-zero"; return; }
+  PROP_N=$((PROP_N + 1))
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    nf=$(printf '%s' "$line" | awk -F'\t' '{print NF}')
+    [ "$nf" = 2 ] || errs="$errs [$line] has $nf TSV fields, want 2;"
+    # THE G1 INVARIANT: a normalised suite path must not still contain the anchor. This alone
+    # catches the defect that started all of this, with one tool and no comparison.
+    case "${line%%	*}" in
+      *"$NB_TEST_ANCHOR"*) errs="$errs [$line] still contains the anchor $NB_TEST_ANCHOR — normalisation did not strip it;" ;;
+    esac
+    # DELIBERATELY NOT asserted: "the path must be RELATIVE". That is NOT an invariant — for an
+    # input carrying no anchor at all both implementations correctly emit the raw absolute name
+    # (the `NO anchor in the path` fixture below pins that identical fallback), so the check
+    # red on correct output the first time it ran. Removed rather than special-cased: an
+    # invariant that needs an exception per fixture is not an invariant, and the anchor-free
+    # check above is the one that actually catches G1 — the divergent python3 output was
+    # `proj/bindings/node/__test__/value.test.js`, which CONTAINS the anchor.
+    case "${line##*	}" in
+      ''|*[!0-9]*) errs="$errs [$line] passed-count is not a number;" ;;
+    esac
+  done <<EOF
+$out
+EOF
+  if [ -z "$errs" ]; then ok "$lbl"; else bad "$lbl —$errs"; fi
+}
+# prop_ids <impl-fn> <label> <meta> <pkg>
+prop_ids() {
+  local fn="$1" lbl="$2" meta="$3" pkg="$4" out line nf errs=""
+  out=$("$fn" "$meta" "$pkg" 2>/dev/null) || { ok "$lbl (implementation refused, as expected for this input)"; PROP_N=$((PROP_N + 1)); return; }
+  PROP_N=$((PROP_N + 1))
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    nf=$(printf '%s' "$line" | awk -F'\t' '{print NF}')
+    [ "$nf" = 3 ] || errs="$errs [$line] has $nf TSV fields, want 3;"
+    case "$line" in
+      *Cargo.toml*) errs="$errs [$line] leaks a manifest path;" ;;
+    esac
+  done <<EOF
+$out
+EOF
+  if [ -z "$errs" ]; then ok "$lbl"; else bad "$lbl —$errs"; fi
+}
+# prop_feats <impl-fn> <label> <meta> <pkg> — output must be SORTED and UNIQUE, since the
+# consumer subtracts it from a resolved set and relies on a stable order.
+prop_feats() {
+  local fn="$1" lbl="$2" meta="$3" pkg="$4" out
+  out=$("$fn" "$meta" "$pkg" 2>/dev/null) || { ok "$lbl (implementation refused, as expected for this input)"; PROP_N=$((PROP_N + 1)); return; }
+  PROP_N=$((PROP_N + 1))
+  if [ "$out" = "$(printf '%s' "$out" | sort -u)" ]; then ok "$lbl"; else bad "$lbl — output is not sorted/unique: [$out]"; fi
+}
 
 # cmp_pair <name> <jq-fn> <py-fn> <args...> — run both, require byte-identical stdout AND the
 # same exit status. Status matters as much as output: one branch failing while the other
 # succeeds is a divergence even when the successful one's output looks right.
 cmp_pair() {
   local nm="$1" fjq="$2" fpy="$3"; shift 3
-  local o1 o2 r1 r2
+  local o1 o2 r1 r2 kind
+
+  # The property KIND is inferred from the implementation's own name, so adding a fixture needs
+  # no extra argument and cannot silently skip its property check by omission.
+  case "$fjq" in
+    _jest_json_suite_counts_*)            kind=jest ;;
+    _package_integration_target_ids_*)    kind=ids ;;
+    _package_declared_features_*)         kind=feats ;;
+    *) bad "$nm — HARNESS ERROR: no property kind known for implementation '$fjq'; refusing to run a comparison with no property coverage behind it"; return ;;
+  esac
+
+  # PROPERTIES FIRST, on every AVAILABLE implementation. These run on a single-tool host, and
+  # they are what makes such a host covered rather than skipped.
+  [ "$have_jq" -eq 1 ] && "prop_$kind" "$fjq" "$nm [prop: jq]" "$@"
+  [ "$have_py" -eq 1 ] && "prop_$kind" "$fpy" "$nm [prop: python3]" "$@"
+
+  if [ "$DIFFERENTIAL" -ne 1 ]; then
+    # DECLARED, never silent, and counted separately from the comparisons that RAN — see the
+    # affirmative summary at the end. A pass line that cannot distinguish "compared and agreed"
+    # from "could not compare" is the vacuous-green shape this whole file exists to prevent.
+    skipped "$nm — differential comparison NOT PERFORMED (jq=$have_jq python3=$have_py; only one implementation is runnable here). The available implementation WAS exercised by the property checks above."
+    return
+  fi
+  DIFF_N=$((DIFF_N + 1))
   o1=$("$fjq" "$@" 2>/dev/null); r1=$?
   o2=$("$fpy" "$@" 2>/dev/null); r2=$?
   if [ "$r1" -ne "$r2" ]; then
@@ -217,5 +336,19 @@ else
 fi
 
 echo
+# AFFIRMATIVE ACCOUNTING. "0 divergences found" must never be reachable from "0 comparisons
+# performed", so the two are reported as separate numbers and the skipped count is named
+# explicitly. A reader can tell, from this line alone, whether the differential half ran.
+echo "differential comparisons PERFORMED: $DIFF_N"
+echo "property checks PERFORMED:          $PROP_N"
+echo "differential comparisons SKIPPED:   $SKIPPED_N$([ "$SKIPPED_N" -gt 0 ] && echo "  (jq=$have_jq python3=$have_py — only one implementation runnable on this host)")"
+if [ "$DIFFERENTIAL" -eq 1 ] && [ "$DIFF_N" -eq 0 ]; then
+  echo "FAIL - both tools are present but ZERO comparisons ran; a parity claim with no comparison behind it is exactly the vacuous green this file exists to prevent" >&2
+  FAIL=$((FAIL + 1))
+fi
+if [ "$PROP_N" -eq 0 ]; then
+  echo "FAIL - ZERO property checks ran, so no implementation was exercised at all" >&2
+  FAIL=$((FAIL + 1))
+fi
 echo "PASS=$PASS FAIL=$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_agent_gate_parser_parity.sh
+++ b/scripts/tests/test_agent_gate_parser_parity.sh
@@ -102,11 +102,99 @@ echo
 # very thing differential testing exists to avoid. These are the checks that give a SINGLE-TOOL
 # host real coverage.
 # ---------------------------------------------------------------------------
-# prop_jest <impl-fn> <label> <json>
+# FIXTURE VALIDITY — the fix for I1, and the reason it was needed.
+#
+# The first cut of these property checks ACCEPTED FAILURE AS SUCCESS. prop_ids and prop_feats
+# called ok() on ANY nonzero exit ("implementation refused, as expected for this input") for
+# EVERY fixture, valid ones included; and prop_jest's per-line loop simply does not execute on
+# empty output, so an implementation emitting NOTHING satisfied every property. Two consequences,
+# the second worse than the first:
+#
+#   1. On a SINGLE-TOOL host — where H1 established the property half as the SOLE carrier of the
+#      divergence class — a parser that rejected valid metadata, or returned nothing at all,
+#      PASSED. The half carrying the weight failed open.
+#   2. TWO EQUALLY BROKEN IMPLEMENTATIONS PASSED THE DIFFERENTIAL COMPARISON. This is not a new
+#      idea; it is documented doctrine: "two defects that cancel are undetectable by a symmetric
+#      test by construction" (CLAUDE.md, on round-trip oracles). A differential test compares A
+#      against B and reports agreement when both fail identically. The property checks exist
+#      precisely to break that symmetry, and they could not, because they accepted empty output
+#      and nonzero exits.
+#
+# So this was the vacuous-pass family at its deepest point in the diff: the guard built to verify
+# the guards had the shape it was built to detect.
+#
+# Every fixture now DECLARES what a correct implementation does with it, and each category
+# ASSERTS rather than tolerates:
+#   nonempty   exit 0 AND non-empty output, then the invariants are judged.
+#   empty      exit 0 AND EMPTY output — asserted, not merely permitted, because "zero targets"
+#              and "zero suites" are real answers whose absence would also be a defect.
+#   reject     NONZERO exit REQUIRED. An implementation that ACCEPTS garbage now reds; the old
+#              code could not distinguish accepting it from refusing it.
+#   accept-any exit 0 required, emptiness not asserted — used ONLY for the real-`cargo metadata`
+#              control, where emptiness is data-dependent and a per-package golden would go
+#              stale and false-red the day a package gains a target. Non-vacuity for that set is
+#              enforced in AGGREGATE instead (see AGG_* below): at least one package must yield
+#              non-empty output per kind, so an implementation returning empty for everything
+#              still fails. That is an affirmative measurement without a curated expectation.
+VALID_N=0; INVALID_N=0; ANY_N=0
+AGG_jest=0; AGG_ids=0; AGG_feats=0
+
+# _prop_gate <label> <validity> <exit-status> <output> — the shared validity assertion. Returns
+# 0 when the caller should go on to judge invariants, 1 when the verdict is already decided.
+_prop_gate() {
+  local lbl="$1" validity="$2" rc="$3" out="$4"
+  case "$validity" in
+    reject)
+      INVALID_N=$((INVALID_N + 1))
+      if [ "$rc" -eq 0 ]; then
+        bad "$lbl — this fixture is INVALID and the implementation ACCEPTED it (exit 0, output [$out]). Accepting garbage is a defect, and the old harness could not tell it from a refusal."
+      else
+        ok "$lbl (correctly REFUSED an invalid fixture, exit=$rc)"
+      fi
+      return 1 ;;
+    empty)
+      VALID_N=$((VALID_N + 1))
+      if [ "$rc" -ne 0 ]; then
+        bad "$lbl — VALID fixture but the implementation exited $rc. A valid input must be accepted."
+        return 1
+      fi
+      if [ -n "$out" ]; then
+        bad "$lbl — this fixture must yield EMPTY output, got [$out]. Emptiness is the correct answer here and is ASSERTED, not merely permitted."
+        return 1
+      fi
+      ok "$lbl (correctly empty for a valid fixture whose answer is 'none')"
+      return 1 ;;
+    nonempty)
+      VALID_N=$((VALID_N + 1))
+      if [ "$rc" -ne 0 ]; then
+        bad "$lbl — VALID fixture but the implementation exited $rc. A valid input must be accepted, and on a single-tool host this check is the only thing that would notice."
+        return 1
+      fi
+      if [ -z "$out" ]; then
+        bad "$lbl — VALID fixture produced NO OUTPUT. An empty result satisfies every per-line invariant vacuously, which is exactly how two equally broken implementations used to agree."
+        return 1
+      fi
+      return 0 ;;
+    accept-any)
+      ANY_N=$((ANY_N + 1))
+      if [ "$rc" -ne 0 ]; then
+        bad "$lbl — real metadata is VALID input but the implementation exited $rc."
+        return 1
+      fi
+      return 0 ;;
+    *)
+      bad "$lbl — HARNESS ERROR: unknown fixture validity '$validity' (want nonempty|empty|reject|accept-any). An unrecognised value is a FAIL, never a pass."
+      return 1 ;;
+  esac
+}
+
+# prop_jest <impl-fn> <label> <validity> <json>
 prop_jest() {
-  local fn="$1" lbl="$2" j="$3" out line nf errs=""
-  out=$("$fn" "$j" 2>/dev/null) || { bad "$lbl — implementation exited non-zero"; return; }
+  local fn="$1" lbl="$2" validity="$3" j="$4" out line nf errs="" rc
+  out=$("$fn" "$j" 2>/dev/null); rc=$?
   PROP_N=$((PROP_N + 1))
+  _prop_gate "$lbl" "$validity" "$rc" "$out" || return
+  [ -n "$out" ] && AGG_jest=1
   while IFS= read -r line; do
     [ -n "$line" ] || continue
     nf=$(printf '%s' "$line" | awk -F'\t' '{print NF}')
@@ -121,8 +209,7 @@ prop_jest() {
     # (the `NO anchor in the path` fixture below pins that identical fallback), so the check
     # red on correct output the first time it ran. Removed rather than special-cased: an
     # invariant that needs an exception per fixture is not an invariant, and the anchor-free
-    # check above is the one that actually catches G1 — the divergent python3 output was
-    # `proj/bindings/node/__test__/value.test.js`, which CONTAINS the anchor.
+    # check above is the one that actually catches G1.
     case "${line##*	}" in
       ''|*[!0-9]*) errs="$errs [$line] passed-count is not a number;" ;;
     esac
@@ -131,11 +218,13 @@ $out
 EOF
   if [ -z "$errs" ]; then ok "$lbl"; else bad "$lbl —$errs"; fi
 }
-# prop_ids <impl-fn> <label> <meta> <pkg>
+# prop_ids <impl-fn> <label> <validity> <meta> <pkg>
 prop_ids() {
-  local fn="$1" lbl="$2" meta="$3" pkg="$4" out line nf errs=""
-  out=$("$fn" "$meta" "$pkg" 2>/dev/null) || { ok "$lbl (implementation refused, as expected for this input)"; PROP_N=$((PROP_N + 1)); return; }
+  local fn="$1" lbl="$2" validity="$3" meta="$4" pkg="$5" out line nf errs="" rc
+  out=$("$fn" "$meta" "$pkg" 2>/dev/null); rc=$?
   PROP_N=$((PROP_N + 1))
+  _prop_gate "$lbl" "$validity" "$rc" "$out" || return
+  [ -n "$out" ] && AGG_ids=1
   while IFS= read -r line; do
     [ -n "$line" ] || continue
     nf=$(printf '%s' "$line" | awk -F'\t' '{print NF}')
@@ -148,20 +237,24 @@ $out
 EOF
   if [ -z "$errs" ]; then ok "$lbl"; else bad "$lbl —$errs"; fi
 }
-# prop_feats <impl-fn> <label> <meta> <pkg> — output must be SORTED and UNIQUE, since the
-# consumer subtracts it from a resolved set and relies on a stable order.
+# prop_feats <impl-fn> <label> <validity> <meta> <pkg> — output must be SORTED and UNIQUE, since
+# the consumer subtracts it from a resolved set and relies on a stable order.
 prop_feats() {
-  local fn="$1" lbl="$2" meta="$3" pkg="$4" out
-  out=$("$fn" "$meta" "$pkg" 2>/dev/null) || { ok "$lbl (implementation refused, as expected for this input)"; PROP_N=$((PROP_N + 1)); return; }
+  local fn="$1" lbl="$2" validity="$3" meta="$4" pkg="$5" out rc
+  out=$("$fn" "$meta" "$pkg" 2>/dev/null); rc=$?
   PROP_N=$((PROP_N + 1))
+  _prop_gate "$lbl" "$validity" "$rc" "$out" || return
+  [ -n "$out" ] && AGG_feats=1
   if [ "$out" = "$(printf '%s' "$out" | sort -u)" ]; then ok "$lbl"; else bad "$lbl — output is not sorted/unique: [$out]"; fi
 }
 
-# cmp_pair <name> <jq-fn> <py-fn> <args...> — run both, require byte-identical stdout AND the
-# same exit status. Status matters as much as output: one branch failing while the other
-# succeeds is a divergence even when the successful one's output looks right.
+# cmp_pair <name> <validity> <jq-fn> <py-fn> <args...> — validity-aware property checks on every
+# available implementation, then (with both tools) a byte-identical comparison.
+#
+# Status matters as much as output: one branch failing while the other succeeds is a divergence
+# even when the successful one's output looks right.
 cmp_pair() {
-  local nm="$1" fjq="$2" fpy="$3"; shift 3
+  local nm="$1" validity="$2" fjq="$3" fpy="$4"; shift 4
   local o1 o2 r1 r2 kind
 
   # The property KIND is inferred from the implementation's own name, so adding a fixture needs
@@ -175,8 +268,8 @@ cmp_pair() {
 
   # PROPERTIES FIRST, on every AVAILABLE implementation. These run on a single-tool host, and
   # they are what makes such a host covered rather than skipped.
-  [ "$have_jq" -eq 1 ] && "prop_$kind" "$fjq" "$nm [prop: jq]" "$@"
-  [ "$have_py" -eq 1 ] && "prop_$kind" "$fpy" "$nm [prop: python3]" "$@"
+  [ "$have_jq" -eq 1 ] && "prop_$kind" "$fjq" "$nm [prop: jq]" "$validity" "$@"
+  [ "$have_py" -eq 1 ] && "prop_$kind" "$fpy" "$nm [prop: python3]" "$validity" "$@"
 
   if [ "$DIFFERENTIAL" -ne 1 ]; then
     # DECLARED, never silent, and counted separately from the comparisons that RAN — see the
@@ -200,6 +293,28 @@ $o1
 $o2"
     return
   fi
+  # AGREEMENT IS NOT ENOUGH FOR A VALID FIXTURE (I1's second clause, stated where the comparison
+  # happens rather than left to the property checks alone). Two implementations that both return
+  # NOTHING, or both refuse, agree perfectly — the symmetric-oracle blindness this file exists to
+  # break. So a `nonempty` fixture must have produced output, and no valid fixture may have been
+  # refused, before agreement counts as evidence.
+  case "$validity" in
+    nonempty)
+      if [ "$r1" -ne 0 ] || [ -z "$o1" ]; then
+        bad "$nm — both implementations AGREE but the fixture is VALID and the shared result is $([ "$r1" -ne 0 ] && echo "a REFUSAL (exit $r1)" || echo "EMPTY"). Two equally broken implementations agree by construction; agreement over a wrong shared answer is not evidence."
+        return
+      fi ;;
+    empty|accept-any)
+      if [ "$r1" -ne 0 ]; then
+        bad "$nm — both implementations AGREE but they both REFUSED a VALID fixture (exit $r1). Agreement over a shared failure is not evidence."
+        return
+      fi ;;
+    reject)
+      if [ "$r1" -eq 0 ]; then
+        bad "$nm — both implementations AGREE but they both ACCEPTED an INVALID fixture (exit 0). Agreement over a shared defect is not evidence."
+        return
+      fi ;;
+  esac
   ok "$nm (both branches identical; exit=$r1)"
 }
 
@@ -216,7 +331,7 @@ cat > "$WORK/prefix.json" <<'JSON'
  {"name":"/repo/bindings/node/__test__/a.test.js","assertionResults":[]}
 ]}
 JSON
-cmp_pair "jest counts: __test__ INSIDE the checkout prefix (the G1 case)" \
+cmp_pair "jest counts: __test__ INSIDE the checkout prefix (the G1 case)" nonempty \
   _jest_json_suite_counts_jq _jest_json_suite_counts_py "$WORK/prefix.json"
 
 # The anchor appearing TWICE in its full three-component form — the residual ambiguity the
@@ -227,14 +342,14 @@ cat > "$WORK/twice.json" <<'JSON'
  {"name":"/x/bindings/node/__test__/y/bindings/node/__test__/z.test.js","assertionResults":[{"status":"passed"}]}
 ]}
 JSON
-cmp_pair "jest counts: the full anchor occurring TWICE" \
+cmp_pair "jest counts: the full anchor occurring TWICE" nonempty \
   _jest_json_suite_counts_jq _jest_json_suite_counts_py "$WORK/twice.json"
 
 # No anchor at all — both must fall back identically rather than one emitting a bare basename.
 cat > "$WORK/noanchor.json" <<'JSON'
 {"testResults":[{"name":"/somewhere/else/odd.test.js","assertionResults":[{"status":"passed"}]}]}
 JSON
-cmp_pair "jest counts: NO anchor in the path (identical fallback)" \
+cmp_pair "jest counts: NO anchor in the path (identical fallback)" nonempty \
   _jest_json_suite_counts_jq _jest_json_suite_counts_py "$WORK/noanchor.json"
 
 # Every assertion status jest emits, so the passed-count filter is compared over the whole
@@ -244,18 +359,18 @@ cat > "$WORK/statuses.json" <<'JSON'
  {"status":"passed"},{"status":"failed"},{"status":"pending"},{"status":"skipped"},
  {"status":"todo"},{"status":"disabled"},{"status":"focused"}]}]}
 JSON
-cmp_pair "jest counts: all assertion statuses" \
+cmp_pair "jest counts: all assertion statuses" nonempty \
   _jest_json_suite_counts_jq _jest_json_suite_counts_py "$WORK/statuses.json"
 
 # Structural edge cases: absent assertionResults, absent testResults, empty testResults.
 printf '{"testResults":[{"name":"/r/bindings/node/__test__/n.test.js"}]}' > "$WORK/noassert.json"
-cmp_pair "jest counts: assertionResults ABSENT" \
+cmp_pair "jest counts: assertionResults ABSENT" nonempty \
   _jest_json_suite_counts_jq _jest_json_suite_counts_py "$WORK/noassert.json"
 printf '{"testResults":[]}' > "$WORK/empty.json"
-cmp_pair "jest counts: testResults EMPTY" \
+cmp_pair "jest counts: testResults EMPTY" empty \
   _jest_json_suite_counts_jq _jest_json_suite_counts_py "$WORK/empty.json"
 printf '{}' > "$WORK/bare.json"
-cmp_pair "jest counts: testResults ABSENT" \
+cmp_pair "jest counts: testResults ABSENT" empty \
   _jest_json_suite_counts_jq _jest_json_suite_counts_py "$WORK/bare.json"
 
 # A path with a SPACE, which this repo tracks under docs/ and which a tab-delimited format
@@ -263,7 +378,7 @@ cmp_pair "jest counts: testResults ABSENT" \
 cat > "$WORK/space.json" <<'JSON'
 {"testResults":[{"name":"/r/bindings/node/__test__/has space.test.js","assertionResults":[{"status":"passed"}]}]}
 JSON
-cmp_pair "jest counts: a suite path containing a SPACE" \
+cmp_pair "jest counts: a suite path containing a SPACE" nonempty \
   _jest_json_suite_counts_jq _jest_json_suite_counts_py "$WORK/space.json"
 
 # ---------------------------------------------------------------------------
@@ -276,30 +391,30 @@ META_BASIC='{"packages":[{"name":"p","manifest_path":"/w/p/Cargo.toml","features
  {"name":"outside_t","kind":["test"],"src_path":"/w/p/other/outside_t.rs"},
  {"name":"abs_t","kind":["test"],"src_path":"/elsewhere/abs_t.rs"}
 ]}]}'
-cmp_pair "target ids: file/dir/outside/absolute src_path shapes" \
+cmp_pair "target ids: file/dir/outside/absolute src_path shapes" nonempty \
   _package_integration_target_ids_jq _package_integration_target_ids_py "$META_BASIC" p
 
-cmp_pair "target ids: package NOT PRESENT (both must fail identically)" \
+cmp_pair "target ids: package NOT PRESENT (both must fail identically)" reject \
   _package_integration_target_ids_jq _package_integration_target_ids_py "$META_BASIC" nosuch
 
 META_DUP='{"packages":[{"name":"p","manifest_path":"/w/p/Cargo.toml","targets":[]},{"name":"p","manifest_path":"/w/q/Cargo.toml","targets":[]}]}'
-cmp_pair "target ids: package name appearing TWICE (ambiguous — both must refuse)" \
+cmp_pair "target ids: package name appearing TWICE (ambiguous — both must refuse)" reject \
   _package_integration_target_ids_jq _package_integration_target_ids_py "$META_DUP" p
 
 META_NOTARGETS='{"packages":[{"name":"p","manifest_path":"/w/p/Cargo.toml","targets":[{"name":"l","kind":["cdylib"],"src_path":"/w/p/src/lib.rs"}]}]}'
-cmp_pair "target ids: NO test targets (zero is a real answer, not a failure)" \
+cmp_pair "target ids: NO test targets (zero is a real answer, not a failure)" empty \
   _package_integration_target_ids_jq _package_integration_target_ids_py "$META_NOTARGETS" p
 
 META_MISSINGFIELDS='{"packages":[{"name":"p","manifest_path":"/w/p/Cargo.toml","targets":[{"name":"t","kind":["test"]}]}]}'
-cmp_pair "target ids: src_path ABSENT" \
+cmp_pair "target ids: src_path ABSENT" nonempty \
   _package_integration_target_ids_jq _package_integration_target_ids_py "$META_MISSINGFIELDS" p
 
 META_NOMANIFEST='{"packages":[{"name":"p","targets":[{"name":"t","kind":["test"],"src_path":"/w/p/tests/t.rs"}]}]}'
-cmp_pair "target ids: manifest_path ABSENT (empty root)" \
+cmp_pair "target ids: manifest_path ABSENT (empty root)" nonempty \
   _package_integration_target_ids_jq _package_integration_target_ids_py "$META_NOMANIFEST" p
 
 META_MULTIKIND='{"packages":[{"name":"p","manifest_path":"/w/p/Cargo.toml","targets":[{"name":"t","kind":["test","bench"],"src_path":"/w/p/tests/t.rs"}]}]}'
-cmp_pair "target ids: multi-kind target including test" \
+cmp_pair "target ids: multi-kind target including test" nonempty \
   _package_integration_target_ids_jq _package_integration_target_ids_py "$META_MULTIKIND" p
 
 # ---------------------------------------------------------------------------
@@ -308,12 +423,12 @@ cmp_pair "target ids: multi-kind target including test" \
 # assumed, and the fixture is deliberately out of order and mixed-case.
 # ---------------------------------------------------------------------------
 META_FEATS='{"packages":[{"name":"p","manifest_path":"/w/p/Cargo.toml","features":{"zeta":[],"Alpha":[],"beta":[],"_under":[],"a-dash":[],"10num":[]},"targets":[]}]}'
-cmp_pair "declared features: ORDERING over mixed case/punctuation/digits" \
+cmp_pair "declared features: ORDERING over mixed case/punctuation/digits" nonempty \
   _package_declared_features_jq _package_declared_features_py "$META_FEATS" p
-cmp_pair "declared features: package NOT PRESENT (both must fail identically)" \
+cmp_pair "declared features: package NOT PRESENT (both must fail identically)" reject \
   _package_declared_features_jq _package_declared_features_py "$META_FEATS" nosuch
 META_NOFEATS='{"packages":[{"name":"p","manifest_path":"/w/p/Cargo.toml","targets":[]}]}'
-cmp_pair "declared features: features table ABSENT (empty is a real answer)" \
+cmp_pair "declared features: features table ABSENT (empty is a real answer)" empty \
   _package_declared_features_jq _package_declared_features_py "$META_NOFEATS" p
 
 # ---------------------------------------------------------------------------
@@ -323,9 +438,9 @@ if command -v cargo >/dev/null 2>&1; then
   REAL_META=$(cargo metadata --format-version 1 --no-deps --manifest-path "$SCRIPT_DIR/../../Cargo.toml" 2>/dev/null)
   if [ -n "$REAL_META" ]; then
     for pkg in cqlite-ffi-common cqlite-node cqlite-core cqlite-cli cqlite-flight; do
-      cmp_pair "REAL metadata: target ids for $pkg" \
+      cmp_pair "REAL metadata: target ids for $pkg" accept-any \
         _package_integration_target_ids_jq _package_integration_target_ids_py "$REAL_META" "$pkg"
-      cmp_pair "REAL metadata: declared features for $pkg" \
+      cmp_pair "REAL metadata: declared features for $pkg" accept-any \
         _package_declared_features_jq _package_declared_features_py "$REAL_META" "$pkg"
     done
   else
@@ -339,6 +454,32 @@ echo
 # AFFIRMATIVE ACCOUNTING. "0 divergences found" must never be reachable from "0 comparisons
 # performed", so the two are reported as separate numbers and the skipped count is named
 # explicitly. A reader can tell, from this line alone, whether the differential half ran.
+# FIXTURE ACCOUNTING (I1). A reader must be able to tell "checked N valid fixtures" from
+# "checked nothing", and the valid/invalid split is what says whether the reject cases ran at all.
+echo "fixtures: valid=$VALID_N invalid=$INVALID_N accept-any(real-metadata)=$ANY_N"
+# AGGREGATE NON-VACUITY for the accept-any set, whose emptiness is data-dependent and therefore
+# not per-fixture assertable without a golden that would go stale. If a parser returned EMPTY for
+# every real package, every per-line invariant would hold vacuously — so at least one must have
+# produced output, per kind that was exercised.
+for _k in jest ids feats; do
+  eval "_agg=\$AGG_$_k"
+  case "$_k" in
+    jest)  _exercised=$([ "$VALID_N" -gt 0 ] && echo 1 || echo 0) ;;
+    *)     _exercised=1 ;;
+  esac
+  if [ "$_exercised" -eq 1 ] && [ "$_agg" -ne 1 ]; then
+    echo "FAIL - every fixture for kind '$_k' produced EMPTY output, so its per-line invariants held vacuously; at least one must yield output or the checks measured nothing" >&2
+    FAIL=$((FAIL + 1))
+  fi
+done
+if [ "$VALID_N" -eq 0 ]; then
+  echo "FAIL - ZERO valid fixtures were judged; a harness that only ever exercised refusals has not tested the parsers" >&2
+  FAIL=$((FAIL + 1))
+fi
+if [ "$INVALID_N" -eq 0 ]; then
+  echo "FAIL - ZERO invalid fixtures were judged, so nothing verified that a parser REFUSES bad input" >&2
+  FAIL=$((FAIL + 1))
+fi
 echo "differential comparisons PERFORMED: $DIFF_N"
 echo "property checks PERFORMED:          $PROP_N"
 echo "differential comparisons SKIPPED:   $SKIPPED_N$([ "$SKIPPED_N" -gt 0 ] && echo "  (jq=$have_jq python3=$have_py — only one implementation runnable on this host)")"

--- a/scripts/tests/test_agent_gate_parser_parity.sh
+++ b/scripts/tests/test_agent_gate_parser_parity.sh
@@ -133,11 +133,35 @@ echo
 #   accept-any exit 0 required, emptiness not asserted — used ONLY for the real-`cargo metadata`
 #              control, where emptiness is data-dependent and a per-package golden would go
 #              stale and false-red the day a package gains a target. Non-vacuity for that set is
-#              enforced in AGGREGATE instead (see AGG_* below): at least one package must yield
-#              non-empty output per kind, so an implementation returning empty for everything
-#              still fails. That is an affirmative measurement without a curated expectation.
+#              enforced in AGGREGATE instead: at least one package must yield non-empty output
+#              per kind, so an implementation returning empty for everything still fails. That is
+#              an affirmative measurement without a curated expectation.
+#
+# TWO POPULATIONS, ACCOUNTED SEPARATELY (roborev round 9, J1). The first cut used ONE aggregate
+# flag per kind, set by ANY fixture — so the SYNTHETIC fixtures satisfied it and the real-metadata
+# floor could never fire: a real `accept-any` case returning empty was invisible behind healthy
+# synthetic siblings.
+#
+# THAT IS F1 AGAIN, ONE LAYER IN, and it is worth naming as such. F1 was `t_passed > 0` measured
+# across 27 jest suites, so one all-skipped suite hid behind 26 passing ones. Here an aggregate
+# flag was certified by a DIFFERENT POPULATION than the one it existed to certify. Same shape:
+# an aggregate satisfied by the wrong subjects. Reaching for aggregate non-vacuity was still the
+# right call — a per-package golden would go stale and false-red — the error was pooling two
+# populations that need separate books.
+#
+# So each kind carries FOUR counters, and the two floors are enforced independently, each only
+# when its own population actually ran:
+#   SYNNE_<kind>   synthetic `nonempty` fixtures judged      -> gates the synthetic floor
+#   AGG_<kind>     a SYNTHETIC fixture produced output
+#   REALN_<kind>   real-metadata `accept-any` cases judged   -> gates the real floor
+#   AGGREAL_<kind> a REAL-METADATA case produced output
+# The split is symmetric on purpose: pooling would also let the real cases satisfy the synthetic
+# floor, which is the same defect mirrored.
 VALID_N=0; INVALID_N=0; ANY_N=0
 AGG_jest=0; AGG_ids=0; AGG_feats=0
+AGGREAL_jest=0; AGGREAL_ids=0; AGGREAL_feats=0
+SYNNE_jest=0; SYNNE_ids=0; SYNNE_feats=0
+REALN_jest=0; REALN_ids=0; REALN_feats=0
 
 # _prop_gate <label> <validity> <exit-status> <output> — the shared validity assertion. Returns
 # 0 when the caller should go on to judge invariants, 1 when the verdict is already decided.
@@ -194,7 +218,12 @@ prop_jest() {
   out=$("$fn" "$j" 2>/dev/null); rc=$?
   PROP_N=$((PROP_N + 1))
   _prop_gate "$lbl" "$validity" "$rc" "$out" || return
-  [ -n "$out" ] && AGG_jest=1
+  # ATTRIBUTE THE OBSERVATION TO ITS POPULATION (J1). Only `nonempty` and `accept-any`
+  # reach here; `empty` and `reject` decide their verdict inside _prop_gate.
+  case "$validity" in
+    accept-any) REALN_jest=$((REALN_jest + 1)); [ -n "$out" ] && AGGREAL_jest=1 ;;
+    *)          SYNNE_jest=$((SYNNE_jest + 1)); [ -n "$out" ] && AGG_jest=1 ;;
+  esac
   while IFS= read -r line; do
     [ -n "$line" ] || continue
     nf=$(printf '%s' "$line" | awk -F'\t' '{print NF}')
@@ -224,7 +253,12 @@ prop_ids() {
   out=$("$fn" "$meta" "$pkg" 2>/dev/null); rc=$?
   PROP_N=$((PROP_N + 1))
   _prop_gate "$lbl" "$validity" "$rc" "$out" || return
-  [ -n "$out" ] && AGG_ids=1
+  # ATTRIBUTE THE OBSERVATION TO ITS POPULATION (J1). Only `nonempty` and `accept-any`
+  # reach here; `empty` and `reject` decide their verdict inside _prop_gate.
+  case "$validity" in
+    accept-any) REALN_ids=$((REALN_ids + 1)); [ -n "$out" ] && AGGREAL_ids=1 ;;
+    *)          SYNNE_ids=$((SYNNE_ids + 1)); [ -n "$out" ] && AGG_ids=1 ;;
+  esac
   while IFS= read -r line; do
     [ -n "$line" ] || continue
     nf=$(printf '%s' "$line" | awk -F'\t' '{print NF}')
@@ -244,7 +278,12 @@ prop_feats() {
   out=$("$fn" "$meta" "$pkg" 2>/dev/null); rc=$?
   PROP_N=$((PROP_N + 1))
   _prop_gate "$lbl" "$validity" "$rc" "$out" || return
-  [ -n "$out" ] && AGG_feats=1
+  # ATTRIBUTE THE OBSERVATION TO ITS POPULATION (J1). Only `nonempty` and `accept-any`
+  # reach here; `empty` and `reject` decide their verdict inside _prop_gate.
+  case "$validity" in
+    accept-any) REALN_feats=$((REALN_feats + 1)); [ -n "$out" ] && AGGREAL_feats=1 ;;
+    *)          SYNNE_feats=$((SYNNE_feats + 1)); [ -n "$out" ] && AGG_feats=1 ;;
+  esac
   if [ "$out" = "$(printf '%s' "$out" | sort -u)" ]; then ok "$lbl"; else bad "$lbl — output is not sorted/unique: [$out]"; fi
 }
 
@@ -457,18 +496,26 @@ echo
 # FIXTURE ACCOUNTING (I1). A reader must be able to tell "checked N valid fixtures" from
 # "checked nothing", and the valid/invalid split is what says whether the reject cases ran at all.
 echo "fixtures: valid=$VALID_N invalid=$INVALID_N accept-any(real-metadata)=$ANY_N"
-# AGGREGATE NON-VACUITY for the accept-any set, whose emptiness is data-dependent and therefore
-# not per-fixture assertable without a golden that would go stale. If a parser returned EMPTY for
-# every real package, every per-line invariant would hold vacuously — so at least one must have
-# produced output, per kind that was exercised.
+# BOTH POPULATIONS REPORTED SEPARATELY (J1), so "synthetic floor met" can never be read as
+# "real-metadata control verified". `real-nonempty` is the line that says the real control
+# actually produced data; a `-` means that population did not run for that kind.
+_syn_line=""; _real_line=""
 for _k in jest ids feats; do
-  eval "_agg=\$AGG_$_k"
-  case "$_k" in
-    jest)  _exercised=$([ "$VALID_N" -gt 0 ] && echo 1 || echo 0) ;;
-    *)     _exercised=1 ;;
-  esac
-  if [ "$_exercised" -eq 1 ] && [ "$_agg" -ne 1 ]; then
-    echo "FAIL - every fixture for kind '$_k' produced EMPTY output, so its per-line invariants held vacuously; at least one must yield output or the checks measured nothing" >&2
+  eval "_sn=\$SYNNE_$_k; _sa=\$AGG_$_k; _rn=\$REALN_$_k; _ra=\$AGGREAL_$_k"
+  _syn_line="$_syn_line $_k=$([ "$_sn" -gt 0 ] && echo "$_sn/nonempty=$_sa" || echo '-')"
+  _real_line="$_real_line $_k=$([ "$_rn" -gt 0 ] && echo "$_rn/nonempty=$_ra" || echo '-')"
+done
+echo "synthetic  fixtures judged (per kind):$_syn_line"
+echo "real-metadata cases judged (per kind):$_real_line"
+# TWO INDEPENDENT FLOORS, each gated on ITS OWN population having run. Pooling them is J1.
+for _k in jest ids feats; do
+  eval "_sn=\$SYNNE_$_k; _sa=\$AGG_$_k; _rn=\$REALN_$_k; _ra=\$AGGREAL_$_k"
+  if [ "$_sn" -gt 0 ] && [ "$_sa" -ne 1 ]; then
+    echo "FAIL - every SYNTHETIC 'nonempty' fixture for kind '$_k' produced EMPTY output, so its per-line invariants held vacuously; at least one must yield output or the checks measured nothing" >&2
+    FAIL=$((FAIL + 1))
+  fi
+  if [ "$_rn" -gt 0 ] && [ "$_ra" -ne 1 ]; then
+    echo "FAIL - every REAL-METADATA case for kind '$_k' produced EMPTY output ($_rn judged). The synthetic floor above cannot see this: it is satisfied by the synthetic fixtures, which is exactly why the two populations are counted apart (J1). A parser that returns nothing for every real workspace package satisfies every per-line invariant vacuously." >&2
     FAIL=$((FAIL + 1))
   fi
 done

--- a/scripts/tests/test_agent_gate_sublanes.sh
+++ b/scripts/tests/test_agent_gate_sublanes.sh
@@ -35,6 +35,19 @@ EXPECTED_EXISTING_SIDE="python-bindings node-bindings"
 # feature set that DIVERGES from MAIN's cli-helpers set, which is precisely the shared-target
 # thrash shape #2657 documents — so all four belong on SIDE, each in its own CARGO_TARGET_DIR.
 EXPECTED_FEATURE_MATRIX_SIDE="flight-tests legacy-heuristics feature-iso-parquet feature-iso-delta-scan"
+# The #3522 binding-side Rust lane. SIDE for the SAME class-(a) reason, and the decision
+# rests on the lane's own build properties rather than on where the classifier happened to
+# put it: it compiles TWO packages whose cqlite-core feature resolutions BOTH diverge from
+# MAIN's. cqlite-node takes cqlite-core with `parquet` (plus state_machine, all-compression,
+# cli-helpers and the defaults), and MAIN never enables parquet; cqlite-ffi-common takes it
+# with `default-features = false`, a third distinct resolution. Building either against
+# MAIN's shared target dir is exactly the feature-thrash shape #2657 documents, so its own
+# CARGO_TARGET_DIR is a positive benefit, not a formality.
+# It is NOT in EXPECTED_MAIN_ONLY because the #2657 exclusion is for LATENCY-SENSITIVE
+# components (tooling-tests' exit-latency self-tests starve under co-scheduled load), and
+# this lane makes no wall-clock assertion at all — it runs cargo test over unit and
+# integration suites.
+EXPECTED_BINDING_RUST_SIDE="binding-rust-tests"
 # Components that MUST stay on the strictly-serial MAIN lane despite being otherwise
 # isolatable — tooling-tests is here because its shell self-tests are latency-sensitive.
 EXPECTED_MAIN_ONLY="tooling-tests"
@@ -80,6 +93,16 @@ for c in $EXPECTED_FEATURE_MATRIX_SIDE; do
   fi
 done
 
+# 3c) The #3522 binding-side Rust lane, asserted per component for the same reason as 3b:
+#     a FAIL should name which lane moved rather than only reporting that the set drifted.
+for c in $EXPECTED_BINDING_RUST_SIDE; do
+  if [ "$(lane_of "$c")" = side ]; then
+    ok "$c runs in the SIDE lane with its own CARGO_TARGET_DIR (#3522: cqlite-node pulls cqlite-core with parquet, cqlite-ffi-common with default-features=false — both diverge from MAIN)"
+  else
+    bad "$c is NOT on the SIDE lane (lane='$(lane_of "$c")') — it compiles cqlite-ffi-common and cqlite-node, whose cqlite-core feature resolutions both diverge from MAIN's, and would thrash the shared target dir (#2657/#3522)"
+  fi
+done
+
 # 4) core-tests (the shared-target long pole) and the guard components that build
 #    cqlite-core under MAIN's feature set MUST stay on the strictly-serial MAIN lane
 #    — moving them to a concurrent lane is the shared-target thrash #1737 documents.
@@ -106,9 +129,15 @@ done
 # 5) The SIDE lane must be exactly the union of the two sets — nothing else silently
 #    joined it, so the MAIN build profile is unchanged for every other component.
 side_sorted=$(printf '%s\n' $side_list | sort)
-expected_side_sorted=$(printf '%s\n' $EXPECTED_NEW_SIDE $EXPECTED_EXISTING_SIDE $EXPECTED_FEATURE_MATRIX_SIDE | sort)
+expected_side_sorted=$(printf '%s\n' $EXPECTED_NEW_SIDE $EXPECTED_EXISTING_SIDE $EXPECTED_FEATURE_MATRIX_SIDE $EXPECTED_BINDING_RUST_SIDE | sort)
+# The COUNT IS DERIVED from the expected sets, never written as a literal (#3522). It used
+# to read "the 11 expected isolatable components", and adding a twelfth made that number
+# wrong in a message that is only ever printed on SUCCESS — so the stale figure would have
+# been asserted as fact by a passing test. The decomposition below stays as PROSE naming the
+# issues, because that is the part a reader needs and the part arithmetic cannot express.
+n_expected_side=$(printf '%s\n' $expected_side_sorted | grep -c .)
 if [ "$side_sorted" = "$expected_side_sorted" ]; then
-  ok "SIDE lane is exactly the 11 expected isolatable components (7 pre-existing + the 4 #1699 feature-matrix lanes; tooling-tests excluded)"
+  ok "SIDE lane is exactly the $n_expected_side expected isolatable components (2 #1737 bindings + 5 #2657 isolatable + 4 #1699 feature-matrix lanes + 1 #3522 binding-side Rust lane; tooling-tests excluded)"
 else
   bad "SIDE lane membership drifted:
 --- got ---
@@ -145,7 +174,7 @@ fi
 # 9) is_side_component and _component_lane agree (single source of truth): every
 #    component the classifier calls "side" must be a member of the union above.
 for c in $side_list; do
-  case " $EXPECTED_NEW_SIDE $EXPECTED_EXISTING_SIDE $EXPECTED_FEATURE_MATRIX_SIDE " in
+  case " $EXPECTED_NEW_SIDE $EXPECTED_EXISTING_SIDE $EXPECTED_FEATURE_MATRIX_SIDE $EXPECTED_BINDING_RUST_SIDE " in
     *" $c "*) : ;;
     *) bad "classifier put unexpected '$c' on the SIDE lane" ;;
   esac

--- a/scripts/tests/test_workspace_test_disposition.sh
+++ b/scripts/tests/test_workspace_test_disposition.sh
@@ -9,6 +9,18 @@
 #   PARTIAL       the gate runs some; the detail names the component, what is not run, and why.
 #   NOT-EXECUTED  nothing runs them; the detail says why (+ an issue when one is filed).
 #
+# Each record carries a SECOND closed field, its CLASS, answering a different question:
+# does the gap make a statement THIS REPOSITORY MAKES TO AGENTS false?
+#   silent                a real gap no committed doctrine claims is covered, or one
+#                         already declared honestly where an agent reads it.
+#   contradicts-doctrine  committed doctrine says it is covered when it is not.
+#   no-gap                nothing to classify — the record is EXECUTED.
+# The two fields are COUPLED and the coupling is checked: EXECUTED <=> no-gap. That is
+# the one cross-field property available without modelling the gate, and it closes the
+# obvious escape — quietly marking an uncomfortable PARTIAL record `no-gap`.
+# The class is DOCUMENTATION, like the detail: this guard does not verify that a
+# `silent` record is really unclaimed, only that a classification was RECORDED.
+#
 # Why it exists. `cargo clippy --workspace --all-targets` compiles every member on
 # every full gate, so a crate can be BUILT by every run and EXECUTE NOTHING — and
 # before #3522 nothing said so. `cqlite-ffi-common` (52 tests) and `cqlite-node`'s 53
@@ -70,6 +82,11 @@ VALID_LABELS="EXECUTED
 PARTIAL
 NOT-EXECUTED"
 
+# The CLOSED class set, for the same reason and matched the same way.
+VALID_CLASSES="silent
+contradicts-doctrine
+no-gap"
+
 fail() { echo "FAIL: $*" >&2; exit 1; }
 ok()   { echo "ok: $*"; }
 
@@ -118,12 +135,14 @@ while IFS= read -r line || [ -n "$line" ]; do
   # Field-count first: a line with the wrong shape must be named as malformed rather
   # than silently yielding an empty package or an empty label.
   nf=$(printf '%s' "$line" | awk -F'\t' '{print NF}')
-  [ "$nf" -eq 3 ] || fail "$CENSUS line $lineno is not a TAB-separated triple (<package> TAB <LABEL> TAB <detail>; found $nf field(s)): $line"
+  [ "$nf" -eq 4 ] || fail "$CENSUS line $lineno is not a TAB-separated record (<package> TAB <LABEL> TAB <CLASS> TAB <detail>; found $nf field(s)): $line"
   pkg=$(printf '%s' "$line" | awk -F'\t' '{print $1}')
   label=$(printf '%s' "$line" | awk -F'\t' '{print $2}')
-  detail=$(printf '%s' "$line" | awk -F'\t' '{print $3}')
+  class=$(printf '%s' "$line" | awk -F'\t' '{print $3}')
+  detail=$(printf '%s' "$line" | awk -F'\t' '{print $4}')
   [ -n "$pkg" ]   || fail "$CENSUS line $lineno has an empty package name: $line"
   [ -n "$label" ] || fail "$CENSUS line $lineno has an empty label: $line"
+  [ -n "$class" ] || fail "$CENSUS line $lineno has an empty class: $line"
   # A record with no detail is a label with no account behind it, which is the
   # documentation half of this guard's whole purpose.
   [ -n "$detail" ] || fail "$CENSUS line $lineno records '$pkg' as $label with NO detail. EXECUTED must NAME the gate component; PARTIAL must name the component AND what is not run AND why; NOT-EXECUTED must say why (+ the tracking issue, when one is filed)"
@@ -131,6 +150,18 @@ while IFS= read -r line || [ -n "$line" ]; do
   # accept `EXECUTEDish` / `Executed`, i.e. check a spelling rather than a state.
   printf '%s\n' "$VALID_LABELS" | grep -qxF "$label" \
     || fail "$CENSUS line $lineno labels '$pkg' as '$label', which is not in the closed label set ($(printf '%s' "$VALID_LABELS" | tr '\n' '/' | sed 's:/$::')). An unrecognised label is a FAIL, never a pass"
+  printf '%s\n' "$VALID_CLASSES" | grep -qxF "$class" \
+    || fail "$CENSUS line $lineno classes '$pkg' as '$class', which is not in the closed class set ($(printf '%s' "$VALID_CLASSES" | tr '\n' '/' | sed 's:/$::')). An unrecognised class is a FAIL, never a pass"
+  # The one CROSS-FIELD property this guard can check without modelling the gate. Both
+  # directions matter: `no-gap` on a PARTIAL/NOT-EXECUTED record is how an uncomfortable
+  # record gets excused without relabelling it (the shape the visible-gap floor below
+  # exists for, one field over), and a gap class on an EXECUTED record is a record that
+  # contradicts itself.
+  if [ "$label" = EXECUTED ]; then
+    [ "$class" = no-gap ] || fail "$CENSUS line $lineno records '$pkg' as EXECUTED but classes it '$class'. EXECUTED means there is no gap to classify, so its class must be no-gap"
+  else
+    [ "$class" != no-gap ] || fail "$CENSUS line $lineno records '$pkg' as $label — a real gap — but classes it no-gap. Classify it 'silent' (no committed doctrine claims it is covered) or 'contradicts-doctrine' (doctrine says it is covered and it is not); no-gap is reserved for EXECUTED records"
+  fi
   case "$RECORDED" in
     *"|$pkg|"*) fail "$CENSUS records '$pkg' more than once (line $lineno) — a package has exactly ONE disposition" ;;
   esac
@@ -181,6 +212,16 @@ if [ "$n_gap" -eq 0 ]; then
   fail "$CENSUS records ZERO NOT-EXECUTED/PARTIAL packages. Either every workspace member's tests are now fully executed by the gate — in which case delete this floor DELIBERATELY, in a reviewed diff that says so — or an uncomfortable record was relabelled. The visible unexecuted set is this census's entire purpose"
 fi
 ok "$n_gap of $n_members member(s) are recorded as PARTIAL or NOT-EXECUTED — the gap this census exists to keep visible is stated, not hidden"
+
+# --- 6. AFFIRMATIVE class census. Not a threshold — a REPORT, so a pasted PASS states
+# ---    how many gaps are recorded as contradicting committed doctrine rather than
+# ---    leaving that count to be rediscovered. `0 RECOGNISED` (never a bare 0), because
+# ---    a bare zero in a gate log reads as a verified all-clear from a scan that only
+# ---    checks what was RECORDED.
+n_doctrine=$(grep -cE '^[^#[:space:]]+	[A-Z-]+	contradicts-doctrine	' "$CENSUS" || true)
+n_silent=$(grep -cE '^[^#[:space:]]+	[A-Z-]+	silent	' "$CENSUS" || true)
+case "$n_doctrine$n_silent" in ''|*[!0-9]*) fail "could not count the recorded gap classes — unmeasurable is not a pass" ;; esac
+ok "gap classes: $n_doctrine RECOGNISED as contradicts-doctrine, $n_silent RECOGNISED as silent (RECORDED classifications, not verified ones — see this script's header)"
 
 echo "PASS: workspace test-execution disposition census is complete and labeled ($n_members members, $n_records records)"
 exit 0

--- a/scripts/tests/test_workspace_test_disposition.sh
+++ b/scripts/tests/test_workspace_test_disposition.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Workspace test-execution disposition census (issue #3522).
+#
+# ONE property, at PACKAGE granularity: every cargo workspace member is EXPLICITLY
+# classified in scripts/tests/workspace-test-disposition.txt as to whether the full
+# agent gate EXECUTES its Rust tests.
+#
+#   EXECUTED      the gate runs them; the detail names the component.
+#   PARTIAL       the gate runs some; the detail names the component, what is not run, and why.
+#   NOT-EXECUTED  nothing runs them; the detail says why (+ an issue when one is filed).
+#
+# Why it exists. `cargo clippy --workspace --all-targets` compiles every member on
+# every full gate, so a crate can be BUILT by every run and EXECUTE NOTHING — and
+# before #3522 nothing said so. `cqlite-ffi-common` (52 tests) and `cqlite-node`'s 53
+# Rust unit tests sat in exactly that hole, reading as covered because the workspace
+# built clean. Without this guard the classification silently decays: the root
+# manifest's `members` includes `tools/*` and `bindings/*`, so a NEW crate joins the
+# workspace with no statement of whether anything runs its tests. That is caught here.
+#
+# This is the PACKAGE-granular sibling of test_tools_crate_disposition.sh, which asks
+# the same shape of question ("is a disposition RECORDED?") about tools/ crates and
+# their READMEs. It is modelled on that script deliberately, including its refusals.
+#
+# ============================ SCOPE, AND WHAT IT IS NOT ======================
+# This is a DOCUMENTATION-COMPLETENESS guard. It verifies that a disposition has been
+# RECORDED and LABELED with a label from a CLOSED set. It does NOT verify that the
+# recorded disposition is TRUE, and it makes no such claim anywhere. A record saying
+# `EXECUTED  core-tests` for a package no component runs passes this guard.
+#
+# THAT LIMIT IS DELIBERATE, AND THE REASON IS RECORDED SO NOBODY "IMPROVES" IT AWAY.
+# test_tools_crate_disposition.sh once DID try to verify truth, by deriving workspace
+# dependents from cargo and cross-checking. It was REMOVED (#1716), because:
+#   * eleven review findings over eight rounds landed in the derivation machinery and
+#     NONE in the list-and-label part — the derivation was where every defect lived;
+#   * its self-tests built scratch workspaces outside the repository, which do not
+#     inherit rust-toolchain.toml, making a MANDATORY gate component's behaviour
+#     host-toolchain-dependent. A flaky mandatory gate is a fleet-wide liability.
+# Verifying truth here would be strictly harder (it would have to model every gate
+# component's cargo invocation, i.e. re-implement the gate). If it is ever worth doing,
+# it is its own issue, not a rider on this one.
+#
+# Consequences, stated rather than left to be discovered:
+#   * Granularity is per-PACKAGE. A new unexecuted TARGET inside an already-recorded
+#     package needs no census update and passes unchanged.
+#   * A PARTIAL record's account of what it omits is DOCUMENTED, not verified.
+# Both are accepted limits of a small guard. A guard that overpromises is worse than a
+# small one, and a guard whose FAIL an agent learns to waive is worse than no guard.
+#
+# NEEDS `cargo metadata` — unlike its tools/ sibling, which needs nothing. The member
+# list must come from cargo (a `members` glob resolved by hand would be a second
+# implementation of cargo's own resolution). A FAILED derivation is therefore a FAIL
+# NAMING THE DERIVATION, never a skip that greens: a guard that could not enumerate its
+# subject has measured nothing.
+# FAILS CLOSED throughout: an unclassifiable or unmeasurable tree is a FAIL.
+# Self-test / negative controls: scripts/tests/test_workspace_test_disposition_selftest.sh
+set -uo pipefail
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+# Resolved from this script's OWN location, with no env override: an override is
+# settable by the party the guard constrains (CLAUDE.md #3312 — "the constrained party
+# must not choose its own enforcer"). A self-test needing a different tree copies this
+# script into that tree; it never redirects this variable.
+ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
+CENSUS="$SCRIPT_DIR/workspace-test-disposition.txt"
+
+# The CLOSED label set. An unrecognised label is a FAIL, not a pass: a permissive
+# branch keyed on "not one of the bad values" would accept `EXECUTED?`, `Executed`, or
+# a typo, which is a spelling check standing in for a state check.
+VALID_LABELS="EXECUTED
+PARTIAL
+NOT-EXECUTED"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok()   { echo "ok: $*"; }
+
+[ -f "$CENSUS" ] || fail "the recorded census $CENSUS does not exist — this guard's subject is missing; refusing to pass vacuously"
+[ -r "$CENSUS" ] || fail "the recorded census $CENSUS is not readable — unmeasurable is not a pass"
+
+# --- 1. DERIVE the workspace member list from cargo. -------------------------
+# `--no-deps` so only workspace members are reported. jq first, then python3, then
+# failure — the same chain and the same direction as the gate's own metadata helpers. A
+# single-parser guard is a false red on a host that has only the other one.
+command -v cargo >/dev/null 2>&1 \
+  || fail "cargo is not on PATH, so the workspace member list cannot be DERIVED. This guard's subject set comes from cargo metadata by design (a hand-resolved \`members\` glob would be a second implementation of cargo's resolution); an underived subject set is not a pass"
+META=$(cargo metadata --no-deps --format-version 1 --manifest-path "$ROOT/Cargo.toml" 2>/dev/null) \
+  || fail "\`cargo metadata --no-deps\` failed under $ROOT — the DERIVATION failed, not the census. An unmeasurable subject set is never a pass"
+[ -n "$META" ] || fail "\`cargo metadata --no-deps\` produced no output — the DERIVATION failed"
+
+if command -v jq >/dev/null 2>&1; then
+  MEMBERS=$(printf '%s' "$META" | jq -r '.packages[].name' | sort -u) \
+    || fail "jq could not extract package names from cargo metadata — the DERIVATION failed"
+elif command -v python3 >/dev/null 2>&1; then
+  MEMBERS=$(printf '%s' "$META" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+for n in sorted({p["name"] for p in d.get("packages", [])}):
+    print(n)
+') || fail "python3 could not extract package names from cargo metadata — the DERIVATION failed"
+else
+  fail "neither jq nor python3 is available, so cargo metadata cannot be parsed — the DERIVATION failed; an unparseable subject set is not a pass"
+fi
+[ -n "$MEMBERS" ] || fail "cargo metadata named ZERO workspace members — the DERIVATION failed (this workspace has 18). A census over an empty subject set would report OK having measured nothing"
+
+n_members=$(printf '%s\n' "$MEMBERS" | grep -c .)
+case "$n_members" in ''|*[!0-9]*) fail "could not count the derived workspace members — unmeasurable is not a pass" ;; esac
+[ "$n_members" -gt 0 ] || fail "counted 0 derived workspace members — refusing to pass vacuously"
+
+# --- 2. PARSE the census. Every non-blank, non-comment line must be a well-formed
+# ---    TAB-separated triple with a label from the closed set.
+RECORDED=""
+n_records=0
+lineno=0
+while IFS= read -r line || [ -n "$line" ]; do
+  lineno=$((lineno + 1))
+  case "$line" in
+    ''|'#'*) continue ;;
+  esac
+  # Field-count first: a line with the wrong shape must be named as malformed rather
+  # than silently yielding an empty package or an empty label.
+  nf=$(printf '%s' "$line" | awk -F'\t' '{print NF}')
+  [ "$nf" -eq 3 ] || fail "$CENSUS line $lineno is not a TAB-separated triple (<package> TAB <LABEL> TAB <detail>; found $nf field(s)): $line"
+  pkg=$(printf '%s' "$line" | awk -F'\t' '{print $1}')
+  label=$(printf '%s' "$line" | awk -F'\t' '{print $2}')
+  detail=$(printf '%s' "$line" | awk -F'\t' '{print $3}')
+  [ -n "$pkg" ]   || fail "$CENSUS line $lineno has an empty package name: $line"
+  [ -n "$label" ] || fail "$CENSUS line $lineno has an empty label: $line"
+  # A record with no detail is a label with no account behind it, which is the
+  # documentation half of this guard's whole purpose.
+  [ -n "$detail" ] || fail "$CENSUS line $lineno records '$pkg' as $label with NO detail. EXECUTED must NAME the gate component; PARTIAL must name the component AND what is not run AND why; NOT-EXECUTED must say why (+ the tracking issue, when one is filed)"
+  # CLOSED set, matched EXACTLY (grep -qxF): a prefix or case-insensitive match would
+  # accept `EXECUTEDish` / `Executed`, i.e. check a spelling rather than a state.
+  printf '%s\n' "$VALID_LABELS" | grep -qxF "$label" \
+    || fail "$CENSUS line $lineno labels '$pkg' as '$label', which is not in the closed label set ($(printf '%s' "$VALID_LABELS" | tr '\n' '/' | sed 's:/$::')). An unrecognised label is a FAIL, never a pass"
+  case "$RECORDED" in
+    *"|$pkg|"*) fail "$CENSUS records '$pkg' more than once (line $lineno) — a package has exactly ONE disposition" ;;
+  esac
+  RECORDED="$RECORDED|$pkg|"
+  n_records=$((n_records + 1))
+done < "$CENSUS"
+
+[ "$n_records" -gt 0 ] || fail "$CENSUS contains no records at all — this guard would then enforce nothing while reporting PASS; refusing to pass vacuously"
+ok "census is well-formed ($n_records record(s), every label from the closed set, no duplicates)"
+
+# --- 3. every DERIVED member must be recorded. This is the half that catches a NEW
+# ---    crate arriving via the `members` globs with no statement of whether anything
+# ---    runs its tests — the #3522 defect itself.
+missing=""
+while IFS= read -r pkg; do
+  [ -n "$pkg" ] || continue
+  case "$RECORDED" in
+    *"|$pkg|"*) ;;
+    *) missing="$missing $pkg" ;;
+  esac
+done <<< "$MEMBERS"
+[ -z "$missing" ] || fail "workspace member(s)$missing exist in \`cargo metadata\` but are recorded in NO disposition (issue #3522). Add a record to $CENSUS: '<package>	EXECUTED	<gate component that runs its tests>', or PARTIAL / NOT-EXECUTED with the reason. Compiling a crate is not covering it: clippy --workspace builds every member on every full gate, so an unrecorded crate reads as covered while executing nothing"
+ok "all $n_members derived workspace member(s) carry a recorded disposition"
+
+# --- 4. every RECORDED package must actually EXIST as a member. Without this, a
+# ---    renamed or removed crate would leave a stale record that the count check
+# ---    below could be satisfied by a compensating addition.
+stale=""
+recorded_list=$(printf '%s' "$RECORDED" | tr '|' '\n' | grep . | sort -u)
+while IFS= read -r pkg; do
+  [ -n "$pkg" ] || continue
+  printf '%s\n' "$MEMBERS" | grep -qxF "$pkg" || stale="$stale $pkg"
+done <<< "$recorded_list"
+[ -z "$stale" ] || fail "$CENSUS records package(s)$stale that \`cargo metadata\` does not name as a workspace member — they were renamed or removed; update the census (issue #3522)"
+ok "every recorded package is a current workspace member"
+
+[ "$n_records" -eq "$n_members" ] \
+  || fail "the census holds $n_records record(s) but cargo names $n_members workspace member(s) — the two halves above passed individually, so this can only mean a counting fault; unmeasurable is not a pass"
+
+# --- 5. affirmative floor on the thing this census EXISTS to make visible: the
+# ---    unexecuted set. If every record were EXECUTED the census would be enforcing
+# ---    nothing interesting — and, far more likely, someone would have "fixed" the
+# ---    uncomfortable records by relabelling them. This is deliberately a FLOOR of one
+# ---    and not a fixed number: closing a real gap must never red the guard.
+n_gap=$(grep -cE '^[^#[:space:]]+	(NOT-EXECUTED|PARTIAL)	' "$CENSUS" || true)
+case "$n_gap" in ''|*[!0-9]*) fail "could not count the NOT-EXECUTED/PARTIAL records — unmeasurable is not a pass" ;; esac
+if [ "$n_gap" -eq 0 ]; then
+  fail "$CENSUS records ZERO NOT-EXECUTED/PARTIAL packages. Either every workspace member's tests are now fully executed by the gate — in which case delete this floor DELIBERATELY, in a reviewed diff that says so — or an uncomfortable record was relabelled. The visible unexecuted set is this census's entire purpose"
+fi
+ok "$n_gap of $n_members member(s) are recorded as PARTIAL or NOT-EXECUTED — the gap this census exists to keep visible is stated, not hidden"
+
+echo "PASS: workspace test-execution disposition census is complete and labeled ($n_members members, $n_records records)"
+exit 0

--- a/scripts/tests/test_workspace_test_disposition.sh
+++ b/scripts/tests/test_workspace_test_disposition.sh
@@ -220,7 +220,11 @@ ok "$n_gap of $n_members member(s) are recorded as PARTIAL or NOT-EXECUTED — t
 # ---    checks what was RECORDED.
 n_doctrine=$(grep -cE '^[^#[:space:]]+	[A-Z-]+	contradicts-doctrine	' "$CENSUS" || true)
 n_silent=$(grep -cE '^[^#[:space:]]+	[A-Z-]+	silent	' "$CENSUS" || true)
-case "$n_doctrine$n_silent" in ''|*[!0-9]*) fail "could not count the recorded gap classes — unmeasurable is not a pass" ;; esac
+# Checked SEPARATELY, never as a concatenation: `"$a$b"` is still numeric when one of
+# the two is EMPTY, so a failed count would slip through as measured — the fail-open
+# shape this file's own header warns about, one level down.
+case "$n_doctrine" in ''|*[!0-9]*) fail "could not count the contradicts-doctrine records — unmeasurable is not a pass" ;; esac
+case "$n_silent"   in ''|*[!0-9]*) fail "could not count the silent records — unmeasurable is not a pass" ;; esac
 ok "gap classes: $n_doctrine RECOGNISED as contradicts-doctrine, $n_silent RECOGNISED as silent (RECORDED classifications, not verified ones — see this script's header)"
 
 echo "PASS: workspace test-execution disposition census is complete and labeled ($n_members members, $n_records records)"

--- a/scripts/tests/test_workspace_test_disposition_selftest.sh
+++ b/scripts/tests/test_workspace_test_disposition_selftest.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# Self-test for scripts/tests/test_workspace_test_disposition.sh (issue #3522).
+#
+# A guard is only worth its green if it is capable of red. Every case builds a scratch
+# cargo workspace, copies the guard AND its census into it at the same relative paths
+# (the guard resolves both from its OWN location, so there is deliberately NO path/env
+# seam to point at a fixture — CLAUDE.md #3312: a case needing a different subject
+# SUBSTITUTES THE ARTIFACT in its own scratch copy of the tree), writes a census for
+# that tree, and asserts the verdict.
+#
+# TWO GREEN CONTROLS, deliberately: without one per shape, a guard hardwired to refuse
+# everything would satisfy every red case below and look fully tested.
+#
+# ON CARGO, AND ON THE #1716 TRAP IT WOULD OTHERWISE WALK INTO. The guard's subject set
+# comes from `cargo metadata`, so this self-test cannot be cargo-free the way its tools/
+# sibling is. #1716 removed a cargo-derived guard partly because its self-test built
+# scratch workspaces OUTSIDE the repository, which do not inherit rust-toolchain.toml —
+# making a MANDATORY gate component's behaviour depend on the host's default toolchain.
+# Three things keep that from recurring here:
+#   1. rust-toolchain.toml is COPIED into every scratch workspace, so cargo resolves the
+#      same toolchain the repo pins. (If it is absent from the repo the case is skipped
+#      with a named reason, never silently.)
+#   2. Only `cargo metadata --no-deps` is ever run — manifest PARSING, no compilation,
+#      no codegen, so there is nothing for a toolchain difference to change.
+#   3. Every scratch manifest declares ZERO dependencies and the runs are forced
+#      OFFLINE (CARGO_NET_OFFLINE=1), so there is no registry access and no network.
+# Measured: 29ms per metadata call. Deterministic, offline, and fast enough to be a
+# mandatory component's neighbour.
+set -uo pipefail
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
+GUARD="$SCRIPT_DIR/test_workspace_test_disposition.sh"
+GUARD_BASE=$(basename "$GUARD")
+CENSUS_BASE="workspace-test-disposition.txt"
+[ -f "$GUARD" ] || { echo "FAIL: guard under test not found at $GUARD" >&2; exit 1; }
+
+TMPROOT=$(mktemp -d "${TMPDIR:-/tmp}/wsdisp.XXXXXX") || exit 1
+trap 'rm -rf "$TMPROOT"' EXIT
+
+fails=0
+pass_case() { echo "ok: $*"; }
+fail_case() { echo "FAIL: $*" >&2; fails=$((fails + 1)); }
+
+TAB=$(printf '\t')
+
+# make_ws <case> <member crates...> — build a scratch workspace and copy the guard in.
+# Prints the workspace path.
+make_ws() {
+  local case_name="$1"; shift
+  local ws="$TMPROOT/$case_name" c
+  mkdir -p "$ws/scripts/tests" "$ws/crates"
+  cat > "$ws/Cargo.toml" <<'WS'
+[workspace]
+resolver = "2"
+members = ["crates/*"]
+WS
+  for c in "$@"; do
+    mkdir -p "$ws/crates/$c/src"
+    printf '[package]\nname = "%s"\nversion = "0.1.0"\nedition = "2021"\npublish = false\n' "$c" \
+      > "$ws/crates/$c/Cargo.toml"
+    echo 'pub fn f() {}' > "$ws/crates/$c/src/lib.rs"
+  done
+  [ -f "$REPO_ROOT/rust-toolchain.toml" ] && cp "$REPO_ROOT/rust-toolchain.toml" "$ws/"
+  cp "$GUARD" "$ws/scripts/tests/$GUARD_BASE"
+  printf '%s' "$ws"
+}
+
+# run_guard <ws> — run the copied guard in its own tree, OFFLINE. Echoes the output,
+# returns the guard's status.
+GUARD_OUT=""
+run_guard() {
+  local ws="$1"
+  GUARD_OUT=$(cd "$ws" && env CARGO_NET_OFFLINE=1 bash "$ws/scripts/tests/$GUARD_BASE" 2>&1)
+  return $?
+}
+
+# expect <case> <PASS|FAIL> <needle> <ws>
+expect() {
+  local case_name="$1" want="$2" needle="$3" ws="$4" rc
+  run_guard "$ws"; rc=$?
+  if [ "$want" = PASS ]; then
+    if [ "$rc" -eq 0 ]; then
+      pass_case "$case_name — guard PASSED as expected"
+    else
+      fail_case "$case_name — expected PASS, got exit $rc: $GUARD_OUT"
+    fi
+    return
+  fi
+  if [ "$rc" -eq 0 ]; then
+    fail_case "$case_name — expected FAIL, but the guard PASSED. A guard that cannot red on this shape is not enforcing it: $GUARD_OUT"
+    return
+  fi
+  # ATTRIBUTED, not merely red: a red for an unrelated reason has the same exit code, so
+  # the message must NAME the planted condition.
+  if printf '%s' "$GUARD_OUT" | grep -qF "$needle"; then
+    pass_case "$case_name — guard FAILED and named the cause ('$needle')"
+  else
+    fail_case "$case_name — guard failed (exit $rc) but never named '$needle', so the red cannot be shown to be this case's: $GUARD_OUT"
+  fi
+}
+
+if [ ! -f "$REPO_ROOT/rust-toolchain.toml" ]; then
+  echo "note: $REPO_ROOT/rust-toolchain.toml is absent, so scratch workspaces run on the host's DEFAULT toolchain (see this script's header). Cases still run; the toolchain-pinning property is UNVERIFIED in this invocation." >&2
+fi
+
+# ---- GREEN CONTROL A: every member recorded, one PARTIAL ---------------------
+ws=$(make_ws green_a alpha beta)
+{
+  printf '# scratch census\n'
+  printf 'alpha%sEXECUTED%sscratch-component runs it\n' "$TAB" "$TAB"
+  printf 'beta%sPARTIAL%sscratch-component runs its lib only; its 2 integration targets are un-run because reasons\n' "$TAB" "$TAB"
+} > "$ws/scripts/tests/$CENSUS_BASE"
+expect "green control A (complete census, one PARTIAL)" PASS "" "$ws"
+
+# ---- GREEN CONTROL B: a different shape — three members, all three labels ----
+ws=$(make_ws green_b alpha beta gamma)
+{
+  printf 'alpha%sEXECUTED%sscratch-component\n' "$TAB" "$TAB"
+  printf 'beta%sNOT-EXECUTED%snothing runs it; tracked as scratch issue #1\n' "$TAB" "$TAB"
+  printf 'gamma%sPARTIAL%sscratch-component runs 1 of 3 targets; the rest are flaky\n' "$TAB" "$TAB"
+} > "$ws/scripts/tests/$CENSUS_BASE"
+expect "green control B (three members, all three labels)" PASS "" "$ws"
+
+# ---- RED: an UNRECORDED member — the #3522 defect itself ---------------------
+ws=$(make_ws red_unrecorded alpha beta gamma)
+{
+  printf 'alpha%sEXECUTED%sscratch-component\n' "$TAB" "$TAB"
+  printf 'beta%sNOT-EXECUTED%snothing runs it\n' "$TAB" "$TAB"
+} > "$ws/scripts/tests/$CENSUS_BASE"
+expect "red: a new workspace member with no recorded disposition" FAIL "gamma" "$ws"
+
+# ---- RED: a label outside the CLOSED set ------------------------------------
+ws=$(make_ws red_label alpha beta)
+{
+  printf 'alpha%sExecuted%swrong case — a spelling is not a state\n' "$TAB" "$TAB"
+  printf 'beta%sPARTIAL%sscratch-component runs some\n' "$TAB" "$TAB"
+} > "$ws/scripts/tests/$CENSUS_BASE"
+expect "red: an unrecognised label (wrong case)" FAIL "closed label set" "$ws"
+
+# ---- RED: a STALE record naming a package that is not a member --------------
+ws=$(make_ws red_stale alpha beta)
+{
+  printf 'alpha%sEXECUTED%sscratch-component\n' "$TAB" "$TAB"
+  printf 'beta%sPARTIAL%sscratch-component\n' "$TAB" "$TAB"
+  printf 'deleted-crate%sNOT-EXECUTED%sthis crate was removed but its record was left behind\n' "$TAB" "$TAB"
+} > "$ws/scripts/tests/$CENSUS_BASE"
+expect "red: a stale record for a package that is no longer a member" FAIL "deleted-crate" "$ws"
+
+# ---- RED: a DUPLICATE record ------------------------------------------------
+ws=$(make_ws red_dup alpha beta)
+{
+  printf 'alpha%sEXECUTED%sscratch-component\n' "$TAB" "$TAB"
+  printf 'alpha%sNOT-EXECUTED%sthe contradicting second record\n' "$TAB" "$TAB"
+  printf 'beta%sPARTIAL%sscratch-component\n' "$TAB" "$TAB"
+} > "$ws/scripts/tests/$CENSUS_BASE"
+expect "red: a package recorded twice" FAIL "more than once" "$ws"
+
+# ---- RED: a record with a label and NO detail behind it ---------------------
+ws=$(make_ws red_nodetail alpha beta)
+{
+  printf 'alpha%sEXECUTED%s\n' "$TAB" "$TAB"
+  printf 'beta%sPARTIAL%sscratch-component\n' "$TAB" "$TAB"
+} > "$ws/scripts/tests/$CENSUS_BASE"
+expect "red: a label with no detail (no account of what runs it / what is omitted)" FAIL "NO detail" "$ws"
+
+# ---- RED: a MALFORMED line (spaces where TABs belong) ----------------------
+ws=$(make_ws red_malformed alpha beta)
+{
+  printf 'alpha EXECUTED scratch-component\n'
+  printf 'beta%sPARTIAL%sscratch-component\n' "$TAB" "$TAB"
+} > "$ws/scripts/tests/$CENSUS_BASE"
+expect "red: a line that is not a TAB-separated triple" FAIL "TAB-separated triple" "$ws"
+
+# ---- RED: a census with comments only, i.e. NO records ---------------------
+ws=$(make_ws red_norecords alpha beta)
+printf '# only a comment\n\n' > "$ws/scripts/tests/$CENSUS_BASE"
+expect "red: a census containing no records at all" FAIL "no records at all" "$ws"
+
+# ---- RED: the affirmative floor — every member labelled EXECUTED ------------
+# The shape this floor exists for is someone relabelling an uncomfortable record.
+ws=$(make_ws red_allexec alpha beta)
+{
+  printf 'alpha%sEXECUTED%sscratch-component\n' "$TAB" "$TAB"
+  printf 'beta%sEXECUTED%sscratch-component\n' "$TAB" "$TAB"
+} > "$ws/scripts/tests/$CENSUS_BASE"
+expect "red: zero PARTIAL/NOT-EXECUTED records (the visible-gap floor)" FAIL "ZERO NOT-EXECUTED/PARTIAL" "$ws"
+
+# ---- RED: the census file is MISSING ---------------------------------------
+ws=$(make_ws red_nocensus alpha beta)
+rm -f "$ws/scripts/tests/$CENSUS_BASE"
+expect "red: the recorded census file does not exist" FAIL "does not exist" "$ws"
+
+# ---- RED: the DERIVATION fails (no workspace manifest to enumerate) --------
+# The property under test is that an unmeasurable subject set FAILs rather than
+# greening — the guard's stated fail-closed direction.
+ws=$(make_ws red_noderive alpha beta)
+{
+  printf 'alpha%sEXECUTED%sscratch-component\n' "$TAB" "$TAB"
+  printf 'beta%sPARTIAL%sscratch-component\n' "$TAB" "$TAB"
+} > "$ws/scripts/tests/$CENSUS_BASE"
+rm -f "$ws/Cargo.toml"
+expect "red: cargo metadata cannot enumerate the members (DERIVATION failure)" FAIL "DERIVATION failed" "$ws"
+
+echo
+if [ "$fails" -ne 0 ]; then
+  echo "RESULT: FAIL ($fails case(s) did not behave as specified)"
+  exit 1
+fi
+echo "RESULT: PASS (2 green controls + 10 attributed red cases)"
+exit 0

--- a/scripts/tests/test_workspace_test_disposition_selftest.sh
+++ b/scripts/tests/test_workspace_test_disposition_selftest.sh
@@ -130,6 +130,30 @@ ws=$(make_ws red_unrecorded alpha beta gamma)
 } > "$ws/scripts/tests/$CENSUS_BASE"
 expect "red: a new workspace member with no recorded disposition" FAIL "gamma" "$ws"
 
+# ---- RED: TWO unrecorded members — BOTH must be named (roborev round 6, G2) ---
+# The single-unrecorded case above is satisfied by a message naming one crate, so it cannot
+# distinguish "reports every unrecorded member" from "reports the first one it finds". This
+# case can: it asserts both names, so a first-offender-only regression fails here.
+ws=$(make_ws red_unrecorded2 alpha beta gamma delta)
+{
+  printf 'alpha%sEXECUTED%sscratch-component\n' "$TAB" "$TAB"
+  printf 'beta%sPARTIAL%sscratch-component runs some\n' "$TAB" "$TAB"
+} > "$ws/scripts/tests/$CENSUS_BASE"
+run_guard "$ws"; _rc=$?
+if [ "$_rc" -eq 0 ]; then
+  fail_case "two unrecorded members — expected FAIL, guard PASSED: $GUARD_OUT"
+else
+  _miss=""
+  for _c in gamma delta; do
+    printf '%s' "$GUARD_OUT" | grep -qF "$_c" || _miss="$_miss $_c"
+  done
+  if [ -z "$_miss" ]; then
+    pass_case "two unrecorded members — guard FAILED and named BOTH (gamma, delta)"
+  else
+    fail_case "two unrecorded members — guard failed but never named:$_miss ($GUARD_OUT)"
+  fi
+fi
+
 # ---- RED: a label outside the CLOSED set ------------------------------------
 ws=$(make_ws red_label alpha beta)
 {

--- a/scripts/tests/test_workspace_test_disposition_selftest.sh
+++ b/scripts/tests/test_workspace_test_disposition_selftest.sh
@@ -108,25 +108,28 @@ fi
 ws=$(make_ws green_a alpha beta)
 {
   printf '# scratch census\n'
-  printf 'alpha%sEXECUTED%sscratch-component runs it\n' "$TAB" "$TAB"
-  printf 'beta%sPARTIAL%sscratch-component runs its lib only; its 2 integration targets are un-run because reasons\n' "$TAB" "$TAB"
+  printf 'alpha%sEXECUTED%sno-gap%sscratch-component runs it\n' "$TAB" "$TAB" "$TAB"
+  printf 'beta%sPARTIAL%ssilent%sscratch-component runs its lib only; its 2 integration targets are un-run because reasons\n' "$TAB" "$TAB" "$TAB"
 } > "$ws/scripts/tests/$CENSUS_BASE"
 expect "green control A (complete census, one PARTIAL)" PASS "" "$ws"
 
 # ---- GREEN CONTROL B: a different shape — three members, all three labels ----
 ws=$(make_ws green_b alpha beta gamma)
 {
-  printf 'alpha%sEXECUTED%sscratch-component\n' "$TAB" "$TAB"
-  printf 'beta%sNOT-EXECUTED%snothing runs it; tracked as scratch issue #1\n' "$TAB" "$TAB"
-  printf 'gamma%sPARTIAL%sscratch-component runs 1 of 3 targets; the rest are flaky\n' "$TAB" "$TAB"
+  printf 'alpha%sEXECUTED%sno-gap%sscratch-component\n' "$TAB" "$TAB" "$TAB"
+  printf 'beta%sNOT-EXECUTED%ssilent%snothing runs it; tracked as scratch issue #1\n' "$TAB" "$TAB" "$TAB"
+  # `contradicts-doctrine` appears in a GREEN control on purpose: it is otherwise only
+  # planted in a RED case below, so a guard that rejected the value outright would pass
+  # every case here and look fully tested.
+  printf 'gamma%sPARTIAL%scontradicts-doctrine%sscratch-component runs 1 of 3 targets; the scratch docs claim all 3\n' "$TAB" "$TAB" "$TAB"
 } > "$ws/scripts/tests/$CENSUS_BASE"
-expect "green control B (three members, all three labels)" PASS "" "$ws"
+expect "green control B (three members, all three labels, all three classes)" PASS "" "$ws"
 
 # ---- RED: an UNRECORDED member — the #3522 defect itself ---------------------
 ws=$(make_ws red_unrecorded alpha beta gamma)
 {
-  printf 'alpha%sEXECUTED%sscratch-component\n' "$TAB" "$TAB"
-  printf 'beta%sNOT-EXECUTED%snothing runs it\n' "$TAB" "$TAB"
+  printf 'alpha%sEXECUTED%sno-gap%sscratch-component\n' "$TAB" "$TAB" "$TAB"
+  printf 'beta%sNOT-EXECUTED%ssilent%snothing runs it\n' "$TAB" "$TAB" "$TAB"
 } > "$ws/scripts/tests/$CENSUS_BASE"
 expect "red: a new workspace member with no recorded disposition" FAIL "gamma" "$ws"
 
@@ -136,8 +139,8 @@ expect "red: a new workspace member with no recorded disposition" FAIL "gamma" "
 # case can: it asserts both names, so a first-offender-only regression fails here.
 ws=$(make_ws red_unrecorded2 alpha beta gamma delta)
 {
-  printf 'alpha%sEXECUTED%sscratch-component\n' "$TAB" "$TAB"
-  printf 'beta%sPARTIAL%sscratch-component runs some\n' "$TAB" "$TAB"
+  printf 'alpha%sEXECUTED%sno-gap%sscratch-component\n' "$TAB" "$TAB" "$TAB"
+  printf 'beta%sPARTIAL%ssilent%sscratch-component runs some\n' "$TAB" "$TAB" "$TAB"
 } > "$ws/scripts/tests/$CENSUS_BASE"
 run_guard "$ws"; _rc=$?
 if [ "$_rc" -eq 0 ]; then
@@ -157,34 +160,73 @@ fi
 # ---- RED: a label outside the CLOSED set ------------------------------------
 ws=$(make_ws red_label alpha beta)
 {
-  printf 'alpha%sExecuted%swrong case — a spelling is not a state\n' "$TAB" "$TAB"
-  printf 'beta%sPARTIAL%sscratch-component runs some\n' "$TAB" "$TAB"
+  printf 'alpha%sExecuted%ssilent%swrong case — a spelling is not a state\n' "$TAB" "$TAB" "$TAB"
+  printf 'beta%sPARTIAL%ssilent%sscratch-component runs some\n' "$TAB" "$TAB" "$TAB"
 } > "$ws/scripts/tests/$CENSUS_BASE"
 expect "red: an unrecognised label (wrong case)" FAIL "closed label set" "$ws"
+
+# ---- RED: a class outside the CLOSED set ------------------------------------
+ws=$(make_ws red_class alpha beta)
+{
+  printf 'alpha%sEXECUTED%sno-gap%sscratch-component\n' "$TAB" "$TAB" "$TAB"
+  printf 'beta%sPARTIAL%sSilent%sa spelling is not a state, here too\n' "$TAB" "$TAB" "$TAB"
+} > "$ws/scripts/tests/$CENSUS_BASE"
+expect "red: an unrecognised class (wrong case)" FAIL "closed class set" "$ws"
+
+# ---- RED: an EMPTY class field ----------------------------------------------
+# Distinct from the malformed-shape case: the record has the right FIELD COUNT and a
+# valid label, so only a per-field emptiness check can see it.
+ws=$(make_ws red_class_empty alpha beta)
+{
+  printf 'alpha%sEXECUTED%sno-gap%sscratch-component\n' "$TAB" "$TAB" "$TAB"
+  printf 'beta%sPARTIAL%s%sclassified with nothing at all\n' "$TAB" "$TAB" "$TAB"
+} > "$ws/scripts/tests/$CENSUS_BASE"
+expect "red: an empty class field" FAIL "empty class" "$ws"
+
+# ---- RED: the COUPLING, direction 1 — a real gap classed no-gap -------------
+# The shape this exists for: excusing an uncomfortable PARTIAL/NOT-EXECUTED record
+# WITHOUT relabelling it, which the visible-gap floor cannot see because the label is
+# untouched.
+ws=$(make_ws red_couple_gap alpha beta)
+{
+  printf 'alpha%sEXECUTED%sno-gap%sscratch-component\n' "$TAB" "$TAB" "$TAB"
+  printf 'beta%sNOT-EXECUTED%sno-gap%snothing runs it, but call it no gap\n' "$TAB" "$TAB" "$TAB"
+} > "$ws/scripts/tests/$CENSUS_BASE"
+expect "red: a PARTIAL/NOT-EXECUTED record classed no-gap (coupling)" FAIL "no-gap is reserved for EXECUTED records" "$ws"
+
+# ---- RED: the COUPLING, direction 2 — an EXECUTED record carrying a gap class -
+# Without this case the coupling check could be one-directional and still pass every
+# other case here; a self-contradicting record would then read as classified.
+ws=$(make_ws red_couple_exec alpha beta)
+{
+  printf 'alpha%sEXECUTED%scontradicts-doctrine%sruns fully AND contradicts doctrine — one of the two is false\n' "$TAB" "$TAB" "$TAB"
+  printf 'beta%sPARTIAL%ssilent%sscratch-component runs some\n' "$TAB" "$TAB" "$TAB"
+} > "$ws/scripts/tests/$CENSUS_BASE"
+expect "red: an EXECUTED record carrying a gap class (coupling, other direction)" FAIL "its class must be no-gap" "$ws"
 
 # ---- RED: a STALE record naming a package that is not a member --------------
 ws=$(make_ws red_stale alpha beta)
 {
-  printf 'alpha%sEXECUTED%sscratch-component\n' "$TAB" "$TAB"
-  printf 'beta%sPARTIAL%sscratch-component\n' "$TAB" "$TAB"
-  printf 'deleted-crate%sNOT-EXECUTED%sthis crate was removed but its record was left behind\n' "$TAB" "$TAB"
+  printf 'alpha%sEXECUTED%sno-gap%sscratch-component\n' "$TAB" "$TAB" "$TAB"
+  printf 'beta%sPARTIAL%ssilent%sscratch-component\n' "$TAB" "$TAB" "$TAB"
+  printf 'deleted-crate%sNOT-EXECUTED%ssilent%sthis crate was removed but its record was left behind\n' "$TAB" "$TAB" "$TAB"
 } > "$ws/scripts/tests/$CENSUS_BASE"
 expect "red: a stale record for a package that is no longer a member" FAIL "deleted-crate" "$ws"
 
 # ---- RED: a DUPLICATE record ------------------------------------------------
 ws=$(make_ws red_dup alpha beta)
 {
-  printf 'alpha%sEXECUTED%sscratch-component\n' "$TAB" "$TAB"
-  printf 'alpha%sNOT-EXECUTED%sthe contradicting second record\n' "$TAB" "$TAB"
-  printf 'beta%sPARTIAL%sscratch-component\n' "$TAB" "$TAB"
+  printf 'alpha%sEXECUTED%sno-gap%sscratch-component\n' "$TAB" "$TAB" "$TAB"
+  printf 'alpha%sNOT-EXECUTED%ssilent%sthe contradicting second record\n' "$TAB" "$TAB" "$TAB"
+  printf 'beta%sPARTIAL%ssilent%sscratch-component\n' "$TAB" "$TAB" "$TAB"
 } > "$ws/scripts/tests/$CENSUS_BASE"
 expect "red: a package recorded twice" FAIL "more than once" "$ws"
 
 # ---- RED: a record with a label and NO detail behind it ---------------------
 ws=$(make_ws red_nodetail alpha beta)
 {
-  printf 'alpha%sEXECUTED%s\n' "$TAB" "$TAB"
-  printf 'beta%sPARTIAL%sscratch-component\n' "$TAB" "$TAB"
+  printf 'alpha%sEXECUTED%sno-gap%s\n' "$TAB" "$TAB" "$TAB"
+  printf 'beta%sPARTIAL%ssilent%sscratch-component\n' "$TAB" "$TAB" "$TAB"
 } > "$ws/scripts/tests/$CENSUS_BASE"
 expect "red: a label with no detail (no account of what runs it / what is omitted)" FAIL "NO detail" "$ws"
 
@@ -192,9 +234,9 @@ expect "red: a label with no detail (no account of what runs it / what is omitte
 ws=$(make_ws red_malformed alpha beta)
 {
   printf 'alpha EXECUTED scratch-component\n'
-  printf 'beta%sPARTIAL%sscratch-component\n' "$TAB" "$TAB"
+  printf 'beta%sPARTIAL%ssilent%sscratch-component\n' "$TAB" "$TAB" "$TAB"
 } > "$ws/scripts/tests/$CENSUS_BASE"
-expect "red: a line that is not a TAB-separated triple" FAIL "TAB-separated triple" "$ws"
+expect "red: a line that is not a TAB-separated record" FAIL "TAB-separated record" "$ws"
 
 # ---- RED: a census with comments only, i.e. NO records ---------------------
 ws=$(make_ws red_norecords alpha beta)
@@ -205,8 +247,8 @@ expect "red: a census containing no records at all" FAIL "no records at all" "$w
 # The shape this floor exists for is someone relabelling an uncomfortable record.
 ws=$(make_ws red_allexec alpha beta)
 {
-  printf 'alpha%sEXECUTED%sscratch-component\n' "$TAB" "$TAB"
-  printf 'beta%sEXECUTED%sscratch-component\n' "$TAB" "$TAB"
+  printf 'alpha%sEXECUTED%sno-gap%sscratch-component\n' "$TAB" "$TAB" "$TAB"
+  printf 'beta%sEXECUTED%sno-gap%sscratch-component\n' "$TAB" "$TAB" "$TAB"
 } > "$ws/scripts/tests/$CENSUS_BASE"
 expect "red: zero PARTIAL/NOT-EXECUTED records (the visible-gap floor)" FAIL "ZERO NOT-EXECUTED/PARTIAL" "$ws"
 
@@ -220,8 +262,8 @@ expect "red: the recorded census file does not exist" FAIL "does not exist" "$ws
 # greening — the guard's stated fail-closed direction.
 ws=$(make_ws red_noderive alpha beta)
 {
-  printf 'alpha%sEXECUTED%sscratch-component\n' "$TAB" "$TAB"
-  printf 'beta%sPARTIAL%sscratch-component\n' "$TAB" "$TAB"
+  printf 'alpha%sEXECUTED%sno-gap%sscratch-component\n' "$TAB" "$TAB" "$TAB"
+  printf 'beta%sPARTIAL%ssilent%sscratch-component\n' "$TAB" "$TAB" "$TAB"
 } > "$ws/scripts/tests/$CENSUS_BASE"
 rm -f "$ws/Cargo.toml"
 expect "red: cargo metadata cannot enumerate the members (DERIVATION failure)" FAIL "DERIVATION failed" "$ws"
@@ -231,5 +273,5 @@ if [ "$fails" -ne 0 ]; then
   echo "RESULT: FAIL ($fails case(s) did not behave as specified)"
   exit 1
 fi
-echo "RESULT: PASS (2 green controls + 10 attributed red cases)"
+echo "RESULT: PASS (2 green controls + 15 attributed red cases)"
 exit 0

--- a/scripts/tests/workspace-test-disposition.txt
+++ b/scripts/tests/workspace-test-disposition.txt
@@ -15,7 +15,7 @@
 # the omission a RECORDED, REVIEWED fact instead of a discovery.
 #
 # FORMAT — one record per line:
-#     <package-name> <TAB> <LABEL> <TAB> <detail>
+#     <package-name> <TAB> <LABEL> <TAB> <CLASS> <TAB> <detail>
 # Blank lines and `#` comments are ignored.
 #
 # LABELS — a CLOSED set. An unrecognised label is a FAIL, not a pass.
@@ -26,26 +26,45 @@
 #   NOT-EXECUTED  no gate component runs them. <detail> says WHY, and cites the
 #                 tracking issue when one is filed.
 #
+# CLASSES — also a CLOSED set, answering a SECOND and different question: does this
+# gap make a statement THIS REPOSITORY MAKES TO AGENTS false? A gap nobody claimed
+# was covered is a backlog item; a gap our own doctrine denies is a false
+# certification, and #3544's lesson is that a certification is only as good as what
+# it actually measured.
+#   silent               a real gap, but no committed doctrine claims it is covered —
+#                        or the gap is already DECLARED honestly where an agent reads
+#                        it (the `flight-tests` census is the model).
+#   contradicts-doctrine committed doctrine (CLAUDE.md, an `exempt:` reason in
+#                        .github/ci-gating-tiers.yml, a component name in the SUMMARY)
+#                        tells a reader this is covered when it is not. <detail> says
+#                        WHERE, and — once corrected — where the WORDING was fixed.
+#                        The wording is fixed in the change that records the class;
+#                        the COVERAGE may still defer to a tracking issue.
+#   no-gap               nothing to classify: the record is EXECUTED.
+# COUPLED, and checked: EXECUTED <=> no-gap. A PARTIAL/NOT-EXECUTED record may never
+# be no-gap (that is how an uncomfortable record gets quietly excused), and an
+# EXECUTED record may never carry a gap class.
+#
 # HOW TO CHANGE IT. Adding a workspace member without adding a record here FAILs the
 # gate. Wiring a member into a component means moving its record to EXECUTED and naming
 # the component. Do NOT "fix" a NOT-EXECUTED record by deleting it: the whole value of
 # this file is that the unexecuted set is visible.
 
-cqlite	NOT-EXECUTED	Workspace ROOT package. 24 integration targets under /tests, 15 of which are root-only (the other 9 are also targets of cqlite-integration-tests, and 6 of those run there). No `cargo test -p cqlite` / `--workspace` invocation exists in the gate or in CI. AUDIT GAP 3.
-cqlite-core	PARTIAL	core-tests (cargo nextest run -p cqlite-core --features cli-helpers) + write-tests + 13 targeted lanes. Of 369 integration targets, 303 execute >0 tests; 66 compile to ZERO tests at that feature set and 41 of those are named by no --test anywhere. AUDIT GAP 10 (families: delta-scan 12, observability-testing 13, dhat-heap 9).
-cqlite-cli	PARTIAL	cli-tests runs 35 of 45 integration targets in two passes. `--lib`/`--bins` is NEVER passed, so all 255 lib/bin unit `#[test]` fns are unexecuted; 8 targets are quarantined and 5 excluded. AUDIT GAP 2.
-cqlite-flight	PARTIAL	flight-tests runs `--lib --bins`; flight-query-semantics-oracle runs 2 integration targets and memory-budget 1. 39 of 42 integration targets are un-run LOCALLY — declared by that lane's own census. CI's Flight tier (the one blocking tier) runs the whole package. AUDIT GAP 7 / issues #3384, #3375.
-cqlite-ffi-common	EXECUTED	binding-rust-tests — `cargo test --no-fail-fast -p cqlite-ffi-common`, ALL targets (lib + tests/dependency_boundary.rs + tests/error_contract_table.rs). Closed AUDIT GAP 1; before #3522 this member executed NOWHERE.
-cqlite-node	PARTIAL	binding-rust-tests runs the RUST half (`--lib --features write-support`); node-bindings runs the WHOLE jest suite against the built napi artifact. Both closed by #3522 (AUDIT GAP 5). Not run: bodies gated on the `observability` feature — building the OTel stack is a cost the gate declines on purpose (#1844).
-cqlite-py	NOT-EXECUTED	Rust half only, and STRUCTURALLY so: a pyo3 cdylib's `cargo test` harness cannot link libpython, which is documented in scripts/agent-gate.sh (search: "cannot link libpython"). Its PYTHON half IS fully covered — python-bindings runs the entire pytest suite. AUDIT GAP 6.
-cqlite-integration-tests	PARTIAL	integration-tests COMPILES the whole package (`--no-run`) then runs 6 named `--test` targets. Unexecuted: the lib unit suite (206 `#[test]` fns), 13 bin targets, and 5 integration targets. AUDIT GAP 4.
-format-compatibility-tests	EXECUTED	format-compat — `cargo test -p format-compatibility-tests`, the whole package.
-cqlite-examples	NOT-EXECUTED	1 `#[test]` fn; compile-only via clippy. No component or workflow runs it. Note the `operator-metrics-doc` component runs a cqlite-core EXAMPLE, not this package.
-xtask	NOT-EXECUTED	20 inline `#[test]` fns + 1 integration target. The oom-audit component BUILDS and RUNS the binary but never `cargo test -p xtask`; no CI job does either. AUDIT GAP 9.
-cassandra-parity	NOT-EXECUTED	25 inline `#[test]` fns + 9 integration targets. The parity-report component runs the BINARY only. `cargo test -p cassandra-parity` exists solely in cassandra-parity.yml, which is path-filtered and `required`-EXEMPT. AUDIT GAP 8.
-ws0-corpus-gen	EXECUTED	tooling-tests — `cargo test -q -p ws0-corpus-gen`, the whole package. The only fully covered tools/ crate.
-sstabledump-validator	NOT-EXECUTED	17 inline `#[test]` fns + 2 integration targets. Zero references in scripts/** and .github/workflows/**. AUDIT GAP 8.
-flight-loadgen	NOT-EXECUTED	21 inline `#[test]` fns. Zero references in scripts/** and .github/workflows/**. AUDIT GAP 8.
-format-validator	NOT-EXECUTED	8 inline `#[test]` fns. Its LIBRARY is exercised INDIRECTLY, as a path dependency of format-compatibility-tests (the format-compat component), but the crate's own unit tests never run. AUDIT GAP 8. See also its tools/ disposition: MIXED.
-memory-safety-runner	NOT-EXECUTED	2 inline `#[test]` fns. Documented UNWIRED in its tools/ disposition; compile-only.
-cqlite-validator	NOT-EXECUTED	Binary only, 0 `#[test]` fns — nothing to execute. Documented UNWIRED in its tools/ disposition.
+cqlite	NOT-EXECUTED	silent	Workspace ROOT package. 24 integration targets under /tests, 15 of which are root-only (the other 9 are also targets of cqlite-integration-tests, and 6 of those run there). No `cargo test -p cqlite` / `--workspace` invocation exists in the gate or in CI. AUDIT GAP 3.
+cqlite-core	PARTIAL	contradicts-doctrine	core-tests (cargo nextest run -p cqlite-core --features cli-helpers) + write-tests + 13 targeted lanes. Of 369 integration targets, 303 execute >0 tests; 66 compile to ZERO tests at that feature set and 41 of those are named by no --test anywhere. AUDIT GAP 10; largest families re-derived on this branch: 13 `delta-scan` and 14 `observability-testing` crate-level-gated targets named by no --test, plus 3 of 5 `dhat-heap`. DOCTRINE: CLAUDE.md's #1699 paragraph called `experimental` the remaining known instance, which these falsify — wording corrected in PR #3574; coverage defers.
+cqlite-cli	PARTIAL	contradicts-doctrine	cli-tests runs 35 of 45 integration targets in two passes. `--lib`/`--bins` is NEVER passed, so all 255 lib/bin unit `#[test]` fns are unexecuted; 8 targets are quarantined and 5 excluded. AUDIT GAP 2. DOCTRINE: CLAUDE.md's gate table said the full gate runs "CLI tests" and `cli-tests` appears in the SUMMARY, so a reader concludes the package is covered — wording corrected in PR #3574; coverage defers.
+cqlite-flight	PARTIAL	silent	flight-tests runs `--lib --bins`; flight-query-semantics-oracle runs 2 integration targets and memory-budget 1. 39 of 42 integration targets are un-run LOCALLY — declared by that lane's own census. CI's Flight tier (the one blocking tier) runs the whole package. AUDIT GAP 7 / issues #3384, #3375.
+cqlite-ffi-common	EXECUTED	no-gap	binding-rust-tests — `cargo test --no-fail-fast -p cqlite-ffi-common`, ALL targets (lib + tests/dependency_boundary.rs + tests/error_contract_table.rs). Closed AUDIT GAP 1; before #3522 this member executed NOWHERE.
+cqlite-node	PARTIAL	silent	binding-rust-tests runs the RUST half (`--lib --features write-support`); node-bindings runs the WHOLE jest suite against the built napi artifact. Both closed by #3522 (AUDIT GAP 5). Not run: bodies gated on the `observability` feature — building the OTel stack is a cost the gate declines on purpose (#1844).
+cqlite-py	NOT-EXECUTED	silent	Rust half only, and STRUCTURALLY so: a pyo3 cdylib's `cargo test` harness cannot link libpython, which is documented in scripts/agent-gate.sh (search: "cannot link libpython"). Its PYTHON half IS fully covered — python-bindings runs the entire pytest suite. AUDIT GAP 6.
+cqlite-integration-tests	PARTIAL	contradicts-doctrine	integration-tests COMPILES the whole package (`--no-run`) then runs 6 named `--test` targets. Unexecuted: the lib unit suite (206 `#[test]` fns), 13 bin targets, and 5 integration targets. AUDIT GAP 4. DOCTRINE: CLAUDE.md's gate table said the full gate runs "integration" tests — wording corrected in PR #3574; coverage defers.
+format-compatibility-tests	EXECUTED	no-gap	format-compat — `cargo test -p format-compatibility-tests`, the whole package.
+cqlite-examples	NOT-EXECUTED	silent	1 `#[test]` fn; compile-only via clippy. No component or workflow runs it. Note the `operator-metrics-doc` component runs a cqlite-core EXAMPLE, not this package.
+xtask	NOT-EXECUTED	silent	20 inline `#[test]` fns + 1 integration target. The oom-audit component BUILDS and RUNS the binary but never `cargo test -p xtask`; no CI job does either. AUDIT GAP 9.
+cassandra-parity	NOT-EXECUTED	contradicts-doctrine	25 inline `#[test]` fns + 9 integration targets. The parity-report component runs the BINARY only. `cargo test -p cassandra-parity` exists solely in cassandra-parity.yml, which is path-filtered and `required`-EXEMPT. AUDIT GAP 8. DOCTRINE: CLAUDE.md labels it tools/ WIRED, which describes crate INVOCATION and not test EXECUTION — wording corrected in PR #3574; coverage defers.
+ws0-corpus-gen	EXECUTED	no-gap	tooling-tests — `cargo test -q -p ws0-corpus-gen`, the whole package. The only fully covered tools/ crate.
+sstabledump-validator	NOT-EXECUTED	contradicts-doctrine	17 inline `#[test]` fns + 2 integration targets. Its BINARY *is* built and run — scripts/ci/test-sstabledump-parity-gate.sh, used by sstabledump-parity-gate.yml (`required`-EXEMPT) — so tools/ WIRED is true of the CRATE; no `cargo test -p sstabledump-validator` exists in scripts/** or .github/workflows/**. AUDIT GAP 8. DOCTRINE: WIRED describes invocation, not test execution — wording corrected in PR #3574; coverage defers.
+flight-loadgen	NOT-EXECUTED	contradicts-doctrine	21 inline `#[test]` fns. Its BINARY *is* built and invoked — scripts/perf/lib-binaries.sh builds it and the WS0 scan driver runs it — so tools/ WIRED is true of the CRATE; no `cargo test -p flight-loadgen` exists in scripts/** or .github/workflows/**. AUDIT GAP 8. DOCTRINE: WIRED describes invocation, not test execution — wording corrected in PR #3574; coverage defers.
+format-validator	NOT-EXECUTED	contradicts-doctrine	8 inline `#[test]` fns. Its LIBRARY is exercised INDIRECTLY, as a path dependency of format-compatibility-tests (the format-compat component), but the crate's own unit tests never run. AUDIT GAP 8. DOCTRINE: its tools/ disposition is MIXED, which names its live/orphaned TARGETS and says nothing about test execution — wording corrected in PR #3574; coverage defers.
+memory-safety-runner	NOT-EXECUTED	silent	2 inline `#[test]` fns. Documented UNWIRED in its tools/ disposition; compile-only.
+cqlite-validator	NOT-EXECUTED	silent	Binary only, 0 `#[test]` fns — nothing to execute. Documented UNWIRED in its tools/ disposition.

--- a/scripts/tests/workspace-test-disposition.txt
+++ b/scripts/tests/workspace-test-disposition.txt
@@ -1,0 +1,51 @@
+# Workspace test-execution disposition census (issue #3522).
+#
+# THE RECORD OF THE #3522 AUDIT. Every cargo workspace member is listed here with a
+# statement of whether the FULL agent gate EXECUTES its Rust tests. Enforced (for
+# COMPLETENESS and LABELING only, never for TRUTH) by
+# scripts/tests/test_workspace_test_disposition.sh, which runs under the gate's
+# `tooling-tests` component. Read that script's header before changing this file: it
+# explains what the guard does and, more importantly, what it deliberately does not do.
+#
+# WHY IT EXISTS. Compiling is not covering. `cargo clippy --workspace --all-targets`
+# compiles every member of this workspace on every full gate, so a crate can be built
+# by every run and execute NOTHING — and nothing said so. That is how
+# `cqlite-ffi-common` (52 tests) and `cqlite-node`'s 53 Rust unit tests sat unexecuted
+# by any gate component or CI job for months while reading as covered. This file makes
+# the omission a RECORDED, REVIEWED fact instead of a discovery.
+#
+# FORMAT — one record per line:
+#     <package-name> <TAB> <LABEL> <TAB> <detail>
+# Blank lines and `#` comments are ignored.
+#
+# LABELS — a CLOSED set. An unrecognised label is a FAIL, not a pass.
+#   EXECUTED      the full gate runs this member's tests. <detail> NAMES the gate
+#                 component(s) that do it.
+#   PARTIAL       the gate runs SOME of them. <detail> names the component(s), WHAT is
+#                 not run, and WHY.
+#   NOT-EXECUTED  no gate component runs them. <detail> says WHY, and cites the
+#                 tracking issue when one is filed.
+#
+# HOW TO CHANGE IT. Adding a workspace member without adding a record here FAILs the
+# gate. Wiring a member into a component means moving its record to EXECUTED and naming
+# the component. Do NOT "fix" a NOT-EXECUTED record by deleting it: the whole value of
+# this file is that the unexecuted set is visible.
+
+cqlite	NOT-EXECUTED	Workspace ROOT package. 24 integration targets under /tests, 15 of which are root-only (the other 9 are also targets of cqlite-integration-tests, and 6 of those run there). No `cargo test -p cqlite` / `--workspace` invocation exists in the gate or in CI. AUDIT GAP 3.
+cqlite-core	PARTIAL	core-tests (cargo nextest run -p cqlite-core --features cli-helpers) + write-tests + 13 targeted lanes. Of 369 integration targets, 303 execute >0 tests; 66 compile to ZERO tests at that feature set and 41 of those are named by no --test anywhere. AUDIT GAP 10 (families: delta-scan 12, observability-testing 13, dhat-heap 9).
+cqlite-cli	PARTIAL	cli-tests runs 35 of 45 integration targets in two passes. `--lib`/`--bins` is NEVER passed, so all 255 lib/bin unit `#[test]` fns are unexecuted; 8 targets are quarantined and 5 excluded. AUDIT GAP 2.
+cqlite-flight	PARTIAL	flight-tests runs `--lib --bins`; flight-query-semantics-oracle runs 2 integration targets and memory-budget 1. 39 of 42 integration targets are un-run LOCALLY — declared by that lane's own census. CI's Flight tier (the one blocking tier) runs the whole package. AUDIT GAP 7 / issues #3384, #3375.
+cqlite-ffi-common	EXECUTED	binding-rust-tests — `cargo test --no-fail-fast -p cqlite-ffi-common`, ALL targets (lib + tests/dependency_boundary.rs + tests/error_contract_table.rs). Closed AUDIT GAP 1; before #3522 this member executed NOWHERE.
+cqlite-node	PARTIAL	binding-rust-tests runs the RUST half (`--lib --features write-support`); node-bindings runs the WHOLE jest suite against the built napi artifact. Both closed by #3522 (AUDIT GAP 5). Not run: bodies gated on the `observability` feature — building the OTel stack is a cost the gate declines on purpose (#1844).
+cqlite-py	NOT-EXECUTED	Rust half only, and STRUCTURALLY so: a pyo3 cdylib's `cargo test` harness cannot link libpython, which is documented in scripts/agent-gate.sh (search: "cannot link libpython"). Its PYTHON half IS fully covered — python-bindings runs the entire pytest suite. AUDIT GAP 6.
+cqlite-integration-tests	PARTIAL	integration-tests COMPILES the whole package (`--no-run`) then runs 6 named `--test` targets. Unexecuted: the lib unit suite (206 `#[test]` fns), 13 bin targets, and 5 integration targets. AUDIT GAP 4.
+format-compatibility-tests	EXECUTED	format-compat — `cargo test -p format-compatibility-tests`, the whole package.
+cqlite-examples	NOT-EXECUTED	1 `#[test]` fn; compile-only via clippy. No component or workflow runs it. Note the `operator-metrics-doc` component runs a cqlite-core EXAMPLE, not this package.
+xtask	NOT-EXECUTED	20 inline `#[test]` fns + 1 integration target. The oom-audit component BUILDS and RUNS the binary but never `cargo test -p xtask`; no CI job does either. AUDIT GAP 9.
+cassandra-parity	NOT-EXECUTED	25 inline `#[test]` fns + 9 integration targets. The parity-report component runs the BINARY only. `cargo test -p cassandra-parity` exists solely in cassandra-parity.yml, which is path-filtered and `required`-EXEMPT. AUDIT GAP 8.
+ws0-corpus-gen	EXECUTED	tooling-tests — `cargo test -q -p ws0-corpus-gen`, the whole package. The only fully covered tools/ crate.
+sstabledump-validator	NOT-EXECUTED	17 inline `#[test]` fns + 2 integration targets. Zero references in scripts/** and .github/workflows/**. AUDIT GAP 8.
+flight-loadgen	NOT-EXECUTED	21 inline `#[test]` fns. Zero references in scripts/** and .github/workflows/**. AUDIT GAP 8.
+format-validator	NOT-EXECUTED	8 inline `#[test]` fns. Its LIBRARY is exercised INDIRECTLY, as a path dependency of format-compatibility-tests (the format-compat component), but the crate's own unit tests never run. AUDIT GAP 8. See also its tools/ disposition: MIXED.
+memory-safety-runner	NOT-EXECUTED	2 inline `#[test]` fns. Documented UNWIRED in its tools/ disposition; compile-only.
+cqlite-validator	NOT-EXECUTED	Binary only, 0 `#[test]` fns — nothing to execute. Documented UNWIRED in its tools/ disposition.


### PR DESCRIPTION
Closes #3522.

## The defect

`cqlite-ffi-common` and `cqlite-node` had test suites that **no full-gate component executed**.
`cargo clippy --workspace --all-targets` compiles every workspace member on every full gate, so a
crate can be built by every run and execute nothing — and nothing said so. #1452 moved the
authoritative FFI error table and its 12-test suite into `cqlite-ffi-common`, where it silently
stopped being gate-covered; it stayed green because `--lite`'s touched-package blast radius and a
plain `cargo test` both still ran it.

This is #1699's lesson at **package** granularity rather than feature granularity: *compiling is not
covering*, and the question to ask of a crate is which lane **executes** it, not which lane compiles
it.

## What changed

**1. New full-gate component `binding-rust-tests`.** Executes `cqlite-ffi-common` (all targets — lib
+ `tests/dependency_boundary.rs` + `tests/error_contract_table.rs`) and `cqlite-node --lib
--features write-support`, plus `cqlite-node`'s derived integration targets. Target sets come from
`cargo metadata` at run time; a failed derivation is a FAIL naming the derivation, never a fallback
to "nothing to run". Every selected target must be affirmatively observed to have executed a
non-zero test count — a green `cargo test` exit is not sufficient, because a suite whose modules are
cfg'd out compiles, runs zero tests and exits 0.

*Why its own component and not part of `node-bindings`:* `node-bindings` SKIPs when node/npm is
absent. Putting the `cqlite-node` Rust tests behind that SKIP would mean a box without npm silently
stops executing them — a coverage hole wearing a SKIP's clothes, which is this issue's own defect
class. `binding-rust-tests` depends on nothing but cargo and never SKIPs.

**2. `node-bindings` widened from 1 jest suite to the whole suite.** It ran `npx jest
write-readback-content` — **1 of 27 files**. Now it runs `npm test`: 27 suites, 504 passed, 2 skipped
(the suite's own `RUN_SLOW_TESTS` gate, per-test, same convention `python-bindings` honours), 0
failed. The suite set is derived from `./node_modules/.bin/jest --listTests` — jest's own answer, not
a `find`, because `testMatch` is recursive and a `find` would undercount and false-red the day a
subdirectory appears. The component joins `DATASET_COMPONENTS`.

**3. The workspace test-execution disposition census** —
`scripts/tests/workspace-test-disposition.txt` plus `test_workspace_test_disposition.sh`, run under
the already-wired `tooling-tests` (deliberately NOT a new `COMPONENTS` entry: a mistake in the array
every fleet lane dispatches has a wider blast radius than one in a script `tooling-tests` already
runs). It derives all 18 members from `cargo metadata` and FAILs if any carries no RECORDED
disposition from a **closed** label set. Bidirectional: a deleted crate leaves a stale record that
fails, not just a new crate lacking one. Its pass line states the gap's **size** (`15 of 18 members
recorded as PARTIAL or NOT-EXECUTED`), because a bare `PASS` would read as an all-clear about a
workspace that is 83% uncovered.

Modelled on `test_tools_crate_disposition.sh` including its most important property: **it checks
that a disposition was RECORDED and LABELED, not that the record is TRUE.** #1716 records why the
truth-verifying version was built and removed.

**4. `scripts/tests/test_agent_gate_binding_rust_lanes.sh`** — the opt-in planted-break harness (see
AC3 below).

**5. Doctrine** — CLAUDE.md's gate table and the #1699 paragraph now carry the package-granular
generalisation.

## AC-by-AC

- **AC1** — a full-gate component executes the `cqlite-ffi-common` test suite. `binding-rust-tests`.
- **AC2** — `tests/dependency_boundary.rs` runs in the gate of record, and the `ffi-integration` RED
  case proves it by planting there and observing the lane go red.
- **AC3** — RED-tested: **5/5 FIRED + ATTRIBUTED**, `RESULT: PASS`. Table below.
- **AC4** — audited exhaustively, reported, and mechanized. 10 gaps found; 2 fixed, 8 recorded in the
  committed census and proposed as separately-ranked follow-ups on the issue thread.
- **Owner widening (2026-08-29)** — `cqlite-node`'s Rust and JS suites both covered.

## AC3 — RED evidence

Each case plants that lane's incident-class break in a throwaway `git worktree` with a dedicated
`CARGO_TARGET_DIR` (a shared one would make the red/green comparison meaningless) and requires
**two** properties: the lane must go red on the plant AND stay silent on a clean tree, and the red
must **NAME** the planted symbol — a bare red is indistinguishable from an unrelated breakage.

| case | lane | clean | planted | attribution |
|---|---|---|---|---|
| `ffi-integration` | `binding-rust-tests` | PASS (exit 3) | FAIL (exit 1) | `brl_3522_planted_dependency_boundary_break` |
| `ffi-error-contract` | `binding-rust-tests` | PASS | FAIL | `brl_3522_planted_error_contract_break` |
| `node-rust-unit` | `binding-rust-tests` | PASS | FAIL | `brl_3522_planted_node_value_break` |
| `zero-tests` | `binding-rust-tests` | PASS | FAIL | `ran 0 tests` |
| `node-jest` | `node-bindings` | PASS | FAIL | `brl_3522_planted_shared_vectors_break` |

`live-tree: UNCHANGED` verified (git status AND HEAD identical to start).

`node-jest` plants in `shared-vectors.test.js` — one of the 26 suites the old filter never ran — so
it proves the widening **gates**, not merely that it runs more files. `zero-tests` is the only case
reaching `check_unittest_targets_ran`'s non-zero-**count** half, i.e. the vacuous-green detector that
is this issue's own defect class; it reds via the guard, not via a compile error (planted as
`#[cfg(any())]`, because an unknown feature name can trip `unexpected_cfgs` and red the case through
a compile failure under `-D warnings` — right colour, wrong mechanism).

### Running the harness was not a formality

On its first execution `zero-tests` reported `HARNESS-ERROR: the plant itself failed to apply`, and
the harness correctly refused to green over it. The plant rewrote `#[cfg(test)]` in
`bindings/node/src/lib.rs`, which contains **none** — the only occurrence there is prose in a
comment. Two reviewers and the lead then produced three different wrong answers about the fix's
scope (a 6-file list, an 8-file list, and "gate the crate root"). The plant now derives the set and
reports it: **10 attributes across 7 files**. Every enumerated version would have under-neutralised
the crate, left the `--lib` count non-zero, and produced a harness reporting a clean 5/5 while the
load-bearing case tested nothing — this issue's defect one level down.

## Review

Five roborev rounds, every one genuine — jobs 148 / 150 / 151 / 153 / 155 at 1.72M / 1.10M / 565k /
3.06M / 1.67M input tokens against a ~18.7k vacuous baseline — plus a `rust-reviewer` pass. **18
blockers fixed across six rounds.** That is a lot for a change that began as "add a package to a gate
component", and the reason is worth stating: nearly every blocker was an instance of ONE property
expressed at a different level. The ones worth a reader's attention:

- **`cqlite-node` integration targets were counted and printed but never executed** — #3522's own
  defect reproduced inside the fix for #3522. Fixed by executing them, not by failing closed on a
  non-zero count (a lane that reds on the correct act of adding a test is a lane agents learn to
  waive).
- **The `node-bindings` fixture rationale was false in three ways** across six sites. No test file
  uses `describe.skip`; the repo convention is to THROW (`result.test.js:353-355` says so). jest
  reports an all-skipped suite as `N skipped`, not `passed`. "7 suites read `CQLITE_DATASETS_ROOT`"
  is 14. The decision stands; only the stated reason was wrong — and a false rationale in a gate log
  is what stops the next person looking.
- **The widening regressed the documented #2078 opt-out.** `skipIfNoDatasets()` throws on an absent
  corpus and never consults `REQUIRE_FIXTURES`, so `AGENT_GATE_ALLOW_MISSING_FIXTURES=1` no longer
  let a fixture-less gate finish. Fixed; an opt-out the SUMMARY reports as taken must actually work.
- **`test_agent_gate_sublanes.sh` did not know about the new component**, and `tooling-tests` runs
  it — so the full gate would have failed. Nothing in the fast loop (`--only`, `--lite`, the RED
  harness) runs `tooling-tests`, so every check on this branch was blind to it by construction.
- **The same defect kept reappearing at finer granularity, and each level looked complete from
  inside.** A crate compiled but never executed (the filed bug). A suite *listed and run* but with no
  assertion that anything in it did work (`t_passed > 0` was aggregate, so one all-skipped suite hid
  behind 26 siblings). A guard whose expectation came from the same source as its measurement, so a
  config exclusion moved both. A verdict whose fail-closed direction was right but whose stated cause
  and remedy were wrong. Four levels, one shape.
- **Two blockers were lessons this file ALREADY RECORDS** and the new code re-broke: `env -u`-not-
  omission (`agent-gate.sh:6511`, working pattern at `:6562`) and glob-not-`find` under ambient shell
  options (the round-34 comment). Not a contributor-quality problem — a property of an 11,800-line
  file whose recorded lessons do not reach someone editing a different part of it.
- **Rounds 1–4 regenerated the classes their own fixes touched** (4 of 10 blockers were introduced by
  earlier fixes), so rounds 5–6 were run as counted CLASS SWEEPS rather than point fixes: 22 sites
  audited / 4 fixed / 18 left with recorded reasons for the pipeline-status class, and every glob site
  audited for the other. After those sweeps roborev's next round produced **no recurrence of either
  class** — which is the evidence that they closed.

## Two corrections to this branch's own record

Recorded here rather than by rewriting history, because a force-push would invalidate the roborev
reviews that certify this head.

**Commit `0962809ef`'s message overstates its own diff.** It says "7 assertions strengthened, 2 new
discriminating cases". The diff says **3 strengthened** (two genuinely under-specifying — `gated_a` →
`gated_a gated_b`, and `off[observability]` → the full
`multi(required-features[write-support,observability]:off[observability])` — plus one in the jest
guards) and **4 new cases**. Two further assertions were converted to exact comparison but were
already sound as single-item strings, so they are not "strengthened" in any meaningful sense. The
diff is authoritative.

**A named open gap in the G1 parser-divergence sweep.** Ten jq→python3 fallback pairs exist in
`agent-gate.sh`. Three are introduced by this branch; all three are now **differentially tested** — 28
comparisons asserting byte-equal stdout *and* equal exit status, with the parity test calling
`_…_jq` and `_…_py` **directly by name** so both branches execute regardless of which the dispatcher
would pick on a given host. The remaining **seven are pre-existing and were audited by reading, not
differentially tested**: they call `cargo metadata` internally and cannot be fixtured without the same
extraction performed for the three. Three of those seven carry the same latent divergence class
(`_package_index`, `_package_unittest_srcs`, `_package_test_targets_gated`: jq's `sub("/[^/]+$")` /
`split("/")[0:-1]` versus python's `os.path.dirname`, plus `os.sep`) and would disagree for a
root-level or componentless `manifest_path` — unreachable for real cargo metadata on Linux/macOS,
which is why it is a **named gap and not a claim of correctness**. Extending the differential harness
to them belongs in the follow-up, not here.

## Residual — reported, not fixed

**Tracking issue: #3595** — *"Eight workspace test-execution gaps the full agent gate does not
cover"*. Filed as **ONE** issue per the coordination lead's ruling, with this PR's audit table
reproduced **verbatim** and an editor's note recording that three of its claims were falsified and
corrected (see #3522 comment 5468888458). **The five `contradicts-doctrine` WORDING fixes landed in
this PR on the corrected grounds; only the COVERAGE is deferred to #3595.**

Eight further gate-execution gaps are recorded with evidence in
`scripts/tests/workspace-test-disposition.txt` and proposed as ranked follow-ups on #3522 under
`coord:follow-up-proposed`. AC4 asks to report rather than silently widen scope. The one a reviewer
should notice: `.github/ci-gating-tiers.yml` registers **exactly one** blocking tier (`flight`);
every other test-running workflow is `exempt:` and cannot red `required` — and two of the three
exempt reasons that justify themselves by "the local agent gate covers this" are provably false
(`cqlite-cli --lib`'s 255 tests; `node-ci.yml`'s claim about a component that ran 1 of 27 files).

Five review nits are batched into a single linked follow-up at merge time rather than triggering
re-verify rounds.
