### PR TITLE
TEMP probe (#1461): mergeability recomputation for identical sha 8444d0c

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -90,9 +90,12 @@ things are worth knowing about relying on it:
   (replayable) instead of being flushed. `close()` is the only path with a
   guarantee.
 
-A `StreamingIterator` that outlives its `Database` raises
-`RuntimeError: Database is closed` from `next()` once the handle is collected,
-the same as it does after an explicit `close()`.
+A `StreamingIterator` that outlives a **writable** `Database` raises
+`RuntimeError: Database is closed` from `next()` once that handle is collected,
+the same as it does after an explicit `close()` — its write engine really was
+closed. An iterator from a **read-only** handle is unaffected and keeps yielding
+rows, because a read-only drop tears nothing down and so has no reason to
+invalidate it.
 
 ### Executing Queries
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -73,6 +73,27 @@ db = cqlite.open(data_dir, schema=schema_path)
 db.close()
 ```
 
+#### Cleanup on garbage collection (safety net, not the recommended path)
+
+A handle that is garbage-collected without `close()` still cleans up
+best-effort: the write engine is closed (flushing any remaining memtable to an
+SSTable), the read engine is shut down, and buffered telemetry is flushed. Two
+things are worth knowing about relying on it:
+
+- **It runs with the GIL held**, because CPython frees the object from its
+  deallocator. The flush and fsync therefore block other Python threads for
+  their duration, where `close()` releases the GIL around the same work. Prefer
+  `with` or an explicit `close()` in threaded code.
+- **It is best-effort by design.** If the handle is dropped from inside a
+  running asyncio/tokio event loop thread, the cleanup is skipped rather than
+  risk an unsafe teardown — so unflushed rows stay in the write-ahead log
+  (replayable) instead of being flushed. `close()` is the only path with a
+  guarantee.
+
+A `StreamingIterator` that outlives its `Database` raises
+`RuntimeError: Database is closed` from `next()` once the handle is collected,
+the same as it does after an explicit `close()`.
+
 ### Executing Queries
 
 ```python

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -77,8 +77,8 @@ db.close()
 
 A handle that is garbage-collected without `close()` still cleans up
 best-effort: the write engine is closed (flushing any remaining memtable to an
-SSTable), the read engine is shut down, and buffered telemetry is flushed. Two
-things are worth knowing about relying on it:
+SSTable), the read engine's shutdown hook is called (today a no-op), and
+buffered telemetry is flushed. Some things are worth knowing about relying on it:
 
 - **It runs with the GIL held**, because CPython frees the object from its
   deallocator. The flush and fsync therefore block other Python threads for

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -85,17 +85,23 @@ things are worth knowing about relying on it:
   their duration, where `close()` releases the GIL around the same work. Prefer
   `with` or an explicit `close()` in threaded code.
 - **It is best-effort by design.** If the handle is dropped from inside a
-  running asyncio/tokio event loop thread, the cleanup is skipped rather than
-  risk an unsafe teardown — so unflushed rows stay in the write-ahead log
-  (replayable) instead of being flushed. `close()` is the only path with a
-  guarantee.
+  running **Tokio runtime context** — CQLite driven from a Rust async host — the
+  cleanup is skipped rather than risk an unsafe teardown, so unflushed rows stay
+  in the write-ahead log (replayable) instead of being flushed. `close()` is the
+  only path with a guarantee.
+- **A Python `asyncio` event loop is NOT such a context.** These bindings have no
+  asyncio integration, so an asyncio thread has no Tokio runtime and nothing is
+  skipped: a handle collected there runs the full flush + fsync with the GIL
+  held, **blocking the event loop** (and up to ~5s more if OpenTelemetry export
+  is enabled and the collector is unreachable). In asyncio code, close handles
+  explicitly — ideally off the loop thread.
 
-A `StreamingIterator` that outlives a **writable** `Database` raises
-`RuntimeError: Database is closed` from `next()` once that handle is collected,
-the same as it does after an explicit `close()` — its write engine really was
-closed. An iterator from a **read-only** handle is unaffected and keeps yielding
-rows, because a read-only drop tears nothing down and so has no reason to
-invalidate it.
+A `StreamingIterator` that outlives its `Database` is **unaffected** by the
+handle being collected, for both read-only and writable handles: it keeps
+yielding its remaining rows. Its rows come from a background task holding its own
+reference to the storage engine, so dropping the handle cannot stop the stream,
+and this cleanup deliberately does not invalidate it. (An explicit `close()`
+still does — that is a user stating intent, and is unchanged; see issue #1462.)
 
 ### Executing Queries
 

--- a/bindings/python/src/database.rs
+++ b/bindings/python/src/database.rs
@@ -68,7 +68,7 @@ use crate::write::{MaintenanceReport, PyWriteEngine, WriteStats};
 /// ```
 #[pyclass(module = "cqlite")]
 pub struct Database {
-    inner: Arc<cqlite_core::Database>,
+    pub(crate) inner: Arc<cqlite_core::Database>,
     /// Closed flag, shared (via `Arc`) with any `StreamingIterator` this
     /// database hands out (issue #1462). `Arc<AtomicBool>` derefs to
     /// `AtomicBool`, so every existing `.load(..)`/`.swap(..)` call site is
@@ -76,12 +76,12 @@ pub struct Database {
     /// exact atomic lets an iterator observe `close()` atomically and raise a
     /// clean `RuntimeError` from `__next__` instead of driving a torn-down
     /// engine.
-    closed: Arc<AtomicBool>,
+    pub(crate) closed: Arc<AtomicBool>,
     /// Optional write engine — present only when opened with `writable=True`.
     /// A `tokio::sync::Mutex` (not `std`) so its guard is `Send` and survives the
     /// `py.allow_threads` boundary (issue #1444): blocking writes (WAL fsync +
     /// SSTable materialization) run with the GIL released, matching the read path.
-    write_engine: Option<Arc<AsyncMutex<PyWriteEngine>>>,
+    pub(crate) write_engine: Option<Arc<AsyncMutex<PyWriteEngine>>>,
     /// W3C `traceparent` captured at `open` time (issue #1039). When set, every
     /// per-call span is re-parented to this trace unless a per-call traceparent
     /// overrides it, so the bindings' Rust spans correlate with the caller's

--- a/bindings/python/src/drop_safety.rs
+++ b/bindings/python/src/drop_safety.rs
@@ -45,10 +45,32 @@
 //! acquires one: no `Python::with_gil`, and no `py.allow_threads` (there is no
 //! token to call it on). None of the three cleanup steps touch a Python object
 //! — they are plain Rust calls on `cqlite_core` handles — so a GIL is not
-//! needed, and `Python::with_gil` during CPython finalization is itself a
-//! hazard (the interpreter may already be past the point where a thread state
-//! can be attached). Keeping the GIL surface at exactly zero removes that
-//! failure mode instead of guarding it.
+//! needed. Keeping the GIL surface at exactly zero removes a failure mode
+//! instead of guarding it.
+//!
+//! **The known cost, stated because it is real: this cleanup runs with the GIL
+//! HELD.** CPython frees a pyclass from its deallocator while the GIL is held,
+//! so the flush + fsync + shutdown below block every other Python thread for
+//! their duration — where an explicit `close()` releases the GIL around the
+//! same work via `py.allow_threads`. Reviewers have raised this twice, so the
+//! answer is recorded here rather than re-argued: **releasing the GIL requires
+//! first ACQUIRING a token, and every mechanism for that can PANIC in `drop`,
+//! which is a process ABORT under `panic = "abort"`.** In pyo3 0.23.5,
+//! `Python::with_gil` panics "If the `auto-initialize` feature is not enabled
+//! and the Python interpreter is not initialized" (`src/marker.rs`, and this
+//! crate does NOT enable `auto-initialize`), which is precisely the
+//! interpreter-teardown case; and GIL acquisition panics outright with "Access
+//! to the GIL is prohibited while a `__traverse__` implmentation is running"
+//! (`src/gil.rs`, `LockGIL::bail`), which a handle freed during a GC traversal
+//! can reach. `Python::assume_gil_acquired` is not an escape either: it is
+//! `unsafe` and its precondition is FALSE whenever the last reference is
+//! released from a Rust thread holding no GIL.
+//!
+//! So the trade is a bounded stall on the *implicit* cleanup path versus a
+//! possible abort — and abort is the exact failure class this issue exists to
+//! prevent. The mitigation is the one the class docs already recommend:
+//! `close()`, or the `with` block, both of which release the GIL properly. This
+//! hook is the net for code that forgot, not the recommended path.
 //!
 //! ## Why native `Drop` and not `__del__`
 //!

--- a/bindings/python/src/drop_safety.rs
+++ b/bindings/python/src/drop_safety.rs
@@ -98,9 +98,11 @@
 //! `closed` records that cleanup *started*, not that it *completed*:
 //! `close()` swaps the flag before its fallible steps and returns early on the
 //! first error. So a `close()` whose write-engine flush fails leaves the flag
-//! set with the read-engine shutdown never done, and this `Drop` then skips the
-//! engine teardown. The telemetry flush still runs (it is unconditional, see
-//! step 7), but the read-side shutdown is lost.
+//! set with the write-engine close never completed, and this `Drop` then skips
+//! the engine teardown. Note precisely what is and is not lost: the read-side
+//! `shutdown()` call is skipped but is today a documented no-op, so nothing is
+//! lost there; the unflushed memtable stays in the WAL, which is replayable;
+//! the telemetry flush is skipped.
 //!
 //! This is NOT a regression — before this module a dropped handle ran nothing at
 //! all — and it is deliberately not fixed here, because both available fixes are
@@ -139,6 +141,14 @@
 //! stated rather than left implicit, because an untested branch whose absence
 //! is unmentioned reads as a covered one — and these two are precisely the
 //! branches whose failure mode is a process abort.
+//!
+//! Completing that census by the same standard: the `try_lock()` `Err` arm and
+//! both `Err(err)` log arms are likewise unexercised and, as far as can be
+//! determined, UNREACHABLE today — pyo3 holds a strong reference to the
+//! `Database` for the duration of any `&self` pymethod, so no other caller can
+//! be inside `close()`/`with_write_engine` on this object while its `Drop` runs,
+//! and the engine `Arc` is never handed to another Python object. They stay as
+//! defence in depth, not as covered code.
 
 use std::sync::atomic::Ordering;
 
@@ -149,29 +159,37 @@ use crate::runtime::existing_runtime;
 
 impl Drop for Database {
     fn drop(&mut self) {
-        // (1) Claim the cleanup FIRST. The `AtomicBool` is the single source of
-        // "already cleaned up" shared with `close()`, so an explicit `close()`
-        // makes the ENGINE teardown below a no-op and vice versa — never a
-        // double shutdown.
-        if !self.closed.swap(true, Ordering::SeqCst) {
-            self.drop_teardown();
-        }
-
-        // (7) Telemetry flush on EVERY path, including the ones that skip the
-        // engine teardown (roborev job 161 finding 2). It belongs outside the
-        // guards because it shares NONE of their hazards: it is synchronous, it
-        // needs no tokio runtime and no GIL, it is process-global and
-        // idempotent, and in a default build it is a literal no-op (the OTel
-        // stack is behind the `observability` feature, and `force_flush` on the
-        // inert guard has an empty body). `close()` already calls it in exactly
-        // these process states, so this adds no new call-site class.
+        // (1) There are TWO cases here, and collapsing them was a real defect
+        // (rust-reviewer B1). The `closed` flag is not private to cleanup: it is
+        // the SAME `Arc<AtomicBool>` every `StreamingIterator` this handle
+        // handed out observes (issue #1462), so flipping it makes those
+        // iterators raise `RuntimeError` from `__next__`. That is right when
+        // real teardown happened, and pure loss when none did.
         //
-        // It also recovers the telemetry half of the `closed`-flag limitation
-        // documented above: after a FAILED `close()` the flag reads
-        // "cleaned up" while the flush never ran, and this call runs it anyway.
-        // A telemetry flush is not a shutdown, so doing it on the already-closed
-        // path cannot double-tear-down anything.
-        crate::observability::flush();
+        // For a READ-ONLY handle none does: `write_engine` is `None`, and
+        // `StorageEngine::shutdown()` is a documented no-op ("Nothing to
+        // shutdown - read-only storage layer",
+        // `cqlite-core/src/storage/mod.rs`). Claiming the flag there would buy
+        // nothing and would silently break a pattern that works today —
+        // `return db.execute_streaming(...)` from a function, letting `db` drop
+        // at return, then iterating. An explicit `close()` invalidating an
+        // iterator is a user stating intent; a GC pass is not.
+        //
+        // So: claim the flag only where there is teardown to guard, and
+        // otherwise READ it without claiming. If `StorageEngine::shutdown` ever
+        // becomes real teardown, this condition MUST change with it — the
+        // coupling is deliberate and stated rather than silent.
+        if self.write_engine.is_some() {
+            if !self.closed.swap(true, Ordering::SeqCst) {
+                self.drop_teardown();
+            }
+        } else if !self.closed.load(Ordering::SeqCst) {
+            // Read-only, not already closed: nothing to tear down, but the
+            // telemetry this handle's queries buffered should still be
+            // exported. `load` rather than `swap` is the whole point —
+            // outstanding iterators stay usable, exactly as before this module.
+            crate::observability::flush();
+        }
     }
 }
 
@@ -179,9 +197,9 @@ impl Database {
     /// The engine half of the drop cleanup: everything that must happen at most
     /// once, and only when this drop won the `closed` race.
     ///
-    /// Split out so `drop` has a single exit point and the unconditional
-    /// telemetry flush cannot be bypassed by an early `return` in here.
-    fn drop_teardown(&mut self) {
+    /// Takes `&self` — nothing here mutates through the reference (`swap`,
+    /// `try_lock` and `block_on` all take `&`).
+    fn drop_teardown(&self) {
         // (2) Re-entrancy guard. `Runtime::block_on` PANICS when the calling
         // thread is already inside a runtime context, and a panic in `drop`
         // aborts the process under `panic = "abort"`. If we are inside a
@@ -254,8 +272,24 @@ impl Database {
             tracing::debug!("cqlite: storage shutdown failed during Database drop: {err}");
         }
 
-        // (6) Telemetry flush is deliberately NOT here — it now runs on every
-        // path from `drop` itself, so an early `return` above can no longer
-        // skip it.
+        // (6) Telemetry flush, independent of (4) and (5), and LAST.
+        //
+        // Round 2 of review moved this OUT to run on every drop path including
+        // the two skip branches. That was wrong and is reverted (rust-reviewer
+        // B2), on measured grounds: with the `observability` feature on it
+        // reaches `BatchSpanProcessor::force_flush`, a `sync_channel` +
+        // `recv_timeout` against a HARD-CODED 5-second `forceflush_timeout`
+        // (`opentelemetry_sdk-0.30.0/src/trace/span_processor.rs`). So it can
+        // block ~5s per call WITH THE GIL HELD, and running it unconditionally
+        // made the RECOMMENDED `with cqlite.open(...)` pattern pay that twice —
+        // once in `close()`, again when the GC freed the same handle. Trading a
+        // multi-second stall on the recommended path for telemetry on the
+        // failed-`close()` path is a bad trade; that gap is a follow-up.
+        //
+        // Keeping it inside the guards is positively right, not just
+        // conservative: in the re-entrancy branch that 5s `recv_timeout` would
+        // park a tokio WORKER thread, and at interpreter finalization there is
+        // no reason to stall teardown on an unreachable collector.
+        crate::observability::flush();
     }
 }

--- a/bindings/python/src/drop_safety.rs
+++ b/bindings/python/src/drop_safety.rs
@@ -75,6 +75,19 @@
 //! pyo3 `cdylib` built with `extension-module`, so `cargo test -p cqlite-py`
 //! cannot link libpython and never runs (the gate documents this exclusion).
 //! A Rust test added here would execute nowhere.
+//!
+//! **DECLARED GAP — the re-entrancy branch (step 2) is covered NOWHERE.** It is
+//! unreachable from the only lane that executes this file: a pytest thread is
+//! never inside a tokio runtime context, so `Handle::try_current()` is always
+//! `Err` there and the branch is never taken. Reaching it needs CPython
+//! embedded in a tokio application (or a pyo3 callback invoked on a runtime
+//! worker thread), which nothing in this repository builds, and the crate has
+//! no Rust test target that could construct one. The runtime-absent branch
+//! (step 3) is equally unexercised: any `Database` that exists at all was
+//! opened through `block_on`, so the runtime is always already built. Both are
+//! stated rather than left implicit, because an untested branch whose absence
+//! is unmentioned reads as a covered one — and these two are precisely the
+//! branches whose failure mode is a process abort.
 
 use std::sync::atomic::Ordering;
 
@@ -98,6 +111,22 @@ impl Drop for Database {
         // runtime there is no safe way to drive the async cleanup from here, so
         // skip it silently. The flag is already set, so the handle is
         // consistently "closed" either way.
+        //
+        // Skipping is not merely the lesser evil, and the tempting alternative
+        // is WORSE. Dispatching the cleanup onto the live runtime
+        // (`Handle::spawn`) would not panic — but a detached task is
+        // CANCELLABLE, and it would be cancelled at runtime shutdown, which is
+        // exactly when an interpreter-teardown drop tends to happen. The flush
+        // writes its SSTable components DIRECTLY into the published data
+        // directory: only the compaction path stages into a tmp dir and
+        // republishes by rename behind a TOC barrier (see
+        // `cqlite-core/src/storage/sstable/writer/finish.rs`). So a cancelled
+        // flush can leave a PARTIAL, DISCOVERABLE SSTable with no publication
+        // barrier. Skipping instead leaves the WAL (`write_dir/wal/`) intact,
+        // which is the write engine's designed idempotent replay marker — a
+        // recoverable state, where a torn SSTable is not. Trading a valid
+        // replay marker for a possibly-truncated published SSTable is a bad
+        // trade even when it flushes successfully most of the time.
         if Handle::try_current().is_ok() {
             tracing::debug!(
                 "cqlite: Database dropped inside a tokio runtime context; \

--- a/bindings/python/src/drop_safety.rs
+++ b/bindings/python/src/drop_safety.rs
@@ -53,7 +53,29 @@
 //!   `blocking_lock()` *panics* in an async context. `try_lock()` cannot panic,
 //!   so contention degrades to a skipped step instead.
 //! * No `unwrap()`, `expect()`, slicing, or arithmetic appears below, so there
-//!   is no implicit panic site left.
+//!   is no implicit panic site in THIS FILE's own statements.
+//!
+//! That qualifier is load-bearing, so it is stated rather than implied: the two
+//! `block_on`s await third-party-scale code (`WriteEngine::close` reaches the
+//! whole SSTable writer; `cqlite-core/src/storage/write_engine/mod.rs` alone
+//! holds ~200 `unwrap`/`expect` occurrences) and this module cannot make those
+//! infallible. A panic escaping them would unwind out of `drop` into pyo3's
+//! trampoline and vanish into `sys.unraisablehook`. Because the profile really
+//! is `panic = "unwind"`, `catch_unwind` IS available and useful — the original
+//! "no `catch_unwind`, abort would catch nothing" reasoning died with the abort
+//! premise — so each awaited step runs inside [`catch_unwind_step`], which turns
+//! an escaping panic into a `tracing::error!` and lets the REMAINING steps run.
+//! That preserves the attempt-each-step-independently policy under a panic
+//! instead of losing every later step to the unwind.
+//!
+//! ## Fork safety
+//!
+//! A separate hazard from the panic ones, and the only DESTRUCTIVE one this
+//! module could have shipped: after `fork()` the child inherits the memtable and
+//! SHARES the parent's file descriptors, so a drop in the child would flush a
+//! duplicate generation, truncate the PARENT's WAL and release its `write_dir`
+//! lock. Step (0) refuses to act on inherited state by comparing the PID that
+//! built the runtime against the current one.
 //!
 //! ## No GIL is taken
 //!
@@ -70,8 +92,9 @@
 //! their duration — where an explicit `close()` releases the GIL around the
 //! same work via `py.allow_threads`. Reviewers have raised this twice, so the
 //! answer is recorded here rather than re-argued: **releasing the GIL requires
-//! first ACQUIRING a token, and every mechanism for that can PANIC in `drop`,
-//! which is a process ABORT under `panic = "abort"`.** In pyo3 0.23.5,
+//! first ACQUIRING a token, and every mechanism for that can PANIC in `drop` —
+//! which, per the section above, is a SILENT `PanicException` on
+//! `sys.unraisablehook`, cleanup half-done, exit code 0.** In pyo3 0.23.5,
 //! `Python::with_gil` panics "If the `auto-initialize` feature is not enabled
 //! and the Python interpreter is not initialized" (`src/marker.rs`, and this
 //! crate does NOT enable `auto-initialize`), which is precisely the
@@ -83,8 +106,8 @@
 //! released from a Rust thread holding no GIL.
 //!
 //! So the trade is a bounded stall on the *implicit* cleanup path versus a
-//! possible abort — and abort is the exact failure class this issue exists to
-//! prevent. The mitigation is the one the class docs already recommend:
+//! silent half-done teardown that reports nothing — the failure class this issue
+//! exists to prevent, and the harder one to notice. The mitigation is the one the class docs already recommend:
 //! `close()`, or the `with` block, both of which release the GIL properly. This
 //! hook is the net for code that forgot, not the recommended path.
 //!
@@ -156,7 +179,7 @@
 //! opened through `block_on`, so the runtime is always already built. Both are
 //! stated rather than left implicit, because an untested branch whose absence
 //! is unmentioned reads as a covered one — and these two are precisely the
-//! branches whose failure mode is a process abort.
+//! branches whose failure mode is a silent, unreported half-teardown.
 //!
 //! Completing that census by the same standard: the `try_lock()` `Err` arm and
 //! both `Err(err)` log arms are likewise unexercised and, as far as can be
@@ -175,15 +198,92 @@
 //! cleanup a read-only handle has, but it is the one place this module spends
 //! real time on a path with nothing else to do. Tracked in #3566.
 
+use std::panic::AssertUnwindSafe;
 use std::sync::atomic::Ordering;
 
 use tokio::runtime::Handle;
 
 use crate::database::Database;
-use crate::runtime::existing_runtime;
+use crate::runtime::{existing_runtime, runtime_belongs_to_this_process};
+
+/// Run one teardown step behind a panic firewall.
+///
+/// A panic escaping the awaited futures would unwind out of `drop`, be caught by
+/// pyo3's `tp_dealloc` trampoline and reported through `sys.unraisablehook` —
+/// silent, exit code 0 — and it would take every LATER cleanup step with it.
+/// This contains it to the one step: the payload is logged, the caller continues.
+///
+/// `AssertUnwindSafe` is sound for the same reason the swallow-after-attempting
+/// policy is: a panicking step leaves engine state this module never touches
+/// again, and the process is on its way to freeing the handle regardless.
+fn catch_unwind_step<T>(step: &str, f: impl FnOnce() -> T) -> Option<T> {
+    match std::panic::catch_unwind(AssertUnwindSafe(f)) {
+        Ok(value) => Some(value),
+        Err(_payload) => {
+            // The payload is deliberately not downcast/formatted: that could
+            // allocate during teardown, and Rust's own panic hook has ALREADY
+            // written the message + location to fd 2 before unwinding began.
+            // Naming the step is the part not already on stderr.
+            tracing::error!(
+                "cqlite: panic escaped {step} during Database drop; that step's \
+                 cleanup is incomplete, later steps still ran"
+            );
+            None
+        }
+    }
+}
 
 impl Drop for Database {
     fn drop(&mut self) {
+        // (0) FORK SAFETY — refuse to act on inherited state (roborev job 168).
+        //
+        // This is a DESTRUCTIVE hazard, not a hygiene one, and it exists only
+        // because this module added a `Drop` at all. `fork()` copies the
+        // memtable and the `Database` object, and SHARES the file descriptors.
+        // `multiprocessing`'s default start method on Linux is `fork`, so a
+        // child that exits (or GCs the inherited handle) is an ordinary thing
+        // for a Python program to do. If this drop ran there, the write-engine
+        // close would, using the PARENT's descriptors:
+        //   * write a duplicate SSTable generation into the parent's data dir,
+        //   * TRUNCATE THE PARENT'S WAL after that flush
+        //     (`cqlite-core/src/storage/write_engine/mod.rs`: "After successful
+        //     flush -> truncate WAL"), destroying the recovery data for rows the
+        //     parent still holds only in memory, and
+        //   * release the parent's exclusive `write_dir` advisory lock — and
+        //     THIS ONE IS NOT PREVENTED BY RETURNING EARLY (rust-reviewer BL-2).
+        //     `impl Drop for WriteEngine` calls
+        //     `fs2::FileExt::unlock(&self.dir_lock)` UNCONDITIONALLY
+        //     (`cqlite-core/src/storage/write_engine/mod.rs`), and flock
+        //     ownership is per open-file-description, which `fork()` SHARES — so
+        //     the child's `LOCK_UN` releases the lock the parent believes it
+        //     holds, admitting a third writer with no error anywhere. An early
+        //     `return` cannot help: this `Drop` returning is exactly when the
+        //     struct's fields are dropped. Hence the `std::mem::forget` below —
+        //     in a child about to `_exit`, LEAKING the inherited engine is
+        //     strictly better than unlocking the parent's write dir.
+        // The inherited multi-threaded runtime cannot be driven either — its
+        // worker threads did not survive the fork.
+        //
+        // Accepted cost, stated: a child that opens its OWN `Database` also
+        // skips its drop cleanup, because the PID anchor belongs to the
+        // inherited runtime rather than to the handle. That child is already
+        // broken for a larger reason — every `block_on` in it drives a
+        // worker-less runtime — so the skip forfeits nothing that worked.
+        if !runtime_belongs_to_this_process() {
+            tracing::debug!(
+                "cqlite: Database dropped in a forked child (runtime belongs to \
+                 another process); skipping teardown and leaking the inherited \
+                 write engine to avoid acting on the parent's descriptors"
+            );
+            // Deliberate leak, scoped to a forked child: stops
+            // `WriteEngine::drop` releasing the PARENT's advisory lock (above).
+            // `self.inner` needs no such treatment — neither
+            // `cqlite_core::Database` nor `StorageEngine` implements `Drop`, and
+            // closing read-only descriptors here mutates no shared lock state.
+            std::mem::forget(self.write_engine.take());
+            return;
+        }
+
         // (1) READ the `closed` flag; never CLAIM it. Two independent review
         // rounds landed here, so the reasoning is recorded rather than left to
         // be rediscovered.
@@ -193,9 +293,16 @@ impl Drop for Database {
         // #1462), so SETTING it makes those iterators raise `RuntimeError` from
         // `__next__`. And setting it buys nothing, because the double-cleanup it
         // would guard against cannot happen: `Drop` runs at most once per
-        // object, and pyo3 holds a strong reference to the pyclass for the whole
-        // of any `&self` pymethod, so `close()` can never overlap this `drop` on
-        // the same handle. Issue #1461's step 1 asks for a `swap` so that "a
+        // object, and `tp_dealloc` only runs at refcount ZERO while CPython's
+        // caller holds a strong reference (the bound method on the frame's value
+        // stack) for the whole of any `&self` pymethod — so `close()` can never
+        // overlap this `drop` on the same handle. Attribute that to CPython
+        // REFCOUNTING, not to pyo3's borrow flag: `Drop` bypasses the borrow flag
+        // entirely, since `tp_dealloc` never checks it. The distinction matters
+        // if this class is ever made `frozen`, or the engine `Arc` handed to a
+        // second pyclass — at that point the read-then-teardown below becomes a
+        // real TOCTOU whose only remaining backstop is `WriteEngine::close`'s own
+        // internal `closed` swap. Issue #1461's step 1 asks for a `swap` so that "a
         // drop that ran makes a later `close()` a no-op" — that sequence is
         // unreachable, so the `swap`'s only observable effect would be breaking
         // a pattern that works today:
@@ -216,6 +323,14 @@ impl Drop for Database {
         // A `load` still satisfies the "AtomicBool-guarded" acceptance
         // criterion: a `close()` that already cleaned up makes this a no-op,
         // which is the half of the guard that is actually reachable.
+        //
+        // CONDITIONAL, and the condition must be re-checked if core changes:
+        // "continuing to iterate is safe" holds because `StorageEngine::shutdown`
+        // is a no-op, and the streaming producer holds its own `Arc` to the SAME
+        // `StorageEngine` instance — not a copy. If read-side shutdown ever
+        // becomes real teardown, step (5) will tear down an engine live iterators
+        // are still reading, and after this change there is NO FLAG LEFT to stop
+        // them. Whoever makes that change owns revisiting this `load`.
         if !self.closed.load(Ordering::SeqCst) {
             self.drop_teardown();
         }
@@ -223,18 +338,20 @@ impl Drop for Database {
 }
 
 impl Database {
-    /// The engine half of the drop cleanup: everything that must happen at most
-    /// once, and only when this drop won the `closed` race.
+    /// The engine half of the drop cleanup: runs when the flag READ in step (1)
+    /// came back false. There is no race to win — the flag is never claimed.
     ///
     /// Takes `&self` — nothing here mutates through the reference (`swap`,
     /// `try_lock` and `block_on` all take `&`).
     fn drop_teardown(&self) {
         // (2) Re-entrancy guard. `Runtime::block_on` PANICS when the calling
-        // thread is already inside a runtime context, and a panic in `drop`
-        // aborts the process under `panic = "abort"`. If we are inside a
-        // runtime there is no safe way to drive the async cleanup from here, so
-        // skip it silently. The flag is already set, so the handle is
-        // consistently "closed" either way.
+        // thread is already inside a tokio runtime context, and a panic in
+        // `drop` is silently swallowed into `sys.unraisablehook` (module docs) —
+        // the worst outcome available, not a loud one. Inside a runtime there is
+        // no safe way to drive the async cleanup, so skip it. Note the flag is
+        // deliberately NOT set here (see step (1)): `closed` stays false and any
+        // outstanding iterator keeps working, which is right precisely because
+        // this branch tore nothing down.
         //
         // Skipping is not merely the lesser evil, and the tempting alternative
         // is WORSE. Dispatching the cleanup onto the live runtime
@@ -270,7 +387,7 @@ impl Database {
 
         // (4) Write engine: close (which flushes any remaining memtable), the
         // same call `close()` makes. `try_lock` rather than `blocking_lock`:
-        // the latter panics in an async context, and a panic here is fatal.
+        // the latter panics in an async context, and a panic here is silent.
         //
         // Contention is an ACCEPTABLE skip: a held lock means another live
         // caller is inside a write operation on this same engine, and that
@@ -279,11 +396,15 @@ impl Database {
         // this hook; the durable guarantee remains explicit `close()`.
         if let Some(engine_arc) = self.write_engine.as_ref() {
             match engine_arc.try_lock() {
-                Ok(mut guard) => match runtime.block_on(guard.inner.close()) {
+                Ok(mut guard) => match catch_unwind_step("write-engine close", || {
+                    runtime.block_on(guard.inner.close())
+                })
+                .unwrap_or(Ok(()))
+                {
                     Ok(()) => {}
                     // Swallowed AFTER being attempted: `drop` has no caller to
-                    // return an error to, and propagating (panicking) would
-                    // abort the interpreter.
+                    // return an error to, and propagating (panicking) would only
+                    // become an unreported `sys.unraisablehook` report.
                     Err(err) => tracing::debug!(
                         "cqlite: write-engine close failed during Database drop: {err}"
                     ),
@@ -310,7 +431,9 @@ impl Database {
         // holding the GIL, which is safe ONLY because both awaited futures are
         // plain Rust that never touch a `Python<'_>`. If anything ever spawns a
         // tokio task that acquires the GIL, this becomes a hard deadlock.
-        if let Err(err) = runtime.block_on(self.inner.shutdown()) {
+        if let Some(Err(err)) = catch_unwind_step("storage shutdown", || {
+            runtime.block_on(self.inner.shutdown())
+        }) {
             tracing::debug!("cqlite: storage shutdown failed during Database drop: {err}");
         }
 

--- a/bindings/python/src/drop_safety.rs
+++ b/bindings/python/src/drop_safety.rs
@@ -1,0 +1,155 @@
+//! Best-effort cleanup when a `Database` handle is dropped without `close()`
+//! (issue #1461).
+//!
+//! `Database::close()` does three things: closes the write engine (which
+//! flushes any remaining memtable to a real SSTable), shuts down the read-side
+//! storage engine, and force-flushes buffered telemetry. A handle that is
+//! garbage-collected without `close()` — plenty of real Python code neither
+//! uses `with` nor a `finally:` — used to skip all three, because `Database`
+//! had no `Drop`. This module is that safety net, and nothing else: it changes
+//! no `close()` semantics and adds no new cleanup policy.
+//!
+//! ## Why this lives in its own file
+//!
+//! `database.rs` is already over the campsite file-size threshold, so the hook
+//! goes here and reads `Database`'s `pub(crate)` fields. `impl Drop` for a type
+//! declared in a sibling module of the same crate is legal Rust; the coherence
+//! rule is per-crate, not per-module.
+//!
+//! ## Panic-freedom is STRUCTURAL, not `catch_unwind`
+//!
+//! The release profile is `panic = "abort"`, so a panic here is a process
+//! abort and `catch_unwind` would catch nothing. There is therefore no
+//! `catch_unwind` anywhere below: every operation that *could* panic is instead
+//! replaced by a fallible/non-panicking form, and the guard is the choice of
+//! API rather than a recovery handler.
+//!
+//! * **`block_on` re-entrancy** — `Runtime::block_on` panics when called from
+//!   inside a runtime context ("cannot block the current thread from within a
+//!   runtime"). `Handle::try_current()` answers whether we are in one, so a
+//!   re-entrant drop skips cleanup and returns.
+//! * **Runtime construction** — this path calls
+//!   [`crate::runtime::existing_runtime`] (a plain `OnceLock::get`), never
+//!   `try_get_runtime`. Building a multi-threaded runtime during interpreter
+//!   finalization is the hazard issue #1461 step 3 forbids. `None` ⇒ no async
+//!   cleanup was ever possible in this process, so skip.
+//! * **The write-engine mutex** — the field is a `tokio::sync::Mutex`, whose
+//!   `blocking_lock()` *panics* in an async context. `try_lock()` cannot panic,
+//!   so contention degrades to a skipped step instead.
+//! * No `unwrap()`, `expect()`, slicing, or arithmetic appears below, so there
+//!   is no implicit panic site left.
+//!
+//! ## No GIL is taken
+//!
+//! `Drop` runs without a `Python<'_>` token and this code deliberately never
+//! acquires one: no `Python::with_gil`, and no `py.allow_threads` (there is no
+//! token to call it on). None of the three cleanup steps touch a Python object
+//! — they are plain Rust calls on `cqlite_core` handles — so a GIL is not
+//! needed, and `Python::with_gil` during CPython finalization is itself a
+//! hazard (the interpreter may already be past the point where a thread state
+//! can be attached). Keeping the GIL surface at exactly zero removes that
+//! failure mode instead of guarding it.
+//!
+//! ## Why native `Drop` and not `__del__`
+//!
+//! Native `Drop` is the reliable hook: it runs whenever the Rust object is
+//! freed, including at interpreter shutdown. A `#[pymethods] __del__` is
+//! optional sugar and is deliberately NOT added — CPython does not guarantee
+//! `__del__` runs for a pyclass that does not define one, so it would add no
+//! coverage, and a second cleanup entry point is one more thing that has to
+//! stay consistent with the `AtomicBool`.
+//!
+//! ## Flush POLICY is out of scope
+//!
+//! Whether a dropped *writable* handle should silently flush unwritten data or
+//! emit a warning is a write-path policy call owned by the N–T write-path
+//! epics; this module deliberately reproduces exactly the behavior `close()`
+//! has today (it flushes). Refine the warn-vs-flush choice there, not here.
+//!
+//! ## Coverage
+//!
+//! The executing lane for this file is the pytest tier
+//! (`bindings/python/tests/test_drop_safety.py`, run by the gate's
+//! `python-bindings` component and by `--lite`'s python tier). There are no
+//! Rust unit tests in this crate's `--lib` target on purpose: `cqlite-py` is a
+//! pyo3 `cdylib` built with `extension-module`, so `cargo test -p cqlite-py`
+//! cannot link libpython and never runs (the gate documents this exclusion).
+//! A Rust test added here would execute nowhere.
+
+use std::sync::atomic::Ordering;
+
+use tokio::runtime::Handle;
+
+use crate::database::Database;
+use crate::runtime::existing_runtime;
+
+impl Drop for Database {
+    fn drop(&mut self) {
+        // (1) Claim the cleanup FIRST. The `AtomicBool` is the single source of
+        // "already cleaned up" shared with `close()`, so an explicit `close()`
+        // makes this drop a no-op and vice versa — never a double shutdown.
+        if self.closed.swap(true, Ordering::SeqCst) {
+            return;
+        }
+
+        // (2) Re-entrancy guard. `Runtime::block_on` PANICS when the calling
+        // thread is already inside a runtime context, and a panic in `drop`
+        // aborts the process under `panic = "abort"`. If we are inside a
+        // runtime there is no safe way to drive the async cleanup from here, so
+        // skip it silently. The flag is already set, so the handle is
+        // consistently "closed" either way.
+        if Handle::try_current().is_ok() {
+            tracing::debug!(
+                "cqlite: Database dropped inside a tokio runtime context; \
+                 skipping teardown cleanup (block_on would panic)"
+            );
+            return;
+        }
+
+        // (3) Runtime availability. Never build one here — see the module docs.
+        let Some(runtime) = existing_runtime() else {
+            tracing::debug!(
+                "cqlite: Database dropped with no tokio runtime built; \
+                 skipping teardown cleanup"
+            );
+            return;
+        };
+
+        // (4) Write engine: close (which flushes any remaining memtable), the
+        // same call `close()` makes. `try_lock` rather than `blocking_lock`:
+        // the latter panics in an async context, and a panic here is fatal.
+        //
+        // Contention is an ACCEPTABLE skip: a held lock means another live
+        // caller is inside a write operation on this same engine, and that
+        // caller — or the `close()`/drop of whichever handle still owns the
+        // engine `Arc` — runs its own cleanup. Best-effort is the contract of
+        // this hook; the durable guarantee remains explicit `close()`.
+        if let Some(engine_arc) = self.write_engine.as_ref() {
+            match engine_arc.try_lock() {
+                Ok(mut guard) => match runtime.block_on(guard.inner.close()) {
+                    Ok(()) => {}
+                    // Swallowed AFTER being attempted: `drop` has no caller to
+                    // return an error to, and propagating (panicking) would
+                    // abort the interpreter.
+                    Err(err) => tracing::debug!(
+                        "cqlite: write-engine close failed during Database drop: {err}"
+                    ),
+                },
+                Err(_) => tracing::debug!(
+                    "cqlite: write engine busy during Database drop; \
+                     skipping its close (another holder will clean up)"
+                ),
+            }
+        }
+
+        // (5) Read-side storage engine shutdown. Attempted INDEPENDENTLY of
+        // step (4): a write-engine failure must not cost us this one.
+        if let Err(err) = runtime.block_on(self.inner.shutdown()) {
+            tracing::debug!("cqlite: storage shutdown failed during Database drop: {err}");
+        }
+
+        // (6) Telemetry flush, independent of (4) and (5). Process-global,
+        // idempotent, and a no-op when observability was never initialised.
+        crate::observability::flush();
+    }
+}

--- a/bindings/python/src/drop_safety.rs
+++ b/bindings/python/src/drop_safety.rs
@@ -59,6 +59,23 @@
 //! coverage, and a second cleanup entry point is one more thing that has to
 //! stay consistent with the `AtomicBool`.
 //!
+//! ## LIMITATION — a FAILED `close()` disables this safety net
+//!
+//! `closed` records that cleanup *started*, not that it *completed*:
+//! `close()` swaps the flag before its fallible steps and returns early on the
+//! first error. So a `close()` whose write-engine flush fails leaves the flag
+//! set with the read-engine shutdown never done, and this `Drop` then skips the
+//! engine teardown. The telemetry flush still runs (it is unconditional, see
+//! step 7), but the read-side shutdown is lost.
+//!
+//! This is NOT a regression — before this module a dropped handle ran nothing at
+//! all — and it is deliberately not fixed here, because both available fixes are
+//! forbidden by issue #1461's own "Do NOT" list: resetting the flag on failure
+//! would *change `close()`'s semantics*, and a separate completion flag would
+//! stop the `AtomicBool` being *the single source of "already cleaned up"*. The
+//! flag lying after a failed `close()` is really a `close()` defect that
+//! predates this issue; it belongs in its own change.
+//!
 //! ## Flush POLICY is out of scope
 //!
 //! Whether a dropped *writable* handle should silently flush unwritten data or
@@ -100,11 +117,37 @@ impl Drop for Database {
     fn drop(&mut self) {
         // (1) Claim the cleanup FIRST. The `AtomicBool` is the single source of
         // "already cleaned up" shared with `close()`, so an explicit `close()`
-        // makes this drop a no-op and vice versa — never a double shutdown.
-        if self.closed.swap(true, Ordering::SeqCst) {
-            return;
+        // makes the ENGINE teardown below a no-op and vice versa — never a
+        // double shutdown.
+        if !self.closed.swap(true, Ordering::SeqCst) {
+            self.drop_teardown();
         }
 
+        // (7) Telemetry flush on EVERY path, including the ones that skip the
+        // engine teardown (roborev job 161 finding 2). It belongs outside the
+        // guards because it shares NONE of their hazards: it is synchronous, it
+        // needs no tokio runtime and no GIL, it is process-global and
+        // idempotent, and in a default build it is a literal no-op (the OTel
+        // stack is behind the `observability` feature, and `force_flush` on the
+        // inert guard has an empty body). `close()` already calls it in exactly
+        // these process states, so this adds no new call-site class.
+        //
+        // It also recovers the telemetry half of the `closed`-flag limitation
+        // documented above: after a FAILED `close()` the flag reads
+        // "cleaned up" while the flush never ran, and this call runs it anyway.
+        // A telemetry flush is not a shutdown, so doing it on the already-closed
+        // path cannot double-tear-down anything.
+        crate::observability::flush();
+    }
+}
+
+impl Database {
+    /// The engine half of the drop cleanup: everything that must happen at most
+    /// once, and only when this drop won the `closed` race.
+    ///
+    /// Split out so `drop` has a single exit point and the unconditional
+    /// telemetry flush cannot be bypassed by an early `return` in here.
+    fn drop_teardown(&mut self) {
         // (2) Re-entrancy guard. `Runtime::block_on` PANICS when the calling
         // thread is already inside a runtime context, and a panic in `drop`
         // aborts the process under `panic = "abort"`. If we are inside a
@@ -177,8 +220,8 @@ impl Drop for Database {
             tracing::debug!("cqlite: storage shutdown failed during Database drop: {err}");
         }
 
-        // (6) Telemetry flush, independent of (4) and (5). Process-global,
-        // idempotent, and a no-op when observability was never initialised.
-        crate::observability::flush();
+        // (6) Telemetry flush is deliberately NOT here — it now runs on every
+        // path from `drop` itself, so an early `return` above can no longer
+        // skip it.
     }
 }

--- a/bindings/python/src/drop_safety.rs
+++ b/bindings/python/src/drop_safety.rs
@@ -262,7 +262,9 @@ impl Drop for Database {
         //     in a child about to `_exit`, LEAKING the inherited engine is
         //     strictly better than unlocking the parent's write dir.
         // The inherited multi-threaded runtime cannot be driven either — its
-        // worker threads did not survive the fork.
+        // worker threads did not survive the fork; measured, not assumed:
+        // disabling this guard makes the forked child's drop HANG FOREVER, which
+        // in turn hangs the parent's `waitpid`.
         //
         // Accepted cost, stated: a child that opens its OWN `Database` also
         // skips its drop cleanup, because the PID anchor belongs to the
@@ -270,13 +272,19 @@ impl Drop for Database {
         // broken for a larger reason — every `block_on` in it drives a
         // worker-less runtime — so the skip forfeits nothing that worked.
         if !runtime_belongs_to_this_process() {
-            tracing::debug!(
-                "cqlite: Database dropped in a forked child (runtime belongs to \
-                 another process); skipping teardown and leaking the inherited \
-                 write engine to avoid acting on the parent's descriptors"
-            );
-            // Deliberate leak, scoped to a forked child: stops
-            // `WriteEngine::drop` releasing the PARENT's advisory lock (above).
+            // FORGET FIRST, BEFORE ANYTHING FALLIBLE (roborev job 174). The leak
+            // is the protection, so nothing may run ahead of it: a
+            // `tracing::debug!` here could (a) DEADLOCK, because a subscriber's
+            // internal locks can be inherited already held by threads that did
+            // not survive the fork, or (b) PANIC, and unwinding out of this
+            // branch would drop `write_engine` — releasing the parent's advisory
+            // lock — before the `forget` ever ran. So the ordering is the fix,
+            // and this branch deliberately emits NO log at all: in a forked
+            // child there is no logging call that is knowably safe, and a silent
+            // skip is the correct trade against corrupting the parent.
+            //
+            // The leak itself is scoped to a child that is about to `_exit`, and
+            // it stops `WriteEngine::drop` releasing the PARENT's advisory lock.
             // `self.inner` needs no such treatment — neither
             // `cqlite_core::Database` nor `StorageEngine` implements `Drop`, and
             // closing read-only descriptors here mutates no shared lock state.

--- a/bindings/python/src/drop_safety.rs
+++ b/bindings/python/src/drop_safety.rs
@@ -81,6 +81,18 @@
 //! coverage, and a second cleanup entry point is one more thing that has to
 //! stay consistent with the `AtomicBool`.
 //!
+//! ## Alignment with cqlite-core's own durability contract
+//!
+//! `cqlite_core::Database::close` documents that "`Drop` is NOT a flush — Tokio
+//! has no async drop, so dropping a handle cannot await a flush and any
+//! un-flushed writer state is left to recovery (WAL replay)"
+//! (`cqlite-core/src/lib.rs`, issue #1693). This module does not contradict
+//! that: a *synchronous* binding may block, so on the normal path it drives the
+//! flush to completion via `block_on` rather than leaving it to recovery. And
+//! where it CANNOT block safely (the re-entrancy branch), it falls back to
+//! exactly the outcome core specifies — un-flushed state left in the WAL for
+//! replay. The two documents agree; only the mechanism differs.
+//!
 //! ## LIMITATION — a FAILED `close()` disables this safety net
 //!
 //! `closed` records that cleanup *started*, not that it *completed*:

--- a/bindings/python/src/drop_safety.rs
+++ b/bindings/python/src/drop_safety.rs
@@ -16,18 +16,34 @@
 //! declared in a sibling module of the same crate is legal Rust; the coherence
 //! rule is per-crate, not per-module.
 //!
-//! ## Panic-freedom is STRUCTURAL, not `catch_unwind`
+//! ## Panic-freedom is STRUCTURAL — and a panic here is SILENT, not fatal
 //!
-//! The release profile is `panic = "abort"`, so a panic here is a process
-//! abort and `catch_unwind` would catch nothing. There is therefore no
-//! `catch_unwind` anywhere below: every operation that *could* panic is instead
-//! replaced by a fallible/non-panicking form, and the guard is the choice of
-//! API rather than a recovery handler.
+//! Get this right before changing anything below, because the obvious guess is
+//! wrong. The shipped Python wheel is **not** built with `panic = "abort"`:
+//! bindings build `--profile release-unwind` (`panic = "unwind"`,
+//! `Cargo.toml`), precisely so pyo3's FFI-boundary `catch_unwind` firewall is
+//! active (issue #1440) — and the full gate's `binding-unwind-profile`
+//! component hard-FAILs any binding definition selecting an abort profile, so
+//! it cannot drift. pyo3 0.23.5's `tp_dealloc` trampoline then DOES catch an
+//! escaping panic (`src/impl_/trampoline.rs`, `trampoline_unraisable`) and
+//! routes it to `PyErr::write_unraisable`.
+//!
+//! So a panic in this `drop` does not abort the process — it becomes a
+//! `PanicException` reported through `sys.unraisablehook` on a **live
+//! interpreter that keeps running, exit code 0**. That is WORSE to rely on than
+//! an abort: it is silent, easy to ship unnoticed, and leaves cleanup half-done
+//! with nothing failing. Hence there is still no `catch_unwind` here and every
+//! operation that *could* panic is replaced by a fallible/non-panicking form —
+//! the guard is the choice of API, chosen so that silent-failure path is never
+//! entered at all.
 //!
 //! * **`block_on` re-entrancy** — `Runtime::block_on` panics when called from
-//!   inside a runtime context ("cannot block the current thread from within a
-//!   runtime"). `Handle::try_current()` answers whether we are in one, so a
-//!   re-entrant drop skips cleanup and returns.
+//!   inside a **tokio** runtime context ("cannot block the current thread from
+//!   within a runtime"). `Handle::try_current()` answers whether we are in one,
+//!   so a re-entrant drop skips cleanup and returns. Note the scope: a Python
+//!   `asyncio` event loop is NOT a tokio runtime and does not trip this guard —
+//!   these bindings have no asyncio integration — so an asyncio-thread drop
+//!   runs the cleanup in full.
 //! * **Runtime construction** — this path calls
 //!   [`crate::runtime::existing_runtime`] (a plain `OnceLock::get`), never
 //!   `try_get_runtime`. Building a multi-threaded runtime during interpreter
@@ -110,7 +126,7 @@
 //! would *change `close()`'s semantics*, and a separate completion flag would
 //! stop the `AtomicBool` being *the single source of "already cleaned up"*. The
 //! flag lying after a failed `close()` is really a `close()` defect that
-//! predates this issue; it belongs in its own change.
+//! predates this issue; it belongs in its own change — filed as **#3566**.
 //!
 //! ## Flush POLICY is out of scope
 //!
@@ -148,7 +164,16 @@
 //! `Database` for the duration of any `&self` pymethod, so no other caller can
 //! be inside `close()`/`with_write_engine` on this object while its `Drop` runs,
 //! and the engine `Arc` is never handed to another Python object. They stay as
-//! defence in depth, not as covered code.
+//! defence in depth, not as covered code. The `if let Some(engine_arc)` at step
+//! (4) is likewise structurally redundant for a read-only handle (the field is
+//! `None`), which is how a read-only drop reaches steps (5) and (6) only.
+//!
+//! One asymmetry worth naming: step (6) runs for a read-only drop too, so the
+//! `def rows(path)` pattern above pays the telemetry flush once per handle —
+//! with the `observability` feature ON, the same ~5s `force_flush` the step-(6)
+//! comment describes. It is kept because it mirrors `close()` and is the only
+//! cleanup a read-only handle has, but it is the one place this module spends
+//! real time on a path with nothing else to do. Tracked in #3566.
 
 use std::sync::atomic::Ordering;
 
@@ -159,36 +184,40 @@ use crate::runtime::existing_runtime;
 
 impl Drop for Database {
     fn drop(&mut self) {
-        // (1) There are TWO cases here, and collapsing them was a real defect
-        // (rust-reviewer B1). The `closed` flag is not private to cleanup: it is
-        // the SAME `Arc<AtomicBool>` every `StreamingIterator` this handle
-        // handed out observes (issue #1462), so flipping it makes those
-        // iterators raise `RuntimeError` from `__next__`. That is right when
-        // real teardown happened, and pure loss when none did.
+        // (1) READ the `closed` flag; never CLAIM it. Two independent review
+        // rounds landed here, so the reasoning is recorded rather than left to
+        // be rediscovered.
         //
-        // For a READ-ONLY handle none does: `write_engine` is `None`, and
-        // `StorageEngine::shutdown()` is a documented no-op ("Nothing to
-        // shutdown - read-only storage layer",
-        // `cqlite-core/src/storage/mod.rs`). Claiming the flag there would buy
-        // nothing and would silently break a pattern that works today —
-        // `return db.execute_streaming(...)` from a function, letting `db` drop
-        // at return, then iterating. An explicit `close()` invalidating an
-        // iterator is a user stating intent; a GC pass is not.
+        // The flag is not private to cleanup: it is the SAME `Arc<AtomicBool>`
+        // every `StreamingIterator` this handle handed out observes (issue
+        // #1462), so SETTING it makes those iterators raise `RuntimeError` from
+        // `__next__`. And setting it buys nothing, because the double-cleanup it
+        // would guard against cannot happen: `Drop` runs at most once per
+        // object, and pyo3 holds a strong reference to the pyclass for the whole
+        // of any `&self` pymethod, so `close()` can never overlap this `drop` on
+        // the same handle. Issue #1461's step 1 asks for a `swap` so that "a
+        // drop that ran makes a later `close()` a no-op" — that sequence is
+        // unreachable, so the `swap`'s only observable effect would be breaking
+        // a pattern that works today:
         //
-        // So: claim the flag only where there is teardown to guard, and
-        // otherwise READ it without claiming. If `StorageEngine::shutdown` ever
-        // becomes real teardown, this condition MUST change with it — the
-        // coupling is deliberate and stated rather than silent.
-        if self.write_engine.is_some() {
-            if !self.closed.swap(true, Ordering::SeqCst) {
-                self.drop_teardown();
-            }
-        } else if !self.closed.load(Ordering::SeqCst) {
-            // Read-only, not already closed: nothing to tear down, but the
-            // telemetry this handle's queries buffered should still be
-            // exported. `load` rather than `swap` is the whole point —
-            // outstanding iterators stay usable, exactly as before this module.
-            crate::observability::flush();
+        //     def rows(path):
+        //         db = cqlite.open(path)
+        //         return db.execute_streaming("SELECT ...")   # db drops here
+        //     for r in rows(p): ...                           # still yields
+        //
+        // Continuing to iterate is genuinely safe for BOTH handle kinds:
+        // `QueryResultIterator` holds only an `mpsc::Receiver`, its producer is a
+        // detached task owning its own `Arc<StorageEngine>` clone, and
+        // `cqlite_core::Database` has no `Drop` — so dropping this binding handle
+        // cannot stop the stream. Closing the WRITE engine cannot invalidate a
+        // READ iterator either. An explicit `close()` invalidating an iterator is
+        // a user stating intent; a GC pass is not.
+        //
+        // A `load` still satisfies the "AtomicBool-guarded" acceptance
+        // criterion: a `close()` that already cleaned up makes this a no-op,
+        // which is the half of the guard that is actually reachable.
+        if !self.closed.load(Ordering::SeqCst) {
+            self.drop_teardown();
         }
     }
 }
@@ -266,8 +295,21 @@ impl Database {
             }
         }
 
-        // (5) Read-side storage engine shutdown. Attempted INDEPENDENTLY of
-        // step (4): a write-engine failure must not cost us this one.
+        // (5) Read-side storage engine shutdown, attempted INDEPENDENTLY of
+        // step (4) so a write-engine failure cannot cost us this call.
+        //
+        // TODAY IT IS A NO-OP and the `Err` arm is unreachable:
+        // `StorageEngine::shutdown()` is `Ok(())` ("Nothing to shutdown -
+        // read-only storage layer", `cqlite-core/src/storage/mod.rs`), and
+        // `cqlite_core::Database::shutdown` merely delegates to it. Kept for
+        // SYMMETRY with `close()`, which makes the same call, so the two stay in
+        // step if read-side teardown ever becomes real — do not read it as live
+        // teardown, and never use it to argue that a drop tore something down.
+        //
+        // Deadlock note, forward-looking: this `block_on` runs on a thread
+        // holding the GIL, which is safe ONLY because both awaited futures are
+        // plain Rust that never touch a `Python<'_>`. If anything ever spawns a
+        // tokio task that acquires the GIL, this becomes a hard deadlock.
         if let Err(err) = runtime.block_on(self.inner.shutdown()) {
             tracing::debug!("cqlite: storage shutdown failed during Database drop: {err}");
         }
@@ -284,7 +326,7 @@ impl Database {
         // made the RECOMMENDED `with cqlite.open(...)` pattern pay that twice —
         // once in `close()`, again when the GC freed the same handle. Trading a
         // multi-second stall on the recommended path for telemetry on the
-        // failed-`close()` path is a bad trade; that gap is a follow-up.
+        // failed-`close()` path is a bad trade; that gap is #3566.
         //
         // Keeping it inside the guards is positively right, not just
         // conservative: in the re-entrancy branch that 5s `recv_timeout` would

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -7,6 +7,7 @@ use pyo3::prelude::*;
 
 mod config;
 mod database;
+mod drop_safety;
 mod error;
 mod observability;
 mod prepared;

--- a/bindings/python/src/observability.rs
+++ b/bindings/python/src/observability.rs
@@ -190,7 +190,8 @@ pub fn ensure_initialized(cfg: ObservabilityConfig) {
 
 /// Force-flush any buffered telemetry through the process-global guard.
 ///
-/// Called from `Database.close()` so a short-lived script that closes its
+/// Called from `Database.close()` so a short-lived script that closes its and from the
+/// `Database` drop path (`crate::drop_safety`, issue #1461).
 /// database sees its spans exported even before interpreter shutdown. Safe to
 /// call when uninitialised (no-op) and idempotent.
 pub fn flush() {

--- a/bindings/python/src/observability.rs
+++ b/bindings/python/src/observability.rs
@@ -190,10 +190,11 @@ pub fn ensure_initialized(cfg: ObservabilityConfig) {
 
 /// Force-flush any buffered telemetry through the process-global guard.
 ///
-/// Called from `Database.close()` so a short-lived script that closes its and from the
-/// `Database` drop path (`crate::drop_safety`, issue #1461).
-/// database sees its spans exported even before interpreter shutdown. Safe to
-/// call when uninitialised (no-op) and idempotent.
+/// Called from two places: `Database.close()`, so a short-lived script that
+/// closes its database sees its spans exported even before interpreter
+/// shutdown; and the `Database` drop path (`crate::drop_safety`, issue #1461),
+/// so a handle that is garbage-collected without `close()` still exports them.
+/// Safe to call when uninitialised (no-op) and idempotent.
 pub fn flush() {
     if let Some(guard) = GUARD.get() {
         guard.force_flush();

--- a/bindings/python/src/runtime.rs
+++ b/bindings/python/src/runtime.rs
@@ -8,21 +8,35 @@ use std::sync::{Mutex, OnceLock};
 use tokio::runtime::Runtime;
 
 /// Global tokio runtime instance.
-static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+static RUNTIME: OnceLock<OwnedRuntime> = OnceLock::new();
+
+/// The shared runtime together with the PID of the process that BUILT it.
+///
+/// One cell, two facts, published atomically — deliberately (roborev job 174).
+/// They were two `OnceLock`s and that could not be made correct: setting the PID
+/// after the runtime left a fork window where the PID read `None` (the
+/// permissive answer, so a child would drive the parent's descriptors), and
+/// setting it before the build left it populated even when the BUILD FAILED — so
+/// a later fork produced a child that builds its own perfectly good runtime and
+/// then mistakes it for the parent's, skipping cleanup for its OWN database and
+/// leaking its own engine and lock. Storing both in one value makes a failed
+/// build leave neither, and a successful one publish both.
+struct OwnedRuntime {
+    runtime: Runtime,
+    /// PID of the process that built `runtime` — the fork-safety anchor (#1461).
+    ///
+    /// `fork()` copies this memory and the cell with it, but NOT the runtime's
+    /// worker threads: only the forking thread exists in the child. So a child
+    /// inheriting a built runtime holds a handle it cannot drive, while ALSO
+    /// inheriting the parent's open descriptors. Comparing this against
+    /// `std::process::id()` is how a teardown path tells "my runtime" from "a
+    /// runtime I inherited".
+    owner_pid: u32,
+}
 
 /// Serializes the fallible slow-path build so at most one runtime is ever
 /// constructed, even under concurrent first use.
 static INIT_LOCK: Mutex<()> = Mutex::new(());
-
-/// PID of the process that built [`RUNTIME`] — the fork-safety anchor (#1461).
-///
-/// `fork()` copies this memory and the `RUNTIME` cell along with it, but it does
-/// NOT copy the runtime's worker threads: only the forking thread exists in the
-/// child. So a child inheriting a built runtime holds a handle that cannot be
-/// driven, while ALSO inheriting the parent's open file descriptors. Comparing
-/// this against `std::process::id()` is how a teardown path tells "my runtime"
-/// from "a runtime I inherited". See [`runtime_belongs_to_this_process`].
-static RUNTIME_OWNER_PID: OnceLock<u32> = OnceLock::new();
 
 /// Returns a reference to the global tokio runtime, building it on first use.
 ///
@@ -42,26 +56,24 @@ static RUNTIME_OWNER_PID: OnceLock<u32> = OnceLock::new();
 /// `sys.unraisablehook` rather than aborting — silent, which is why the fallible
 /// form is preferred here regardless.)
 pub fn try_get_runtime() -> Result<&'static Runtime, std::io::Error> {
-    get_or_try_init(&RUNTIME, &INIT_LOCK, || {
-        // Record the owning PID INSIDE the initializer, BEFORE the runtime is
-        // published (rust-reviewer NIT-1). Setting it after `get_or_try_init`
-        // returned would leave a window in which `RUNTIME` is visible but the
-        // PID is not, and a `fork()` there gives a child whose
-        // `RUNTIME_OWNER_PID` is `None` — which the accessor has to treat as
-        // "nothing inherited", the PERMISSIVE answer, so the child would go on
-        // to drive the parent's descriptors. Ordered this way the only reachable
-        // skew is PID-set-but-runtime-unset, which every caller already handles
-        // via `existing_runtime()` returning `None`.
+    let owned = get_or_try_init(&RUNTIME, &INIT_LOCK, || {
+        // Build first, then pair the runtime with the PID of the process that
+        // built it, and publish the pair as ONE value. Both facts become visible
+        // together or not at all — see `OwnedRuntime` for the two windows the
+        // previous two-cell arrangement could not close simultaneously.
         //
-        // A `set` on an already-populated cell is a no-op, so a forked child
-        // calling this inherits the PARENT's pid rather than overwriting it,
-        // which is exactly the signal the accessor needs.
-        let _ = RUNTIME_OWNER_PID.set(std::process::id());
+        // `std::process::id()` is read AFTER a successful build, so it names the
+        // process that actually owns the worker threads.
         tokio::runtime::Builder::new_multi_thread()
             .thread_name("cqlite-py-worker")
             .enable_all()
             .build()
-    })
+            .map(|runtime| OwnedRuntime {
+                runtime,
+                owner_pid: std::process::id(),
+            })
+    })?;
+    Ok(&owned.runtime)
 }
 
 /// Whether the shared runtime (if any) was built by THIS process.
@@ -76,8 +88,8 @@ pub fn try_get_runtime() -> Result<&'static Runtime, std::io::Error> {
 /// inherited to get wrong, and the caller's own `existing_runtime()` check is
 /// what handles that case.
 pub fn runtime_belongs_to_this_process() -> bool {
-    match RUNTIME_OWNER_PID.get() {
-        Some(pid) => *pid == std::process::id(),
+    match RUNTIME.get() {
+        Some(owned) => owned.owner_pid == std::process::id(),
         None => true,
     }
 }
@@ -95,7 +107,7 @@ pub fn runtime_belongs_to_this_process() -> bool {
 /// this question instead: if the answer is `None` no async cleanup was ever
 /// possible on this process anyway, and the caller skips it silently.
 pub fn existing_runtime() -> Option<&'static Runtime> {
-    RUNTIME.get()
+    RUNTIME.get().map(|owned| &owned.runtime)
 }
 
 /// Serialized get-or-build for a process-global [`OnceLock`].

--- a/bindings/python/src/runtime.rs
+++ b/bindings/python/src/runtime.rs
@@ -14,6 +14,16 @@ static RUNTIME: OnceLock<Runtime> = OnceLock::new();
 /// constructed, even under concurrent first use.
 static INIT_LOCK: Mutex<()> = Mutex::new(());
 
+/// PID of the process that built [`RUNTIME`] — the fork-safety anchor (#1461).
+///
+/// `fork()` copies this memory and the `RUNTIME` cell along with it, but it does
+/// NOT copy the runtime's worker threads: only the forking thread exists in the
+/// child. So a child inheriting a built runtime holds a handle that cannot be
+/// driven, while ALSO inheriting the parent's open file descriptors. Comparing
+/// this against `std::process::id()` is how a teardown path tells "my runtime"
+/// from "a runtime I inherited". See [`runtime_belongs_to_this_process`].
+static RUNTIME_OWNER_PID: OnceLock<u32> = OnceLock::new();
+
 /// Returns a reference to the global tokio runtime, building it on first use.
 ///
 /// The runtime is lazily initialized on first access using a multi-threaded
@@ -33,11 +43,43 @@ static INIT_LOCK: Mutex<()> = Mutex::new(());
 /// form is preferred here regardless.)
 pub fn try_get_runtime() -> Result<&'static Runtime, std::io::Error> {
     get_or_try_init(&RUNTIME, &INIT_LOCK, || {
+        // Record the owning PID INSIDE the initializer, BEFORE the runtime is
+        // published (rust-reviewer NIT-1). Setting it after `get_or_try_init`
+        // returned would leave a window in which `RUNTIME` is visible but the
+        // PID is not, and a `fork()` there gives a child whose
+        // `RUNTIME_OWNER_PID` is `None` — which the accessor has to treat as
+        // "nothing inherited", the PERMISSIVE answer, so the child would go on
+        // to drive the parent's descriptors. Ordered this way the only reachable
+        // skew is PID-set-but-runtime-unset, which every caller already handles
+        // via `existing_runtime()` returning `None`.
+        //
+        // A `set` on an already-populated cell is a no-op, so a forked child
+        // calling this inherits the PARENT's pid rather than overwriting it,
+        // which is exactly the signal the accessor needs.
+        let _ = RUNTIME_OWNER_PID.set(std::process::id());
         tokio::runtime::Builder::new_multi_thread()
             .thread_name("cqlite-py-worker")
             .enable_all()
             .build()
     })
+}
+
+/// Whether the shared runtime (if any) was built by THIS process.
+///
+/// `false` means the runtime — and any `Database` reachable from this code — was
+/// inherited across a `fork()`. Nothing in that state is safe to drive: the
+/// runtime's worker threads did not survive the fork, and every open file
+/// descriptor is shared with the parent, so acting on them corrupts the
+/// PARENT's state (issue #1461, roborev job 168).
+///
+/// `true` when no runtime has been built at all — there is then nothing
+/// inherited to get wrong, and the caller's own `existing_runtime()` check is
+/// what handles that case.
+pub fn runtime_belongs_to_this_process() -> bool {
+    match RUNTIME_OWNER_PID.get() {
+        Some(pid) => *pid == std::process::id(),
+        None => true,
+    }
 }
 
 /// Returns the global tokio runtime **only if it has already been built**.

--- a/bindings/python/src/runtime.rs
+++ b/bindings/python/src/runtime.rs
@@ -37,6 +37,22 @@ pub fn try_get_runtime() -> Result<&'static Runtime, std::io::Error> {
     })
 }
 
+/// Returns the global tokio runtime **only if it has already been built**.
+///
+/// The non-building counterpart of [`try_get_runtime`]: a plain `OnceLock::get`,
+/// so it never constructs a runtime, never spawns a thread, and never allocates.
+///
+/// This exists for teardown paths — see `crate::drop_safety` (issue #1461).
+/// `Drop` for a `#[pyclass]` can run during interpreter finalization, and
+/// building a multi-threaded tokio runtime at that point is exactly the hazard
+/// issue #1461 step 3 forbids (threads spawned while CPython is tearing down,
+/// with no caller left to surface an error to). A teardown path therefore asks
+/// this question instead: if the answer is `None` no async cleanup was ever
+/// possible on this process anyway, and the caller skips it silently.
+pub fn existing_runtime() -> Option<&'static Runtime> {
+    RUNTIME.get()
+}
+
 /// Serialized get-or-build for a process-global [`OnceLock`].
 ///
 /// Preserves `OnceLock::get_or_init`'s single-initializer guarantee while

--- a/bindings/python/src/runtime.rs
+++ b/bindings/python/src/runtime.rs
@@ -27,7 +27,10 @@ static INIT_LOCK: Mutex<()> = Mutex::new(());
 /// panicking initializer, a failed build does **not** poison the cell: a later
 /// call can retry once resources are available, and the error is surfaced to the
 /// caller (mapped to a catchable Python exception at the binding boundary) rather
-/// than aborting the host process under `panic = "abort"`.
+/// than panicking. (The wheel ships `--profile release-unwind`, so an escaping
+/// panic would be caught by pyo3's FFI firewall and reported through
+/// `sys.unraisablehook` rather than aborting — silent, which is why the fallible
+/// form is preferred here regardless.)
 pub fn try_get_runtime() -> Result<&'static Runtime, std::io::Error> {
     get_or_try_init(&RUNTIME, &INIT_LOCK, || {
         tokio::runtime::Builder::new_multi_thread()

--- a/bindings/python/tests/test_drop_safety.py
+++ b/bindings/python/tests/test_drop_safety.py
@@ -31,11 +31,17 @@ import os
 import signal
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
 
 import cqlite
+
+# Deadline for reaping the forked child. Deliberately generous: it is a LIVENESS
+# bound (did the child exit at all?), never a latency assertion — the child's own
+# work is a memtable flush that takes milliseconds.
+_FORK_REAP_TIMEOUT_S = 60.0
 
 SCHEMA_TEXT = """\
 CREATE KEYSPACE IF NOT EXISTS drop_test
@@ -444,7 +450,31 @@ def test_fork_child_drop_does_not_touch_parent_state(tmp_path, schema_file):
         except BaseException:
             os._exit(70)
 
-    _waited_pid, status = os.waitpid(pid, 0)
+    # Reap with a DEADLINE, not a blocking waitpid. This is a liveness guard, not
+    # a performance assertion: the regression this test exists for makes the
+    # child HANG FOREVER (its drop drives an inherited worker-less runtime), and a
+    # blocking `waitpid` would turn that into a stalled suite instead of a
+    # readable failure. Observed for real while developing this test — a broken
+    # guard hung two pytest runs for 17 minutes.
+    deadline = time.monotonic() + _FORK_REAP_TIMEOUT_S
+    status = None
+    while time.monotonic() < deadline:
+        waited_pid, wait_status = os.waitpid(pid, os.WNOHANG)
+        if waited_pid == pid:
+            status = wait_status
+            break
+        time.sleep(0.05)
+
+    if status is None:
+        # Kill and reap so we never leak the child, THEN fail with the diagnosis.
+        os.kill(pid, signal.SIGKILL)
+        os.waitpid(pid, 0)
+        pytest.fail(
+            "the forked child never exited: its drop is hanging, which is what "
+            "happens when the fork guard does not fire (the inherited runtime has "
+            "no worker threads, so block_on never returns)"
+        )
+
     assert os.WIFEXITED(status), f"forked child did not exit normally: {status!r}"
     assert os.WEXITSTATUS(status) == 0, (
         f"forked child exited {os.WEXITSTATUS(status)} (70 = it raised)"

--- a/bindings/python/tests/test_drop_safety.py
+++ b/bindings/python/tests/test_drop_safety.py
@@ -26,7 +26,6 @@ asserted by its *effect*, never by how long it took.
 from __future__ import annotations
 
 import errno
-import fcntl
 import gc
 import os
 import signal
@@ -468,6 +467,11 @@ def test_fork_child_drop_does_not_touch_parent_state(tmp_path, schema_file):
     #
     # The probe must use a FRESH open(): a duplicated/inherited fd shares the
     # open-file-description and would not conflict with itself.
+    # `fcntl` is Unix-only, so it is imported HERE rather than at module scope:
+    # a top-level import fails COLLECTION on Windows, before the skipif on this
+    # test can take effect (roborev job 174).
+    import fcntl
+
     lock_path = write_dir / "wal" / ".lock"
     if not lock_path.is_file():
         pytest.fail(

--- a/bindings/python/tests/test_drop_safety.py
+++ b/bindings/python/tests/test_drop_safety.py
@@ -197,11 +197,20 @@ print("CONSTRUCTED", flush=True)
 
 
 def test_drop_does_not_raise_at_teardown(tmp_path, schema_file):
-    """Dropping at interpreter teardown must not abort or raise.
+    """Dropping at interpreter teardown must not abort, panic, or raise.
 
-    Run in a child process: an abort (SIGABRT, rc<0) or a panic during
-    finalization would kill the pytest runner itself, so it can only be observed
-    as a test failure from outside.
+    Run in a child process because an abort would kill the pytest runner itself.
+
+    WHICH ASSERT DETECTS WHAT — worth stating, because the intuitive reading is
+    wrong. The wheel ships ``--profile release-unwind`` (``panic = "unwind"``,
+    gate component ``binding-unwind-profile``, #1440), and pyo3's ``tp_dealloc``
+    trampoline catches an escaping panic and reports it via
+    ``sys.unraisablehook``. So a panic in ``Drop`` does NOT change the exit code:
+    the child still exits 0. The detector for a panic is therefore the
+    ``"panicked at"`` stderr needle (Rust's default hook prints before
+    unwinding, independently of ``catch_unwind``), plus ``"exception ignored
+    in"``, which is what CPython prints for an unraisable. ``returncode`` is the
+    detector for a hard abort/segfault only.
     """
     data_dir = tmp_path / "teardown-data"
     data_dir.mkdir()
@@ -231,17 +240,19 @@ def test_drop_does_not_raise_at_teardown(tmp_path, schema_file):
         "precondition failed: the child had already flushed before exiting, so a "
         f"Data.db here could not be attributed to the teardown drop:\n{ctx}"
     )
+    # More specific diagnostic first: a hard abort is rc == -SIGABRT, and saying
+    # so beats "did not exit cleanly" when it fires.
+    assert proc.returncode != -signal.SIGABRT, f"child died on SIGABRT:\n{ctx}"
     assert proc.returncode == 0, f"child did not exit cleanly:\n{ctx}"
 
-    # SIGABRT is detected by the returncode assert above (-6), NOT by stderr:
-    # `subprocess.run` is given an argv list, so no shell runs, and the
-    # "Aborted (core dumped)" text is a SHELL message the child never writes
-    # itself. An "abort" needle here would therefore detect nothing it names
-    # while red-flagging any future log line containing "aborting".
-    assert proc.returncode != -signal.SIGABRT, f"child died on SIGABRT:\n{ctx}"
-
     lowered = proc.stderr.lower()
-    for needle in ("panicked at", "fatal python error", "segmentation fault"):
+    for needle in (
+        "panicked at",
+        "panicexception",
+        "exception ignored in",
+        "fatal python error",
+        "segmentation fault",
+    ):
         assert needle not in lowered, (
             f"child stderr reports a {needle!r} during teardown:\n{ctx}"
         )
@@ -257,29 +268,23 @@ def test_drop_does_not_raise_at_teardown(tmp_path, schema_file):
     )
 
 
-def test_streaming_iterator_after_drop_raises(tmp_path, schema_file):
-    """An iterator outliving its ``Database`` fails cleanly after the drop.
+def test_writable_iterator_survives_drop(tmp_path, schema_file):
+    """An iterator outliving a WRITABLE ``Database`` keeps working after the drop.
 
-    Issue #1462 established the contract for an explicit ``close()``: a
-    ``StreamingIterator`` that outlives cleanup must raise a clean
-    ``RuntimeError`` from ``__next__`` rather than drive a torn-down engine
-    (undefined behavior / a possible FFI panic).  Adding Drop extends that
-    cleanup to the *implicit* path, so this pins the same contract there.
+    This inverts an earlier version of this test, and the reason is the point.
+    That version asserted ``RuntimeError``, justified by #1462's contract for an
+    explicit ``close()``.  Two independent review rounds showed the
+    justification was false: a ``StreamingIterator`` reads an ``mpsc::Receiver``
+    fed by a detached task holding its OWN ``Arc<StorageEngine>``, so closing the
+    WRITE engine cannot invalidate it, and ``cqlite_core::Database`` has no
+    ``Drop`` — nothing the drop does can stop the stream.  Setting the shared
+    ``closed`` flag would only have broken a working pattern in exchange for
+    nothing, so the drop now READS that flag instead of claiming it, and this
+    safety net is purely additive: no user-visible iterator behavior changes.
 
-    Scope note, corrected after review: this holds for a WRITABLE handle, where
-    the drop really does close the write engine, so the flag flip accompanies
-    real teardown.  It deliberately does NOT hold for a read-only handle — see
-    ``test_readonly_iterator_survives_drop`` — because there the drop tears down
-    nothing (``StorageEngine::shutdown()`` is a documented no-op) and flipping
-    the flag would break a working read pattern in exchange for nothing.  An
-    earlier version of this docstring claimed the engine "really is shut down"
-    for every handle; that was false, and the asymmetry below is the fix.
-
-    Hermetic on purpose (no dataset corpus): ``__next__`` loads the shared
-    ``parent_closed`` flag BEFORE it locks the inner iterator or blocks on a
-    refill, so the contract is observable even when the result set is empty.
-    That ordering is the property under test, and an empty stream isolates it
-    from anything to do with rows.
+    Hermetic: the empty stream isolates *which exception ends the iteration*.
+    ``StopIteration`` means the iterator is still valid and merely exhausted;
+    ``RuntimeError: Database is closed`` would mean the drop invalidated it.
     """
     db, _write_dir = _open_writable(tmp_path, schema_file, "iterdrop")
 
@@ -289,7 +294,7 @@ def test_streaming_iterator_after_drop_raises(tmp_path, schema_file):
     del db
     gc.collect()
 
-    with pytest.raises(RuntimeError, match="Database is closed"):
+    with pytest.raises(StopIteration):
         next(iterator)
 
 
@@ -308,20 +313,49 @@ def test_readonly_iterator_survives_drop(tmp_path):
             db = cqlite.open(path)
             return db.execute_streaming("SELECT ...")   # db drops at return
 
-    So the drop must READ that flag without claiming it.  Hermetic: an empty
-    data dir gives an empty stream, and the property under test is which
-    exception ends it — ``StopIteration`` (iterator still valid, exhausted) and
-    NOT ``RuntimeError: Database is closed``.
-    """
-    data_dir = tmp_path / "ro-data"
-    data_dir.mkdir()
+    So the drop must READ that flag without claiming it.
 
-    db = cqlite.open(str(data_dir))
+    This case uses a NON-EMPTY corpus on purpose: an empty stream would only show
+    that no ``RuntimeError`` is raised, which is weaker than the claim being
+    made.  Here rows are written by a first (writable) handle, then read back by
+    a second, read-only handle whose iterator must keep DELIVERING rows across
+    the drop — the property the README promises.
+    """
+    # Phase 1: produce a real SSTable to read.
+    write_dir = tmp_path / "ro-src-wd"
+    data_dir = tmp_path / "ro-src-data"
+    data_dir.mkdir()
+    schema = tmp_path / "ro-schema.cql"
+    schema.write_text(SCHEMA_TEXT)
+    producer = cqlite.open(
+        str(data_dir), schema=str(schema), writable=True, write_dir=str(write_dir)
+    )
+    for i in range(3):
+        producer.execute(
+            f"INSERT INTO drop_test.items (id, name, value) VALUES ({i}, 'r{i}', {i})"
+        )
+    producer.close()
+
+    sstable_dir = write_dir / "data"
+    if not any(sstable_dir.rglob("*-Data.db")):
+        pytest.fail(
+            f"fixture setup failed: no *-Data.db under {sstable_dir}, so this test "
+            "could not read anything back and would prove nothing"
+        )
+
+    # Phase 2: read-only handle, pull one row, then drop the handle mid-stream.
+    db = cqlite.open(str(sstable_dir), schema=str(schema))
     iterator = db.execute_streaming("SELECT * FROM drop_test.items")
+
+    first = next(iterator)
+    assert isinstance(first, cqlite.Row)
 
     del db
     gc.collect()
 
-    # Must NOT raise RuntimeError. Exhaustion (StopIteration) is the pass.
-    with pytest.raises(StopIteration):
-        next(iterator)
+    # The remaining rows must still arrive — not merely "no RuntimeError".
+    rest = list(iterator)
+    assert len(rest) == 2, (
+        "read-only drop broke a live iterator: expected the remaining 2 rows "
+        f"after the handle was collected, got {len(rest)}"
+    )

--- a/bindings/python/tests/test_drop_safety.py
+++ b/bindings/python/tests/test_drop_safety.py
@@ -216,3 +216,13 @@ def test_drop_does_not_raise_at_teardown(tmp_path, schema_file):
         assert needle not in lowered, (
             f"child stderr reports a {needle!r} during teardown:\n{ctx}"
         )
+
+    # Non-vacuity: a clean exit alone is also what a MISSING Drop hook looks
+    # like, so additionally require that the finalization-time drop actually did
+    # the work. CPython clears ``__main__``'s globals during finalization, which
+    # deallocates the handle and runs the Rust ``Drop``; the flushed generation
+    # file is the proof it ran there, not merely that nothing crashed.
+    assert _count_data_db(write_dir) >= 1, (
+        "child exited cleanly but the teardown drop ran no cleanup: expected a "
+        f"flushed *-Data.db under {write_dir / 'data'}\n{ctx}"
+    )

--- a/bindings/python/tests/test_drop_safety.py
+++ b/bindings/python/tests/test_drop_safety.py
@@ -1,0 +1,218 @@
+"""Drop safety net for ``cqlite.Database`` (issue #1461).
+
+``Database.close()`` does three things: closes the write engine (which flushes
+any remaining memtable to a real SSTable), shuts down the read-side storage
+engine, and flushes buffered telemetry.  Before this issue there was no
+``impl Drop``, so a handle that was garbage-collected without ``close()`` —
+plenty of real code neither uses ``with`` nor a ``finally:`` — skipped all
+three.  These tests pin the *mechanic*: a dropped handle runs ``close()``'s
+path best-effort, exactly once, and can never take the interpreter down while
+doing it.
+
+Observable side effect used throughout: closing a writable handle with a
+non-empty memtable materializes ``write_dir/data/<ks>/<table>/*-Data.db``.  If
+Drop runs the write-engine close, that file appears after ``del`` + a GC pass;
+if it does not, the directory stays empty.  That is a *file on disk*, not an
+introspection hook, so it cannot pass vacuously.
+
+No dataset fixtures are needed: every case writes its own schema and SSTables
+into ``tmp_path``.  The one thing that could be "present but unreadable" is the
+temp directory itself, and that is asserted (``pytest.fail``, never ``skip``).
+
+Deliberately no wall-clock threshold asserts anywhere in this file: cleanup is
+asserted by its *effect*, never by how long it took.
+"""
+
+from __future__ import annotations
+
+import gc
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import cqlite
+
+SCHEMA_TEXT = """\
+CREATE KEYSPACE IF NOT EXISTS drop_test
+  WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
+
+USE drop_test;
+
+CREATE TABLE IF NOT EXISTS items (
+    id    INT PRIMARY KEY,
+    name  TEXT,
+    value INT
+);
+"""
+
+
+@pytest.fixture()
+def schema_file(tmp_path: Path) -> Path:
+    """A minimal writable schema on disk.
+
+    FAIL LOUDLY (never skip): if the temp dir is present-but-unwritable the
+    whole premise of these tests is gone, and a skip would hide it.
+    """
+    path = tmp_path / "drop-schema.cql"
+    try:
+        path.write_text(SCHEMA_TEXT)
+    except OSError as exc:  # pragma: no cover - environment failure
+        pytest.fail(f"cannot write schema fixture to {path}: {exc}")
+    if not path.is_file():
+        pytest.fail(f"schema fixture missing after write: {path}")
+    return path
+
+
+def _count_data_db(write_dir: Path) -> int:
+    """Number of flushed generation files under ``write_dir``.
+
+    Flushed SSTables land under ``data/<keyspace>/<table>/``, so recurse rather
+    than globbing the top level (same helper shape as
+    ``test_auto_flush_cliff.py``).
+    """
+    data_path = Path(write_dir) / "data"
+    if not data_path.exists():
+        return 0
+    return len(list(data_path.rglob("*-Data.db")))
+
+
+def _open_writable(tmp_path: Path, schema_file: Path, name: str):
+    """Open a writable handle over freshly-created empty dirs."""
+    data_dir = tmp_path / f"{name}-data"
+    data_dir.mkdir(exist_ok=True)
+    write_dir = tmp_path / f"{name}-wd"
+    db = cqlite.open(
+        str(data_dir),
+        schema=str(schema_file),
+        writable=True,
+        write_dir=str(write_dir),
+    )
+    return db, write_dir
+
+
+def test_drop_without_close_runs_cleanup(tmp_path, schema_file):
+    """A handle dropped WITHOUT ``close()`` still flushes the memtable.
+
+    This is the regression the issue exists for: on ``main`` (no ``impl Drop``)
+    the post-GC Data.db count stays 0.
+    """
+    db, write_dir = _open_writable(tmp_path, schema_file, "nodclose")
+
+    result = db.execute(
+        "INSERT INTO drop_test.items (id, name, value) VALUES (1, 'dropped', 42)"
+    )
+    assert result.rows_affected == 1
+
+    # Precondition: the row is still only in the memtable — nothing on disk yet,
+    # so a post-GC Data.db can only have come from the cleanup path.
+    assert _count_data_db(write_dir) == 0, (
+        "precondition failed: memtable already flushed before drop, so this "
+        "test could not attribute a Data.db to the Drop hook"
+    )
+    assert not db.is_closed
+
+    # Drop WITHOUT close(). `del` removes the only strong reference; the GC pass
+    # makes collection deterministic even if a cycle is involved.
+    del db
+    del result
+    gc.collect()
+
+    assert _count_data_db(write_dir) >= 1, (
+        "Drop did not run close()'s path: expected at least one flushed "
+        f"*-Data.db under {write_dir / 'data'}, found none "
+        f"(contents: {sorted(str(p) for p in Path(write_dir).rglob('*'))})"
+    )
+
+
+def test_double_cleanup_is_safe(tmp_path, schema_file):
+    """``close()`` then drop is a single cleanup, not two.
+
+    The ``AtomicBool`` swap is the single source of "already cleaned up", so the
+    drop after an explicit ``close()`` must be a silent no-op: no error, and —
+    observably — no SECOND flush producing an extra generation file.
+    """
+    db, write_dir = _open_writable(tmp_path, schema_file, "double")
+
+    db.execute(
+        "INSERT INTO drop_test.items (id, name, value) VALUES (2, 'closed', 7)"
+    )
+    db.close()
+    assert db.is_closed
+
+    after_close = _count_data_db(write_dir)
+    assert after_close >= 1, (
+        f"close() did not flush: expected a *-Data.db under {write_dir / 'data'}"
+    )
+
+    # Idempotent explicit close, then drop. Neither may raise, and neither may
+    # produce a second generation file.
+    db.close()
+    del db
+    gc.collect()
+
+    assert _count_data_db(write_dir) == after_close, (
+        "drop after close() ran cleanup a second time: generation-file count "
+        f"went {after_close} -> {_count_data_db(write_dir)}"
+    )
+
+
+# The child body for the teardown test. Constructs a writable handle, writes a
+# row, and exits IMMEDIATELY without close() — so the Rust Drop runs during
+# interpreter finalization, which is the hazardous moment (the tokio runtime may
+# be gone; a panic there is a process abort under `panic = "abort"`).
+_TEARDOWN_DRIVER = """\
+import sys
+
+import cqlite
+
+data_dir, write_dir, schema = sys.argv[1], sys.argv[2], sys.argv[3]
+db = cqlite.open(
+    data_dir, schema=schema, writable=True, write_dir=write_dir
+)
+db.execute("INSERT INTO drop_test.items (id, name, value) VALUES (3, 'teardown', 9)")
+print("CONSTRUCTED", flush=True)
+# No close(), no del: fall off the end of the script so the handle is dropped by
+# interpreter finalization.
+"""
+
+
+def test_drop_does_not_raise_at_teardown(tmp_path, schema_file):
+    """Dropping at interpreter teardown must not abort or raise.
+
+    Run in a child process: an abort (SIGABRT, rc<0) or a panic during
+    finalization would kill the pytest runner itself, so it can only be observed
+    as a test failure from outside.
+    """
+    data_dir = tmp_path / "teardown-data"
+    data_dir.mkdir()
+    write_dir = tmp_path / "teardown-wd"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _TEARDOWN_DRIVER,
+            str(data_dir),
+            str(write_dir),
+            str(schema_file),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    ctx = (
+        f"rc={proc.returncode}\nstdout={proc.stdout!r}\nstderr={proc.stderr!r}"
+    )
+    assert "CONSTRUCTED" in proc.stdout, (
+        f"child never reached the drop point, so this test proved nothing:\n{ctx}"
+    )
+    assert proc.returncode == 0, f"child did not exit cleanly:\n{ctx}"
+
+    lowered = proc.stderr.lower()
+    for needle in ("panicked at", "abort", "fatal python error", "segmentation fault"):
+        assert needle not in lowered, (
+            f"child stderr reports a {needle!r} during teardown:\n{ctx}"
+        )

--- a/bindings/python/tests/test_drop_safety.py
+++ b/bindings/python/tests/test_drop_safety.py
@@ -26,6 +26,7 @@ asserted by its *effect*, never by how long it took.
 from __future__ import annotations
 
 import gc
+import signal
 import subprocess
 import sys
 from pathlib import Path
@@ -180,6 +181,15 @@ db = cqlite.open(
     data_dir, schema=schema, writable=True, write_dir=write_dir
 )
 db.execute("INSERT INTO drop_test.items (id, name, value) VALUES (3, 'teardown', 9)")
+
+# Report the pre-exit generation count so the parent can prove the Data.db it
+# checks for came from the teardown drop and not from an auto-flush that had
+# already crossed its threshold (the same precondition test 1 asserts).
+from pathlib import Path as _Path
+
+_data = _Path(write_dir) / "data"
+_pre = len(list(_data.rglob("*-Data.db"))) if _data.exists() else 0
+print(f"PREFLUSH={_pre}", flush=True)
 print("CONSTRUCTED", flush=True)
 # No close(), no del: fall off the end of the script so the handle is dropped by
 # interpreter finalization.
@@ -217,10 +227,21 @@ def test_drop_does_not_raise_at_teardown(tmp_path, schema_file):
     assert "CONSTRUCTED" in proc.stdout, (
         f"child never reached the drop point, so this test proved nothing:\n{ctx}"
     )
+    assert "PREFLUSH=0" in proc.stdout, (
+        "precondition failed: the child had already flushed before exiting, so a "
+        f"Data.db here could not be attributed to the teardown drop:\n{ctx}"
+    )
     assert proc.returncode == 0, f"child did not exit cleanly:\n{ctx}"
 
+    # SIGABRT is detected by the returncode assert above (-6), NOT by stderr:
+    # `subprocess.run` is given an argv list, so no shell runs, and the
+    # "Aborted (core dumped)" text is a SHELL message the child never writes
+    # itself. An "abort" needle here would therefore detect nothing it names
+    # while red-flagging any future log line containing "aborting".
+    assert proc.returncode != -signal.SIGABRT, f"child died on SIGABRT:\n{ctx}"
+
     lowered = proc.stderr.lower()
-    for needle in ("panicked at", "abort", "fatal python error", "segmentation fault"):
+    for needle in ("panicked at", "fatal python error", "segmentation fault"):
         assert needle not in lowered, (
             f"child stderr reports a {needle!r} during teardown:\n{ctx}"
         )
@@ -245,10 +266,14 @@ def test_streaming_iterator_after_drop_raises(tmp_path, schema_file):
     (undefined behavior / a possible FFI panic).  Adding Drop extends that
     cleanup to the *implicit* path, so this pins the same contract there.
 
-    This IS a user-visible behavior change and is deliberate: on ``main`` the
-    pattern below kept yielding rows purely because nothing ever cleaned up.
-    Now the engine really is shut down, so continuing to iterate would be the
-    exact hazard #1462 exists to prevent — failing loudly is the safe direction.
+    Scope note, corrected after review: this holds for a WRITABLE handle, where
+    the drop really does close the write engine, so the flag flip accompanies
+    real teardown.  It deliberately does NOT hold for a read-only handle — see
+    ``test_readonly_iterator_survives_drop`` — because there the drop tears down
+    nothing (``StorageEngine::shutdown()`` is a documented no-op) and flipping
+    the flag would break a working read pattern in exchange for nothing.  An
+    earlier version of this docstring claimed the engine "really is shut down"
+    for every handle; that was false, and the asymmetry below is the fix.
 
     Hermetic on purpose (no dataset corpus): ``__next__`` loads the shared
     ``parent_closed`` flag BEFORE it locks the inner iterator or blocks on a
@@ -265,4 +290,38 @@ def test_streaming_iterator_after_drop_raises(tmp_path, schema_file):
     gc.collect()
 
     with pytest.raises(RuntimeError, match="Database is closed"):
+        next(iterator)
+
+
+def test_readonly_iterator_survives_drop(tmp_path):
+    """A READ-ONLY handle's iterator keeps working after the handle is dropped.
+
+    The counterpart to the test above, and the regression guard for review
+    finding B1.  A read-only ``Database`` has no write engine, and
+    ``StorageEngine::shutdown()`` is a documented no-op ("Nothing to shutdown -
+    read-only storage layer"), so a drop tears down NOTHING.  If it claimed the
+    shared ``closed`` flag anyway it would invalidate every outstanding
+    iterator — silently breaking this pattern, which works today, in exchange
+    for no cleanup at all:
+
+        def rows(path):
+            db = cqlite.open(path)
+            return db.execute_streaming("SELECT ...")   # db drops at return
+
+    So the drop must READ that flag without claiming it.  Hermetic: an empty
+    data dir gives an empty stream, and the property under test is which
+    exception ends it — ``StopIteration`` (iterator still valid, exhausted) and
+    NOT ``RuntimeError: Database is closed``.
+    """
+    data_dir = tmp_path / "ro-data"
+    data_dir.mkdir()
+
+    db = cqlite.open(str(data_dir))
+    iterator = db.execute_streaming("SELECT * FROM drop_test.items")
+
+    del db
+    gc.collect()
+
+    # Must NOT raise RuntimeError. Exhaustion (StopIteration) is the pass.
+    with pytest.raises(StopIteration):
         next(iterator)

--- a/bindings/python/tests/test_drop_safety.py
+++ b/bindings/python/tests/test_drop_safety.py
@@ -25,7 +25,10 @@ asserted by its *effect*, never by how long it took.
 
 from __future__ import annotations
 
+import errno
+import fcntl
 import gc
+import os
 import signal
 import subprocess
 import sys
@@ -207,10 +210,13 @@ def test_drop_does_not_raise_at_teardown(tmp_path, schema_file):
     trampoline catches an escaping panic and reports it via
     ``sys.unraisablehook``. So a panic in ``Drop`` does NOT change the exit code:
     the child still exits 0. The detector for a panic is therefore the
-    ``"panicked at"`` stderr needle (Rust's default hook prints before
-    unwinding, independently of ``catch_unwind``), plus ``"exception ignored
-    in"``, which is what CPython prints for an unraisable. ``returncode`` is the
-    detector for a hard abort/segfault only.
+    ``"panicked at"`` stderr needle: Rust's default hook writes the message and
+    location to fd 2 before unwinding begins, so it survives interpreter
+    finalization and is independent of ``catch_unwind``. ``"panicexception"``
+    carries it too. ``"exception ignored in"`` is kept as a cheap extra but is
+    NOT reliable here — pyo3's trampoline passes a null context object, and
+    CPython prints that prefix only when it has a context or an ``err_msg``.
+    ``returncode`` detects a hard abort/segfault only.
     """
     data_dir = tmp_path / "teardown-data"
     data_dir.mkdir()
@@ -286,7 +292,15 @@ def test_writable_iterator_survives_drop(tmp_path, schema_file):
     ``StopIteration`` means the iterator is still valid and merely exhausted;
     ``RuntimeError: Database is closed`` would mean the drop invalidated it.
     """
-    db, _write_dir = _open_writable(tmp_path, schema_file, "iterdrop")
+    db, write_dir = _open_writable(tmp_path, schema_file, "iterdrop")
+
+    # Round 4's claim is a CONJUNCTION — the teardown still happens AND the flag
+    # is not flipped — so this test pins both halves. Without the row, it would
+    # pass with `impl Drop` deleted entirely.
+    db.execute(
+        "INSERT INTO drop_test.items (id, name, value) VALUES (5, 'conj', 12)"
+    )
+    assert _count_data_db(write_dir) == 0, "precondition: nothing flushed yet"
 
     iterator = db.execute_streaming("SELECT * FROM drop_test.items")
 
@@ -294,6 +308,13 @@ def test_writable_iterator_survives_drop(tmp_path, schema_file):
     del db
     gc.collect()
 
+    # Half 1: the teardown RAN (the memtable reached an SSTable).
+    assert _count_data_db(write_dir) >= 1, (
+        "the writable drop did not flush, so this test would pass with the Drop "
+        "impl deleted and proves nothing about the flag"
+    )
+
+    # Half 2: and it did NOT invalidate the iterator.
     with pytest.raises(StopIteration):
         next(iterator)
 
@@ -330,7 +351,12 @@ def test_readonly_iterator_survives_drop(tmp_path):
     producer = cqlite.open(
         str(data_dir), schema=str(schema), writable=True, write_dir=str(write_dir)
     )
-    for i in range(3):
+    # Enough rows that a buffer_size=1 stream CANNOT have them all in flight, so
+    # the detached producer task must still be running after the handle dies.
+    # With 3 rows and the default 1024-row buffer, `list(iterator)` would just
+    # drain a full buffer and prove nothing about producer survival.
+    row_count = 50
+    for i in range(row_count):
         producer.execute(
             f"INSERT INTO drop_test.items (id, name, value) VALUES ({i}, 'r{i}', {i})"
         )
@@ -345,7 +371,14 @@ def test_readonly_iterator_survives_drop(tmp_path):
 
     # Phase 2: read-only handle, pull one row, then drop the handle mid-stream.
     db = cqlite.open(str(sstable_dir), schema=str(schema))
-    iterator = db.execute_streaming("SELECT * FROM drop_test.items")
+    # buffer_size=1 keeps at most one row in flight, so the rows that arrive
+    # after the handle is collected can only have come from a producer task that
+    # is STILL RUNNING — which is the actual claim (it owns its own
+    # Arc<StorageEngine>, so handle teardown cannot stop it).
+    iterator = db.execute_streaming(
+        "SELECT * FROM drop_test.items",
+        config=cqlite.StreamingConfig(buffer_size=1),
+    )
 
     first = next(iterator)
     assert isinstance(first, cqlite.Row)
@@ -353,9 +386,109 @@ def test_readonly_iterator_survives_drop(tmp_path):
     del db
     gc.collect()
 
-    # The remaining rows must still arrive — not merely "no RuntimeError".
+    # The remaining rows must still ARRIVE — not merely "no RuntimeError".
     rest = list(iterator)
-    assert len(rest) == 2, (
-        "read-only drop broke a live iterator: expected the remaining 2 rows "
-        f"after the handle was collected, got {len(rest)}"
+    assert len(rest) == row_count - 1, (
+        "read-only drop broke a live iterator: expected the remaining "
+        f"{row_count - 1} rows after the handle was collected, got {len(rest)}"
+    )
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="fork() is Unix-only")
+def test_fork_child_drop_does_not_touch_parent_state(tmp_path, schema_file):
+    """A forked child's drop must NOT act on the parent's inherited descriptors.
+
+    The one DESTRUCTIVE hazard adding a ``Drop`` could introduce, so it gets a
+    real regression test rather than a comment.  ``fork()`` copies the memtable
+    and the ``Database`` object and SHARES the file descriptors, and
+    ``multiprocessing``'s default start method on Linux is ``fork`` — so a child
+    exiting or collecting the inherited handle is ordinary Python.  If the
+    child's drop ran the write-engine close it would, through the PARENT's fds:
+    write a duplicate SSTable generation, TRUNCATE THE PARENT'S WAL (the write
+    engine truncates after a successful flush), and release the parent's
+    exclusive ``write_dir`` lock.
+
+    The parent asserts all three stayed intact — no duplicate generation, WAL
+    unchanged, and its exclusive ``write_dir`` lock still held — then closes
+    normally to prove the guard suppressed only the child's teardown, not its own.
+
+    The lock assertion is the load-bearing one, because an early ``return`` alone
+    does NOT prevent that effect: ``WriteEngine``'s own ``Drop`` unlocks
+    unconditionally, and returning from ``Database::drop`` is precisely when its
+    fields get dropped. The guard therefore leaks the inherited engine.
+    """
+    db, write_dir = _open_writable(tmp_path, schema_file, "forked")
+    db.execute(
+        "INSERT INTO drop_test.items (id, name, value) VALUES (4, 'forked', 11)"
+    )
+
+    wal = write_dir / "wal" / "commitlog.wal"
+    if not wal.is_file():
+        pytest.fail(
+            f"fixture setup failed: no WAL at {wal}, so this test could not "
+            "detect a truncation and would prove nothing"
+        )
+    wal_size_before = wal.stat().st_size
+    assert wal_size_before > 0, "WAL is empty before the fork; nothing to protect"
+    assert _count_data_db(write_dir) == 0, "precondition: nothing flushed yet"
+
+    pid = os.fork()
+    if pid == 0:
+        # CHILD. Drop the inherited handle deterministically, then leave without
+        # running interpreter finalization or pytest teardown. _exit(0) skips
+        # atexit/flush handlers on purpose: the Rust Drop above is the only thing
+        # under test here.
+        try:
+            del db
+            gc.collect()
+            os._exit(0)
+        except BaseException:
+            os._exit(70)
+
+    _waited_pid, status = os.waitpid(pid, 0)
+    assert os.WIFEXITED(status), f"forked child did not exit normally: {status!r}"
+    assert os.WEXITSTATUS(status) == 0, (
+        f"forked child exited {os.WEXITSTATUS(status)} (70 = it raised)"
+    )
+
+    assert _count_data_db(write_dir) == 0, (
+        "the forked child's drop flushed an SSTable into the PARENT's data dir: "
+        f"{sorted(str(x) for x in (write_dir / 'data').rglob('*-Data.db'))}"
+    )
+    assert wal.stat().st_size == wal_size_before, (
+        "the forked child's drop truncated the PARENT's WAL: "
+        f"{wal_size_before} -> {wal.stat().st_size} bytes"
+    )
+
+    # THIRD effect, and the one an early `return` alone does NOT prevent:
+    # `impl Drop for WriteEngine` releases the write_dir advisory lock
+    # unconditionally, and flock ownership is per open-file-description — which
+    # fork() SHARES — so an inherited engine's drop would unlock the lock the
+    # PARENT holds. The guard therefore leaks the inherited engine instead.
+    #
+    # The probe must use a FRESH open(): a duplicated/inherited fd shares the
+    # open-file-description and would not conflict with itself.
+    lock_path = write_dir / "wal" / ".lock"
+    if not lock_path.is_file():
+        pytest.fail(
+            f"fixture setup failed: no advisory lock file at {lock_path}, so the "
+            "lock half of this test could not be checked and would prove nothing"
+        )
+    probe_fd = os.open(str(lock_path), os.O_RDWR)
+    try:
+        with pytest.raises(OSError) as lock_attempt:
+            fcntl.flock(probe_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        assert lock_attempt.value.errno in (errno.EACCES, errno.EAGAIN), (
+            "expected the parent's exclusive write_dir lock to block this probe, "
+            f"got errno={lock_attempt.value.errno}"
+        )
+    finally:
+        os.close(probe_fd)
+
+    # The parent's own cleanup must still work — the guard is about inherited
+    # state, not a blanket disable.
+    db.close()
+    assert _count_data_db(write_dir) >= 1, (
+        "parent close() after the fork failed to flush, so the fork guard is "
+        "suppressing more than the child's teardown"
     )

--- a/bindings/python/tests/test_drop_safety.py
+++ b/bindings/python/tests/test_drop_safety.py
@@ -127,11 +127,19 @@ def test_drop_without_close_runs_cleanup(tmp_path, schema_file):
 
 
 def test_double_cleanup_is_safe(tmp_path, schema_file):
-    """``close()`` then drop is a single cleanup, not two.
+    """``close()`` then drop must not error and must not flush twice.
 
-    The ``AtomicBool`` swap is the single source of "already cleaned up", so the
-    drop after an explicit ``close()`` must be a silent no-op: no error, and —
-    observably — no SECOND flush producing an extra generation file.
+    WHAT THIS TEST CAN AND CANNOT SEE — stated because the name promises more
+    than any Python-visible assertion can deliver.  It pins: no exception, and
+    no second generation file.  It does NOT prove the Rust ``AtomicBool`` guard
+    is what prevented the second cleanup, because
+    ``WriteEngine::close`` is ALSO internally idempotent (its own ``closed``
+    swap in ``cqlite-core/src/storage/write_engine/mod.rs``), so a second call
+    would return ``Ok`` without flushing even if the binding-level guard were
+    removed entirely.  The guard's effect is therefore not observable from
+    Python, and this is a no-crash / no-extra-flush regression guard rather than
+    proof of the guard.  Treating it as proof is the mistake this docstring
+    exists to prevent.
     """
     db, write_dir = _open_writable(tmp_path, schema_file, "double")
 

--- a/bindings/python/tests/test_drop_safety.py
+++ b/bindings/python/tests/test_drop_safety.py
@@ -226,3 +226,35 @@ def test_drop_does_not_raise_at_teardown(tmp_path, schema_file):
         "child exited cleanly but the teardown drop ran no cleanup: expected a "
         f"flushed *-Data.db under {write_dir / 'data'}\n{ctx}"
     )
+
+
+def test_streaming_iterator_after_drop_raises(tmp_path, schema_file):
+    """An iterator outliving its ``Database`` fails cleanly after the drop.
+
+    Issue #1462 established the contract for an explicit ``close()``: a
+    ``StreamingIterator`` that outlives cleanup must raise a clean
+    ``RuntimeError`` from ``__next__`` rather than drive a torn-down engine
+    (undefined behavior / a possible FFI panic).  Adding Drop extends that
+    cleanup to the *implicit* path, so this pins the same contract there.
+
+    This IS a user-visible behavior change and is deliberate: on ``main`` the
+    pattern below kept yielding rows purely because nothing ever cleaned up.
+    Now the engine really is shut down, so continuing to iterate would be the
+    exact hazard #1462 exists to prevent — failing loudly is the safe direction.
+
+    Hermetic on purpose (no dataset corpus): ``__next__`` loads the shared
+    ``parent_closed`` flag BEFORE it locks the inner iterator or blocks on a
+    refill, so the contract is observable even when the result set is empty.
+    That ordering is the property under test, and an empty stream isolates it
+    from anything to do with rows.
+    """
+    db, _write_dir = _open_writable(tmp_path, schema_file, "iterdrop")
+
+    iterator = db.execute_streaming("SELECT * FROM drop_test.items")
+
+    # Drop the parent WITHOUT close(); the iterator keeps the Python reference.
+    del db
+    gc.collect()
+
+    with pytest.raises(RuntimeError, match="Database is closed"):
+        next(iterator)


### PR DESCRIPTION
Temporary probe PR — same head sha as #3575 (`8444d0c`), pushed under a second branch to force GitHub to compute mergeability from scratch. #3575 reports `mergeable: false / dirty` while a real `git merge` of this sha into `main` succeeds cleanly in both directions, with and without rename detection. If this PR reports mergeable, #3575's state is a poisoned cache. Will be closed either way.