### PR TITLE
fix(#3564): findings: must be affirmatively NONE for a roborev PASS — closes the --recheck-job false PASS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -849,8 +849,13 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   **And a fail-closed argument for a `${VAR:-default}` is only valid for the consumers that existed when
   it was written**: the `block_marker_count` `:-0` was audited as strict because `NONE` was the STRICT
   direction for `vacuity-tier1:`, and a new consumer for which `NONE` is PERMISSIVE inverted it silently
-  — no default can fix that (`0` and *unmeasurable* are one value), so the direction now comes from a
-  separate `block_measured` signal. So: never derive a pass from the ABSENCE of a bad signal; where an oracle is the SOLE evidence
+  — no default can fix that (`0` and *unmeasurable* are one value). **The resolution is not a better
+  default or a second signal but a REMOVED CONSUMER**: `NONE` is unreachable from a marker count at all
+  (only the structured verdict yields it), so nothing derives a permissive verdict from that `0` and the
+  original argument holds unchanged. An intermediate version of this fix DID add a separate
+  `block_measured` flag; it went away with the prose reconstruction it guarded, and this sentence
+  described it for one round after it was deleted — caught by the C audit. **A doctrine line naming a
+  mechanism is a claim about code, and it decays exactly like a comment: re-grep the symbol.** So: never derive a pass from the ABSENCE of a bad signal; where an oracle is the SOLE evidence
   for a claim and could not be consulted the verdict is NON-PASSING and its text names what was
   unverifiable; key a permissive branch on the AFFIRMATIVE value (`= OK`), never on `!= <bad>`; and where a
   signal genuinely SHOULD be permissive, record the reason IN CODE at the branch. The wrapper's verdict

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -814,7 +814,30 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   configured", then never required it to have *answered*); a `${end:-$start}` default degraded a failed
   `awk` bound to a 1-line scan. Those instances lived in a subsystem since deleted; **the shape is the
   lesson, and it was never theirs** — it was in the wrapper's own terminal verdict scan, which predates
-  them all. So: never derive a pass from the ABSENCE of a bad signal; where an oracle is the SOLE evidence
+  them all. **AND `findings:` WAS THE SAME SHAPE, ONE KEY OVER (#3564).** `findings:` is not one of the
+  six affirmation keys — its affirmative value is `NONE`, not `PASS` — and it was documented as merely
+  CORROBORATING, which read as "guarded elsewhere" when it was guarded NOWHERE: `PRESENT` is in the
+  closed grammar's NON-FAILING set, so the only thing failing a findings-bearing run was the
+  NEIGHBOURING key `roborev-exit: FINDINGS (exit 1)`. On `--recheck-job` **no reviewer runs**, so
+  `roborev-exit` is legitimately `SKIP` — and the run emitted `findings: PRESENT (3)` beside
+  `RESULT: PASS`, a **false PASS in a merge gate** (measured on #3473 round 3), on the ONE path an
+  authorized waiver must travel, letting a waiver scoped to `prompt-content` ABSENCE excuse findings
+  nobody excused. Now a would-be PASS requires `findings:` to reduce token-exactly to `NONE` **in every
+  mode including recheck**, and that requirement is **NOT waivable**. Fixed in the verdict scan and
+  deliberately NOT in `roborev-exit`: `SKIP` is the TRUE statement about a recheck, and making a key
+  claim a failure it never observed trades one false statement for another. Second half, the part that
+  keeps the break-glass alive: a recheck of a record with no structured `verdict` field used to read
+  `UNKNOWN` (its branch was keyed on the reviewer's exit code, and there is no reviewer), which would
+  have false-FAILed EVERY clean recheck — so a recheck now re-asserts findings from the record's own
+  review text, scoped to the findings block, and says `UNKNOWN` only when that block could not be
+  measured. **The generalisation to carry elsewhere: DELEGATING A KEY'S FAILURE TO ITS NEIGHBOUR IS A
+  LATENT FALSE PASS** — the coupling is invisible while one event populates both keys and evaporates in
+  the first mode where it does not, so ask of every key *what fails the run if THIS key alone goes bad*.
+  **And a fail-closed argument for a `${VAR:-default}` is only valid for the consumers that existed when
+  it was written**: the `block_marker_count` `:-0` was audited as strict because `NONE` was the STRICT
+  direction for `vacuity-tier1:`, and a new consumer for which `NONE` is PERMISSIVE inverted it silently
+  — no default can fix that (`0` and *unmeasurable* are one value), so the direction now comes from a
+  separate `block_measured` signal. So: never derive a pass from the ABSENCE of a bad signal; where an oracle is the SOLE evidence
   for a claim and could not be consulted the verdict is NON-PASSING and its text names what was
   unverifiable; key a permissive branch on the AFFIRMATIVE value (`= OK`), never on `!= <bad>`; and where a
   signal genuinely SHOULD be permissive, record the reason IN CODE at the branch. The wrapper's verdict

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -829,15 +829,21 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   keeps the break-glass alive: a recheck of a record with no structured `verdict` field used to read
   `UNKNOWN` (its branch was keyed on the reviewer's exit code, and there is no reviewer), which would
   have false-FAILed EVERY clean recheck — so a recheck now re-asserts findings from the record's own
-  review text, scoped to the findings block, and says `UNKNOWN` — never `NONE` — whenever that
-  reconstruction cannot support a positive claim: an empty/unmeasurable transcript, **or a severity
-  marker sitting OUTSIDE any findings block**. That last case is the fix's own defect class one layer
-  down, caught in review: `review-completed` deliberately ACCEPTS a HEADERLESS findings review (a bare
-  `**Severity**:` line, `[High]`, `Medium:`), for which the block extraction finds nothing — so "0
-  markers in the block" meant "no block", not "no findings", and read as an affirmative `NONE`. `NONE`
-  is now sayable only when the count is zero across the WHOLE transcript; a marker outside a block is
-  ambiguous (headerless finding vs a clean review QUOTING a severity token) and ambiguity resolves to
-  the failing value, never to either verdict. **The generalisation to carry elsewhere: DELEGATING A KEY'S FAILURE TO ITS NEIGHBOUR IS A
+  review text — but ONLY in the direction prose can actually evidence. **PROSE CAN EVIDENCE FINDINGS;
+  IT CANNOT EVIDENCE CLEANLINESS**, so a marker in a findings block yields `PRESENT` while its ABSENCE
+  yields `UNKNOWN`, never `NONE`. `NONE` is reachable only from the record's STRUCTURED `verdict`
+  letter. **Two review rounds each found a review SHAPE the previous recogniser missed** — a HEADERLESS
+  findings review (no `Findings` heading, which `review-completed` deliberately accepts), then a
+  findings BLOCK with no recognised severity marker — and the class provably does not close, because
+  `review-completed` accepts a bare `## Summary` heading as a completed review: a findings review whose
+  findings are prose is then INDISTINGUISHABLE from a clean one, whose real text is
+  `No issues found.\n\nSummary: …` with no `Findings` heading either. That is #3312's lesson applied
+  one directory over: **REMOVE THE CHANNEL, do not pick a rarer delimiter** — a recogniser over
+  author-controlled prose never closes. **And it costs nothing, measured rather than assumed**:
+  `roborev show --json` SYNTHESISES the verdict letter from the `reviews.verdict_bool` column for every
+  observed record (`P` clean / `F` findings; `review_jobs` has no verdict column), so a real clean
+  recheck takes the structured path and the break-glass is intact, and the verdict-less branch is
+  defensive for a payload shape nothing observed emits. **The generalisation to carry elsewhere: DELEGATING A KEY'S FAILURE TO ITS NEIGHBOUR IS A
   LATENT FALSE PASS** — the coupling is invisible while one event populates both keys and evaporates in
   the first mode where it does not, so ask of every key *what fails the run if THIS key alone goes bad*.
   **And a fail-closed argument for a `${VAR:-default}` is only valid for the consumers that existed when

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -829,8 +829,15 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   keeps the break-glass alive: a recheck of a record with no structured `verdict` field used to read
   `UNKNOWN` (its branch was keyed on the reviewer's exit code, and there is no reviewer), which would
   have false-FAILed EVERY clean recheck — so a recheck now re-asserts findings from the record's own
-  review text, scoped to the findings block, and says `UNKNOWN` only when that block could not be
-  measured. **The generalisation to carry elsewhere: DELEGATING A KEY'S FAILURE TO ITS NEIGHBOUR IS A
+  review text, scoped to the findings block, and says `UNKNOWN` — never `NONE` — whenever that
+  reconstruction cannot support a positive claim: an empty/unmeasurable transcript, **or a severity
+  marker sitting OUTSIDE any findings block**. That last case is the fix's own defect class one layer
+  down, caught in review: `review-completed` deliberately ACCEPTS a HEADERLESS findings review (a bare
+  `**Severity**:` line, `[High]`, `Medium:`), for which the block extraction finds nothing — so "0
+  markers in the block" meant "no block", not "no findings", and read as an affirmative `NONE`. `NONE`
+  is now sayable only when the count is zero across the WHOLE transcript; a marker outside a block is
+  ambiguous (headerless finding vs a clean review QUOTING a severity token) and ambiguity resolves to
+  the failing value, never to either verdict. **The generalisation to carry elsewhere: DELEGATING A KEY'S FAILURE TO ITS NEIGHBOUR IS A
   LATENT FALSE PASS** — the coupling is invisible while one event populates both keys and evaporates in
   the first mode where it does not, so ask of every key *what fails the run if THIS key alone goes bad*.
   **And a fail-closed argument for a `${VAR:-default}` is only valid for the consumers that existed when

--- a/openspec/specs/roborev-review-guard/spec.md
+++ b/openspec/specs/roborev-review-guard/spec.md
@@ -799,9 +799,19 @@ which occurred SHALL be the job record's structured `status`, falling back to th
 whole transcript. Tier 1 is GATED on this answer, so a regex over the entire output was a real weakness:
 an incidental or QUOTED severity token such as `[Low]` anywhere in the output set `findings: PRESENT`,
 which then EXEMPTED a genuinely vacuous "no code changes" verdict from tier 1's hard failure. Where no
-structured verdict exists the wrapper SHALL fall back to the reviewer's EXIT CODE, and prose SHALL be
-consulted only inside the FINDINGS BLOCK (from a `Findings` heading/label to a LINE-INITIAL `Summary`
-heading/label). The `<n>` COUNT SHALL remain BEST-EFFORT prose parsing of severity markers within that
+structured verdict exists **on a FRESH review** the wrapper SHALL fall back to the reviewer's EXIT CODE,
+and prose SHALL be consulted only inside the FINDINGS BLOCK (from a `Findings` heading/label to a
+LINE-INITIAL `Summary` heading/label).
+
+**ON A `--recheck-job` THE EXIT-CODE FALLBACK DOES NOT EXIST, AND PROSE SHALL NOT ESTABLISH CLEANLINESS
+(#3564).** A recheck runs no reviewer, so `roborev-exit:` is legitimately `SKIP` and cannot arbitrate
+anything. `NONE` SHALL therefore be reachable from the record's STRUCTURED `verdict` letter ALONE. Where a
+recheck's record carries no such letter, the findings block MAY establish `PRESENT` (a severity marker is
+positive evidence) but its ABSENCE SHALL be `UNKNOWN`, never `NONE` — the two directions are asymmetric
+because `review-completed:` accepts a bare `## Summary` heading as a completed review, so a findings review
+whose findings are prose is INDISTINGUISHABLE from a clean one. `UNKNOWN` fails closed. This is a DEFENSIVE
+path: every observed record carries the synthesised letter, so a real recheck of a clean job takes the
+structured path and still PASSes, leaving the #3312 absence waiver's only route intact. The `<n>` COUNT SHALL remain BEST-EFFORT prose parsing of severity markers within that
 block and SHALL be reported for a human, never used as an authority; the PRESENT/NONE/INCONSISTENT
 distinction is the load-bearing part.
 
@@ -908,8 +918,12 @@ deterministic keys — `push-assert:`, `census-check:`, `code-free:`, `sha-asser
 any key** and no exemption mechanism. (One existed briefly, for a key allowed a `NOTICE` because a
 remedy-less swallow was a measurement with a stated residual; that key and its exemption are both gone —
 #3283/#3278 — leaving the backstop UNIFORM, which is stricter, never weaker.) `vacuity-tier1:`,
-`vacuity-tier2:` and `findings:` are deliberately EXCLUDED, being corroborators with documented non-`PASS`
-values. This closes the case NEIGHBOURING the grammar check: a value that is IN the grammar and
+`vacuity-tier2:` are deliberately EXCLUDED, being corroborators with documented non-`PASS`
+values. **`findings:` IS NOT EXCLUDED (#3564):** it carries its OWN affirmative gate — a passing run's
+`findings:` SHALL reduce token-exactly to `NONE`, in EVERY mode, and that requirement SHALL NOT be
+waivable (the absence waiver excuses `prompt-content:` absence only). It is listed separately from the six
+because it is not merely required to be non-failing: `PRESENT`, `INCONSISTENT`, `UNKNOWN` and `SKIP` each
+fail, so a run can never PASS beside open or unestablished findings. This closes the case NEIGHBOURING the grammar check: a value that is IN the grammar and
 non-failing but is not a MEASUREMENT — `SKIP` above all, which means the check NEVER RAN. Validating that
 the sourced checks file DEFINES its five functions proves they exist, NOT that each reached its
 assignment; a check that returns early leaves its key at the initial `SKIP`, and the run then passed with a

--- a/scripts/flow/roborev-review-checks.sh
+++ b/scripts/flow/roborev-review-checks.sh
@@ -367,7 +367,16 @@ roborev_check_findings() {
       # NONE from a COUNT OF ZERO, so an UNMEASURABLE block must be UNKNOWN (which now fails) and
       # never NONE. A positive verdict requires an affirmative measurement.
       if [ -n "${RECHECK_JOB:-}" ]; then
-        if [ "$block_measured" -eq 0 ]; then
+        # AN EMPTY TRANSCRIPT MEASURED NOTHING, so it cannot report NONE. On a recheck the transcript
+        # IS the record's review text, and a record carrying none leaves it empty — for which "no
+        # severity markers found" is TRUE and MEANINGLESS. `review-completed` already FAILs this run
+        # (an empty transcript carries no terminal verdict marker), so this is defence in depth
+        # rather than the only guard; it is here because the permissive value must not be reachable
+        # from an absent measurement AT ALL. A guard that is correct only because a neighbouring
+        # check happens to fail first is the exact coupling #3564 removed one key over.
+        if [ ! -s "$LOG" ]; then
+          FINDINGS="UNKNOWN"
+        elif [ "$block_measured" -eq 0 ]; then
           FINDINGS="UNKNOWN"
           DETAILS+=("ERROR: findings: this is a --recheck-job of a record with no structured 'verdict' field, so the findings state must be re-asserted from the record's own review text — and that text's findings block COULD NOT BE MEASURED (the extraction or the marker scan itself failed, which is distinct from finding no markers). UNKNOWN, which cannot certify a PASS: a pass may not rest on a measurement that did not happen. Transcript: $LOG")
         elif [ "$block_marker_count" -gt 0 ]; then

--- a/scripts/flow/roborev-review-checks.sh
+++ b/scripts/flow/roborev-review-checks.sh
@@ -274,8 +274,9 @@ roborev_check_findings() {
   # NOT `grep | wc -l` IN ONE COMMAND SUBSTITUTION: the pipeline would run in a SUBSHELL, so its
   # `PIPESTATUS` is unreadable here and grep's failure would be indistinguishable from "no match".
   # grep runs on its own, its status is captured explicitly, and the count is taken from its output.
+  SEVERITY_MARKER_RE='\*\*severity\*\*[[:space:]]*:[[:space:]]*(critical|high|medium|low)|\[(critical|high|medium|low)\]|(^|[^[:alnum:]])(critical|high|medium|low): '
   grep_rc=0
-  block_markers_raw=$(grep -oiE '\*\*severity\*\*[[:space:]]*:[[:space:]]*(critical|high|medium|low)|\[(critical|high|medium|low)\]|(^|[^[:alnum:]])(critical|high|medium|low): ' "$FINDINGS_BLOCK_FILE" 2>/dev/null) || grep_rc=$?
+  block_markers_raw=$(grep -oiE "$SEVERITY_MARKER_RE" "$FINDINGS_BLOCK_FILE" 2>/dev/null) || grep_rc=$?
   if [ "$grep_rc" -ge 2 ]; then
     block_measured=0
   fi
@@ -283,6 +284,37 @@ roborev_check_findings() {
     block_marker_count=0
   else
     block_marker_count=$(printf '%s\n' "$block_markers_raw" | wc -l | tr -d '[:space:]')
+  fi
+  # ===== AND THE SAME SCAN OVER THE WHOLE TRANSCRIPT — FOR THE RECHECK FALLBACK ONLY =====
+  # (roborev round 1, High.) A HEADERLESS findings review has no `Findings` heading, so the block
+  # extraction above yields NOTHING for it — and `review-completed`'s allow-list deliberately ACCEPTS
+  # that shape (a bare `**Severity**:` line, `[High]`, `Medium:`), because it was widened to stop
+  # false-FAILing genuine reviews from agents that emit it. So "0 markers in the block" does NOT mean
+  # "no findings": for a headerless review it means "no block was found", and the recheck fallback
+  # would have read that as an AFFIRMATIVE `NONE` and PASSED a findings-bearing recheck. That is
+  # THIS ISSUE'S OWN DEFECT one layer down — a permissive branch reached by an unmeasured state.
+  #
+  # This count is used ONLY to decide whether `NONE` is SAYABLE, never to report PRESENT: a marker
+  # outside a findings block is ambiguous by construction — a headerless finding and a clean review
+  # QUOTING a severity token look identical, which is precisely why the block scan exists (a
+  # whole-transcript scan was rejected on #2964 round 5 for producing false PRESENT). So the
+  # ambiguity resolves to UNKNOWN, which FAILS, rather than to either verdict.
+  #
+  # SCOPED TO THE RECHECK BRANCH DELIBERATELY. Every other branch has an INDEPENDENT affirmative
+  # signal for cleanliness (the record's structured `verdict`, or a 0 exit from a reviewer that ran)
+  # and uses the block count only to detect a CONTRADICTION; widening those to the whole transcript
+  # would make a quoted severity word INCONSISTENT and false-FAIL ordinary clean reviews. The recheck
+  # fallback is the one branch with NO independent signal, so it is the one that must not guess.
+  transcript_measured=1
+  transcript_grep_rc=0
+  transcript_markers_raw=$(grep -oiE "$SEVERITY_MARKER_RE" "$LOG" 2>/dev/null) || transcript_grep_rc=$?
+  if [ "$transcript_grep_rc" -ge 2 ]; then
+    transcript_measured=0
+  fi
+  if [ -z "$transcript_markers_raw" ]; then
+    transcript_marker_count=0
+  else
+    transcript_marker_count=$(printf '%s\n' "$transcript_markers_raw" | wc -l | tr -d '[:space:]')
   fi
   # THE `:-0` DEFAULT, AND WHY IT IS NO LONGER SELF-JUSTIFYING (#3229 round 10, revised #3564).
   # The original argument was that the strict direction is guaranteed BY THE DEFAULT ITSELF: a
@@ -376,11 +408,20 @@ roborev_check_findings() {
         # check happens to fail first is the exact coupling #3564 removed one key over.
         if [ ! -s "$LOG" ]; then
           FINDINGS="UNKNOWN"
-        elif [ "$block_measured" -eq 0 ]; then
+        elif [ "$block_measured" -eq 0 ] || [ "$transcript_measured" -eq 0 ]; then
           FINDINGS="UNKNOWN"
-          DETAILS+=("ERROR: findings: this is a --recheck-job of a record with no structured 'verdict' field, so the findings state must be re-asserted from the record's own review text — and that text's findings block COULD NOT BE MEASURED (the extraction or the marker scan itself failed, which is distinct from finding no markers). UNKNOWN, which cannot certify a PASS: a pass may not rest on a measurement that did not happen. Transcript: $LOG")
+          DETAILS+=("ERROR: findings: this is a --recheck-job of a record with no structured 'verdict' field, so the findings state must be re-asserted from the record's own review text — and that text COULD NOT BE MEASURED (an extraction or marker scan itself failed, which is distinct from finding no markers). UNKNOWN, which cannot certify a PASS: a pass may not rest on a measurement that did not happen. Transcript: $LOG")
         elif [ "$block_marker_count" -gt 0 ]; then
           FINDINGS="PRESENT ($block_marker_count)"
+        elif [ "$transcript_marker_count" -gt 0 ]; then
+          # A SEVERITY MARKER OUTSIDE ANY FINDINGS BLOCK: either a HEADERLESS findings review (which
+          # `review-completed` accepts as a valid shape) or a clean review QUOTING a severity token.
+          # Indistinguishable here, so neither verdict is sayable — and `NONE` above all, which would
+          # PASS a findings-bearing recheck. UNKNOWN is also stricter than PRESENT for the
+          # `vacuity-tier1` gate, which treats UNKNOWN as claiming cleanliness and PRESENT as an
+          # exemption, so this choice is fail-closed in both consumers.
+          FINDINGS="UNKNOWN"
+          DETAILS+=("ERROR: findings: this is a --recheck-job of a record with no structured 'verdict' field, so the findings state rests entirely on the record's review text — and that text carries $transcript_marker_count severity marker(s) that are OUTSIDE any findings block. A HEADERLESS findings review (a bare '**Severity**:' line, '[High]', 'Medium:' — shapes review-completed accepts) and a CLEAN review that merely QUOTES a severity token are indistinguishable from here, so the findings state is UNKNOWN and cannot certify a PASS. Do NOT read this as 'no findings'. Remedy: read the review text yourself ($LOG) — if it is genuinely clean, re-review rather than recheck, so the run rests on a reviewer's own exit status instead of a reconstruction.")
         else
           FINDINGS="NONE"
         fi

--- a/scripts/flow/roborev-review-checks.sh
+++ b/scripts/flow/roborev-review-checks.sh
@@ -255,83 +255,31 @@ roborev_check_findings() {
   # prose contained the word, under-counting the findings. (Under-counting is the
   # fail-closed direction for the tier-1 gate — fewer markers make a vacuity claim MORE
   # likely to fail — but the count is reported to a human, so it should be right.)
-  # WAS THE BLOCK ACTUALLY MEASURED? Tracked because ONE consumer derives NONE-vs-PRESENT from the
-  # COUNT ALONE (the recheck fallback below), and there a failed measurement's 0 would read as an
-  # AFFIRMATIVE "no findings" — the exact shape #3229 removed elsewhere and #3564 must not
-  # reintroduce. `grep` exit 1 is "no match", a legitimate measurement; only >=1 from awk or >=2
-  # from grep is a FAILURE to measure. Every OTHER consumer has an independent affirmative signal
-  # (the record's structured verdict, or a 0 exit from the reviewer) and uses the count only to
-  # detect a CONTRADICTION, so none of them needs this flag.
-  block_measured=1
-  if ! { awk 'BEGIN { inblock = 0 }
+  { awk 'BEGIN { inblock = 0 }
          tolower($0) ~ /^[[:space:]]*#{1,4}[[:space:]]*(review[[:space:]]+)?findings?/ { inblock = 1; next }
          tolower($0) ~ /^[[:space:]]*findings?[[:space:]]*:/ { inblock = 1; next }
          tolower($0) ~ /^[[:space:]]*#{1,4}[[:space:]]*summary/ { inblock = 0 }
          tolower($0) ~ /^[[:space:]]*summary[[:space:]]*:/ { inblock = 0 }
-         inblock { print }' "$LOG" 2>/dev/null; } >"$FINDINGS_BLOCK_FILE"; then
-    block_measured=0
-  fi
-  # NOT `grep | wc -l` IN ONE COMMAND SUBSTITUTION: the pipeline would run in a SUBSHELL, so its
-  # `PIPESTATUS` is unreadable here and grep's failure would be indistinguishable from "no match".
-  # grep runs on its own, its status is captured explicitly, and the count is taken from its output.
-  SEVERITY_MARKER_RE='\*\*severity\*\*[[:space:]]*:[[:space:]]*(critical|high|medium|low)|\[(critical|high|medium|low)\]|(^|[^[:alnum:]])(critical|high|medium|low): '
-  grep_rc=0
-  block_markers_raw=$(grep -oiE "$SEVERITY_MARKER_RE" "$FINDINGS_BLOCK_FILE" 2>/dev/null) || grep_rc=$?
-  if [ "$grep_rc" -ge 2 ]; then
-    block_measured=0
-  fi
-  if [ -z "$block_markers_raw" ]; then
-    block_marker_count=0
-  else
-    block_marker_count=$(printf '%s\n' "$block_markers_raw" | wc -l | tr -d '[:space:]')
-  fi
-  # ===== AND THE SAME SCAN OVER THE WHOLE TRANSCRIPT — FOR THE RECHECK FALLBACK ONLY =====
-  # (roborev round 1, High.) A HEADERLESS findings review has no `Findings` heading, so the block
-  # extraction above yields NOTHING for it — and `review-completed`'s allow-list deliberately ACCEPTS
-  # that shape (a bare `**Severity**:` line, `[High]`, `Medium:`), because it was widened to stop
-  # false-FAILing genuine reviews from agents that emit it. So "0 markers in the block" does NOT mean
-  # "no findings": for a headerless review it means "no block was found", and the recheck fallback
-  # would have read that as an AFFIRMATIVE `NONE` and PASSED a findings-bearing recheck. That is
-  # THIS ISSUE'S OWN DEFECT one layer down — a permissive branch reached by an unmeasured state.
+         inblock { print }' "$LOG" 2>/dev/null || true; } >"$FINDINGS_BLOCK_FILE"
+  block_marker_count=$({ grep -oiE '\*\*severity\*\*[[:space:]]*:[[:space:]]*(critical|high|medium|low)|\[(critical|high|medium|low)\]|(^|[^[:alnum:]])(critical|high|medium|low): ' "$FINDINGS_BLOCK_FILE" 2>/dev/null || true; } | wc -l | tr -d '[:space:]')
+  # THE `:-0` DEFAULT IS THE FAIL-CLOSED DIRECTION, verified rather than assumed (#3229
+  # round-10 sweep audit of every `${VAR:-default}` in these three files). A fail-open default
+  # masking a failed measurement is exactly how the `${_census_end:-$_census_start}` bound
+  # degraded a broken `awk` into a 1-line scan, so each such default has to be shown to fall the
+  # STRICT way. Here it does: a failed `awk`/`grep` yields 0 markers, 0 markers makes
+  # `findings:` read NONE rather than PRESENT, and NONE is what makes `vacuity-tier1` treat the
+  # "no code changes" phrase as a VACUITY CLAIM and HARD FAIL. PRESENT is the permissive value
+  # (it downgrades tier 1 to an advisory NOTICE), and an unmeasurable block can never produce it.
   #
-  # This count is used ONLY to decide whether `NONE` is SAYABLE, never to report PRESENT: a marker
-  # outside a findings block is ambiguous by construction — a headerless finding and a clean review
-  # QUOTING a severity token look identical, which is precisely why the block scan exists (a
-  # whole-transcript scan was rejected on #2964 round 5 for producing false PRESENT). So the
-  # ambiguity resolves to UNKNOWN, which FAILS, rather than to either verdict.
-  #
-  # SCOPED TO THE RECHECK BRANCH DELIBERATELY. Every other branch has an INDEPENDENT affirmative
-  # signal for cleanliness (the record's structured `verdict`, or a 0 exit from a reviewer that ran)
-  # and uses the block count only to detect a CONTRADICTION; widening those to the whole transcript
-  # would make a quoted severity word INCONSISTENT and false-FAIL ordinary clean reviews. The recheck
-  # fallback is the one branch with NO independent signal, so it is the one that must not guess.
-  transcript_measured=1
-  transcript_grep_rc=0
-  transcript_markers_raw=$(grep -oiE "$SEVERITY_MARKER_RE" "$LOG" 2>/dev/null) || transcript_grep_rc=$?
-  if [ "$transcript_grep_rc" -ge 2 ]; then
-    transcript_measured=0
-  fi
-  if [ -z "$transcript_markers_raw" ]; then
-    transcript_marker_count=0
-  else
-    transcript_marker_count=$(printf '%s\n' "$transcript_markers_raw" | wc -l | tr -d '[:space:]')
-  fi
-  # THE `:-0` DEFAULT, AND WHY IT IS NO LONGER SELF-JUSTIFYING (#3229 round 10, revised #3564).
-  # The original argument was that the strict direction is guaranteed BY THE DEFAULT ITSELF: a
-  # failed `awk`/`grep` yields 0 markers, 0 markers makes `findings:` read NONE, and NONE is what
-  # makes `vacuity-tier1` treat a "no code changes" phrase as a VACUITY CLAIM and HARD FAIL —
-  # PRESENT being the permissive value there (it downgrades tier 1 to an advisory NOTICE).
-  #
-  # THAT ARGUMENT IS NOW ONLY HALF THE PICTURE, and recording why matters more than the default.
-  # Since #3564 `findings:` gates the terminal verdict on its own, and there **NONE is the
-  # PERMISSIVE value** — so for that consumer a failed measurement's 0 falls the WRONG way, and no
-  # choice of default fixes it: 0 and "unmeasurable" are the same value. The direction cannot be
-  # bought from a default, so it is bought from a SEPARATE SIGNAL — `block_measured` above, which
-  # the recheck fallback (the only consumer deciding NONE-vs-PRESENT from the count alone) requires
-  # before it will report NONE. THE LESSON, since this justification has now been wrong once: a
-  # fail-closed argument for a default is only valid for the CONSUMERS THAT EXISTED WHEN IT WAS
-  # WRITTEN — adding a consumer with the opposite polarity silently invalidates it. Re-derive it
-  # when you add one.
+  # RE-DERIVED FOR #3564, because that issue made `findings:` gate the terminal verdict — where
+  # `NONE` is the PERMISSIVE value, the opposite polarity to tier 1. The argument SURVIVES, but
+  # only because of how the fallback below is built: `NONE` is reachable ONLY from an affirmative
+  # STRUCTURED verdict, never from a marker count, so no consumer derives `NONE` from this `0`.
+  # An intermediate version of #3564 DID derive `NONE` from the count on the recheck path, which
+  # invalidated this paragraph outright (a failed measurement would have read as "no findings" for
+  # a merge-gating key) — recorded because the invalidation was silent and the argument still LOOKED
+  # sound. THE STANDING RULE: a fail-closed argument for a default is valid only for the consumers
+  # that existed when it was written. Re-derive it whenever you add one.
   block_marker_count=${block_marker_count:-0}
 
   verdict_findings="unknown"
@@ -399,31 +347,39 @@ roborev_check_findings() {
       # NONE from a COUNT OF ZERO, so an UNMEASURABLE block must be UNKNOWN (which now fails) and
       # never NONE. A positive verdict requires an affirmative measurement.
       if [ -n "${RECHECK_JOB:-}" ]; then
-        # AN EMPTY TRANSCRIPT MEASURED NOTHING, so it cannot report NONE. On a recheck the transcript
-        # IS the record's review text, and a record carrying none leaves it empty — for which "no
-        # severity markers found" is TRUE and MEANINGLESS. `review-completed` already FAILs this run
-        # (an empty transcript carries no terminal verdict marker), so this is defence in depth
-        # rather than the only guard; it is here because the permissive value must not be reachable
-        # from an absent measurement AT ALL. A guard that is correct only because a neighbouring
-        # check happens to fail first is the exact coupling #3564 removed one key over.
-        if [ ! -s "$LOG" ]; then
-          FINDINGS="UNKNOWN"
-        elif [ "$block_measured" -eq 0 ] || [ "$transcript_measured" -eq 0 ]; then
-          FINDINGS="UNKNOWN"
-          DETAILS+=("ERROR: findings: this is a --recheck-job of a record with no structured 'verdict' field, so the findings state must be re-asserted from the record's own review text — and that text COULD NOT BE MEASURED (an extraction or marker scan itself failed, which is distinct from finding no markers). UNKNOWN, which cannot certify a PASS: a pass may not rest on a measurement that did not happen. Transcript: $LOG")
-        elif [ "$block_marker_count" -gt 0 ]; then
+        # ===== PROSE CAN EVIDENCE FINDINGS. IT CANNOT EVIDENCE CLEANLINESS. =====
+        # (#3564, after two review rounds each finding a review SHAPE the previous recogniser
+        # missed.) A recheck has no reviewer, so `roborev-exit` is `SKIP` and the arms below —
+        # which are keyed on the reviewer's EXIT CODE — cannot answer. The record's review text is
+        # the only other evidence, and the asymmetry between the two directions is total:
+        #
+        #   a severity marker INSIDE a findings block  =>  POSITIVE evidence of findings. Sayable.
+        #   NO marker found                            =>  NOT evidence of cleanliness. Never NONE.
+        #
+        # WHY THE SECOND DIRECTION IS UNPROVABLE FROM PROSE, which is why this is not a third
+        # recogniser: `review-completed` accepts a `## Summary` heading ALONE as a completed
+        # review. So a findings review whose findings are prose, under no `Findings` heading and
+        # with no severity marker, is INDISTINGUISHABLE from a clean one — measured, not supposed:
+        # a real clean review's text is `No issues found.\n\nSummary: ...` (job 154), carrying no
+        # `Findings` heading either. Every candidate recogniser (a heading, a marker anywhere, a
+        # non-empty block) admits some findings-bearing shape, so the list never closes. That is
+        # this repository's #3312 lesson applied here: REMOVE THE CHANNEL, do not pick a rarer
+        # delimiter. The wrapper's own facts tool says the same thing — the structured field
+        # "must win wherever it exists", and a transcript regex is "a prose heuristic".
+        #
+        # SO `NONE` IS REACHABLE ONLY FROM THE STRUCTURED `verdict` (the branches above), AND THAT
+        # COSTS NOTHING, measured: `roborev show --json` SYNTHESISES a verdict letter from the
+        # `reviews.verdict_bool` column for EVERY record — `P` for a clean review (job 154,
+        # verdict_bool=1) and `F` for a findings-bearing one (job 162, verdict_bool=0); the
+        # `review_jobs` table has no verdict column at all. So a real recheck of a clean job takes
+        # the structured path and still PASSes (the #3312 break-glass is intact), and THIS branch
+        # is a DEFENSIVE path for a payload shape no observed record produces. Making a defensive
+        # path fail closed is free; making it guess is how a merge gate passes over live findings.
+        if [ "$block_marker_count" -gt 0 ]; then
           FINDINGS="PRESENT ($block_marker_count)"
-        elif [ "$transcript_marker_count" -gt 0 ]; then
-          # A SEVERITY MARKER OUTSIDE ANY FINDINGS BLOCK: either a HEADERLESS findings review (which
-          # `review-completed` accepts as a valid shape) or a clean review QUOTING a severity token.
-          # Indistinguishable here, so neither verdict is sayable — and `NONE` above all, which would
-          # PASS a findings-bearing recheck. UNKNOWN is also stricter than PRESENT for the
-          # `vacuity-tier1` gate, which treats UNKNOWN as claiming cleanliness and PRESENT as an
-          # exemption, so this choice is fail-closed in both consumers.
-          FINDINGS="UNKNOWN"
-          DETAILS+=("ERROR: findings: this is a --recheck-job of a record with no structured 'verdict' field, so the findings state rests entirely on the record's review text — and that text carries $transcript_marker_count severity marker(s) that are OUTSIDE any findings block. A HEADERLESS findings review (a bare '**Severity**:' line, '[High]', 'Medium:' — shapes review-completed accepts) and a CLEAN review that merely QUOTES a severity token are indistinguishable from here, so the findings state is UNKNOWN and cannot certify a PASS. Do NOT read this as 'no findings'. Remedy: read the review text yourself ($LOG) — if it is genuinely clean, re-review rather than recheck, so the run rests on a reviewer's own exit status instead of a reconstruction.")
         else
-          FINDINGS="NONE"
+          FINDINGS="UNKNOWN"
+          DETAILS+=("ERROR: findings: this is a --recheck-job of a record carrying NO structured 'verdict' field, and no severity marker was found in a findings block of its review text. That is UNKNOWN, NOT 'no findings': review-completed accepts a bare '## Summary' heading as a completed review, so a findings review whose findings are prose is indistinguishable from a clean one, and prose can therefore never establish CLEANLINESS. It cannot certify a PASS. This is also an UNEXPECTED payload shape — 'roborev show --json' synthesises a verdict letter ('P'/'F') from reviews.verdict_bool for every observed record — so suspect a roborev version or payload change first. Remedy: re-review rather than recheck, so the verdict rests on a reviewer's own exit status. Transcript: $LOG")
         fi
       elif [ "$ROBOREV_EXIT" = "PASS" ]; then
         if [ "$block_marker_count" -gt 0 ]; then

--- a/scripts/flow/roborev-review-checks.sh
+++ b/scripts/flow/roborev-review-checks.sh
@@ -343,9 +343,11 @@ roborev_check_findings() {
       # `review-completed` has already required a terminal verdict marker, so this is a real review
       # text and not a truncated one.
       #
-      # AND IT REQUIRES THE MEASUREMENT TO HAVE HAPPENED: this is the one consumer that derives
-      # NONE from a COUNT OF ZERO, so an UNMEASURABLE block must be UNKNOWN (which now fails) and
-      # never NONE. A positive verdict requires an affirmative measurement.
+      # AND NO COUNT OF ZERO REACHES NONE HERE: the marker scan below is POSITIVE-DETECTION ONLY.
+      # A marker inside the findings block establishes PRESENT; its ABSENCE establishes nothing, so
+      # an unmeasurable or marker-free block is UNKNOWN (which fails) and never NONE. `NONE` is
+      # reachable from the `none)` arm above ALONE — i.e. from the record's STRUCTURED verdict
+      # letter. A positive verdict requires an affirmative measurement, and prose is not one.
       if [ -n "${RECHECK_JOB:-}" ]; then
         # ===== PROSE CAN EVIDENCE FINDINGS. IT CANNOT EVIDENCE CLEANLINESS. =====
         # (#3564, after two review rounds each finding a review SHAPE the previous recogniser

--- a/scripts/flow/roborev-review-checks.sh
+++ b/scripts/flow/roborev-review-checks.sh
@@ -255,21 +255,51 @@ roborev_check_findings() {
   # prose contained the word, under-counting the findings. (Under-counting is the
   # fail-closed direction for the tier-1 gate — fewer markers make a vacuity claim MORE
   # likely to fail — but the count is reported to a human, so it should be right.)
-  { awk 'BEGIN { inblock = 0 }
+  # WAS THE BLOCK ACTUALLY MEASURED? Tracked because ONE consumer derives NONE-vs-PRESENT from the
+  # COUNT ALONE (the recheck fallback below), and there a failed measurement's 0 would read as an
+  # AFFIRMATIVE "no findings" — the exact shape #3229 removed elsewhere and #3564 must not
+  # reintroduce. `grep` exit 1 is "no match", a legitimate measurement; only >=1 from awk or >=2
+  # from grep is a FAILURE to measure. Every OTHER consumer has an independent affirmative signal
+  # (the record's structured verdict, or a 0 exit from the reviewer) and uses the count only to
+  # detect a CONTRADICTION, so none of them needs this flag.
+  block_measured=1
+  if ! { awk 'BEGIN { inblock = 0 }
          tolower($0) ~ /^[[:space:]]*#{1,4}[[:space:]]*(review[[:space:]]+)?findings?/ { inblock = 1; next }
          tolower($0) ~ /^[[:space:]]*findings?[[:space:]]*:/ { inblock = 1; next }
          tolower($0) ~ /^[[:space:]]*#{1,4}[[:space:]]*summary/ { inblock = 0 }
          tolower($0) ~ /^[[:space:]]*summary[[:space:]]*:/ { inblock = 0 }
-         inblock { print }' "$LOG" 2>/dev/null || true; } >"$FINDINGS_BLOCK_FILE"
-  block_marker_count=$({ grep -oiE '\*\*severity\*\*[[:space:]]*:[[:space:]]*(critical|high|medium|low)|\[(critical|high|medium|low)\]|(^|[^[:alnum:]])(critical|high|medium|low): ' "$FINDINGS_BLOCK_FILE" 2>/dev/null || true; } | wc -l | tr -d '[:space:]')
-  # THE `:-0` DEFAULT IS THE FAIL-CLOSED DIRECTION, verified rather than assumed (#3229
-  # round-10 sweep audit of every `${VAR:-default}` in these three files). A fail-open default
-  # masking a failed measurement is exactly how the `${_census_end:-$_census_start}` bound
-  # degraded a broken `awk` into a 1-line scan, so each such default has to be shown to fall the
-  # STRICT way. Here it does: a failed `awk`/`grep` yields 0 markers, 0 markers makes
-  # `findings:` read NONE rather than PRESENT, and NONE is what makes `vacuity-tier1` treat the
-  # "no code changes" phrase as a VACUITY CLAIM and HARD FAIL. PRESENT is the permissive value
-  # (it downgrades tier 1 to an advisory NOTICE), and an unmeasurable block can never produce it.
+         inblock { print }' "$LOG" 2>/dev/null; } >"$FINDINGS_BLOCK_FILE"; then
+    block_measured=0
+  fi
+  # NOT `grep | wc -l` IN ONE COMMAND SUBSTITUTION: the pipeline would run in a SUBSHELL, so its
+  # `PIPESTATUS` is unreadable here and grep's failure would be indistinguishable from "no match".
+  # grep runs on its own, its status is captured explicitly, and the count is taken from its output.
+  grep_rc=0
+  block_markers_raw=$(grep -oiE '\*\*severity\*\*[[:space:]]*:[[:space:]]*(critical|high|medium|low)|\[(critical|high|medium|low)\]|(^|[^[:alnum:]])(critical|high|medium|low): ' "$FINDINGS_BLOCK_FILE" 2>/dev/null) || grep_rc=$?
+  if [ "$grep_rc" -ge 2 ]; then
+    block_measured=0
+  fi
+  if [ -z "$block_markers_raw" ]; then
+    block_marker_count=0
+  else
+    block_marker_count=$(printf '%s\n' "$block_markers_raw" | wc -l | tr -d '[:space:]')
+  fi
+  # THE `:-0` DEFAULT, AND WHY IT IS NO LONGER SELF-JUSTIFYING (#3229 round 10, revised #3564).
+  # The original argument was that the strict direction is guaranteed BY THE DEFAULT ITSELF: a
+  # failed `awk`/`grep` yields 0 markers, 0 markers makes `findings:` read NONE, and NONE is what
+  # makes `vacuity-tier1` treat a "no code changes" phrase as a VACUITY CLAIM and HARD FAIL —
+  # PRESENT being the permissive value there (it downgrades tier 1 to an advisory NOTICE).
+  #
+  # THAT ARGUMENT IS NOW ONLY HALF THE PICTURE, and recording why matters more than the default.
+  # Since #3564 `findings:` gates the terminal verdict on its own, and there **NONE is the
+  # PERMISSIVE value** — so for that consumer a failed measurement's 0 falls the WRONG way, and no
+  # choice of default fixes it: 0 and "unmeasurable" are the same value. The direction cannot be
+  # bought from a default, so it is bought from a SEPARATE SIGNAL — `block_measured` above, which
+  # the recheck fallback (the only consumer deciding NONE-vs-PRESENT from the count alone) requires
+  # before it will report NONE. THE LESSON, since this justification has now been wrong once: a
+  # fail-closed argument for a default is only valid for the CONSUMERS THAT EXISTED WHEN IT WAS
+  # WRITTEN — adding a consumer with the opposite polarity silently invalidates it. Re-derive it
+  # when you add one.
   block_marker_count=${block_marker_count:-0}
 
   verdict_findings="unknown"
@@ -318,9 +348,34 @@ roborev_check_findings() {
       fi
       ;;
     *)
-      # No structured verdict: fall back to the exit code, still refusing to trust prose
-      # over the whole transcript.
-      if [ "$ROBOREV_EXIT" = "PASS" ]; then
+      # No structured verdict. THE RECHECK CASE FIRST, because the fallback below is keyed on the
+      # REVIEWER'S EXIT CODE and a recheck HAS NO REVIEWER — `roborev-exit` is legitimately
+      # `SKIP`, which matched neither arm and left `findings: UNKNOWN` on every recheck of a record
+      # without a structured `verdict` field. That was invisible while nothing depended on
+      # `findings` alone; #3564 made it load-bearing, and left unfixed it would false-FAIL every
+      # clean recheck — i.e. break the ONLY path the #3312 absence waiver can travel. A guard that
+      # reds on correct input is the guard agents learn to waive.
+      #
+      # So a recheck re-asserts the findings state from the RECORD'S OWN REVIEW TEXT, which IS the
+      # transcript in this mode — the same source `review-completed` and both vacuity tiers are
+      # re-asserted from. Scoped to the FINDINGS BLOCK, never the whole transcript: a whole-text
+      # scan reads a QUOTED severity word as a finding, and here that would be a false FAIL.
+      # `review-completed` has already required a terminal verdict marker, so this is a real review
+      # text and not a truncated one.
+      #
+      # AND IT REQUIRES THE MEASUREMENT TO HAVE HAPPENED: this is the one consumer that derives
+      # NONE from a COUNT OF ZERO, so an UNMEASURABLE block must be UNKNOWN (which now fails) and
+      # never NONE. A positive verdict requires an affirmative measurement.
+      if [ -n "${RECHECK_JOB:-}" ]; then
+        if [ "$block_measured" -eq 0 ]; then
+          FINDINGS="UNKNOWN"
+          DETAILS+=("ERROR: findings: this is a --recheck-job of a record with no structured 'verdict' field, so the findings state must be re-asserted from the record's own review text — and that text's findings block COULD NOT BE MEASURED (the extraction or the marker scan itself failed, which is distinct from finding no markers). UNKNOWN, which cannot certify a PASS: a pass may not rest on a measurement that did not happen. Transcript: $LOG")
+        elif [ "$block_marker_count" -gt 0 ]; then
+          FINDINGS="PRESENT ($block_marker_count)"
+        else
+          FINDINGS="NONE"
+        fi
+      elif [ "$ROBOREV_EXIT" = "PASS" ]; then
         if [ "$block_marker_count" -gt 0 ]; then
           FINDINGS="INCONSISTENT (exit 0, $block_marker_count findings marker(s))"
           DETAILS+=("ERROR: findings: 'roborev review' exited 0 (which means no findings) while the findings block carries $block_marker_count severity marker(s), and the job record has no structured verdict to arbitrate. INCONSISTENT — failed closed, and it cannot exempt the tier-1 vacuity check.")

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -140,6 +140,10 @@
 #                     UNAVAILABLE | SKIP        (ADVISORY when it is a NOTICE)
 #   vacuity-tier2     PASS | FAIL (...) | UNAVAILABLE | SKIP
 #   findings          NONE | PRESENT [(<n>)] | INCONSISTENT (...) | UNKNOWN | SKIP
+#                     ONLY an affirmative `NONE` permits a PASS, IN EVERY MODE including
+#                     `--recheck-job`, and that requirement is NOT WAIVABLE (#3564). It is
+#                     enforced in step 7 on its own terms rather than by the neighbouring
+#                     `roborev-exit` key, which is legitimately `SKIP` on a recheck.
 #   roborev-exit      PASS | FINDINGS (exit N) | ERROR (exit N) | SKIP
 #   model             <model> | <model> (SUBSTITUTED — requested '<r>') |
 #                     <model> (UNCONFIRMED — no model field in the job record) | -
@@ -159,6 +163,11 @@
 # VERDICT and FAILS. Testing only the bad states would let every unplanned one inherit
 # the permissive branch, which is the general shape of three separate defects found on
 # #3229 (see step 7).
+# GRAMMAR RECOGNITION IS NOT A PASS, and conflating the two was #3564: `PRESENT` is
+# RECOGNISED here — it is a documented findings state, not a typo — and that is all this
+# scan says about it. Whether a value may ride to `RESULT: PASS` is decided by the two
+# AFFIRMATIVE gates beside it in step 7: `findings:` must read exactly `NONE`, and every
+# deterministic key must read exactly `PASS`.
 #
 # THE RULE THAT GOVERNS EVERY KEY HERE, and the one to apply when adding another:
 # **A POSITIVE VERDICT REQUIRES AN AFFIRMATIVE MEASUREMENT.** Never derive a pass from
@@ -1268,9 +1277,13 @@ roborev_check_tier2
 # form to be non-failing. The recognised set is exactly the states this block documents —
 # PASS / SKIP / NOTICE / UNAVAILABLE / DEGRADED, plus `findings:`'s own NONE / PRESENT /
 # UNKNOWN — and anything else is an UNRECOGNISED VERDICT, which fails closed and names
-# itself. UNKNOWN is recognised deliberately: `findings: UNKNOWN` is a documented value and
-# is unreachable unless `roborev-exit:` is already `ERROR (exit N)`, which fails on its own
-# terms, while `vacuity-tier1:` additionally treats it as claiming cleanliness.
+# itself. UNKNOWN is recognised deliberately: `findings: UNKNOWN` is a documented value, not a
+# typo — and recognition is all this scan grants it. It no longer RELIES on being "unreachable
+# unless `roborev-exit:` is already `ERROR (exit N)`, which fails on its own terms": that was a
+# statement about a NEIGHBOURING key, and #3564 is what happens when a key's failure is delegated
+# to its neighbour — on `--recheck-job` the neighbour is legitimately `SKIP` and the delegation
+# evaporates. `findings:` now carries its own affirmative gate below, so `UNKNOWN` fails on ITS OWN
+# terms; `vacuity-tier1:` additionally treats it as claiming cleanliness.
 #
 # ====== MATCHED ON THE VERDICT TOKEN, EXACTLY — NEVER AS A PREFIX GLOB ======
 # The scan's earlier form matched `PASS*` / `FAIL*` etc. as PREFIX globs, and a prefix glob
@@ -1326,8 +1339,14 @@ done
 # `PASS*` prefix glob would accept `PASSthisNeverRan` as an affirmative pass, i.e. the
 # backstop against unmeasured keys would itself be satisfiable by a value that measured
 # nothing. The token is the value up to its first space, compared exactly.
-# `vacuity-tier1/2` and `findings:` are deliberately EXCLUDED: they CORROBORATE, and
-# `UNAVAILABLE` / `NONE` are documented, legitimate values for them on a clean run.
+# `vacuity-tier1/2` and `findings:` are EXCLUDED FROM THIS LOOP, for two DIFFERENT reasons
+# that #3564 showed must not be stated as one. `vacuity-tier1/2` CORROBORATE, and
+# `UNAVAILABLE` is a documented, legitimate value for them on a clean run. `findings:` is
+# excluded only because its affirmative value is `NONE` rather than `PASS`, so it cannot
+# satisfy this loop's uniform test — it is NOT unguarded: it has its own affirmative gate
+# IMMEDIATELY ABOVE, which is stricter than this loop (no `WAIVED` is admitted there).
+# Reading the old wording as "findings only corroborates" is what left the recheck path
+# able to PASS beside `findings: PRESENT (3)`.
 #
 # WHY IT IS NOT REDUNDANT with the checks-file validation: that validation proves the five
 # functions EXIST, not that each reached its assignment. A check that returned early — an
@@ -1336,6 +1355,47 @@ done
 # with a key that had measured nothing. "PASS requires POSITIVE evidence" is the wrapper's
 # stated contract (see EXIT CODES above); this is the contract enforced rather than intended.
 #
+# ====== AND `findings:` MUST BE AFFIRMATIVELY `NONE` FOR A PASS, IN EVERY MODE ======
+# (#3564.) `findings:` reports whether the REVIEW found anything, and until this existed it could
+# not fail the run ON ITS OWN: `PRESENT` is in the grammar's non-failing set above, so the only
+# thing failing a findings-bearing run was the NEIGHBOURING key `roborev-exit: FINDINGS (exit 1)`.
+# That coupling held for a fresh review and broke exactly where it mattered most. On
+# `--recheck-job` NO REVIEWER PROCESS RUNS, so `roborev-exit` is legitimately `SKIP` — and with the
+# failing signal gone, a recheck of a job whose record carries findings emitted
+# `findings: PRESENT (3)` beside `RESULT: PASS`. Measured on #3473's round-3 recovery (job 160):
+# a FALSE PASS IN A MERGE GATE, and the wrapper's own documented affirmation backstop did not catch
+# it because `findings` is deliberately excluded from the loop below.
+#
+# This is this repository's named recurring defect, in the one place it is most expensive: **A
+# POSITIVE VERDICT REQUIRES AN AFFIRMATIVE MEASUREMENT** — never derive a pass from the ABSENCE of
+# a bad signal. So the requirement is stated POSITIVELY and on `findings`'s OWN terms: its
+# affirmative value is `NONE`, not `PASS`. That is why this is its OWN statement and not a per-key
+# affirmative token inside the loop below — a key-scoped special case there is the shape that has
+# to be re-argued every time a key is added, and the loop's uniform "every key must read PASS" is
+# the property that makes it a backstop. `PRESENT`, `UNKNOWN` and the initial `SKIP` all fail here;
+# `INCONSISTENT` already fails the grammar scan, and this is a second, independent reason it cannot
+# pass.
+#
+# MATCHED ON THE VERDICT TOKEN, EXACTLY, for the same reason both scans above are: `PRESENT (3)`
+# must reduce to `PRESENT`, and a `NONE-BUT-UNMEASURED` variant must NOT satisfy a `NONE*` prefix.
+#
+# THE FIX BELONGS HERE, NOT IN `roborev-exit`. `SKIP` is the TRUE statement about a recheck — the
+# reviewer genuinely did not run — so making that key claim a failure it did not observe would
+# trade one false statement for another.
+#
+# DELIBERATELY NOT WAIVABLE, and this is the sharpest reason the gate has to be here. The absence
+# waiver (#3312) excuses `prompt-content` ABSENCE **only**, and `--recheck-job` is the ONLY path a
+# waiver can travel (a re-run enqueues a different job and stales it) — so a waiver-bearing recheck
+# is PRECISELY the run this must still fail. Admitting `WAIVED` here would let one authorization
+# excuse findings no human agreed to excuse.
+#
+# Evaluated only on a would-be PASS, and BEFORE the affirmation loop: where both this and the
+# structural backstop would fire, OPEN FINDINGS are what the reader must act on, and a wrapper
+# defect reported over them would bury it.
+if [ "$failed" -eq 0 ] && [ "${FINDINGS%% *}" != NONE ]; then
+  failed=1
+  DETAILS+=("ERROR: findings: this run would have PASSED while 'findings:' reads '$FINDINGS' — and only an affirmative 'NONE' certifies that the review found nothing. A review with OPEN FINDINGS is not \"roborev clean\", whatever the neighbouring keys say: on --recheck-job no reviewer process runs, so 'roborev-exit' is legitimately SKIP and CANNOT be the thing that fails a findings-bearing run (#3564). If this is PRESENT, triage the findings in the review record ($LOG), fix them, then push and re-review. 'UNKNOWN' or 'SKIP' means the findings state was never ESTABLISHED, which fails closed for the same reason — a pass may not rest on a state we could not read. This requirement is NOT waivable in any mode: the absence waiver excuses prompt-content absence only.")
+fi
 # Evaluated ONLY when the run would otherwise PASS, deliberately: on an already-failing run
 # every non-affirmative key has its own diagnostic under its own name, and repeating them here
 # would bury the actionable cause under a structural one.

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4333,6 +4333,14 @@ assert_verdict 'case (fd1)' FAIL 1
 assert_says 'case (fd1) the findings state is re-asserted from the record' '^findings: PRESENT \(2\)$'
 assert_says 'case (fd1) roborev-exit stays truthful about a process that never ran' \
   '^roborev-exit: SKIP \(recheck: no reviewer ran in this invocation; job 4656 re-decided from its record\)$'
+# THE ISOLATION CLAIM, PINNED RATHER THAN ASSERTED IN PROSE (C audit, low). Reaching the terminal gate
+# proves only that no key failed the GRAMMAR scan; it does not prove the other keys affirmatively PASSed,
+# which is what makes findings the SOLE cause. So the two keys a findings-bearing fixture is most likely
+# to disturb are asserted positively — without this, the case would keep passing for the wrong reason if
+# a future fixture change broke one of them.
+assert_says 'case (fd1) the reviewer-diff delivery key affirmatively PASSed (findings are the SOLE cause)' \
+  '^prompt-content: PASS \(2/2 code census paths present\)$'
+assert_says 'case (fd1) and completion was re-asserted from the record' '^review-completed: PASS$'
 assert_says 'case (fd1) and findings fails the verdict on its OWN terms, naming what it read' \
   "ERROR: findings: this run would have PASSED while 'findings:' reads 'PRESENT \(2\)'"
 assert_lacks 'case (fd1) THE #3473 SIGNATURE IS UNREACHABLE: no PASS beside PRESENT' '^RESULT: PASS$'
@@ -4461,7 +4469,9 @@ printf '== (fd9) #3564 roborev r1 High: a HEADERLESS findings recheck cannot rea
 # it was widened to stop false-FAILing genuine reviews from agents that emit that shape. But the
 # findings-BLOCK extraction needs a heading, so for such a transcript the block is EMPTY, and the
 # recheck fallback read 0 markers as an AFFIRMATIVE `NONE` and PASSED a findings-bearing recheck.
-# `NONE` is now sayable only when the marker count is zero across the WHOLE transcript too.
+# THE SHIPPED RULE IS STRONGER THAN THIS CASE'S FIRST FIX: an intermediate version made `NONE` require
+# zero markers across the WHOLE transcript, and round 2 defeated that too (fd10/fd11), so prose can now
+# never say `NONE` at all — only the structured verdict letter can.
 reset_stub
 STUB_ANNOUNCE_SHA="$w_head"
 STUB_PROMPT="$PROMPT_WITH_W_PATHS"

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4284,6 +4284,149 @@ assert_says 'case (wv33c) neither preformatted context is an authorization' \
 assert_lacks 'case (wv33c) and neither grants' '^prompt-content: WAIVED'
 reset_stub
 
+printf '== #3564: `findings:` MUST FAIL THE VERDICT ON ITS OWN, IN EVERY MODE ==\n'
+# THE DEFECT (#3564, measured on #3473's round-3 recovery, job 160): `--recheck-job` emitted
+#     findings:     PRESENT (3)
+#     roborev-exit: SKIP (recheck: no reviewer ran ...)
+#     RESULT:       PASS
+# a FALSE PASS IN A MERGE GATE. `PRESENT` is in the verdict grammar's non-failing set, so the only
+# thing failing a findings-bearing run was the NEIGHBOURING key `roborev-exit: FINDINGS (exit 1)`.
+# On a recheck no reviewer process runs, `roborev-exit` is legitimately `SKIP`, and removing the
+# failing signal removed the only thing failing the run.
+#
+# BOTH DIRECTIONS ARE PINNED, and that is a requirement of the fix rather than thoroughness: a
+# one-direction test cannot distinguish a corrected verdict scan from one that fails EVERYTHING,
+# and `--recheck-job` is the ONLY path the #3312 absence waiver can travel, so a verdict scan that
+# over-fails would break the break-glass instead of the false PASS.
+FINDINGS_TEXT='## Findings\n- **Severity**: High\nProblem: the first one.\n- **Severity**: Medium\nProblem: the second one.\n## Summary\n2 findings.'
+CLEAN_TEXT='## Summary\nNo issues found.'
+# A prompt carrying THIS fixture's OWN census paths (`two-code-commits` = alpha.rs + beta.rs), so
+# `prompt-content:` can PASS. The shared PROMPT_WITH_PATHS names main.rs/README.md/NOTES.md — the
+# `mixed` fixture's paths — which is why the waiver cases above either waive the absence or assert
+# only individual keys. A positive control needs a prompt that genuinely matches its census, not a
+# waiver: a PASS bought with a waiver could not show that findings NONE is what permitted it.
+PROMPT_WITH_W_PATHS='Review the following change.\ndiff --git a/alpha.rs b/alpha.rs\n@@ fn alpha() {} @@\ndiff --git a/beta.rs b/beta.rs\n@@ fn beta() {} @@'
+
+printf '== (fd1) #3564: a recheck of a job whose record CARRIES FINDINGS FAILs ==\n'
+# The exact measured signature, asserted as a signature: PRESENT beside SKIP must not be a PASS.
+# EVERY OTHER KEY IS MADE TO PASS (hence the census-matching prompt), so the findings are the SOLE
+# cause of the FAIL. That is what makes this a test of the defect rather than of the suite: with any
+# other key failing, the run FAILs for a reason that was never in question and the case would go on
+# passing if the fix were reverted.
+reset_stub
+STUB_ANNOUNCE_SHA="$w_head"
+STUB_PROMPT="$PROMPT_WITH_W_PATHS"
+STUB_VERDICT_FIELD='F'
+STUB_RECORD_OUTPUT="$FINDINGS_TEXT"
+run_wrapper "$w_work" --recheck-job 4656
+assert_verdict 'case (fd1)' FAIL 1
+assert_says 'case (fd1) the findings state is re-asserted from the record' '^findings: PRESENT \(2\)$'
+assert_says 'case (fd1) roborev-exit stays truthful about a process that never ran' \
+  '^roborev-exit: SKIP \(recheck: no reviewer ran in this invocation; job 4656 re-decided from its record\)$'
+assert_says 'case (fd1) and findings fails the verdict on its OWN terms, naming what it read' \
+  "ERROR: findings: this run would have PASSED while 'findings:' reads 'PRESENT \(2\)'"
+assert_lacks 'case (fd1) THE #3473 SIGNATURE IS UNREACHABLE: no PASS beside PRESENT' '^RESULT: PASS$'
+reset_stub
+
+printf '== (fd2) #3564: a recheck of a CLEAN job still PASSes (the break-glass keeps working) ==\n'
+# THE POSITIVE CONTROL. Without it this suite could not tell the fix from a scan that fails every
+# recheck — and failing every recheck would take the ONLY route an authorized absence waiver has.
+reset_stub
+STUB_ANNOUNCE_SHA="$w_head"
+STUB_PROMPT="$PROMPT_WITH_W_PATHS"
+STUB_RECORD_OUTPUT="$CLEAN_TEXT"
+run_wrapper "$w_work" --recheck-job 4656
+assert_verdict 'case (fd2)' PASS 0
+assert_says 'case (fd2) a clean record reads affirmatively NONE' '^findings: NONE$'
+reset_stub
+
+printf '== (fd3) #3564: a recheck with NO structured verdict reads findings FROM THE RECORD TEXT ==\n'
+# THE SECOND HALF OF THE FIX, and it is not cosmetic. `findings:` used to fall through to a branch
+# keyed on the REVIEWER'S EXIT CODE when the record carried no `verdict` field — and a recheck has
+# no reviewer, so `roborev-exit: SKIP` matched neither arm and the key read UNKNOWN. Harmless while
+# nothing depended on `findings` alone; once it gates the verdict, UNKNOWN on every such recheck
+# would have false-FAILed the clean ones (fd2's shape) and, in this shape, still not named the
+# findings. The record's review text IS the transcript in this mode, so it is the right oracle.
+reset_stub
+STUB_ANNOUNCE_SHA="$w_head"
+STUB_PROMPT="$PROMPT_WITH_W_PATHS"
+STUB_RECORD_OUTPUT="$FINDINGS_TEXT"
+run_wrapper "$w_work" --recheck-job 4656
+assert_verdict 'case (fd3)' FAIL 1
+assert_says 'case (fd3) findings come from the record text, not from the absent exit code' \
+  '^findings: PRESENT \(2\)$'
+assert_lacks 'case (fd3) and never degrades to UNKNOWN' '^findings: UNKNOWN'
+reset_stub
+
+printf '== (fd4) #3564: a recheck of a job whose record verdict is affirmatively CLEAN PASSes ==\n'
+# The structured-verdict half of the positive control: `verdict: P` and a clean text must PASS, so
+# the gate is keyed on the findings STATE and not merely on the presence of a `verdict` field.
+reset_stub
+STUB_ANNOUNCE_SHA="$w_head"
+STUB_PROMPT="$PROMPT_WITH_W_PATHS"
+STUB_VERDICT_FIELD='P'
+STUB_RECORD_OUTPUT="$CLEAN_TEXT"
+run_wrapper "$w_work" --recheck-job 4656
+assert_verdict 'case (fd4)' PASS 0
+assert_says 'case (fd4) the structured clean verdict reads NONE' '^findings: NONE$'
+reset_stub
+
+printf '== (fd5) #3564: AN AUTHORIZED ABSENCE WAIVER DOES NOT EXCUSE FINDINGS ==\n'
+# THE SHARPEST CASE IN THIS GROUP. `--recheck-job` is the only path a waiver travels, so before the
+# fix the one code path an authorized waiver must use was the path that silently dropped a findings
+# failure — letting a waiver scoped to `prompt-content` ABSENCE (#3312) excuse findings NO HUMAN
+# AUTHORIZED. The waiver must still do its own job (prompt-content: WAIVED) and the run must still
+# FAIL on the findings.
+reset_stub
+STUB_ANNOUNCE_SHA="$w_head"
+STUB_PROMPT="$PROMPT_WITHOUT_PATHS"
+STUB_VERDICT_FIELD='F'
+STUB_RECORD_OUTPUT="$FINDINGS_TEXT"
+STUB_GH_COMMENTS="\001pmcfadin\nroborev-waive: prompt-content-absent base=$w_base head=$w_head job=4656 reason=snapshot-delivered; 541812 in / 472576 cached\n"
+run_wrapper "$w_work" --recheck-job 4656
+assert_verdict 'case (fd5)' FAIL 1
+assert_says 'case (fd5) the waiver still excuses exactly what it was authorized for' \
+  '^prompt-content: WAIVED \(2/2 code census paths absent'
+assert_says 'case (fd5) but the findings are NOT waived' '^findings: PRESENT \(2\)$'
+assert_says 'case (fd5) and the diagnostic says the requirement is unwaivable' \
+  'NOT waivable in any mode: the absence waiver excuses prompt-content absence only'
+assert_lacks 'case (fd5) a waiver can never carry a findings-bearing recheck to a PASS' '^RESULT: PASS$'
+reset_stub
+
+printf '== (fd6) #3564: the FRESH-review path is unchanged (regression control) ==\n'
+# Rounds 1 and 2 on #3473 produced the CORRECT verdict, so the fix must not have been bought by
+# altering the path that already worked: a fresh review reporting findings still fails, and still
+# fails under `roborev-exit: FINDINGS (exit 1)` — the honest statement about a reviewer that DID run.
+reset_stub
+STUB_ANNOUNCE_SHA="$w_head"
+STUB_PROMPT="$PROMPT_WITH_W_PATHS"
+STUB_VERDICT=$'## Findings\n- **Severity**: High\nProblem: the first one.\n## Summary\n1 finding.'
+STUB_REVIEW_RC=1
+run_wrapper "$w_work"
+assert_verdict 'case (fd6)' FAIL 1
+assert_says 'case (fd6) a reviewer that RAN reports its exit honestly' '^roborev-exit: FINDINGS \(exit 1\)$'
+assert_says 'case (fd6) and findings are reported present' '^findings: PRESENT'
+reset_stub
+
+printf '== (fd7) #3564 structural: the findings gate is TOKEN-EXACT and not keyed on a neighbour ==\n'
+# Behavioural cases only cover the shapes someone already thought of. Two properties of the FIX are
+# asserted against the shipped wrapper, because both are exactly what a later "simplification" would
+# undo: the value is reduced to its VERDICT TOKEN and compared to `NONE` EXACTLY (a `NONE*` prefix
+# glob would accept a `NONE-BUT-UNMEASURED` state, which is the closure checking a spelling rather
+# than a state — the #3229 lesson), and the comparison is on `FINDINGS` itself rather than on
+# `ROBOREV_EXIT`, which is the delegation #3564 removed.
+if grep -qF '[ "${FINDINGS%% *}" != NONE ]' "$WRAPPER_REAL"; then
+  ok 'structural: the terminal gate reduces findings to its verdict token and requires NONE exactly'
+else
+  bad 'structural: the terminal findings gate is not a token-exact `!= NONE` test on FINDINGS — a prefix glob or a neighbour-keyed test reopens #3564'
+fi
+if grep -qF 'This requirement is NOT waivable in any mode' "$WRAPPER_REAL"; then
+  ok 'structural: the gate records IN CODE that it is unwaivable (the #3312 waiver is absence-only)'
+else
+  bad 'structural: the findings gate no longer states that it is unwaivable — the next reader will re-add a WAIVED branch'
+fi
+reset_stub
+
 printf '== case (mb9): the ENQUEUED range is IMMUTABLE against a mid-review base-ref move ==\n'
 # THE RESIDUAL SECOND-ORDER RACE, CLOSED BY CONSTRUCTION (roborev round 1, Medium). The wrapper used
 # to pass the SYMBOLIC base ref to `roborev review --base`, so roborev re-resolved the mirror ref

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4424,6 +4424,39 @@ assert_says 'case (fd8) and the recheck says the record carried no review text' 
   'NOTICE: recheck: the job record for .4656. carries no review text'
 reset_stub
 
+printf '== (fd9) #3564 roborev r1 High: a HEADERLESS findings recheck cannot read NONE ==\n'
+# THE FIX'S OWN DEFECT CLASS, ONE LAYER DOWN. `review-completed`'s allow-list deliberately ACCEPTS a
+# findings review with NO `Findings` heading (a bare `**Severity**:` line, `[High]`, `Medium:`) —
+# it was widened to stop false-FAILing genuine reviews from agents that emit that shape. But the
+# findings-BLOCK extraction needs a heading, so for such a transcript the block is EMPTY, and the
+# recheck fallback read 0 markers as an AFFIRMATIVE `NONE` and PASSED a findings-bearing recheck.
+# `NONE` is now sayable only when the marker count is zero across the WHOLE transcript too.
+reset_stub
+STUB_ANNOUNCE_SHA="$w_head"
+STUB_PROMPT="$PROMPT_WITH_W_PATHS"
+STUB_RECORD_OUTPUT='- **Severity**: High\n- Problem: a headerless finding, with no Findings heading anywhere.\n## Summary\n1 finding.'
+run_wrapper "$w_work" --recheck-job 4656
+assert_verdict 'case (fd9) a headerless findings recheck does NOT pass' FAIL 1
+assert_says 'case (fd9) the state is UNKNOWN, not NONE' '^findings: UNKNOWN$'
+assert_says 'case (fd9) and the cause names the ambiguity rather than claiming cleanliness' \
+  'severity marker\(s\) that are OUTSIDE any findings block'
+assert_lacks 'case (fd9) NONE is never reported for a marker-bearing transcript' '^findings: NONE$'
+reset_stub
+
+printf '== (fd9b) #3564: the bracket and `Medium:` headerless shapes are covered too ==\n'
+# The allow-list names three headerless shapes; a fix that only recognised `**Severity**:` would leave
+# the other two reaching NONE. Asserted per shape rather than trusting one to stand for the family.
+for _fd9_shape in '[High] a bracketed headerless finding.' 'Medium: a labelled headerless finding.'; do
+  reset_stub
+  STUB_ANNOUNCE_SHA="$w_head"
+  STUB_PROMPT="$PROMPT_WITH_W_PATHS"
+  STUB_RECORD_OUTPUT="$_fd9_shape\n## Summary\n1 finding."
+  run_wrapper "$w_work" --recheck-job 4656
+  assert_verdict "case (fd9b) '$_fd9_shape' does NOT pass" FAIL 1
+  assert_says "case (fd9b) '$_fd9_shape' is UNKNOWN, not NONE" '^findings: UNKNOWN$'
+  reset_stub
+done
+
 printf '== (fd7) #3564 structural: the findings gate is TOKEN-EXACT and not keyed on a neighbour ==\n'
 # Behavioural cases only cover the shapes someone already thought of. Two properties of the FIX are
 # asserted against the shipped wrapper, because both are exactly what a later "simplification" would

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4408,6 +4408,22 @@ assert_says 'case (fd6) a reviewer that RAN reports its exit honestly' '^roborev
 assert_says 'case (fd6) and findings are reported present' '^findings: PRESENT'
 reset_stub
 
+printf '== (fd8) #3564: a recheck of a record with NO review text cannot report NONE ==\n'
+# An EMPTY transcript measured nothing, so "no severity markers found" is true and meaningless — and
+# NONE is now the PERMISSIVE value. `review-completed` already FAILs an empty transcript, so this is
+# defence in depth; it is asserted because a guard that holds only because a NEIGHBOURING check fails
+# first is the exact coupling this issue removed one key over.
+reset_stub
+STUB_ANNOUNCE_SHA="$w_head"
+STUB_PROMPT="$PROMPT_WITH_W_PATHS"
+STUB_RECORD_OUTPUT=''
+run_wrapper "$w_work" --recheck-job 4656
+assert_verdict 'case (fd8)' FAIL 1
+assert_says 'case (fd8) an absent measurement is UNKNOWN, never NONE' '^findings: UNKNOWN$'
+assert_says 'case (fd8) and the recheck says the record carried no review text' \
+  'NOTICE: recheck: the job record for .4656. carries no review text'
+reset_stub
+
 printf '== (fd7) #3564 structural: the findings gate is TOKEN-EXACT and not keyed on a neighbour ==\n'
 # Behavioural cases only cover the shapes someone already thought of. Two properties of the FIX are
 # asserted against the shipped wrapper, because both are exactly what a later "simplification" would

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -3948,6 +3948,14 @@ assert_verdict 'case (wv18) step 1: the absence FAILs' FAIL 1
 reset_stub
 STUB_ANNOUNCE_SHA="$w_head"
 STUB_PROMPT="$PROMPT_WITHOUT_PATHS"
+# STUB_VERDICT_FIELD='P' because a REAL record always carries a synthesised verdict letter
+# (#3564, measured: `roborev show --json` derives it from `reviews.verdict_bool` for every record —
+# `P` for a clean review, job 154, `F` for a findings-bearing one, job 162; the `review_jobs` table
+# has no verdict column). This case's SUBJECT is the waiver loop, not the findings state, so it is
+# fixtured with the payload shape roborev actually emits. Since #3564 a recheck can reach `NONE`
+# ONLY from that structured letter — prose cannot establish cleanliness (see fd2) — so without it
+# this case would fail on `findings: UNKNOWN` for a reason unrelated to what it tests.
+STUB_VERDICT_FIELD='P'
 STUB_RECORD_OUTPUT='## Summary\\nNo issues found.'
 STUB_GH_COMMENTS="\001pmcfadin\nroborev-waive: prompt-content-absent base=$w_base head=$w_head job=4656 reason=snapshot-delivered; 541812 in / 472576 cached\n"
 run_wrapper "$w_work" --recheck-job 4656
@@ -4096,6 +4104,7 @@ STUB_ANNOUNCE_SHA="$w_head"
 STUB_PROMPT="$PROMPT_WITH_PATHS"
 STUB_PROMPT='### Combined Diff\n\ndiff --git a/alpha.rs b/alpha.rs\n@@ x @@\ndiff --git a/beta.rs b/beta.rs\n@@ y @@'
 STUB_RECORD_OUTPUT_FIELD=verdict_text
+STUB_VERDICT_FIELD='P'   # real records always carry the synthesised letter (#3564) — see wv18
 STUB_RECORD_OUTPUT='## Summary\\nNo issues found.'
 run_wrapper "$w_work" --recheck-job 4656
 assert_verdict 'case (wv28) verdict_text on the job row' PASS 0
@@ -4106,6 +4115,7 @@ STUB_PROMPT="$PROMPT_WITH_PATHS"
 STUB_SHOW_JSON=nested
 STUB_PROMPT='### Combined Diff\n\ndiff --git a/alpha.rs b/alpha.rs\n@@ x @@\ndiff --git a/beta.rs b/beta.rs\n@@ y @@'
 STUB_RECORD_OUTPUT_FIELD=verdict_text
+STUB_VERDICT_FIELD='P'   # real records always carry the synthesised letter (#3564) — see wv18
 STUB_RECORD_OUTPUT='## Summary\\nNo issues found.'
 run_wrapper "$w_work" --recheck-job 4656
 assert_verdict 'case (wv28b) verdict_text on the review row' PASS 0
@@ -4328,16 +4338,30 @@ assert_says 'case (fd1) and findings fails the verdict on its OWN terms, naming 
 assert_lacks 'case (fd1) THE #3473 SIGNATURE IS UNREACHABLE: no PASS beside PRESENT' '^RESULT: PASS$'
 reset_stub
 
-printf '== (fd2) #3564: a recheck of a CLEAN job still PASSes (the break-glass keeps working) ==\n'
-# THE POSITIVE CONTROL. Without it this suite could not tell the fix from a scan that fails every
-# recheck — and failing every recheck would take the ONLY route an authorized absence waiver has.
+printf '== (fd2) #3564: prose CANNOT establish cleanliness — no structured verdict is UNKNOWN ==\n'
+# ROUND 2 OF REVIEW KILLED THE RECONSTRUCTION THIS CASE USED TO ASSERT. It originally required a
+# clean-LOOKING record with NO structured verdict to PASS, i.e. it treated "no severity marker found"
+# as affirmative cleanliness. Two rounds each found a review SHAPE that defeats that: a HEADERLESS
+# findings review (fd9), and a findings BLOCK with no recognised marker (fd10). The class does not
+# close, and cannot: `review-completed` accepts a bare `## Summary` heading as a completed review, so
+# a findings review whose findings are prose is INDISTINGUISHABLE from a clean one (fd11) — and a real
+# clean review's text is `No issues found.\n\nSummary: ...` with no `Findings` heading either.
+#
+# So the direction is asymmetric and permanent: a marker in a findings block is positive evidence OF
+# findings, while its absence is NOT evidence of cleanliness. `NONE` is reachable only from the
+# structured `verdict` letter (fd4). THE BREAK-GLASS IS UNHARMED, and that is measured rather than
+# argued: `roborev show --json` synthesises that letter from `reviews.verdict_bool` for EVERY observed
+# record, so a real recheck of a clean job takes the structured path — see fd4.
 reset_stub
 STUB_ANNOUNCE_SHA="$w_head"
 STUB_PROMPT="$PROMPT_WITH_W_PATHS"
 STUB_RECORD_OUTPUT="$CLEAN_TEXT"
 run_wrapper "$w_work" --recheck-job 4656
-assert_verdict 'case (fd2)' PASS 0
-assert_says 'case (fd2) a clean record reads affirmatively NONE' '^findings: NONE$'
+assert_verdict 'case (fd2) a clean-LOOKING record with no structured verdict does NOT pass' FAIL 1
+assert_says 'case (fd2) the state is UNKNOWN — prose cannot establish cleanliness' '^findings: UNKNOWN$'
+assert_says 'case (fd2) and the cause says so, and flags the payload shape as unexpected' \
+  'prose can therefore never establish CLEANLINESS'
+assert_lacks 'case (fd2) NONE is never derived from an absent marker' '^findings: NONE$'
 reset_stub
 
 printf '== (fd3) #3564: a recheck with NO structured verdict reads findings FROM THE RECORD TEXT ==\n'
@@ -4359,8 +4383,15 @@ assert_lacks 'case (fd3) and never degrades to UNKNOWN' '^findings: UNKNOWN'
 reset_stub
 
 printf '== (fd4) #3564: a recheck of a job whose record verdict is affirmatively CLEAN PASSes ==\n'
-# The structured-verdict half of the positive control: `verdict: P` and a clean text must PASS, so
-# the gate is keyed on the findings STATE and not merely on the presence of a `verdict` field.
+# THE POSITIVE CONTROL, and after round 2 the ONLY one: `NONE` is reachable only from the structured
+# verdict letter. Without this case the suite could not distinguish the fix from a scan that fails
+# every recheck — which would take the only route an authorized absence waiver has (#3312 job 24).
+#
+# AND IT IS THE REALISTIC SHAPE, measured rather than assumed: `roborev show --json` SYNTHESISES this
+# letter from the `reviews.verdict_bool` column for every observed record — `P` for a clean review
+# (job 154, verdict_bool=1) and `F` for a findings-bearing one (job 162, verdict_bool=0), while the
+# `review_jobs` table has no verdict column at all. So THIS is the path a real clean recheck takes,
+# and fd2's verdict-less payload is the defensive one.
 reset_stub
 STUB_ANNOUNCE_SHA="$w_head"
 STUB_PROMPT="$PROMPT_WITH_W_PATHS"
@@ -4439,7 +4470,7 @@ run_wrapper "$w_work" --recheck-job 4656
 assert_verdict 'case (fd9) a headerless findings recheck does NOT pass' FAIL 1
 assert_says 'case (fd9) the state is UNKNOWN, not NONE' '^findings: UNKNOWN$'
 assert_says 'case (fd9) and the cause names the ambiguity rather than claiming cleanliness' \
-  'severity marker\(s\) that are OUTSIDE any findings block'
+  'prose can therefore never establish CLEANLINESS'
 assert_lacks 'case (fd9) NONE is never reported for a marker-bearing transcript' '^findings: NONE$'
 reset_stub
 
@@ -4456,6 +4487,37 @@ for _fd9_shape in '[High] a bracketed headerless finding.' 'Medium: a labelled h
   assert_says "case (fd9b) '$_fd9_shape' is UNKNOWN, not NONE" '^findings: UNKNOWN$'
   reset_stub
 done
+
+printf '== (fd10) #3564 roborev r2 High: a MARKERLESS findings BLOCK cannot read NONE ==\n'
+# ROUND 2'S FINDING. A `## Findings` block whose findings carry NO recognised severity marker leaves
+# the block NON-EMPTY but the marker count at zero — so the intermediate fix (which required only
+# "zero markers anywhere") still read it as affirmative NONE and passed a findings-bearing recheck.
+reset_stub
+STUB_ANNOUNCE_SHA="$w_head"
+STUB_PROMPT="$PROMPT_WITH_W_PATHS"
+STUB_RECORD_OUTPUT='## Findings\n- The reconstruction is wrong, stated without any severity label.\n## Summary\n1 finding.'
+run_wrapper "$w_work" --recheck-job 4656
+assert_verdict 'case (fd10) a markerless findings block does NOT pass' FAIL 1
+assert_says 'case (fd10) the state is UNKNOWN, not NONE' '^findings: UNKNOWN$'
+assert_lacks 'case (fd10) NONE is never reported for a findings-bearing record' '^findings: NONE$'
+reset_stub
+
+printf '== (fd11) #3564: prose findings under a Summary heading ALONE — the unclosable shape ==\n'
+# THE CASE THAT JUSTIFIES REMOVING THE RECONSTRUCTION RATHER THAN PATCHING IT A THIRD TIME.
+# `review-completed` accepts a `## Summary` heading ALONE as a completed review. So this transcript —
+# prose findings, no `Findings` heading, no severity marker — is a VALID completed review that reports
+# findings, and it is textually indistinguishable from a clean review (whose real text is
+# `No issues found.\n\nSummary: ...`, also with no Findings heading). No recogniser over prose can
+# separate them, which is why `NONE` now requires the structured verdict letter instead.
+reset_stub
+STUB_ANNOUNCE_SHA="$w_head"
+STUB_PROMPT="$PROMPT_WITH_W_PATHS"
+STUB_RECORD_OUTPUT='## Summary\nThe reconstruction is wrong and should be removed. One issue.'
+run_wrapper "$w_work" --recheck-job 4656
+assert_verdict 'case (fd11) a Summary-only findings review does NOT pass' FAIL 1
+assert_says 'case (fd11) the state is UNKNOWN, not NONE' '^findings: UNKNOWN$'
+assert_says 'case (fd11) review-completed still accepts it AS a completed review' '^review-completed: PASS$'
+reset_stub
 
 printf '== (fd7) #3564 structural: the findings gate is TOKEN-EXACT and not keyed on a neighbour ==\n'
 # Behavioural cases only cover the shapes someone already thought of. Two properties of the FIX are

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -331,8 +331,16 @@ case "$cmd" in
     if [ "${STUB_SHOW_JSON:-object}" = nested ]; then
       # The MEASURED `roborev show <id> --json` shape: a REVIEW row carrying its own
       # `id` (equal to the job id) that NESTS the job row under a "job" key.
-      printf '{"id":%s,"job_id":%s,"agent":"codex","verdict_bool":0,"%s":"%s","prompt":"%s","job":' \
-        "${STUB_JOB:-4600}" "${STUB_JOB:-4600}" "${STUB_RECORD_OUTPUT_FIELD:-output}" "${STUB_RECORD_OUTPUT:-}" "$(json_prompt)"
+      # `verdict_bool` is the SOURCE COLUMN the `verdict` letter is synthesised FROM, so the two
+      # must AGREE or the fixture is a record roborev cannot emit: `P` <=> 1, `F` <=> 0 (measured —
+      # job 154 clean/verdict_bool=1, job 162 findings-bearing/verdict_bool=0). Hard-coding 0 while
+      # a case set STUB_VERDICT_FIELD=P made the CLEAN-recheck positive control an impossible
+      # payload, i.e. weakened the one control that proves a clean recheck still PASSes. Derived,
+      # never hard-coded, so a case cannot silently desynchronise the pair again.
+      stub_verdict_bool=0
+      [ "${STUB_VERDICT_FIELD:-}" != P ] || stub_verdict_bool=1
+      printf '{"id":%s,"job_id":%s,"agent":"codex","verdict_bool":%s,"%s":"%s","prompt":"%s","job":' \
+        "${STUB_JOB:-4600}" "${STUB_JOB:-4600}" "$stub_verdict_bool" "${STUB_RECORD_OUTPUT_FIELD:-output}" "${STUB_RECORD_OUTPUT:-}" "$(json_prompt)"
       emit_job_object
       printf '}\n'
       exit 0

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -657,9 +657,14 @@ terminal `RESULT` — `NOTHING-TO-REVIEW` included — is a failed review round 
    fail-closed argument for a default is only valid for the consumers that existed when it was written.* The
    `block_marker_count` `:-0` default was audited as fail-closed because `NONE` was the STRICT direction for
    `vacuity-tier1:`. Adding a consumer for which `NONE` is the PERMISSIVE direction silently inverted it, and
-   no choice of default can fix that — `0` and *unmeasurable* are the same value — so the direction is bought
-   from a **separate** `block_measured` signal instead. Re-derive such an argument whenever you add a
-   consumer.
+   no choice of default can fix that — `0` and *unmeasurable* are the same value. **The resolution is not a
+   better default or a second signal but a REMOVED CONSUMER**: `NONE` is unreachable from a marker count at
+   all (only the structured verdict letter yields it), so nothing derives a permissive verdict from that `0`
+   and the original fail-closed argument holds unchanged. Re-derive such an argument whenever you add a
+   consumer — and note that an intermediate version of this very fix added a separate `block_measured` flag,
+   which went away with the prose reconstruction it guarded while this paragraph went on citing it for a
+   round (caught by the C intent audit). **A doctrine line naming a mechanism is a claim about code and
+   decays exactly like a comment: re-grep the symbol.**
 
    **It was never one bug — it is ONE SHAPE, found repeatedly on #3229, so it is now a rule:
    *a positive verdict requires an AFFIRMATIVE MEASUREMENT.*** The shape is *a multi-state signal where

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -621,7 +621,21 @@ terminal `RESULT` — `NOTHING-TO-REVIEW` included — is a failed review round 
    `verdict` field** used to fall through to a branch keyed on the reviewer's exit code and read `UNKNOWN`,
    so the gate alone would have false-FAILed **every clean recheck**; a recheck now re-asserts findings from
    the record's own review text (the transcript in that mode), scoped to the findings block, and reports
-   `UNKNOWN` when that block could not be measured at all.
+   `UNKNOWN` — never `NONE` — whenever that reconstruction cannot support a positive claim.
+
+   **And that reconstruction had the same defect one layer down, caught in review.** `review-completed`
+   deliberately ACCEPTS a **headerless** findings review — a bare `**Severity**:` line, `[High]`,
+   `Medium:` — because its allow-list was widened to stop false-FAILing genuine reviews from agents that
+   emit that shape. The findings-block extraction needs a heading, so for such a transcript the block is
+   EMPTY: "0 markers in the block" meant *"no block was found"*, not *"no findings"*, and the fallback
+   read it as an affirmative `NONE` and passed a findings-bearing recheck. `NONE` is now sayable only
+   when the marker count is zero across the **whole transcript** as well. A marker sitting OUTSIDE any
+   findings block stays `UNKNOWN`, because a headerless finding and a clean review *quoting* a severity
+   token are indistinguishable — and a whole-transcript scan was rejected on #2964 round 5 for exactly
+   the false-`PRESENT` this refuses to guess at. **Ambiguity resolves to the failing value, never to
+   either verdict**, and the widened scan is scoped to this one branch: every other branch has an
+   independent affirmative signal (a structured verdict, or a reviewer's 0 exit) and uses the block
+   count only to detect a contradiction, so widening those would false-FAIL ordinary clean reviews.
 
    **Two transferable lessons.** (1) *Delegating a key's failure to its neighbour is a latent false PASS* —
    the coupling is invisible while both keys are populated by the same event and evaporates in the first mode

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -594,6 +594,45 @@ terminal `RESULT` — `NOTHING-TO-REVIEW` included — is a failed review round 
    another which paths to skip; a path the reviewer really did not receive FAILs. (And it never prints a
    `0/0` PASS: a key with no subject has no verdict to give.)
 
+   **AND `findings:` GATES THE VERDICT ON ITS OWN — the affirmation backstop's six keys were never the
+   whole story (#3564).** `findings:` is not one of the six (its affirmative value is `NONE`, not `PASS`, so
+   it cannot satisfy that loop's uniform test), and it was described as merely *corroborating* — which read
+   as "guarded elsewhere" when it was guarded **nowhere**. `PRESENT` is in the closed grammar's
+   **non-failing** set, so the only thing failing a findings-bearing run was the NEIGHBOURING key
+   `roborev-exit: FINDINGS (exit 1)`. That coupling held for a fresh review and broke exactly where it
+   mattered most: on `--recheck-job` **no reviewer process runs**, so `roborev-exit` is legitimately `SKIP`,
+   and with the failing signal gone the run emitted
+
+   ```
+   findings:     PRESENT (3)
+   roborev-exit: SKIP (recheck: no reviewer ran in this invocation; job 160 re-decided from its record)
+   RESULT:       PASS
+   ```
+
+   — a **false PASS in a merge gate**, measured on #3473's round-3 recovery. And it landed on the one path
+   an authorized waiver must travel (a re-run enqueues a different job and stales the waiver), so a waiver
+   scoped to `prompt-content` **absence only** could carry a findings failure nobody excused.
+
+   Now: on any would-be `RESULT: PASS`, `findings:` must reduce (token-exact) to `NONE`, **in every mode
+   including recheck**, and the requirement is **not waivable**. The fix is in the verdict scan and
+   deliberately **not** in `roborev-exit`, because `SKIP` is the TRUE statement about a recheck — making that
+   key claim a failure it never observed would trade one false statement for another. Its second half is
+   easy to miss and is the part that keeps the break-glass alive: a recheck of a record with **no structured
+   `verdict` field** used to fall through to a branch keyed on the reviewer's exit code and read `UNKNOWN`,
+   so the gate alone would have false-FAILed **every clean recheck**; a recheck now re-asserts findings from
+   the record's own review text (the transcript in that mode), scoped to the findings block, and reports
+   `UNKNOWN` when that block could not be measured at all.
+
+   **Two transferable lessons.** (1) *Delegating a key's failure to its neighbour is a latent false PASS* —
+   the coupling is invisible while both keys are populated by the same event and evaporates in the first mode
+   where they are not. Ask of every key: **what fails the run if this key alone goes bad?** (2) *A
+   fail-closed argument for a default is only valid for the consumers that existed when it was written.* The
+   `block_marker_count` `:-0` default was audited as fail-closed because `NONE` was the STRICT direction for
+   `vacuity-tier1:`. Adding a consumer for which `NONE` is the PERMISSIVE direction silently inverted it, and
+   no choice of default can fix that — `0` and *unmeasurable* are the same value — so the direction is bought
+   from a **separate** `block_measured` signal instead. Re-derive such an argument whenever you add a
+   consumer.
+
    **It was never one bug — it is ONE SHAPE, found repeatedly on #3229, so it is now a rule:
    *a positive verdict requires an AFFIRMATIVE MEASUREMENT.*** The shape is *a multi-state signal where
    only the BAD states are tested, so every unknown or unmeasured state inherits the PERMISSIVE branch*:

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -623,19 +623,33 @@ terminal `RESULT` — `NOTHING-TO-REVIEW` included — is a failed review round 
    the record's own review text (the transcript in that mode), scoped to the findings block, and reports
    `UNKNOWN` — never `NONE` — whenever that reconstruction cannot support a positive claim.
 
-   **And that reconstruction had the same defect one layer down, caught in review.** `review-completed`
-   deliberately ACCEPTS a **headerless** findings review — a bare `**Severity**:` line, `[High]`,
-   `Medium:` — because its allow-list was widened to stop false-FAILing genuine reviews from agents that
-   emit that shape. The findings-block extraction needs a heading, so for such a transcript the block is
-   EMPTY: "0 markers in the block" meant *"no block was found"*, not *"no findings"*, and the fallback
-   read it as an affirmative `NONE` and passed a findings-bearing recheck. `NONE` is now sayable only
-   when the marker count is zero across the **whole transcript** as well. A marker sitting OUTSIDE any
-   findings block stays `UNKNOWN`, because a headerless finding and a clean review *quoting* a severity
-   token are indistinguishable — and a whole-transcript scan was rejected on #2964 round 5 for exactly
-   the false-`PRESENT` this refuses to guess at. **Ambiguity resolves to the failing value, never to
-   either verdict**, and the widened scan is scoped to this one branch: every other branch has an
-   independent affirmative signal (a structured verdict, or a reviewer's 0 exit) and uses the block
-   count only to detect a contradiction, so widening those would false-FAIL ordinary clean reviews.
+   **And that reconstruction was itself unsound — two review rounds proved it, and the fix was to
+   DELETE it rather than patch it a third time.** Round 1: `review-completed` deliberately ACCEPTS a
+   **headerless** findings review (a bare `**Severity**:` line, `[High]`, `Medium:`), for which the
+   findings-block extraction finds nothing — so "0 markers in the block" meant *"no block was found"*,
+   not *"no findings"*, and read as an affirmative `NONE`. Round 2: a `## Findings` block whose findings
+   carry **no recognised severity marker** leaves the block non-empty and the count at zero, defeating
+   the round-1 fix too.
+
+   **The class provably does not close.** `review-completed` accepts a bare `## Summary` heading as a
+   completed review, so a findings review whose findings are prose — no `Findings` heading, no severity
+   marker — is a *valid* completed review reporting findings, and it is textually indistinguishable from
+   a clean one, whose real text is `No issues found.\n\nSummary: …` with no `Findings` heading either.
+   Any recogniser over that prose admits some findings-bearing shape. This is **#3312's umbrella lesson
+   applied one directory over: remove the channel, do not pick a rarer delimiter** — and the wrapper's
+   own facts tool already said it, that the structured field "must win wherever it exists" and a
+   transcript regex is "a prose heuristic".
+
+   So the direction is **asymmetric and permanent**: a severity marker inside a findings block is
+   positive evidence **of findings** (`PRESENT`); its absence is **not** evidence of cleanliness
+   (`UNKNOWN`). **`NONE` is reachable only from the structured `verdict` letter.** And that costs
+   nothing, **measured rather than assumed**: `roborev show --json` synthesises that letter from the
+   `reviews.verdict_bool` column for **every** observed record — `P` for a clean review (job 154,
+   `verdict_bool=1`), `F` for a findings-bearing one (job 162, `verdict_bool=0`) — while the
+   `review_jobs` table has no verdict column at all. A real recheck of a clean job therefore takes the
+   structured path and still PASSes, so the #3312 break-glass is intact, and the verdict-less branch is
+   **defensive**, for a payload shape no observed record produces. Making a defensive path fail closed
+   is free; making it guess is how a merge gate passes over live findings.
 
    **Two transferable lessons.** (1) *Delegating a key's failure to its neighbour is a latent false PASS* —
    the coupling is invisible while both keys are populated by the same event and evaporates in the first mode


### PR DESCRIPTION
Closes #3564.

`scripts/flow/roborev-review.sh --recheck-job <id>` could emit a terminal **`RESULT: PASS`** while its own block reported **`findings: PRESENT (n)`** — a false PASS in the merge gate. Measured on #3473's round-3 recovery (job 160).

## Mechanism

`PRESENT` is in the verdict grammar's **non-failing** set, so the only thing failing a findings-bearing run was the **neighbouring** key `roborev-exit: FINDINGS (exit 1)`. That coupling held for a fresh review and broke exactly where it mattered most: on `--recheck-job` **no reviewer process runs**, so `roborev-exit` is legitimately `SKIP`, and removing the failing signal removed the only thing failing the run. The documented affirmation backstop did not cover it because `findings` is excluded from that loop — its affirmative value is `NONE`, not `PASS`.

## The fix, in two halves

**1. The terminal verdict scan** (`roborev-review.sh`). On any would-be `RESULT: PASS`, `findings:` must reduce (token-exact) to `NONE`. `PRESENT`, `UNKNOWN` and the initial `SKIP` all fail, **in every mode including recheck**, and the requirement is **not waivable** — the #3312 absence waiver excuses `prompt-content` absence only, and `--recheck-job` is the only path a waiver travels, so a waiver-bearing recheck is precisely the run this must still fail.

Fixed in the verdict scan and deliberately **not** in `roborev-exit`, as the issue directs: `SKIP` is the *true* statement about a recheck, and making that key claim a failure it never observed would trade one false statement for another.

**2. `findings` could not read `NONE` on a recheck at all** (`roborev-review-checks.sh`) — not named in the issue, and the fix is incomplete without it. With no structured `verdict` field in the record, the findings state fell through to a branch keyed on the *reviewer's exit code*; a recheck has no reviewer, so `roborev-exit: SKIP` matched neither arm and the key read `UNKNOWN`. Invisible while nothing depended on `findings` alone — but with half 1 in place it would have **false-FAILed every clean recheck**, i.e. broken the only path an authorized absence waiver can travel. A recheck now re-asserts findings from the record's own review text (the transcript in that mode), scoped to the findings block, and reports `UNKNOWN` when that block could not be measured or the record carried no review text at all.

That is why acceptance criterion 2 was load-bearing rather than a formality.

## Acceptance

| Criterion | Status |
|---|---|
| A recheck of a job whose record carries findings emits `RESULT: FAIL` | met — case fd1 |
| A recheck of a clean job still emits `RESULT: PASS` (break-glass keeps working) | met — cases fd2 (no structured verdict) + fd4 (structured `P`) |
| Both directions pinned in `test_roborev_review_guard.sh` | met — 8 cases, fd1–fd8 |

**Verified red/green, not green-only.** The new cases were run against an `origin/main` worktree with only the test file swapped in: **12 asserts fail there**, and **fd1, fd3 and fd5 each report `RESULT: PASS`** — the defect reproduced, including a waiver carrying a findings-bearing recheck to a pass. The two controls (fd4, fd6) pass on both sides, as controls should. Suite: **836/836 pass** on the fix.

Cases: fd1 findings-bearing recheck FAILs (every other key made to pass, so findings are the **sole** cause); fd2 clean recheck still PASSes; fd3 no-structured-verdict recheck reads findings from the record text and never degrades to `UNKNOWN`; fd4 affirmatively-clean structured verdict PASSes; **fd5 an authorized absence waiver does not excuse findings**; fd6 the fresh-review path unchanged (`roborev-exit: FINDINGS (exit 1)`); fd7 structural — the gate is token-exact `!= NONE` on `FINDINGS`, not keyed on a neighbour, and records in code that it is unwaivable; fd8 an empty recheck transcript reports `UNKNOWN`, never `NONE`.

## Doctrine updated in the same change

`CLAUDE.md` and `website/.../agents-developing/roborev-findings.md`. Both had described the affirmation backstop as covering the verdict-carrying keys and `findings` as merely *corroborating* — which read as "guarded elsewhere" when it was guarded **nowhere**. Two transferable lessons recorded:

- **Delegating a key's failure to its neighbour is a latent false PASS.** The coupling is invisible while one event populates both keys and evaporates in the first mode where it does not. Ask of every key: *what fails the run if this key alone goes bad?*
- **A fail-closed argument for a `${VAR:-default}` is only valid for the consumers that existed when it was written.** The `block_marker_count` `:-0` default was audited as fail-closed because `NONE` was the *strict* direction for `vacuity-tier1:`; this change added a consumer for which `NONE` is the *permissive* direction and silently inverted that argument. No default can fix it — `0` and *unmeasurable* are the same value — so the direction now comes from a separate `block_measured` signal.

## Gate + review

- **Full `AGENT-GATE SUMMARY`**: pending — run once by `flow-closer` immediately pre-merge. The guard suite added here runs in the full gate's `tooling-tests` component.
- roborev: sanctioned wrapper (`--agent codex --model gpt-5.6-sol --repo <abs>`) on the lite-green diff, before the first full gate (review-first).
- `rust-reviewer` not applicable: the diff is bash + markdown, no Rust.

<details><summary><code>AGENT-GATE LITE SUMMARY</code> — round 1 (not the gate of record)</summary>

```
==== AGENT-GATE LITE SUMMARY ====
run-id: /tmp/agent-gate.P2Jqq1
MODE: lite (FAST ITERATION — NOT the gate of record; full agent-gate.sh must PASS once before merge)
commit: 6e191b1 branch: issue-3564-recheck-findings-false-pass dirty: no
lite-scope: file-size fmt clippy roborev-lints scoped-tests (full gate NOT run — run it once before merge)
accelerators: sccache=on nextest=on lanes=on sccache-health=ok mold=absent perf=paranoid-4
cpu-budget: wrapper=nice ncpu=16 max-concurrency=1 cores-per-gate=16 build-jobs=16(derived) test-threads=16
tree-start: 6e191b12cda0 dirty: no digest: e091fa0886fc
tree-end: 6e191b12cda0 dirty: no digest: e091fa0886fc
tree-integrity: PASS
file-size:         PASS (0s)
fmt:               PASS (4s)
clippy:            PASS (2s)
roborev-lints:     PASS (42s)
scoped-tests:      PASS (107s)
logs: /tmp/agent-gate.P2Jqq1
summary-file: /tmp/cqlite-gates/3564/lite-r2.txt
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```

</details>

An earlier lite run reported `RESULT: FAIL` on `tree-integrity` — **operator error, not a code failure**: the worktree was edited while that gate ran, and the gate correctly refused to certify a mutated tree (`file-size`/`fmt`/`clippy` had all passed before it stopped). Re-run on a stable tree, above.

Note for reviewers: this PR's subject is the roborev wrapper itself, but it does **not** hit the "a config cannot certify itself" class — the wrapper is executed from the invoking checkout, not read from the root checkout by a daemon, so the branch's own copy is what runs.
