### PR TITLE
fix(#3465): premerge-assert requires a full gate of record at the certified sha

### DIFF
--- a/.claude/agents/flow-closer.md
+++ b/.claude/agents/flow-closer.md
@@ -149,7 +149,9 @@ This keeps a genuinely-alive multi-hour close from being reaped by `flow-board`'
 4. **Who fixes what (closer ↔ implementer boundary).**
    - A **mechanical** blocker (fmt/clippy nit, a missing assertion, a one-line fix) you fix
      **inline** in the worktree, re-cert with `scripts/agent-gate.sh --lite` (+ any diff-
-     relevant parity/integration target), and re-review.
+     relevant parity/integration target), and re-review. `--lite` is a fast re-check, NEVER
+     the gate of record — the fix still has to be re-certified per the two
+     re-certification bullets at the end of this step.
    - A **src-design** blocker (needs real implementation judgment) → you have no `Agent`
      tool, so **emit a NEEDS-SPAWN packet and end your turn**; the lead respawns a fresh
      `sstable-developer` (explicit model) to fix it TDD and re-invokes you with its
@@ -161,6 +163,14 @@ This keeps a genuinely-alive multi-hour close from being reaped by `flow-board`'
      **postdate the final src change AND the final rebase** — if you fixed src (yours or the
      implementer's) or rebased after step 1, **re-run the full gate** (back to step 1).
      `--lite` re-certs are never the gate of record.
+   - **The ONE exception is #1892 post-gate polish, and it has its own premerge form.** If the
+     diff since the full PASS at `X` is **test/docs-only** (no src, no `Cargo.*`, no build
+     script, no workflow, no test-data — decide it by running
+     `git diff --name-only origin/main...HEAD | bash scripts/ci/classify-docs-only.sh`, not by
+     eye), do **NOT** re-run the full gate: re-certify with
+     `scripts/agent-gate.sh --delta X --anchor-run-id <id>` and pass **BOTH** summaries to
+     premerge-assert (step 5a, Case B). A **code** fix has no such route — it needs a NEW full
+     gate at the new head.
 5. **Merge on green (worker-merges-own-PR model).** When gate PASS + C PASS (design) +
    roborev clean (a terminal `RESULT: PASS` from the wrapper — never `NOTHING-TO-REVIEW`)
    all hold on the final tree: beat the heartbeat, rebase on `origin/main`
@@ -171,23 +181,50 @@ This keeps a genuinely-alive multi-hour close from being reaped by `flow-board`'
    **(a) Scripted pre-merge SHA + gate-of-record assert (#2456/#2668/#3465).** Never merge a
    head the gate of record did not cover — and never merge without a gate of record at all.
    Run the script with the SHA whose gate SUMMARY you hold (`git rev-parse HEAD` on the
-   certified worktree tip) **and the summary file of the FULL gate from step 1**:
+   certified worktree tip) **and the summary file of the FULL gate from step 1** — which is the
+   literal path step 1 wrote, `/tmp/gate-<N>.txt`:
    ```bash
-   bash scripts/flow/premerge-assert.sh <pr> <certified-sha> <gate-summary-file>
+   # CASE A — the usual shape: the full gate ran on the head being merged.
+   bash scripts/flow/premerge-assert.sh <pr> <certified-sha> /tmp/gate-<N>.txt
+   # CASE B — #1892 post-gate polish: full PASS at anchor X, then a test/docs-only diff.
+   bash scripts/flow/premerge-assert.sh <pr> <certified-sha> /tmp/gate-<N>.txt /tmp/delta-<N>.txt
    ```
    The third argument is **REQUIRED** (an optional one would leave the convention
    honour-system): it is the `AGENT_GATE_SUMMARY_FILE` you already hold from step 1's full
-   gate — e.g. `/tmp/cqlite-gates/<issue>/full-gate.txt`. A `--lite` or `--delta` summary is
-   NOT acceptable there and the script refuses it by name.
-   It exits `0` (prints `PREMERGE: OK <sha>` **and** `PREMERGE: GATE-OF-RECORD …`) only when
-   the summary holds exactly one `==== AGENT-GATE SUMMARY ====` block with `RESULT: PASS`,
-   `tree-integrity: PASS`, and `commit:`/`tree-start:` matching `<certified-sha>`, **and** the
-   PR is OPEN **and** its `headRefOid` equals `<certified-sha>`. On exit `2` → **do NOT
-   merge**: `PREMERGE: NO-GATE-OF-RECORD` → return terminal packet `verdict: no-gate-of-record`
-   (the remedy is to RUN the full gate, never to hand-edit a summary); stale head or
-   closed/merged PR → `verdict: stale-head`; either with the script output. On exit `3`
-   (gh/network/usage failure) → **do NOT merge**, return `verdict: gh-failure` with the script
-   output. Fail closed — never "assume ok".
+   gate. A `--lite` summary is never acceptable anywhere, and a `--delta` summary is never
+   acceptable as the THIRD argument — both are refused by name.
+   The **fourth argument is optional and is the only way a `--delta` re-cert can certify a
+   merge.** CLAUDE.md's #1892 rule mandates `--delta`, "never a repeat full gate", for a
+   test/docs-only diff on top of a full PASS at anchor `X`, and mandates that the PR record
+   BOTH blocks — so in Case B the third argument is the **ANCHOR's** full summary (its sha need
+   NOT equal `<certified-sha>`) and the fourth is the delta block, which must carry
+   `MODE: delta`, `RESULT: PASS`, `tree-integrity: PASS`, a `delta-anchor:` naming exactly that
+   anchor, and its OWN `commit:`/`tree-start:` at `<certified-sha>`. The chain is closed end to
+   end: full PASS at X → delta anchored at X → delta ran on the merged tree.
+   It exits `0` (prints `PREMERGE: OK <sha>`, `PREMERGE: SCOPE …` **and**
+   `PREMERGE: GATE-OF-RECORD …`, plus `PREMERGE: DELTA-RECERT …` in Case B) only when the
+   summary holds exactly one `==== AGENT-GATE SUMMARY ====` block with `RESULT: PASS`,
+   `tree-integrity: PASS`, no `nested-under:` line, and `commit:`/`tree-start:` covering
+   `<certified-sha>` (Case A) or the delta chain above (Case B), **and** the PR is OPEN **and**
+   its `headRefOid` equals `<certified-sha>`.
+   **What exit 0 does NOT prove (#3650) — do not over-report it.** It proves the diff is
+   unchanged since certification and that a full gate PASSed on **that exact tree**. It does
+   **not** prove the change was certified against the `main` it will join: a squash-merge
+   composes this diff with main's CURRENT tip, so for any PR whose base is behind main the
+   certified tree and the merged tree are different objects (measured on #3358/PR #3362). The
+   script says so itself on the success path (`PREMERGE: SCOPE`); a gate on the merge result is
+   #3650. Report the verdict as "gate of record verified at `<sha>`", never as "certified
+   against main".
+   On exit `2` → **do NOT merge**: `PREMERGE: NO-GATE-OF-RECORD` → return terminal packet
+   `verdict: no-gate-of-record` (the remedy is to RUN the full gate — or, for a test/docs-only
+   polish diff, the anchored delta pair above — never to hand-edit a summary); stale head or
+   closed/merged PR → `verdict: stale-head`; either with the script output. On exit `3` → **do
+   NOT merge**, and read the MARKER, because exit 3 has three distinct causes: `PREMERGE: USAGE`
+   → `verdict: usage-error` (you called the script wrong — e.g. the third argument is missing;
+   fix the call and re-run, this is NOT a GitHub outage); `PREMERGE: TOOL-FAILURE` →
+   `verdict: tool-failure` (a broken box: `awk` missing/ENOMEM — fix the box and re-run the
+   ASSERT, never the gate); `PREMERGE: GH-FAILURE` → `verdict: gh-failure`. Fail closed — never
+   "assume ok".
 
    **(b) Re-read for a fresh `HOLD:` order.** Immediately before merge, one pass over the
    issue + PR comments for a manager hold:

--- a/.claude/agents/flow-closer.md
+++ b/.claude/agents/flow-closer.md
@@ -168,17 +168,26 @@ This keeps a genuinely-alive multi-hour close from being reaped by `flow-board`'
    `git push` the certified tip, open the nits follow-up issue if any, then — **before** arming
    `gh pr merge --auto` — run the two mechanical pre-merge guards:
 
-   **(a) Scripted pre-merge SHA assert (#2456/#2668).** Never merge a head the gate of
-   record did not cover. Run the script with the SHA whose gate SUMMARY you hold
-   (`git rev-parse HEAD` on the certified worktree tip):
+   **(a) Scripted pre-merge SHA + gate-of-record assert (#2456/#2668/#3465).** Never merge a
+   head the gate of record did not cover — and never merge without a gate of record at all.
+   Run the script with the SHA whose gate SUMMARY you hold (`git rev-parse HEAD` on the
+   certified worktree tip) **and the summary file of the FULL gate from step 1**:
    ```bash
-   bash scripts/flow/premerge-assert.sh <pr> <certified-sha>
+   bash scripts/flow/premerge-assert.sh <pr> <certified-sha> <gate-summary-file>
    ```
-   It exits `0` (prints `PREMERGE: OK <sha>`) only when the PR is OPEN **and** its
-   `headRefOid` equals `<certified-sha>`. On exit `2` (stale head or closed/merged PR) →
-   **do NOT merge**, return terminal packet `verdict: stale-head` with the script output.
-   On exit `3` (gh/network failure) → **do NOT merge**, return `verdict: gh-failure` with
-   the script output. Fail closed — never "assume ok".
+   The third argument is **REQUIRED** (an optional one would leave the convention
+   honour-system): it is the `AGENT_GATE_SUMMARY_FILE` you already hold from step 1's full
+   gate — e.g. `/tmp/cqlite-gates/<issue>/full-gate.txt`. A `--lite` or `--delta` summary is
+   NOT acceptable there and the script refuses it by name.
+   It exits `0` (prints `PREMERGE: OK <sha>` **and** `PREMERGE: GATE-OF-RECORD …`) only when
+   the summary holds exactly one `==== AGENT-GATE SUMMARY ====` block with `RESULT: PASS`,
+   `tree-integrity: PASS`, and `commit:`/`tree-start:` matching `<certified-sha>`, **and** the
+   PR is OPEN **and** its `headRefOid` equals `<certified-sha>`. On exit `2` → **do NOT
+   merge**: `PREMERGE: NO-GATE-OF-RECORD` → return terminal packet `verdict: no-gate-of-record`
+   (the remedy is to RUN the full gate, never to hand-edit a summary); stale head or
+   closed/merged PR → `verdict: stale-head`; either with the script output. On exit `3`
+   (gh/network/usage failure) → **do NOT merge**, return `verdict: gh-failure` with the script
+   output. Fail closed — never "assume ok".
 
    **(b) Re-read for a fresh `HOLD:` order.** Immediately before merge, one pass over the
    issue + PR comments for a manager hold:

--- a/.claude/agents/flow-lead.md
+++ b/.claude/agents/flow-lead.md
@@ -53,7 +53,9 @@ back into one.
 
 - **Default:** the moment **local certification** is met — `agent-gate.sh` PASS + **C** PASS
   (design-driven) + roborev clean — the closer runs `bash scripts/flow/premerge-assert.sh <pr>
-  <certified-sha>`, re-reads for a fresh `HOLD:` order, then **arms `gh pr merge --auto --squash
+  <certified-sha> <gate-summary-file>` — the third argument is REQUIRED and is the FULL gate's own
+  summary file, so a merge with NO gate of record is now mechanically refused (#3465) — re-reads for
+  a fresh `HOLD:` order, then **arms `gh pr merge --auto --squash
   --delete-branch`** and `flow-finalize`s. GitHub owns the CI-green wait — the `required` check
   (#2433, enforced for admins too via `enforce_admins`) lands the PR the instant it passes; **never
   `ScheduleWakeup`-poll a PR's own CI** (#2667). Do NOT wait for the owner. **Seam 1 (spec approval)

--- a/.claude/skills/flow-address/SKILL.md
+++ b/.claude/skills/flow-address/SKILL.md
@@ -59,5 +59,7 @@ Resolve them in the worktree and reply per thread.
 7. **Re-certify and re-arm merge-on-green (#2667).** The owner's comments are input, NOT a merge
    gate — unless a comment is an explicit `HOLD:` or raises a product/scope question. After addressing
    them, re-certify (lite + any diff-relevant targets; a full/delta gate per the gate contract if the
-   certified SHA changed), re-run `bash scripts/flow/premerge-assert.sh <pr> <certified-sha>`, then re-arm
+   certified SHA changed), re-run `bash scripts/flow/premerge-assert.sh <pr> <certified-sha> <gate-summary-file>` — the third
+   argument is REQUIRED and must be the FULL gate's summary file for that certified SHA (#3465); a
+   `--lite`/`--delta` summary is refused by name — then re-arm
    `gh pr merge --auto --squash --delete-branch`.

--- a/.claude/skills/flow-address/SKILL.md
+++ b/.claude/skills/flow-address/SKILL.md
@@ -58,8 +58,19 @@ Resolve them in the worktree and reply per thread.
    ```
 7. **Re-certify and re-arm merge-on-green (#2667).** The owner's comments are input, NOT a merge
    gate — unless a comment is an explicit `HOLD:` or raises a product/scope question. After addressing
-   them, re-certify (lite + any diff-relevant targets; a full/delta gate per the gate contract if the
-   certified SHA changed), re-run `bash scripts/flow/premerge-assert.sh <pr> <certified-sha> <gate-summary-file>` — the third
-   argument is REQUIRED and must be the FULL gate's summary file for that certified SHA (#3465); a
-   `--lite`/`--delta` summary is refused by name — then re-arm
-   `gh pr merge --auto --squash --delete-branch`.
+   them, re-certify (lite + any diff-relevant targets), then re-run premerge-assert in the shape that
+   matches what you changed (#3465) and re-arm `gh pr merge --auto --squash --delete-branch`:
+   ```bash
+   # A CODE fix moved the certified SHA -> it needs a NEW full gate at the new head:
+   bash scripts/flow/premerge-assert.sh <pr> <certified-sha> <full-gate-summary>
+   # A TEST/DOCS-ONLY fix on top of a full PASS at anchor X -> #1892's --delta re-cert,
+   # never a repeat full gate; pass BOTH the anchor's full summary AND the delta summary:
+   bash scripts/flow/premerge-assert.sh <pr> <certified-sha> <anchor-full-summary> <delta-summary>
+   ```
+   The third argument is REQUIRED and must always be a FULL-gate `RESULT: PASS` block; `--lite` is
+   refused by name everywhere, and a `--delta` block is accepted ONLY as the optional fourth argument
+   (where the script checks that its `delta-anchor:` names the third argument's block and that its own
+   `commit:`/`tree-start:` are at the certified SHA). `--lite` is never the gate of record.
+   Exit 0 proves the diff is unchanged since certification and that a full gate PASSed on that exact
+   tree — **not** that it was certified against current `main` (a squash-merge composes the diff with
+   main's tip; #3650). Report it that way.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -985,8 +985,17 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   to merge unless the PR head still equals the certified SHA **AND** a gate of record exists for it —
   and re-reads comments for a fresh `HOLD:` order. **The third argument is REQUIRED, and that is the
   #3465 mechanism**: verifying the head against a *claimed* certified sha never verified that a
-  certified sha EXISTS, so PR #3408 merged on 22 `--lite` PASSes and not one full
-  `scripts/agent-gate.sh` run. The script now requires the summary file to hold exactly ONE
+  certified sha EXISTS. **Two distinct escapes, one mechanism.** #3408 = **no gate at all** (merged on
+  22 `--lite` PASSes and not one full `scripts/agent-gate.sh` run, because nothing in the merge path
+  ever asked for the block). #3616 = **a real gate, someone else's** — a closer located its run dir by
+  RECENCY (`ls -t /tmp/agent-gate.*`), read a PEER LANE's dir, saw 33 of 37 components PASS and was
+  about to merge #3616 on PR #3580's verdict; the count, the dir and the timestamps were all real, and
+  only the `run-id:` line exposed it, read by a human. With 14000-27000 stale run dirs per box and up
+  to 4 concurrent gates, recency picks a peer ROUTINELY. **That second class is what the
+  `commit:`+`tree-start:` binding refuses**: a peer's summary carries the OTHER PR's branch head, so
+  requiring both abbreviations to match the certified sha converts "a human might notice the `run-id:`
+  line" into a mechanical refusal at the merge point — the sha compare is the guard, not bookkeeping.
+  The script now requires the summary file to hold exactly ONE
   `==== AGENT-GATE SUMMARY ====` block (whole-line-anchored; `--lite`/`--delta` headers are distinct
   and refused by name, as is a second or unterminated block) with `RESULT: PASS` and
   `tree-integrity: PASS` compared **token-exactly** (`INCOMPLETE` is the launch sentinel, not a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -981,10 +981,10 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   stops, emits a `NEEDS-SPAWN {role: spec-auditor, …}` packet, and the lead spawns `spec-auditor`
   then re-invokes with the verdict; a src-design fix respawns `sstable-developer` the same way).
   Before arming `gh pr merge --auto` the closer runs the scripted pre-merge assert
-  `scripts/flow/premerge-assert.sh <pr> <certified-sha> <gate-summary-file>` (#2456/#3465) — refusing
-  to merge unless the PR head still equals the certified SHA **AND** a gate of record exists for it —
-  and re-reads comments for a fresh `HOLD:` order. **The third argument is REQUIRED, and that is the
-  #3465 mechanism**: verifying the head against a *claimed* certified sha never verified that a
+  `scripts/flow/premerge-assert.sh <pr> <certified-sha> <gate-of-record-summary> [<delta-summary>]`
+  (#2456/#3465) — refusing to merge unless the PR head still equals the certified SHA **AND** a gate
+  of record exists for it — and re-reads comments for a fresh `HOLD:` order. **The third argument is
+  REQUIRED, and that is the #3465 mechanism**: verifying the head against a *claimed* certified sha never verified that a
   certified sha EXISTS. **Two distinct escapes, one mechanism.** #3408 = **no gate at all** (merged on
   22 `--lite` PASSes and not one full `scripts/agent-gate.sh` run, because nothing in the merge path
   ever asked for the block). #3616 = **a real gate, someone else's** — a closer located its run dir by
@@ -1005,7 +1005,31 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   launch the gate — #2874's reader contract needs the launcher) and it cannot prove the summary came
   from a real run rather than a hand-written file: a **hostile invoker is out of the threat model**;
   what this closes is **accident and drift** — a diligent worker with no step in its path telling it
-  the gate of record was never run. `dirty:` is REPORTED in the success line, not enforced. With
+  the gate of record was never run. `dirty:` is REPORTED in the success line, not enforced (failing on it
+  is proposed separately in #3648). **The FOURTH argument is optional and is the ONLY way a `--delta`
+  re-cert can certify a merge** — because #1892 *mandates* `--delta`, "never a repeat full gate", for a
+  test/docs-only diff on top of a full PASS at anchor `X`, and mandates that the PR record BOTH blocks.
+  A 3-arg-only guard therefore red on correct, doctrine-mandated input, which is the guard agents learn
+  to waive. So: **Case A (3 args)** the full block's `commit:`/`tree-start:` must cover the certified
+  sha; **Case B (4 args)** the third argument is the ANCHOR's full PASS (its sha need NOT be the
+  certified sha) and the fourth must be one `==== AGENT-GATE DELTA SUMMARY ====` block with
+  `MODE: delta` (asserted affirmatively — the inverse of Case A's belt), `RESULT: PASS`,
+  `tree-integrity: PASS`, a `delta-anchor:` naming exactly that anchor (an `(UNRESOLVED)` anchor
+  refuses), and its OWN `commit:`/`tree-start:` at the certified sha. Either way a full-gate PASS must
+  EXIST and the merged tree is covered — directly, or by an anchored delta re-cert on top of it. A
+  block carrying `nested-under:` (#2874) is refused outright: a nested sub-gate runs at the SAME tree,
+  so the sha binding provably cannot see it.
+  **What a `PREMERGE: OK` does NOT prove (#3650) — it says so itself, on a `PREMERGE: SCOPE` line.**
+  It proves the diff is unchanged since certification and that a full gate PASSed on **that exact
+  tree**. It does NOT prove the change was certified against the `main` it will join: a squash-merge
+  composes the diff with main's CURRENT tip, so for any PR whose base is behind main **the certified
+  tree and the merged tree are different objects**. Measured on #3358/PR #3362: base `2bde26a7c` with
+  main 10 commits ahead, whose head gate FAILed `core-tests` only because a known flake's fix
+  (`5e08db201`, #3514) was on main and absent from that base — the benign direction; the malign one is
+  a PASS at a stale head hiding an interaction with something that landed in between. A gate on the
+  MERGE RESULT is #3650 and is deliberately not implemented here (nor is a staleness bound or a "your
+  base is N commits behind" advisory). Report the verdict as "gate of record verified at `<sha>`",
+  never "certified against main". With
   `--auto` armed, GitHub lands the PR on the `required` check going green (#2667); no CI busy-wait.
 - **Severity triage (#2088, rubric `docs/development/roborev-severity.md`)**: roborev **blockers**
   are fixed pre-merge — each re-triggers `fix → --lite (+ any diff-relevant parity/integration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -981,9 +981,23 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   stops, emits a `NEEDS-SPAWN {role: spec-auditor, …}` packet, and the lead spawns `spec-auditor`
   then re-invokes with the verdict; a src-design fix respawns `sstable-developer` the same way).
   Before arming `gh pr merge --auto` the closer runs the scripted pre-merge assert
-  `scripts/flow/premerge-assert.sh <pr> <certified-sha>` (#2456) — refusing to merge unless the PR
-  head still equals the certified SHA — and re-reads comments for a fresh `HOLD:` order. With `--auto`
-  armed, GitHub lands the PR on the `required` check going green (#2667); no CI busy-wait.
+  `scripts/flow/premerge-assert.sh <pr> <certified-sha> <gate-summary-file>` (#2456/#3465) — refusing
+  to merge unless the PR head still equals the certified SHA **AND** a gate of record exists for it —
+  and re-reads comments for a fresh `HOLD:` order. **The third argument is REQUIRED, and that is the
+  #3465 mechanism**: verifying the head against a *claimed* certified sha never verified that a
+  certified sha EXISTS, so PR #3408 merged on 22 `--lite` PASSes and not one full
+  `scripts/agent-gate.sh` run. The script now requires the summary file to hold exactly ONE
+  `==== AGENT-GATE SUMMARY ====` block (whole-line-anchored; `--lite`/`--delta` headers are distinct
+  and refused by name, as is a second or unterminated block) with `RESULT: PASS` and
+  `tree-integrity: PASS` compared **token-exactly** (`INCOMPLETE` is the launch sentinel, not a
+  verdict — #3041; a mutated-mid-run tree is not a certification — #2926), and with BOTH `commit:`
+  (7 hex) and `tree-start:` (12 hex) prefix-matching the certified sha **at each value's own width**
+  — a non-hex placeholder REFUSES rather than being skipped. It cannot verify `run-id:` (it did not
+  launch the gate — #2874's reader contract needs the launcher) and it cannot prove the summary came
+  from a real run rather than a hand-written file: a **hostile invoker is out of the threat model**;
+  what this closes is **accident and drift** — a diligent worker with no step in its path telling it
+  the gate of record was never run. `dirty:` is REPORTED in the success line, not enforced. With
+  `--auto` armed, GitHub lands the PR on the `required` check going green (#2667); no CI busy-wait.
 - **Severity triage (#2088, rubric `docs/development/roborev-severity.md`)**: roborev **blockers**
   are fixed pre-merge — each re-triggers `fix → --lite (+ any diff-relevant parity/integration
   target) → re-review` (#2087). **Nits** never trigger

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -17,14 +17,29 @@
 # is the real guard.
 #
 # #3465 adds the OTHER half. Verifying that the PR head equals a *claimed*
-# certified sha never verified that a certified sha EXISTS. PR #3408 merged with
-# NO full gate of record at all — 22 `--lite` PASSes and not one
-# `scripts/agent-gate.sh` run — because nothing in the merge path ever asked for
-# the full `==== AGENT-GATE SUMMARY ====` block. The gate-of-record convention
-# was honour-system doctrine; this script is the one point every merge passes
-# through, so the convention becomes a mechanism here: a summary file carrying a
-# FULL-gate block with `RESULT: PASS`, `tree-integrity: PASS`, and provenance
-# (`commit:` + `tree-start:`) matching the certified sha is now REQUIRED.
+# certified sha never verified that a certified sha EXISTS. The gate-of-record
+# convention was honour-system doctrine; this script is the one point every merge
+# passes through, so the convention becomes a mechanism here: a summary file
+# carrying a FULL-gate block with `RESULT: PASS`, `tree-integrity: PASS`, and
+# provenance (`commit:` + `tree-start:`) matching the certified sha is REQUIRED.
+#
+# TWO DISTINCT ESCAPES, ONE MECHANISM
+#   * #3408 — NO GATE AT ALL. That PR merged on 22 `--lite` PASSes and not one
+#     `scripts/agent-gate.sh` run, because nothing in the merge path ever asked
+#     for the full `==== AGENT-GATE SUMMARY ====` block. Refused here by the
+#     block/marker/RESULT checks: lite and delta emit DISTINCT headers.
+#   * #3616 — A REAL GATE, SOMEONE ELSE'S. A closer located its gate run dir by
+#     RECENCY (`ls -t /tmp/agent-gate.*`), read a PEER LANE's run dir, saw 33 of
+#     37 components PASS, and was about to merge #3616 on PR #3580's verdict. The
+#     count was real, the dir was real, the timestamps were plausible; only the
+#     `run-id:` line exposed it, and only because a human read it. With
+#     14000-27000 stale run dirs per box and up to 4 concurrent gates, recency
+#     picks a peer ROUTINELY. This is what the `commit:` + `tree-start:` binding
+#     below refuses: a peer's summary for a different PR carries THAT PR's branch
+#     head, so requiring both abbreviations to match the certified sha turns a
+#     cross-lane verdict from "a human might notice the run-id line" into a
+#     mechanical refusal at the merge point. The sha comparison is therefore not
+#     bookkeeping — it is the guard for the #3616 class.
 #
 # The gate-summary argument is deliberately REQUIRED, not optional: an optional
 # argument would leave the honour system exactly where it is. Omitting it is a
@@ -41,7 +56,10 @@
 #  1. `run-id:` CANNOT be verified here. The #2874 reader contract says a reader
 #     must confirm the summary's `run-id:` matches the run IT launched — this
 #     script did not launch the gate, so it has nothing to compare against. It
-#     therefore does not look at `run-id:` at all rather than pretend to.
+#     therefore does not look at `run-id:` at all rather than pretend to. That is
+#     precisely why the `commit:`/`tree-start:` binding carries the weight for the
+#     #3616 cross-lane class above: it is the only property of a peer's summary
+#     this script CAN falsify without having launched the run.
 #  2. This assert proves a summary EXISTS claiming a full-gate PASS at this sha
 #     with an intact tree. It cannot prove that summary was produced by a
 #     genuine gate run rather than hand-written. A HOSTILE INVOKER IS OUT OF THE
@@ -308,7 +326,9 @@ fi
 # equality against the 40-hex certified sha. Compare each value at ITS OWN exact
 # width, using the value's own length — never a glob, never `case $x in $y*)`,
 # never a fixed assumed width. BOTH must match: two independent widths off one
-# verified capture is materially stronger than one 7-hex compare. A non-hex value
+# verified capture is materially stronger than one 7-hex compare — and this pair
+# is what refuses the #3616 cross-lane class (a peer lane's perfectly valid
+# summary, recovered by recency, naming a DIFFERENT PR's head). A non-hex value
 # ("(not captured)", "(capture unavailable — no git worktree)", "selftest",
 # "unverified") REFUSES — it is never skipped.
 assert_sha_prefix() {

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -224,7 +224,7 @@ done <<GATE_PARSE
 $gate_parse
 GATE_PARSE
 
-gp_k=""; gp_v=""; gp_v_name=""; gp_label=""
+gp_k=""; gp_v=""
 # Every field is keyed on its AFFIRMATIVE value: an unparseable/absent count is
 # refused, never treated as "no problem found".
 for gp_k in blocks lite delta unterminated n_mode n_result n_ti n_commit n_ts; do
@@ -265,18 +265,23 @@ if [ "$n_mode" -ne 0 ]; then
     "This block was produced by (or doctored from) a lite/delta run."
 fi
 
-for gp_k in n_result:RESULT n_ti:tree-integrity n_commit:commit n_ts:tree-start; do
-  gp_v_name="${gp_k%%:*}"
-  gp_label="${gp_k#*:}"
-  eval "gp_v=\${$gp_v_name}"
-  if [ "$gp_v" -eq 0 ]; then
-    refuse_no_gate "The full-gate block has no '$gp_label:' line — it cannot certify anything."
+# assert_single_key <count> <label>: the key must appear EXACTLY once. Zero
+# certifies nothing; more than one is ambiguous and a "last one wins" rule would
+# let a doctored line override the real verdict. Asserted per key, immediately
+# before that key is USED, so the diagnostic names the first thing that is wrong
+# — e.g. the #3041 launch sentinel (a FULL-header block carrying `tree-start:` and
+# `RESULT: INCOMPLETE`, with no `tree-integrity:`/`commit:` yet) is reported as
+# the INCOMPLETE verdict it is, not as a missing tree-integrity line.
+assert_single_key() {
+  if [ "$1" -eq 0 ]; then
+    refuse_no_gate "The full-gate block has no '$2:' line — it cannot certify anything."
   fi
-  if [ "$gp_v" -gt 1 ]; then
-    refuse_no_gate "The full-gate block has $gp_v '$gp_label:' lines — AMBIGUOUS, refusing."
+  if [ "$1" -gt 1 ]; then
+    refuse_no_gate "The full-gate block has $1 '$2:' lines — AMBIGUOUS, refusing."
   fi
-done
+}
 
+assert_single_key "$n_result" RESULT
 # Verdict TOKENS are compared EXACTLY, never by prefix (#3229): a `PASS*` glob
 # accepts `PASSthisNeverRan` and `PASS-MEASUREMENT-DID-NOT-HAPPEN`, i.e. it would
 # check a SPELLING rather than a STATE. awk already gave us the first
@@ -289,6 +294,7 @@ if [ "$v_result" != PASS ]; then
     "only at the terminal emit. Such a summary means still running, queued, or died."
 fi
 
+assert_single_key "$n_ti" tree-integrity
 if [ "$v_ti" != PASS ]; then
   refuse_no_gate \
     "tree-integrity verdict token is '$v_ti', not PASS." \
@@ -328,7 +334,9 @@ assert_sha_prefix() {
   fi
 }
 
+assert_single_key "$n_commit" commit
 assert_sha_prefix commit "$v_commit"
+assert_single_key "$n_ts" tree-start
 assert_sha_prefix tree-start "$v_ts"
 
 # `dirty:` is REPORTED, not enforced — DELIBERATELY. Failing on `dirty: yes` is

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# premerge-assert.sh — the #2456 pre-merge SHA guard, as a script (issue #2668).
+# premerge-assert.sh — the #2456 pre-merge SHA guard + the #3465 gate-of-record
+# guard, as a script (issues #2668, #3465).
 #
 # WHY THIS EXISTS
 # ---------------
@@ -15,25 +16,54 @@
 # on push but CANNOT catch a "merge of an old green head" — this SHA assertion
 # is the real guard.
 #
-# This encodes the #2456 rule mechanically so the closer runs it instead of
-# remembering it: immediately before `gh pr merge`, assert that the PR is OPEN
-# and its headRefOid equals the locally-certified SHA. Refuse (non-zero) on any
-# mismatch, on a closed/merged PR, or on a gh/network failure — FAIL CLOSED,
-# never "assume ok".
+# #3465 adds the OTHER half. Verifying that the PR head equals a *claimed*
+# certified sha never verified that a certified sha EXISTS. PR #3408 merged with
+# NO full gate of record at all — 22 `--lite` PASSes and not one
+# `scripts/agent-gate.sh` run — because nothing in the merge path ever asked for
+# the full `==== AGENT-GATE SUMMARY ====` block. The gate-of-record convention
+# was honour-system doctrine; this script is the one point every merge passes
+# through, so the convention becomes a mechanism here: a summary file carrying a
+# FULL-gate block with `RESULT: PASS`, `tree-integrity: PASS`, and provenance
+# (`commit:` + `tree-start:`) matching the certified sha is now REQUIRED.
 #
-# We parse with gh's built-in `--jq` (jq expression run inside gh), so gh's JSON
-# serialization is NOT load-bearing — we never read raw JSON with sed/regex.
+# The gate-summary argument is deliberately REQUIRED, not optional: an optional
+# argument would leave the honour system exactly where it is. Omitting it is a
+# usage failure (exit 3), which breaks pre-#3465 callers loudly and on purpose.
+#
+# We parse gh with gh's built-in `--jq` (jq expression run inside gh), so gh's
+# JSON serialization is NOT load-bearing — we never read raw JSON with
+# sed/regex. The gate summary is parsed by whole-line-anchored marker matching
+# after ANSI stripping (#3400: colour survives redirection to a file, and the
+# gate's own mandated capture is coloured).
+#
+# TWO RESIDUALS, STATED RATHER THAN FAKED
+# ---------------------------------------
+#  1. `run-id:` CANNOT be verified here. The #2874 reader contract says a reader
+#     must confirm the summary's `run-id:` matches the run IT launched — this
+#     script did not launch the gate, so it has nothing to compare against. It
+#     therefore does not look at `run-id:` at all rather than pretend to.
+#  2. This assert proves a summary EXISTS claiming a full-gate PASS at this sha
+#     with an intact tree. It cannot prove that summary was produced by a
+#     genuine gate run rather than hand-written. A HOSTILE INVOKER IS OUT OF THE
+#     THREAT MODEL — whoever runs this script controls the process and could
+#     edit the script, fake the file, or skip the script entirely; no check
+#     inside a process defends against the party that controls the process. What
+#     this guard defends is ACCIDENT AND DRIFT, which is the observed failure
+#     mode: a diligent worker with no step in its path telling it the gate of
+#     record was never run.
 #
 # USAGE
-#   scripts/flow/premerge-assert.sh <pr-number> <certified-sha>
+#   scripts/flow/premerge-assert.sh <pr-number> <certified-sha> <gate-summary-file>
 #
 # ENVIRONMENT
 #   GH_REPO   the target repo (default: pmcfadin/cqlite). `gh` honors GH_REPO
 #             natively; we pass --repo explicitly too so the default applies.
 #
 # EXIT CODES
-#   0   head matches + PR OPEN     — prints "PREMERGE: OK <sha>"
-#   2   head moved (mismatch), OR PR closed/merged — LOUD multi-line refusal
+#   0   gate of record verified + head matches + PR OPEN
+#       — prints "PREMERGE: OK <sha>" and "PREMERGE: GATE-OF-RECORD ..."
+#   2   no/invalid gate of record, OR head moved (mismatch), OR PR closed/merged
+#       — LOUD multi-line refusal
 #   3   gh/network/usage failure   — fail closed, never merge on uncertainty
 #
 # macOS bash 3.2 compatible, shellcheck-clean.
@@ -42,18 +72,22 @@ set -euo pipefail
 repo="${GH_REPO:-pmcfadin/cqlite}"
 
 usage() {
-  printf 'usage: %s <pr-number> <certified-sha>\n' "$(basename "$0")" >&2
+  printf 'usage: %s <pr-number> <certified-sha> <gate-summary-file>\n' "$(basename "$0")" >&2
+  printf '       <gate-summary-file> is REQUIRED: the AGENT_GATE_SUMMARY_FILE of the\n' >&2
+  printf '       FULL gate of record (a "==== AGENT-GATE SUMMARY ====" block with\n' >&2
+  printf '       RESULT: PASS, tree-integrity: PASS, at the certified sha). See #3465.\n' >&2
 }
 
-if [ "$#" -ne 2 ]; then
+if [ "$#" -ne 3 ]; then
   usage
   exit 3
 fi
 
 pr="$1"
 certified="$2"
+summary_file="$3"
 
-if [ -z "$pr" ] || [ -z "$certified" ]; then
+if [ -z "$pr" ] || [ -z "$certified" ] || [ -z "$summary_file" ]; then
   usage
   exit 3
 fi
@@ -74,6 +108,238 @@ if [ "${#certified}" -ne 40 ]; then
   usage
   exit 3
 fi
+
+# ---------------------------------------------------------------------------
+# GATE OF RECORD (#3465) — checked FIRST, before any `gh` call. It is offline
+# and cheap, and "you have no gate of record" must be reportable without a
+# network round trip.
+# ---------------------------------------------------------------------------
+
+refuse_no_gate() {
+  printf '========================================================\n' >&2
+  printf 'PREMERGE: NO-GATE-OF-RECORD — REFUSING TO MERGE\n' >&2
+  printf '  summary file: %s\n' "$summary_file" >&2
+  printf '  certified sha: %s\n' "$certified" >&2
+  while [ "$#" -gt 0 ]; do
+    printf '  %s\n' "$1" >&2
+    shift
+  done
+  printf '  The FULL gate is the only run that counts (#719). Run it once,\n' >&2
+  printf '  immediately pre-merge, with the mandated redirect:\n' >&2
+  printf '    AGENT_GATE_SUMMARY_FILE=<path> bash scripts/agent-gate.sh > gate.log 2>&1\n' >&2
+  printf '  then pass <path> as the third argument. See #3465.\n' >&2
+  printf '========================================================\n' >&2
+  exit 2
+}
+
+if [ ! -f "$summary_file" ]; then
+  refuse_no_gate "The gate summary file does not exist (or is not a regular file)."
+fi
+if [ ! -r "$summary_file" ]; then
+  refuse_no_gate "The gate summary file exists but is not readable."
+fi
+if [ ! -s "$summary_file" ]; then
+  refuse_no_gate "The gate summary file is EMPTY — nothing was certified."
+fi
+
+# Parse the summary by REDIRECTION, never a pipe (#3400: a piped `while read`
+# runs in a subshell and its verdict is discarded). One awk pass:
+#   * strips ANSI escapes and a trailing CR before matching anything
+#   * counts blocks by WHOLE-LINE-EXACT marker equality, never substring —
+#     CLAUDE.md, issue threads and PR bodies quote these markers in prose, and
+#     "==== END AGENT-GATE SUMMARY ====" CONTAINS the start marker as a substring
+#   * also counts LITE/DELTA blocks purely so a refusal can NAME what it found
+#     (those headers are distinct by construction: scripts/agent-gate.sh)
+#   * emits key=value lines with per-key occurrence COUNTS, so a duplicated key
+#     inside one block is refusable rather than silently last-wins
+gate_parse=$(awk '
+  BEGIN {
+    S = "==== AGENT-GATE SUMMARY ===="
+    E = "==== END AGENT-GATE SUMMARY ===="
+    LS = "==== AGENT-GATE LITE SUMMARY ===="
+    DS = "==== AGENT-GATE DELTA SUMMARY ===="
+    blocks = 0; lite = 0; delta = 0; open = 0; unterminated = 0
+    n_result = 0; n_ti = 0; n_commit = 0; n_ts = 0; n_mode = 0
+    v_result = ""; v_ti = ""; v_commit = ""; v_ts = ""; v_dirty = ""
+  }
+  {
+    gsub(/\033\[[0-9;]*[a-zA-Z]/, "")
+    sub(/\r$/, "")
+  }
+  $0 == S { blocks++; if (open == 1) unterminated = 1; open = 1; next }
+  $0 == E { if (open == 1) open = 0; next }
+  $0 == LS { lite++; next }
+  $0 == DS { delta++; next }
+  open == 1 {
+    if ($1 == "MODE:")           { n_mode++ }
+    else if ($1 == "RESULT:")    { n_result++; v_result = $2 }
+    else if ($1 == "tree-integrity:") { n_ti++; v_ti = $2 }
+    else if ($1 == "tree-start:") { n_ts++; v_ts = $2 }
+    else if ($1 == "commit:") {
+      n_commit++; v_commit = $2
+      for (i = 2; i < NF; i++) if ($i == "dirty:") v_dirty = $(i + 1)
+    }
+    next
+  }
+  END {
+    if (open == 1) unterminated = 1
+    print "blocks=" blocks
+    print "lite=" lite
+    print "delta=" delta
+    print "unterminated=" unterminated
+    print "n_mode=" n_mode
+    print "n_result=" n_result
+    print "n_ti=" n_ti
+    print "n_commit=" n_commit
+    print "n_ts=" n_ts
+    print "v_result=" v_result
+    print "v_ti=" v_ti
+    print "v_commit=" v_commit
+    print "v_ts=" v_ts
+    print "v_dirty=" v_dirty
+  }
+' <"$summary_file") || refuse_no_gate "Could not parse the gate summary file (awk failed)."
+
+blocks=""; lite=""; delta=""; unterminated=""
+n_mode=""; n_result=""; n_ti=""; n_commit=""; n_ts=""
+v_result=""; v_ti=""; v_commit=""; v_ts=""; v_dirty=""
+while IFS='=' read -r gp_k gp_v; do
+  case "$gp_k" in
+    blocks)       blocks="$gp_v" ;;
+    lite)         lite="$gp_v" ;;
+    delta)        delta="$gp_v" ;;
+    unterminated) unterminated="$gp_v" ;;
+    n_mode)       n_mode="$gp_v" ;;
+    n_result)     n_result="$gp_v" ;;
+    n_ti)         n_ti="$gp_v" ;;
+    n_commit)     n_commit="$gp_v" ;;
+    n_ts)         n_ts="$gp_v" ;;
+    v_result)     v_result="$gp_v" ;;
+    v_ti)         v_ti="$gp_v" ;;
+    v_commit)     v_commit="$gp_v" ;;
+    v_ts)         v_ts="$gp_v" ;;
+    v_dirty)      v_dirty="$gp_v" ;;
+  esac
+done <<GATE_PARSE
+$gate_parse
+GATE_PARSE
+
+gp_k=""; gp_v=""; gp_v_name=""; gp_label=""
+# Every field is keyed on its AFFIRMATIVE value: an unparseable/absent count is
+# refused, never treated as "no problem found".
+for gp_k in blocks lite delta unterminated n_mode n_result n_ti n_commit n_ts; do
+  eval "gp_v=\${$gp_k}"
+  case "$gp_v" in
+    ''|*[!0-9]*)
+      refuse_no_gate "Gate summary parse produced no usable '$gp_k' count — refusing (fail closed)."
+      ;;
+  esac
+done
+
+if [ "$unterminated" != 0 ]; then
+  refuse_no_gate \
+    "An AGENT-GATE SUMMARY block is UNTERMINATED (no exact '==== END AGENT-GATE SUMMARY ====')." \
+    "A truncated summary certifies nothing — the gate may still be running or have died."
+fi
+
+if [ "$blocks" -eq 0 ]; then
+  refuse_no_gate \
+    "The file contains ZERO full-gate blocks (found $lite lite, $delta delta)." \
+    "--lite and --delta emit DISTINCT headers and are NOT the gate of record:" \
+    "  --lite  is fast iteration; --delta re-certifies a post-full-PASS polish round." \
+    "This is the #3408 failure exactly: many lite PASSes, no full gate."
+fi
+
+if [ "$blocks" -gt 1 ]; then
+  refuse_no_gate \
+    "The file contains $blocks full-gate blocks — AMBIGUOUS." \
+    "Refusing rather than picking one (a 'take the last block' rule would let a" \
+    "stale or foreign run certify this merge). Point at ONE run's summary file."
+fi
+
+# Belt for the header separation above: the FULL gate emits NO `MODE:` line;
+# --lite and --delta each emit one naming themselves.
+if [ "$n_mode" -ne 0 ]; then
+  refuse_no_gate \
+    "The full-gate block carries a MODE: line — the FULL gate emits none." \
+    "This block was produced by (or doctored from) a lite/delta run."
+fi
+
+for gp_k in n_result:RESULT n_ti:tree-integrity n_commit:commit n_ts:tree-start; do
+  gp_v_name="${gp_k%%:*}"
+  gp_label="${gp_k#*:}"
+  eval "gp_v=\${$gp_v_name}"
+  if [ "$gp_v" -eq 0 ]; then
+    refuse_no_gate "The full-gate block has no '$gp_label:' line — it cannot certify anything."
+  fi
+  if [ "$gp_v" -gt 1 ]; then
+    refuse_no_gate "The full-gate block has $gp_v '$gp_label:' lines — AMBIGUOUS, refusing."
+  fi
+done
+
+# Verdict TOKENS are compared EXACTLY, never by prefix (#3229): a `PASS*` glob
+# accepts `PASSthisNeverRan` and `PASS-MEASUREMENT-DID-NOT-HAPPEN`, i.e. it would
+# check a SPELLING rather than a STATE. awk already gave us the first
+# whitespace-delimited token after the key, so this is a token-exact compare.
+if [ "$v_result" != PASS ]; then
+  refuse_no_gate \
+    "RESULT verdict token is '$v_result', not PASS." \
+    "INCOMPLETE is the launch-time liveness SENTINEL, not a verdict (#3041): it is" \
+    "written when the gate starts (before the slot is even granted) and overwritten" \
+    "only at the terminal emit. Such a summary means still running, queued, or died."
+fi
+
+if [ "$v_ti" != PASS ]; then
+  refuse_no_gate \
+    "tree-integrity verdict token is '$v_ti', not PASS." \
+    "A run whose worktree mutated mid-run cannot certify (#2926); PENDING means the" \
+    "run never reached its terminal emit, and SKIP means the check never ran."
+fi
+
+# The sha comparison. `commit:` carries a 7-char abbreviation and `tree-start:` a
+# 12-char one (both `printf '%.Ns'` of the same VERIFIED capture in
+# scripts/agent-gate.sh), so "matches the certified sha" cannot be string
+# equality against the 40-hex certified sha. Compare each value at ITS OWN exact
+# width, using the value's own length — never a glob, never `case $x in $y*)`,
+# never a fixed assumed width. BOTH must match: two independent widths off one
+# verified capture is materially stronger than one 7-hex compare. A non-hex value
+# ("(not captured)", "(capture unavailable — no git worktree)", "selftest",
+# "unverified") REFUSES — it is never skipped.
+assert_sha_prefix() {
+  # $1 = label, $2 = value from the summary
+  local label="$1" val="$2" n
+  case "$val" in
+    ''|*[!0-9a-f]*)
+      refuse_no_gate \
+        "'$label:' value '$val' is not lowercase hex — nothing verifiable was recorded." \
+        "The gate writes a non-hex placeholder when its capture failed or there was no" \
+        "git worktree; such a run proves nothing about which tree it executed against."
+      ;;
+  esac
+  n=${#val}
+  if [ "$n" -lt 4 ] || [ "$n" -gt 40 ]; then
+    refuse_no_gate "'$label:' value '$val' is $n hex chars — outside the 4..40 range."
+  fi
+  if [ "${certified:0:n}" != "$val" ]; then
+    refuse_no_gate \
+      "'$label:' value '$val' does not match the certified sha at $n chars." \
+      "certified: $certified" \
+      "The gate of record ran against a DIFFERENT tree than the one being merged."
+  fi
+}
+
+assert_sha_prefix commit "$v_commit"
+assert_sha_prefix tree-start "$v_ts"
+
+# `dirty:` is REPORTED, not enforced — DELIBERATELY. Failing on `dirty: yes` is
+# not in the owner's ruling on #3465 and is not absorbed into this change; a
+# follow-up issue will propose it. This is a decision, not an oversight: print it
+# so a dirty gate of record is VISIBLE at the merge point.
+[ -n "$v_dirty" ] || v_dirty=unknown
+
+# ---------------------------------------------------------------------------
+# PR HEAD + STATE (#2456)
+# ---------------------------------------------------------------------------
 
 # Fetch head + state in ONE call, extracted by gh's built-in jq into two
 # whitespace-separated tokens: "<headRefOid> <state>". Because gh runs the jq
@@ -124,4 +390,6 @@ if [ "$actual" != "$certified" ]; then
 fi
 
 printf 'PREMERGE: OK %s\n' "$certified"
+printf 'PREMERGE: GATE-OF-RECORD commit: %s tree-start: %s tree-integrity: PASS dirty: %s summary: %s\n' \
+  "$v_commit" "$v_ts" "$v_dirty" "$summary_file"
 exit 0

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -21,7 +21,7 @@
 # convention was honour-system doctrine; this script is the one point every merge
 # passes through, so the convention becomes a mechanism here: a summary file
 # carrying a FULL-gate block with `RESULT: PASS`, `tree-integrity: PASS`, and
-# provenance (`commit:` + `tree-start:`) matching the certified sha is REQUIRED.
+# provenance (`commit:` + `tree-start:`) covering the certified sha is REQUIRED.
 #
 # TWO DISTINCT ESCAPES, ONE MECHANISM
 #   * #3408 — NO GATE AT ALL. That PR merged on 22 `--lite` PASSes and not one
@@ -41,15 +41,42 @@
 #     mechanical refusal at the merge point. The sha comparison is therefore not
 #     bookkeeping — it is the guard for the #3616 class.
 #
-# The gate-summary argument is deliberately REQUIRED, not optional: an optional
+# The gate-of-record argument is deliberately REQUIRED, not optional: an optional
 # argument would leave the honour system exactly where it is. Omitting it is a
 # usage failure (exit 3), which breaks pre-#3465 callers loudly and on purpose.
 #
+# TWO ACCEPTED SHAPES (#3465 review blocker): DIRECT, or ANCHORED DELTA
+# --------------------------------------------------------------------
+# CLAUDE.md's #1892 post-gate-polish rule MANDATES that a test/docs-only diff on
+# top of a full PASS at anchor `X` re-certifies with `scripts/agent-gate.sh
+# --delta X` and "never a repeat full gate", and that the PR record BOTH the
+# delta block AND the anchor's full SUMMARY. So the merged head `Y` legitimately
+# differs from the gate of record's `X`, and a guard that accepted only the
+# 3-argument shape red on correct, doctrine-mandated input — the guard agents
+# learn to waive. Hence the OPTIONAL fourth argument:
+#
+#   CASE A (3 args) — DIRECT. The full block's `commit:`/`tree-start:` must
+#     cover the certified sha. The gate of record ran on the merged tree itself.
+#   CASE B (4 args) — ANCHORED DELTA. The full block is the ANCHOR (its sha need
+#     NOT be the certified sha), and the fourth argument must be a `--delta`
+#     block that (i) is a PASS with an intact tree, (ii) names that exact anchor
+#     in `delta-anchor:`, and (iii) whose OWN `commit:`/`tree-start:` cover the
+#     certified sha. The chain is therefore closed end to end: full PASS at X →
+#     delta re-cert anchored at X → delta ran on Y → Y is the PR head.
+#
+# In BOTH cases a full-gate PASS must EXIST, and the merged tree is covered
+# either directly (A) or by an anchored delta re-cert on top of it (B). What is
+# never accepted is a delta or lite block ALONE — the #3408 escape.
+#
 # We parse gh with gh's built-in `--jq` (jq expression run inside gh), so gh's
 # JSON serialization is NOT load-bearing — we never read raw JSON with
-# sed/regex. The gate summary is parsed by whole-line-anchored marker matching
-# after ANSI stripping (#3400: colour survives redirection to a file, and the
-# gate's own mandated capture is coloured).
+# sed/regex. The gate summary is parsed by whole-line-anchored marker matching,
+# after an ANSI strip that is BELT rather than the load-bearing part: the summary
+# FILE's block lines are `echo`s of computed strings (scripts/agent-gate.sh
+# emit_summary), so they are not coloured; `CARGO_TERM_COLOR` colours cargo
+# output inside `gate.log`, not the block. The strip covers the case where the
+# block was recovered from a coloured CAPTURE rather than from the summary file
+# (#3400: colour survives redirection).
 #
 # TWO RESIDUALS, STATED RATHER THAN FAKED
 # ---------------------------------------
@@ -60,8 +87,8 @@
 #     precisely why the `commit:`/`tree-start:` binding carries the weight for the
 #     #3616 cross-lane class above: it is the only property of a peer's summary
 #     this script CAN falsify without having launched the run.
-#  2. This assert proves a summary EXISTS claiming a full-gate PASS at this sha
-#     with an intact tree. It cannot prove that summary was produced by a
+#  2. This assert proves a summary EXISTS claiming a full-gate PASS covering this
+#     sha with an intact tree. It cannot prove that summary was produced by a
 #     genuine gate run rather than hand-written. A HOSTILE INVOKER IS OUT OF THE
 #     THREAT MODEL — whoever runs this script controls the process and could
 #     edit the script, fake the file, or skip the script entirely; no check
@@ -69,9 +96,29 @@
 #     this guard defends is ACCIDENT AND DRIFT, which is the observed failure
 #     mode: a diligent worker with no step in its path telling it the gate of
 #     record was never run.
+#  3. THE CERTIFIED TREE IS NOT THE MERGED TREE (#3650). A squash-merge composes
+#     this diff with main's CURRENT tip, not with the base the branch was written
+#     against, so for any PR whose base is behind main the tree this script
+#     certifies and the tree that lands are DIFFERENT OBJECTS. Measured on
+#     #3358/PR #3362: base 2bde26a7c with main 10 commits ahead, whose head gate
+#     FAILed `core-tests` only because the fix for a known flake (5e08db201,
+#     #3514) was on main and absent from that base — the benign direction. The
+#     MALIGN direction is a PASS at a stale head hiding an interaction with
+#     something that landed in between: this assert would accept it, and the
+#     merge would compose two things never tested together. So this script
+#     proves FACT 1 — the diff is unchanged since certification and a full gate
+#     of record PASSed on that exact tree — and it explicitly does NOT prove
+#     FACT 2 — that the diff was certified against the main it will join. Fact 2
+#     is a gate on the MERGE RESULT and is filed as #3650; it is deliberately
+#     NOT implemented here, and neither is a staleness bound or a "your base is N
+#     commits behind" advisory. The success path SAYS so (`PREMERGE: SCOPE`),
+#     because an enforcement that certifies the wrong tree while CLAIMING to
+#     close #3465 would be the vacuous-pass shape one level up — worse than the
+#     gap it replaces, which is at least visible.
 #
 # USAGE
-#   scripts/flow/premerge-assert.sh <pr-number> <certified-sha> <gate-summary-file>
+#   scripts/flow/premerge-assert.sh <pr-number> <certified-sha> \
+#       <gate-of-record-summary> [<delta-summary>]
 #
 # ENVIRONMENT
 #   GH_REPO   the target repo (default: pmcfadin/cqlite). `gh` honors GH_REPO
@@ -79,10 +126,13 @@
 #
 # EXIT CODES
 #   0   gate of record verified + head matches + PR OPEN
-#       — prints "PREMERGE: OK <sha>" and "PREMERGE: GATE-OF-RECORD ..."
+#       — prints "PREMERGE: OK <sha>", "PREMERGE: SCOPE ..." (what was and was
+#         NOT proven, #3650) and "PREMERGE: GATE-OF-RECORD ..."
+#         (plus "PREMERGE: DELTA-RECERT ..." in Case B)
 #   2   no/invalid gate of record, OR head moved (mismatch), OR PR closed/merged
 #       — LOUD multi-line refusal
-#   3   gh/network/usage failure   — fail closed, never merge on uncertainty
+#   3   gh/network failure, a required TOOL failing, or a usage error
+#       — fail closed, never merge on uncertainty
 #
 # macOS bash 3.2 compatible, shellcheck-clean.
 set -euo pipefail
@@ -90,13 +140,18 @@ set -euo pipefail
 repo="${GH_REPO:-pmcfadin/cqlite}"
 
 usage() {
-  printf 'usage: %s <pr-number> <certified-sha> <gate-summary-file>\n' "$(basename "$0")" >&2
-  printf '       <gate-summary-file> is REQUIRED: the AGENT_GATE_SUMMARY_FILE of the\n' >&2
-  printf '       FULL gate of record (a "==== AGENT-GATE SUMMARY ====" block with\n' >&2
-  printf '       RESULT: PASS, tree-integrity: PASS, at the certified sha). See #3465.\n' >&2
+  printf 'usage: %s <pr-number> <certified-sha> <gate-of-record-summary> [<delta-summary>]\n' \
+    "$(basename "$0")" >&2
+  printf '       <gate-of-record-summary> is REQUIRED: the AGENT_GATE_SUMMARY_FILE of the\n' >&2
+  printf '       FULL gate (a "==== AGENT-GATE SUMMARY ====" block with RESULT: PASS and\n' >&2
+  printf '       tree-integrity: PASS). With 3 args it must be AT the certified sha.\n' >&2
+  printf '       <delta-summary> is OPTIONAL: an "==== AGENT-GATE DELTA SUMMARY ====" block\n' >&2
+  printf '       whose delta-anchor: is the full block above and whose own commit:/\n' >&2
+  printf '       tree-start: are AT the certified sha (the #1892 post-gate-polish route).\n' >&2
+  printf '       See #3465.\n' >&2
 }
 
-if [ "$#" -ne 3 ]; then
+if [ "$#" -ne 3 ] && [ "$#" -ne 4 ]; then
   usage
   exit 3
 fi
@@ -104,8 +159,15 @@ fi
 pr="$1"
 certified="$2"
 summary_file="$3"
+delta_file="${4:-}"
 
 if [ -z "$pr" ] || [ -z "$certified" ] || [ -z "$summary_file" ]; then
+  usage
+  exit 3
+fi
+# An EMPTY fourth argument is a usage failure, not "3-arg mode": a caller whose
+# variable expanded to nothing must be told, never silently downgraded.
+if [ "$#" -eq 4 ] && [ -z "$delta_file" ]; then
   usage
   exit 3
 fi
@@ -137,6 +199,7 @@ refuse_no_gate() {
   printf '========================================================\n' >&2
   printf 'PREMERGE: NO-GATE-OF-RECORD — REFUSING TO MERGE\n' >&2
   printf '  summary file: %s\n' "$summary_file" >&2
+  [ -n "$delta_file" ] && printf '  delta summary file: %s\n' "$delta_file" >&2
   printf '  certified sha: %s\n' "$certified" >&2
   while [ "$#" -gt 0 ]; do
     printf '  %s\n' "$1" >&2
@@ -145,54 +208,93 @@ refuse_no_gate() {
   printf '  The FULL gate is the only run that counts (#719). Run it once,\n' >&2
   printf '  immediately pre-merge, with the mandated redirect:\n' >&2
   printf '    AGENT_GATE_SUMMARY_FILE=<path> bash scripts/agent-gate.sh > gate.log 2>&1\n' >&2
-  printf '  then pass <path> as the third argument. See #3465.\n' >&2
+  printf '  then pass <path> as the third argument.\n' >&2
+  printf '  If the ONLY diff since a full PASS at anchor X is test/docs-only, the\n' >&2
+  printf '  sanctioned route is the ANCHORED DELTA PAIR (#1892) — not a repeat full\n' >&2
+  printf '  gate: scripts/agent-gate.sh --delta X --anchor-run-id <id>, then pass BOTH\n' >&2
+  printf '  summaries: <anchor-full-summary> <delta-summary>. See #3465.\n' >&2
   printf '========================================================\n' >&2
   exit 2
 }
 
-if [ ! -f "$summary_file" ]; then
-  refuse_no_gate "The gate summary file does not exist (or is not a regular file)."
-fi
-if [ ! -r "$summary_file" ]; then
-  refuse_no_gate "The gate summary file exists but is not readable."
-fi
-if [ ! -s "$summary_file" ]; then
-  refuse_no_gate "The gate summary file is EMPTY — nothing was certified."
-fi
+# A required TOOL failing is NOT "no gate of record" and must NOT be answered
+# with "go run a 45-minute gate" (#3465 review nit 6). The header reserves exit 3
+# for tool/usage failure; route it there, naming the tool.
+refuse_tool_failure() {
+  printf '========================================================\n' >&2
+  printf 'PREMERGE: TOOL-FAILURE\n' >&2
+  printf '  %s failed while parsing %s.\n' "$1" "$2" >&2
+  printf '  This is a broken/absent tool on THIS box (missing, ENOMEM, bad PATH),\n' >&2
+  printf '  not a verdict about the gate of record. Fix the box and re-run this\n' >&2
+  printf '  assert — do NOT re-run the gate. Refusing to merge (fail closed).\n' >&2
+  printf '========================================================\n' >&2
+  exit 3
+}
+
+# assert_readable_summary <file> <what> — the three file-level preconditions.
+assert_readable_summary() {
+  if [ ! -f "$1" ]; then
+    refuse_no_gate "The $2 file does not exist (or is not a regular file)."
+  fi
+  if [ ! -r "$1" ]; then
+    refuse_no_gate "The $2 file exists but is not readable."
+  fi
+  if [ ! -s "$1" ]; then
+    refuse_no_gate "The $2 file is EMPTY — nothing was certified."
+  fi
+}
 
 # Parse the summary by REDIRECTION, never a pipe (#3400: a piped `while read`
 # runs in a subshell and its verdict is discarded). One awk pass:
-#   * strips ANSI escapes and a trailing CR before matching anything
-#   * counts blocks by WHOLE-LINE-EXACT marker equality, never substring —
-#     CLAUDE.md, issue threads and PR bodies quote these markers in prose, and
-#     "==== END AGENT-GATE SUMMARY ====" CONTAINS the start marker as a substring
-#   * also counts LITE/DELTA blocks purely so a refusal can NAME what it found
-#     (those headers are distinct by construction: scripts/agent-gate.sh)
+#   * strips ANSI escapes and a trailing CR before matching anything (belt — see
+#     the header: the summary file's own block lines are not coloured)
+#   * counts blocks by WHOLE-LINE-EXACT marker equality, never substring. That
+#     anchoring defends against (a) PROSE copies of a marker — indented,
+#     `>`-quoted, fenced, or mid-sentence — which CLAUDE.md, issue bodies, PR
+#     comments and the very doctrine files this change edits all contain, and
+#     (b) a TRUNCATED pattern such as `AGENT-GATE SUMMARY ====`, which matches
+#     ALL FOUR markers (full/lite start and end). Note the end marker does NOT
+#     contain the start marker as a substring — `END ` sits between `====` and
+#     `AGENT-GATE` — so substring matching would fail for the reasons above,
+#     not for that one.
+#   * counts all three block families so a refusal can NAME what it found
+#     (the headers are distinct by construction: scripts/agent-gate.sh)
 #   * emits key=value lines with per-key occurrence COUNTS, so a duplicated key
 #     inside one block is refusable rather than silently last-wins
-gate_parse=$(awk '
+# WANT selects which family is "the block": full (default) or delta.
+_gate_awk() {
+  awk -v WANT="$2" '
   BEGIN {
-    S = "==== AGENT-GATE SUMMARY ===="
-    E = "==== END AGENT-GATE SUMMARY ===="
-    LS = "==== AGENT-GATE LITE SUMMARY ===="
-    DS = "==== AGENT-GATE DELTA SUMMARY ===="
-    blocks = 0; lite = 0; delta = 0; open = 0; unterminated = 0
+    FULL_S  = "==== AGENT-GATE SUMMARY ===="
+    FULL_E  = "==== END AGENT-GATE SUMMARY ===="
+    LITE_S  = "==== AGENT-GATE LITE SUMMARY ===="
+    DELTA_S = "==== AGENT-GATE DELTA SUMMARY ===="
+    DELTA_E = "==== END AGENT-GATE DELTA SUMMARY ===="
+    if (WANT == "delta") { S = DELTA_S; E = DELTA_E } else { S = FULL_S; E = FULL_E }
+    blocks = 0; full = 0; lite = 0; delta = 0; open = 0; unterminated = 0
     n_result = 0; n_ti = 0; n_commit = 0; n_ts = 0; n_mode = 0
+    n_anchor = 0; n_nested = 0; anchor_unresolved = 0
     v_result = ""; v_ti = ""; v_commit = ""; v_ts = ""; v_dirty = ""
+    v_mode = ""; v_anchor = ""
   }
   {
     gsub(/\033\[[0-9;]*[a-zA-Z]/, "")
     sub(/\r$/, "")
   }
-  $0 == S { blocks++; if (open == 1) unterminated = 1; open = 1; next }
-  $0 == E { if (open == 1) open = 0; next }
-  $0 == LS { lite++; next }
-  $0 == DS { delta++; next }
+  $0 == FULL_S  { full++;  if (S == FULL_S)  { blocks++; if (open == 1) unterminated = 1; open = 1 } next }
+  $0 == DELTA_S { delta++; if (S == DELTA_S) { blocks++; if (open == 1) unterminated = 1; open = 1 } next }
+  $0 == LITE_S  { lite++;  next }
+  $0 == E       { if (open == 1) open = 0; next }
   open == 1 {
-    if ($1 == "MODE:")           { n_mode++ }
-    else if ($1 == "RESULT:")    { n_result++; v_result = $2 }
-    else if ($1 == "tree-integrity:") { n_ti++; v_ti = $2 }
-    else if ($1 == "tree-start:") { n_ts++; v_ts = $2 }
+    if ($1 == "MODE:")                { n_mode++;   v_mode = $2 }
+    else if ($1 == "RESULT:")         { n_result++; v_result = $2 }
+    else if ($1 == "tree-integrity:") { n_ti++;     v_ti = $2 }
+    else if ($1 == "tree-start:")     { n_ts++;     v_ts = $2 }
+    else if ($1 == "nested-under:")   { n_nested++ }
+    else if ($1 == "delta-anchor:") {
+      n_anchor++; v_anchor = $2
+      for (i = 2; i <= NF; i++) if ($i == "(UNRESOLVED)") anchor_unresolved = 1
+    }
     else if ($1 == "commit:") {
       n_commit++; v_commit = $2
       for (i = 2; i < NF; i++) if ($i == "dirty:") v_dirty = $(i + 1)
@@ -202,6 +304,7 @@ gate_parse=$(awk '
   END {
     if (open == 1) unterminated = 1
     print "blocks=" blocks
+    print "full=" full
     print "lite=" lite
     print "delta=" delta
     print "unterminated=" unterminated
@@ -210,160 +313,308 @@ gate_parse=$(awk '
     print "n_ti=" n_ti
     print "n_commit=" n_commit
     print "n_ts=" n_ts
+    print "n_anchor=" n_anchor
+    print "n_nested=" n_nested
+    print "anchor_unresolved=" anchor_unresolved
     print "v_result=" v_result
     print "v_ti=" v_ti
     print "v_commit=" v_commit
     print "v_ts=" v_ts
     print "v_dirty=" v_dirty
+    print "v_mode=" v_mode
+    print "v_anchor=" v_anchor
   }
-' <"$summary_file") || refuse_no_gate "Could not parse the gate summary file (awk failed)."
+' <"$1"
+}
 
-blocks=""; lite=""; delta=""; unterminated=""
-n_mode=""; n_result=""; n_ti=""; n_commit=""; n_ts=""
-v_result=""; v_ti=""; v_commit=""; v_ts=""; v_dirty=""
-while IFS='=' read -r gp_k gp_v; do
-  case "$gp_k" in
-    blocks)       blocks="$gp_v" ;;
-    lite)         lite="$gp_v" ;;
-    delta)        delta="$gp_v" ;;
-    unterminated) unterminated="$gp_v" ;;
-    n_mode)       n_mode="$gp_v" ;;
-    n_result)     n_result="$gp_v" ;;
-    n_ti)         n_ti="$gp_v" ;;
-    n_commit)     n_commit="$gp_v" ;;
-    n_ts)         n_ts="$gp_v" ;;
-    v_result)     v_result="$gp_v" ;;
-    v_ti)         v_ti="$gp_v" ;;
-    v_commit)     v_commit="$gp_v" ;;
-    v_ts)         v_ts="$gp_v" ;;
-    v_dirty)      v_dirty="$gp_v" ;;
-  esac
-done <<GATE_PARSE
-$gate_parse
+# gate_parse_file <file> <want> <what> — run the parse and publish its fields as
+# GP_* globals (bash 3.2: no namerefs, no associative arrays). Every COUNT is
+# validated as a non-negative integer here, keyed on its AFFIRMATIVE value: an
+# unparseable/absent count is refused, never treated as "no problem found".
+gate_parse_file() {
+  local gp_out gp_k gp_v
+  gp_out=$(_gate_awk "$1" "$2") || refuse_tool_failure awk "$3"
+  GP_blocks=""; GP_full=""; GP_lite=""; GP_delta=""; GP_unterminated=""
+  GP_n_mode=""; GP_n_result=""; GP_n_ti=""; GP_n_commit=""; GP_n_ts=""
+  GP_n_anchor=""; GP_n_nested=""; GP_anchor_unresolved=""
+  GP_v_result=""; GP_v_ti=""; GP_v_commit=""; GP_v_ts=""; GP_v_dirty=""
+  GP_v_mode=""; GP_v_anchor=""
+  while IFS='=' read -r gp_k gp_v; do
+    case "$gp_k" in
+      blocks)       GP_blocks="$gp_v" ;;
+      full)         GP_full="$gp_v" ;;
+      lite)         GP_lite="$gp_v" ;;
+      delta)        GP_delta="$gp_v" ;;
+      unterminated) GP_unterminated="$gp_v" ;;
+      n_mode)       GP_n_mode="$gp_v" ;;
+      n_result)     GP_n_result="$gp_v" ;;
+      n_ti)         GP_n_ti="$gp_v" ;;
+      n_commit)     GP_n_commit="$gp_v" ;;
+      n_ts)         GP_n_ts="$gp_v" ;;
+      n_anchor)     GP_n_anchor="$gp_v" ;;
+      n_nested)     GP_n_nested="$gp_v" ;;
+      anchor_unresolved) GP_anchor_unresolved="$gp_v" ;;
+      v_result)     GP_v_result="$gp_v" ;;
+      v_ti)         GP_v_ti="$gp_v" ;;
+      v_commit)     GP_v_commit="$gp_v" ;;
+      v_ts)         GP_v_ts="$gp_v" ;;
+      v_dirty)      GP_v_dirty="$gp_v" ;;
+      v_mode)       GP_v_mode="$gp_v" ;;
+      v_anchor)     GP_v_anchor="$gp_v" ;;
+    esac
+  done <<GATE_PARSE
+$gp_out
 GATE_PARSE
+  for gp_k in blocks full lite delta unterminated n_mode n_result n_ti n_commit \
+              n_ts n_anchor n_nested anchor_unresolved; do
+    eval "gp_v=\${GP_$gp_k}"
+    case "$gp_v" in
+      ''|*[!0-9]*)
+        refuse_no_gate "Gate summary parse produced no usable '$gp_k' count for the $3 — refusing (fail closed)."
+        ;;
+    esac
+  done
+}
 
-gp_k=""; gp_v=""
-# Every field is keyed on its AFFIRMATIVE value: an unparseable/absent count is
-# refused, never treated as "no problem found".
-for gp_k in blocks lite delta unterminated n_mode n_result n_ti n_commit n_ts; do
-  eval "gp_v=\${$gp_k}"
-  case "$gp_v" in
-    ''|*[!0-9]*)
-      refuse_no_gate "Gate summary parse produced no usable '$gp_k' count — refusing (fail closed)."
+# assert_single_key <count> <label> <what>: the key must appear EXACTLY once.
+# Zero certifies nothing; more than one is ambiguous and a "last one wins" rule
+# would let a doctored line override the real verdict. Asserted per key,
+# immediately before that key is USED, so the diagnostic names the first thing
+# that is wrong — e.g. the #3041 launch sentinel (a FULL-header block carrying
+# `tree-start:` and `RESULT: INCOMPLETE`, with no `tree-integrity:`/`commit:`
+# yet) is reported as the INCOMPLETE verdict it is, not as a missing
+# tree-integrity line.
+assert_single_key() {
+  if [ "$1" -eq 0 ]; then
+    refuse_no_gate "The $3 has no '$2:' line — it cannot certify anything."
+  fi
+  if [ "$1" -gt 1 ]; then
+    refuse_no_gate "The $3 has $1 '$2:' lines — AMBIGUOUS, refusing."
+  fi
+}
+
+# assert_hex_abbrev <label> <value> <what>: the value must be a lowercase-hex
+# abbreviation of SOME sha. A non-hex value ("(not captured)", "(capture
+# unavailable — no git worktree)", "selftest", "unverified") REFUSES — it is
+# never skipped.
+assert_hex_abbrev() {
+  local n
+  case "$2" in
+    ''|*[!0-9a-f]*)
+      refuse_no_gate \
+        "'$1:' value '$2' in the $3 is not lowercase hex — nothing verifiable was recorded." \
+        "The gate writes a non-hex placeholder when its capture failed or there was no" \
+        "git worktree; such a run proves nothing about which tree it executed against."
       ;;
   esac
-done
+  n=${#2}
+  # FLOOR 7, not 4 (#3465 review nit 5): 7 is the NARROWEST abbreviation the gate
+  # ever emits (`commit:` is `printf '%.7s'`; `tree-start:` is `%.12s`), and a
+  # 4-hex value accepted at its own width is a 1-in-65536 accidental cross-lane
+  # match — precisely the #3616 class this compare exists to refuse. Accepting a
+  # width the gate cannot produce buys nothing and weakens the binding.
+  if [ "$n" -lt 7 ] || [ "$n" -gt 40 ]; then
+    refuse_no_gate \
+      "'$1:' value '$2' in the $3 is $n hex chars — outside the 7..40 range." \
+      "The gate emits 7 (commit:) and 12 (tree-start:) hex; a narrower value cannot" \
+      "bind a run to a tree (a 4-hex 'match' is 1-in-65536 by accident)."
+  fi
+}
 
-if [ "$unterminated" != 0 ]; then
-  refuse_no_gate \
-    "An AGENT-GATE SUMMARY block is UNTERMINATED (no exact '==== END AGENT-GATE SUMMARY ====')." \
-    "A truncated summary certifies nothing — the gate may still be running or have died."
-fi
+# assert_covers <label> <value> <full-40-sha> <what> <subject>: the abbreviation
+# must be a prefix of the full sha AT ITS OWN EXACT WIDTH.
+#
+# `commit:` carries a 7-char abbreviation and `tree-start:` a 12-char one (both
+# `printf '%.Ns'` of the same VERIFIED capture in scripts/agent-gate.sh), so
+# "matches the certified sha" cannot be string equality against the 40-hex sha.
+# Compare each value at ITS OWN width, using the value's own length — never a
+# glob, never `case $x in $y*)`, never a fixed assumed width. BOTH must match:
+# two independent widths off one verified capture is materially stronger than one
+# 7-hex compare — and this pair is what refuses the #3616 cross-lane class (a
+# peer lane's perfectly valid summary, recovered by recency, naming a DIFFERENT
+# PR's head).
+assert_covers() {
+  local label="$1" val="$2" full="$3" what="$4" subject="$5" n
+  assert_hex_abbrev "$label" "$val" "$what"
+  n=${#val}
+  if [ "${full:0:n}" != "$val" ]; then
+    refuse_no_gate \
+      "'$label:' value '$val' in the $what does not match the $subject at $n chars." \
+      "$subject: $full" \
+      "That run executed against a DIFFERENT tree than the one it must cover." \
+      "If the only diff since the gate's anchor is test/docs-only, the route is the" \
+      "ANCHORED DELTA PAIR below — a fourth argument, not a repeat full gate."
+  fi
+}
 
-if [ "$blocks" -eq 0 ]; then
+# assert_pass_block <what>: the verdict half every accepted block must satisfy —
+# terminated, RESULT: PASS, tree-integrity: PASS, and not a nested sub-gate.
+assert_pass_block() {
+  local what="$1"
+  if [ "$GP_unterminated" != 0 ]; then
+    refuse_no_gate \
+      "A block in the $what is UNTERMINATED (no exact end marker)." \
+      "A truncated summary certifies nothing — the gate may still be running or have died."
+  fi
+
+  assert_single_key "$GP_n_result" RESULT "$what"
+  # Verdict TOKENS are compared EXACTLY, never by prefix (#3229): a `PASS*` glob
+  # accepts `PASSthisNeverRan` and `PASS-MEASUREMENT-DID-NOT-HAPPEN`, i.e. it would
+  # check a SPELLING rather than a STATE. awk already gave us the first
+  # whitespace-delimited token after the key, so this is a token-exact compare.
+  if [ "$GP_v_result" != PASS ]; then
+    refuse_no_gate \
+      "RESULT verdict token in the $what is '$GP_v_result', not PASS." \
+      "INCOMPLETE is the launch-time liveness SENTINEL, not a verdict (#3041): it is" \
+      "written when the gate starts (before the slot is even granted) and overwritten" \
+      "only at the terminal emit. Such a summary means still running, queued, or died." \
+      "PARTIAL is an --only run, which does NOT count as the gate."
+  fi
+
+  assert_single_key "$GP_n_ti" tree-integrity "$what"
+  if [ "$GP_v_ti" != PASS ]; then
+    refuse_no_gate \
+      "tree-integrity verdict token in the $what is '$GP_v_ti', not PASS." \
+      "A run whose worktree mutated mid-run cannot certify (#2926); PENDING means the" \
+      "run never reached its terminal emit, and SKIP means the check never ran."
+  fi
+
+  # A NESTED sub-gate (#2874: launched by an enclosing gate, stamped
+  # `nested-under: <parent-run-id>`) emits the SAME markers at the SAME tree, so
+  # the sha binding provably cannot distinguish it from the real thing — this
+  # one affirmative line closes the only wrong-file class the sha compare cannot
+  # see. A self-test/sub-gate verdict is about the gate's own machinery, never
+  # about this PR.
+  if [ "$GP_n_nested" -ne 0 ]; then
+    refuse_no_gate \
+      "The $what carries a 'nested-under:' line — it is a NESTED sub-gate (#2874)." \
+      "A sub-gate spawned by an enclosing gate runs at the SAME tree, so the sha" \
+      "binding cannot tell it apart; it certifies the gate's machinery, not this PR."
+  fi
+}
+
+# --- the FULL gate of record (arg 3) -----------------------------------------
+assert_readable_summary "$summary_file" "gate summary"
+gate_parse_file "$summary_file" full "gate summary"
+
+if [ "$GP_blocks" -eq 0 ]; then
   refuse_no_gate \
-    "The file contains ZERO full-gate blocks (found $lite lite, $delta delta)." \
-    "--lite and --delta emit DISTINCT headers and are NOT the gate of record:" \
-    "  --lite  is fast iteration; --delta re-certifies a post-full-PASS polish round." \
+    "The file contains ZERO full-gate blocks (found $GP_lite lite, $GP_delta delta)." \
+    "--lite and --delta emit DISTINCT headers; NEITHER is the gate of record:" \
+    "  --lite  is fast iteration and is never acceptable here." \
+    "  --delta re-certifies a post-full-PASS test/docs-only round — pass the ANCHOR's" \
+    "          FULL summary as argument 3 and the delta summary as argument 4." \
     "This is the #3408 failure exactly: many lite PASSes, no full gate."
 fi
 
-if [ "$blocks" -gt 1 ]; then
+if [ "$GP_blocks" -gt 1 ]; then
   refuse_no_gate \
-    "The file contains $blocks full-gate blocks — AMBIGUOUS." \
+    "The file contains $GP_blocks full-gate blocks — AMBIGUOUS." \
     "Refusing rather than picking one (a 'take the last block' rule would let a" \
     "stale or foreign run certify this merge). Point at ONE run's summary file."
 fi
 
 # Belt for the header separation above: the FULL gate emits NO `MODE:` line;
-# --lite and --delta each emit one naming themselves.
-if [ "$n_mode" -ne 0 ]; then
+# --lite and --delta each emit one naming themselves. (An `--only` run emits the
+# FULL markers with a LOWERCASE `mode: PARTIAL (--only …)` line, which this
+# case-sensitive check deliberately does NOT catch — that run is refused by the
+# `RESULT: PARTIAL` compare above, which is the property that matters.)
+if [ "$GP_n_mode" -ne 0 ]; then
   refuse_no_gate \
     "The full-gate block carries a MODE: line — the FULL gate emits none." \
     "This block was produced by (or doctored from) a lite/delta run."
 fi
 
-# assert_single_key <count> <label>: the key must appear EXACTLY once. Zero
-# certifies nothing; more than one is ambiguous and a "last one wins" rule would
-# let a doctored line override the real verdict. Asserted per key, immediately
-# before that key is USED, so the diagnostic names the first thing that is wrong
-# — e.g. the #3041 launch sentinel (a FULL-header block carrying `tree-start:` and
-# `RESULT: INCOMPLETE`, with no `tree-integrity:`/`commit:` yet) is reported as
-# the INCOMPLETE verdict it is, not as a missing tree-integrity line.
-assert_single_key() {
-  if [ "$1" -eq 0 ]; then
-    refuse_no_gate "The full-gate block has no '$2:' line — it cannot certify anything."
+assert_pass_block "full-gate block"
+
+assert_single_key "$GP_n_commit" commit "full-gate block"
+assert_single_key "$GP_n_ts" tree-start "full-gate block"
+full_commit="$GP_v_commit"
+full_ts="$GP_v_ts"
+full_dirty="$GP_v_dirty"
+
+if [ -z "$delta_file" ]; then
+  # CASE A — DIRECT: the gate of record ran on the merged tree itself.
+  assert_covers commit "$full_commit" "$certified" "full-gate block" "certified sha"
+  assert_covers tree-start "$full_ts" "$certified" "full-gate block" "certified sha"
+else
+  # CASE B — ANCHORED DELTA (#1892). The full block is the ANCHOR: its sha need
+  # not be the certified sha, but it must still be a real, verifiable sha, and
+  # the delta block must name exactly it.
+  assert_hex_abbrev commit "$full_commit" "full-gate block"
+  assert_hex_abbrev tree-start "$full_ts" "full-gate block"
+
+  assert_readable_summary "$delta_file" "delta summary"
+  gate_parse_file "$delta_file" delta "delta summary"
+
+  if [ "$GP_blocks" -eq 0 ]; then
+    refuse_no_gate \
+      "The fourth argument holds ZERO delta blocks (found $GP_full full, $GP_lite lite)." \
+      "It must be the AGENT_GATE_SUMMARY_FILE of a 'scripts/agent-gate.sh --delta' run" \
+      "('==== AGENT-GATE DELTA SUMMARY ====' — a DISTINCT header, by construction)."
   fi
-  if [ "$1" -gt 1 ]; then
-    refuse_no_gate "The full-gate block has $1 '$2:' lines — AMBIGUOUS, refusing."
+  if [ "$GP_blocks" -gt 1 ]; then
+    refuse_no_gate \
+      "The fourth argument holds $GP_blocks delta blocks — AMBIGUOUS." \
+      "Point at ONE run's summary file; picking one would let a stale run re-certify."
   fi
-}
 
-assert_single_key "$n_result" RESULT
-# Verdict TOKENS are compared EXACTLY, never by prefix (#3229): a `PASS*` glob
-# accepts `PASSthisNeverRan` and `PASS-MEASUREMENT-DID-NOT-HAPPEN`, i.e. it would
-# check a SPELLING rather than a STATE. awk already gave us the first
-# whitespace-delimited token after the key, so this is a token-exact compare.
-if [ "$v_result" != PASS ]; then
-  refuse_no_gate \
-    "RESULT verdict token is '$v_result', not PASS." \
-    "INCOMPLETE is the launch-time liveness SENTINEL, not a verdict (#3041): it is" \
-    "written when the gate starts (before the slot is even granted) and overwritten" \
-    "only at the terminal emit. Such a summary means still running, queued, or died."
-fi
+  # The INVERSE of the full block's belt: here a `MODE: delta` line is REQUIRED
+  # and asserted AFFIRMATIVELY. A delta block always carries it
+  # (scripts/agent-gate.sh SUMMARY_MODE_LINE), so its absence means the block was
+  # doctored or is not what its header claims.
+  assert_single_key "$GP_n_mode" MODE "delta block"
+  if [ "$GP_v_mode" != delta ]; then
+    refuse_no_gate \
+      "The delta block's MODE token is '$GP_v_mode', not 'delta'." \
+      "A --delta run stamps 'MODE: delta (TEST/DOCS-ONLY RE-CERTIFICATION …)'; anything" \
+      "else is a different mode wearing the delta header."
+  fi
 
-assert_single_key "$n_ti" tree-integrity
-if [ "$v_ti" != PASS ]; then
-  refuse_no_gate \
-    "tree-integrity verdict token is '$v_ti', not PASS." \
-    "A run whose worktree mutated mid-run cannot certify (#2926); PENDING means the" \
-    "run never reached its terminal emit, and SKIP means the check never ran."
-fi
+  assert_pass_block "delta block"
 
-# The sha comparison. `commit:` carries a 7-char abbreviation and `tree-start:` a
-# 12-char one (both `printf '%.Ns'` of the same VERIFIED capture in
-# scripts/agent-gate.sh), so "matches the certified sha" cannot be string
-# equality against the 40-hex certified sha. Compare each value at ITS OWN exact
-# width, using the value's own length — never a glob, never `case $x in $y*)`,
-# never a fixed assumed width. BOTH must match: two independent widths off one
-# verified capture is materially stronger than one 7-hex compare — and this pair
-# is what refuses the #3616 cross-lane class (a peer lane's perfectly valid
-# summary, recovered by recency, naming a DIFFERENT PR's head). A non-hex value
-# ("(not captured)", "(capture unavailable — no git worktree)", "selftest",
-# "unverified") REFUSES — it is never skipped.
-assert_sha_prefix() {
-  # $1 = label, $2 = value from the summary
-  local label="$1" val="$2" n
-  case "$val" in
+  # delta-anchor: must name the FULL block above. The gate emits
+  # 'delta-anchor: <40-hex> (full-gate PASS commit)' from `git rev-parse
+  # --verify`, and 'delta-anchor: <ref> (UNRESOLVED)' on the ERROR path — the
+  # latter MUST refuse (it certifies nothing about any tree).
+  assert_single_key "$GP_n_anchor" delta-anchor "delta block"
+  if [ "$GP_anchor_unresolved" -ne 0 ]; then
+    refuse_no_gate \
+      "The delta block's 'delta-anchor:' is (UNRESOLVED) — the anchor did not resolve" \
+      "to a commit, so that run re-certified nothing against the gate of record."
+  fi
+  case "$GP_v_anchor" in
     ''|*[!0-9a-f]*)
       refuse_no_gate \
-        "'$label:' value '$val' is not lowercase hex — nothing verifiable was recorded." \
-        "The gate writes a non-hex placeholder when its capture failed or there was no" \
-        "git worktree; such a run proves nothing about which tree it executed against."
+        "The delta block's 'delta-anchor:' value '$GP_v_anchor' is not lowercase hex."
       ;;
   esac
-  n=${#val}
-  if [ "$n" -lt 4 ] || [ "$n" -gt 40 ]; then
-    refuse_no_gate "'$label:' value '$val' is $n hex chars — outside the 4..40 range."
-  fi
-  if [ "${certified:0:n}" != "$val" ]; then
+  if [ "${#GP_v_anchor}" -ne 40 ]; then
     refuse_no_gate \
-      "'$label:' value '$val' does not match the certified sha at $n chars." \
-      "certified: $certified" \
-      "The gate of record ran against a DIFFERENT tree than the one being merged."
+      "The delta block's 'delta-anchor:' value '$GP_v_anchor' is ${#GP_v_anchor} hex chars," \
+      "not the full 40 the gate resolves it to (git rev-parse --verify of the anchor)."
   fi
-}
+  delta_anchor="$GP_v_anchor"
+  # Both of the anchor block's independent widths must prefix that anchor sha.
+  assert_covers commit "$full_commit" "$delta_anchor" "full-gate block" "delta block's anchor sha"
+  assert_covers tree-start "$full_ts" "$delta_anchor" "full-gate block" "delta block's anchor sha"
 
-assert_single_key "$n_commit" commit
-assert_sha_prefix commit "$v_commit"
-assert_single_key "$n_ts" tree-start
-assert_sha_prefix tree-start "$v_ts"
+  # ...and the delta run's OWN provenance must cover the tree being merged.
+  assert_single_key "$GP_n_commit" commit "delta block"
+  assert_single_key "$GP_n_ts" tree-start "delta block"
+  assert_covers commit "$GP_v_commit" "$certified" "delta block" "certified sha"
+  assert_covers tree-start "$GP_v_ts" "$certified" "delta block" "certified sha"
+  delta_commit="$GP_v_commit"
+  delta_ts="$GP_v_ts"
+  delta_dirty="$GP_v_dirty"
+  [ -n "$delta_dirty" ] || delta_dirty=unknown
+fi
 
 # `dirty:` is REPORTED, not enforced — DELIBERATELY. Failing on `dirty: yes` is
-# not in the owner's ruling on #3465 and is not absorbed into this change; a
-# follow-up issue will propose it. This is a decision, not an oversight: print it
-# so a dirty gate of record is VISIBLE at the merge point.
-[ -n "$v_dirty" ] || v_dirty=unknown
+# not in the owner's ruling on #3465 and is not absorbed into this change; it is
+# proposed separately in #3648. This is a decision, not an oversight: print it so
+# a dirty gate of record is VISIBLE at the merge point.
+[ -n "$full_dirty" ] || full_dirty=unknown
 
 # ---------------------------------------------------------------------------
 # PR HEAD + STATE (#2456)
@@ -418,6 +669,16 @@ if [ "$actual" != "$certified" ]; then
 fi
 
 printf 'PREMERGE: OK %s\n' "$certified"
+# Scope clause (#3650) — printed on EVERY success so `GATE-OF-RECORD` can never be
+# read as "certified against main". See residual 3 in the header.
+printf 'PREMERGE: SCOPE this proves a full gate PASSed on THIS tree (%s); it does NOT prove\n' \
+  "$certified"
+printf 'PREMERGE: SCOPE the tree was certified against current main (#3650) — a squash-merge\n'
+printf 'PREMERGE: SCOPE composes this diff with main tip, which no gate here has executed.\n'
 printf 'PREMERGE: GATE-OF-RECORD commit: %s tree-start: %s tree-integrity: PASS dirty: %s summary: %s\n' \
-  "$v_commit" "$v_ts" "$v_dirty" "$summary_file"
+  "$full_commit" "$full_ts" "$full_dirty" "$summary_file"
+if [ -n "$delta_file" ]; then
+  printf 'PREMERGE: DELTA-RECERT anchor: %s commit: %s tree-start: %s tree-integrity: PASS dirty: %s summary: %s\n' \
+    "$delta_anchor" "$delta_commit" "$delta_ts" "$delta_dirty" "$delta_file"
+fi
 exit 0

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -131,8 +131,11 @@
 #         (plus "PREMERGE: DELTA-RECERT ..." in Case B)
 #   2   no/invalid gate of record, OR head moved (mismatch), OR PR closed/merged
 #       — LOUD multi-line refusal
-#   3   gh/network failure, a required TOOL failing, or a usage error
-#       — fail closed, never merge on uncertainty
+#   3   gh/network failure, a required TOOL failing, or a usage error — fail
+#       closed, never merge on uncertainty. The three are distinguished by the
+#       printed marker, NOT by the code: `PREMERGE: USAGE` (you called it wrong),
+#       `PREMERGE: TOOL-FAILURE` (a broken box — fix the box, do NOT re-run the
+#       gate), `PREMERGE: GH-FAILURE` (auth/network/no-such-PR).
 #
 # macOS bash 3.2 compatible, shellcheck-clean.
 set -euo pipefail
@@ -140,6 +143,10 @@ set -euo pipefail
 repo="${GH_REPO:-pmcfadin/cqlite}"
 
 usage() {
+  # A distinct grepable marker (#3465 review nit 8): exit 3 covers a USAGE error,
+  # a TOOL failure and a GH failure, and a caller must be able to tell them apart
+  # — "you called me wrong" is not "GitHub is down". The exit CODES are unchanged.
+  printf 'PREMERGE: USAGE — the call is wrong (this is NOT a gh/network failure)\n' >&2
   printf 'usage: %s <pr-number> <certified-sha> <gate-of-record-summary> [<delta-summary>]\n' \
     "$(basename "$0")" >&2
   printf '       <gate-of-record-summary> is REQUIRED: the AGENT_GATE_SUMMARY_FILE of the\n' >&2

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -230,7 +230,7 @@ fi
 # pre-#3465 two-argument invocation must FAIL LOUDLY (usage, exit 3).
 if run 3 "pre-#3465 two-arg invocation -> exit 3 (usage)" 2421 "$CERTIFIED"; then
   case "$OUT" in
-    *"gate-summary-file"*) ok "usage: two-arg call fails closed and names <gate-summary-file>" ;;
+    *"gate-of-record-summary"*) ok "usage: two-arg call fails closed and names <gate-of-record-summary>" ;;
     *) bad "usage: two-arg refusal must name the missing argument (got: $OUT)" ;;
   esac
 fi
@@ -283,14 +283,14 @@ refused "launch sentinel (RESULT: INCOMPLETE) alone -> refuse" "$T/sentinel.txt"
 
 # --- Case 14: RESULT: FAIL -> refuse -----------------------------------------
 full_summary "$T/result-fail.txt" "$C7" "$C12" PASS FAIL
-refused "RESULT: FAIL -> refuse" "$T/result-fail.txt" "RESULT verdict token is 'FAIL'"
+refused "RESULT: FAIL -> refuse" "$T/result-fail.txt" "RESULT verdict token in the full-gate block is 'FAIL'"
 
 # --- Case 15: near-miss RESULT verdict tokens -> refuse (token-exact) --------
 # A `PASS*` prefix test would check a SPELLING rather than a STATE.
 for near in PASSthisNeverRan PASS-MEASUREMENT-DID-NOT-HAPPEN PASSED; do
   full_summary "$T/near-$near.txt" "$C7" "$C12" PASS "$near"
   refused "near-miss RESULT token '$near' -> refuse (token-exact, not a prefix)" \
-    "$T/near-$near.txt" "RESULT verdict token is '$near'"
+    "$T/near-$near.txt" "RESULT verdict token in the full-gate block is '$near'"
 done
 
 # --- Case 16: tree-integrity FAIL / PENDING / SKIP -> refuse -----------------
@@ -298,11 +298,11 @@ done
 # means it never reached the terminal emit; SKIP means the check never ran.
 full_summary "$T/ti-fail.txt" "$C7" "$C12" \
   "FAIL (tree-mutated-midrun; head da9a7cb->ca8eb01; changed: src/lib.rs)" PASS
-refused "tree-integrity: FAIL -> refuse" "$T/ti-fail.txt" "tree-integrity verdict token is 'FAIL'"
+refused "tree-integrity: FAIL -> refuse" "$T/ti-fail.txt" "tree-integrity verdict token in the full-gate block is 'FAIL'"
 full_summary "$T/ti-pending.txt" "$C7" "$C12" PENDING PASS
-refused "tree-integrity: PENDING -> refuse" "$T/ti-pending.txt" "token is 'PENDING'"
+refused "tree-integrity: PENDING -> refuse" "$T/ti-pending.txt" "token in the full-gate block is 'PENDING'"
 full_summary "$T/ti-skip.txt" "$C7" "$C12" "SKIP (no capture)" PASS
-refused "tree-integrity: SKIP -> refuse" "$T/ti-skip.txt" "token is 'SKIP'"
+refused "tree-integrity: SKIP -> refuse" "$T/ti-skip.txt" "token in the full-gate block is 'SKIP'"
 
 # --- Case 17: missing RESULT / tree-integrity lines -> refuse ----------------
 full_summary "$T/no-result.txt" "$C7" "$C12" PASS "-"
@@ -330,23 +330,31 @@ refused "#3616: a valid full-gate PASS naming a PEER LANE's sha -> refuse" \
 # ...and the single-field variants, which is where the two independent widths pay.
 full_summary "$T/commit-mismatch.txt" "ca8eb01" "$C12" PASS PASS
 refused "commit: mismatch (7 hex of a different sha) -> refuse" \
-  "$T/commit-mismatch.txt" "'commit:' value 'ca8eb01' does not match"
+  "$T/commit-mismatch.txt" "'commit:' value 'ca8eb01' in the full-gate block does not match the certified sha at 7 chars"
 full_summary "$T/tstart-mismatch.txt" "$C7" "ca8eb016def1" PASS PASS
 refused "tree-start: mismatch (12 hex of a different sha) -> refuse" \
-  "$T/tstart-mismatch.txt" "'tree-start:' value 'ca8eb016def1' does not match"
+  "$T/tstart-mismatch.txt" "'tree-start:' value 'ca8eb016def1' in the full-gate block does not match the certified sha at 12 chars"
 # A tree-start that agrees on the FIRST 7 chars but diverges at 8..12 is exactly
 # what the second, wider compare buys over the 7-hex one.
 full_summary "$T/tstart-wide.txt" "$C7" "da9a7cbffff0" PASS PASS
 refused "tree-start: diverges only beyond 7 chars -> refuse (the wider compare pays)" \
-  "$T/tstart-wide.txt" "'tree-start:' value 'da9a7cbffff0' does not match"
-# ...and one that matches at 7 but is TRUNCATED there still has to match at its
-# own width, which it does — proving the compare uses the VALUE's length, not a
-# fixed assumed width.
-full_summary "$T/tstart-short.txt" "$C7" "da9a" PASS PASS
-if run 0 "4-hex tree-start that prefixes the certified sha -> accepted at ITS width" \
+  "$T/tstart-wide.txt" "'tree-start:' value 'da9a7cbffff0' in the full-gate block does not match"
+# ...and one that is NARROWER than the 12 the gate emits still has to match at
+# its OWN width, which it does — proving the compare uses the VALUE's length, not
+# a fixed assumed width. 8 hex, not 4: 4 would be BELOW the floor (next case), and
+# pinning the loosest accepted width would make that leniency a requirement.
+full_summary "$T/tstart-short.txt" "$C7" "da9a7cb2" PASS PASS
+if run 0 "8-hex tree-start that prefixes the certified sha -> accepted at ITS width" \
   2421 "$CERTIFIED" "$T/tstart-short.txt"; then
-  ok "width: the compare uses the VALUE's own length (4 hex accepted, not padded/globbed)"
+  ok "width: the compare uses the VALUE's own length (8 hex accepted, not padded/globbed)"
 fi
+# The FLOOR is 7 — the narrowest abbreviation the gate ever emits (commit: is
+# printf '%.7s'). A 4-hex value that DOES prefix the certified sha is refused
+# anyway: accepted at its own width it would be a 1-in-65536 accidental
+# cross-lane match, i.e. the #3616 class this compare exists to refuse.
+full_summary "$T/tstart-4hex.txt" "$C7" "da9a" PASS PASS
+refused "4-hex tree-start (below the 7 floor) -> refuse even though it prefixes" \
+  "$T/tstart-4hex.txt" "is 4 hex chars — outside the 7..40 range"
 
 # --- Case 19: non-hex commit:/tree-start: -> refuse, never skipped -----------
 # The gate writes these placeholders when its capture failed or there was no git

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -409,9 +409,12 @@ refused "MODE: line inside a FULL-header block -> refuse" \
   "$T/full-with-mode.txt" "carries a MODE: line"
 
 # --- Case 23: prose QUOTING the markers is not a block ----------------------
-# CLAUDE.md, issue threads and PR bodies quote these markers inline; and
-# "==== END AGENT-GATE SUMMARY ====" CONTAINS the start marker as a substring, so
-# a substring match would count every terminator as a new block.
+# Whole-line-exact anchoring defends against PROSE copies of a marker —
+# indented, `>`-quoted, fenced or mid-sentence — which CLAUDE.md, issue bodies,
+# PR comments and the doctrine files this change edits all contain, and against
+# a TRUNCATED pattern such as `AGENT-GATE SUMMARY ====`, which matches all four
+# markers (full/lite start and end). Note the end marker does NOT contain the
+# start marker as a substring: `END ` sits between `====` and `AGENT-GATE`.
 {
   printf 'The gate emits a "%s" block whose RESULT: PASS is the verdict.\n' "$FULL_S"
   printf 'Its terminator is %s and it is not a block opener.\n' "$FULL_E"
@@ -435,9 +438,12 @@ if run 0 "prose quoting the markers + ONE real block -> exit 0" \
 fi
 
 # --- Case 24: ANSI-coloured summary still parses (#3400) --------------------
-# Colour SURVIVES redirection to a file, and the gate's own mandated capture is
-# coloured (18 workflows set CARGO_TERM_COLOR=always). A parser keyed on
-# uncoloured text would refuse a perfectly good gate of record.
+# BELT, stated precisely: the summary FILE's block lines are `echo`s of computed
+# strings (scripts/agent-gate.sh emit_summary), so they are NOT coloured —
+# CARGO_TERM_COLOR colours cargo output inside gate.log, not the block. What the
+# strip covers is a block RECOVERED FROM A COLOURED CAPTURE rather than from the
+# summary file, and colour does survive redirection (#3400). Non-vacuous either
+# way: without the strip this fixture refuses a perfectly good gate of record.
 ESC=$(printf '\033')
 sed -e "s/RESULT: PASS/${ESC}[32mRESULT${ESC}[0m: ${ESC}[1;32mPASS${ESC}[0m/" \
     -e "s/tree-integrity: PASS/tree-integrity: ${ESC}[32mPASS${ESC}[0m/" \

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -310,8 +310,24 @@ refused "no RESULT: line -> refuse" "$T/no-result.txt" "no 'RESULT:' line"
 full_summary "$T/no-ti.txt" "$C7" "$C12" "-" PASS
 refused "no tree-integrity: line -> refuse" "$T/no-ti.txt" "no 'tree-integrity:' line"
 
-# --- Case 18: commit: / tree-start: mismatch -> refuse ----------------------
-# Each is compared at ITS OWN width (7 and 12), against a DIFFERENT sha here.
+# --- Case 18: commit: / tree-start: mismatch -> refuse (the #3616 class) -----
+# This is the OTHER motivating escape, distinct from #3408's "no gate at all":
+# #3616 = "a real gate, someone else's". A closer located its run dir by RECENCY
+# (`ls -t /tmp/agent-gate.*`), read a PEER LANE's dir, saw 33/37 components PASS
+# and was about to merge #3616 on PR #3580's verdict — the count, the dir and the
+# timestamps were all real, and only the `run-id:` line (read by a human) exposed
+# it. premerge-assert cannot verify `run-id:` (it did not launch the gate), so the
+# sha binding is what makes a cross-lane verdict a mechanical refusal.
+# Each abbreviation is compared at ITS OWN width (7 and 12), against a DIFFERENT
+# sha here.
+#
+# First the composite #3616 shape: a fully well-formed FULL block, RESULT: PASS,
+# tree-integrity: PASS, everything a genuine gate of record has — except that its
+# provenance names a peer PR's head throughout.
+full_summary "$T/peer-lane.txt" "ca8eb01" "ca8eb016def1" PASS PASS
+refused "#3616: a valid full-gate PASS naming a PEER LANE's sha -> refuse" \
+  "$T/peer-lane.txt" "does not match the certified sha"
+# ...and the single-field variants, which is where the two independent widths pay.
 full_summary "$T/commit-mismatch.txt" "ca8eb01" "$C12" PASS PASS
 refused "commit: mismatch (7 hex of a different sha) -> refuse" \
   "$T/commit-mismatch.txt" "'commit:' value 'ca8eb01' does not match"

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -866,6 +866,30 @@ if run 0 "success path prints SCOPE in the anchored-delta case too" \
   esac
 fi
 
+# --- Case 40: the three exit-3 causes are DISTINGUISHABLE (nit 8) ------------
+# Exit 3 covers a usage error, a tool failure and a gh failure. The CODES are
+# unchanged (documented), so the caller tells them apart by the MARKER — a
+# forgotten third argument must never be escalated upward as a GitHub outage.
+if run 3 "usage error prints PREMERGE: USAGE" 2421 "$CERTIFIED"; then
+  case "$OUT" in
+    *"PREMERGE: USAGE"*) ok "exit 3: a usage error carries the PREMERGE: USAGE marker" ;;
+    *) bad "exit 3: usage error must carry PREMERGE: USAGE (got: $OUT)" ;;
+  esac
+  case "$OUT" in
+    *"GH-FAILURE"*|*"TOOL-FAILURE"*)
+      bad "exit 3: a usage error must not read as a gh/tool failure (got: $OUT)" ;;
+    *) ok "exit 3: a usage error is NOT reported as a gh failure" ;;
+  esac
+fi
+export MOCK_GH_FAIL=1
+if run 3 "gh failure prints PREMERGE: GH-FAILURE only" 2421 "$CERTIFIED" "$GOOD"; then
+  case "$OUT" in
+    *"PREMERGE: USAGE"*) bad "exit 3: a gh failure must not read as a usage error (got: $OUT)" ;;
+    *) ok "exit 3: a gh failure is NOT reported as a usage error" ;;
+  esac
+fi
+export MOCK_GH_FAIL=0
+
 # --- summary -----------------------------------------------------------------
 printf '\n=== premerge-assert: %d passed, %d failed ===\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
 #
-# Regression tests for scripts/flow/premerge-assert.sh (issue #2668).
+# Regression tests for scripts/flow/premerge-assert.sh (issues #2668, #3465).
 #
 # Fast + hermetic: `gh` is shimmed by a PATH-prepended mock that emits the
 # two-token line the script's `--jq '.headRefOid + " " + .state'` expression
 # would produce (or a failure), driven by env vars — no network, no GitHub.
+#
+# #3465 adds the gate-of-record half: the assert now takes a THIRD, REQUIRED
+# argument naming the FULL gate's summary file, and refuses to merge without a
+# `==== AGENT-GATE SUMMARY ====` block carrying RESULT: PASS, tree-integrity:
+# PASS, and provenance matching the certified sha. Those cases refuse BEFORE the
+# `gh` call, so most of them do not need the mock at all — but they run with it on
+# PATH anyway, so a case that wrongly reaches `gh` cannot pass by accident.
 #
 # Run standalone:   bash scripts/tests/test_premerge_assert.sh
 set -uo pipefail
@@ -57,19 +64,108 @@ run() {
 CERTIFIED="da9a7cb2abc00000000000000000000000000000"   # full 40-char hex
 STALE="ca8eb016def11111111111111111111111111111"       # full 40-char hex
 
-# --- Case 1: match -> exit 0 --------------------------------------------------
+# The two abbreviations the gate ACTUALLY writes for $CERTIFIED: `commit:` is
+# `printf '%.7s'` and `tree-start:` is `_tree_short` = `printf '%.12s'`, both of
+# the same verified capture (scripts/agent-gate.sh). Two independent widths.
+C7="da9a7cb"
+C12="da9a7cb2abc0"
+
+# --- summary fixture builders -------------------------------------------------
+# emit_summary_block <start-marker> <end-marker> <mode-line|-> <commit-val|-> \
+#                    <tree-start-val|-> <tree-integrity-val|-> <result-val|->
+# A "-" omits that line entirely. Line SHAPES are copied from a real full-gate
+# summary (/tmp/cqlite-gates/**/full-gate.txt), trailing fields included, so the
+# parser is exercised against the grammar the gate emits and not a simplification.
+emit_summary_block() {
+  local start="$1" end="$2" mode="$3" commit="$4" tstart="$5" ti="$6" result="$7"
+  printf '%s\n' "$start"
+  printf 'run-id: /tmp/agent-gate.9cIQgX\n'
+  [ "$mode" = "-" ] || printf '%s\n' "$mode"
+  [ "$commit" = "-" ] || printf 'commit: %s branch: issue-3465-require-gate-of-record dirty: no\n' "$commit"
+  printf 'datasets: 144 Data.db files under /data/datasets\n'
+  printf 'accelerators: sccache=on nextest=on lanes=on mold=absent perf=paranoid-4\n'
+  [ "$tstart" = "-" ] || printf 'tree-start: %s dirty: no digest: 671a6275687c\n' "$tstart"
+  printf 'tree-end: %s dirty: no digest: 671a6275687c\n' "$tstart"
+  [ "$ti" = "-" ] || printf 'tree-integrity: %s\n' "$ti"
+  printf 'file-size:         PASS (0s)\n'
+  printf 'smoke:             PASS (193s)\n'
+  printf 'logs: /tmp/agent-gate.9cIQgX\n'
+  [ "$result" = "-" ] || printf 'RESULT: %s\n' "$result"
+  printf '%s\n' "$end"
+}
+
+FULL_S="==== AGENT-GATE SUMMARY ===="
+FULL_E="==== END AGENT-GATE SUMMARY ===="
+LITE_S="==== AGENT-GATE LITE SUMMARY ===="
+LITE_E="==== END AGENT-GATE LITE SUMMARY ===="
+DELTA_S="==== AGENT-GATE DELTA SUMMARY ===="
+DELTA_E="==== END AGENT-GATE DELTA SUMMARY ===="
+
+# full_block [commit] [tree-start] [tree-integrity] [result] -> STDOUT.
+# Separate from full_summary because composing two blocks into one file cannot go
+# through a `>"$f"` helper: `full_summary /dev/stdout` inside a `{ } > file` group
+# TRUNCATES the file, which silently produced a ONE-block fixture for a
+# two-block case (found while writing these tests — the case passed vacuously).
+full_block() {
+  emit_summary_block "$FULL_S" "$FULL_E" "-" \
+    "${1:-$C7}" "${2:-$C12}" "${3:-PASS}" "${4:-PASS}"
+}
+
+# full_summary <file> [commit] [tree-start] [tree-integrity] [result]
+full_summary() {
+  local f="$1"
+  shift
+  full_block "$@" >"$f"
+}
+
+GOOD="$T/full-pass.txt"
+full_summary "$GOOD"
+
+# refused <description> <summary-file> [needle] — every gate-of-record refusal is
+# exit 2 with the NO-GATE-OF-RECORD verdict; an optional needle pins the cause so
+# a case cannot pass by refusing for the WRONG reason.
+refused() {
+  local desc="$1" f="$2" needle="${3:-}"
+  if run 2 "$desc" 2421 "$CERTIFIED" "$f"; then
+    case "$OUT" in
+      *"PREMERGE: NO-GATE-OF-RECORD"*) ;;
+      *) bad "$desc: missing NO-GATE-OF-RECORD verdict (got: $OUT)"; return 1 ;;
+    esac
+    if [ -n "$needle" ] && [ "${OUT#*"$needle"}" = "$OUT" ]; then
+      bad "$desc: refusal does not name the cause '$needle' (got: $OUT)"
+      return 1
+    fi
+    ok "$desc"
+  fi
+}
+
 export MOCK_GH_FAIL=0
 export MOCK_GH_OUT="$CERTIFIED OPEN"
-if run 0 "match: OPEN + head==certified -> exit 0" 2421 "$CERTIFIED"; then
+
+# =============================================================================
+# Pre-#3465 behaviour, now carrying the third argument
+# =============================================================================
+
+# --- Case 1: match -> exit 0 --------------------------------------------------
+if run 0 "match: OPEN + head==certified + gate of record -> exit 0" 2421 "$CERTIFIED" "$GOOD"; then
   case "$OUT" in
     *"PREMERGE: OK $CERTIFIED"*) ok "match: prints PREMERGE: OK <sha>" ;;
     *) bad "match: missing 'PREMERGE: OK <sha>' (got: $OUT)" ;;
+  esac
+  case "$OUT" in
+    *"PREMERGE: GATE-OF-RECORD commit: $C7 tree-start: $C12 tree-integrity: PASS dirty: no"*)
+      ok "match: prints the GATE-OF-RECORD evidence line (commit/tree-start/integrity/dirty)" ;;
+    *) bad "match: missing GATE-OF-RECORD evidence line (got: $OUT)" ;;
+  esac
+  case "$OUT" in
+    *"summary: $GOOD"*) ok "match: evidence line names the summary file" ;;
+    *) bad "match: evidence line must name the summary file (got: $OUT)" ;;
   esac
 fi
 
 # --- Case 2: mismatch -> exit 2, message names BOTH SHAs -----------------------
 export MOCK_GH_OUT="$STALE OPEN"
-if run 2 "mismatch: head moved -> exit 2" 2421 "$CERTIFIED"; then
+if run 2 "mismatch: head moved -> exit 2" 2421 "$CERTIFIED" "$GOOD"; then
   if [ "${OUT#*"$CERTIFIED"}" != "$OUT" ] && [ "${OUT#*"$STALE"}" != "$OUT" ]; then
     ok "mismatch: message contains BOTH SHAs"
   else
@@ -83,7 +179,7 @@ fi
 
 # --- Case 3: merged/closed PR -> exit 2 ---------------------------------------
 export MOCK_GH_OUT="$CERTIFIED MERGED"
-if run 2 "merged PR -> exit 2" 2421 "$CERTIFIED"; then
+if run 2 "merged PR -> exit 2" 2421 "$CERTIFIED" "$GOOD"; then
   case "$OUT" in
     *"NOT-OPEN"*|*"closed or merged"*) ok "merged: distinct not-open refusal message" ;;
     *) bad "merged: missing not-open message (got: $OUT)" ;;
@@ -93,13 +189,14 @@ fi
 # --- Case 4: gh/network failure -> exit 3 (fail closed) -----------------------
 export MOCK_GH_FAIL=1
 export MOCK_GH_OUT=""
-if run 3 "gh failure -> exit 3 (fail closed)" 2421 "$CERTIFIED"; then
+if run 3 "gh failure -> exit 3 (fail closed)" 2421 "$CERTIFIED" "$GOOD"; then
   case "$OUT" in
     *"GH-FAILURE"*) ok "gh-failure: distinct fail-closed message" ;;
     *) bad "gh-failure: missing GH-FAILURE message (got: $OUT)" ;;
   esac
 fi
 export MOCK_GH_FAIL=0
+export MOCK_GH_OUT="$CERTIFIED OPEN"
 
 # --- Case 5: usage guard -> exit 3 --------------------------------------------
 if run 3 "missing args -> exit 3" 2421; then
@@ -108,22 +205,283 @@ fi
 
 # --- Case 6: malformed --jq output (missing state token) -> exit 3 ------------
 export MOCK_GH_OUT="$CERTIFIED"   # only one token, no state
-if run 3 "malformed --jq output -> exit 3" 2421 "$CERTIFIED"; then
+if run 3 "malformed --jq output -> exit 3" 2421 "$CERTIFIED" "$GOOD"; then
   ok "malformed: fails closed (exit 3)"
 fi
+export MOCK_GH_OUT="$CERTIFIED OPEN"
 
 # --- Case 7: certified SHA passed UPPERCASE -> still matches (normalization) --
-export MOCK_GH_OUT="$CERTIFIED OPEN"   # mock head is lowercase
 CERT_UPPER=$(printf '%s' "$CERTIFIED" | tr '[:lower:]' '[:upper:]')
-if run 0 "uppercase certified SHA -> normalized match -> exit 0" 2421 "$CERT_UPPER"; then
-  ok "normalization: uppercase certified SHA still matches lowercase head"
+if run 0 "uppercase certified SHA -> normalized match -> exit 0" 2421 "$CERT_UPPER" "$GOOD"; then
+  ok "normalization: uppercase certified SHA still matches lowercase head + summary"
 fi
 
 # --- Case 8: certified SHA wrong length -> exit 3 -----------------------------
-export MOCK_GH_OUT="$CERTIFIED OPEN"
-if run 3 "short certified SHA -> exit 3" 2421 "da9a7cb2"; then
+if run 3 "short certified SHA -> exit 3" 2421 "da9a7cb2" "$GOOD"; then
   ok "validation: abbreviated (non-40-char) SHA fails closed (exit 3)"
 fi
+
+# =============================================================================
+# #3465 — the gate of record is REQUIRED
+# =============================================================================
+
+# --- Case 9: the third argument is REQUIRED, not optional ---------------------
+# An OPTIONAL argument would leave the honour system exactly where it is, so the
+# pre-#3465 two-argument invocation must FAIL LOUDLY (usage, exit 3).
+if run 3 "pre-#3465 two-arg invocation -> exit 3 (usage)" 2421 "$CERTIFIED"; then
+  case "$OUT" in
+    *"gate-summary-file"*) ok "usage: two-arg call fails closed and names <gate-summary-file>" ;;
+    *) bad "usage: two-arg refusal must name the missing argument (got: $OUT)" ;;
+  esac
+fi
+if run 3 "empty third argument -> exit 3 (usage)" 2421 "$CERTIFIED" ""; then
+  ok "usage: an EMPTY summary path is a usage failure, not an absent-file refusal"
+fi
+
+# --- Case 10: summary file absent / empty -------------------------------------
+refused "summary file absent -> refuse" "$T/does-not-exist.txt" "does not exist"
+: >"$T/empty.txt"
+refused "summary file EMPTY -> refuse" "$T/empty.txt" "EMPTY"
+
+# --- Case 11: LITE-only summary -> refuse (this is literally the #3465 case) --
+# PR #3408 merged on 22 lite PASSes and no full gate. --lite emits DISTINCT
+# markers plus a MODE line, so a lite summary carries ZERO full-gate blocks.
+emit_summary_block "$LITE_S" "$LITE_E" \
+  "MODE: lite (FAST ITERATION — NOT the gate of record; full agent-gate.sh must PASS once before merge)" \
+  "$C7" "$C12" PASS PASS >"$T/lite-only.txt"
+refused "LITE-only summary (the #3408 case) -> refuse" "$T/lite-only.txt" "ZERO full-gate blocks"
+if [ "${OUT#*"found 1 lite"}" != "$OUT" ]; then
+  ok "lite-only: refusal NAMES the lite block it found (actionable diagnostic)"
+else
+  bad "lite-only: refusal should name the lite block it found (got: $OUT)"
+fi
+
+# --- Case 12: DELTA-only summary -> refuse ------------------------------------
+emit_summary_block "$DELTA_S" "$DELTA_E" \
+  "MODE: delta (TEST/DOCS-ONLY RE-CERTIFICATION — NOT the gate of record; gate of record = the full agent-gate.sh PASS at anchor abc1234)" \
+  "$C7" "$C12" PASS PASS >"$T/delta-only.txt"
+refused "DELTA-only summary -> refuse" "$T/delta-only.txt" "ZERO full-gate blocks"
+if [ "${OUT#*"0 lite, 1 delta"}" != "$OUT" ]; then
+  ok "delta-only: refusal NAMES the delta block it found"
+else
+  bad "delta-only: refusal should name the delta block it found (got: $OUT)"
+fi
+
+# --- Case 13: the #3041 launch SENTINEL alone -> refuse -----------------------
+# The gate writes this at LAUNCH (before the #1825 slot is even granted): a
+# FULL-header block with run-id + tree-start + `RESULT: INCOMPLETE (gate did not
+# finish)` and NO tree-integrity/commit. It is a liveness placeholder, NOT a
+# verdict — accepting it would certify a still-queued or dead gate.
+{
+  printf '%s\n' "$FULL_S"
+  printf 'run-id: /tmp/agent-gate.9cIQgX\n'
+  printf 'tree-start: %s dirty: no digest: 671a6275687c\n' "$C12"
+  printf 'RESULT: INCOMPLETE (gate did not finish)\n'
+  printf '%s\n' "$FULL_E"
+} >"$T/sentinel.txt"
+refused "launch sentinel (RESULT: INCOMPLETE) alone -> refuse" "$T/sentinel.txt" "INCOMPLETE"
+
+# --- Case 14: RESULT: FAIL -> refuse -----------------------------------------
+full_summary "$T/result-fail.txt" "$C7" "$C12" PASS FAIL
+refused "RESULT: FAIL -> refuse" "$T/result-fail.txt" "RESULT verdict token is 'FAIL'"
+
+# --- Case 15: near-miss RESULT verdict tokens -> refuse (token-exact) --------
+# A `PASS*` prefix test would check a SPELLING rather than a STATE.
+for near in PASSthisNeverRan PASS-MEASUREMENT-DID-NOT-HAPPEN PASSED; do
+  full_summary "$T/near-$near.txt" "$C7" "$C12" PASS "$near"
+  refused "near-miss RESULT token '$near' -> refuse (token-exact, not a prefix)" \
+    "$T/near-$near.txt" "RESULT verdict token is '$near'"
+done
+
+# --- Case 16: tree-integrity FAIL / PENDING / SKIP -> refuse -----------------
+# A run whose worktree mutated mid-run is not a certification (#2926); PENDING
+# means it never reached the terminal emit; SKIP means the check never ran.
+full_summary "$T/ti-fail.txt" "$C7" "$C12" \
+  "FAIL (tree-mutated-midrun; head da9a7cb->ca8eb01; changed: src/lib.rs)" PASS
+refused "tree-integrity: FAIL -> refuse" "$T/ti-fail.txt" "tree-integrity verdict token is 'FAIL'"
+full_summary "$T/ti-pending.txt" "$C7" "$C12" PENDING PASS
+refused "tree-integrity: PENDING -> refuse" "$T/ti-pending.txt" "token is 'PENDING'"
+full_summary "$T/ti-skip.txt" "$C7" "$C12" "SKIP (no capture)" PASS
+refused "tree-integrity: SKIP -> refuse" "$T/ti-skip.txt" "token is 'SKIP'"
+
+# --- Case 17: missing RESULT / tree-integrity lines -> refuse ----------------
+full_summary "$T/no-result.txt" "$C7" "$C12" PASS "-"
+refused "no RESULT: line -> refuse" "$T/no-result.txt" "no 'RESULT:' line"
+full_summary "$T/no-ti.txt" "$C7" "$C12" "-" PASS
+refused "no tree-integrity: line -> refuse" "$T/no-ti.txt" "no 'tree-integrity:' line"
+
+# --- Case 18: commit: / tree-start: mismatch -> refuse ----------------------
+# Each is compared at ITS OWN width (7 and 12), against a DIFFERENT sha here.
+full_summary "$T/commit-mismatch.txt" "ca8eb01" "$C12" PASS PASS
+refused "commit: mismatch (7 hex of a different sha) -> refuse" \
+  "$T/commit-mismatch.txt" "'commit:' value 'ca8eb01' does not match"
+full_summary "$T/tstart-mismatch.txt" "$C7" "ca8eb016def1" PASS PASS
+refused "tree-start: mismatch (12 hex of a different sha) -> refuse" \
+  "$T/tstart-mismatch.txt" "'tree-start:' value 'ca8eb016def1' does not match"
+# A tree-start that agrees on the FIRST 7 chars but diverges at 8..12 is exactly
+# what the second, wider compare buys over the 7-hex one.
+full_summary "$T/tstart-wide.txt" "$C7" "da9a7cbffff0" PASS PASS
+refused "tree-start: diverges only beyond 7 chars -> refuse (the wider compare pays)" \
+  "$T/tstart-wide.txt" "'tree-start:' value 'da9a7cbffff0' does not match"
+# ...and one that matches at 7 but is TRUNCATED there still has to match at its
+# own width, which it does — proving the compare uses the VALUE's length, not a
+# fixed assumed width.
+full_summary "$T/tstart-short.txt" "$C7" "da9a" PASS PASS
+if run 0 "4-hex tree-start that prefixes the certified sha -> accepted at ITS width" \
+  2421 "$CERTIFIED" "$T/tstart-short.txt"; then
+  ok "width: the compare uses the VALUE's own length (4 hex accepted, not padded/globbed)"
+fi
+
+# --- Case 19: non-hex commit:/tree-start: -> refuse, never skipped -----------
+# The gate writes these placeholders when its capture failed or there was no git
+# worktree. "Nothing was recorded" must REFUSE, not be waved through.
+full_summary "$T/commit-unverified.txt" "unverified" "$C12" PASS PASS
+refused "commit: unverified (capture failed) -> refuse" \
+  "$T/commit-unverified.txt" "is not lowercase hex"
+full_summary "$T/tstart-selftest.txt" "$C7" "selftest" PASS PASS
+refused "tree-start: selftest -> refuse" "$T/tstart-selftest.txt" "is not lowercase hex"
+# `tree-start: (not captured)` — the awk token is the literal "(not".
+full_summary "$T/tstart-notcap.txt" "$C7" "(not" PASS PASS
+refused "tree-start: (not captured) -> refuse" "$T/tstart-notcap.txt" "is not lowercase hex"
+# An UPPERCASE hex abbreviation is not something git emits; refuse rather than
+# silently normalize a value whose provenance we cannot explain.
+full_summary "$T/commit-upper.txt" "DA9A7CB" "$C12" PASS PASS
+refused "commit: UPPERCASE hex -> refuse" "$T/commit-upper.txt" "is not lowercase hex"
+# Missing lines entirely.
+full_summary "$T/no-commit.txt" "-" "$C12" PASS PASS
+refused "no commit: line -> refuse" "$T/no-commit.txt" "no 'commit:' line"
+full_summary "$T/no-tstart.txt" "$C7" "-" PASS PASS
+refused "no tree-start: line -> refuse" "$T/no-tstart.txt" "no 'tree-start:' line"
+
+# --- Case 20: TWO full-gate blocks -> refuse (ambiguous, never "take the last") --
+{ full_block "$C7" "$C12" PASS FAIL
+  full_block "$C7" "$C12" PASS PASS
+} >"$T/two-blocks.txt"
+if [ "$(grep -c -x -F "$FULL_S" "$T/two-blocks.txt")" -eq 2 ]; then
+  ok "two-blocks fixture: the file really does hold TWO full-gate start markers"
+else
+  bad "two-blocks fixture: expected 2 start markers in the fixture"
+fi
+refused "two full-gate blocks -> refuse as AMBIGUOUS" "$T/two-blocks.txt" "2 full-gate blocks"
+if [ "${OUT#*"take the last block"}" != "$OUT" ]; then
+  ok "two-blocks: refusal explains why 'take the last one' is unsafe"
+else
+  bad "two-blocks: expected the rationale for refusing rather than picking (got: $OUT)"
+fi
+
+# --- Case 21: an UNTERMINATED full block -> refuse ---------------------------
+# A killed/truncated gate leaves a start marker with no exact end marker.
+full_summary "$T/unterminated.txt"
+grep -v -x -F "$FULL_E" "$T/unterminated.txt" >"$T/unterminated2.txt"
+refused "unterminated full block (truncated file) -> refuse" \
+  "$T/unterminated2.txt" "UNTERMINATED"
+
+# --- Case 22: a MODE: line inside a FULL-header block -> refuse --------------
+# Belt for the header separation: the FULL gate emits NO MODE: line.
+emit_summary_block "$FULL_S" "$FULL_E" \
+  "MODE: lite (FAST ITERATION — NOT the gate of record)" \
+  "$C7" "$C12" PASS PASS >"$T/full-with-mode.txt"
+refused "MODE: line inside a FULL-header block -> refuse" \
+  "$T/full-with-mode.txt" "carries a MODE: line"
+
+# --- Case 23: prose QUOTING the markers is not a block ----------------------
+# CLAUDE.md, issue threads and PR bodies quote these markers inline; and
+# "==== END AGENT-GATE SUMMARY ====" CONTAINS the start marker as a substring, so
+# a substring match would count every terminator as a new block.
+{
+  printf 'The gate emits a "%s" block whose RESULT: PASS is the verdict.\n' "$FULL_S"
+  printf 'Its terminator is %s and it is not a block opener.\n' "$FULL_E"
+  printf '  %s\n' "$FULL_S"      # indented -> not whole-line-exact
+  printf 'RESULT: PASS\n'
+  printf 'tree-integrity: PASS\n'
+} >"$T/prose-only.txt"
+refused "prose quoting the markers -> counted as ZERO blocks" \
+  "$T/prose-only.txt" "ZERO full-gate blocks"
+
+# A real block AFTER prose that quotes the markers still parses as exactly one.
+{ cat "$T/prose-only.txt"; full_block; } >"$T/prose-then-block.txt"
+if [ "$(grep -c -x -F "$FULL_S" "$T/prose-then-block.txt")" -eq 1 ]; then
+  ok "prose+block fixture: exactly one whole-line-exact start marker, plus quoted ones"
+else
+  bad "prose+block fixture: expected exactly 1 whole-line-exact start marker"
+fi
+if run 0 "prose quoting the markers + ONE real block -> exit 0" \
+  2421 "$CERTIFIED" "$T/prose-then-block.txt"; then
+  ok "anchoring: quoted/indented markers are inert; the one real block certifies"
+fi
+
+# --- Case 24: ANSI-coloured summary still parses (#3400) --------------------
+# Colour SURVIVES redirection to a file, and the gate's own mandated capture is
+# coloured (18 workflows set CARGO_TERM_COLOR=always). A parser keyed on
+# uncoloured text would refuse a perfectly good gate of record.
+ESC=$(printf '\033')
+sed -e "s/RESULT: PASS/${ESC}[32mRESULT${ESC}[0m: ${ESC}[1;32mPASS${ESC}[0m/" \
+    -e "s/tree-integrity: PASS/tree-integrity: ${ESC}[32mPASS${ESC}[0m/" \
+    -e "s/^${FULL_S}\$/${ESC}[1m${FULL_S}${ESC}[0m/" \
+    "$GOOD" >"$T/coloured.txt"
+if grep -q "$ESC" "$T/coloured.txt"; then
+  ok "colour fixture: the fixture really does contain ANSI escapes"
+else
+  bad "colour fixture: expected ANSI escapes in the fixture"
+fi
+if run 0 "ANSI-coloured full summary -> still parsed -> exit 0" \
+  2421 "$CERTIFIED" "$T/coloured.txt"; then
+  ok "ansi: escapes are stripped before marker/verdict matching (#3400)"
+fi
+
+# --- Case 25: dirty: is REPORTED, not enforced -------------------------------
+# Deliberate: failing on `dirty: yes` is not in the #3465 ruling. It must be
+# VISIBLE at the merge point, but it does not block.
+{
+  printf '%s\n' "$FULL_S"
+  printf 'commit: %s branch: main dirty: yes\n' "$C7"
+  printf 'tree-start: %s dirty: yes digest: 671a6275687c\n' "$C12"
+  printf 'tree-integrity: PASS\n'
+  printf 'RESULT: PASS\n'
+  printf '%s\n' "$FULL_E"
+} >"$T/dirty.txt"
+if run 0 "dirty: yes -> still exit 0 (reported, not enforced)" 2421 "$CERTIFIED" "$T/dirty.txt"; then
+  case "$OUT" in
+    *"dirty: yes"*) ok "dirty: a dirty gate of record is REPORTED in the evidence line" ;;
+    *) bad "dirty: the evidence line must report dirty: yes (got: $OUT)" ;;
+  esac
+fi
+
+# --- Case 26: the mutated-path commit: parenthetical parses ------------------
+# On the #2926 mutation path `commit:` carries a trailing parenthetical; token
+# extraction must be robust to it. (tree-integrity is FAIL there, so this fixture
+# keeps integrity PASS and only exercises the LINE SHAPE.)
+{
+  printf '%s\n' "$FULL_S"
+  printf 'commit: %s branch: main dirty: no (VERIFIED START — the identity this run executed against)\n' "$C7"
+  printf 'tree-start: %s dirty: no digest: 671a6275687c\n' "$C12"
+  printf 'tree-integrity: PASS\n'
+  printf 'RESULT: PASS\n'
+  printf '%s\n' "$FULL_E"
+} >"$T/commit-paren.txt"
+if run 0 "commit: with a trailing parenthetical -> token extracted -> exit 0" \
+  2421 "$CERTIFIED" "$T/commit-paren.txt"; then
+  ok "shape: commit: token extraction survives a trailing parenthetical"
+fi
+
+# --- Case 27: the gate-of-record check runs BEFORE any gh call ---------------
+# It is offline and cheap, and "you have no gate of record" must be reportable
+# without a network round trip. Proven by a gh mock that FAILS: a missing gate of
+# record must still yield the NO-GATE-OF-RECORD refusal (exit 2), not GH-FAILURE.
+export MOCK_GH_FAIL=1
+if run 2 "no gate of record + gh DOWN -> NO-GATE-OF-RECORD (offline check first)" \
+  2421 "$CERTIFIED" "$T/lite-only.txt"; then
+  case "$OUT" in
+    *"NO-GATE-OF-RECORD"*)
+      case "$OUT" in
+        *"GH-FAILURE"*) bad "ordering: reached gh before validating the summary (got: $OUT)" ;;
+        *) ok "ordering: the summary is validated BEFORE any gh call" ;;
+      esac
+      ;;
+    *) bad "ordering: expected NO-GATE-OF-RECORD with gh down (got: $OUT)" ;;
+  esac
+fi
+export MOCK_GH_FAIL=0
 
 # --- summary -----------------------------------------------------------------
 printf '\n=== premerge-assert: %d passed, %d failed ===\n' "$PASS" "$FAIL"

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -507,6 +507,359 @@ if run 2 "no gate of record + gh DOWN -> NO-GATE-OF-RECORD (offline check first)
 fi
 export MOCK_GH_FAIL=0
 
+# =============================================================================
+# #3465 review — the ANCHORED DELTA PAIR (optional 4th argument)
+# =============================================================================
+# CLAUDE.md's #1892 rule MANDATES that a test/docs-only diff on top of a full
+# PASS at anchor X re-certifies with `--delta X` and "never a repeat full gate",
+# and that the PR record BOTH blocks. So the merged head legitimately differs
+# from the gate of record's sha, and a 3-arg-only guard red on correct,
+# doctrine-mandated input.
+ANCHOR="ab12cd34ef560000000000000000000000000000"   # the full gate's sha (X)
+A7="ab12cd3"
+A12="ab12cd34ef56"
+if [ "${#ANCHOR}" -eq 40 ] && [ "${ANCHOR:0:7}" = "$A7" ] && [ "${ANCHOR:0:12}" = "$A12" ]; then
+  ok "anchor fixture: ANCHOR is 40 hex and A7/A12 are its own 7/12-char prefixes"
+else
+  bad "anchor fixture: ANCHOR/A7/A12 are inconsistent"
+fi
+
+DELTA_MODE="MODE: delta (TEST/DOCS-ONLY RE-CERTIFICATION — NOT the gate of record; gate of record = the full agent-gate.sh PASS at anchor $ANCHOR)"
+
+# delta_block [anchor] [commit] [tree-start] [tree-integrity] [result] [mode] \
+#             [anchor-parenthetical] -> STDOUT.  "-" omits a line entirely.
+# Line SHAPES are copied from scripts/agent-gate.sh's delta emit site
+# (anchor_meta + SUMMARY_MODE_LINE), trailing fields included.
+delta_block() {
+  local anchor="${1:-$ANCHOR}" commit="${2:-$C7}" tstart="${3:-$C12}" \
+        ti="${4:-PASS}" result="${5:-PASS}" mode="${6:-$DELTA_MODE}" \
+        paren="${7:-(full-gate PASS commit)}"
+  printf '%s\n' "$DELTA_S"
+  printf 'run-id: /tmp/agent-gate.dLt4Qx\n'
+  [ "$mode" = "-" ] || printf '%s\n' "$mode"
+  [ "$commit" = "-" ] || printf 'commit: %s branch: issue-3465-require-gate-of-record dirty: no\n' "$commit"
+  [ "$anchor" = "-" ] || printf 'delta-anchor: %s %s\n' "$anchor" "$paren"
+  printf 'delta-anchor-run-id: /tmp/agent-gate.9cIQgX\n'
+  printf 'gate-of-record: full agent-gate.sh run at %s (this DELTA re-certifies a test/docs-only diff; it is NOT a substitute for the full gate)\n' "$anchor"
+  printf 'delta-executors: cargo test -p cqlite-core --test issue_3465 (3), docs (2)\n'
+  [ "$tstart" = "-" ] || printf 'tree-start: %s dirty: no digest: 671a6275687c\n' "$tstart"
+  printf 'tree-end: %s dirty: no digest: 671a6275687c\n' "$tstart"
+  [ "$ti" = "-" ] || printf 'tree-integrity: %s\n' "$ti"
+  printf 'logs: /tmp/agent-gate.dLt4Qx\n'
+  [ "$result" = "-" ] || printf 'RESULT: %s\n' "$result"
+  printf '%s\n' "$DELTA_E"
+}
+delta_summary() { local f="$1"; shift; delta_block "$@" >"$f"; }
+
+# refused_pair <desc> <full-file> <delta-file> [needle] — a 4-arg refusal.
+refused_pair() {
+  local desc="$1" f="$2" d="$3" needle="${4:-}"
+  if run 2 "$desc" 2421 "$CERTIFIED" "$f" "$d"; then
+    case "$OUT" in
+      *"PREMERGE: NO-GATE-OF-RECORD"*) ;;
+      *) bad "$desc: missing NO-GATE-OF-RECORD verdict (got: $OUT)"; return 1 ;;
+    esac
+    if [ -n "$needle" ] && [ "${OUT#*"$needle"}" = "$OUT" ]; then
+      bad "$desc: refusal does not name the cause '$needle' (got: $OUT)"
+      return 1
+    fi
+    ok "$desc"
+  fi
+}
+
+ANCHORFULL="$T/anchor-full.txt"
+full_summary "$ANCHORFULL" "$A7" "$A12" PASS PASS
+GOODDELTA="$T/good-delta.txt"
+delta_summary "$GOODDELTA"
+
+# --- Case 28(a): 3-arg call with an ANCHOR-only summary still refuses ---------
+# The red half of the blocker: without the fourth argument the anchor's full
+# PASS names a different tree than the head being merged, and that is exactly
+# the #3616 shape — indistinguishable from a peer lane's summary.
+refused "anchor-only full summary at a MOVED head (3 args) -> refuse" \
+  "$ANCHORFULL" "does not match the certified sha"
+
+# --- Case 28(b): the anchored delta PAIR at that same moved head -> accept ---
+if run 0 "anchored delta pair (full PASS at X + delta at Y) -> exit 0" \
+  2421 "$CERTIFIED" "$ANCHORFULL" "$GOODDELTA"; then
+  case "$OUT" in
+    *"PREMERGE: OK $CERTIFIED"*) ok "delta pair: prints PREMERGE: OK <sha>" ;;
+    *) bad "delta pair: missing PREMERGE: OK (got: $OUT)" ;;
+  esac
+  case "$OUT" in
+    *"PREMERGE: GATE-OF-RECORD commit: $A7 tree-start: $A12"*)
+      ok "delta pair: the GATE-OF-RECORD line names the ANCHOR's provenance" ;;
+    *) bad "delta pair: GATE-OF-RECORD line must name the anchor (got: $OUT)" ;;
+  esac
+  case "$OUT" in
+    *"PREMERGE: DELTA-RECERT anchor: $ANCHOR commit: $C7 tree-start: $C12"*)
+      ok "delta pair: a DISTINCT DELTA-RECERT line names the anchor + the merged tree" ;;
+    *) bad "delta pair: missing the DELTA-RECERT evidence line (got: $OUT)" ;;
+  esac
+  case "$OUT" in
+    *"summary: $GOODDELTA"*) ok "delta pair: the DELTA-RECERT line names the delta summary file" ;;
+    *) bad "delta pair: DELTA-RECERT must name the delta summary file (got: $OUT)" ;;
+  esac
+fi
+
+# --- Case 28(c): delta-anchor: naming a DIFFERENT sha -> refuse --------------
+# This is the property that makes the pair a CHAIN rather than two unrelated
+# blocks: without it, ANY full PASS could anchor ANY delta run.
+delta_summary "$T/delta-wrong-anchor.txt" "$STALE"
+refused_pair "delta-anchor: names a DIFFERENT sha than the full block -> refuse" \
+  "$ANCHORFULL" "$T/delta-wrong-anchor.txt" \
+  "in the full-gate block does not match the delta block's anchor sha"
+
+# --- Case 28(d): the delta run's OWN provenance must cover the merged tree ---
+delta_summary "$T/delta-wrong-commit.txt" "$ANCHOR" "ca8eb01" "$C12"
+refused_pair "delta commit: does not match the certified sha -> refuse" \
+  "$ANCHORFULL" "$T/delta-wrong-commit.txt" \
+  "'commit:' value 'ca8eb01' in the delta block does not match the certified sha"
+delta_summary "$T/delta-wrong-tstart.txt" "$ANCHOR" "$C7" "ca8eb016def1"
+refused_pair "delta tree-start: does not match the certified sha -> refuse" \
+  "$ANCHORFULL" "$T/delta-wrong-tstart.txt" \
+  "'tree-start:' value 'ca8eb016def1' in the delta block does not match the certified sha"
+
+# --- Case 28(e): delta-anchor: (UNRESOLVED) -> refuse ------------------------
+# scripts/agent-gate.sh emits this on its ERROR path when the --delta anchor does
+# not resolve to a commit. Tested at RESULT: PASS so the needle pins the ANCHOR
+# check rather than the RESULT check...
+delta_summary "$T/delta-unresolved.txt" "$ANCHOR" "$C7" "$C12" PASS PASS "$DELTA_MODE" "(UNRESOLVED)"
+refused_pair "delta-anchor: (UNRESOLVED) -> refuse" \
+  "$ANCHORFULL" "$T/delta-unresolved.txt" "(UNRESOLVED)"
+# ...and once in the shape the gate really emits it (RESULT: ERROR, a ref name
+# rather than a resolved sha), which must also refuse.
+delta_summary "$T/delta-unresolved-real.txt" "HEAD~3" "$C7" "$C12" PASS ERROR \
+  "$DELTA_MODE" "(UNRESOLVED)"
+refused_pair "delta-anchor: (UNRESOLVED) in its real RESULT: ERROR shape -> refuse" \
+  "$ANCHORFULL" "$T/delta-unresolved-real.txt"
+
+# --- Case 29: the delta-anchor value's own shape -----------------------------
+delta_summary "$T/delta-no-anchor.txt" "-"
+refused_pair "delta block with NO delta-anchor: line -> refuse" \
+  "$ANCHORFULL" "$T/delta-no-anchor.txt" "has no 'delta-anchor:' line"
+delta_summary "$T/delta-anchor-short.txt" "$A12"
+refused_pair "delta-anchor: abbreviated (12 hex, not the resolved 40) -> refuse" \
+  "$ANCHORFULL" "$T/delta-anchor-short.txt" "is 12 hex chars,"
+delta_summary "$T/delta-anchor-nonhex.txt" "unverified"
+refused_pair "delta-anchor: non-hex -> refuse" \
+  "$ANCHORFULL" "$T/delta-anchor-nonhex.txt" "is not lowercase hex"
+
+# --- Case 30: the fourth argument must BE a delta block ----------------------
+refused_pair "a FULL summary passed as the fourth argument -> refuse" \
+  "$ANCHORFULL" "$GOOD" "holds ZERO delta blocks"
+if [ "${OUT#*"found 1 full"}" != "$OUT" ]; then
+  ok "fourth-arg: refusal NAMES the full block it found instead of a delta one"
+else
+  bad "fourth-arg: refusal should name what it found (got: $OUT)"
+fi
+refused_pair "a LITE summary passed as the fourth argument -> refuse" \
+  "$ANCHORFULL" "$T/lite-only.txt" "holds ZERO delta blocks"
+{ delta_block; delta_block; } >"$T/two-deltas.txt"
+if [ "$(grep -c -x -F "$DELTA_S" "$T/two-deltas.txt")" -eq 2 ]; then
+  ok "two-deltas fixture: the file really does hold TWO delta start markers"
+else
+  bad "two-deltas fixture: expected 2 delta start markers"
+fi
+refused_pair "TWO delta blocks in the fourth argument -> refuse as AMBIGUOUS" \
+  "$ANCHORFULL" "$T/two-deltas.txt" "holds 2 delta blocks"
+refused_pair "fourth-argument file absent -> refuse" \
+  "$ANCHORFULL" "$T/no-such-delta.txt" "delta summary file does not exist"
+: >"$T/empty-delta.txt"
+refused_pair "fourth-argument file EMPTY -> refuse" \
+  "$ANCHORFULL" "$T/empty-delta.txt" "delta summary file is EMPTY"
+if run 3 "EMPTY fourth argument -> exit 3 (usage, never a silent 3-arg downgrade)" \
+  2421 "$CERTIFIED" "$ANCHORFULL" ""; then
+  ok "usage: an empty fourth argument is a usage failure, not '3-arg mode'"
+fi
+if run 3 "five arguments -> exit 3 (usage)" 2421 "$CERTIFIED" "$ANCHORFULL" "$GOODDELTA" extra; then
+  ok "usage: a fifth argument fails closed rather than being ignored"
+fi
+
+# --- Case 31: MODE: delta is REQUIRED in the delta block (the INVERSE belt) --
+# In the FULL block a MODE: line is a refusal; in the DELTA block its ABSENCE
+# is, and the token is asserted AFFIRMATIVELY rather than merely tolerated.
+delta_summary "$T/delta-no-mode.txt" "$ANCHOR" "$C7" "$C12" PASS PASS "-"
+refused_pair "delta block with NO MODE: line -> refuse (presence is REQUIRED here)" \
+  "$ANCHORFULL" "$T/delta-no-mode.txt" "has no 'MODE:' line"
+delta_summary "$T/delta-mode-lite.txt" "$ANCHOR" "$C7" "$C12" PASS PASS \
+  "MODE: lite (FAST ITERATION — NOT the gate of record)"
+refused_pair "delta header + MODE: lite -> refuse (token asserted, not presence)" \
+  "$ANCHORFULL" "$T/delta-mode-lite.txt" "MODE token is 'lite', not 'delta'"
+
+# --- Case 32: the delta block's own verdicts ---------------------------------
+delta_summary "$T/delta-result-fail.txt" "$ANCHOR" "$C7" "$C12" PASS FAIL
+refused_pair "delta RESULT: FAIL -> refuse" \
+  "$ANCHORFULL" "$T/delta-result-fail.txt" "RESULT verdict token in the delta block is 'FAIL'"
+delta_summary "$T/delta-ti-fail.txt" "$ANCHOR" "$C7" "$C12" \
+  "FAIL (tree-mutated-midrun; head da9a7cb->ca8eb01; changed: docs/x.md)" PASS
+refused_pair "delta tree-integrity: FAIL -> refuse" \
+  "$ANCHORFULL" "$T/delta-ti-fail.txt" "tree-integrity verdict token in the delta block is 'FAIL'"
+delta_block >"$T/delta-unterminated.txt.full"
+grep -v -x -F "$DELTA_E" "$T/delta-unterminated.txt.full" >"$T/delta-unterminated.txt"
+refused_pair "UNTERMINATED delta block -> refuse" \
+  "$ANCHORFULL" "$T/delta-unterminated.txt" "UNTERMINATED"
+
+# --- Case 33: the ANCHOR block is still held to the full-gate contract -------
+# Case B relaxes ONLY the anchor's sha binding. Everything else it must satisfy
+# in Case A it must still satisfy here.
+{ full_block "$A7" "$A12" PASS FAIL; } >"$T/anchor-fail.txt"
+refused_pair "anchor block RESULT: FAIL -> refuse even with a valid delta" \
+  "$T/anchor-fail.txt" "$GOODDELTA" "RESULT verdict token in the full-gate block is 'FAIL'"
+refused_pair "a LITE-only file as the ANCHOR -> refuse (the #3408 case, 4-arg form)" \
+  "$T/lite-only.txt" "$GOODDELTA" "ZERO full-gate blocks"
+full_summary "$T/anchor-nonhex.txt" "unverified" "$A12" PASS PASS
+refused_pair "anchor commit: non-hex -> refuse (a real sha is still required)" \
+  "$T/anchor-nonhex.txt" "$GOODDELTA" "is not lowercase hex"
+
+# =============================================================================
+# #3465 review — the remaining refusal branches
+# =============================================================================
+
+# --- Case 34: DUPLICATE keys inside one block -> refuse ----------------------
+# "Last one wins" would let a doctored line override the real verdict. Without
+# these fixtures the >1 branch of assert_single_key was dead code.
+{
+  printf '%s\n' "$FULL_S"
+  printf 'commit: %s branch: main dirty: no\n' "$C7"
+  printf 'tree-start: %s dirty: no digest: 671a6275687c\n' "$C12"
+  printf 'tree-integrity: PASS\n'
+  printf 'RESULT: FAIL\n'
+  printf 'RESULT: PASS\n'
+  printf '%s\n' "$FULL_E"
+} >"$T/dup-result.txt"
+refused "TWO RESULT: lines in one block -> refuse as AMBIGUOUS" \
+  "$T/dup-result.txt" "has 2 'RESULT:' lines"
+{
+  printf '%s\n' "$FULL_S"
+  printf 'commit: ca8eb01 branch: main dirty: no\n'
+  printf 'commit: %s branch: main dirty: no\n' "$C7"
+  printf 'tree-start: %s dirty: no digest: 671a6275687c\n' "$C12"
+  printf 'tree-integrity: PASS\n'
+  printf 'RESULT: PASS\n'
+  printf '%s\n' "$FULL_E"
+} >"$T/dup-commit.txt"
+refused "TWO commit: lines in one block -> refuse as AMBIGUOUS" \
+  "$T/dup-commit.txt" "has 2 'commit:' lines"
+
+# --- Case 35: an UNREADABLE summary file -> refuse ---------------------------
+# Distinct from absent and from empty. Skipped when running as root, which
+# ignores the mode bit.
+if [ "$(id -u)" = "0" ]; then
+  ok "unreadable summary: SKIPPED (running as root ignores the mode bit)"
+else
+  cp "$GOOD" "$T/unreadable.txt"
+  chmod 000 "$T/unreadable.txt"
+  refused "summary file present but UNREADABLE -> refuse" \
+    "$T/unreadable.txt" "is not readable"
+  chmod 644 "$T/unreadable.txt"
+fi
+
+# --- Case 36: the PARSER TOOL failing is exit 3, not exit 2 ------------------
+# A missing/ENOMEM-ing awk is a broken BOX, not a verdict about the gate of
+# record — telling that caller to re-run a 45-minute gate would be the wrong
+# remedy, so this one path exits 3 and NAMES the tool.
+BADBIN="$T/badbin"
+mkdir -p "$BADBIN"
+printf '#!/bin/sh\necho "awk: cannot allocate" >&2\nexit 1\n' >"$BADBIN/awk"
+chmod +x "$BADBIN/awk"
+OUT=$(PATH="$BADBIN:$BIN:$PATH" bash "$ASSERT" 2421 "$CERTIFIED" "$GOOD" 2>&1)
+RC=$?
+if [ "$RC" -eq 3 ]; then
+  case "$OUT" in
+    *"TOOL-FAILURE"*awk*) ok "tool failure: a failing awk is exit 3 and NAMES the tool" ;;
+    *) bad "tool failure: exit 3 but the message must name the tool (got: $OUT)" ;;
+  esac
+  case "$OUT" in
+    *"NO-GATE-OF-RECORD"*) bad "tool failure: must NOT be reported as NO-GATE-OF-RECORD (got: $OUT)" ;;
+    *) ok "tool failure: not misreported as a missing gate of record" ;;
+  esac
+else
+  bad "tool failure: wanted exit 3, got $RC (output: $OUT)"
+fi
+
+# --- Case 37: the REAL --only shape -> refused by RESULT, not by the belt ----
+# scripts/agent-gate.sh emits, for --only, the FULL markers, RESULT: PARTIAL and
+# a LOWERCASE `mode: PARTIAL (--only …)` line. The MODE: belt is case-sensitive
+# ($1 == "MODE:") and deliberately does NOT catch it: the property that matters
+# is the RESULT compare. This is the most plausible real mis-invocation.
+{
+  printf '%s\n' "$FULL_S"
+  printf 'run-id: /tmp/agent-gate.9cIQgX\n'
+  printf 'commit: %s branch: issue-3465-require-gate-of-record dirty: no\n' "$C7"
+  printf 'tree-start: %s dirty: no digest: 671a6275687c\n' "$C12"
+  printf 'tree-end: %s dirty: no digest: 671a6275687c\n' "$C12"
+  printf 'tree-integrity: PASS\n'
+  printf 'mode: PARTIAL (--only file-size) - does NOT count as the gate\n'
+  printf 'file-size:         PASS (0s)\n'
+  printf 'RESULT: PARTIAL\n'
+  printf '%s\n' "$FULL_E"
+} >"$T/only-partial.txt"
+if grep -q -x -F 'mode: PARTIAL (--only file-size) - does NOT count as the gate' "$T/only-partial.txt"; then
+  ok "--only fixture: carries the LOWERCASE mode: PARTIAL line the gate really emits"
+else
+  bad "--only fixture: expected the verbatim lowercase mode: PARTIAL line"
+fi
+refused "a real --only summary (RESULT: PARTIAL) -> refuse" \
+  "$T/only-partial.txt" "RESULT verdict token in the full-gate block is 'PARTIAL'"
+case "$OUT" in
+  *"carries a MODE: line"*)
+    bad "--only: refused by the case-sensitive MODE: belt, not by RESULT (got: $OUT)" ;;
+  *) ok "--only: the case-sensitive MODE: belt is deliberately NOT what catches it" ;;
+esac
+
+# --- Case 38: a NESTED sub-gate block -> refuse ------------------------------
+# #2874: a gate spawned by an enclosing gate stamps `nested-under: <parent>` and
+# emits the FULL markers at the SAME tree, so the sha binding provably cannot
+# distinguish it. One affirmative line closes the only wrong-file class the sha
+# compare cannot see.
+{
+  printf '%s\n' "$FULL_S"
+  printf 'run-id: /tmp/agent-gate.nested1\n'
+  printf 'nested-under: /tmp/agent-gate.9cIQgX\n'
+  printf 'commit: %s branch: main dirty: no\n' "$C7"
+  printf 'tree-start: %s dirty: no digest: 671a6275687c\n' "$C12"
+  printf 'tree-integrity: PASS\n'
+  printf 'RESULT: PASS\n'
+  printf '%s\n' "$FULL_E"
+} >"$T/nested.txt"
+refused "nested sub-gate (nested-under:) at the RIGHT sha -> refuse" \
+  "$T/nested.txt" "nested-under"
+delta_summary "$T/delta-plain.txt"
+{ grep -v -x -F "$DELTA_E" "$T/delta-plain.txt"
+  printf 'nested-under: /tmp/agent-gate.9cIQgX\n'
+  printf '%s\n' "$DELTA_E"
+} >"$T/delta-nested.txt"
+refused_pair "nested sub-gate in the DELTA block -> refuse" \
+  "$ANCHORFULL" "$T/delta-nested.txt" "nested-under"
+
+# --- Case 39: the success path DISCLAIMS what it did not prove (#3650) ------
+# A squash-merge composes this diff with main's CURRENT tip, so the tree
+# certified here and the tree that lands are different objects for any PR whose
+# base is behind main. `PREMERGE: GATE-OF-RECORD` must not be readable as full
+# certification.
+if run 0 "success path prints the SCOPE disclaimer" 2421 "$CERTIFIED" "$GOOD"; then
+  case "$OUT" in
+    *"PREMERGE: SCOPE"*) ok "scope: the success path prints a PREMERGE: SCOPE clause" ;;
+    *) bad "scope: missing the PREMERGE: SCOPE clause (got: $OUT)" ;;
+  esac
+  case "$OUT" in
+    *"#3650"*) ok "scope: the clause names the follow-up issue (#3650)" ;;
+    *) bad "scope: the clause must name #3650 (got: $OUT)" ;;
+  esac
+  case "$OUT" in
+    *"does NOT prove"*) ok "scope: the clause states what was NOT proven" ;;
+    *) bad "scope: the clause must state what was NOT proven (got: $OUT)" ;;
+  esac
+fi
+if run 0 "success path prints SCOPE in the anchored-delta case too" \
+  2421 "$CERTIFIED" "$ANCHORFULL" "$GOODDELTA"; then
+  case "$OUT" in
+    *"PREMERGE: SCOPE"*) ok "scope: the delta pair carries the same disclaimer" ;;
+    *) bad "scope: the delta pair must carry the SCOPE clause too (got: $OUT)" ;;
+  esac
+fi
+
 # --- summary -----------------------------------------------------------------
 printf '\n=== premerge-assert: %d passed, %d failed ===\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -129,10 +129,17 @@ roborev pass actually ran on. Three mechanical rules keep the merge honest:
   `scripts/flow/premerge-assert.sh <pr> <certified-sha> <gate-summary-file>` — which asserts the PR is
   OPEN and its `headRefOid` **equals the locally-certified tip**, exiting non-zero (and printing a
   loud refusal) on a moved head, a closed/merged PR, or a gh failure.
-  **The third argument is REQUIRED (#3465).** Verifying the head against a *claimed* certified sha
-  never verified that a certified sha EXISTS — PR #3408 merged on 22 `--lite` PASSes and no full
-  `scripts/agent-gate.sh` run at all, because nothing in the merge path ever asked for the gate of
-  record. It is now asked for here, at the one point every merge passes through: the summary file must
+  **The third argument is REQUIRED (#3465), and it closes TWO distinct escapes with one mechanism.**
+  Verifying the head against a *claimed* certified sha never verified that a certified sha EXISTS.
+  **#3408 = no gate at all**: it merged on 22 `--lite` PASSes and no full `scripts/agent-gate.sh` run,
+  because nothing in the merge path ever asked for the gate of record. **PR #3616 = a real gate,
+  someone else's**: a closer located its run dir by RECENCY (`ls -t /tmp/agent-gate.*`), read a PEER
+  LANE's dir, saw 33 of 37 components PASS, and was about to merge #3616 on PR #3580's verdict — the
+  count, the dir and the timestamps were all real, and only the `run-id:` line exposed it, read by a
+  human. With 14000-27000 stale run dirs per box and up to 4 concurrent gates, recency picks a peer
+  routinely. This script **cannot** verify `run-id:` (see below), so the `commit:`+`tree-start:`
+  binding is what makes that class a mechanical refusal: a peer's summary carries the OTHER PR's
+  branch head. It is now asked for here, at the one point every merge passes through: the summary file must
   hold exactly ONE whole-line-anchored `==== AGENT-GATE SUMMARY ====` block (`--lite`/`--delta` emit
   distinct headers and are refused by name; a second or unterminated block is ambiguous and also
   refused) with `RESULT: PASS` and `tree-integrity: PASS` compared **token-exactly** — `INCOMPLETE` is

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -126,7 +126,8 @@ roborev pass actually ran on. Three mechanical rules keep the merge honest:
 
 - **Pre-merge SHA + gate-of-record assertion (#2456/#2668/#3465, scripted hard precondition).**
   Immediately before arming `gh pr merge --auto`, the closer does `git push`, then runs
-  `scripts/flow/premerge-assert.sh <pr> <certified-sha> <gate-summary-file>` — which asserts the PR is
+  `scripts/flow/premerge-assert.sh <pr> <certified-sha> <gate-of-record-summary> [<delta-summary>]` —
+  which asserts the PR is
   OPEN and its `headRefOid` **equals the locally-certified tip**, exiting non-zero (and printing a
   loud refusal) on a moved head, a closed/merged PR, or a gh failure.
   **The third argument is REQUIRED (#3465), and it closes TWO distinct escapes with one mechanism.**
@@ -153,7 +154,24 @@ roborev pass actually ran on. Three mechanical rules keep the merge honest:
   the summary came from a genuine gate rather than a hand-written file — a hostile invoker is out of
   the threat model, since whoever runs the script controls the process. What it closes is **accident
   and drift**, which is the observed failure mode. `dirty:` is reported in the success line, not
-  enforced. The closer **refuses to merge on any
+  enforced (failing on it is proposed separately in #3648).
+  **The OPTIONAL fourth argument is the only way a `--delta` re-cert can certify a merge.** #1892
+  *mandates* `--delta` — "never a repeat full gate" — for a test/docs-only diff on top of a full PASS
+  at anchor `X`, and mandates that the PR record BOTH blocks, so a 3-arg-only guard red on correct,
+  doctrine-mandated input: the guard agents learn to waive. With four arguments the third is the
+  ANCHOR's full PASS (its sha need NOT be the certified sha) and the fourth is exactly one
+  `==== AGENT-GATE DELTA SUMMARY ====` block carrying `MODE: delta` (asserted affirmatively — the
+  inverse of the full block's `MODE:` belt), `RESULT: PASS`, `tree-integrity: PASS`, a `delta-anchor:`
+  naming exactly that anchor (an `(UNRESOLVED)` anchor refuses), and its OWN `commit:`/`tree-start:`
+  at the certified sha. A block carrying `nested-under:` (#2874) is refused in either shape: a nested
+  sub-gate runs at the SAME tree, so the sha binding provably cannot distinguish it.
+  **And what `PREMERGE: OK` does NOT prove (#3650), which the success path states itself on a
+  `PREMERGE: SCOPE` line:** it proves the diff is unchanged since certification and that a full gate
+  PASSed on THAT EXACT TREE — not that the change was certified against the `main` it will join. A
+  squash-merge composes the diff with main's CURRENT tip, so for any PR whose base is behind main the
+  certified tree and the merged tree are different objects (measured on #3358/PR #3362). A gate on the
+  MERGE RESULT is #3650; it is deliberately not implemented here, and neither is a staleness bound.
+  Report a pass as "gate of record verified at `<sha>`", never "certified against main". The closer **refuses to merge on any
   non-zero exit** (fail closed). It also re-reads issue/PR comments for a fresh `HOLD:` order in the
   same pre-merge pass. Motivated by the 2026-07-14 stale-merge escape on
   #2299/PR #2421: the closer certified a rebased-and-fixed tip locally but never pushed it, so

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -124,11 +124,29 @@ ever regress (contexts emptied, `enforce_admins` disabled), this doctrine govern
 The `flow-closer` certifies a **specific SHA** — the tree the full gate of record and the final
 roborev pass actually ran on. Three mechanical rules keep the merge honest:
 
-- **Pre-merge SHA assertion (#2456/#2668, scripted hard precondition).** Immediately before
-  arming `gh pr merge --auto`, the closer does `git push`, then runs
-  `scripts/flow/premerge-assert.sh <pr> <certified-sha>` — which asserts the PR is OPEN and its
-  `headRefOid` **equals the locally-certified tip**, exiting non-zero (and printing a loud refusal)
-  on a moved head, a closed/merged PR, or a gh failure. The closer **refuses to merge on any
+- **Pre-merge SHA + gate-of-record assertion (#2456/#2668/#3465, scripted hard precondition).**
+  Immediately before arming `gh pr merge --auto`, the closer does `git push`, then runs
+  `scripts/flow/premerge-assert.sh <pr> <certified-sha> <gate-summary-file>` — which asserts the PR is
+  OPEN and its `headRefOid` **equals the locally-certified tip**, exiting non-zero (and printing a
+  loud refusal) on a moved head, a closed/merged PR, or a gh failure.
+  **The third argument is REQUIRED (#3465).** Verifying the head against a *claimed* certified sha
+  never verified that a certified sha EXISTS — PR #3408 merged on 22 `--lite` PASSes and no full
+  `scripts/agent-gate.sh` run at all, because nothing in the merge path ever asked for the gate of
+  record. It is now asked for here, at the one point every merge passes through: the summary file must
+  hold exactly ONE whole-line-anchored `==== AGENT-GATE SUMMARY ====` block (`--lite`/`--delta` emit
+  distinct headers and are refused by name; a second or unterminated block is ambiguous and also
+  refused) with `RESULT: PASS` and `tree-integrity: PASS` compared **token-exactly** — `INCOMPLETE` is
+  the launch-time liveness sentinel and not a verdict (#3041), and a mutated-mid-run tree is not a
+  certification (#2926) — and with BOTH `commit:` (7 hex) and `tree-start:` (12 hex) prefix-matching
+  the certified sha **at each value's own width**; a non-hex placeholder (`(not captured)`,
+  `unverified`, `selftest`) REFUSES rather than being skipped. An OPTIONAL argument would have left the
+  convention honour-system, so the pre-#3465 two-argument call is a loud usage failure.
+  **What it does NOT do, stated rather than implied:** it cannot verify `run-id:` (the #2874 reader
+  contract requires the party that LAUNCHED the run, which this script is not), and it cannot prove
+  the summary came from a genuine gate rather than a hand-written file — a hostile invoker is out of
+  the threat model, since whoever runs the script controls the process. What it closes is **accident
+  and drift**, which is the observed failure mode. `dirty:` is reported in the success line, not
+  enforced. The closer **refuses to merge on any
   non-zero exit** (fail closed). It also re-reads issue/PR comments for a fresh `HOLD:` order in the
   same pre-merge pass. Motivated by the 2026-07-14 stale-merge escape on
   #2299/PR #2421: the closer certified a rebased-and-fixed tip locally but never pushed it, so

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -82,13 +82,31 @@ carry).
   and never poll a PR's own CI.
 - **Residual — re-run order.** A tier re-run *after* `required` has already gone green cannot be
   retracted by a finished job: **re-run the tier, then re-run `required`**, in that order.
-  `scripts/flow/premerge-assert.sh <pr> <certified-sha> <gate-summary-file>` remains the closer's last
-  look — and since #3465 it is where the gate of record stops being a convention: the third argument
-  is REQUIRED, and the script refuses the merge unless that file holds one full
-  `==== AGENT-GATE SUMMARY ====` block with `RESULT: PASS`, `tree-integrity: PASS`, and
-  `commit:`/`tree-start:` matching the certified sha. A `--lite` or `--delta` summary is refused by
-  name (their headers are distinct by construction), which is exactly the PR #3408 escape: 22 lite
-  PASSes and no full gate. **The sha half of the same check closes a second, different escape (PR
+  `scripts/flow/premerge-assert.sh <pr> <certified-sha> <gate-of-record-summary> [<delta-summary>]`
+  remains the closer's last look — and since #3465 it is where the gate of record stops being a
+  convention: the third argument is REQUIRED, and the script refuses the merge unless that file holds
+  one full `==== AGENT-GATE SUMMARY ====` block with `RESULT: PASS`, `tree-integrity: PASS`, no
+  `nested-under:` line (#2874: a nested sub-gate runs at the SAME tree, so the sha binding provably
+  cannot see it) and `commit:`/`tree-start:` covering the certified sha. A `--lite` summary is refused
+  by name anywhere, and a `--delta` summary as the THIRD argument (their headers are distinct by
+  construction) — which is exactly the PR #3408 escape: 22 lite PASSes and no full gate.
+  **The OPTIONAL fourth argument is how a `--delta` re-cert certifies a merge.** #1892 *mandates*
+  `--delta`, "never a repeat full gate", for a test/docs-only diff on top of a full PASS at anchor
+  `X`, and mandates the PR record BOTH blocks — so a 3-arg-only guard red on correct, mandated input.
+  In that shape the third argument is the ANCHOR's full PASS (its sha need not be the certified sha)
+  and the fourth is one `==== AGENT-GATE DELTA SUMMARY ====` block carrying `MODE: delta` (asserted
+  affirmatively, the inverse of the full block's belt), `RESULT: PASS`, `tree-integrity: PASS`, a
+  `delta-anchor:` naming exactly that anchor — an `(UNRESOLVED)` anchor refuses — and its own
+  `commit:`/`tree-start:` at the certified sha. The chain is closed end to end; a delta block ALONE
+  is still the #3408 escape and still refused.
+  **What a `PREMERGE: OK` does NOT prove (#3650), printed on the success path as `PREMERGE: SCOPE`.**
+  It proves the diff is unchanged since certification and that a full gate PASSed on THAT EXACT TREE.
+  It does not prove the change was certified against the `main` it will join: a squash-merge composes
+  the diff with main's CURRENT tip, so for any PR whose base is behind main the certified tree and the
+  merged tree are **different objects** (measured on #3358/PR #3362 — a head gate FAILing only because
+  a known flake's fix was on main and not in that base; the malign direction is a PASS at a stale head
+  hiding an interaction with something that landed in between). A gate on the merge result is #3650 and
+  is deliberately not part of this mechanism. **The sha half of the same check closes a second, different escape (PR
   #3616): a real gate, someone else's.** A closer located its gate run dir by recency
   (`ls -t /tmp/agent-gate.*`), read a PEER LANE's dir, saw 33 of 37 components PASS and was about to
   merge #3616 on PR #3580's verdict — everything about it was real, and only the `run-id:` line

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -88,7 +88,14 @@ carry).
   `==== AGENT-GATE SUMMARY ====` block with `RESULT: PASS`, `tree-integrity: PASS`, and
   `commit:`/`tree-start:` matching the certified sha. A `--lite` or `--delta` summary is refused by
   name (their headers are distinct by construction), which is exactly the PR #3408 escape: 22 lite
-  PASSes and no full gate.
+  PASSes and no full gate. **The sha half of the same check closes a second, different escape (PR
+  #3616): a real gate, someone else's.** A closer located its gate run dir by recency
+  (`ls -t /tmp/agent-gate.*`), read a PEER LANE's dir, saw 33 of 37 components PASS and was about to
+  merge #3616 on PR #3580's verdict — everything about it was real, and only the `run-id:` line
+  exposed it, read by a human. `premerge-assert.sh` cannot verify `run-id:` (it did not launch the
+  gate, and #2874's reader contract belongs to whoever did), so requiring BOTH `commit:` (7 hex) and
+  `tree-start:` (12 hex) to match the certified sha is what turns a cross-lane verdict into a
+  mechanical refusal: a peer's summary names the OTHER PR's head.
 - **Break-glass is per-tier, and it actually works.** `ci:waive:<tier-id>` (an owner action) excuses a
   tier that is **absent** or **pending at the deadline**; it can **never** excuse a failed or cancelled
   one, and there is no blanket waiver. The label takes effect without a re-run: `required` re-reads the

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -82,7 +82,13 @@ carry).
   and never poll a PR's own CI.
 - **Residual — re-run order.** A tier re-run *after* `required` has already gone green cannot be
   retracted by a finished job: **re-run the tier, then re-run `required`**, in that order.
-  `scripts/flow/premerge-assert.sh` remains the closer's last look.
+  `scripts/flow/premerge-assert.sh <pr> <certified-sha> <gate-summary-file>` remains the closer's last
+  look — and since #3465 it is where the gate of record stops being a convention: the third argument
+  is REQUIRED, and the script refuses the merge unless that file holds one full
+  `==== AGENT-GATE SUMMARY ====` block with `RESULT: PASS`, `tree-integrity: PASS`, and
+  `commit:`/`tree-start:` matching the certified sha. A `--lite` or `--delta` summary is refused by
+  name (their headers are distinct by construction), which is exactly the PR #3408 escape: 22 lite
+  PASSes and no full gate.
 - **Break-glass is per-tier, and it actually works.** `ci:waive:<tier-id>` (an owner action) excuses a
   tier that is **absent** or **pending at the deadline**; it can **never** excuse a failed or cancelled
   one, and there is no blanket waiver. The label takes effect without a re-run: `required` re-reads the


### PR DESCRIPTION
Closes #3465.

## The gap

`premerge-assert.sh` verified that a PR's head still equals a **claimed** certified sha. It never verified that a certified sha **exists**. So the doctrine's central control — "the full gate is the only run that counts" — was honour-system, and it failed openly: **PR #3408 merged with 22 `--lite` PASSes and no full gate of record.** The worker said so in the thread; no step objected.

Owner ruling (2026-08-30) selected option (a): put the check where every merge already passes through.

## What this does

`premerge-assert.sh` takes a **third, required** argument naming the gate summary file:

```
scripts/flow/premerge-assert.sh <pr-number> <certified-sha> <gate-of-record-summary> [<delta-summary>]
```

Required, not optional — an optional argument would leave the honour system exactly where it is. Missing it is a usage failure (exit 3), which breaks every existing caller loudly and on purpose; all callers are updated in this change.

It refuses to merge (exit 2, `PREMERGE: NO-GATE-OF-RECORD`) unless the file holds exactly one **full**-gate block with `RESULT: PASS`, `tree-integrity: PASS`, and a `commit:`/`tree-start:` matching the certified sha. Refusal cases: zero full blocks, more than one (ambiguous — never "take the last"), an unterminated block, a `MODE:` line, a verdict token that is not exactly `PASS`, a non-hex or duplicated key, or a sha mismatch. Validation runs **before** the `gh` call, so a missing gate of record is reported without needing network.

## Two escapes, one mechanism

- **#3408 — no gate at all.** `--lite` and `--delta` emit *distinct* headers (`agent-gate.sh:2781-2795`), so a lite-only summary yields zero full blocks and is refused.
- **PR #3616 — a real gate, someone else's.** A closer located its run dir by recency, read a peer lane's output, and was about to merge on PR #3580's verdict; only the `run-id:` line exposed it. A peer's summary carries that PR's branch head, so requiring `commit:` **and** `tree-start:` to match the certified sha makes the cross-lane class a mechanical refusal.

## The sha comparison

`commit:` carries a **7-char** abbreviation (`printf '%.7s'`, `agent-gate.sh:4648/4650`) and `tree-start:` a **12-char** one (`_tree_short`, `:3280`), so "matches the certified sha" cannot be string equality against a 40-hex value. Each is compared at **its own** width — never a hardcoded width, never a glob — and both must match: two independent widths off the same verified capture. A non-hex value (`(not captured)`, `selftest`, `(capture unavailable …)`) refuses rather than being skipped.

## The `--delta` path (review blocker, fixed)

The sha binding, applied literally, made the sanctioned `--delta` post-gate-polish path (#1892) **permanently unmergeable**: full gate PASSes at anchor `X` → a test/docs-only fix moves head to `Y` → CLAUDE.md mandates `--delta X` and "never a repeat full gate" → the anchor summary carries `commit: X`, which does not match certified sha `Y`. With no env opt-out that is a hard stop, and three documents routed workers straight into it — the "a guard that reds on correct input is the guard agents learn to waive" failure.

Resolved from standing doctrine (CLAUDE.md already states a delta re-cert's gate of record **is** the anchor's full PASS, and that both summaries must be recorded), via the optional 4th argument. With it, the anchor block must still be a genuine full `RESULT: PASS`/`tree-integrity: PASS` gate of record whose sha need not equal the certified sha; the delta block must be exactly one delta block with `MODE: delta` asserted affirmatively, `RESULT: PASS`, `tree-integrity: PASS`, a 40-hex `delta-anchor:` prefix-matching the anchor block, and its own `commit:`/`tree-start:` covering the certified sha. `delta-anchor: … (UNRESOLVED)` refuses. **No `--lite` path** — lite is never the gate of record.

## SCOPE — what this proves, and what it does not (#3650)

A squash-merge composes this diff with **current** `main`, so **the tree certified at the PR head is not the tree that lands**. There are two facts; this PR ships one.

- **SHIPPED** — the diff is unchanged since certification, and a full gate of record PASSed on that exact tree.
- **NOT SHIPPED — #3650** — the diff was certified against the main it will join (a gate on the merge result).

An enforcement that certified the wrong tree while claiming to close #3465 would be the vacuous-pass shape one level up, so the guard states its own scope in three places: a `PREMERGE: SCOPE` clause in the success output, a third documented residual in the script header, and the doctrine text. Passing this assert cannot be read as "certified against main". The freshness question that comes with #3650 (time bound vs commit distance vs re-derive at merge) is an owner decision and is deliberately **not** picked here.

## Deliberately not done

- **`dirty:` is reported, not enforced (#3648).** A gate that ran `dirty: yes` certified sha-plus-uncommitted-diff rather than the sha — arguably the same proxy family — but it is not in the owner's ruling, so it is surfaced in the evidence line with an in-code note and a follow-up issue owed rather than absorbed here.
- **`run-id:` cannot be verified here** (#2874's reader contract binds the party that *launched* the gate; this script did not). Documented as a residual, not faked.
- **A hand-written summary is out of the threat model.** A hostile invoker controls the process; this guard defends against **accident and drift** — which is exactly the observed failure: a diligent worker, working openly, with no step telling it the gate was missing.

## Verification

- `scripts/tests/test_premerge_assert.sh`: **102 assertions, 102 pass** (was 8). Executed by the full gate's `tooling-tests` component (`agent-gate.sh:11681`), so the guard is itself gate-covered.
- Red/green contrast: lite-only summary → refused; peer's sha → refused naming the 7-char mismatch; genuine full PASS at a matching sha → `PREMERGE: OK` + `PREMERGE: GATE-OF-RECORD`.
- **Mutation-tested, twice.** Removing each load-bearing property reds the suite: lite-header-accepted-as-full 38 fail, verdict-prefix 3, tree-integrity 3, sha-binding 4 (control 53/53); and for the delta code, non-matching `delta-anchor` 1, delta `RESULT` check 1, `MODE: delta` requirement 2, `nested-under:` refusal 2, duplicate-key branch 2 (control 102/0). The tests are not merely present.
- roborev: round 1 `RESULT: PASS`/`findings: NONE` (job 216) on the pre-fix diff; a second round runs on the rebased head.
- Rebased onto current `main` before the gate of record, conflict-free, so the certification is against the closest available approximation of the merge result.
- `shellcheck` is **not installed on this box**, so the file's "shellcheck-clean" header claim was not tool-verified this round — hand-checked only. Stated rather than implied.
- Full `AGENT-GATE SUMMARY` (gate of record) + spec-auditor C: pending, run by `flow-closer`.

## Retroactive gate on #3408 (owner ruling item 2)

`RESULT: PASS` on the merged sha `59fbe9417455…` — 30/30 components, zero SKIPs, `tree-integrity: PASS`. Posted in full on #3465. That commit's gate declared 30 components against today's 36, so six lanes added since could not run; nothing was present then and absent now. **#3408 merged with no gate of record and nothing was broken by it** — the gap was real, the outcome lucky.

## Doctrine updated in the same change

CLAUDE.md (flow-closer section), `.claude/agents/flow-closer.md`, `.claude/agents/flow-lead.md`, `.claude/skills/flow-address/SKILL.md`, and the website `agents-developing/delivery-pipeline` + `gate-contract` pages.
