### PR TITLE
fix(#3601): acquire_lock's per-lane lock — three-valued probes, a parsed pid, a verified publish, and no diagnostic that names a step it did not run

### DIFF
--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -3004,11 +3004,39 @@ acquire_lock() {
     # else" — which had not happened, together with "re-run this supervisor", which loops forever. Same
     # family as the AC7 addendum: a message that sends the operator after a problem that is not there.
     # The realistic cause is the parent directory becoming unwritable after the lock appeared.
+    #
+    # AND THE IDENTITY WE MEASURED IS STALE BY THE TIME WE GET HERE (#3601, roborev job 242 B18). The
+    # liveness verdict above describes the pid file as it was read BEFORE the rename was attempted; the
+    # path can be replaced in between, so the object now at that name may belong to a LIVE holder. The
+    # previous wording declared "this lock IS stale and this run is entitled to it" and printed the
+    # NON-RECURSIVE REMOVAL COMMAND for it.
+    #
+    # THAT IS WHY THIS ONE IS NOT MERELY ANOTHER OVERCLAIM. The code destroys nothing here; the printed
+    # line does, in the operator's hands, and remedies in this file exist precisely to be pasted. It is
+    # the sibling of "a remedy that cannot work is worse than none" — a remedy that WORKS, aimed at the
+    # wrong target. So this branch now re-reads the lock, reports what is ACTUALLY there, declares
+    # nothing stale or removable, and prints only a READ-ONLY inspection: the one command shape that is
+    # safe under the assumption that the lock is live. `ls -ldn` names the object without following a
+    # symlink and `ls -lna` shows a directory's contents (both measured rc=0 on all three shapes under
+    # #3549), `--` because the path is `TMPDIR`-derived, and the path is rendered paste-safe.
+    local after_mv='' identity=''
+    after_mv="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")" || after_mv='unparseable post-rename-probe-aborted'
+    case "$after_mv" in
+      "pid $holder_pid")
+        identity="it still records pid $holder_pid, the holder this run measured as dead. That is consistent with the same lock still being there, but it is NOT proof: this run cannot establish that the object now at that name is the same one it measured, so it does not declare the lock stale"
+        ;;
+      'pid '*)
+        identity="it now records a DIFFERENT holder, pid ${after_mv#pid }, and not the pid $holder_pid this run measured as dead. Something took that name while the rename was failing, and that holder may be ALIVE — the dead-holder measurement above no longer describes what is at that path"
+        ;;
+      *)
+        identity="its pid file no longer reads as a usable holder record ([$after_mv]), so this run cannot tell whether the object now at that name is the stale lock it measured or something else that has since taken the name"
+        ;;
+    esac
     supervisor_lock_refuse \
-      "refusing to start — a DEAD holder's lock could not be cleared" \
-      "the recorded holder (pid $holder_pid) is affirmatively gone, so this lock IS stale and this run is entitled to it — but renaming it aside FAILED, so nothing was cleared and nothing was claimed. That is a FILESYSTEM failure, not contention: the lock's parent directory must be writable to clear a lock, and being able to READ a lock does not imply that. No other holder is implied and nothing here has been modified" \
-      "make the lock's parent directory writable by this user and re-run; the stale lock will then be cleared automatically, because its holder is already known to be dead. If you would rather clear it by hand, the next line does it non-recursively once the pid file is gone$(supervisor_lock_shape_note)" \
-      "$(supervisor_lock_clear_command)"
+      "refusing to start — a lock this run measured as stale could not be cleared" \
+      "renaming the lock aside FAILED, so nothing was cleared and nothing was claimed; nothing at that path has been modified by this run. That is a FILESYSTEM failure, not contention: clearing a lock needs WRITE permission on its PARENT directory, which reading one does not. AND THE IDENTITY OF WHAT IS THERE IS NOW UNESTABLISHED — $identity" \
+      "make the lock's parent directory writable by this user and RE-RUN: the next start re-measures the holder from scratch and will either reclaim the lock, if it is genuinely stale, or name its live holder. Do NOT remove anything on the strength of this message — this run measured a dead holder BEFORE its rename failed and cannot vouch for what is at that path now. To see what is actually there, run the next line, on its own, exactly as printed; it only reads" \
+      "ls -ldn -- $(supervisor_shell_quote "$SUPERVISOR_LOCK") && ls -lna -- $(supervisor_shell_quote "$SUPERVISOR_LOCK")"
   fi
   takerc=0
   supervisor_lock_take || takerc=$?

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -2693,6 +2693,15 @@ supervisor_lock_refuse_unowned() {
   local cause="${1:-not-owned unrecorded}" detail=''
   case "$cause" in
     'declined'*)
+      # AND IT DOES NOT NAME A CAUSE IT DID NOT OBSERVE (#3601, roborev job 242 B19). It used to conclude
+      # "the directory at that name is therefore not the one this process created: a peer renamed ours
+      # aside and published its own between our two steps". Finding a `pid` record proves only that
+      # publication must be DECLINED. It does not identify how the record got there: a peer renaming ours
+      # aside and publishing is one way, and something writing a `pid` file straight into the directory we
+      # created — an external writer, an operator, a stray tool — is another, and this code cannot tell
+      # them apart. Directory-instance identity is not verifiable on this path and per #3683 cannot be
+      # made so here, so the specific race is a story, not an observation.
+      #
       # WHAT THIS PATH MAY CLAIM, NARROWED TO WHAT IS TRUE (#3601, roborev job 238 B15 — the SEVENTH
       # instance of the alibi family, and it is in the text written to FIX the family's second instance).
       # It used to say the run "wrote NOTHING" and that "NOTHING at that path has been modified", and
@@ -2702,7 +2711,7 @@ supervisor_lock_refuse_unowned() {
       # the only one this path establishes — is that THE EXISTING HOLDER RECORD WAS NOT OVERWRITTEN OR
       # PUBLISHED OVER. That is what it says now, and the test asserts PRESERVATION OF THAT RECORD rather
       # than an absence of modification the code never provided.
-      detail="the lock directory was created by this process and then found to ALREADY CONTAIN a holder record, so this run declined to publish over it; that record reads [${cause#declined }] and is INTACT — it was neither overwritten nor replaced. The directory at that name is therefore not the one this process created: a peer renamed ours aside and published its own between our two steps. This run did write and then remove its own scratch entries in that directory (a staging file, and an ownership marker), so it is not true that nothing there was touched — what is true, and what matters, is that the holder record itself was left exactly as found"
+      detail="the lock directory was created by this process and a holder record then APPEARED in the lock before this run could publish its own, so it declined to publish over it; that record reads [${cause#declined }] and is INTACT — it was neither overwritten nor replaced. HOW that record got there is NOT established by this run: another supervisor may have taken the name, or something may have written a pid file into the directory directly, and nothing here can tell those apart. This run did write and then remove its own scratch entries in that directory (a staging file, and an ownership marker), so it is not true that nothing there was touched — what is true, and what matters, is that the holder record itself was left exactly as found"
       ;;
     *)
       # This path DID write: `pid` at that name currently holds OUR pid, over whatever was there. Saying

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -900,7 +900,7 @@ log_size() {
   # it would kill its caller. Measured: the bare call `log_size "$f"` from a `set -e` shell produced NO
   # output at all. The pre-#3601 form was safe only by accident, because its one caller sits inside a
   # `set +e` region; a probe's correctness must not depend on that.
-  n="$(wc -c <"$f" 2>/dev/null | tr -d ' ')" || n=''
+  n="$( { wc -c <"$f"; } 2>/dev/null | tr -d ' ')" || n=''
   # The digits are enumerated rather than given as a `[0-9]` RANGE, whose members are decided by the
   # caller's collation.
   case "$n" in
@@ -2010,43 +2010,153 @@ supervisor_legacy_lock_guard() {
 # measure no pid liveness at all.
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# THE PER-LANE LOCK'S CONSTANTS — DELIBERATELY NOT KNOBS (#3601, roborev job 231 B6).
+#
+# Every one of these is an UNCONDITIONAL assignment, not the file's `${VAR:-default}` knob form, and
+# that is the point: a `${VAR:-…}` here would be settable from the environment, and CLAUDE.md's #3312
+# ruling is that a test-only seam is one more thing a real invoker can set — while this suite's own
+# doctrine (`test_worker_supervisor.sh`, the inherited-state drives) says a knob added so tests can go
+# fast ends up testing the knob instead of the code. An earlier cut of this change DID expose
+# `SUPERVISOR_LOCK_PID_TRIES`/`_WAIT` as knobs for exactly that reason; they are constants now and the
+# cases drive the shipped values.
+#
+# The re-read window is sized for PRODUCTION, not for the tests: the state it waits out is ONE rename
+# wide (microseconds), so 2s is five orders of magnitude of margin and survives a heavily loaded box,
+# and it is paid ONLY on a start that finds a peer's lock pid-less — never on an ordinary start.
+SUPERVISOR_LOCK_PID_TRIES=40
+SUPERVISOR_LOCK_PID_WAIT=0.05
+# How far into the pid file the NUL scan looks. Any legitimate pid file is a handful of bytes, so this is
+# four orders of magnitude of headroom; beyond it the scan reports `could-not-measure`, never `nul-free`.
+SUPERVISOR_PID_NUL_SCAN=4096
+# The pid-space ceiling used when the platform does not publish one. 4194304 is Linux's own
+# `PID_MAX_LIMIT` on 64-bit — i.e. the largest value any Linux box can configure — and every other
+# platform this script supports is lower (macOS caps at 99999). It is therefore conservative in the ONE
+# direction that matters: it can never reject a pid a real process could hold, so it cannot turn a live
+# holder into "malformed" and wedge the lane.
+SUPERVISOR_PID_MAX_FALLBACK=4194304
+
+# supervisor_pid_space_ceiling — the largest pid this platform can issue, from AUTHORITATIVE METADATA
+# where the platform publishes it, else the conservative constant above (#3601, roborev job 231 B3).
+#
+# WHY A VALUE BOUND REPLACED A DIGIT-COUNT BOUND. The digit count was 10, and every real pid space is at
+# most 7 digits — so a 10-digit corruption was ACCEPTED, cast to `pid_t` by `kill`, reliably reported
+# ESRCH, became an affirmative `dead` and RECLAIMED THE LOCK, while a 15-digit corruption refused. Same
+# defect class, two different widths, opposite outcomes: the guarantee had a hole in exactly the
+# direction #3601 is about. A pid that cannot exist on this platform is malformed content, and that is
+# decidable from the platform's own published bound rather than from a guess about digit widths.
+#
+# THIS IS NOT THE DELETED `pid_max` READ COMING BACK. #3549 removed a `/proc/sys/kernel/pid_max` read
+# from the LEGACY guard's classifier because that classifier's verdict could not change the decision.
+# Here it does: it selects between refusing and reclaiming. The suite asserts the deletion as a PROPERTY
+# over the legacy functions rather than as a name ban over the file, for that reason.
+#
+# AN UNREADABLE BOUND IS NOT LICENCE TO ACCEPT MORE. Every failure path lands on the constant, which is
+# STRICTER than the old digit rule, never looser — so "cannot read the platform bound" tightens nothing
+# and loosens nothing; it just stops being able to tighten further.
+supervisor_pid_space_ceiling() {
+  local b=''
+  if [[ -r /proc/sys/kernel/pid_max ]]; then
+    { IFS= read -r b; } 2>/dev/null </proc/sys/kernel/pid_max || b=''
+    # Validated the same way a holder pid is: enumerated digits (collation-free), and short enough that
+    # the arithmetic comparison below cannot overflow a 64-bit shell integer.
+    case "$b" in
+      '' | *[!0123456789]*) b='' ;;
+    esac
+    if [[ -n "$b" && "${#b}" -gt 18 ]]; then b=''; fi
+  fi
+  if [[ -z "$b" ]]; then b="$SUPERVISOR_PID_MAX_FALLBACK"; fi
+  printf '%s' "$b"
+}
+
 # supervisor_lock_pid_nul_free <file> — echo EXACTLY one of
 #   nul-free | contains-nul | could-not-measure <cause>
 #
-# WHY THIS CANNOT BE DONE IN THE SHELL, WHICH IS THE WHOLE REASON IT EXISTS (#3601, roborev job 231).
-# A NUL byte is invisible to every check that runs on a shell VARIABLE: bash cannot hold one, and `read`
-# discards it silently. MEASURED on bash 5.2.21: a pid file whose bytes are `4242 NUL LF` reads back as
-# the string `4242`, length 4 — non-empty, single line, all decimal digits, non-zero. It therefore
-# passed every gate in `supervisor_lock_pid_read` and the lock got RECLAIMED, which is precisely the
-# AC1 defect this parser exists to close: a partially-written pid file is exactly where NULs come from,
-# since a crash mid-write can leave allocated-but-zeroed bytes. So the check MUST look at the file's
-# bytes, before any shell variable is involved, and comparing the byte count against the NUL-stripped
-# byte count is the portable way to do it (`wc -c` and `tr -d '\000'` are both POSIX; no GNU-only flag,
-# nothing that needs `grep -P`, `od` parsing or bash 4).
+# WHY THIS EXISTS AT ALL (#3601, roborev job 231). A NUL byte is invisible to every check that runs on a
+# shell VARIABLE: bash cannot hold one, and `read` discards it silently. MEASURED on bash 5.2.21 — a pid
+# file whose bytes are `4242 NUL LF` reads back as the string `4242`, length 4: non-empty, single line,
+# all decimal digits, non-zero. It therefore passed every gate in `supervisor_lock_pid_read`, the
+# liveness probe said `dead`, and the lock was RECLAIMED — precisely the AC1 defect this parser exists to
+# close, from precisely the input AC1 is about, since a crash mid-write can leave allocated-but-zeroed
+# bytes. So the check must observe the FILE'S BYTES, not the string the shell was able to hold.
 #
-# BASH'S OWN WARNING IS NOT A USABLE SIGNAL, and this is worth recording because it looks like one.
-# `$(cat …)` on such a file does emit `warning: … ignored null byte in input` — on STDERR, which the
-# idiom at every one of these sites (`2>/dev/null`) already suppresses. Re-plumbing that redirection to
-# catch it would make correctness depend on matching bash's message TEXT, which is not a stable
-# contract: the same defect class as a gate parser keyed on cargo's literal status words (CLAUDE.md
-# #3400). The byte count is a measurement; the warning is a presentation detail.
+# BASH'S OWN WARNING IS NOT A USABLE SIGNAL, recorded because it looks like one. `$(cat …)` on such a
+# file does emit `warning: … ignored null byte in input` — on STDERR, which the `2>/dev/null` in use at
+# every one of these sites already suppresses; and keying correctness on bash's message TEXT would be
+# the same defect class as a gate parser keyed on cargo's literal status words (CLAUDE.md #3400).
 #
-# A FAILED MEASUREMENT IS NOT "NO NULS FOUND" — the third value, for the same reason `log_size` in this
-# file grew one (#3601): both counts are external commands and either can fail, and folding that onto
-# the permissive answer is how an unmeasurable read becomes an accepted pid. The counts are validated as
-# DIGIT STRINGS and compared as STRINGS, never with `-eq`, because `-eq` reads an empty operand as 0 and
-# two failed measurements would then compare EQUAL and report `nul-free`.
+# THE PRIMARY DETECTOR IS A BUILTIN, AND THAT CHOICE IS LOAD-BEARING, NOT STYLISTIC. `read -d ''` sets
+# the delimiter to NUL, so read STOPS AT the first NUL byte and its stop condition is a direct
+# observation of the raw bytes — no fork, no `PATH` dependency, and nothing for the shell to have
+# discarded first. The obvious alternative, comparing `wc -c` against `tr -d '\000' | wc -c`, was BUILT
+# AND MEASURED AND REJECTED AS PRIMARY: it makes this parser — which `supervisor_lock_publish` calls on
+# EVERY start, for the read-back — depend on two external commands, and with `wc` unavailable a
+# supervisor could not start AT ALL, on a FRESH uncontended lock, refusing forever with a diagnostic
+# about a read-back that never happened. Turning a missing coreutils tool into "this lane can never
+# start" is the permanent-refusal harm this whole change exists to remove (#3549 lead ruling 2).
 #
-# THE TWO COUNTS COME FROM TWO OPENS, so a file rewritten between them yields mismatched counts and is
-# reported `contains-nul` — a REFUSAL. The ambiguity therefore costs a start and can never cost a live
-# holder its lock, which is the direction every branch here is biased in.
+# IT SURVIVES AS THE FALLBACK, chosen by CAPABILITY rather than by guess: a `read` that rejects `-d` (or
+# `-n`) exits >1, which is distinguishable from both "found a NUL" (0) and "reached EOF" (1), and only
+# then is the byte-count form used. This is deliberately a capability probe against the real file and
+# not a version test. Two implementations of one predicate is a cost — CLAUDE.md's ruling is that a
+# second implementation's correctness is only knowable by DIFFERENTIAL TESTING — so both paths are
+# driven over the same NUL / clean / unmeasurable inputs by the suite, with the fallback forced through
+# a shipped-derived override rather than assumed unreachable.
 #
-# Both operands are supplied by REDIRECTION, never as arguments, so an option-shaped path (#3601 AC7)
-# needs no `--` and no quoting argument here.
+# A FAILED MEASUREMENT IS NOT "NO NULS FOUND", in either path — the third value, for the same reason
+# `log_size` grew one in this change. In the fallback the two counts are validated as DIGIT STRINGS and
+# compared as STRINGS, never with `-eq`, because `-eq` reads an empty operand as 0 and two failed
+# measurements would then compare EQUAL and report `nul-free`.
+#
+# Both paths open the file by REDIRECTION, never as an argument, so an option-shaped path (#3601 AC7)
+# needs no `--` and no quoting here.
 supervisor_lock_pid_nul_free() {
+  local f="$1" probe='' rrc=0 opened=0
+  # `opened=1` is the FIRST command inside the group, so a FAILED REDIRECTION — which never executes the
+  # group's body — is distinguishable from a `read` that ran and reported EOF. Both return 1, and
+  # folding "could not open" onto "no NUL found" would be the permissive collapse this function is for.
+  # `2>/dev/null` precedes `<"$f"`: redirections are applied LEFT TO RIGHT, so a failed open is only
+  # silent if stderr is already redirected when it is attempted.
+  { opened=1; IFS= read -r -d '' -n "$SUPERVISOR_PID_NUL_SCAN" probe; } 2>/dev/null <"$f" || rrc=$?
+  if [[ "$opened" -eq 0 ]]; then
+    printf '%s' 'could-not-measure pid-file-unreadable-by-the-nul-scan'
+    return 0
+  fi
+  if [[ "$rrc" -eq 0 ]]; then
+    # read returned SUCCESS, which means it stopped for one of two reasons and they are told apart by
+    # how much it consumed: fewer characters than the scan bound means it hit the NUL DELIMITER; exactly
+    # the bound means it hit the character LIMIT, and a NUL beyond that point is unobserved — which is
+    # `could-not-measure`, never `nul-free`.
+    if [[ "${#probe}" -lt "$SUPERVISOR_PID_NUL_SCAN" ]]; then
+      printf '%s' 'contains-nul'
+    else
+      printf '%s' 'could-not-measure pid-file-longer-than-the-nul-scan-bound'
+    fi
+    return 0
+  fi
+  if [[ "$rrc" -eq 1 ]]; then
+    # EOF with no NUL delimiter anywhere in the file: AFFIRMATIVELY NUL-free. This is the only branch
+    # that permits acceptance, and it depends on `-d ''` alone — never on `-n`, whose only job is to
+    # bound memory, so an ignored `-n` cannot manufacture a false `nul-free`.
+    printf '%s' 'nul-free'
+    return 0
+  fi
+  # rrc > 1: `read` refused the options, so THIS SHELL cannot run the builtin probe. Fall back.
+  supervisor_lock_pid_nul_free_bytes "$f"
+}
+
+# supervisor_lock_pid_nul_free_bytes <file> — the FALLBACK, same three values, for a shell whose `read`
+# does not support `-d`/`-n`. Compares the file's byte count against its NUL-stripped byte count; `wc -c`
+# and `tr -d '\000'` are both POSIX (no GNU-only flag, no `grep -P`, no `od` parsing, no bash 4).
+#
+# TWO OPENS, so a file rewritten between them yields mismatched counts and is reported `contains-nul` —
+# a REFUSAL. The ambiguity costs a start and can never cost a live holder its lock, which is the
+# direction every branch here is biased in. `wc`'s leading whitespace differs across platforms, so both
+# counts are whitespace-stripped before they are compared.
+supervisor_lock_pid_nul_free_bytes() {
   local f="$1" raw='' stripped=''
-  raw="$(wc -c <"$f" 2>/dev/null | tr -d '[:space:]')" || raw=''
-  stripped="$(tr -d '\000' <"$f" 2>/dev/null | wc -c | tr -d '[:space:]')" || stripped=''
+  raw="$( { wc -c <"$f"; } 2>/dev/null | tr -d '[:space:]')" || raw=''
+  stripped="$( { tr -d '\000' <"$f"; } 2>/dev/null | wc -c | tr -d '[:space:]')" || stripped=''
   case "$raw" in
     '' | *[!0123456789]*)
       printf '%s' 'could-not-measure raw-byte-count-unmeasurable'
@@ -2080,12 +2190,13 @@ supervisor_lock_pid_nul_free() {
 # than using a `[0-9]` RANGE, whose members are decided by the caller's collation (a locale-dependent
 # digit test cost #3549 a review round).
 #
-# THE ONE EXCEPTION IS THE NUL CHECK, AND IT IS NOT A CHOICE: a NUL byte cannot be represented in a
-# bash variable at all, so no builtin comparison can see one, and the bytes must be measured outside the
-# shell. `supervisor_lock_pid_nul_free` does that and is THREE-valued, so a `PATH` that cannot supply
-# `wc`/`tr` makes this parser REFUSE with a named cause rather than accept an unverified pid — the
-# dependency costs a start, never a live holder's lock. It runs LAST, after the cheap builtin gates, so
-# the ordinary refusal paths fork nothing.
+# THE NUL CHECK IS ALSO BUILTIN-ONLY ON THE PATH THAT RUNS (`supervisor_lock_pid_nul_free`, whose
+# primary detector is `read -d ''`), so the whole parser forks nothing and no verdict depends on `PATH`.
+# Its `wc`/`tr` FALLBACK is reached only by a shell that rejects `read -d ''`, and even then the probe
+# is THREE-valued: an unavailable tool makes this parser REFUSE with a named cause rather than accept an
+# unverified pid. The NUL check runs LAST, after the cheap structural gates, because by then the content
+# is known to be a short run of decimal digits and a NUL is the one remaining thing that could make
+# those digits a different number than the file records.
 supervisor_lock_pid_read() {
   local f="$1" first='' line='' n=0 readrc=0
   if [[ ! -e "$f" && ! -L "$f" ]]; then
@@ -2105,7 +2216,7 @@ supervisor_lock_pid_read() {
       if [[ "$n" -eq 1 ]]; then first="$line"; fi
       if [[ "$n" -ge 2 ]]; then break; fi
       line=''
-    done; } <"$f" 2>/dev/null || readrc=$?
+    done; } 2>/dev/null <"$f" || readrc=$?
   if [[ "$readrc" -ne 0 ]]; then
     printf '%s' 'unparseable pid-file-unreadable'
     return 0
@@ -2131,12 +2242,21 @@ supervisor_lock_pid_read() {
       return 0
       ;;
   esac
-  # A WELL-FORMEDNESS bound, deliberately NOT a platform pid bound: nothing is read from the platform
-  # (no `/proc/sys/kernel/pid_max` — that read was deleted in #3549 and is not coming back). Ten digits
-  # is above every pid space in existence and far below where a decimal conversion could overflow, so
-  # anything longer is malformed content, not an unusual pid.
-  if [[ "${#first}" -gt 10 ]]; then
+  # TWO BOUNDS, IN THIS ORDER, AND THE ORDER IS REQUIRED. The digit count is checked FIRST purely so the
+  # value comparison below cannot overflow a 64-bit shell integer (19 digits can; 18 cannot). It is not
+  # the correctness bound and is deliberately far too loose to be one.
+  if [[ "${#first}" -gt 18 ]]; then
     printf '%s' 'unparseable pid-digit-count-out-of-well-formedness-bound'
+    return 0
+  fi
+  # ...and then the bound that actually decides: a pid this platform CANNOT ISSUE is malformed content,
+  # not an unusual pid (#3601, roborev job 231 B3). The previous 10-digit rule accepted a corruption that
+  # `kill` then reported ESRCH for, which became an affirmative `dead` and RECLAIMED the lock — while a
+  # wider corruption of the same kind refused.
+  local pidceil=''
+  pidceil="$(supervisor_pid_space_ceiling)" || pidceil="$SUPERVISOR_PID_MAX_FALLBACK"
+  if [[ "$first" -gt "$pidceil" ]]; then
+    printf '%s' 'unparseable pid-above-the-platform-pid-space'
     return 0
   fi
   # LAST GATE BEFORE ACCEPTANCE: the FILE'S BYTES, not the string the shell was able to hold (#3601,
@@ -2208,6 +2328,11 @@ supervisor_lock_holder_liveness() {
   printf '%s' 'unknown kill-0-verdict-unrecognised'
 }
 
+# Where `supervisor_lock_take` reports WHICH step failed. A plain variable rather than an echoed value
+# because `take` installs the EXIT trap, and a function whose output is captured runs in a subshell where
+# a trap would be discarded. Assigned before any call can read it, so `set -u` is satisfied.
+SUPERVISOR_LOCK_TAKE_CAUSE=''
+
 # supervisor_lock_publish — the `mkdir` has already succeeded, so the NAME is ours. Publish our pid and
 # then VERIFY WE OWN THE LOCK by reading it back. Returns 0 only on verified ownership.
 #
@@ -2227,18 +2352,39 @@ supervisor_lock_holder_liveness() {
 # reclaims a pid-less lock and would rename ours aside mid-startup. It is a point-in-time verification
 # and does not prove nobody steals the lock later; `supervisor_lock_release` re-checks ownership at exit
 # for exactly that reason.
+#
+# IT ECHOES WHICH STEP FAILED, AND THAT IS NOT COSMETIC (#3601, roborev job 231 B1). A single "publish
+# failed" collapsed three different facts — the write never happened, the rename never happened, the
+# lock is not ours — onto one caller verdict, and the refusal built from it then ASSERTED all three
+# steps had run: it told the operator "our pid was published into it, and reading it back did not return
+# our pid" for an ENOSPC that never wrote a byte. On a fleet that hits ENOSPC routinely that is a
+# diagnostic pointing at a race that did not occur. Distinguishing them also decides whether the
+# directory we just created is ours to remove again, which is the difference between recovering and
+# manufacturing the undecidable state ourselves.
 supervisor_lock_publish() {
   local tmpf="$SUPERVISOR_LOCK/pid.tmp.$$" state=''
-  printf '%s\n' "$$" >"$tmpf" 2>/dev/null || return 1
+  # THE GROUP FORM IS REQUIRED, NOT TIDINESS: a redirection that fails is reported by the SHELL, and
+  # `2>/dev/null` attached to the command does not suppress that — measured, it printed the raw
+  # `TMPDIR`-derived path to stderr, which is both noise and the unrendered-path class (#3549 job 201
+  # F1). Redirecting the group's stderr FIRST covers the redirection setup itself.
+  if ! { printf '%s\n' "$$" >"$tmpf"; } 2>/dev/null; then
+    printf '%s' 'write-failed'
+    return 1
+  fi
   # `--` because both operands are `TMPDIR`-derived and may be option-shaped (#3601 AC7); quoting stops
   # word-splitting and globbing and does nothing about option parsing.
   if ! mv -f -- "$tmpf" "$SUPERVISOR_LOCK/pid" 2>/dev/null; then
     rm -f -- "$tmpf" 2>/dev/null || true
+    printf '%s' 'rename-failed'
     return 1
   fi
-  state="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")" || true
-  [[ "$state" == "pid $$" ]] || return 1
-  return 0
+  state="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")" || state='unparseable read-back-aborted'
+  if [[ "$state" == "pid $$" ]]; then
+    printf '%s' 'ok'
+    return 0
+  fi
+  printf '%s' "not-owned $state"
+  return 1
 }
 
 # supervisor_lock_release — the EXIT trap. Remove the lock ONLY while it is still OURS.
@@ -2250,14 +2396,28 @@ supervisor_lock_publish() {
 # it holds exclusion. Ownership is decided by the same one observation the publish used, so the two
 # cannot disagree. A lock that is NOT ours is left exactly as found and the fact is logged — never
 # silently, because "my lock vanished" is otherwise unattributable.
+#
+# THIS CLOSES ONE HALF OF ITS PROBLEM AND IS RECORDED AS PARTIAL, DELIBERATELY (#3601, roborev job 231).
+# CLOSED: the UNCONDITIONAL DELETE. Before this change the trap was `rm -rf "$SUPERVISOR_LOCK"` with no
+# ownership test at all, so a run that had lost its lock deleted the new holder's on the way out.
+# NOT CLOSED: the read and the removal are two operations, so a lock that becomes someone else's between
+# them is still removed. Closing that needs serialization across classify -> reclaim -> claim, which is
+# the same root as the reclaim ABA race at the rename below, and it is tracked as ONE follow-up rather
+# than patched here: the primitive it needs is a lock protecting a lock, whose own staleness reopens
+# "how does a stale instance get cleared, and by whom?" one level down. Left as an explicit partial
+# because dropping the ownership test to avoid a half-fix would REGRESS to the unconditional delete.
 supervisor_lock_release() {
   local state=''
-  state="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")" || true
+  state="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")" || state='unparseable read-aborted'
   if [[ "$state" == "pid $$" ]]; then
     rm -rf -- "$SUPERVISOR_LOCK" 2>/dev/null || true
     return 0
   fi
-  log "exit: NOT removing $SUPERVISOR_LOCK — it no longer holds this process's pid ($$); its pid file reads [$state]. Something else owns that name now, so removing it would break a holder that is not us (#3601)."
+  # Rendered, not interpolated raw (#3549 job 201 F1 class, at a new site — #3601 roborev job 231 B7):
+  # the path comes from the environment, and a newline or an ESC in it would split this line or forge an
+  # unprefixed one. `supervisor_shell_quote` renders the path as a paste-safe value; `supervisor_one_line`
+  # guarantees the composed message is ONE physical line whatever it interpolated.
+  log "$(supervisor_one_line "exit: NOT removing $(supervisor_shell_quote "$SUPERVISOR_LOCK") — it no longer holds this process's pid ($$); its pid file reads [$state]. Something else owns that name now, so removing it would break a holder that is not us (#3601).")"
   return 0
 }
 
@@ -2305,21 +2465,66 @@ supervisor_lock_refuse() {
 # The trap is installed only AFTER ownership is verified. A crash in the window before that leaves an
 # ordinary reclaimable stale lock (case 2 of the clearing story above), which is the benign residue.
 supervisor_lock_take() {
+  SUPERVISOR_LOCK_TAKE_CAUSE=''
   # `--` because the operand is `TMPDIR`-derived and may be option-shaped (#3601 AC7).
   mkdir -- "$SUPERVISOR_LOCK" 2>/dev/null || return 1
-  if supervisor_lock_publish; then
+  local pub=''
+  # `supervisor_lock_publish` runs in a command substitution, which is a SUBSHELL — fine, because it
+  # installs no trap. The `trap` below must NOT be inside one, which is why the cause travels back
+  # through a variable instead of this function echoing it.
+  pub="$(supervisor_lock_publish)" || true
+  if [[ "$pub" == 'ok' ]]; then
     trap 'supervisor_lock_release' EXIT
     return 0
   fi
-  return 2
+  SUPERVISOR_LOCK_TAKE_CAUSE="$pub"
+  if [[ "$pub" == 'not-owned'* ]]; then
+    # The NAME became ours and the directory now holds someone else's pid. Leaving it alone is the whole
+    # point: it is a live holder's lock as far as we can tell.
+    return 2
+  fi
+  # WE CREATED THE DIRECTORY AND NEVER PUBLISHED INTO IT (#3601, roborev job 231 B1). Leaving it would
+  # MANUFACTURE the pid-less lock that every other branch here refuses to reclaim — this run would wedge
+  # its own lane until an operator cleared it, which is the lead's ruling 2 inverted: we would have
+  # created the undecidable state ourselves and then refused over it.
+  #
+  # THE REMOVAL IS NON-RECURSIVE, AND THAT IS WHAT MAKES IT SAFE. Between our `mkdir` and here a peer
+  # running pre-#3601 code could have reclaimed our pid-less directory and written its OWN pid into it;
+  # `rmdir` REFUSES a non-empty directory, so it can only ever remove the empty shell we made, never a
+  # holder's record. Our own staging file is removed first because it is unambiguously ours.
+  rm -f -- "$SUPERVISOR_LOCK/pid.tmp.$$" 2>/dev/null || true
+  rmdir -- "$SUPERVISOR_LOCK" 2>/dev/null || true
+  return 3
 }
 
 # supervisor_lock_refuse_unowned — the name became ours and the read-back said it is not.
 supervisor_lock_refuse_unowned() {
+  local cause="${1:-not-owned unrecorded}"
   supervisor_lock_refuse \
     "refusing to start — this run CREATED the lock and then could not verify it OWNS it" \
-    "the lock directory was created by this process, our pid was published into it, and reading it back did not return our pid ($$) — so between those two steps something else took the lock name. The most likely cause is a supervisor running PRE-#3601 code on this box: it reads a lock whose pid file is not yet present as STALE and renames it aside, which is the defect #3601 fixes. Starting now would put two supervisors in one worktree, so this run stops instead" \
+    "the lock directory was created by this process and our pid was published into it; reading it back did not return our pid ($$) — the read-back said [${cause#not-owned }] — so between those two steps something else took the lock name. The most likely cause is a supervisor running PRE-#3601 code on this box: it reads a lock whose pid file is not yet present as STALE and renames it aside, which is the defect #3601 fixes. Starting now would put two supervisors in one worktree, so this run stops instead" \
     "re-run this supervisor: if the other holder is a real one, the next start will say so and name its pid; if it was a pre-#3601 reclaim, upgrade every checkout on this box that can launch a supervisor past #3601 so no peer reclaims a pid-less lock again"
+}
+
+# supervisor_lock_refuse_publish_failed <cause> — the lock NAME became ours and we could not record
+# ourselves in it (#3601, roborev job 231 B1).
+#
+# THIS IS A SEPARATE REFUSAL BECAUSE IT IS A SEPARATE FACT, and conflating it cost a false diagnostic:
+# an ENOSPC or a read-only filesystem never writes a byte, so telling the operator that "our pid was
+# published and read back wrong" describes a race that did not happen and hides the one that did. It also
+# reports that the directory we created was REMOVED AGAIN, because an operator who reads "could not
+# start" and then finds a lock sitting there will otherwise go looking for a holder.
+supervisor_lock_refuse_publish_failed() {
+  local cause="$1" what=''
+  case "$cause" in
+    write-failed)  what='writing our pid into the lock FAILED — no byte of it was written' ;;
+    rename-failed) what='publishing our pid into the lock FAILED at the rename — the staging file was written and could not be moved into place' ;;
+    *)             what="recording our pid in the lock FAILED ([$cause])" ;;
+  esac
+  supervisor_lock_refuse \
+    "refusing to start — the lock name became ours and this run could not record itself in it" \
+    "$what. This is a FILESYSTEM failure, not contention: no other holder is implied. The usual causes are a full filesystem (ENOSPC — routine on this fleet) or a read-only mount. The directory this run created has been REMOVED AGAIN, non-recursively, so this failure leaves no pid-less lock behind for the next start to have to refuse over" \
+    "check free space and mount options for the filesystem holding the path named above (df, mount), then re-run this supervisor. Nothing needs clearing by hand"
 }
 
 # supervisor_lock_refuse_undecidable <cause> <what-was-observed> — the "cannot tell" refusal, and the
@@ -2337,8 +2542,45 @@ supervisor_lock_refuse_undecidable() {
   supervisor_lock_refuse \
     "refusing to start — the lock is HELD and this run could NOT DECIDE whether its holder is alive ($cause)" \
     "$observed. THIS IS NOT A REPORT THAT THE HOLDER IS DEAD, and it is not a report that it is alive: it is a report that the question was undecidable here. A reclaim needs AFFIRMATIVE evidence that the recorded holder is gone, and there is none, so this run stops rather than take a lock that may belong to a live supervisor (#3601). An ordinary stale lock — one left by a holder that was killed — carries a well-formed pid, is decided automatically, and never reaches this message" \
-    "PRECONDITION FIRST — establish that no supervisor is running for this lane (bash scripts/flow/claim-heartbeat.sh dead-lanes, and check for a live worker-supervisor process for this lane). Once you have, clear the lock by running the next line, on its own, exactly as printed. It is NON-RECURSIVE on purpose: it REFUSES if anything is still inside the lock, so it cannot delete a holder's record you have not examined — if it refuses, list the contents and decide before removing anything" \
-    "rmdir -- $(supervisor_shell_quote "$SUPERVISOR_LOCK")"
+    "PRECONDITION FIRST — establish that no supervisor is running for this lane (bash scripts/flow/claim-heartbeat.sh dead-lanes, and check for a live worker-supervisor process for this lane). Once you have, clear the lock by running the next line, on its own, exactly as printed. It is NON-RECURSIVE on purpose: it REFUSES if anything is still inside, so it cannot delete a holder's record you have not examined — if it refuses, list the contents and decide before removing anything$(supervisor_lock_shape_note)" \
+    "$(supervisor_lock_clear_command)"
+}
+
+# supervisor_lock_clear_command / supervisor_lock_shape_note — THE REMEDY MUST MATCH WHAT IS ACTUALLY AT
+# THAT NAME (#3601, roborev job 231 B2).
+#
+# A refusal that prints a command which CANNOT WORK is worse than one that prints none: it spends the
+# operator's trust and then fails, and they have no way to tell whether the failure means "wrong command"
+# or "something is seriously wrong with this lock". `rmdir` is right for a DIRECTORY and wrong for every
+# other shape, and the other shapes are reachable — a lock NAME that is a regular file or a dangling
+# symlink refuses with `pid-file-absent`, because `<file>/pid` does not exist.
+#
+# `-L` IS TESTED BEFORE `-d`, and that order is the whole correctness of it: `[[ -d ]]` FOLLOWS a symlink,
+# so a symlink-to-a-directory would otherwise be handed `rmdir`, which fails with ENOTDIR. `rm -f` on a
+# symlink removes the LINK and never touches the target, so it is the safe answer for both link shapes.
+# Every command emitted here is NON-RECURSIVE, so none of them can delete contents nobody examined.
+supervisor_lock_clear_command() {
+  local shown=''
+  shown="$(supervisor_shell_quote "$SUPERVISOR_LOCK")" || true
+  if [[ -L "$SUPERVISOR_LOCK" ]]; then
+    printf 'rm -f -- %s' "$shown"
+  elif [[ -d "$SUPERVISOR_LOCK" ]]; then
+    printf 'rmdir -- %s' "$shown"
+  elif [[ -e "$SUPERVISOR_LOCK" ]]; then
+    printf 'rm -f -- %s' "$shown"
+  fi
+}
+
+supervisor_lock_shape_note() {
+  if [[ -L "$SUPERVISOR_LOCK" ]]; then
+    printf '%s' '. NOTE: that name is a SYMLINK, not a lock directory — the line below removes the LINK and does not touch whatever it points at, which is why it is not an rmdir'
+  elif [[ -d "$SUPERVISOR_LOCK" ]]; then
+    printf ''
+  elif [[ -e "$SUPERVISOR_LOCK" ]]; then
+    printf '%s' '. NOTE: that name is NOT a directory, so it is not a lock this script could ever have written — the line below removes that one file, non-recursively'
+  else
+    printf '%s' '. NOTE: nothing exists at that name any more, so there is nothing to clear and no command is printed below'
+  fi
 }
 
 # supervisor_lock_refuse_lost_race — a dead holder's lock was cleared and the name was taken again
@@ -2371,7 +2613,10 @@ acquire_lock() {
     return 0
   fi
   if [[ "$takerc" -eq 2 ]]; then
-    supervisor_lock_refuse_unowned
+    supervisor_lock_refuse_unowned "$SUPERVISOR_LOCK_TAKE_CAUSE"
+  fi
+  if [[ "$takerc" -eq 3 ]]; then
+    supervisor_lock_refuse_publish_failed "$SUPERVISOR_LOCK_TAKE_CAUSE"
   fi
 
   # `mkdir` FAILING IS NOT YET EVIDENCE OF CONTENTION, and conflating the two is the diagnostic defect
@@ -2388,10 +2633,12 @@ acquire_lock() {
 
   # THE NAME IS TAKEN. WHO HOLDS IT? Three-valued, and only an AFFIRMATIVE `dead` reclaims.
   local holder='' holder_pid='' liveness='' tries=0
-  local tries_max="${SUPERVISOR_LOCK_PID_TRIES:-20}" wait_secs="${SUPERVISOR_LOCK_PID_WAIT:-0.05}"
-  # An unusable knob falls back to the DEFAULT, never to "no wait": the collapse has to go toward
-  # measuring, not toward the permissive answer the wait exists to avoid.
-  case "$tries_max" in '' | *[!0123456789]*) tries_max=20 ;; esac
+  # THE BOUNDS ARE CONSTANTS, NOT KNOBS (#3601, roborev job 231 B5/B6). An earlier cut of this change
+  # read them from the environment so the cases could go fast, which is both a seam a real invoker can
+  # set (CLAUDE.md #3312) and a knob the tests would then be testing instead of the code — and its
+  # validation covered only the try count, leaving `sleep "$wait_secs"` to be handed anything at all
+  # (`999999` makes the window this code calls bounded unbounded; `--help` puts sleep's usage on our
+  # stdout). Being literals, there is nothing to validate and nothing to override.
 
   # THE PROBE ASSIGNMENTS CARRY A FAIL-CLOSED FALLBACK (#3549 job 201 F3, same shape). Both probes
   # return 0 on every path they take, so these are unreachable today — but a non-zero inside a `$( )`
@@ -2413,7 +2660,7 @@ acquire_lock() {
   # a writer passes through (the name not yet renamed into place; a pre-#3601 peer's `echo $$ >…/pid`
   # between create and write). A garbled, multi-line or non-decimal pid is not a startup artifact of any
   # writer, so re-reading it would only add delay to a refusal that is already decided.
-  while [[ "$tries" -lt "$tries_max" ]]; do
+  while [[ "$tries" -lt "$SUPERVISOR_LOCK_PID_TRIES" ]]; do
     case "$holder" in
       'unparseable pid-file-absent' | 'unparseable pid-file-empty') ;;
       *) break ;;
@@ -2422,7 +2669,7 @@ acquire_lock() {
     # A `sleep` that cannot take a fractional argument (some minimal builds) fails harmlessly: the loop
     # then spins its bounded number of iterations instead of pausing, which measures the same property
     # with less patience.
-    sleep "$wait_secs" 2>/dev/null || true
+    sleep "$SUPERVISOR_LOCK_PID_WAIT" 2>/dev/null || true
     holder="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")" || holder='unparseable pid-probe-aborted'
   done
 
@@ -2462,7 +2709,7 @@ acquire_lock() {
   esac
 
   # THE ONLY RECLAIMING PATH, AND IT IS REACHED ONLY FROM AN AFFIRMATIVE `dead`.
-  log "reclaiming stale lock $SUPERVISOR_LOCK (holder pid $holder_pid is affirmatively DEAD: the kernel reports no such process)"
+  log "$(supervisor_one_line "reclaiming stale lock $(supervisor_shell_quote "$SUPERVISOR_LOCK") (holder pid $holder_pid is affirmatively DEAD: the kernel reports no such process)")"
   # Atomic reclaim (rename-then-remove), not rm-then-mkdir: two supervisors racing a dead-pid lock both
   # taking the rm-then-mkdir path could both end up believing they won. `mv` on the same filesystem is
   # atomic, so only ONE racer's mv can succeed against a given stale directory name; that racer removes
@@ -2471,6 +2718,18 @@ acquire_lock() {
   # it refuses loudly instead of silently co-running. `--` on both operands: `TMPDIR`-derived (#3601 AC7).
   if mv -f -- "$SUPERVISOR_LOCK" "$SUPERVISOR_LOCK.stale.$$" 2>/dev/null; then
     rm -rf -- "$SUPERVISOR_LOCK.stale.$$" 2>/dev/null || true
+  elif [[ -e "$SUPERVISOR_LOCK" || -L "$SUPERVISOR_LOCK" ]]; then
+    # THE RENAME FAILED AND THE LOCK IS STILL THERE (#3601, roborev job 231 B2). Ignoring this was a
+    # MISDIAGNOSIS, not just a missing branch: the `take` below then failed too and the run printed the
+    # lost-race refusal — "a stale lock was cleared and the name was immediately claimed by someone
+    # else" — which had not happened, together with "re-run this supervisor", which loops forever. Same
+    # family as the AC7 addendum: a message that sends the operator after a problem that is not there.
+    # The realistic cause is the parent directory becoming unwritable after the lock appeared.
+    supervisor_lock_refuse \
+      "refusing to start — a DEAD holder's lock could not be cleared" \
+      "the recorded holder (pid $holder_pid) is affirmatively gone, so this lock IS stale and this run is entitled to it — but renaming it aside FAILED, so nothing was cleared and nothing was claimed. That is a FILESYSTEM failure, not contention: the lock's parent directory must be writable to clear a lock, and being able to READ a lock does not imply that. No other holder is implied and nothing here has been modified" \
+      "make the lock's parent directory writable by this user and re-run; the stale lock will then be cleared automatically, because its holder is already known to be dead. If you would rather clear it by hand, the next line does it non-recursively once the pid file is gone$(supervisor_lock_shape_note)" \
+      "$(supervisor_lock_clear_command)"
   fi
   takerc=0
   supervisor_lock_take || takerc=$?
@@ -2478,7 +2737,10 @@ acquire_lock() {
     return 0
   fi
   if [[ "$takerc" -eq 2 ]]; then
-    supervisor_lock_refuse_unowned
+    supervisor_lock_refuse_unowned "$SUPERVISOR_LOCK_TAKE_CAUSE"
+  fi
+  if [[ "$takerc" -eq 3 ]]; then
+    supervisor_lock_refuse_publish_failed "$SUPERVISOR_LOCK_TAKE_CAUSE"
   fi
   supervisor_lock_refuse_lost_race
 }

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -2403,7 +2403,7 @@ supervisor_lock_publish() {
 # ownership test at all, so a run that had lost its lock deleted the new holder's on the way out.
 # NOT CLOSED: the read and the removal are two operations, so a lock that becomes someone else's between
 # them is still removed. Closing that needs serialization across classify -> reclaim -> claim, which is
-# the same root as the reclaim ABA race at the rename below, and it is tracked as ONE follow-up rather
+# the same root as the reclaim ABA race at the rename below, and it is tracked as ONE follow-up (#3683)
 # than patched here: the primitive it needs is a lock protecting a lock, whose own staleness reopens
 # "how does a stale instance get cleared, and by whom?" one level down. Left as an explicit partial
 # because dropping the ownership test to avoid a half-fix would REGRESS to the unconditional delete.
@@ -2711,12 +2711,35 @@ acquire_lock() {
 
   # THE ONLY RECLAIMING PATH, AND IT IS REACHED ONLY FROM AN AFFIRMATIVE `dead`.
   log "$(supervisor_one_line "reclaiming stale lock $(supervisor_shell_quote "$SUPERVISOR_LOCK") (holder pid $holder_pid is affirmatively DEAD: the kernel reports no such process)")"
-  # Atomic reclaim (rename-then-remove), not rm-then-mkdir: two supervisors racing a dead-pid lock both
-  # taking the rm-then-mkdir path could both end up believing they won. `mv` on the same filesystem is
-  # atomic, so only ONE racer's mv can succeed against a given stale directory name; that racer removes
-  # the renamed-aside copy and falls through to its own take below. The loser's mv fails (the name is
-  # already gone), so it falls through to its own take, which fails against the winner's fresh lock, and
-  # it refuses loudly instead of silently co-running. `--` on both operands: `TMPDIR`-derived (#3601 AC7).
+  # Reclaim by rename-then-remove, not rm-then-mkdir: the rename is a single atomic operation, so a
+  # racer that loses it does not get a window in which the lock name simply does not exist.
+  #
+  # WHAT THIS DOES **NOT** DO, STATED HERE BECAUSE THE COMMENT THAT USED TO SIT ON THIS LINE CLAIMED
+  # OTHERWISE (#3601, roborev job 231 F1; tracked as #3683). The prior wording asserted that "only ONE
+  # racer's mv can succeed" and that the loser therefore "refuses loudly instead of silently
+  # co-running". Both are FALSE, and the interleaving that falsifies them is this one:
+  #
+  #   A and B both read holder pid P and both get an affirmative `dead`.
+  #   A renames the stale lock aside, removes it, takes the name, publishes pid A -- A is now LIVE.
+  #   B's rename now runs. The name EXISTS again (it is A's fresh, live lock), so B's `mv` SUCCEEDS,
+  #   moving A's lock aside; B removes it and takes the name. A and B now BOTH believe they hold the
+  #   lane, and nothing printed a refusal.
+  #
+  # So the rename serialises the case where the loser arrives BEFORE the winner republishes, and it does
+  # not close the ABA window where the loser arrives AFTER. Closing that needs serialisation across
+  # classify -> reclaim -> claim (the same root as the read-then-remove in `supervisor_lock_release`),
+  # which is one follow-up (#3683) and not a widening of this change: the primitive it needs is a lock
+  # protecting a lock, whose own staleness reopens "how does a stale instance get cleared, and by whom?"
+  # one level down. Two shortcuts are already measured closed -- `mkdir`+`mv` is not atomic (it leaves a
+  # pid-less window), and `mv -T` is NOT `RENAME_NOREPLACE`: it refuses a non-empty target but SUCCEEDS
+  # against an EMPTY one, which is exactly a peer's pid-less window, besides being GNU-only.
+  #
+  # NARROWED, NOT CLOSED: this path is now reached ONLY from an affirmative `dead`, where the pre-#3601
+  # code reclaimed on ANY non-live answer (unparseable pid, EPERM, pid-less window), so the set of states
+  # that can reach the race is much smaller than it was -- but it is not empty. Do not read the paragraph
+  # above as a guarantee; it is a bound.
+  #
+  # `--` on both operands: `TMPDIR`-derived (#3601 AC7).
   if mv -f -- "$SUPERVISOR_LOCK" "$SUPERVISOR_LOCK.stale.$$" 2>/dev/null; then
     rm -rf -- "$SUPERVISOR_LOCK.stale.$$" 2>/dev/null || true
   elif [[ -e "$SUPERVISOR_LOCK" || -L "$SUPERVISOR_LOCK" ]]; then

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -2618,16 +2618,21 @@ supervisor_lock_take() {
   # has already removed the directory we just created — contention — and with EACCES/ENOSPC when the
   # filesystem cannot take a zero-byte file. Reporting the first as the second sends an operator to check
   # a disk that is fine.
-  if ! { : >"$marker"; } 2>/dev/null && [[ ! -d "$SUPERVISOR_LOCK" ]]; then
-    SUPERVISOR_LOCK_TAKE_CAUSE='marker-failed-lock-gone cleanup-declined-lock-already-gone'
-    return 3
-  fi
-  if [[ ! -e "$marker" && ! -L "$marker" ]]; then
+  # ONE OUTCOME VARIABLE, SO EACH BRANCH HAS A LINE OF ITS OWN. An earlier cut folded the write and the
+  # existence re-test into two `if`s whose conditions were indistinguishable from the un-create's, which
+  # made a mutant unable to name either uniquely — `sv_mutant_override` correctly refused it.
+  local marker_written=0
+  if { : >"$marker"; } 2>/dev/null; then marker_written=1; fi
+  if [[ "$marker_written" -eq 0 ]]; then
     # NO OWNERSHIP EVIDENCE, SO NO REMOVAL. We know we created the directory and we cannot PROVE the one
     # at that name now is still ours, so it is left in place and reported. That risks the empty-lock wedge
     # B1 removed — but the cause is a filesystem that cannot take a zero-byte file, the same failure the
     # remedy names, and guessing our way to a deletion is how a peer's lock gets destroyed.
-    SUPERVISOR_LOCK_TAKE_CAUSE='marker-failed cleanup-declined-no-ownership-evidence'
+    if [[ ! -d "$SUPERVISOR_LOCK" ]]; then
+      SUPERVISOR_LOCK_TAKE_CAUSE='marker-failed-lock-gone cleanup-declined-lock-already-gone'
+    else
+      SUPERVISOR_LOCK_TAKE_CAUSE='marker-failed cleanup-declined-no-ownership-evidence'
+    fi
     return 3
   fi
   # `supervisor_lock_publish` runs in a command substitution, which is a SUBSHELL — fine, because it

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -881,14 +881,29 @@ captured_question() {
     | head -n 3 | tr '\n' ' ' | cut -c1-300
 }
 
-# log_size <logfile>: byte size of the file, or 0 when absent. A wedged
-# interactive prompt produces NO further output, so a frozen byte size across two
-# consecutive scans is the positive evidence that distinguishes a genuine wedge
-# from a busy worker that merely printed a tool name and kept writing.
+# log_size <logfile>: byte size of the file, `0` when absent, or `-1` when it COULD NOT BE MEASURED. A
+# wedged interactive prompt produces NO further output, so a frozen byte size across two consecutive
+# scans is the positive evidence that distinguishes a genuine wedge from a busy worker that merely
+# printed a tool name and kept writing.
+#
+# A FAILED MEASUREMENT IS NOT A VALUE (#3601). This used to return the EMPTY STRING when `wc` failed,
+# and empty collapses to `0` in the caller's `-eq` comparison — so two UNMEASURABLE reads compared
+# EQUAL and a healthy worker's log read as frozen. `-1` is the same "no measurement" sentinel the
+# caller's `prev_size` already starts at, so an unmeasurable read can never satisfy the caller's
+# `-ge 0` guards and can never be mistaken for a real byte count.
 log_size() {
-  local f="$1"
+  local f="$1" n
   [[ -f "$f" ]] || { printf '0'; return 0; }
-  wc -c <"$f" 2>/dev/null | tr -d ' '
+  n="$(wc -c <"$f" 2>/dev/null | tr -d ' ')"
+  # The digits are enumerated rather than given as a `[0-9]` RANGE, whose members are decided by the
+  # caller's collation.
+  case "$n" in
+    '' | *[!0123456789]*)
+      printf '%s' '-1'
+      return 0
+      ;;
+  esac
+  printf '%s' "$n"
 }
 
 marker_field() {
@@ -2741,7 +2756,11 @@ run_iteration() {
       # this scan and the prior one AND the log did not grow between them (and
       # the process is still alive — the loop condition). prev_size<0 = no prior
       # scan yet, so the very first scan can never confirm.
-      if [[ "$prev_sig" -eq 1 && "$cur_sig" -eq 1 && "$prev_size" -ge 0 && "$cur_size" -eq "$prev_size" ]]; then
+      # AND BOTH SCANS MUST BE REAL MEASUREMENTS (#3601). `log_size` reports `-1` when it could not
+      # measure; without `cur_size -ge 0` two FAILED reads compare equal and the log reads as frozen —
+      # the "an empty probe is not a zero" shape. A `-1` also propagates into `prev_size` below, so the
+      # next scan cannot confirm against it either.
+      if [[ "$prev_sig" -eq 1 && "$cur_sig" -eq 1 && "$prev_size" -ge 0 && "$cur_size" -ge 0 && "$cur_size" -eq "$prev_size" ]]; then
         local qtext
         qtext="$(captured_question "$logfile")"
         printf '%s' "$qtext" >"$stuck_flag"

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -2749,6 +2749,13 @@ run_iteration() {
   local deadline=$((t0 + MAX_ITER_SECS))
   local stuck_notified=0 g now
   local last_scan_ts=$t0 prev_size=-1 prev_sig=0 cur_size cur_sig
+  # SWEPT AND LEFT TWO-VALUED, DELIBERATELY (#3601 call-site audit). `#3601` made the LOCK's liveness
+  # probe three-valued because that pid comes off DISK, from a process we have never seen, possibly
+  # owned by another user — so `kill -0` failing there could mean EPERM and reading it as death stole a
+  # live holder's lock. None of that applies here: `$wpid` is the pid of a child THIS SHELL just forked,
+  # same uid, same session, so EPERM is not reachable and a non-zero `kill -0` means exactly one thing.
+  # Recorded so a later sweep of the `kill -0` sites does not "fix" a correct one — the three-valued
+  # probe belongs where the pid's provenance is untrusted, not everywhere the primitive appears.
   while kill -0 "$wpid" 2>/dev/null; do
     now=$(date +%s)
     if [[ "$now" -ge "$deadline" ]]; then

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -2435,7 +2435,15 @@ supervisor_lock_publish() {
   # word-splitting and globbing and does nothing about option parsing.
   if ! mv -f -- "$tmpf" "$SUPERVISOR_LOCK/pid" 2>/dev/null; then
     rm -f -- "$tmpf" 2>/dev/null || true
-    printf '%s' 'rename-failed'
+    # A RACE AND AN I/O ERROR SHARE THIS FAILURE, AND THEY WANT OPPOSITE ACTIONS (#3601, job 244 sweep).
+    # The rename fails with ENOENT when a peer has removed the directory under us — contention, where the
+    # answer is "re-run" — and with EACCES/ENOSPC when the filesystem is broken, where the answer is "fix
+    # the box" and re-running loops forever. They are told apart by whether the directory is still there.
+    if [[ ! -d "$SUPERVISOR_LOCK" ]]; then
+      printf '%s' 'rename-failed-lock-gone'
+    else
+      printf '%s' 'rename-failed'
+    fi
     return 1
   fi
   state="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")" || state='unparseable read-back-aborted'
@@ -2606,7 +2614,15 @@ supervisor_lock_take() {
   # the publish is what makes it the narrowest window available to this code, and nothing here can make it
   # zero — that needs serialisation of the complete claim-and-publication operation, which is #3683,
   # together with the reclaim ABA and the release read-then-remove. Do not read the marker as a guarantee.
-  if ! { : >"$marker"; } 2>/dev/null; then
+  # SAME PREDICATE AS THE RENAME BELOW (#3601, job 244 sweep): this write fails with ENOENT when a peer
+  # has already removed the directory we just created — contention — and with EACCES/ENOSPC when the
+  # filesystem cannot take a zero-byte file. Reporting the first as the second sends an operator to check
+  # a disk that is fine.
+  if ! { : >"$marker"; } 2>/dev/null && [[ ! -d "$SUPERVISOR_LOCK" ]]; then
+    SUPERVISOR_LOCK_TAKE_CAUSE='marker-failed-lock-gone cleanup-declined-lock-already-gone'
+    return 3
+  fi
+  if [[ ! -e "$marker" && ! -L "$marker" ]]; then
     # NO OWNERSHIP EVIDENCE, SO NO REMOVAL. We know we created the directory and we cannot PROVE the one
     # at that name now is still ours, so it is left in place and reported. That risks the empty-lock wedge
     # B1 removed — but the cause is a filesystem that cannot take a zero-byte file, the same failure the
@@ -2740,48 +2756,91 @@ supervisor_lock_refuse_publish_failed() {
   case "$cause" in
     *' '*) cleanup="${cause#* }" ;;
   esac
+  # THE NATURE OF THE FAILURE IS CARRIED SEPARATELY FROM THE STEP THAT FAILED (#3601, job 244 sweep). The
+  # same step fails for two reasons that want OPPOSITE actions — a peer removing the directory (re-run)
+  # versus a broken filesystem (fix the box, and re-running loops) — so the first action an operator is
+  # given is selected by the nature, not by the step.
+  local nature='' nature_line='' first_action=''
   case "$pub" in
-    marker-failed) what='writing our OWNERSHIP MARKER into the lock FAILED — this run got the lock name and could not record, even provisionally, that the directory is its own' ;;
-    write-failed)  what='writing our pid into the lock FAILED — no byte of it was written' ;;
-    rename-failed) what='publishing our pid into the lock FAILED at the rename — the staging file was written and could not be moved into place' ;;
-    *)             what="recording our pid in the lock FAILED ([$pub])" ;;
+    marker-failed)
+      what='writing our OWNERSHIP MARKER into the lock FAILED — this run got the lock name and could not record, even provisionally, that the directory is its own'
+      nature='filesystem'
+      ;;
+    marker-failed-lock-gone)
+      what='writing our OWNERSHIP MARKER into the lock FAILED because the lock directory this run had just created was ALREADY GONE'
+      nature='contention'
+      ;;
+    write-failed)
+      what='writing our pid into the lock FAILED — no byte of it was written'
+      nature='filesystem'
+      ;;
+    rename-failed)
+      what='publishing our pid into the lock FAILED at the rename — the staging file was written and could not be moved into place'
+      nature='filesystem'
+      ;;
+    rename-failed-lock-gone)
+      what='publishing our pid into the lock FAILED at the rename because the lock directory this run had created was ALREADY GONE'
+      nature='contention'
+      ;;
+    *)
+      what="recording our pid in the lock FAILED ([$pub])"
+      nature='unestablished'
+      ;;
+  esac
+  case "$nature" in
+    filesystem)
+      nature_line='This is a FILESYSTEM failure, not contention: no other holder is implied by the failure itself. The usual causes are a full filesystem (ENOSPC — routine on this fleet) or a read-only mount'
+      first_action='check free space and mount options for the filesystem holding the path named above (df, mount) — re-running without changing either will fail the same way'
+      ;;
+    contention)
+      nature_line='This is CONTENTION, not a filesystem fault: something removed or replaced the directory this run had just created, while this run was recording itself in it. No disk or permission problem is implied'
+      first_action='re-run this supervisor — nothing needs fixing and nothing needs clearing; the next start will either take the lock or name whoever holds it'
+      ;;
+    *)
+      nature_line='Whether this was a filesystem fault or contention is NOT established by the failure itself, so this refusal does not claim either'
+      first_action='inspect the path named above and the filesystem holding it (df, mount) before re-running: this run could not tell a broken filesystem from a peer taking the name'
+      ;;
   esac
   # EVERY SENTENCE BELOW IS BOUND TO AN OBSERVATION `supervisor_lock_take` ACTUALLY MADE (#3601 B9).
   case "$cleanup" in
     cleanup-verified-absent)
       aftermath='The directory this run created has been removed again and its absence was VERIFIED after the removal, so this failure leaves no pid-less lock behind for the next start to have to refuse over'
-      remedy='check free space and mount options for the filesystem holding the path named above (df, mount), then re-run this supervisor. Nothing needs clearing by hand'
+      remedy="$first_action. Nothing needs clearing by hand"
       ;;
     'cleanup-failed-foreign-holder '*)
       aftermath="This run then tried to remove the directory it had created and it REMAINS — and it now holds a holder record that is NOT ours ([${cleanup#cleanup-failed-foreign-holder }]). A peer published into it while our publish was failing; the removal is NON-RECURSIVE precisely so that it cannot delete that record, and nothing of that peer's has been touched"
-      remedy='nothing to clear: the path named above belongs to another holder, which this run left intact. Fix the filesystem problem named above and re-run; the next start will read that holder and report it by pid'
+      remedy="nothing to clear: the path named above belongs to another holder, which this run left intact. $first_action; the next start will read that holder and report it by pid"
+      ;;
+    cleanup-declined-lock-already-gone)
+      aftermath='There was nothing for this run to remove: the directory it created was already gone when it looked. Nothing was removed and nothing is left behind by this run'
+      remedy="$first_action"
       ;;
     cleanup-declined-no-ownership-evidence)
       aftermath='This run therefore did NOT attempt to remove the directory it created: with no marker written it cannot prove the directory now at that name is still its own, and a removal on that guess is how a peer that took the name in the meantime loses its lock. A lock MAY be sitting at that path — this run makes no claim either way'
-      remedy="fix the filesystem problem named above and re-run. If starts keep refusing over a lock at that path, inspect it and clear it with the next line, which is NON-RECURSIVE and refuses if anything is inside that you have not examined$(supervisor_lock_shape_note)"
+      remedy="$first_action. If starts keep refusing over a lock at that path, inspect it and clear it with the next line, which is NON-RECURSIVE and refuses if anything is inside that you have not examined$(supervisor_lock_shape_note)"
       cmd="$(supervisor_lock_clear_command)"
       ;;
     'cleanup-declined-foreign-holder '*)
       aftermath="This run then found that the directory at that name is NOT the one it created — its ownership marker is gone from it — and that it holds a holder record ([${cleanup#cleanup-declined-foreign-holder }]). Another supervisor took the name while our publish was failing, so this run removed NOTHING"
-      remedy='nothing to clear: the path named above belongs to another holder, which this run left intact. Fix the filesystem problem named above and re-run; the next start will read that holder and report it by pid'
+      remedy="nothing to clear: the path named above belongs to another holder, which this run left intact. $first_action; the next start will read that holder and report it by pid"
       ;;
     'cleanup-declined-foreign-instance '*)
       aftermath="This run then found that the directory at that name is NOT the one it created — its ownership marker is gone from it — and that it carries no holder record yet ([${cleanup#cleanup-declined-foreign-instance }]). That is another supervisor's start in progress, which is exactly the lock a blind removal would have destroyed, so this run removed NOTHING"
-      remedy='nothing to clear: another supervisor is starting at that path and this run left it alone. Fix the filesystem problem named above and re-run; the next start will read that holder and report it by pid'
+      remedy="nothing to clear: another supervisor is starting at that path and this run left it alone. $first_action; the next start will read that holder and report it by pid"
       ;;
     'cleanup-failed-residual '*)
       aftermath="This run then tried to remove the directory it had created and it REMAINS ([${cleanup#cleanup-failed-residual }]) — the removal did NOT succeed, so a lock DOES sit at that path and the next start will refuse over it until it is cleared"
-      remedy="fix the filesystem problem named above, then clear the leftover lock with the next line, on its own, exactly as printed — it is NON-RECURSIVE, so it refuses if anything is inside that you have not examined$(supervisor_lock_shape_note)"
+      remedy="$first_action. Then clear the leftover lock with the next line, on its own, exactly as printed — it is NON-RECURSIVE, so it refuses if anything is inside that you have not examined$(supervisor_lock_shape_note)"
       cmd="$(supervisor_lock_clear_command)"
       ;;
     *)
       aftermath='The removal outcome for the directory this run created was NOT ESTABLISHED, so this refusal makes no claim about whether a lock remains at that path'
-      remedy='fix the filesystem problem named above, then inspect the path named above before re-running: this run could not establish whether it left a lock there'
+      remedy="$first_action. Then inspect the path named above before re-running: this run could not establish whether it left a lock there"
       ;;
   esac
   supervisor_lock_refuse \
     "refusing to start — the lock name became ours and this run could not record itself in it" \
-    "$what. This is a FILESYSTEM failure, not contention: no other holder is implied by the failure itself. The usual causes are a full filesystem (ENOSPC — routine on this fleet) or a read-only mount. $aftermath" \
+    "$what. $nature_line. $aftermath" \
     "$remedy" \
     "$cmd"
 }
@@ -2858,6 +2917,19 @@ supervisor_lock_refuse_lost_race() {
     "nothing is wrong: re-run this supervisor. If it keeps losing, the winner is a live supervisor for this lane and the next start will name its pid"
 }
 
+# supervisor_lock_refuse_uncreatable [<phase-note>] — `mkdir` failed AND nothing is at that name, so the
+# failure is about the PATH and not about a holder (#3601 AC7 addendum; reused post-reclaim by job 244 B20).
+#
+# TWO CALL SITES, ONE TEXT, because the operator's problem is identical in both: the lock path cannot be
+# created. The optional phase note says WHERE in the start we were, which is the only thing that differs.
+supervisor_lock_refuse_uncreatable() {
+  local phase="${1:-}"
+  supervisor_lock_refuse \
+    "refusing to start — the lock directory could NOT BE CREATED, and nothing exists at that path" \
+    "this is NOT contention: no lock is there and no holder is implied${phase:+ ($phase)}. \`mkdir\` failed for a reason to do with the PATH itself — the parent directory missing, not a directory, or not writable by this user, or the filesystem being full" \
+    "check the parent directory of the path named above: it must exist, be a directory, and be writable by this user, and the filesystem must have space. The path is \${TMPDIR:-/tmp}-derived unless this run's launcher named it, so a TMPDIR pointing somewhere absent, read-only or full is the usual cause. Re-running WITHOUT changing any of that will fail exactly the same way"
+}
+
 acquire_lock() {
   # IDENTITY FIRST: both the lock path and the claim actor are derived FROM it, so resolving it after
   # them would leave them on a stale inference.
@@ -2890,10 +2962,7 @@ acquire_lock() {
   # `mkdir` also fails when the parent is missing, unwritable, or not a directory. So before attributing
   # the failure to a holder, check that something IS at that name.
   if [[ ! -e "$SUPERVISOR_LOCK" && ! -L "$SUPERVISOR_LOCK" ]]; then
-    supervisor_lock_refuse \
-      "refusing to start — the lock directory could NOT BE CREATED, and nothing exists at that path" \
-      "this is NOT contention: no lock is there and no holder is implied. \`mkdir\` failed for a reason to do with the PATH itself — the parent directory missing, not a directory, or not writable by this user" \
-      "check the parent directory of the path named above: it must exist, be a directory, and be writable by this user. The path is \${TMPDIR:-/tmp}-derived unless this run's launcher named it, so a TMPDIR pointing somewhere absent or read-only is the usual cause"
+    supervisor_lock_refuse_uncreatable ''
   fi
 
   # THE NAME IS TAKEN. WHO HOLDS IT? Three-valued, and only an AFFIRMATIVE `dead` reclaims.
@@ -3058,7 +3127,21 @@ acquire_lock() {
   if [[ "$takerc" -eq 3 ]]; then
     supervisor_lock_refuse_publish_failed "$SUPERVISOR_LOCK_TAKE_CAUSE"
   fi
-  supervisor_lock_refuse_lost_race
+  # STATUS 1 IS `mkdir` FAILING, AND THAT IS TWO DIFFERENT FACTS WITH OPPOSITE REMEDIES (#3601, roborev
+  # job 244 B20). EEXIST means someone else took the name — a race, and re-running is exactly right.
+  # EACCES/ENOSPC/ENOENT mean the path cannot hold a lock — and then "a stale lock was cleared and the
+  # name was claimed by someone else, re-run this supervisor" tells an operator that nothing is wrong and
+  # sends them into a retry loop over a state that cannot resolve until permissions or disk are fixed.
+  #
+  # THIS IS #3601'S OWN HEADLINE DEFECT, ONE BRANCH OVER: the AC7 addendum exists because the pre-fix code
+  # "blames the lock rather than the path shape, and an operator goes looking for a stale lock that isn't
+  # there". Shipping this issue with a fresh instance of its own rationale is not defensible. The FIRST
+  # take already disambiguates exactly this way, which is what makes the omission here an oversight rather
+  # than a design choice — so the same existence test decides it.
+  if [[ -e "$SUPERVISOR_LOCK" || -L "$SUPERVISOR_LOCK" ]]; then
+    supervisor_lock_refuse_lost_race
+  fi
+  supervisor_lock_refuse_uncreatable 'after a stale lock was successfully cleared, so the name was free a moment ago'
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -1528,7 +1528,9 @@ supervisor_one_line() {
 # (`supervisor_legacy_lock_state`) that opened the lock directory, enumerated it, parsed its `pid` file
 # and measured the recorded pid's liveness, producing `live <pid>` / `stale <pid>` / `unknown <cause>`;
 # it needed a pid-liveness probe (`supervisor_pid_liveness`, deleted with it — this was its only
-# caller), a platform pid bound read from `/proc/sys/kernel/pid_max`, a NUL probe, a single-line parse,
+# caller; #3601 later rebuilt the CAPABILITY, under a name that says whose question it answers, for the
+# PER-LANE lock, where the verdict does change the decision — see the probes above `acquire_lock`), a
+# platform pid bound read from `/proc/sys/kernel/pid_max`, a NUL probe, a single-line parse,
 # a collation-free digit test, and a wholesale neutralisation of the caller's inherited glob/match state
 # (`GLOBIGNORE`, `dotglob`, `nullglob`, `failglob`, `noglob`, `nocasematch`, …) with per-option
 # verification and an order-sensitive restore — because the enumeration's correctness depended on all of
@@ -1927,6 +1929,320 @@ supervisor_legacy_lock_guard() {
   esac
 }
 
+# ---------------------------------------------------------------------------
+# THE PER-LANE LOCK'S HOLDER PROBES (#3601) — WHY THEY EXIST AND WHY THEY ARE SHAPED LIKE THIS
+#
+# `acquire_lock` below claims a per-lane lock with `mkdir`, and when the name is already taken it has
+# to answer ONE question: MAY WE TAKE IT? Before #3601 it answered with `cat` + `kill -0`, which is
+# two-valued in three separate ways at once, and every one of them collapsed onto the PERMISSIVE
+# answer — RECLAIM:
+#
+#   * the recorded pid was used UNPARSED, so an empty, garbled or multi-line `pid` file made `kill -0`
+#     fail, and that failure read as "the holder is dead";
+#   * `kill -0` fails with EPERM as well as ESRCH, so a LIVE holder owned by another user read as dead;
+#   * `mkdir` followed by `echo $$ >…/pid` leaves a window in which the lock exists with NO pid file,
+#     and a peer arriving in that window read a STARTING holder as a dead one.
+#
+# In all three the outcome is identical and it is the worst one available: the lock is taken from a LIVE
+# holder and two supervisors run in one worktree — the concurrency the lock exists to prevent.
+#
+# THE PROBES ARE THREE-VALUED AND "CANNOT TELL" REFUSES. That is the standing rule (CLAUDE.md; #3549
+# lead ruling 1), and it is the whole content of this fix: `dead` is the ONLY verdict that licenses a
+# reclaim, and it must be AFFIRMATIVE — evidence the process is GONE, never absence of evidence that it
+# is there.
+#
+# AND A REFUSAL IS NOT A DEAD END — RULING 2, WHICH IS THE HARD HALF. "Cannot tell ⇒ refuse" applied
+# without an answer to "then how does a stale lock EVER get cleared, and by whom?" produces a lane
+# blocked forever by a directory, and a guard that never permits work is broken, not fail-closed. The
+# answer, in full:
+#
+#   1. NORMAL EXIT — the holder's own EXIT trap (`supervisor_lock_release`) removes the lock. Nobody
+#      else is involved and nothing has to be cleared.
+#   2. HOLDER KILLED (-9, OOM, reboot) — the lock survives WITH a well-formed pid. The next start reads
+#      it, `supervisor_lock_holder_liveness` returns an AFFIRMATIVE `dead`, and the lock is RECLAIMED
+#      AUTOMATICALLY, exactly as before #3601. This is the stale case that actually happens on this
+#      fleet; it needs no operator, and nothing in this change narrows it.
+#   3. THE UNDECIDABLE REMAINDER — a pid file that is PERSISTENTLY absent or unparseable, or a liveness
+#      probe that could not answer. Only here do we refuse, and every such refusal PRINTS THE PATH AND
+#      A COMMAND THAT CLEARS IT, so the operator is the mechanism and the refusal is the instruction.
+#      A refusal naming no remedy is what turns "fail closed" into "wedged", which is itself a defect.
+#
+# WHY (3) IS A VANISHINGLY SMALL SET, BY CONSTRUCTION RATHER THAN BY HOPE. The pid is published by
+# RENAME (`supervisor_lock_publish`), so the `pid` NAME never exists holding partial content: a reader
+# either does not see the name, or sees the complete value. The only undecidable shapes left are a lock
+# whose holder died inside the one-rename window after `mkdir`, and a `pid` file corrupted by something
+# outside this script. Neither is a state a healthy supervisor passes through.
+#
+# WHAT THESE PROBES DO NOT DEFEND AGAINST, STATED. Anything that can WRITE our lock directory can write
+# any pid it likes into it, and no parse can tell a forged pid from a recorded one. That is not a hole
+# these probes could close: whoever can write `$SUPERVISOR_LOCK` can also `rmdir` it. The parse's job is
+# to reject content no legitimate writer produces (crash residue, a partial write, a truncated file),
+# not to authenticate the writer.
+#
+# WHY NOT `supervisor_pid_liveness`, THE NAME AC3 ASKED FOR: that symbol was DELETED in #3549's final
+# form together with the legacy classifier that was its only caller (see the note above
+# `supervisor_legacy_lock_presence`), and the deletion is asserted by this file's suite. It is not
+# revived here, because the argument that removed it — a verdict that cannot change the decision is a
+# description generator on the decision path — is TRUE of the legacy guard and FALSE here: on this path
+# the verdict selects between refusing and reclaiming. So the capability is rebuilt under a name that
+# says WHOSE question it answers, and the legacy path is asserted (as a PROPERTY, not a name) to
+# measure no pid liveness at all.
+# ---------------------------------------------------------------------------
+
+# supervisor_lock_pid_read <pid-file> — echo EXACTLY one of
+#   pid <digits>          a single, canonical, non-zero decimal pid
+#   unparseable <cause>   nothing usable is there, for a NAMED reason
+#
+# Every failure is a NAMED cause and never a bare empty string, because the caller must be able to tell
+# "no pid" from "pid 0" from "unreadable" — collapsing them is the original defect.
+#
+# NO EXTERNAL COMMAND. `read` and `[[ ]]` only, so no verdict depends on `PATH`, and the file is opened
+# by REDIRECTION — which parses no options, so an option-shaped path (#3601 AC7) needs no `--` here.
+# The digit test enumerates the ten digits rather than using a `[0-9]` RANGE, whose members are decided
+# by the caller's collation (a locale-dependent digit test cost #3549 a review round).
+supervisor_lock_pid_read() {
+  local f="$1" first='' line='' n=0 readrc=0
+  if [[ ! -e "$f" && ! -L "$f" ]]; then
+    printf '%s' 'unparseable pid-file-absent'
+    return 0
+  fi
+  if [[ ! -f "$f" ]]; then
+    printf '%s' 'unparseable pid-name-is-not-a-regular-file'
+    return 0
+  fi
+  # ONE redirection over the whole loop, so both lines come from ONE open. A failed open makes the
+  # group return non-zero, which is CAPTURED (never folded into "empty"): unreadable and empty are
+  # different facts with different remedies. `|| [[ -n "$line" ]]` keeps a final line that has no
+  # trailing newline, which `read` reports as failure while still assigning it.
+  { while IFS= read -r line || [[ -n "$line" ]]; do
+      n=$((n + 1))
+      if [[ "$n" -eq 1 ]]; then first="$line"; fi
+      if [[ "$n" -ge 2 ]]; then break; fi
+      line=''
+    done; } <"$f" 2>/dev/null || readrc=$?
+  if [[ "$readrc" -ne 0 ]]; then
+    printf '%s' 'unparseable pid-file-unreadable'
+    return 0
+  fi
+  if [[ "$n" -eq 0 ]]; then
+    printf '%s' 'unparseable pid-file-empty'
+    return 0
+  fi
+  if [[ "$n" -gt 1 ]]; then
+    printf '%s' 'unparseable pid-file-has-more-than-one-line'
+    return 0
+  fi
+  case "$first" in
+    '' | *[!0123456789]*)
+      printf '%s' 'unparseable pid-not-all-decimal-digits'
+      return 0
+      ;;
+    # `0*` is BOTH halves of "non-zero and canonical" in one pattern: it rejects `0` itself (a pid 0
+    # target means the whole process GROUP to `kill`, which is the most dangerous operand available
+    # here) and rejects a leading-zero spelling, which no legitimate writer of `$$` produces.
+    0*)
+      printf '%s' 'unparseable pid-zero-or-leading-zero'
+      return 0
+      ;;
+  esac
+  # A WELL-FORMEDNESS bound, deliberately NOT a platform pid bound: nothing is read from the platform
+  # (no `/proc/sys/kernel/pid_max` — that read was deleted in #3549 and is not coming back). Ten digits
+  # is above every pid space in existence and far below where a decimal conversion could overflow, so
+  # anything longer is malformed content, not an unusual pid.
+  if [[ "${#first}" -gt 10 ]]; then
+    printf '%s' 'unparseable pid-digit-count-out-of-well-formedness-bound'
+    return 0
+  fi
+  printf 'pid %s' "$first"
+}
+
+# supervisor_lock_holder_liveness <pid> — echo EXACTLY one of
+#   live | dead | unknown <cause>
+#
+# `dead` REQUIRES AFFIRMATIVE EVIDENCE OF ABSENCE. `kill -0` returning non-zero is not that evidence: it
+# fails with EPERM (the process EXISTS and we may not signal it — another user's, or one this uid cannot
+# reach) exactly as it fails with ESRCH, and reading the first as the second is what reclaimed live
+# holders' locks.
+#
+# THE TWO WITNESSES, AND THE DIRECTION EACH IS USED IN:
+#   * procfs — `/proc/<pid>` existing is a LOCALE-FREE witness that the process EXISTS. It is used in
+#     that ONE direction. ABSENCE of `/proc/<pid>` is NOT absence of the process (`hidepid=2` hides
+#     another user's pid entirely), so it never yields `dead`. `/proc/self` is checked first so that a
+#     host with no procfs at all (macOS) is distinguished from a host whose procfs answered "no".
+#   * the errno text — bash renders `kill`'s errno, so the two cases are distinguishable by message.
+#     It is read under a `C` locale so the patterns are deterministic; a message matching NEITHER
+#     pattern yields `unknown`, never `dead`.
+#
+# The locale is set by ASSIGNMENT INSIDE the subshell, not as a prefix to the builtin: a temporary
+# assignment to a regular builtin is not guaranteed to reach `setlocale`, and this probe's correctness
+# would then depend on the caller's environment.
+supervisor_lock_holder_liveness() {
+  local pid="$1" msg='' rc=0
+  msg="$( LC_ALL=C; LC_MESSAGES=C; export LC_ALL LC_MESSAGES; kill -0 "$pid" 2>&1 )" || rc=$?
+  if [[ "$rc" -eq 0 ]]; then
+    printf '%s' 'live'
+    return 0
+  fi
+  if [[ -d /proc/self && -d "/proc/$pid" ]]; then
+    printf '%s' 'live'
+    return 0
+  fi
+  case "$msg" in
+    *'No such process'*)
+      printf '%s' 'dead'
+      return 0
+      ;;
+    *'Operation not permitted'*)
+      printf '%s' 'live'
+      return 0
+      ;;
+  esac
+  printf '%s' 'unknown kill-0-verdict-unrecognised'
+}
+
+# supervisor_lock_publish — the `mkdir` has already succeeded, so the NAME is ours. Publish our pid and
+# then VERIFY WE OWN THE LOCK by reading it back. Returns 0 only on verified ownership.
+#
+# THIS IS WHERE THE TUPLE IS MADE UNNECESSARY (#3549 lead ruling 5). The question "do we hold this
+# lock?" was previously answered by inference from three separate values (a parsed pid, its liveness,
+# its identity), and pinning them one at a time is what cost that issue four rounds. It is answered here
+# by ONE observation: the lock's `pid` file reads back as OUR pid.
+#
+# THE PUBLISH IS A RENAME, WHICH IS WHAT CLOSES THE PARTIAL-PID HALF OF AC2. `echo $$ >…/pid` creates
+# the `pid` NAME and then writes it, so a peer can observe the name holding nothing. A rename makes the
+# name appear only with its complete content: a reader sees the name absent, or sees the whole value.
+# The residual window is therefore "the `pid` name is not there yet", one rename wide, and the caller
+# resolves that by measuring persistence rather than by assuming death.
+#
+# WHAT THE READ-BACK DOES AND DOES NOT PROVE. It proves the publish landed and was not clobbered by a
+# racer between the `mkdir` and this read — the case that matters, because a peer running PRE-#3601 code
+# reclaims a pid-less lock and would rename ours aside mid-startup. It is a point-in-time verification
+# and does not prove nobody steals the lock later; `supervisor_lock_release` re-checks ownership at exit
+# for exactly that reason.
+supervisor_lock_publish() {
+  local tmpf="$SUPERVISOR_LOCK/pid.tmp.$$" state=''
+  printf '%s\n' "$$" >"$tmpf" 2>/dev/null || return 1
+  # `--` because both operands are `TMPDIR`-derived and may be option-shaped (#3601 AC7); quoting stops
+  # word-splitting and globbing and does nothing about option parsing.
+  if ! mv -f -- "$tmpf" "$SUPERVISOR_LOCK/pid" 2>/dev/null; then
+    rm -f -- "$tmpf" 2>/dev/null || true
+    return 1
+  fi
+  state="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")" || true
+  [[ "$state" == "pid $$" ]] || return 1
+  return 0
+}
+
+# supervisor_lock_release — the EXIT trap. Remove the lock ONLY while it is still OURS.
+#
+# THE PRE-#3601 TRAP WAS AN UNCONDITIONAL `rm -rf "$SUPERVISOR_LOCK"`, which is the same defect class as
+# the reclaim it sat next to, pointing the other way: by the time we exit, the directory at that name
+# may be a DIFFERENT holder's lock (a peer reclaimed ours, or an operator cleared it and a new
+# supervisor started), and deleting it hands the lane to a third process while the second one believes
+# it holds exclusion. Ownership is decided by the same one observation the publish used, so the two
+# cannot disagree. A lock that is NOT ours is left exactly as found and the fact is logged — never
+# silently, because "my lock vanished" is otherwise unattributable.
+supervisor_lock_release() {
+  local state=''
+  state="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")" || true
+  if [[ "$state" == "pid $$" ]]; then
+    rm -rf -- "$SUPERVISOR_LOCK" 2>/dev/null || true
+    return 0
+  fi
+  log "exit: NOT removing $SUPERVISOR_LOCK — it no longer holds this process's pid ($$); its pid file reads [$state]. Something else owns that name now, so removing it would break a holder that is not us (#3601)."
+  return 0
+}
+
+# supervisor_lock_refuse <headline> <detail> <remedy-prose> [<remedy-command>] — the per-lane lock's
+# refusal channel, and the counterpart of ruling 2: NO REFUSAL LEAVES WITHOUT A REMEDY.
+#
+# `printf`, never `echo`: `echo` inherits `xpg_echo` and would interpret a backslash sequence in a
+# `TMPDIR`-derived path (this was the FOURTH SHAPE recorded as a residual at this call site under #3549;
+# it is closed for these lines by this emitter). Prose is rendered through `supervisor_one_line` so no
+# interpolated path can split a line or forge an unprefixed one, and a printed COMMAND is built by the
+# caller through `supervisor_shell_quote` so it is paste-safe and stays on one physical line — the same
+# contract the legacy guard's emitter holds, for the same reasons, stated at length there.
+supervisor_lock_refuse() {
+  local headline="$1" detail="$2" remedy="$3" remedy_cmd="${4:-}" shown=''
+  headline="$(supervisor_one_line "$headline")" || true
+  detail="$(supervisor_one_line "$detail")" || true
+  remedy="$(supervisor_one_line "$remedy")" || true
+  shown="$(supervisor_shell_quote "$SUPERVISOR_LOCK")" || true
+  printf '%s\n' "worker-supervisor: $headline (lock $shown)" >&2
+  printf '%s\n' "worker-supervisor: $detail" >&2
+  printf '%s\n' "worker-supervisor: remedy — $remedy" >&2
+  # A command that is not one physical line is DEMOTED TO PROSE rather than printed bare, so the
+  # one-bare-line-is-the-command contract holds by the EMITTER's rules and not by a caller's discipline.
+  case "$remedy_cmd" in
+    '') ;;
+    *"$SUPERVISOR_LF"* | *"$SUPERVISOR_CR"* | *"$SUPERVISOR_ESC"*)
+      printf '%s\n' "worker-supervisor: a remedy command for this state carries an embedded control character, so it is NOT printed as a runnable line; rendered for reading only: $(supervisor_one_line "$remedy_cmd")" >&2
+      ;;
+    *)
+      printf '%s\n' "$remedy_cmd" >&2
+      ;;
+  esac
+  exit 1
+}
+
+# supervisor_lock_take — claim the lock NAME and prove we own it. Returns
+#   0 = the lock is ours, published and read back, EXIT trap installed
+#   1 = the name was not free (or could not be created) — nothing was written
+#   2 = the name became ours but the published pid did NOT read back as ours
+#
+# Return 2 is a genuine state, not paranoia: a peer running PRE-#3601 code reclaims a pid-less lock, so
+# it can rename ours aside inside our own publish window. Distinguishing it from 1 matters because the
+# two have different remedies (1 = someone holds it; 2 = someone took it FROM us mid-startup).
+#
+# The trap is installed only AFTER ownership is verified. A crash in the window before that leaves an
+# ordinary reclaimable stale lock (case 2 of the clearing story above), which is the benign residue.
+supervisor_lock_take() {
+  # `--` because the operand is `TMPDIR`-derived and may be option-shaped (#3601 AC7).
+  mkdir -- "$SUPERVISOR_LOCK" 2>/dev/null || return 1
+  if supervisor_lock_publish; then
+    trap 'supervisor_lock_release' EXIT
+    return 0
+  fi
+  return 2
+}
+
+# supervisor_lock_refuse_unowned — the name became ours and the read-back said it is not.
+supervisor_lock_refuse_unowned() {
+  supervisor_lock_refuse \
+    "refusing to start — this run CREATED the lock and then could not verify it OWNS it" \
+    "the lock directory was created by this process, our pid was published into it, and reading it back did not return our pid ($$) — so between those two steps something else took the lock name. The most likely cause is a supervisor running PRE-#3601 code on this box: it reads a lock whose pid file is not yet present as STALE and renames it aside, which is the defect #3601 fixes. Starting now would put two supervisors in one worktree, so this run stops instead" \
+    "re-run this supervisor: if the other holder is a real one, the next start will say so and name its pid; if it was a pre-#3601 reclaim, upgrade every checkout on this box that can launch a supervisor past #3601 so no peer reclaims a pid-less lock again"
+}
+
+# supervisor_lock_refuse_undecidable <cause> <what-was-observed> — the "cannot tell" refusal, and the
+# only place ruling 2's remedy obligation actually bites: this is the branch that would otherwise leave a
+# lane blocked by a directory with nothing to do about it.
+#
+# THE PRINTED COMMAND IS `rmdir`, AND THE CHOICE IS THE SAFETY ARGUMENT. `rmdir` is NON-RECURSIVE and
+# REFUSES a non-empty directory, so a mis-paste cannot delete a holder's pid record: the worst outcome is
+# "Directory not empty", which is itself the signal to go and look. `rm -rf` would be the opposite — it
+# would silently destroy the evidence of the very state we could not decide. `--` terminates option
+# parsing because the path is `TMPDIR`-derived, and the path is rendered by `supervisor_shell_quote` so
+# the line is paste-safe on one physical line.
+supervisor_lock_refuse_undecidable() {
+  local cause="$1" observed="$2"
+  supervisor_lock_refuse \
+    "refusing to start — the lock is HELD and this run could NOT DECIDE whether its holder is alive ($cause)" \
+    "$observed. THIS IS NOT A REPORT THAT THE HOLDER IS DEAD, and it is not a report that it is alive: it is a report that the question was undecidable here. A reclaim needs AFFIRMATIVE evidence that the recorded holder is gone, and there is none, so this run stops rather than take a lock that may belong to a live supervisor (#3601). An ordinary stale lock — one left by a holder that was killed — carries a well-formed pid, is decided automatically, and never reaches this message" \
+    "PRECONDITION FIRST — establish that no supervisor is running for this lane (bash scripts/flow/claim-heartbeat.sh dead-lanes, and check for a live worker-supervisor process for this lane). Once you have, clear the lock by running the next line, on its own, exactly as printed. It is NON-RECURSIVE on purpose: it REFUSES if anything is still inside the lock, so it cannot delete a holder's record you have not examined — if it refuses, list the contents and decide before removing anything" \
+    "rmdir -- $(supervisor_shell_quote "$SUPERVISOR_LOCK")"
+}
+
+# supervisor_lock_refuse_lost_race — a dead holder's lock was cleared and the name was taken again
+# before we could claim it. This is the loud exit the pre-#3601 code reached as "failed to acquire lock",
+# kept loud and given the cause it always had: we lost a race, we are not co-running.
+supervisor_lock_refuse_lost_race() {
+  supervisor_lock_refuse \
+    "refusing to start — the lock name was taken again before this run could claim it" \
+    "a stale lock left by a dead holder was cleared and the name was immediately claimed by someone else, so this run did NOT get the lock. Only one racer can win the rename, which is what stops both from believing they did; the loser stops here rather than co-running" \
+    "nothing is wrong: re-run this supervisor. If it keeps losing, the winner is a live supervisor for this lane and the next start will name its pid"
+}
+
 acquire_lock() {
   # IDENTITY FIRST: both the lock path and the claim actor are derived FROM it, so resolving it after
   # them would leave them on a stale inference.
@@ -1940,45 +2256,118 @@ acquire_lock() {
   supervisor_legacy_lock_guard
   supervisor_claim_actor
   supervisor_migrate_legacy_claim
-  if mkdir "$SUPERVISOR_LOCK" 2>/dev/null; then
-    echo $$ >"$SUPERVISOR_LOCK/pid"
-    trap 'rm -rf "$SUPERVISOR_LOCK" 2>/dev/null || true' EXIT
+
+  local takerc=0
+  supervisor_lock_take || takerc=$?
+  if [[ "$takerc" -eq 0 ]]; then
     return 0
   fi
-  # KNOWN RESIDUAL, recorded at the site (#3549 class sweep): this pid is used UNPARSED, the liveness
-  # test below is TWO-VALUED (a `kill -0` failing with EPERM — a live process owned by another user —
-  # reads as dead and the lock is RECLAIMED), and the message asserts "another instance" without
-  # corroborating the process identity. Out of scope for #3549 (a different lock, with reclaim
-  # semantics of its own), not an oversight. The three-valued liveness probe that used to be quoted
-  # here was DELETED with the legacy classifier (lead's second ruling), so this residual now stands on
-  # its own description rather than pointing at code.
-  # FOURTH SHAPE, same scope decision (#3549, job 205 F2 sweep): this lock's own refusals below still
-  # emit with `echo` and interpolate an unrendered `$SUPERVISOR_LOCK`, so they inherit `xpg_echo` and a
-  # control character in `TMPDIR` exactly as the legacy guard's did before F2. Listed, not fixed here.
-  local holder_pid=""
-  [[ -f "$SUPERVISOR_LOCK/pid" ]] && holder_pid="$(cat "$SUPERVISOR_LOCK/pid" 2>/dev/null || true)"
-  if [[ -n "$holder_pid" ]] && kill -0 "$holder_pid" 2>/dev/null; then
-    echo "worker-supervisor: another instance is already running (pid $holder_pid, lock $SUPERVISOR_LOCK)" >&2
-    exit 1
+  if [[ "$takerc" -eq 2 ]]; then
+    supervisor_lock_refuse_unowned
   fi
-  log "reclaiming stale lock $SUPERVISOR_LOCK (holder pid $holder_pid not alive)"
-  # Atomic reclaim (rename-then-remove), not rm-then-mkdir: two supervisors
-  # racing a dead-pid lock both taking the rm-then-mkdir path could both end up
-  # believing they won. `mv` on the same filesystem is atomic, so only ONE
-  # racer's mv can succeed against a given stale directory name; that racer
-  # removes the renamed-aside copy and falls through to its own mkdir below.
-  # The loser's mv fails (the name is already gone), so it falls through to the
-  # normal mkdir-fails path and exits loudly instead of silently co-running.
-  if mv "$SUPERVISOR_LOCK" "$SUPERVISOR_LOCK.stale.$$" 2>/dev/null; then
-    rm -rf "$SUPERVISOR_LOCK.stale.$$"
+
+  # `mkdir` FAILING IS NOT YET EVIDENCE OF CONTENTION, and conflating the two is the diagnostic defect
+  # #3601's addendum measured: with an option-shaped `TMPDIR` the pre-fix code printed "reclaiming stale
+  # lock" and then "failed to acquire lock", sending an operator to hunt a stale lock that did not exist.
+  # `mkdir` also fails when the parent is missing, unwritable, or not a directory. So before attributing
+  # the failure to a holder, check that something IS at that name.
+  if [[ ! -e "$SUPERVISOR_LOCK" && ! -L "$SUPERVISOR_LOCK" ]]; then
+    supervisor_lock_refuse \
+      "refusing to start — the lock directory could NOT BE CREATED, and nothing exists at that path" \
+      "this is NOT contention: no lock is there and no holder is implied. \`mkdir\` failed for a reason to do with the PATH itself — the parent directory missing, not a directory, or not writable by this user" \
+      "check the parent directory of the path named above: it must exist, be a directory, and be writable by this user. The path is \${TMPDIR:-/tmp}-derived unless this run's launcher named it, so a TMPDIR pointing somewhere absent or read-only is the usual cause"
   fi
-  if mkdir "$SUPERVISOR_LOCK" 2>/dev/null; then
-    echo $$ >"$SUPERVISOR_LOCK/pid"
-    trap 'rm -rf "$SUPERVISOR_LOCK" 2>/dev/null || true' EXIT
+
+  # THE NAME IS TAKEN. WHO HOLDS IT? Three-valued, and only an AFFIRMATIVE `dead` reclaims.
+  local holder='' holder_pid='' liveness='' tries=0
+  local tries_max="${SUPERVISOR_LOCK_PID_TRIES:-20}" wait_secs="${SUPERVISOR_LOCK_PID_WAIT:-0.05}"
+  # An unusable knob falls back to the DEFAULT, never to "no wait": the collapse has to go toward
+  # measuring, not toward the permissive answer the wait exists to avoid.
+  case "$tries_max" in '' | *[!0123456789]*) tries_max=20 ;; esac
+
+  holder="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")"
+  # THE PID-LESS WINDOW IS RESOLVED BY MEASURING PERSISTENCE, WHICH IS NOT A TIMING HEURISTIC — and it
+  # will read like one, so here is the difference. A heuristic infers WHAT is happening from HOW LONG it
+  # has been happening. This measures a different property: a pid-less lock is a state a STARTING holder
+  # passes through in ONE rename, and a state a lock abandoned inside that window stays in FOREVER.
+  # Transient and persistent are distinguishable by observation alone, and re-reading is how you observe
+  # it. Both outcomes are affirmative: either a pid APPEARS — a real answer, and the wait ends early —
+  # or it PERSISTENTLY does not, which is itself the answer "this is not a holder that is starting". The
+  # second branch still refuses; it does not conclude death. The bound exists because an unbounded wait
+  # is a hang, and it is short because the state it waits out is one rename wide.
+  #
+  # ONLY THE TWO TRANSIENT CAUSES ARE RE-READ. `pid-file-absent` and `pid-file-empty` are the two states
+  # a writer passes through (the name not yet renamed into place; a pre-#3601 peer's `echo $$ >…/pid`
+  # between create and write). A garbled, multi-line or non-decimal pid is not a startup artifact of any
+  # writer, so re-reading it would only add delay to a refusal that is already decided.
+  while [[ "$tries" -lt "$tries_max" ]]; do
+    case "$holder" in
+      'unparseable pid-file-absent' | 'unparseable pid-file-empty') ;;
+      *) break ;;
+    esac
+    tries=$((tries + 1))
+    # A `sleep` that cannot take a fractional argument (some minimal builds) fails harmlessly: the loop
+    # then spins its bounded number of iterations instead of pausing, which measures the same property
+    # with less patience.
+    sleep "$wait_secs" 2>/dev/null || true
+    holder="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")"
+  done
+
+  case "$holder" in
+    'pid '*)
+      holder_pid="${holder#pid }"
+      ;;
+    *)
+      supervisor_lock_refuse_undecidable "${holder#unparseable }" \
+        "the lock exists and this run could not read a usable holder pid out of it after $((tries + 1)) read(s) over a bounded window; the pid probe's verdict was [$holder]"
+      ;;
+  esac
+
+  liveness="$(supervisor_lock_holder_liveness "$holder_pid")"
+  case "$liveness" in
+    live)
+      # AC4: THE REFUSAL SAYS WHAT IT KNOWS AND SAYS WHAT IT DID NOT CHECK. It has established that pid
+      # $holder_pid EXISTS; it has NOT established that the process is a supervisor. Pids are reused, so
+      # a lock left by a dead holder can name a number the kernel has since given to something else.
+      #
+      # WHY NO IDENTITY PROBE IS RUN, rather than one being added: the verdict could not change the
+      # decision. `live` refuses whatever the process turns out to be, because reclaiming on an identity
+      # GUESS is precisely how a live holder's lock gets stolen — and #3549's ruling on exactly this
+      # shape is that machinery whose output cannot change the decision is not a guard but a description
+      # generator on the decision path. So the scope is DECLARED in the text an operator reads instead,
+      # which is AC4's own second option.
+      supervisor_lock_refuse \
+        "another instance is already running (pid $holder_pid)" \
+        "pid $holder_pid is recorded as this lane's lock holder and that process EXISTS (verified: it is signallable, or the kernel reports it exists but is not ours to signal). ITS IDENTITY IS NOT VERIFIED — this run did not check that pid $holder_pid is a worker-supervisor, and pids are REUSED, so a lock abandoned by a dead holder can name a number that now belongs to an unrelated process" \
+        "if that pid IS the supervisor for this lane, wait for it or stop it. If it is NOT — check with: ps -p $holder_pid -o pid,ppid,user,lstart,args — then the lock is stale in a way this run cannot prove, and clearing it is the operator's call once no supervisor is running for this lane"
+      ;;
+    dead) ;;
+    *)
+      supervisor_lock_refuse_undecidable "holder-liveness-${liveness#unknown }" \
+        "the lock records holder pid $holder_pid, and the liveness probe could not decide whether that process exists (verdict [$liveness])"
+      ;;
+  esac
+
+  # THE ONLY RECLAIMING PATH, AND IT IS REACHED ONLY FROM AN AFFIRMATIVE `dead`.
+  log "reclaiming stale lock $SUPERVISOR_LOCK (holder pid $holder_pid is affirmatively DEAD: the kernel reports no such process)"
+  # Atomic reclaim (rename-then-remove), not rm-then-mkdir: two supervisors racing a dead-pid lock both
+  # taking the rm-then-mkdir path could both end up believing they won. `mv` on the same filesystem is
+  # atomic, so only ONE racer's mv can succeed against a given stale directory name; that racer removes
+  # the renamed-aside copy and falls through to its own take below. The loser's mv fails (the name is
+  # already gone), so it falls through to its own take, which fails against the winner's fresh lock, and
+  # it refuses loudly instead of silently co-running. `--` on both operands: `TMPDIR`-derived (#3601 AC7).
+  if mv -f -- "$SUPERVISOR_LOCK" "$SUPERVISOR_LOCK.stale.$$" 2>/dev/null; then
+    rm -rf -- "$SUPERVISOR_LOCK.stale.$$" 2>/dev/null || true
+  fi
+  takerc=0
+  supervisor_lock_take || takerc=$?
+  if [[ "$takerc" -eq 0 ]]; then
     return 0
   fi
-  echo "worker-supervisor: failed to acquire lock $SUPERVISOR_LOCK" >&2
-  exit 1
+  if [[ "$takerc" -eq 2 ]]; then
+    supervisor_lock_refuse_unowned
+  fi
+  supervisor_lock_refuse_lost_race
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -2648,9 +2648,16 @@ supervisor_lock_refuse_unowned() {
   local cause="${1:-not-owned unrecorded}" detail=''
   case "$cause" in
     'declined'*)
-      # Only THIS path may claim the path is untouched: the publish saw a record already there and
-      # returned without writing (its staging file is removed on the way out).
-      detail="the lock directory was created by this process and then found to ALREADY CONTAIN a holder record, so this run declined to overwrite it and wrote NOTHING; that record reads [${cause#declined }]. The directory at that name is therefore not the one this process created — a peer renamed ours aside and published its own between our two steps. NOTHING at that path has been modified by this run"
+      # WHAT THIS PATH MAY CLAIM, NARROWED TO WHAT IS TRUE (#3601, roborev job 238 B15 — the SEVENTH
+      # instance of the alibi family, and it is in the text written to FIX the family's second instance).
+      # It used to say the run "wrote NOTHING" and that "NOTHING at that path has been modified", and
+      # both are false in detail: `supervisor_lock_publish` writes its staging file `pid.tmp.$$` BEFORE it
+      # tests for an existing `pid`, and `supervisor_lock_take` may then remove an ownership marker from
+      # the very directory being described. The load-bearing claim — the only one an operator needs and
+      # the only one this path establishes — is that THE EXISTING HOLDER RECORD WAS NOT OVERWRITTEN OR
+      # PUBLISHED OVER. That is what it says now, and the test asserts PRESERVATION OF THAT RECORD rather
+      # than an absence of modification the code never provided.
+      detail="the lock directory was created by this process and then found to ALREADY CONTAIN a holder record, so this run declined to publish over it; that record reads [${cause#declined }] and is INTACT — it was neither overwritten nor replaced. The directory at that name is therefore not the one this process created: a peer renamed ours aside and published its own between our two steps. This run did write and then remove its own scratch entries in that directory (a staging file, and an ownership marker), so it is not true that nothing there was touched — what is true, and what matters, is that the holder record itself was left exactly as found"
       ;;
     *)
       # This path DID write: `pid` at that name currently holds OUR pid, over whatever was there. Saying

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -2537,21 +2537,58 @@ supervisor_lock_take() {
   SUPERVISOR_LOCK_TAKE_CAUSE=''
   # `--` because the operand is `TMPDIR`-derived and may be option-shaped (#3601 AC7).
   mkdir -- "$SUPERVISOR_LOCK" 2>/dev/null || return 1
-  local pub=''
+  local marker="$SUPERVISOR_LOCK/own.$$" pub=''
+  # THE OWNERSHIP MARKER, WRITTEN BEFORE ANYTHING ELSE (#3601, roborev job 236 B12).
+  #
+  # WHY IT EXISTS. The un-create below used to be an UNCONDITIONAL `rmdir`, which is not bound to the
+  # directory this process created: a legacy peer can rename ours aside and `mkdir` its OWN pid-less lock
+  # at the same name, and a non-recursive `rmdir` then SUCCEEDS against the peer's empty startup
+  # directory — deleting a live peer's lock and freeing the name for a third claimant. That is a
+  # regression the previous round introduced, not a pre-existing defect: it traded "we wedge our own lane
+  # with an empty lock" for "we can delete a peer's startup lock", which is the worse of the two. The
+  # marker makes the removal conditional on the directory still being the instance we made.
+  #
+  # WHY A STALE MARKER CANNOT ALIAS US. This path is reached only when OUR `mkdir` succeeded, which means
+  # the directory did not exist a moment ago — so it cannot already contain an `own.<pid>` left by a dead
+  # process that happened to have our pid. Pid reuse therefore cannot forge this token for this decision.
+  #
+  # NARROWED, NOT CLOSED — AND HERE IS THE BOUND, BECAUSE THE MARKER IS NOT AIRTIGHT. Creating it is a
+  # SECOND step after `mkdir`, so there is a window in which the directory exists without it. A peer that
+  # replaces the directory inside THAT window receives our marker in its own directory, and the un-create
+  # would then remove the peer's directory exactly as before. What makes this worth doing anyway is the
+  # window's SIZE: it is two adjacent syscalls with no intervening I/O, where the window it replaces
+  # spanned the whole publish attempt (a write, a decline test and a rename). Ordering the marker before
+  # the publish is what makes it the narrowest window available to this code, and nothing here can make it
+  # zero — that needs serialisation of the complete claim-and-publication operation, which is #3683,
+  # together with the reclaim ABA and the release read-then-remove. Do not read the marker as a guarantee.
+  if ! { : >"$marker"; } 2>/dev/null; then
+    # NO OWNERSHIP EVIDENCE, SO NO REMOVAL. We know we created the directory and we cannot PROVE the one
+    # at that name now is still ours, so it is left in place and reported. That risks the empty-lock wedge
+    # B1 removed — but the cause is a filesystem that cannot take a zero-byte file, the same failure the
+    # remedy names, and guessing our way to a deletion is how a peer's lock gets destroyed.
+    SUPERVISOR_LOCK_TAKE_CAUSE='marker-failed cleanup-declined-no-ownership-evidence'
+    return 3
+  fi
   # `supervisor_lock_publish` runs in a command substitution, which is a SUBSHELL — fine, because it
   # installs no trap. The `trap` below must NOT be inside one, which is why the cause travels back
   # through a variable instead of this function echoing it.
   pub="$(supervisor_lock_publish)" || true
   if [[ "$pub" == 'ok' ]]; then
+    # The marker's job is done the moment ownership is verified, and it must not outlive it: a held lock
+    # carrying an extra file makes the non-recursive clear command an operator is handed elsewhere refuse.
+    if ! rm -f -- "$marker" 2>/dev/null; then
+      log "$(supervisor_one_line "startup: could not remove our own ownership marker $(supervisor_shell_quote "$marker") after acquiring the lock. Harmless to this run — the lock is held and its release removes the directory wholesale — but a non-recursive manual clear of that lock would refuse until the marker is gone (#3601).")"
+    fi
     trap 'supervisor_lock_release' EXIT
     return 0
   fi
   SUPERVISOR_LOCK_TAKE_CAUSE="$pub"
   # `declined` joins `not-owned` (#3601 B11): both mean the directory at that name is not ours, so both
-  # LEAVE IT ALONE. The difference is only whether we wrote into it, and the refusal says which.
+  # LEAVE IT ALONE. The difference is only whether we wrote into it, and the refusal says which. Our own
+  # marker is removed either way — it is unambiguously ours by name, and on the `declined` path it may be
+  # sitting in the PEER's directory, where leaving it would be litter in someone else's lock.
   if [[ "$pub" == 'not-owned'* || "$pub" == 'declined'* ]]; then
-    # The NAME became ours and the directory now holds someone else's pid. Leaving it alone is the whole
-    # point: it is a live holder's lock as far as we can tell.
+    rm -f -- "$marker" 2>/dev/null || true
     return 2
   fi
   # WE CREATED THE DIRECTORY AND NEVER PUBLISHED INTO IT (#3601, roborev job 231 B1). Leaving it would
@@ -2559,10 +2596,21 @@ supervisor_lock_take() {
   # its own lane until an operator cleared it, which is the lead's ruling 2 inverted: we would have
   # created the undecidable state ourselves and then refused over it.
   #
-  # THE REMOVAL IS NON-RECURSIVE, AND THAT IS WHAT MAKES IT SAFE. Between our `mkdir` and here a peer
-  # running pre-#3601 code could have reclaimed our pid-less directory and written its OWN pid into it;
-  # `rmdir` REFUSES a non-empty directory, so it can only ever remove the empty shell we made, never a
-  # holder's record. Our own staging file is removed first because it is unambiguously ours.
+  # SO THE REMOVAL IS BOUND TO THE INSTANCE WE CREATED, not merely non-recursive (#3601 B12). The
+  # non-recursive `rmdir` protects a peer that has already PUBLISHED — the directory is then non-empty and
+  # the removal fails harmlessly — and protects nothing at all against a peer that has `mkdir`'d and not
+  # yet published, which is an EMPTY directory a `rmdir` succeeds against. The marker is what distinguishes
+  # those: if it is gone, the directory at that name is not the one we made, and we remove NOTHING.
+  if [[ ! -e "$marker" && ! -L "$marker" ]]; then
+    local foreign=''
+    foreign="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")" || foreign='unparseable residual-probe-aborted'
+    case "$foreign" in
+      'pid '*) SUPERVISOR_LOCK_TAKE_CAUSE="$pub cleanup-declined-foreign-holder $foreign" ;;
+      *)       SUPERVISOR_LOCK_TAKE_CAUSE="$pub cleanup-declined-foreign-instance $foreign" ;;
+    esac
+    return 3
+  fi
+  rm -f -- "$marker" 2>/dev/null || true
   rm -f -- "$SUPERVISOR_LOCK/pid.tmp.$$" 2>/dev/null || true
   rmdir -- "$SUPERVISOR_LOCK" 2>/dev/null || true
   # ...AND THE OUTCOME IS VERIFIED, NOT ASSUMED (#3601, roborev job 231 B9). Both removals above ignore
@@ -2573,7 +2621,7 @@ supervisor_lock_take() {
   # was told there was nothing to clear. Same defect family as the refusal that claimed a read-back it
   # never made (B1) and the mutant comment that claimed an isolation it did not have (B4) — an artifact
   # asserting a step that did not run, which is worse than no artifact because it is what stops the next
-  # reader looking. So the verdict carries what was OBSERVED after the attempt, and the three cases are
+  # reader looking. So the verdict carries what was OBSERVED after the attempt, and the cases are
   # distinguished because their remedies differ: nothing to do, a foreign holder to leave alone, or a
   # residual to clear.
   if [[ ! -e "$SUPERVISOR_LOCK" && ! -L "$SUPERVISOR_LOCK" ]]; then
@@ -2632,6 +2680,7 @@ supervisor_lock_refuse_publish_failed() {
     *' '*) cleanup="${cause#* }" ;;
   esac
   case "$pub" in
+    marker-failed) what='writing our OWNERSHIP MARKER into the lock FAILED — this run got the lock name and could not record, even provisionally, that the directory is its own' ;;
     write-failed)  what='writing our pid into the lock FAILED — no byte of it was written' ;;
     rename-failed) what='publishing our pid into the lock FAILED at the rename — the staging file was written and could not be moved into place' ;;
     *)             what="recording our pid in the lock FAILED ([$pub])" ;;
@@ -2645,6 +2694,19 @@ supervisor_lock_refuse_publish_failed() {
     'cleanup-failed-foreign-holder '*)
       aftermath="This run then tried to remove the directory it had created and it REMAINS — and it now holds a holder record that is NOT ours ([${cleanup#cleanup-failed-foreign-holder }]). A peer published into it while our publish was failing; the removal is NON-RECURSIVE precisely so that it cannot delete that record, and nothing of that peer's has been touched"
       remedy='nothing to clear: the path named above belongs to another holder, which this run left intact. Fix the filesystem problem named above and re-run; the next start will read that holder and report it by pid'
+      ;;
+    cleanup-declined-no-ownership-evidence)
+      aftermath='This run therefore did NOT attempt to remove the directory it created: with no marker written it cannot prove the directory now at that name is still its own, and a removal on that guess is how a peer that took the name in the meantime loses its lock. A lock MAY be sitting at that path — this run makes no claim either way'
+      remedy="fix the filesystem problem named above and re-run. If starts keep refusing over a lock at that path, inspect it and clear it with the next line, which is NON-RECURSIVE and refuses if anything is inside that you have not examined$(supervisor_lock_shape_note)"
+      cmd="$(supervisor_lock_clear_command)"
+      ;;
+    'cleanup-declined-foreign-holder '*)
+      aftermath="This run then found that the directory at that name is NOT the one it created — its ownership marker is gone from it — and that it holds a holder record ([${cleanup#cleanup-declined-foreign-holder }]). Another supervisor took the name while our publish was failing, so this run removed NOTHING"
+      remedy='nothing to clear: the path named above belongs to another holder, which this run left intact. Fix the filesystem problem named above and re-run; the next start will read that holder and report it by pid'
+      ;;
+    'cleanup-declined-foreign-instance '*)
+      aftermath="This run then found that the directory at that name is NOT the one it created — its ownership marker is gone from it — and that it carries no holder record yet ([${cleanup#cleanup-declined-foreign-instance }]). That is another supervisor's start in progress, which is exactly the lock a blind removal would have destroyed, so this run removed NOTHING"
+      remedy='nothing to clear: another supervisor is starting at that path and this run left it alone. Fix the filesystem problem named above and re-run; the next start will read that holder and report it by pid'
       ;;
     'cleanup-failed-residual '*)
       aftermath="This run then tried to remove the directory it had created and it REMAINS ([${cleanup#cleanup-failed-residual }]) — the removal did NOT succeed, so a lock DOES sit at that path and the next start will refuse over it until it is cleared"
@@ -2711,7 +2773,13 @@ supervisor_lock_shape_note() {
   if [[ -L "$SUPERVISOR_LOCK" ]]; then
     printf '%s' '. NOTE: that name is a SYMLINK, not a lock directory — the line below removes the LINK and does not touch whatever it points at, which is why it is not an rmdir'
   elif [[ -d "$SUPERVISOR_LOCK" ]]; then
-    printf ''
+    # THE ONE CASE WHERE A CORRECT `rmdir` STILL REFUSES, NAMED RATHER THAN LEFT TO SURPRISE (#3601 B12).
+    # This is NOT the B2 defect of printing a command that could never work for the shape at that name:
+    # `rmdir` is the right command for a directory, and it refuses only when there is content the
+    # operator must look at first, which is the safety property it was chosen for. A supervisor killed
+    # between creating its lock and recording its pid leaves an ownership marker behind — a state this
+    # change introduced — so the note says so and says what to do when the line refuses.
+    printf '%s' '. NOTE: the line below is NON-RECURSIVE and will REFUSE if anything is inside — including an `own.<pid>` ownership marker or a `pid.tmp.<pid>` staging file left by a supervisor killed between creating this lock and recording its pid. If it refuses, list the contents (ls -lna on the path above) and decide before removing anything'
   elif [[ -e "$SUPERVISOR_LOCK" ]]; then
     printf '%s' '. NOTE: that name is NOT a directory, so it is not a lock this script could ever have written — the line below removes that one file, non-recursively'
   else

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -894,7 +894,13 @@ captured_question() {
 log_size() {
   local f="$1" n
   [[ -f "$f" ]] || { printf '0'; return 0; }
-  n="$(wc -c <"$f" 2>/dev/null | tr -d ' ')"
+  # `|| n=''` IS LOAD-BEARING UNDER `set -e`, NOT DEFENSIVE PADDING. `wc` failing makes the pipeline
+  # non-zero (`pipefail`), and a non-zero command substitution in an ASSIGNMENT aborts an errexit shell
+  # before the classification below ever runs — so without this the probe would not return a sentinel,
+  # it would kill its caller. Measured: the bare call `log_size "$f"` from a `set -e` shell produced NO
+  # output at all. The pre-#3601 form was safe only by accident, because its one caller sits inside a
+  # `set +e` region; a probe's correctness must not depend on that.
+  n="$(wc -c <"$f" 2>/dev/null | tr -d ' ')" || n=''
   # The digits are enumerated rather than given as a `[0-9]` RANGE, whose members are decided by the
   # caller's collation.
   case "$n" in
@@ -2300,7 +2306,12 @@ acquire_lock() {
   # measuring, not toward the permissive answer the wait exists to avoid.
   case "$tries_max" in '' | *[!0123456789]*) tries_max=20 ;; esac
 
-  holder="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")"
+  # THE PROBE ASSIGNMENTS CARRY A FAIL-CLOSED FALLBACK (#3549 job 201 F3, same shape). Both probes
+  # return 0 on every path they take, so these are unreachable today — but a non-zero inside a `$( )`
+  # makes the ASSIGNMENT non-zero, and under this script's own errexit that would abort the start
+  # silently instead of refusing. The fallbacks land on the REFUSING verdict of each probe, so an
+  # unforeseen internal failure costs a start and can never cost a live holder its lock.
+  holder="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")" || holder='unparseable pid-probe-aborted'
   # THE PID-LESS WINDOW IS RESOLVED BY MEASURING PERSISTENCE, WHICH IS NOT A TIMING HEURISTIC — and it
   # will read like one, so here is the difference. A heuristic infers WHAT is happening from HOW LONG it
   # has been happening. This measures a different property: a pid-less lock is a state a STARTING holder
@@ -2325,7 +2336,7 @@ acquire_lock() {
     # then spins its bounded number of iterations instead of pausing, which measures the same property
     # with less patience.
     sleep "$wait_secs" 2>/dev/null || true
-    holder="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")"
+    holder="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")" || holder='unparseable pid-probe-aborted'
   done
 
   case "$holder" in
@@ -2338,7 +2349,7 @@ acquire_lock() {
       ;;
   esac
 
-  liveness="$(supervisor_lock_holder_liveness "$holder_pid")"
+  liveness="$(supervisor_lock_holder_liveness "$holder_pid")" || liveness='unknown liveness-probe-aborted'
   case "$liveness" in
     live)
       # AC4: THE REFUSAL SAYS WHAT IT KNOWS AND SAYS WHAT IT DID NOT CHECK. It has established that pid

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -2471,22 +2471,67 @@ supervisor_lock_release() {
   state="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")" || state='unparseable read-aborted'
   if [[ "$state" == "pid $$" ]]; then
     rm -rf -- "$SUPERVISOR_LOCK" 2>/dev/null || true
-    # THE REMOVAL'S OUTCOME IS CHECKED, AND A FAILURE IS REPORTED (#3601, roborev job 231 B9 class sweep).
-    # This branch made no false claim — it made NO claim, silently — but the silence is the same problem
-    # one step earlier: a lock left behind by a supervisor that exited cleanly is unattributable, and the
-    # next start has to refuse over it or reclaim it. It is self-healing (the pid recorded is ours, and we
-    # are about to be gone, so the next start gets an affirmative `dead` and reclaims), which is why this
-    # reports rather than escalates.
-    if [[ -e "$SUPERVISOR_LOCK" || -L "$SUPERVISOR_LOCK" ]]; then
-      log "$(supervisor_one_line "exit: FAILED to remove our own lock $(supervisor_shell_quote "$SUPERVISOR_LOCK") — it still exists after the removal. It records this process's pid ($$), so the next start will find its holder affirmatively dead and reclaim it automatically; no action is needed unless starts keep refusing (#3601).")"
+    if [[ ! -e "$SUPERVISOR_LOCK" && ! -L "$SUPERVISOR_LOCK" ]]; then
+      return 0
     fi
+    # THE SURVIVING LOCK IS RE-READ, BECAUSE `rm -rf` CAN SUCCEED IN PART (#3601, roborev job 240 B16).
+    #
+    # `rm -rf` recurses: it unlinks the CONTENTS first and the directory last, and those need permission
+    # on DIFFERENT directories — unlinking `<lock>/pid` needs write on `<lock>`, unlinking `<lock>` needs
+    # write on its PARENT. So an unwritable parent produces a partial removal, and MEASURED it does
+    # exactly that: `pid` is gone and the directory remains. The previous wording asserted the pid record
+    # was still there and promised the next start would reclaim automatically; in that state the next
+    # start sees a PID-LESS lock, which is undecidable, and REFUSES INDEFINITELY. So the promise was not
+    # merely inaccurate, it pointed away from a wedge — and our own read-only-parent suite case reaches
+    # this state, which is how it was found.
+    #
+    # THIS REPORTS THE WEDGE; IT DOES NOT PREVENT IT, and that distinction is the honest one. The
+    # alternative fix — rename the directory aside before deleting it, so the NAME is freed atomically —
+    # CANNOT prevent this wedge, and that is measured rather than argued: `mv <lock> <lock>.aside` needs
+    # write on the same PARENT that just refused the unlink, and fails with the same EACCES. Restoring the
+    # pid record instead would need a test-then-write against a directory that may by then be a peer's,
+    # i.e. the clobber hazard B11/B12 exist to remove, on the one path that runs at exit with no ability
+    # to report the outcome. So this path stays DIAGNOSIS ONLY: no new operation, no new window, and no
+    # new primitive — serialising the whole release is #3683.
+    #
+    # WHAT IT BUYS, precisely: the state was already reachable before this change (the pre-#3601 trap was
+    # the same unconditional `rm -rf`, silently), and it was undiagnosed. It is now named at the moment it
+    # happens, with the cause an operator must fix — the parent's permissions — because the remedy printed
+    # by a later start's refusal (`rmdir`) needs that same permission and fails without it.
+    local after=''
+    after="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")" || after='unparseable post-removal-probe-aborted'
+    case "$after" in
+      "pid $$")
+        log "$(supervisor_one_line "exit: FAILED to remove our own lock $(supervisor_shell_quote "$SUPERVISOR_LOCK") — it still exists and STILL records this process's pid ($$), verified after the attempt. The next start will find that holder affirmatively dead and reclaim it automatically; no action is needed unless starts keep refusing (#3601).")"
+        ;;
+      'pid '*)
+        log "$(supervisor_one_line "exit: did NOT remove $(supervisor_shell_quote "$SUPERVISOR_LOCK") — it still exists and now records holder pid ${after#pid }, which is not this process ($$). Something took that name during our exit; its record is intact and this run did not overwrite it. The next start will read that holder and report it by pid (#3601).")"
+        ;;
+      *)
+        log "$(supervisor_one_line "exit: PARTIALLY removed our own lock $(supervisor_shell_quote "$SUPERVISOR_LOCK") — the pid record is GONE and the directory REMAINS (its pid file now reads [$after]). This will NOT clear itself: a pid-less lock is undecidable, so the next start REFUSES over it rather than reclaiming it. ACTION IS NEEDED. \`rm -rf\` removes a directory's contents before the directory itself, and those need write permission on DIFFERENT directories, so the usual cause is that this lock's PARENT directory is not writable by this user — check that first, because the removal a refusing start prints needs the same permission and will fail without it (#3601).")"
+        ;;
+    esac
     return 0
   fi
+  # NOT OURS — AND "NOT OURS" IS NOT THE SAME FACT AS "SOMEONE ELSE'S" (#3601, roborev job 240 B17).
+  # Every state other than our own pid used to be reported as "Something else owns that name now",
+  # including absent, unreadable, malformed and NUL-bearing records. Those establish only that ownership
+  # CANNOT BE VERIFIED; attributing them to another process names a holder that may not exist, and sends
+  # an operator looking for it. The decision is the same either way — we remove nothing — so only the
+  # wording differs, which is exactly why it has to be the wording that is true.
+  #
   # Rendered, not interpolated raw (#3549 job 201 F1 class, at a new site — #3601 roborev job 231 B7):
   # the path comes from the environment, and a newline or an ESC in it would split this line or forge an
   # unprefixed one. `supervisor_shell_quote` renders the path as a paste-safe value; `supervisor_one_line`
   # guarantees the composed message is ONE physical line whatever it interpolated.
-  log "$(supervisor_one_line "exit: NOT removing $(supervisor_shell_quote "$SUPERVISOR_LOCK") — it no longer holds this process's pid ($$); its pid file reads [$state]. Something else owns that name now, so removing it would break a holder that is not us (#3601).")"
+  case "$state" in
+    'pid '*)
+      log "$(supervisor_one_line "exit: NOT removing $(supervisor_shell_quote "$SUPERVISOR_LOCK") — it records holder pid ${state#pid }, not this process ($$). Another holder owns that name, so removing it would break a holder that is not us (#3601).")"
+      ;;
+    *)
+      log "$(supervisor_one_line "exit: NOT removing $(supervisor_shell_quote "$SUPERVISOR_LOCK") — this run could not VERIFY that it owns it: its pid file reads [$state], which is an absent, unreadable or malformed record. That does NOT establish that another process holds this lock, and it is not a reason to delete one either — an unverifiable record is left exactly as found (#3601).")"
+      ;;
+  esac
   return 0
 }
 
@@ -2747,7 +2792,7 @@ supervisor_lock_refuse_undecidable() {
   supervisor_lock_refuse \
     "refusing to start — the lock is HELD and this run could NOT DECIDE whether its holder is alive ($cause)" \
     "$observed. THIS IS NOT A REPORT THAT THE HOLDER IS DEAD, and it is not a report that it is alive: it is a report that the question was undecidable here. A reclaim needs AFFIRMATIVE evidence that the recorded holder is gone, and there is none, so this run stops rather than take a lock that may belong to a live supervisor (#3601). An ordinary stale lock — one left by a holder that was killed — carries a well-formed pid, is decided automatically, and never reaches this message" \
-    "PRECONDITION FIRST — establish that no supervisor is running for this lane (bash scripts/flow/claim-heartbeat.sh dead-lanes, and check for a live worker-supervisor process for this lane). Once you have, clear the lock by running the next line, on its own, exactly as printed. It is NON-RECURSIVE on purpose: it REFUSES if anything is still inside, so it cannot delete a holder's record you have not examined — if it refuses, list the contents and decide before removing anything$(supervisor_lock_shape_note)" \
+    "PRECONDITION FIRST — establish that no supervisor is running for this lane (bash scripts/flow/claim-heartbeat.sh dead-lanes, and check for a live worker-supervisor process for this lane). Once you have, clear the lock by running the next line, on its own, exactly as printed. It is NON-RECURSIVE on purpose: it REFUSES if anything is still inside, so it cannot delete a holder's record you have not examined — if it refuses, list the contents and decide before removing anything. Removing a lock also needs WRITE permission on its PARENT directory, which reading one does not: if the line below fails with a permission error, that is why, and it is also how a supervisor's own exit can leave a pid-less lock here (#3601)$(supervisor_lock_shape_note)" \
     "$(supervisor_lock_clear_command)"
 }
 

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -2030,44 +2030,70 @@ SUPERVISOR_LOCK_PID_WAIT=0.05
 # How far into the pid file the NUL scan looks. Any legitimate pid file is a handful of bytes, so this is
 # four orders of magnitude of headroom; beyond it the scan reports `could-not-measure`, never `nul-free`.
 SUPERVISOR_PID_NUL_SCAN=4096
-# The pid-space ceiling used when the platform does not publish one. 4194304 is Linux's own
-# `PID_MAX_LIMIT` on 64-bit — i.e. the largest value any Linux box can configure — and every other
-# platform this script supports is lower (macOS caps at 99999). It is therefore conservative in the ONE
-# direction that matters: it can never reject a pid a real process could hold, so it cannot turn a live
-# holder into "malformed" and wedge the lane.
-SUPERVISOR_PID_MAX_FALLBACK=4194304
-
-# supervisor_pid_space_ceiling — the largest pid this platform can issue, from AUTHORITATIVE METADATA
-# where the platform publishes it, else the conservative constant above (#3601, roborev job 231 B3).
+# supervisor_pid_space_ceiling — echo EXACTLY one of
+#   authoritative <inclusive-max>   the largest pid this platform can ISSUE, from its own metadata
+#   unknown <cause>                 this platform publishes no bound we can read
 #
-# WHY A VALUE BOUND REPLACED A DIGIT-COUNT BOUND. The digit count was 10, and every real pid space is at
-# most 7 digits — so a 10-digit corruption was ACCEPTED, cast to `pid_t` by `kill`, reliably reported
-# ESRCH, became an affirmative `dead` and RECLAIMED THE LOCK, while a 15-digit corruption refused. Same
-# defect class, two different widths, opposite outcomes: the guarantee had a hole in exactly the
-# direction #3601 is about. A pid that cannot exist on this platform is malformed content, and that is
-# decidable from the platform's own published bound rather than from a guess about digit widths.
+# WHY A VALUE BOUND REPLACED A DIGIT-COUNT BOUND (#3601, roborev job 231 B3). The digit count was 10 and
+# every real pid space is at most 7 digits, so a 10-digit corruption was ACCEPTED, cast to `pid_t` by
+# `kill`, reliably reported ESRCH, became an affirmative `dead` and RECLAIMED THE LOCK — while a 15-digit
+# corruption of the same kind refused. One defect class, two widths, opposite outcomes, and the accepting
+# width is the direction #3601 exists to close.
+#
+# THE VALUE IS EXCLUSIVE AND IS CONVERTED (#3601, roborev job 231 B10). `proc(5)` on
+# `/proc/sys/kernel/pid_max`: "This file specifies the value at which PIDs wrap around (i.e., the value
+# in this file is one greater than the maximum PID)." So `pid_max` itself is NOT an issuable pid, and
+# accepting a holder pid equal to it was an off-by-one that let exactly one malformed value through. The
+# inclusive maximum is `pid_max - 1`, and that is what this echoes. A suite case pinned the pre-fix
+# boundary as correct and was fixed with the code, not around it.
+#
+# AND THERE IS NO CROSS-PLATFORM FALLBACK CONSTANT ANY MORE, WHICH IS THE POINT OF THE THIRD VALUE. An
+# earlier cut of this change substituted Linux's own `PID_MAX_LIMIT` (4194304) wherever `/proc` was
+# absent. On macOS, whose real ceiling is 99999, that accepted values up to 42x the platform limit — so
+# malformed pids passed there — and, worse, it was a GUESS ABOUT A PLATFORM WE HAD NOT MEASURED
+# presented as a bound, which is the no-heuristics violation this repository forbids outright
+# (CLAUDE.md #28: authoritative metadata only, never inference). An unmeasurable ceiling is not licence
+# to accept anything, and it is equally not licence to invent a number.
+#
+# SO WHAT DOES `unknown` DO? It makes the platform check NOT APPLY, and — this is the half that matters —
+# the parser then does not CLAIM it applied one. It cannot mean "refuse every pid": that would wedge
+# every non-Linux box permanently, which is the lead's ruling 2 (a guard that never permits work is
+# broken, not fail-closed). It is sound for this specific check, and only because of what the check IS:
+# a REJECTION-ONLY filter. It can turn `accept` into `refuse` and never the reverse, so its absence
+# cannot cause a wrong reclaim that was not already possible — it only fails to tighten. That reasoning
+# does NOT generalise to the liveness or NUL probes, whose verdicts SELECT the reclaim; theirs is
+# `cannot tell => refuse`. The residual with no platform bound is stated at the call site.
 #
 # THIS IS NOT THE DELETED `pid_max` READ COMING BACK. #3549 removed a `/proc/sys/kernel/pid_max` read
 # from the LEGACY guard's classifier because that classifier's verdict could not change the decision.
-# Here it does: it selects between refusing and reclaiming. The suite asserts the deletion as a PROPERTY
-# over the legacy functions rather than as a name ban over the file, for that reason.
-#
-# AN UNREADABLE BOUND IS NOT LICENCE TO ACCEPT MORE. Every failure path lands on the constant, which is
-# STRICTER than the old digit rule, never looser — so "cannot read the platform bound" tightens nothing
-# and loosens nothing; it just stops being able to tighten further.
+# Here it does. The suite asserts the deletion as a PROPERTY over the legacy functions rather than as a
+# name ban over the file, for that reason.
 supervisor_pid_space_ceiling() {
   local b=''
-  if [[ -r /proc/sys/kernel/pid_max ]]; then
-    { IFS= read -r b; } 2>/dev/null </proc/sys/kernel/pid_max || b=''
-    # Validated the same way a holder pid is: enumerated digits (collation-free), and short enough that
-    # the arithmetic comparison below cannot overflow a 64-bit shell integer.
-    case "$b" in
-      '' | *[!0123456789]*) b='' ;;
-    esac
-    if [[ -n "$b" && "${#b}" -gt 18 ]]; then b=''; fi
+  if [[ ! -r /proc/sys/kernel/pid_max ]]; then
+    printf '%s' 'unknown no-platform-pid-bound-published'
+    return 0
   fi
-  if [[ -z "$b" ]]; then b="$SUPERVISOR_PID_MAX_FALLBACK"; fi
-  printf '%s' "$b"
+  { IFS= read -r b; } 2>/dev/null </proc/sys/kernel/pid_max || b=''
+  # Validated the way a holder pid is: enumerated digits (collation-free, no `[0-9]` range), and short
+  # enough that the arithmetic below cannot overflow a 64-bit shell integer.
+  case "$b" in
+    '' | *[!0123456789]*)
+      printf '%s' 'unknown platform-pid-bound-unparseable'
+      return 0
+      ;;
+  esac
+  if [[ "${#b}" -gt 18 ]]; then
+    printf '%s' 'unknown platform-pid-bound-out-of-arithmetic-range'
+    return 0
+  fi
+  # A wrap point below 2 cannot issue a usable pid at all, so it is not a bound we can convert; saying so
+  # beats echoing `authoritative 0`, which would refuse every pid on this box.
+  if [[ "$b" -lt 2 ]]; then
+    printf '%s' 'unknown platform-pid-bound-implausible'
+    return 0
+  fi
+  printf 'authoritative %s' "$((b - 1))"
 }
 
 # supervisor_lock_pid_nul_free <file> — echo EXACTLY one of
@@ -2254,12 +2280,22 @@ supervisor_lock_pid_read() {
   # not an unusual pid (#3601, roborev job 231 B3). The previous 10-digit rule accepted a corruption that
   # `kill` then reported ESRCH for, which became an affirmative `dead` and RECLAIMED the lock — while a
   # wider corruption of the same kind refused.
+  # THE PLATFORM BOUND, WHEN THE PLATFORM PUBLISHES ONE — and nothing pretending to be one when it does
+  # not (#3601, roborev job 231 B10). `unknown` leaves this gate UNAPPLIED, so on a platform with no
+  # published pid space the parser is exactly as strong here as it was before the bound existed: the
+  # structural gates and the 18-digit arithmetic guard above still reject, and a plausible-looking
+  # corruption within them is still accepted, probed, and reclaimed if the kernel says no such process.
+  # That residual is REAL and is stated rather than papered over with a guessed constant.
   local pidceil=''
-  pidceil="$(supervisor_pid_space_ceiling)" || pidceil="$SUPERVISOR_PID_MAX_FALLBACK"
-  if [[ "$first" -gt "$pidceil" ]]; then
-    printf '%s' 'unparseable pid-above-the-platform-pid-space'
-    return 0
-  fi
+  pidceil="$(supervisor_pid_space_ceiling)" || pidceil='unknown ceiling-probe-aborted'
+  case "$pidceil" in
+    'authoritative '*)
+      if [[ "$first" -gt "${pidceil#authoritative }" ]]; then
+        printf '%s' 'unparseable pid-above-the-platform-pid-space'
+        return 0
+      fi
+      ;;
+  esac
   # LAST GATE BEFORE ACCEPTANCE: the FILE'S BYTES, not the string the shell was able to hold (#3601,
   # roborev job 231). Everything above ran on a value `read` had already stripped NULs out of, so a
   # `<digits> NUL LF` file satisfied all of it. It is deliberately last: it is the only gate that forks,

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -2471,6 +2471,15 @@ supervisor_lock_release() {
   state="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")" || state='unparseable read-aborted'
   if [[ "$state" == "pid $$" ]]; then
     rm -rf -- "$SUPERVISOR_LOCK" 2>/dev/null || true
+    # THE REMOVAL'S OUTCOME IS CHECKED, AND A FAILURE IS REPORTED (#3601, roborev job 231 B9 class sweep).
+    # This branch made no false claim — it made NO claim, silently — but the silence is the same problem
+    # one step earlier: a lock left behind by a supervisor that exited cleanly is unattributable, and the
+    # next start has to refuse over it or reclaim it. It is self-healing (the pid recorded is ours, and we
+    # are about to be gone, so the next start gets an affirmative `dead` and reclaims), which is why this
+    # reports rather than escalates.
+    if [[ -e "$SUPERVISOR_LOCK" || -L "$SUPERVISOR_LOCK" ]]; then
+      log "$(supervisor_one_line "exit: FAILED to remove our own lock $(supervisor_shell_quote "$SUPERVISOR_LOCK") — it still exists after the removal. It records this process's pid ($$), so the next start will find its holder affirmatively dead and reclaim it automatically; no action is needed unless starts keep refusing (#3601).")"
+    fi
     return 0
   fi
   # Rendered, not interpolated raw (#3549 job 201 F1 class, at a new site — #3601 roborev job 231 B7):
@@ -2556,6 +2565,27 @@ supervisor_lock_take() {
   # holder's record. Our own staging file is removed first because it is unambiguously ours.
   rm -f -- "$SUPERVISOR_LOCK/pid.tmp.$$" 2>/dev/null || true
   rmdir -- "$SUPERVISOR_LOCK" 2>/dev/null || true
+  # ...AND THE OUTCOME IS VERIFIED, NOT ASSUMED (#3601, roborev job 231 B9). Both removals above ignore
+  # their exit status — deliberately, because a peer populating the directory is a legitimate reason for
+  # `rmdir` to refuse — so NOTHING here knows whether the lock is gone until it looks. The refusal built
+  # from this cause used to state unconditionally that the directory "has been REMOVED AGAIN": with a
+  # peer's record inside, or a filesystem that refuses the removal, the lock REMAINED while the operator
+  # was told there was nothing to clear. Same defect family as the refusal that claimed a read-back it
+  # never made (B1) and the mutant comment that claimed an isolation it did not have (B4) — an artifact
+  # asserting a step that did not run, which is worse than no artifact because it is what stops the next
+  # reader looking. So the verdict carries what was OBSERVED after the attempt, and the three cases are
+  # distinguished because their remedies differ: nothing to do, a foreign holder to leave alone, or a
+  # residual to clear.
+  if [[ ! -e "$SUPERVISOR_LOCK" && ! -L "$SUPERVISOR_LOCK" ]]; then
+    SUPERVISOR_LOCK_TAKE_CAUSE="$pub cleanup-verified-absent"
+    return 3
+  fi
+  local residual=''
+  residual="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")" || residual='unparseable residual-probe-aborted'
+  case "$residual" in
+    'pid '*) SUPERVISOR_LOCK_TAKE_CAUSE="$pub cleanup-failed-foreign-holder $residual" ;;
+    *)       SUPERVISOR_LOCK_TAKE_CAUSE="$pub cleanup-failed-residual $residual" ;;
+  esac
   return 3
 }
 
@@ -2570,15 +2600,20 @@ supervisor_lock_refuse_unowned() {
   local cause="${1:-not-owned unrecorded}" detail=''
   case "$cause" in
     'declined'*)
-      detail="the lock directory was created by this process and then found to ALREADY CONTAIN a holder record, so this run declined to overwrite it and wrote NOTHING; that record reads [${cause#declined }]. The directory at that name is therefore not the one this process created — a peer renamed ours aside and published its own between our two steps"
+      # Only THIS path may claim the path is untouched: the publish saw a record already there and
+      # returned without writing (its staging file is removed on the way out).
+      detail="the lock directory was created by this process and then found to ALREADY CONTAIN a holder record, so this run declined to overwrite it and wrote NOTHING; that record reads [${cause#declined }]. The directory at that name is therefore not the one this process created — a peer renamed ours aside and published its own between our two steps. NOTHING at that path has been modified by this run"
       ;;
     *)
-      detail="the lock directory was created by this process and our pid was published into it; reading it back did not return our pid ($$) — the read-back said [${cause#not-owned }] — so between those two steps something else took the lock name"
+      # This path DID write: `pid` at that name currently holds OUR pid, over whatever was there. Saying
+      # "nothing has been modified" here would be false, and it was — for about an hour, until the B9
+      # class sweep read it back (#3601, roborev job 231 B9).
+      detail="the lock directory was created by this process and our pid WAS published into it; reading it back did not return our pid ($$) — the read-back said [${cause#not-owned }] — so between those two steps something else took the lock name, and our published pid may have overwritten that holder's record (the race #3683 closes)"
       ;;
   esac
   supervisor_lock_refuse \
     "refusing to start — this run CREATED the lock and then could not verify it OWNS it" \
-    "$detail. The most likely cause is a supervisor running PRE-#3601 code on this box: it reads a lock whose pid file is not yet present as STALE and renames it aside, which is the defect #3601 fixes. Starting now would put two supervisors in one worktree, so this run stops instead. NOTHING at that path has been modified by this run" \
+    "$detail. The most likely cause is a supervisor running PRE-#3601 code on this box: it reads a lock whose pid file is not yet present as STALE and renames it aside, which is the defect #3601 fixes. Starting now would put two supervisors in one worktree, so this run stops instead" \
     "re-run this supervisor: if the other holder is a real one, the next start will say so and name its pid; if it was a pre-#3601 reclaim, upgrade every checkout on this box that can launch a supervisor past #3601 so no peer reclaims a pid-less lock again"
 }
 
@@ -2591,16 +2626,41 @@ supervisor_lock_refuse_unowned() {
 # reports that the directory we created was REMOVED AGAIN, because an operator who reads "could not
 # start" and then finds a lock sitting there will otherwise go looking for a holder.
 supervisor_lock_refuse_publish_failed() {
-  local cause="$1" what=''
+  local cause="$1" pub="$1" cleanup='' what='' aftermath='' remedy='' cmd=''
+  pub="${cause%% *}"
   case "$cause" in
+    *' '*) cleanup="${cause#* }" ;;
+  esac
+  case "$pub" in
     write-failed)  what='writing our pid into the lock FAILED — no byte of it was written' ;;
     rename-failed) what='publishing our pid into the lock FAILED at the rename — the staging file was written and could not be moved into place' ;;
-    *)             what="recording our pid in the lock FAILED ([$cause])" ;;
+    *)             what="recording our pid in the lock FAILED ([$pub])" ;;
+  esac
+  # EVERY SENTENCE BELOW IS BOUND TO AN OBSERVATION `supervisor_lock_take` ACTUALLY MADE (#3601 B9).
+  case "$cleanup" in
+    cleanup-verified-absent)
+      aftermath='The directory this run created has been removed again and its absence was VERIFIED after the removal, so this failure leaves no pid-less lock behind for the next start to have to refuse over'
+      remedy='check free space and mount options for the filesystem holding the path named above (df, mount), then re-run this supervisor. Nothing needs clearing by hand'
+      ;;
+    'cleanup-failed-foreign-holder '*)
+      aftermath="This run then tried to remove the directory it had created and it REMAINS — and it now holds a holder record that is NOT ours ([${cleanup#cleanup-failed-foreign-holder }]). A peer published into it while our publish was failing; the removal is NON-RECURSIVE precisely so that it cannot delete that record, and nothing of that peer's has been touched"
+      remedy='nothing to clear: the path named above belongs to another holder, which this run left intact. Fix the filesystem problem named above and re-run; the next start will read that holder and report it by pid'
+      ;;
+    'cleanup-failed-residual '*)
+      aftermath="This run then tried to remove the directory it had created and it REMAINS ([${cleanup#cleanup-failed-residual }]) — the removal did NOT succeed, so a lock DOES sit at that path and the next start will refuse over it until it is cleared"
+      remedy="fix the filesystem problem named above, then clear the leftover lock with the next line, on its own, exactly as printed — it is NON-RECURSIVE, so it refuses if anything is inside that you have not examined$(supervisor_lock_shape_note)"
+      cmd="$(supervisor_lock_clear_command)"
+      ;;
+    *)
+      aftermath='The removal outcome for the directory this run created was NOT ESTABLISHED, so this refusal makes no claim about whether a lock remains at that path'
+      remedy='fix the filesystem problem named above, then inspect the path named above before re-running: this run could not establish whether it left a lock there'
+      ;;
   esac
   supervisor_lock_refuse \
     "refusing to start — the lock name became ours and this run could not record itself in it" \
-    "$what. This is a FILESYSTEM failure, not contention: no other holder is implied. The usual causes are a full filesystem (ENOSPC — routine on this fleet) or a read-only mount. The directory this run created has been REMOVED AGAIN, non-recursively, so this failure leaves no pid-less lock behind for the next start to have to refuse over" \
-    "check free space and mount options for the filesystem holding the path named above (df, mount), then re-run this supervisor. Nothing needs clearing by hand"
+    "$what. This is a FILESYSTEM failure, not contention: no other holder is implied by the failure itself. The usual causes are a full filesystem (ENOSPC — routine on this fleet) or a read-only mount. $aftermath" \
+    "$remedy" \
+    "$cmd"
 }
 
 # supervisor_lock_refuse_undecidable <cause> <what-was-observed> — the "cannot tell" refusal, and the
@@ -2665,7 +2725,7 @@ supervisor_lock_shape_note() {
 supervisor_lock_refuse_lost_race() {
   supervisor_lock_refuse \
     "refusing to start — the lock name was taken again before this run could claim it" \
-    "a stale lock left by a dead holder was cleared and the name was immediately claimed by someone else, so this run did NOT get the lock. Only one racer can win the rename, which is what stops both from believing they did; the loser stops here rather than co-running" \
+    "a stale lock left by a dead holder is gone from that name and the name was claimed again before this run could take it, so this run did NOT get the lock. WHO cleared it and WHO holds it now are both unestablished — this run reached its own claim and found the name taken, which is all it observed; it does not know that its own rename is what cleared the lock, and it has not read the new holder. The loser stops here rather than co-running" \
     "nothing is wrong: re-run this supervisor. If it keeps losing, the winner is a live supervisor for this lane and the next start will name its pid"
 }
 

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -2408,6 +2408,29 @@ supervisor_lock_publish() {
     printf '%s' 'write-failed'
     return 1
   fi
+  # DECLINE RATHER THAN OVERWRITE (#3601, roborev job 231 F3/B11; race tracked as #3683). Publication is
+  # NOT bound to the directory instance this process created: a peer can rename our pid-less directory
+  # away, create and publish its OWN lock at the same name, and our `mv -f` then overwrites THAT peer's
+  # ownership record — destroying the evidence of who holds the lane, which is strictly worse than
+  # failing to start. In the legitimate case the directory was created microseconds ago by our own
+  # `mkdir`, so `pid` CANNOT exist and this branch is never taken; if it does exist the directory is not
+  # the one we made, and declining costs us a start we were not entitled to anyway.
+  #
+  # NARROWED, NOT CLOSED — DO NOT READ THIS AS A GUARANTEE. Test-then-move is NOT equivalent to an atomic
+  # create-exclusive: a peer that publishes between this test and the rename below is still overwritten.
+  # The window shrinks from "the whole publish" to "between these two lines" and no further, because
+  # closing it needs serialisation across the complete claim-and-publication operation — the same
+  # primitive as the reclaim ABA above and the read-then-remove in `supervisor_lock_release`, all three
+  # tracked as ONE follow-up (#3683). `mv -n` was considered and NOT used: it is outside POSIX, and GNU
+  # `mv -n` exits 0 WITHOUT MOVING, so its success proves nothing about publication and a platform
+  # lacking `-n` would fail every publish outright — a wedge in exchange for a narrower window that
+  # #3683 closes properly.
+  if [[ -e "$SUPERVISOR_LOCK/pid" || -L "$SUPERVISOR_LOCK/pid" ]]; then
+    rm -f -- "$tmpf" 2>/dev/null || true
+    state="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")" || state='unparseable read-back-aborted'
+    printf '%s' "declined $state"
+    return 1
+  fi
   # `--` because both operands are `TMPDIR`-derived and may be option-shaped (#3601 AC7); quoting stops
   # word-splitting and globbing and does nothing about option parsing.
   if ! mv -f -- "$tmpf" "$SUPERVISOR_LOCK/pid" 2>/dev/null; then
@@ -2515,7 +2538,9 @@ supervisor_lock_take() {
     return 0
   fi
   SUPERVISOR_LOCK_TAKE_CAUSE="$pub"
-  if [[ "$pub" == 'not-owned'* ]]; then
+  # `declined` joins `not-owned` (#3601 B11): both mean the directory at that name is not ours, so both
+  # LEAVE IT ALONE. The difference is only whether we wrote into it, and the refusal says which.
+  if [[ "$pub" == 'not-owned'* || "$pub" == 'declined'* ]]; then
     # The NAME became ours and the directory now holds someone else's pid. Leaving it alone is the whole
     # point: it is a live holder's lock as far as we can tell.
     return 2
@@ -2535,11 +2560,25 @@ supervisor_lock_take() {
 }
 
 # supervisor_lock_refuse_unowned — the name became ours and the read-back said it is not.
+#
+# TWO REACHING PATHS, TWO DIFFERENT TRUTHS, AND THE TEXT MUST NOT MIX THEM UP (#3601, B9 family). The
+# `declined` path never wrote anything — a `pid` file already existed, so the publish refused to
+# overwrite it — while the `not-owned` path DID publish and then read back someone else's pid. Saying
+# "our pid was published into it" on the declined path would assert a step that did not run, which is the
+# defect class B1, B4 and the reclaim comment were all instances of.
 supervisor_lock_refuse_unowned() {
-  local cause="${1:-not-owned unrecorded}"
+  local cause="${1:-not-owned unrecorded}" detail=''
+  case "$cause" in
+    'declined'*)
+      detail="the lock directory was created by this process and then found to ALREADY CONTAIN a holder record, so this run declined to overwrite it and wrote NOTHING; that record reads [${cause#declined }]. The directory at that name is therefore not the one this process created — a peer renamed ours aside and published its own between our two steps"
+      ;;
+    *)
+      detail="the lock directory was created by this process and our pid was published into it; reading it back did not return our pid ($$) — the read-back said [${cause#not-owned }] — so between those two steps something else took the lock name"
+      ;;
+  esac
   supervisor_lock_refuse \
     "refusing to start — this run CREATED the lock and then could not verify it OWNS it" \
-    "the lock directory was created by this process and our pid was published into it; reading it back did not return our pid ($$) — the read-back said [${cause#not-owned }] — so between those two steps something else took the lock name. The most likely cause is a supervisor running PRE-#3601 code on this box: it reads a lock whose pid file is not yet present as STALE and renames it aside, which is the defect #3601 fixes. Starting now would put two supervisors in one worktree, so this run stops instead" \
+    "$detail. The most likely cause is a supervisor running PRE-#3601 code on this box: it reads a lock whose pid file is not yet present as STALE and renames it aside, which is the defect #3601 fixes. Starting now would put two supervisors in one worktree, so this run stops instead. NOTHING at that path has been modified by this run" \
     "re-run this supervisor: if the other holder is a real one, the next start will say so and name its pid; if it was a pre-#3601 reclaim, upgrade every checkout on this box that can launch a supervisor past #3601 so no peer reclaims a pid-less lock again"
 }
 

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -2761,51 +2761,35 @@ supervisor_lock_refuse_publish_failed() {
   case "$cause" in
     *' '*) cleanup="${cause#* }" ;;
   esac
-  # THE NATURE OF THE FAILURE IS CARRIED SEPARATELY FROM THE STEP THAT FAILED (#3601, job 244 sweep). The
-  # same step fails for two reasons that want OPPOSITE actions — a peer removing the directory (re-run)
-  # versus a broken filesystem (fix the box, and re-running loops) — so the first action an operator is
-  # given is selected by the nature, not by the step.
-  local nature='' nature_line='' first_action=''
+  # THE STEP THAT FAILED IS REPORTED; THE *CAUSE* IS NOT CLAIMED (#3601, roborev job 245 B21). An earlier
+  # cut carried a `nature` per cause — `filesystem` for a failed write or rename, `contention` when the
+  # directory had vanished — derived from a post-failure `-d` test. That test cannot decide it in either
+  # direction (see `supervisor_lock_nature_unestablished`), and `write-failed` claimed a filesystem fault
+  # with no test at all. So each branch now states only WHAT it observed, and the shared ambiguity text
+  # states what could have caused it, with the order to check.
+  local what='' nature_line='' first_action=''
   case "$pub" in
     marker-failed)
-      what='writing our OWNERSHIP MARKER into the lock FAILED — this run got the lock name and could not record, even provisionally, that the directory is its own'
-      nature='filesystem'
+      what='writing our OWNERSHIP MARKER into the lock FAILED — this run got the lock name and could not record, even provisionally, that the directory is its own; the directory was still there when this run looked'
       ;;
     marker-failed-lock-gone)
-      what='writing our OWNERSHIP MARKER into the lock FAILED because the lock directory this run had just created was ALREADY GONE'
-      nature='contention'
+      what='writing our OWNERSHIP MARKER into the lock FAILED, and the lock directory this run had just created was GONE when this run looked'
       ;;
     write-failed)
       what='writing our pid into the lock FAILED — no byte of it was written'
-      nature='filesystem'
       ;;
     rename-failed)
-      what='publishing our pid into the lock FAILED at the rename — the staging file was written and could not be moved into place'
-      nature='filesystem'
+      what='publishing our pid into the lock FAILED at the rename — the staging file was written and could not be moved into place; the lock directory was still there when this run looked'
       ;;
     rename-failed-lock-gone)
-      what='publishing our pid into the lock FAILED at the rename because the lock directory this run had created was ALREADY GONE'
-      nature='contention'
+      what='publishing our pid into the lock FAILED at the rename, and the lock directory this run had created was GONE when this run looked'
       ;;
     *)
       what="recording our pid in the lock FAILED ([$pub])"
-      nature='unestablished'
       ;;
   esac
-  case "$nature" in
-    filesystem)
-      nature_line='This is a FILESYSTEM failure, not contention: no other holder is implied by the failure itself. The usual causes are a full filesystem (ENOSPC — routine on this fleet) or a read-only mount'
-      first_action='check free space and mount options for the filesystem holding the path named above (df, mount) — re-running without changing either will fail the same way'
-      ;;
-    contention)
-      nature_line='This is CONTENTION, not a filesystem fault: something removed or replaced the directory this run had just created, while this run was recording itself in it. No disk or permission problem is implied'
-      first_action='re-run this supervisor — nothing needs fixing and nothing needs clearing; the next start will either take the lock or name whoever holds it'
-      ;;
-    *)
-      nature_line='Whether this was a filesystem fault or contention is NOT established by the failure itself, so this refusal does not claim either'
-      first_action='inspect the path named above and the filesystem holding it (df, mount) before re-running: this run could not tell a broken filesystem from a peer taking the name'
-      ;;
-  esac
+  nature_line="$(supervisor_lock_nature_unestablished)"
+  first_action="$(supervisor_lock_nature_actions)"
   # EVERY SENTENCE BELOW IS BOUND TO AN OBSERVATION `supervisor_lock_take` ACTUALLY MADE (#3601 B9).
   case "$cleanup" in
     cleanup-verified-absent)
@@ -2922,6 +2906,49 @@ supervisor_lock_refuse_lost_race() {
     "nothing is wrong: re-run this supervisor. If it keeps losing, the winner is a live supervisor for this lane and the next start will name its pid"
 }
 
+# supervisor_lock_nature_unestablished / supervisor_lock_nature_actions — THE ONE THING EVERY FAILURE
+# SITE IN THIS FILE MAY SAY ABOUT *WHY* AN OPERATION FAILED (#3601, roborev job 245 B21).
+#
+# WHY THERE IS NO CONFIDENT VERDICT LEFT. Every one of these sites tried to tell contention apart from a
+# filesystem fault by looking at whether the lock path exists AFTER the failure. That is unsound in BOTH
+# directions, and the two directions were introduced two rounds apart:
+#   * job 244 (B20) fixed "contention reported as a disk problem": `mkdir` fails with EEXIST, the name is
+#     present, and the code called it a path failure.
+#   * job 245 (B21) is the inverse it created: contender A moves the old lock aside, B's operation fails
+#     while the name is ABSENT, A republishes before B reaches the check — and B reports a filesystem
+#     fault and sends an operator to repair permissions on a box that is fine.
+# A post-failure existence test cannot decide this, because a peer can remove or recreate that name
+# between the failure and the check, either way round. The failing call's errno is the only thing that
+# could decide it and this script cannot see it.
+#
+# AND IT IS NOT RECOVERED BY PARSING `mv`/`mkdir` STDERR. Message text is locale-dependent and is not a
+# contract — that is the cargo-output-parse defect class this repo has already paid for (CLAUDE.md
+# #3400), and a locale-sensitive guess dressed as a verdict is worse than an honest ambiguity.
+#
+# SO THE AMBIGUITY IS PRESERVED — AND MADE ACTIONABLE, which is the whole point. The sweep's value was
+# telling "retry" apart from "fix the box", and going ambiguous gives that up unless the text says both
+# possibilities WITH what to check for each and in what order. An honest "it is one of these two, here is
+# how to tell" beats a confident wrong nature and it also beats a shrug.
+#
+# THE SOUND ALTERNATIVE, NOT BUILT HERE, RECORDED SO IT IS NOT REDISCOVERED: measure the filesystem
+# AFFIRMATIVELY instead of inferring it — try to create and unlink a scratch file in the lock's PARENT, so
+# a success proves the filesystem is fine (hence contention) and a failure demonstrates the fault. That is
+# a real answer rather than an inference, and it is deliberately NOT added here: it puts a new write on
+# every failure path, and a mechanism that produces one new instance per fix is one to remove rather than
+# iterate. It belongs with #3683/#3697.
+#
+# APPLIED AT ALL FIVE SITES, not the three the finding named. The first `take`'s uncreatable refusal and
+# the reclaim rename's refusal made the same claim from the same kind of test, and `write-failed` claimed
+# a filesystem fault with no test at all; leaving those confident while fixing the others would have been
+# the same defect with a smaller blast radius.
+supervisor_lock_nature_unestablished() {
+  printf '%s' "WHETHER THIS WAS CONTENTION OR A FILESYSTEM FAULT IS NOT ESTABLISHED: this script cannot see the failing call's error code, and the state of that path afterwards cannot decide it either, because a peer can remove or recreate the name between the failure and any check made here — in either direction"
+}
+
+supervisor_lock_nature_actions() {
+  printf '%s' "IT IS ONE OF TWO THINGS AND THIS IS THE ORDER TO TELL THEM APART. (1) A FILESYSTEM FAULT: check the PARENT directory of the path named above — it must exist, be a directory, be writable by this user, and its filesystem must have free space and not be mounted read-only (ls -ld on the parent, df, mount). If any of those is wrong, that is the cause, and re-running changes nothing until it is fixed. (2) CONTENTION: if all of those are clean, another supervisor was taking or releasing this lock at the same moment, nothing is wrong with this box, and re-running is sufficient"
+}
+
 # supervisor_lock_refuse_uncreatable [<phase-note>] — `mkdir` failed AND nothing is at that name, so the
 # failure is about the PATH and not about a holder (#3601 AC7 addendum; reused post-reclaim by job 244 B20).
 #
@@ -2931,8 +2958,8 @@ supervisor_lock_refuse_uncreatable() {
   local phase="${1:-}"
   supervisor_lock_refuse \
     "refusing to start — the lock directory could NOT BE CREATED, and nothing exists at that path" \
-    "this is NOT contention: no lock is there and no holder is implied${phase:+ ($phase)}. \`mkdir\` failed for a reason to do with the PATH itself — the parent directory missing, not a directory, or not writable by this user, or the filesystem being full" \
-    "check the parent directory of the path named above: it must exist, be a directory, and be writable by this user, and the filesystem must have space. The path is \${TMPDIR:-/tmp}-derived unless this run's launcher named it, so a TMPDIR pointing somewhere absent, read-only or full is the usual cause. Re-running WITHOUT changing any of that will fail exactly the same way"
+    "\`mkdir\` failed and NOTHING is at that name now${phase:+ ($phase)}. $(supervisor_lock_nature_unestablished)" \
+    "$(supervisor_lock_nature_actions). The path is \${TMPDIR:-/tmp}-derived unless this run's launcher named it, so a TMPDIR pointing somewhere absent, read-only or full is the usual first cause to check"
 }
 
 acquire_lock() {
@@ -3117,8 +3144,8 @@ acquire_lock() {
     esac
     supervisor_lock_refuse \
       "refusing to start — a lock this run measured as stale could not be cleared" \
-      "renaming the lock aside FAILED, so nothing was cleared and nothing was claimed; nothing at that path has been modified by this run. That is a FILESYSTEM failure, not contention: clearing a lock needs WRITE permission on its PARENT directory, which reading one does not. AND THE IDENTITY OF WHAT IS THERE IS NOW UNESTABLISHED — $identity" \
-      "make the lock's parent directory writable by this user and RE-RUN: the next start re-measures the holder from scratch and will either reclaim the lock, if it is genuinely stale, or name its live holder. Do NOT remove anything on the strength of this message — this run measured a dead holder BEFORE its rename failed and cannot vouch for what is at that path now. To see what is actually there, run the next line, on its own, exactly as printed; it only reads" \
+      "renaming the lock aside FAILED, so nothing was cleared and nothing was claimed; nothing at that path has been modified by this run. $(supervisor_lock_nature_unestablished). AND THE IDENTITY OF WHAT IS THERE IS NOW UNESTABLISHED TOO — $identity" \
+      "$(supervisor_lock_nature_actions). Either way, RE-RUN rather than clearing anything by hand: the next start re-measures the holder from scratch and will reclaim the lock if it is genuinely stale, or name its live holder. Do NOT remove anything on the strength of this message — this run measured a dead holder BEFORE its rename failed and cannot vouch for what is at that path now. To see what is actually there, run the next line, on its own, exactly as printed; it only reads" \
       "ls -ldn -- $(supervisor_shell_quote "$SUPERVISOR_LOCK") && ls -lna -- $(supervisor_shell_quote "$SUPERVISOR_LOCK")"
   fi
   takerc=0

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -2010,6 +2010,63 @@ supervisor_legacy_lock_guard() {
 # measure no pid liveness at all.
 # ---------------------------------------------------------------------------
 
+# supervisor_lock_pid_nul_free <file> — echo EXACTLY one of
+#   nul-free | contains-nul | could-not-measure <cause>
+#
+# WHY THIS CANNOT BE DONE IN THE SHELL, WHICH IS THE WHOLE REASON IT EXISTS (#3601, roborev job 231).
+# A NUL byte is invisible to every check that runs on a shell VARIABLE: bash cannot hold one, and `read`
+# discards it silently. MEASURED on bash 5.2.21: a pid file whose bytes are `4242 NUL LF` reads back as
+# the string `4242`, length 4 — non-empty, single line, all decimal digits, non-zero. It therefore
+# passed every gate in `supervisor_lock_pid_read` and the lock got RECLAIMED, which is precisely the
+# AC1 defect this parser exists to close: a partially-written pid file is exactly where NULs come from,
+# since a crash mid-write can leave allocated-but-zeroed bytes. So the check MUST look at the file's
+# bytes, before any shell variable is involved, and comparing the byte count against the NUL-stripped
+# byte count is the portable way to do it (`wc -c` and `tr -d '\000'` are both POSIX; no GNU-only flag,
+# nothing that needs `grep -P`, `od` parsing or bash 4).
+#
+# BASH'S OWN WARNING IS NOT A USABLE SIGNAL, and this is worth recording because it looks like one.
+# `$(cat …)` on such a file does emit `warning: … ignored null byte in input` — on STDERR, which the
+# idiom at every one of these sites (`2>/dev/null`) already suppresses. Re-plumbing that redirection to
+# catch it would make correctness depend on matching bash's message TEXT, which is not a stable
+# contract: the same defect class as a gate parser keyed on cargo's literal status words (CLAUDE.md
+# #3400). The byte count is a measurement; the warning is a presentation detail.
+#
+# A FAILED MEASUREMENT IS NOT "NO NULS FOUND" — the third value, for the same reason `log_size` in this
+# file grew one (#3601): both counts are external commands and either can fail, and folding that onto
+# the permissive answer is how an unmeasurable read becomes an accepted pid. The counts are validated as
+# DIGIT STRINGS and compared as STRINGS, never with `-eq`, because `-eq` reads an empty operand as 0 and
+# two failed measurements would then compare EQUAL and report `nul-free`.
+#
+# THE TWO COUNTS COME FROM TWO OPENS, so a file rewritten between them yields mismatched counts and is
+# reported `contains-nul` — a REFUSAL. The ambiguity therefore costs a start and can never cost a live
+# holder its lock, which is the direction every branch here is biased in.
+#
+# Both operands are supplied by REDIRECTION, never as arguments, so an option-shaped path (#3601 AC7)
+# needs no `--` and no quoting argument here.
+supervisor_lock_pid_nul_free() {
+  local f="$1" raw='' stripped=''
+  raw="$(wc -c <"$f" 2>/dev/null | tr -d '[:space:]')" || raw=''
+  stripped="$(tr -d '\000' <"$f" 2>/dev/null | wc -c | tr -d '[:space:]')" || stripped=''
+  case "$raw" in
+    '' | *[!0123456789]*)
+      printf '%s' 'could-not-measure raw-byte-count-unmeasurable'
+      return 0
+      ;;
+  esac
+  case "$stripped" in
+    '' | *[!0123456789]*)
+      printf '%s' 'could-not-measure nul-stripped-byte-count-unmeasurable'
+      return 0
+      ;;
+  esac
+  if [[ "$raw" == "$stripped" ]]; then
+    printf '%s' 'nul-free'
+  else
+    printf '%s' 'contains-nul'
+  fi
+  return 0
+}
+
 # supervisor_lock_pid_read <pid-file> — echo EXACTLY one of
 #   pid <digits>          a single, canonical, non-zero decimal pid
 #   unparseable <cause>   nothing usable is there, for a NAMED reason
@@ -2017,10 +2074,18 @@ supervisor_legacy_lock_guard() {
 # Every failure is a NAMED cause and never a bare empty string, because the caller must be able to tell
 # "no pid" from "pid 0" from "unreadable" — collapsing them is the original defect.
 #
-# NO EXTERNAL COMMAND. `read` and `[[ ]]` only, so no verdict depends on `PATH`, and the file is opened
-# by REDIRECTION — which parses no options, so an option-shaped path (#3601 AC7) needs no `--` here.
-# The digit test enumerates the ten digits rather than using a `[0-9]` RANGE, whose members are decided
-# by the caller's collation (a locale-dependent digit test cost #3549 a review round).
+# THE STRUCTURAL PARSE USES NO EXTERNAL COMMAND — `read` and `[[ ]]` only, so none of those verdicts
+# depends on `PATH` — and the file is opened by REDIRECTION, which parses no options, so an
+# option-shaped path (#3601 AC7) needs no `--` here. The digit test enumerates the ten digits rather
+# than using a `[0-9]` RANGE, whose members are decided by the caller's collation (a locale-dependent
+# digit test cost #3549 a review round).
+#
+# THE ONE EXCEPTION IS THE NUL CHECK, AND IT IS NOT A CHOICE: a NUL byte cannot be represented in a
+# bash variable at all, so no builtin comparison can see one, and the bytes must be measured outside the
+# shell. `supervisor_lock_pid_nul_free` does that and is THREE-valued, so a `PATH` that cannot supply
+# `wc`/`tr` makes this parser REFUSE with a named cause rather than accept an unverified pid — the
+# dependency costs a start, never a live holder's lock. It runs LAST, after the cheap builtin gates, so
+# the ordinary refusal paths fork nothing.
 supervisor_lock_pid_read() {
   local f="$1" first='' line='' n=0 readrc=0
   if [[ ! -e "$f" && ! -L "$f" ]]; then
@@ -2074,6 +2139,28 @@ supervisor_lock_pid_read() {
     printf '%s' 'unparseable pid-digit-count-out-of-well-formedness-bound'
     return 0
   fi
+  # LAST GATE BEFORE ACCEPTANCE: the FILE'S BYTES, not the string the shell was able to hold (#3601,
+  # roborev job 231). Everything above ran on a value `read` had already stripped NULs out of, so a
+  # `<digits> NUL LF` file satisfied all of it. It is deliberately last: it is the only gate that forks,
+  # and by here the content is known to be a short run of decimal digits, so a NUL is the one remaining
+  # thing that could make those digits a different number than the file records.
+  #
+  # A file that carries BOTH a NUL and other junk is refused ABOVE, under whichever gate it trips
+  # first, and that cause is also true of it — the dangerous shape, the one that reaches this line, is
+  # the file whose NUL-stripped content is a clean plausible pid.
+  local nul=''
+  nul="$(supervisor_lock_pid_nul_free "$f")" || nul='could-not-measure nul-probe-aborted'
+  case "$nul" in
+    nul-free) ;;
+    contains-nul)
+      printf '%s' 'unparseable pid-file-contains-nul'
+      return 0
+      ;;
+    *)
+      printf '%s' "unparseable pid-file-nul-check-${nul}"
+      return 0
+      ;;
+  esac
   printf 'pid %s' "$first"
 }
 

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -2022,9 +2022,10 @@ supervisor_legacy_lock_guard() {
 # cases drive the shipped values.
 #
 # The re-read window is sized for PRODUCTION, not for the tests: the state it waits out is ONE rename
-# wide (microseconds), so 2s is five orders of magnitude of margin and survives a heavily loaded box,
+# wide (microseconds), so 1s is four orders of magnitude of margin and survives a heavily loaded box,
 # and it is paid ONLY on a start that finds a peer's lock pid-less — never on an ordinary start.
-SUPERVISOR_LOCK_PID_TRIES=40
+# 20 x 0.05s = 1s.
+SUPERVISOR_LOCK_PID_TRIES=20
 SUPERVISOR_LOCK_PID_WAIT=0.05
 # How far into the pid file the NUL scan looks. Any legitimate pid file is a handful of bytes, so this is
 # four orders of magnitude of headroom; beyond it the scan reports `could-not-measure`, never `nul-free`.

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -8390,6 +8390,124 @@ test_lane_lock_publish_declines_instead_of_clobbering() {
 t test_lane_lock_publish_declines_instead_of_clobbering
 
 
+
+
+# ---------------------------------------------------------------------------
+# NO DIAGNOSTIC NAMES A STEP THAT DID NOT RUN (#3601, roborev job 231 B9 — and the CLASS, not just the
+# reported instance).
+#
+# THE REPORTED INSTANCE: `supervisor_lock_take` ignores its two cleanup failures — deliberately, because a
+# peer populating the directory is a legitimate reason for `rmdir` to refuse — and the refusal then stated
+# unconditionally that the directory "has been REMOVED AGAIN". With a peer's record inside, or a
+# filesystem that refuses the removal, the lock REMAINED while the operator was told there was nothing to
+# clear.
+#
+# THE CLASS: four instances of it landed in this one diff — a refusal claiming a read-back that never ran
+# (B1), a mutant comment claiming an isolation it did not have (B4), a code comment vouching for the race
+# it sits on (fixed by hand), and this one. The lead's ruling is that such an artifact is worse than no
+# artifact, because it is what stops the next reader looking. So the cases below assert the property for
+# EVERY branch of the cleanup, including the two the reported finding did not name.
+# ---------------------------------------------------------------------------
+test_lane_lock_cleanup_outcome_is_verified_not_claimed() {
+  local d tmp lane lock out rc ovr
+  d="$(new_case_dir)"
+  common_env "$d"
+  tmp="$d/tmp"
+  lane="lane3601cln$$"
+  mkdir -p "$tmp"
+  lock="$tmp/cqlite-worker-supervisor-$lane.lock"
+
+  # The publish's write is failed by a shipped-derived override in every case below; `take`'s cleanup and
+  # the refusal — the code being asserted — stay shipped.
+  ovr="$d/f-write.sh"; : >"$ovr"
+  if ! sv_mutant_override "$ovr" supervisor_lock_publish \
+       '  if ! { printf '"'"'%s\n'"'"' "$$" >"$tmpf"; } 2>/dev/null; then' \
+       '  if true; then'; then
+    return 0
+  fi
+
+  # ---- (a) THE CLEANUP SUCCEEDS: only here may the refusal say the directory is gone, and it says the
+  # absence was VERIFIED rather than assumed.
+  rm -rf "$lock"
+  out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")"; rc=$?
+  if [[ "$rc" -ne 0 ]] && [[ "$out" == *"absence was VERIFIED after the removal"* ]] \
+     && [[ "$out" == *"Nothing needs clearing by hand"* ]] && [[ ! -e "$lock" ]]; then
+    pass "lane-lock B9 (cleanup succeeded): the refusal claims the removal ONLY with the absence verified afterwards, and the lock really is gone"
+  else
+    fail "lane-lock-b9-verified: rc=$rc lock=[$([[ -e "$lock" ]] && echo present || echo gone)] out=[$out]"
+  fi
+
+  # ---- (b) A PEER'S RECORD BLOCKS THE `rmdir`: the lock REMAINS, and the refusal must say so, name the
+  # foreign holder, and offer NO removal command — the record is not ours to delete.
+  local ovrb
+  ovrb="$d/f-write-peer.sh"; : >"$ovrb"
+  rm -rf "$lock"
+  if sv_mutant_override "$ovrb" supervisor_lock_publish \
+       '  local tmpf="$SUPERVISOR_LOCK/pid.tmp.$$" state='"''" \
+       '  local tmpf="$SUPERVISOR_LOCK/pid.tmp.$$" state='"''"'
+  printf "%s\n" 717171 >"$SUPERVISOR_LOCK/pid" 2>/dev/null || true
+  if true; then printf "%s" write-failed; return 1; fi'; then
+    out="$(lane_lock_drive_at "$d" "$ovrb" "$tmp" "$lane")"; rc=$?
+    local bare
+    bare="$(printf '%s\n' "$out" | grep -vE "$SV_DIAG_RE" | grep -v '^$' | head -1)"
+    if [[ "$rc" -ne 0 ]] && [[ "$out" == *"it REMAINS"* ]] && [[ "$out" == *"NOT ours ([pid 717171])"* ]] \
+       && [[ "$out" != *"absence was VERIFIED"* ]] && [[ -z "$bare" ]]; then
+      pass "lane-lock B9 (peer record blocks the cleanup): the refusal says the lock REMAINS, names the foreign holder, and prints NO removal command — a record we do not own is not ours to offer for deletion"
+    else
+      fail "lane-lock-b9-foreign: rc=$rc bare=[$bare] out=[$out]"
+    fi
+    if [[ "$(cat "$lock/pid" 2>/dev/null || true)" == "717171" ]]; then
+      pass "lane-lock B9: and the peer's record survives — the cleanup's \`rmdir\` is non-recursive precisely so it cannot delete it"
+    else
+      fail "lane-lock-b9-foreign-destroyed: pid=[$(cat "$lock/pid" 2>/dev/null || true)]"
+    fi
+  fi
+
+  # ---- (c) A RESIDUAL THAT IS NOT A HOLDER: the lock remains with unusable content, so the refusal says
+  # it remains AND offers the non-recursive clear command, which the (b) case must not.
+  local ovrc
+  ovrc="$d/f-write-junk.sh"; : >"$ovrc"
+  rm -rf "$lock"
+  if sv_mutant_override "$ovrc" supervisor_lock_publish \
+       '  local tmpf="$SUPERVISOR_LOCK/pid.tmp.$$" state='"''" \
+       '  local tmpf="$SUPERVISOR_LOCK/pid.tmp.$$" state='"''"'
+  printf "%s\n" not-a-pid >"$SUPERVISOR_LOCK/pid" 2>/dev/null || true
+  if true; then printf "%s" write-failed; return 1; fi'; then
+    out="$(lane_lock_drive_at "$d" "$ovrc" "$tmp" "$lane")"; rc=$?
+    local barec
+    barec="$(printf '%s\n' "$out" | grep -vE "$SV_DIAG_RE" | grep -v '^$' | head -1)"
+    if [[ "$rc" -ne 0 ]] && [[ "$out" == *"it REMAINS"* ]] && [[ "$out" == *"unparseable pid-not-all-decimal-digits"* ]] \
+       && [[ "$barec" == 'rmdir -- '* ]]; then
+      pass "lane-lock B9 (residual, not a holder): the refusal says the lock REMAINS, names what is in it, and DOES offer the non-recursive clear — the three cleanup outcomes get three different remedies because the right action differs"
+    else
+      fail "lane-lock-b9-residual: rc=$rc bare=[$barec] out=[$out]"
+    fi
+  fi
+
+  # ---- (d) MUTANT CONTRAST: the pre-B9 spelling — the cleanup verdict is asserted unconditionally, so
+  # the operator is told the directory was removed while it demonstrably remains. Applied to the shipped
+  # `take` by ONE substitution, driven over case (b)'s staging.
+  local ovrd mout
+  ovrd="$d/m-claim.sh"; : >"$ovrd"
+  rm -rf "$lock"
+  if sv_mutant_override "$ovrd" supervisor_lock_take \
+       '  if [[ ! -e "$SUPERVISOR_LOCK" && ! -L "$SUPERVISOR_LOCK" ]]; then' \
+       '  if true; then'; then
+    cat "$ovrb" >>"$ovrd"
+    mout="$(lane_lock_drive_at "$d" "$ovrd" "$tmp" "$lane")" || true
+    if [[ "$mout" == *"absence was VERIFIED after the removal"* ]] && [[ -e "$lock" ]]; then
+      pass "lane-lock B9 MUTANT: with the cleanup verdict asserted rather than observed, the refusal tells the operator the directory was removed WHILE IT IS STILL THERE — the exact false artifact, so the asserts above are the verification doing the work"
+    else
+      fail "lane-lock-mutant-b9: lock=[$([[ -e "$lock" ]] && echo present || echo gone)] out=[$mout] — the unconditional claim must be shown to lie"
+    fi
+  fi
+
+  rm -rf "$lock" "$tmp"
+}
+
+t test_lane_lock_cleanup_outcome_is_verified_not_claimed
+
+
 # ---------------------------------------------------------------------------
 # Test 48 (#3549, roborev job 196 F2): THE SUITE LEAVES NO FIXTURE PROCESS BEHIND.
 #

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -8075,6 +8075,34 @@ test_lane_lock_failed_reclaim_rename_is_named() {
   else
     fail "lane-lock-mv-misattributed: rc=$rc out=[$out] — the pre-fix path printed the lost-race refusal plus 're-run this supervisor', which loops"
   fi
+  # ---- B18: THE IDENTITY IS UNESTABLISHED BY NOW, AND THE PRINTED COMMAND MUST BE SAFE IF THE LOCK IS
+  # LIVE (#3601, roborev job 242). The liveness verdict describes the pid file as it was BEFORE the
+  # rename was attempted; the path can be replaced in between. The pre-B18 text declared "this lock IS
+  # stale and this run is entitled to it" and printed the non-recursive REMOVAL for it — the code
+  # destroys nothing, but the operator pasting that line does, and these remedies exist to be pasted.
+  if [[ "$out" == *"IDENTITY OF WHAT IS THERE IS NOW UNESTABLISHED"* ]] \
+     && [[ "$out" == *"does not declare the lock stale"* ]] \
+     && [[ "$out" == *"Do NOT remove anything on the strength of this message"* ]]; then
+    pass "lane-lock B18: after a failed rename the refusal reports the identity as UNESTABLISHED, declines to call the lock stale, and tells the operator not to remove anything on its word"
+  else
+    fail "lane-lock-b18-declares-stale: out=[$out] — a lock whose identity is unverified must not be declared stale or removable"
+  fi
+  local b18_bare b18_rc=0
+  b18_bare="$(printf '%s\n' "$out" | grep -vE "$SV_DIAG_RE" | grep -v '^$' | head -1)"
+  if [[ "$b18_bare" == 'ls -ldn -- '* ]] && [[ "$out" != *$'\n''rmdir -- '* ]] \
+     && ! printf '%s\n' "$out" | grep -qE '^(rmdir|rm) '; then
+    pass "lane-lock B18: the ONLY command printed on this branch is a READ-ONLY inspection and no removal appears anywhere in the refusal — the one command shape that is safe if the lock turns out to be live"
+  else
+    fail "lane-lock-b18-prints-removal: bare=[$b18_bare] — a paste-ready removal aimed at a possibly-live holder is harm via the operator's hands"
+  fi
+  # ...and it must RUN verbatim, or it is the "remedy that cannot work" defect in the other direction.
+  eval "$b18_bare" >/dev/null 2>&1 || b18_rc=$?
+  if [[ "$b18_rc" -eq 0 && -d "$lock" && -f "$lock/pid" ]]; then
+    pass "lane-lock B18: that line runs verbatim (rc=0) and removes nothing — the lock and its record are untouched after the operator's inspection"
+  else
+    fail "lane-lock-b18-remedy-unrunnable: rc=$b18_rc lock=[$([[ -d "$lock" ]] && echo present || echo GONE)]"
+  fi
+
   # It also must not have destroyed the dead holder's lock on the way out, and must not have claimed it.
   if [[ -d "$lock" && -f "$lock/pid" ]] && [[ "$out" != *"ACQUIRED="* ]]; then
     pass "lane-lock B2: the lock is left exactly as found and nothing was claimed"
@@ -8097,6 +8125,55 @@ test_lane_lock_failed_reclaim_rename_is_named() {
       pass "lane-lock B2 MUTANT: with the rename's failure swallowed the identical case falls through to the lost-race refusal — a claim contest that did not happen — so the assert above is the new branch doing the work"
     else
       fail "lane-lock-mutant-mv: out=[$mout] — the pre-fix swallow must be shown to misattribute"
+    fi
+  fi
+  chmod 0755 "$ro" 2>/dev/null || true
+
+  # ---- B18 (b): A DIFFERENT HOLDER APPEARS between the liveness verdict and the failed rename — the
+  # interleaving the finding is about. Fault-injected on the liveness probe so it publishes a foreign pid
+  # and THEN answers `dead`, which is exactly the ordering the real race produces; the branch under test
+  # (`acquire_lock`'s post-rename reclassification) is shipped code.
+  local ovrb mout
+  ovrb="$d/f-swap-holder.sh"; : >"$ovrb"
+  rm -rf "$lock"
+  mkdir -p "$lock"
+  printf '%s\n' "$dead" >"$lock/pid"
+  chmod 0555 "$ro" 2>/dev/null || true
+  if sv_mutant_override "$ovrb" supervisor_lock_holder_liveness \
+       '  local pid="$1" msg='"''"' rc=0' \
+       '  local pid="$1" msg='"''"' rc=0
+  printf "%s\n" 987654 >"$SUPERVISOR_LOCK/pid" 2>/dev/null || true
+  printf "%s" dead
+  return 0'; then
+    mout="$(lane_lock_drive_at "$d" "$ovrb" "$ro" "$lane")" || true
+    chmod 0755 "$ro" 2>/dev/null || true
+    if [[ "$mout" == *"now records a DIFFERENT holder, pid 987654"* ]] \
+       && [[ "$mout" == *"may be ALIVE"* ]] \
+       && ! printf '%s\n' "$mout" | grep -qE '^(rmdir|rm) '; then
+      pass "lane-lock B18 (different holder): when the record changed under us the refusal names the NEW pid, says it may be alive, and still prints no removal — the case where the pre-B18 text would have aimed a paste-ready delete at a live holder"
+    else
+      fail "lane-lock-b18-different-holder: out=[$mout]"
+    fi
+  fi
+  chmod 0755 "$ro" 2>/dev/null || true
+
+  # ---- B18 MUTANT: the pre-B18 remedy restored — the removal command comes back, aimed at a lock whose
+  # identity this run cannot vouch for.
+  local ovrm2
+  ovrm2="$d/m-b18.sh"; : >"$ovrm2"
+  rm -rf "$lock"
+  mkdir -p "$lock"
+  printf '%s\n' "$dead" >"$lock/pid"
+  chmod 0555 "$ro" 2>/dev/null || true
+  if sv_mutant_override "$ovrm2" acquire_lock \
+       '      "ls -ldn -- $(supervisor_shell_quote "$SUPERVISOR_LOCK") && ls -lna -- $(supervisor_shell_quote "$SUPERVISOR_LOCK")"' \
+       '      "$(supervisor_lock_clear_command)"'; then
+    mout="$(lane_lock_drive_at "$d" "$ovrm2" "$ro" "$lane")" || true
+    chmod 0755 "$ro" 2>/dev/null || true
+    if printf '%s\n' "$mout" | grep -qE '^rmdir -- '; then
+      pass "lane-lock B18 MUTANT: with the pre-fix remedy restored the refusal prints a paste-ready REMOVAL for a lock it cannot vouch for — the harm, reproduced, so the read-only assert above is doing the work"
+    else
+      fail "lane-lock-mutant-b18: out=[$mout] — the pre-fix remedy must be shown to print a removal"
     fi
   fi
   chmod 0755 "$ro" 2>/dev/null || true
@@ -8458,6 +8535,17 @@ test_lane_lock_publish_declines_instead_of_clobbering() {
       pass "lane-lock B15: the holder record is byte-for-byte as the peer left it — the refusal's one load-bearing claim is measured, not asserted"
     else
       fail "lane-lock-b15-record-not-preserved: pid=[$(cat "$lock/pid" 2>/dev/null || true)]"
+    fi
+    # NEGATIVE CONTROL for B19: the refusal must not name a CAUSE it did not observe. Finding a `pid`
+    # record proves publication must be declined; it does not identify how the record got there, and
+    # directory-instance identity is unverifiable on this path (#3683). The pre-B19 text asserted a
+    # specific race ("a peer renamed ours aside and published its own between our two steps").
+    if [[ "$out" == *"APPEARED in the lock"* ]] \
+       && [[ "$out" == *"HOW that record got there is NOT established"* ]] \
+       && [[ "$out" != *"renamed ours aside"* ]]; then
+      pass "lane-lock B19: the refusal reports that a holder record APPEARED and was preserved, and says outright that how it got there is not established — the invented race is gone"
+    else
+      fail "lane-lock-b19-invents-a-race: out=[$out] — naming one of several possible causes as the cause is a claim beyond the evidence"
     fi
     # NEGATIVE CONTROL for the wording: the refusal must NOT claim the path is untouched, because it is
     # not. This is the assert that stops the false claim being reintroduced by a well-meaning edit.

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -7548,9 +7548,14 @@ test_lane_lock_publish_is_read_back_before_it_is_trusted() {
   # ---- (3) NON-VACUITY: the same forgery with the read-back BLINDED must acquire. Without this, (2)
   # could be passing because of the forgery rather than because of the check.
   ovr="$d/m-pub-blind.sh"; : >"$ovr"
+  # THE TARGET IS THE COMPARISON, NOT THE READ ITSELF: B11 added a second, identical read-back line in
+  # the decline branch, so a substitution on the read would no longer be unique — `sv_mutant_override`
+  # correctly refused it as a moved source. The comparison occurs once and expresses the same mutation
+  # (forge a foreign pid, then accept regardless of what came back).
   if sv_mutant_override "$ovr" supervisor_lock_publish \
-       '  state="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")" || state='"'"'unparseable read-back-aborted'"'"'' \
-       '  printf '"'"'%s\n'"'"' 424243 >"$SUPERVISOR_LOCK/pid"; state="pid $$"'; then
+       '  if [[ "$state" == "pid $$" ]]; then' \
+       '  printf '"'"'%s\n'"'"' 424243 >"$SUPERVISOR_LOCK/pid" 2>/dev/null || true
+  if true; then'; then
     out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")"; rc=$?
     if [[ "$rc" -eq 0 && "$out" == *"ACQUIRED=$lock"* ]]; then
       pass "lane-lock publish MUTANT: with the read-back blinded the SAME forged publish is accepted and the run starts holding a lock whose pid is someone else's — so (2) is the read-back refusing, not the forgery failing"
@@ -8051,8 +8056,10 @@ test_lane_lock_failed_reclaim_rename_is_named() {
        '  elif false; then'; then
     mout="$(lane_lock_drive_at "$d" "$ovr" "$ro" "$lane")" || true
     chmod 0755 "$ro" 2>/dev/null || true
-    if [[ "$mout" == *"immediately claimed by someone else"* ]]; then
-      pass "lane-lock B2 MUTANT: with the rename's failure swallowed the identical case reports a race that did not happen — so the assert above is the new branch doing the work"
+    # The expected string is the CURRENT lost-race wording. It changed once already, in the B9 class
+    # sweep, which removed the attribution this mutant is demonstrating — so match the surviving text.
+    if [[ "$mout" == *"taken again before this run could claim it"* ]]; then
+      pass "lane-lock B2 MUTANT: with the rename's failure swallowed the identical case falls through to the lost-race refusal — a claim contest that did not happen — so the assert above is the new branch doing the work"
     else
       fail "lane-lock-mutant-mv: out=[$mout] — the pre-fix swallow must be shown to misattribute"
     fi
@@ -8087,7 +8094,7 @@ test_lane_lock_pid_bound_is_the_platform_pid_space() {
     env SUP="$SUPERVISOR" F="$d/pidfile" bash -c 'source "$SUP"; printf "%s" "$(supervisor_lock_pid_read "$F")"' 2>/dev/null || true
   }
 
-  ceiling="$(env SUP="$SUPERVISOR" bash -c 'source "$SUPERVISOR"; supervisor_pid_space_ceiling' 2>/dev/null || true)"
+  ceiling="$(env SUP="$SUPERVISOR" bash -c 'source "$SUP"; supervisor_pid_space_ceiling' 2>/dev/null || true)"
   # THE PROBE IS THREE-VALUED, so the case must handle BOTH of its answers rather than requiring the one
   # this host happens to give (#3601, roborev job 231 B10). An earlier cut of this case required the
   # ceiling to parse as a bare number, which on a platform that publishes none would have failed a

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -7039,19 +7039,49 @@ test_lane_lock_pidless_window_is_never_read_as_dead() {
   lock="$tmp/cqlite-worker-supervisor-$lane.lock"
 
   # ---- (i) A REAL PEER HOLDING A PID-LESS LOCK THAT IT THEN PUBLISHES.
+  #
+  # THE INTERLEAVING IS SEQUENCED BY OBSERVABLE EVENTS, NOT BY A TUNED `sleep` (see the header note on
+  # this component's latency). A `sleep 0.4` in the peer would be exactly the load-dependent shape that
+  # flakes a serial gate component: under co-scheduled load the peer publishes late, the arriving run
+  # exhausts its window, and a correct implementation reds. So the two processes BLOCK ON EACH OTHER:
+  #
+  #   * the PEER creates the lock, then waits for a sentinel file before publishing;
+  #   * the sentinel is created by the ARRIVING RUN's own first read of the pid file — an override that
+  #     ADDS a `touch` to the shipped parse and changes nothing else, derived by `sv_mutant_override` so
+  #     it cannot drift into a re-implementation;
+  #   * the arriving run then re-reads until the pid appears, which is what it does in production.
+  #
+  # So the ordering is PROVEN rather than hoped: the peer CANNOT publish before the arriving run has
+  # entered the window, and the arriving run does not leave the window until the peer publishes. Load
+  # changes how long the case takes (normally milliseconds) and cannot change what it measures. The two
+  # bounds present are generous safety stops, not tuned values, and each FAILS LOUDLY if reached.
   rm -rf "$lock"
-  fixture_bg bash -c 'mkdir -p "$1"; sleep "$2"; printf "%s\n" "$$" >"$1/pid"; sleep 30' _ "$lock" 0.4
-  peer=$FIXTURE_LAST_PID
-  # Wait for the peer to have CREATED the lock, so the drive genuinely starts inside the window rather
-  # than before it. This is a precondition wait on an observable fact, not a timing guess.
-  local waited=0
-  while [[ ! -d "$lock" && "$waited" -lt 50 ]]; do sleep 0.02; waited=$((waited + 1)); done
-  if [[ -d "$lock" && ! -f "$lock/pid" ]]; then
-    pass "lane-lock AC2 PREMISE (i): the drive below starts with the peer's lock present and PID-LESS — the interleaving is staged, not assumed"
+  local probe_seen="$d/first-read-happened"
+  rm -f "$probe_seen"
+  ovr="$d/m-observe.sh"; : >"$ovr"
+  if sv_mutant_override "$ovr" supervisor_lock_pid_read \
+       "  local f=\"\$1\" first='' line='' n=0 readrc=0" \
+       "  local f=\"\$1\" first='' line='' n=0 readrc=0
+  : >>\"$probe_seen\""; then
+    pass "lane-lock AC2 PREMISE (i): the arriving run's first pid read is observable — the peer's publish is sequenced on it, so the interleaving needs no tuned delay"
   else
-    fail "lane-lock-window-premise: lock present=[$([[ -d "$lock" ]] && echo yes || echo no)] pid present=[$([[ -f "$lock/pid" ]] && echo yes || echo no)] — the window was not staged and the assert below has no subject"
+    fail "lane-lock-window-observer: the observing override could not be derived; the interleaving below would be timing-dependent, so the case stops rather than becoming a flake"
+    return 0
   fi
-  out="$(lane_lock_drive_at "$d" - "$tmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=200 SUPERVISOR_LOCK_PID_WAIT=0.02)"; rc=$?
+  # The peer's wait is bounded so a failed handshake ends the case instead of hanging the suite; it
+  # publishes anyway on expiry, which makes the assert below FAIL loudly rather than block.
+  fixture_bg bash -c 'mkdir -p "$1"; i=0; while [[ ! -e "$2" && "$i" -lt 1500 ]]; do sleep 0.02; i=$((i + 1)); done; printf "%s\n" "$$" >"$1/pid"; sleep 60' _ "$lock" "$probe_seen"
+  peer=$FIXTURE_LAST_PID
+  # Precondition, polled on an OBSERVABLE state change with a generous bound: the lock must exist and be
+  # PID-LESS before the arriving run starts, or the window was never staged.
+  local waited=0
+  while [[ ! -d "$lock" && "$waited" -lt 1500 ]]; do sleep 0.02; waited=$((waited + 1)); done
+  if [[ -d "$lock" && ! -f "$lock/pid" ]] && [[ ! -e "$probe_seen" ]]; then
+    pass "lane-lock AC2 PREMISE (i): the arriving run starts with the peer's lock present and PID-LESS, and the peer is blocked until that run reads it — the interleaving is staged, not assumed"
+  else
+    fail "lane-lock-window-premise: lock present=[$([[ -d "$lock" ]] && echo yes || echo no)] pid present=[$([[ -f "$lock/pid" ]] && echo yes || echo no)] sentinel=[$([[ -e "$probe_seen" ]] && echo yes || echo no)] — the window was not staged and the assert below has no subject"
+  fi
+  out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=1500 SUPERVISOR_LOCK_PID_WAIT=0.02)"; rc=$?
   peerpid="$(cat "$lock/pid" 2>/dev/null || true)"
   if [[ "$rc" -ne 0 ]] && lane_refusal_ok "$out" && [[ "$out" != *"reclaiming stale lock"* ]] \
      && [[ -d "$lock" ]] && [[ -n "$peerpid" ]] && [[ "$out" == *"already running (pid $peerpid)"* ]]; then
@@ -7615,7 +7645,7 @@ test_log_size_unmeasurable_is_not_zero() {
   export MAX_ISSUES=1
   export BREAKER_N=2
   export STUCK_POLL_SECS=1
-  export MAX_ITER_SECS=8
+  export MAX_ITER_SECS=6
   jf="$JOURNAL_FILE"
   mkdir -p "$d2/shadow"
   printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$d2/shadow/wc"
@@ -7658,7 +7688,7 @@ test_log_size_unmeasurable_is_not_zero() {
     export MAX_ISSUES=1
     export BREAKER_N=2
     export STUCK_POLL_SECS=1
-    export MAX_ITER_SECS=8
+    export MAX_ITER_SECS=6
     jf3="$JOURNAL_FILE"
     mkdir -p "$d3/shadow"
     printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$d3/shadow/wc"

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -6955,7 +6955,16 @@ test_lane_lock_holder_pid_is_parsed_before_use() {
       TRAILING)    printf '%s x\n' "$dead" >"$lock/pid" ;;
       ZERO)        printf '0\n' >"$lock/pid" ;;
       LEADINGZERO) printf '0%s\n' "$dead" >"$lock/pid" ;;
-      OVERLONG)    printf '123456789012345\n' >"$lock/pid" ;;
+      # 19 DIGITS, AND THE WIDTH IS LOAD-BEARING (#3601, roborev job 236 B14). This fixture was 15
+      # digits, which only exceeds a bound the platform PUBLISHES: where none is published the ceiling
+      # gate does not apply and the parser's own platform-independent guard allows up to 18, so a
+      # 15-digit value is ACCEPTED and this shape's required refusal failed — on macOS/bash 3.2, a
+      # platform this file explicitly supports. 19 digits is past the arithmetic-length guard, which is
+      # a property of the shell's integer width rather than of any platform's pid space, so this shape
+      # refuses everywhere. Same class as B13, and surfaced BY the B13 fix: making the no-bound branch
+      # measured on this host instead of platform-conditional is what made this sibling's assumption
+      # visible.
+      OVERLONG)    printf '1234567890123456789\n' >"$lock/pid" ;;
       NOTAFILE)    mkdir -p "$lock/pid" ;;
       # REAL NUL BYTES, WRITTEN AS BYTES (#3601, roborev job 231) — not a stand-in, because the entire
       # defect is that a NUL is INVISIBLE to every check that runs on a shell variable. `NUL` is the
@@ -6992,6 +7001,29 @@ test_lane_lock_holder_pid_is_parsed_before_use() {
         ;;
     esac
   done
+
+  # ---- (1b) THE `OVERLONG` WIDTH IS PINNED MECHANICALLY, NOT BY THE COMMENT ABOVE IT (#3601 B14). A
+  # comment saying "19 digits, because 15 only beats a published bound" does not stop the next edit
+  # shrinking it, and the shrink is INVISIBLE on this host — it reds only on a platform without
+  # `/proc/sys/kernel/pid_max`, which nobody runs the suite on. So the same fixture content is driven
+  # through the parser with the ceiling FORCED to `unknown`, which is the macOS shape, and must still
+  # refuse. This is the mechanism-not-care point: a human catches instance N, a test catches the class.
+  local ovr_unk over_verdict
+  ovr_unk="$d/f-unknown-ceiling.sh"; : >"$ovr_unk"
+  if sv_mutant_override "$ovr_unk" supervisor_pid_space_ceiling \
+       "  printf 'authoritative %s' \"\$((b - 1))\"" \
+       "  printf '%s' 'unknown forced-for-test'; return 0"; then
+    rm -rf "$lock"
+    mkdir -p "$lock"
+    printf '1234567890123456789\n' >"$lock/pid"
+    over_verdict="$(env SUP="$SUPERVISOR" OVR="$ovr_unk" F="$lock/pid" bash -c 'source "$SUP"; source "$OVR"; printf "%s" "$(supervisor_lock_pid_read "$F")"' 2>/dev/null || true)"
+    if [[ "$over_verdict" == 'unparseable pid-digit-count-out-of-well-formedness-bound' ]]; then
+      pass "lane-lock AC1 (OVERLONG, platform-independent): the fixture is refused by the ARITHMETIC-LENGTH guard even with no platform pid bound published [$over_verdict] — so this shape's refusal does not depend on the host publishing a ceiling"
+    else
+      fail "lane-lock-overlong-platform-dependent: verdict=[$over_verdict] — this fixture must be wide enough to be refused with no published ceiling, or the shape reds on macOS (the B14 defect); 15 digits was not"
+    fi
+    rm -rf "$lock"
+  fi
 
   # ---- (2) THE PRINTED REMEDY IS NON-RECURSIVE, AND THAT IS THE SAFETY PROPERTY. With content still in
   # the lock the printed line must FAIL rather than delete something nobody examined — the opposite of

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -7544,12 +7544,26 @@ test_log_size_unmeasurable_is_not_zero() {
   mkdir -p "$shadow"
   printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$shadow/wc"
   chmod +x "$shadow/wc"
-  unmeasurable="$(env SUP="$SUPERVISOR" F="$d/some.log" PATH="$shadow:$PATH" bash -c 'source "$SUP"; log_size "$F"' 2>/dev/null || true)"
+  # TWO CALLER SHAPES, AND THE DIFFERENCE IS THE POINT. The BARE call runs the probe in the caller's own
+  # shell, which inherits the supervisor's `set -euo pipefail`; the WRAPPED call runs it inside a command
+  # substitution, where errexit is NOT inherited. A failing `wc` makes an internal pipeline non-zero, and
+  # in the bare shape that aborts the caller BEFORE the probe classifies anything — measured: the bare
+  # call produced NO OUTPUT AT ALL, no sentinel and no error, i.e. the probe killed its caller instead of
+  # answering. The pre-#3601 form was safe only because its one caller sits inside a `set +e` region, and
+  # a probe whose correctness depends on that is one edit away from taking the supervisor down.
+  local unmeasurable_bare=''
+  unmeasurable_bare="$(env SUP="$SUPERVISOR" F="$d/some.log" PATH="$shadow:$PATH" bash -c 'source "$SUP"; log_size "$F"' 2>/dev/null || true)"
+  unmeasurable="$(env SUP="$SUPERVISOR" F="$d/some.log" PATH="$shadow:$PATH" bash -c 'source "$SUP"; printf "%s" "$(log_size "$F")"' 2>/dev/null || true)"
 
   if [[ "$absent" == "0" && "$present" == "5" && "$unmeasurable" == "-1" ]]; then
     pass "log_size: absent=[0] (a real zero), present=[5] (a real count), unmeasurable=[-1] (a NAMED non-value) — three answers, so a failed measurement can never be mistaken for a byte count"
   else
     fail "log-size-collapses: absent=[$absent] present=[$present] unmeasurable=[$unmeasurable] — an unmeasurable read must not come back as an empty string (which \`-eq\` reads as 0) or as any real count"
+  fi
+  if [[ "$unmeasurable_bare" == "-1" ]]; then
+    pass "log_size (errexit caller): the BARE call from a shell carrying the supervisor's own \`set -euo pipefail\` still returns the sentinel — the probe answers rather than aborting its caller"
+  else
+    fail "log-size-aborts-errexit-caller: bare=[$unmeasurable_bare] — a failing internal pipeline aborted the caller before the probe could classify anything, so it returns no sentinel at all"
   fi
 
   # ---- THE CONSUMER, BEHAVIOURALLY. Same wedge scenario as the genuine-wedge case (a worker that

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -8599,6 +8599,156 @@ test_lane_lock_sweep_no_unobserved_attribution() {
 t test_lane_lock_sweep_no_unobserved_attribution
 
 
+
+
+# ---------------------------------------------------------------------------
+# THE UN-CREATE IS BOUND TO THE DIRECTORY INSTANCE THIS RUN CREATED (#3601, roborev job 236 B12).
+#
+# THE DEFECT, AND IT WAS A REGRESSION THIS DIFF INTRODUCED. B1 made a failed publish remove the directory
+# it had created, so a run would stop manufacturing the pid-less lock every other branch refuses to
+# reclaim. But the removal was an UNCONDITIONAL `rmdir`, not bound to the instance: a legacy peer can
+# rename ours aside and `mkdir` its OWN pid-less lock at the same name, and a non-recursive `rmdir`
+# SUCCEEDS against that empty startup directory. B1 therefore traded "we wedge our own lane with an empty
+# lock" for "we can delete a peer's startup lock" — the worse of the two.
+#
+# WHY NON-RECURSIVE WAS NOT ENOUGH, which is the whole subtlety: `rmdir` protects a peer that has already
+# PUBLISHED (non-empty directory, removal fails harmlessly) and protects nothing at all against a peer
+# that has `mkdir`'d and not yet published. The dangerous case is precisely the empty one.
+#
+# WHAT IS FIXED AND WHAT IS NOT: the UNCONDITIONAL DESTRUCTION is gone. The race is not closed — creating
+# the marker is a second step after `mkdir`, so a peer that replaces the directory inside THAT window
+# still receives our marker — and the site says so with the bound (two adjacent syscalls, no intervening
+# I/O, versus the whole publish attempt before). #3683 closes it.
+# ---------------------------------------------------------------------------
+test_lane_lock_uncreate_is_bound_to_the_created_instance() {
+  local d tmp lane lock out rc ovr swap contents
+  d="$(new_case_dir)"
+  common_env "$d"
+  tmp="$d/tmp"
+  lane="lane3601inst$$"
+  mkdir -p "$tmp"
+  lock="$tmp/cqlite-worker-supervisor-$lane.lock"
+
+  # ---- (1) THE MARKER DOES NOT OUTLIVE THE ACQUIRE. A held lock carrying an extra file would make the
+  # non-recursive clear command handed to operators elsewhere refuse, so this is a property of the fix and
+  # not an incidental detail.
+  rm -rf "$lock"
+  local body_peek
+  body_peek="${SV_DRIVE_BODY/'exit 0'/'printf "CONTENTS=[%s]\n" "$(ls -A "$SUPERVISOR_LOCK" | tr "\n" " ")"; trap - EXIT; exit 0'}"
+  if [[ "$body_peek" == "$SV_DRIVE_BODY" ]]; then
+    fail "lane-lock-b12-premise: the contents-peek drive body was not derived from the shipped one"
+    return 0
+  fi
+  out="$( cd "$d" && env -u SUPERVISOR_LOCK TMPDIR="$tmp" LANE_ID="$lane" LOCK_CMD="" CLAIM_CMD="" \
+            bash -c "$body_peek" _ "$SUPERVISOR" 2>&1 )"
+  contents="$(printf '%s\n' "$out" | grep -o 'CONTENTS=\[[^]]*\]' || true)"
+  if [[ "$contents" == 'CONTENTS=[pid ]' ]]; then
+    pass "lane-lock B12: an acquired lock holds exactly \`pid\` — the ownership marker is removed the moment ownership is verified, so it cannot make a later manual clear refuse"
+  else
+    fail "lane-lock-b12-marker-outlives: $contents — the marker must not survive a successful acquire"
+  fi
+  rm -rf "$lock"
+
+  # ---- (2) THE REPORTED INTERLEAVING, STAGED FOR REAL. The publish fails, and BEFORE it does, a peer
+  # renames our directory aside and `mkdir`s its own PID-LESS lock at the same name — the exact case a
+  # non-recursive `rmdir` succeeds against. Fault-injected on the publish; `take`'s un-create decision,
+  # which is what is being asserted, is shipped code.
+  swap='  local tmpf="$SUPERVISOR_LOCK/pid.tmp.$$" state='"''"'
+  mv -- "$SUPERVISOR_LOCK" "$SUPERVISOR_LOCK.peeraside" 2>/dev/null || true
+  mkdir -- "$SUPERVISOR_LOCK" 2>/dev/null || true
+  if true; then printf "%s" write-failed; return 1; fi'
+  ovr="$d/f-swap.sh"; : >"$ovr"
+  if sv_mutant_override "$ovr" supervisor_lock_publish \
+       '  local tmpf="$SUPERVISOR_LOCK/pid.tmp.$$" state='"''" "$swap"; then
+    out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")"; rc=$?
+    if [[ "$rc" -ne 0 ]] && [[ -d "$lock" ]]; then
+      pass "lane-lock B12: with a peer's PID-LESS lock at that name the run refuses and the peer's lock SURVIVES — the case a bare non-recursive removal destroys"
+    else
+      fail "lane-lock-b12-peer-lock-destroyed: rc=$rc lock=[$([[ -d "$lock" ]] && echo present || echo DESTROYED)] — this is the regression B1 introduced and B12 removes"
+    fi
+    if [[ "$out" == *"NOT the one it created"* ]] && [[ "$out" == *"removed NOTHING"* ]] \
+       && [[ "$out" == *"start in progress"* ]] && [[ "$out" != *"absence was VERIFIED"* ]]; then
+      pass "lane-lock B12: and the refusal says WHY it removed nothing — the marker is gone, so the directory is another run's start in progress — instead of claiming a removal (the B9 family)"
+    else
+      fail "lane-lock-b12-diagnostic: out=[$out]"
+    fi
+  fi
+  rm -rf "$lock" "$lock.peeraside"
+
+  # ---- (3) NON-VACUITY: with NO peer, the same failed publish still un-creates its own directory and the
+  # absence is verified. Without this, (2) is satisfied by code that never removes anything at all — which
+  # would reinstate the wedge B1 fixed.
+  ovr="$d/f-write.sh"; : >"$ovr"
+  if sv_mutant_override "$ovr" supervisor_lock_publish \
+       '  if ! { printf '"'"'%s\n'"'"' "$$" >"$tmpf"; } 2>/dev/null; then' \
+       '  if true; then'; then
+    out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")" || true
+    if [[ "$out" == *"absence was VERIFIED after the removal"* ]] && [[ ! -e "$lock" ]]; then
+      pass "lane-lock B12 NON-VACUITY: with no peer involved the run still removes the directory it created and verifies its absence — the instance binding costs the legitimate path nothing"
+    else
+      fail "lane-lock-b12-nonvacuity: lock=[$([[ -e "$lock" ]] && echo present || echo gone)] out=[$out] — declining to remove our OWN empty lock would reinstate the wedge B1 fixed"
+    fi
+  fi
+
+  # ---- (4) MUTANT CONTRAST: the marker check disabled, which is the pre-B12 spelling. The identical
+  # staging from (2) must then DESTROY the peer's lock.
+  rm -rf "$lock" "$lock.peeraside"
+  local ovrm mout
+  ovrm="$d/m-uncond.sh"; : >"$ovrm"
+  if sv_mutant_override "$ovrm" supervisor_lock_take \
+       '  if [[ ! -e "$marker" && ! -L "$marker" ]]; then' \
+       '  if false; then'; then
+    # the same peer-swap fault, appended so ONE override carries both
+    if sv_mutant_override "$ovrm" supervisor_lock_publish \
+         '  local tmpf="$SUPERVISOR_LOCK/pid.tmp.$$" state='"''" "$swap"; then
+      mout="$(lane_lock_drive_at "$d" "$ovrm" "$tmp" "$lane")" || true
+      if [[ ! -d "$lock" ]] && [[ "$mout" == *"absence was VERIFIED"* ]]; then
+        pass "lane-lock B12 MUTANT: with the instance binding removed the identical case DELETES the peer's pid-less lock and reports the absence as its own success — the regression, measured, so (2) is the marker doing the work"
+      else
+        fail "lane-lock-mutant-b12: lock=[$([[ -d "$lock" ]] && echo present || echo gone)] out=[$mout] — the unconditional form must be shown to destroy the peer's lock"
+      fi
+    fi
+  fi
+  rm -rf "$lock" "$lock.peeraside"
+
+  # ---- (5) A MARKER THAT CANNOT BE WRITTEN IS NOT OWNERSHIP EVIDENCE, so nothing is removed. Staged with
+  # a lock directory whose creation succeeds and whose contents cannot be written — the parent is
+  # writable-and-searchable, the created directory is not writable, which `mkdir -m` cannot express, so
+  # the marker write is faulted instead and the DECISION is shipped.
+  local ovrk
+  ovrk="$d/f-marker.sh"; : >"$ovrk"
+  if sv_mutant_override "$ovrk" supervisor_lock_take \
+       '  if ! { : >"$marker"; } 2>/dev/null; then' \
+       '  if true; then'; then
+    out="$(lane_lock_drive_at "$d" "$ovrk" "$tmp" "$lane")"; rc=$?
+    if [[ "$rc" -ne 0 ]] && [[ "$out" == *"did NOT attempt to remove"* ]] \
+       && [[ "$out" == *"cannot prove"* ]] && [[ "$out" == *"makes no claim either way"* ]]; then
+      pass "lane-lock B12: a marker that could not be written leaves the directory ALONE and says so — no ownership evidence means no removal, and the refusal claims nothing about what is at that path"
+    else
+      fail "lane-lock-b12-marker-failed: rc=$rc out=[$out] — with no marker the run must neither remove nor claim"
+    fi
+  fi
+  rm -rf "$lock"
+
+  # ---- (6) THE RESIDUAL IS STATED AT THE SITE, in the same NARROWED-NOT-CLOSED form as the other two,
+  # and does not present the marker as airtight. The comment is the artifact a reviewer is asked to trust
+  # about a window that is still open, which is the B9 family if it overclaims.
+  local body
+  body="$(sed -n '/^supervisor_lock_take()/,/^}/p' "$SUPERVISOR")"
+  if [[ "$body" == *'NARROWED, NOT CLOSED'* ]] && [[ "$body" == *'#3683'* ]] \
+     && [[ "$body" == *'two adjacent syscalls'* ]] \
+     && [[ "$body" == *'not read the marker as a guarantee'* ]]; then
+    pass "lane-lock B12: the site states the marker's OWN window, bounds it (two adjacent syscalls), names #3683 and says explicitly not to read it as a guarantee"
+  else
+    fail "lane-lock-b12-comment-overclaims: the marker's own absence window must be stated with its bound; presenting it as airtight is the alibi family"
+  fi
+
+  rm -rf "$tmp"
+}
+
+t test_lane_lock_uncreate_is_bound_to_the_created_instance
+
+
 # ---------------------------------------------------------------------------
 # Test 48 (#3549, roborev job 196 F2): THE SUITE LEAVES NO FIXTURE PROCESS BEHIND.
 #

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -4824,6 +4824,15 @@ legacy_lock_drive() {
 # ordinary case exercises. The override file holds exactly the pre-fix spelling of one function.
 SV_DRIVE_BODY_OVERRIDE="${SV_DRIVE_BODY/'source "$1"; '/'source "$1"; source "$2"; '}"
 
+# SV_MAIN_DRIVE_BODY — the WHOLE supervisor loop, not just `acquire_lock`, for the cases whose subject is
+# inside `run_iteration`. ONE body used by both a control and its mutant, differing only in argument 2
+# (the override file; empty for the control), because a contrast whose two sides differ in their ENTRY
+# POINT does not isolate the property under test (#3601, roborev job 231 B4). No `|| true` and no
+# `2>/dev/null` on the source: swallowing a startup failure would let a broken mutant read as a result.
+# `main` is called explicitly because the supervisor's own guard runs it only when executed directly.
+SV_MAIN_DRIVE_BODY='source "$1"; [[ -z "${2:-}" ]] || source "$2"; main'
+
+
 # legacy_lock_drive_override <override-file> <tmp> <lane> — the ordinary drive with one shipped function
 # replaced by the file's redefinition (sourced AFTER the supervisor).
 legacy_lock_drive_override() {
@@ -6918,7 +6927,7 @@ test_lane_lock_holder_pid_is_parsed_before_use() {
   rm -rf "$lock"
   mkdir -p "$lock"
   printf '%s\n' "$dead" >"$lock/pid"
-  out="$(lane_lock_drive_at "$d" - "$tmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=2 SUPERVISOR_LOCK_PID_WAIT=0.01)"; rc=$?
+  out="$(lane_lock_drive_at "$d" - "$tmp" "$lane")"; rc=$?
   if [[ "$rc" -eq 0 && "$out" == *"ACQUIRED=$lock"* && "$out" == *"affirmatively DEAD"* ]]; then
     pass "lane-lock AC1 NON-VACUITY: a well-formed pid whose process is affirmatively gone is still RECLAIMED automatically — the refusals below are decisions, not a guard that always says no"
   else
@@ -6952,7 +6961,7 @@ test_lane_lock_holder_pid_is_parsed_before_use() {
       NULMID)      printf '%s\000%s\n' "${dead%?}" "${dead#${dead%?}}" >"$lock/pid" ;;
     esac
     staged="$(ls -A "$lock" | tr '\n' ' ')"
-    out="$(lane_lock_drive_at "$d" - "$tmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=2 SUPERVISOR_LOCK_PID_WAIT=0.01)"; rc=$?
+    out="$(lane_lock_drive_at "$d" - "$tmp" "$lane")"; rc=$?
     if [[ "$rc" -ne 0 ]] && lane_refusal_ok "$out" \
        && [[ "$out" == *"could NOT DECIDE"* ]] && [[ "$out" != *"reclaiming stale lock"* ]] \
        && [[ -d "$lock" ]] && [[ "$(ls -A "$lock" | tr '\n' ' ')" == "$staged" ]]; then
@@ -6984,7 +6993,7 @@ test_lane_lock_holder_pid_is_parsed_before_use() {
   rm -rf "$lock"
   mkdir -p "$lock"
   printf 'not-a-pid\n' >"$lock/pid"
-  out="$(lane_lock_drive_at "$d" - "$tmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=2 SUPERVISOR_LOCK_PID_WAIT=0.01)" || true
+  out="$(lane_lock_drive_at "$d" - "$tmp" "$lane")" || true
   local bare rmrc=0
   bare="$(printf '%s\n' "$out" | grep -vE "$SV_DIAG_RE" | grep -v '^$' | head -1)"
   eval "$bare" 2>/dev/null || rmrc=$?
@@ -7007,7 +7016,7 @@ test_lane_lock_holder_pid_is_parsed_before_use() {
   if sv_mutant_override "$ovr" supervisor_lock_pid_read \
        "      printf '%s' 'unparseable pid-not-all-decimal-digits'" \
        "      printf '%s' 'pid $dead'"; then
-    mout="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=2 SUPERVISOR_LOCK_PID_WAIT=0.01)" || mrc=$?
+    mout="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")" || mrc=$?
     if [[ "$mrc" -eq 0 && "$mout" == *"ACQUIRED=$lock"* && "$mout" == *"reclaiming stale lock"* ]]; then
       pass "lane-lock AC1 MUTANT: with the parse's non-digit rejection turned back into a holder pid, the SAME drive RECLAIMS the lock (the measured pre-fix behaviour) — so the refusals above are the parse doing the work, not the harness"
     else
@@ -7089,7 +7098,7 @@ test_lane_lock_pidless_window_is_never_read_as_dead() {
   else
     fail "lane-lock-window-premise: lock present=[$([[ -d "$lock" ]] && echo yes || echo no)] pid present=[$([[ -f "$lock/pid" ]] && echo yes || echo no)] sentinel=[$([[ -e "$probe_seen" ]] && echo yes || echo no)] — the window was not staged and the assert below has no subject"
   fi
-  out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=1500 SUPERVISOR_LOCK_PID_WAIT=0.02)"; rc=$?
+  out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")"; rc=$?
   peerpid="$(cat "$lock/pid" 2>/dev/null || true)"
   if [[ "$rc" -ne 0 ]] && lane_refusal_ok "$out" && [[ "$out" != *"reclaiming stale lock"* ]] \
      && [[ -d "$lock" ]] && [[ -n "$peerpid" ]] && [[ "$out" == *"already running (pid $peerpid)"* ]]; then
@@ -7105,7 +7114,7 @@ test_lane_lock_pidless_window_is_never_read_as_dead() {
   # measurement is of PERSISTENCE, so a short bound is sufficient to establish it and the case does not
   # pay for the long window (i) needs.
   mkdir -p "$lock"
-  out="$(lane_lock_drive_at "$d" - "$tmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=3 SUPERVISOR_LOCK_PID_WAIT=0.01)"; rc=$?
+  out="$(lane_lock_drive_at "$d" - "$tmp" "$lane")"; rc=$?
   if [[ "$rc" -ne 0 ]] && lane_refusal_ok "$out" && [[ "$out" == *"pid-file-absent"* ]] \
      && [[ "$out" != *"reclaiming stale lock"* ]] && [[ -d "$lock" ]]; then
     pass "lane-lock AC2 (ii): a PERSISTENTLY pid-less lock is UNDECIDABLE and refuses — it is never read as stale, and the lock is left as found"
@@ -7144,7 +7153,7 @@ test_lane_lock_pidless_window_is_never_read_as_dead() {
   if sv_mutant_override "$ovr" supervisor_lock_pid_read \
        "    printf '%s' 'unparseable pid-file-absent'" \
        "    printf '%s' 'pid $deadpid'"; then
-    mout="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=3 SUPERVISOR_LOCK_PID_WAIT=0.01)" || mrc=$?
+    mout="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")" || mrc=$?
     if [[ "$mrc" -eq 0 && "$mout" == *"ACQUIRED=$lock"* && "$mout" == *"reclaiming stale lock"* ]]; then
       pass "lane-lock AC2 MUTANT: with a pid-less lock reported as a (dead) holder pid, the SAME drive RECLAIMS a lock whose holder it never established — the measured pre-fix behaviour, so the refusals above are the probe doing the work"
     else
@@ -7357,7 +7366,7 @@ test_lane_lock_option_shaped_tmpdir_starts_normally() {
   rm -rf "$lock"
   mkdir -p "$lock"
   printf '%s\n' "$dead" >"$lock/pid"
-  out="$(lane_lock_drive_at "$optdir" - "$opttmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=2 SUPERVISOR_LOCK_PID_WAIT=0.01)"; rc=$?
+  out="$(lane_lock_drive_at "$optdir" - "$opttmp" "$lane")"; rc=$?
   if [[ "$rc" -eq 0 && "$out" == *"reclaiming stale lock"* && "$out" == *"LOCKDIR=yes"* ]]; then
     pass "lane-lock AC7 (reclaim): the rename-aside and removal operands are option-safe too — a genuinely stale lock under an option-shaped TMPDIR is still cleared automatically"
   else
@@ -7379,7 +7388,7 @@ test_lane_lock_option_shaped_tmpdir_starts_normally() {
   if sv_mutant_override "$ovr" supervisor_lock_take \
        '  mkdir -- "$SUPERVISOR_LOCK" 2>/dev/null || return 1' \
        '  mkdir "$SUPERVISOR_LOCK" 2>/dev/null || return 1'; then
-    mout="$(lane_lock_drive_at "$optdir" "$ovr" "$opttmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=2 SUPERVISOR_LOCK_PID_WAIT=0.01)" || mrc=$?
+    mout="$(lane_lock_drive_at "$optdir" "$ovr" "$opttmp" "$lane")" || mrc=$?
     if [[ "$mrc" -ne 0 && "$mout" != *"ACQUIRED="* ]]; then
       pass "lane-lock AC7 MUTANT: with \`--\` stripped from the claim's mkdir the SAME case FAILS to start (rc=$mrc) — so the terminator is load-bearing, not decoration"
     else
@@ -7395,7 +7404,7 @@ test_lane_lock_option_shaped_tmpdir_starts_normally() {
   if sv_mutant_override "$ovr" acquire_lock \
        '  if mv -f -- "$SUPERVISOR_LOCK" "$SUPERVISOR_LOCK.stale.$$" 2>/dev/null; then' \
        '  if mv -f "$SUPERVISOR_LOCK" "$SUPERVISOR_LOCK.stale.$$" 2>/dev/null; then'; then
-    mout="$(lane_lock_drive_at "$optdir" "$ovr" "$opttmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=2 SUPERVISOR_LOCK_PID_WAIT=0.01)" || mrc=$?
+    mout="$(lane_lock_drive_at "$optdir" "$ovr" "$opttmp" "$lane")" || mrc=$?
     if [[ "$mrc" -ne 0 && "$mout" != *"ACQUIRED="* ]]; then
       pass "lane-lock AC7 MUTANT (reclaim mv): with \`--\` stripped from the rename-aside the SAME reclaim FAILS (rc=$mrc) — the reclaim path's terminator is load-bearing on its own"
     else
@@ -7576,7 +7585,7 @@ test_lane_lock_uncreatable_path_is_not_reported_as_contention() {
     skip "lane-lock (uncreatable path): this uid can write a 0555 directory (running as root), so an uncreatable lock path is not stageable here — unmeasurable on this host rather than passing vacuously"
     return 0
   fi
-  out="$(lane_lock_drive_at "$d" - "$ro" "$lane" SUPERVISOR_LOCK_PID_TRIES=2 SUPERVISOR_LOCK_PID_WAIT=0.01)"; rc=$?
+  out="$(lane_lock_drive_at "$d" - "$ro" "$lane")"; rc=$?
   chmod 0755 "$ro" 2>/dev/null || true
   if [[ "$rc" -ne 0 ]] && [[ "$out" == *"could NOT BE CREATED"* ]] \
      && [[ "$out" == *"NOT contention"* ]] && [[ "$out" != *"reclaiming stale lock"* ]] \
@@ -7653,13 +7662,13 @@ test_log_size_unmeasurable_is_not_zero() {
   export MAX_ISSUES=1
   export BREAKER_N=2
   export STUCK_POLL_SECS=1
-  export MAX_ITER_SECS=6
+  export MAX_ITER_SECS=5
   jf="$JOURNAL_FILE"
   mkdir -p "$d2/shadow"
   printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$d2/shadow/wc"
   chmod +x "$d2/shadow/wc"
 
-  env PATH="$d2/shadow:$PATH" bash "$SUPERVISOR" >"$d2/stdout.log" 2>&1
+  env PATH="$d2/shadow:$PATH" bash -c "$SV_MAIN_DRIVE_BODY" _ "$SUPERVISOR" '' >"$d2/stdout.log" 2>&1
   rc=$?
   scount=$(jline_count "$jf" '"outcome":"stuck-on-question"')
   acount=$(jline_count "$jf" '"outcome":"abnormal"')
@@ -7676,6 +7685,14 @@ test_log_size_unmeasurable_is_not_zero() {
   # until something compares it.
   local ovr mval
   ovr="$d/m-logsize.sh"; : >"$ovr"
+  # THE PREMISE THIS CONTRAST NEEDS, ASSERTED RATHER THAN COMMENTED: control and mutant reach the
+  # supervisor's `main` through ONE body, so the only difference between the two runs is the override.
+  if [[ "$SV_MAIN_DRIVE_BODY" == *'source "$1"'* && "$SV_MAIN_DRIVE_BODY" == *'main'* \
+        && "$SV_MAIN_DRIVE_BODY" != *'2>/dev/null'* ]]; then
+    pass "log_size CONTRAST PREMISE: control and mutant share one entry body that sources the shipped supervisor and calls its own \`main\`, with no error suppression around the source — so the contrast below isolates the probe"
+  else
+    fail "log-size-contrast-premise: [$SV_MAIN_DRIVE_BODY] — control and mutant must differ only in the override file"
+  fi
   if sv_mutant_override "$ovr" log_size \
        "      printf '%s' '-1'" \
        "      printf '%s' ''"; then
@@ -7696,15 +7713,19 @@ test_log_size_unmeasurable_is_not_zero() {
     export MAX_ISSUES=1
     export BREAKER_N=2
     export STUCK_POLL_SECS=1
-    export MAX_ITER_SECS=6
+    export MAX_ITER_SECS=5
     jf3="$JOURNAL_FILE"
     mkdir -p "$d3/shadow"
     printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$d3/shadow/wc"
     chmod +x "$d3/shadow/wc"
-    # The supervisor is run with the mutant sourced AFTER it, through the same `bash` entry the ordinary
-    # case uses, so only the probe differs.
-    env PATH="$d3/shadow:$PATH" SUP="$SUPERVISOR" OVR="$ovr" \
-      bash -c 'source "$SUP" 2>/dev/null || true; source "$OVR"; main "$@"' _ >"$d3/stdout.log" 2>&1 || true
+    # THE SAME ENTRY POINT AS THE CONTROL, WHICH IS THE ONLY THING THAT MAKES THIS A CONTRAST (#3601,
+    # roborev job 231 B4). An earlier cut ran the control as `bash "$SUPERVISOR"` and the mutant as
+    # `bash -c 'source …; main "$@"'` with a `2>/dev/null || true` on the source that additionally
+    # swallowed errexit during startup — two differences besides the probe, under a comment that claimed
+    # there were none. A mutant IS the evidence for its property, so a comment asserting an isolation the
+    # code does not provide is a false claim in the artifact a reviewer is asked to trust. Both sides now
+    # run `$SV_MAIN_DRIVE_BODY` and differ in ONE argument: the override file, empty for the control.
+    env PATH="$d3/shadow:$PATH" bash -c "$SV_MAIN_DRIVE_BODY" _ "$SUPERVISOR" "$ovr" >"$d3/stdout.log" 2>&1 || true
     mscount=$(jline_count "$jf3" '"outcome":"stuck-on-question"')
     if [[ "$mscount" -ge 1 ]]; then
       pass "log_size CONSUMER MUTANT: with the pre-fix probe the identical run reports a wedge (stuck=$mscount) from a measurement that never happened — so the consumer assert above is the sentinel doing the work"
@@ -7783,7 +7804,7 @@ test_lane_lock_nul_bearing_pid_file_refuses() {
   fi
 
   # ---- (2) END TO END: refuse, reclaim nothing, leave the lock exactly as found, print the way out.
-  out="$(lane_lock_drive_at "$d" - "$tmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=2 SUPERVISOR_LOCK_PID_WAIT=0.01)"; rc=$?
+  out="$(lane_lock_drive_at "$d" - "$tmp" "$lane")"; rc=$?
   if [[ "$rc" -ne 0 ]] && lane_refusal_ok "$out" && [[ "$out" == *"pid-file-contains-nul"* ]] \
      && [[ "$out" != *"reclaiming stale lock"* ]] && [[ -f "$lock/pid" ]] \
      && [[ "$(wc -c <"$lock/pid" | tr -d '[:space:]')" == "$raw_bytes" ]]; then
@@ -7827,7 +7848,7 @@ test_lane_lock_nul_bearing_pid_file_refuses() {
   if sv_mutant_override "$ovr" supervisor_lock_pid_read \
        '    nul-free) ;;' \
        '    nul-free | contains-nul) ;;'; then
-    mout="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=2 SUPERVISOR_LOCK_PID_WAIT=0.01)" || mrc=$?
+    mout="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")" || mrc=$?
     if [[ "$mrc" -eq 0 && "$mout" == *"ACQUIRED=$lock"* && "$mout" == *"reclaiming stale lock"* ]]; then
       pass "lane-lock NUL MUTANT: with the NUL gate removed the SAME byte-for-byte file is ACCEPTED and the lock RECLAIMED — the measured pre-job-231 behaviour, so the refusals above are that gate doing the work"
     else
@@ -7839,6 +7860,320 @@ test_lane_lock_nul_bearing_pid_file_refuses() {
 }
 
 t test_lane_lock_nul_bearing_pid_file_refuses
+
+
+
+
+# ---------------------------------------------------------------------------
+# THE LOCK NAME BECAME OURS AND WE COULD NOT RECORD OURSELVES IN IT (#3601, roborev job 231 B1).
+#
+# Three facts were collapsed onto one caller verdict — the write never happened, the rename never
+# happened, the lock is not ours — and the refusal built from that collapse ASSERTED all three steps had
+# run: it told the operator "our pid was published into it, and reading it back did not return our pid"
+# for an ENOSPC that never wrote a byte. On a fleet that hits ENOSPC routinely that points the operator
+# at a race that did not occur. Worse, the empty directory we had just created was LEFT BEHIND, so this
+# run manufactured the pid-less lock every other branch here refuses to reclaim and wedged its own lane.
+#
+# THE FAULT IS INJECTED, AND THE CODE UNDER TEST IS SHIPPED. A read-only lock directory is a REAL
+# filesystem failure for the publish (no mutation at all); the end-to-end half needs `mkdir` to succeed
+# and only the write to fail, which no permission bit can stage, so the WRITE is failed by a
+# shipped-derived override while `take`'s cleanup and the refusal — the things being asserted — stay
+# shipped code. That is fault injection, not a mutant contrast; the contrast is the non-vacuity case.
+# ---------------------------------------------------------------------------
+test_lane_lock_publish_failure_is_named_and_leaves_nothing() {
+  local d tmp lane lock out rc verdict ovr
+  d="$(new_case_dir)"
+  common_env "$d"
+  tmp="$d/tmp"
+  lane="lane3601pubfail$$"
+  mkdir -p "$tmp"
+  lock="$tmp/cqlite-worker-supervisor-$lane.lock"
+
+  # ---- (1) THE SHIPPED PUBLISH, against a REAL unwritable lock directory: it must say WHICH step failed.
+  mkdir -p "$lock"
+  chmod 0555 "$lock" 2>/dev/null || true
+  if ( : >"$lock/.probe" ) 2>/dev/null; then
+    rm -f "$lock/.probe" 2>/dev/null || true
+    chmod 0755 "$lock" 2>/dev/null || true
+    skip "lane-lock B1: this uid can write a 0555 directory (running as root), so a publish write failure is not stageable here — unmeasurable on this host rather than passing vacuously"
+  else
+    verdict="$(env SUP="$SUPERVISOR" L="$lock" bash -c 'source "$SUP"; SUPERVISOR_LOCK="$L"; printf "%s" "$(supervisor_lock_publish)"' 2>&1 || true)"
+    chmod 0755 "$lock" 2>/dev/null || true
+    if [[ "$verdict" == 'write-failed' ]]; then
+      pass "lane-lock B1: the publish reports WHICH step failed [$verdict] — and reports it SILENTLY, with no shell redirection error leaking the raw path to stderr"
+    else
+      fail "lane-lock-publish-cause: verdict=[$verdict] — expected exactly 'write-failed'; a stray shell error here is also the unrendered-path class (#3549 job 201 F1)"
+    fi
+  fi
+  rm -rf "$lock"
+
+  # ---- (2) END TO END with the write failed: the refusal must name a FILESYSTEM failure, must NOT claim
+  # the read-back happened, and the directory this run created must be GONE.
+  ovr="$d/f-write.sh"; : >"$ovr"
+  if sv_mutant_override "$ovr" supervisor_lock_publish \
+       '  if ! { printf '"'"'%s\n'"'"' "$$" >"$tmpf"; } 2>/dev/null; then' \
+       '  if true; then'; then
+    out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")"; rc=$?
+    if [[ "$rc" -ne 0 ]] && [[ "$out" == *"could not record itself in it"* ]] \
+       && [[ "$out" == *"FILESYSTEM failure, not contention"* ]] \
+       && [[ "$out" != *"reading it back did not return our pid"* ]] \
+       && [[ "$out" != *"ACQUIRED="* ]]; then
+      pass "lane-lock B1: a publish that never wrote produces its OWN refusal naming a filesystem failure, and does NOT claim a read-back that never ran"
+    else
+      fail "lane-lock-publish-misdiagnosed: rc=$rc out=[$out] — the refusal must not assert steps that did not run"
+    fi
+    if [[ ! -e "$lock" && ! -L "$lock" ]]; then
+      pass "lane-lock B1: the directory this run created and never published into was REMOVED AGAIN — the run does not manufacture the pid-less lock it would then have to refuse over (ruling 2)"
+    else
+      fail "lane-lock-publish-residue: [$(ls -A "$lock" 2>/dev/null | tr '\n' ' ')] — an unpublished lock left behind wedges this lane until an operator clears it"
+    fi
+    # NON-VACUITY: the SAME drive with the shipped publish acquires normally, so (2) measured the
+    # injected failure and not a broken fixture.
+    out="$(lane_lock_drive_at "$d" - "$tmp" "$lane")"; rc=$?
+    if [[ "$rc" -eq 0 && "$out" == *"ACQUIRED=$lock"* ]]; then
+      pass "lane-lock B1 NON-VACUITY: the identical drive with the shipped publish ACQUIRES — so the refusal above is the injected write failure, not the harness"
+    else
+      fail "lane-lock-publish-nonvacuity: rc=$rc out=[$out]"
+    fi
+  fi
+
+  # ---- (3) THE NON-RECURSIVE CLEANUP CANNOT EAT A PEER'S RECORD. If a peer reclaimed our pid-less
+  # directory and wrote its own pid into it while our publish was failing, `rmdir` refuses and the peer's
+  # record survives. Staged by failing the write AND pre-seeding a foreign pid into the directory the
+  # moment it exists — which is what a pre-#3601 peer's reclaim looks like from here.
+  rm -rf "$lock"
+  ovr="$d/f-write-peer.sh"; : >"$ovr"
+  if sv_mutant_override "$ovr" supervisor_lock_publish \
+       '  if ! { printf '"'"'%s\n'"'"' "$$" >"$tmpf"; } 2>/dev/null; then' \
+       '  printf "%s\n" 515151 >"$SUPERVISOR_LOCK/pid" 2>/dev/null || true
+  if true; then'; then
+    out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")" || true
+    if [[ -d "$lock" ]] && [[ "$(cat "$lock/pid" 2>/dev/null || true)" == "515151" ]]; then
+      pass "lane-lock B1: with a foreign pid already in the directory the cleanup's \`rmdir\` REFUSES and the peer's record survives — the un-create can only ever remove the empty shell we made"
+    else
+      fail "lane-lock-cleanup-destructive: lock=[$([[ -d "$lock" ]] && echo present || echo GONE)] pid=[$(cat "$lock/pid" 2>/dev/null || true)] — the cleanup deleted a record it does not own"
+    fi
+  fi
+
+  rm -rf "$lock" "$tmp"
+}
+
+t test_lane_lock_publish_failure_is_named_and_leaves_nothing
+
+
+# ---------------------------------------------------------------------------
+# A FAILED RECLAIM RENAME IS NAMED, NOT MISATTRIBUTED (#3601, roborev job 231 B2).
+#
+# `if mv …; then rm …; fi` with no `else` swallowed the failure, the following claim then failed too, and
+# the run printed the LOST-RACE refusal: "a stale lock was cleared and the name was immediately claimed
+# by someone else" — which had not happened — followed by "re-run this supervisor", which loops forever.
+# Same family as the AC7 addendum this issue already fixed: a message that sends an operator after a
+# problem that is not there.
+#
+# STAGED WITHOUT MUTATION: a lock holding a DEAD pid inside a directory that is readable and searchable
+# but NOT WRITABLE. The holder is affirmatively dead, so the run is entitled to the lock and reaches the
+# rename; the rename cannot succeed, because clearing a lock needs write permission on its PARENT and
+# being able to read a lock does not imply that.
+# ---------------------------------------------------------------------------
+test_lane_lock_failed_reclaim_rename_is_named() {
+  local d ro lane lock out rc dead ovr mout
+  d="$(new_case_dir)"
+  common_env "$d"
+  ro="$d/ro-parent"
+  lane="lane3601mvfail$$"
+  mkdir -p "$ro"
+  lock="$ro/cqlite-worker-supervisor-$lane.lock"
+
+  fixture_bg sleep 0.1
+  dead=$FIXTURE_LAST_PID
+  fixture_wait "$dead"
+
+  mkdir -p "$lock"
+  printf '%s\n' "$dead" >"$lock/pid"
+  chmod 0555 "$ro" 2>/dev/null || true
+  if ( : >"$ro/.probe" ) 2>/dev/null; then
+    rm -f "$ro/.probe" 2>/dev/null || true
+    chmod 0755 "$ro" 2>/dev/null || true
+    skip "lane-lock B2: this uid can write a 0555 directory (running as root), so a failed reclaim rename is not stageable here — unmeasurable on this host rather than passing vacuously"
+    rm -rf "$ro"
+    return 0
+  fi
+  out="$(lane_lock_drive_at "$d" - "$ro" "$lane")"; rc=$?
+  chmod 0755 "$ro" 2>/dev/null || true
+
+  if [[ "$rc" -ne 0 ]] && [[ "$out" == *"could not be cleared"* ]] \
+     && [[ "$out" == *"FILESYSTEM failure, not contention"* ]] \
+     && [[ "$out" != *"immediately claimed by someone else"* ]]; then
+    pass "lane-lock B2: a reclaim whose rename FAILS says so, names a filesystem cause, and never claims a race that did not happen"
+  else
+    fail "lane-lock-mv-misattributed: rc=$rc out=[$out] — the pre-fix path printed the lost-race refusal plus 're-run this supervisor', which loops"
+  fi
+  # It also must not have destroyed the dead holder's lock on the way out, and must not have claimed it.
+  if [[ -d "$lock" && -f "$lock/pid" ]] && [[ "$out" != *"ACQUIRED="* ]]; then
+    pass "lane-lock B2: the lock is left exactly as found and nothing was claimed"
+  else
+    fail "lane-lock-mv-residue: lock=[$([[ -d "$lock" ]] && echo present || echo GONE)] out=[$out]"
+  fi
+
+  # ---- MUTANT CONTRAST: the pre-fix swallow, restored by one substitution — the `elif` branch becomes
+  # unreachable, and the SAME case then produces the lost-race misdiagnosis.
+  ovr="$d/m-mv.sh"; : >"$ovr"
+  chmod 0555 "$ro" 2>/dev/null || true
+  if sv_mutant_override "$ovr" acquire_lock \
+       '  elif [[ -e "$SUPERVISOR_LOCK" || -L "$SUPERVISOR_LOCK" ]]; then' \
+       '  elif false; then'; then
+    mout="$(lane_lock_drive_at "$d" "$ovr" "$ro" "$lane")" || true
+    chmod 0755 "$ro" 2>/dev/null || true
+    if [[ "$mout" == *"immediately claimed by someone else"* ]]; then
+      pass "lane-lock B2 MUTANT: with the rename's failure swallowed the identical case reports a race that did not happen — so the assert above is the new branch doing the work"
+    else
+      fail "lane-lock-mutant-mv: out=[$mout] — the pre-fix swallow must be shown to misattribute"
+    fi
+  fi
+  chmod 0755 "$ro" 2>/dev/null || true
+  rm -rf "$ro"
+}
+
+t test_lane_lock_failed_reclaim_rename_is_named
+
+
+# ---------------------------------------------------------------------------
+# THE PID BOUND IS THE PLATFORM'S PID SPACE, NOT A DIGIT COUNT (#3601, roborev job 231 B3).
+#
+# The bound was 10 digits and every real pid space is at most 7, so a 10-digit corruption was ACCEPTED,
+# cast to `pid_t` by `kill`, reliably reported ESRCH, became an affirmative `dead` and RECLAIMED THE
+# LOCK — while a 15-digit corruption of the same kind refused. One defect class, two widths, opposite
+# outcomes, and the accepting one is the direction #3601 exists to close.
+#
+# THE ASSERT IS CONSISTENCY PLUS A REAL CEILING: both widths must refuse, a pid just above the platform
+# ceiling must refuse, and a pid the platform CAN issue must still be accepted — because a bound that
+# rejected real pids would turn live holders into "malformed" and wedge the lane, which is the same harm
+# pointing the other way.
+# ---------------------------------------------------------------------------
+test_lane_lock_pid_bound_is_the_platform_pid_space() {
+  local d ceiling verdict f
+  d="$(new_case_dir)"
+  common_env "$d"
+  ceiling="$(env SUP="$SUPERVISOR" bash -c 'source "$SUP"; supervisor_pid_space_ceiling' 2>/dev/null || true)"
+  case "$ceiling" in
+    '' | *[!0123456789]*)
+      fail "lane-lock-pid-ceiling: [$ceiling] — the ceiling must be a decimal number on every platform, from the platform where it publishes one and from the conservative constant where it does not"
+      return 0
+      ;;
+  esac
+  pass "lane-lock B3: the pid-space ceiling resolves to [$ceiling] on this host"
+
+  probe_pid() {
+    printf '%s\n' "$1" >"$d/pidfile"
+    env SUP="$SUPERVISOR" F="$d/pidfile" bash -c 'source "$SUP"; printf "%s" "$(supervisor_lock_pid_read "$F")"' 2>/dev/null || true
+  }
+  # The two widths that used to disagree.
+  local ten fifteen above at_ceiling
+  ten="$(probe_pid 9999999999)"
+  fifteen="$(probe_pid 999999999999999)"
+  if [[ "$ten" == 'unparseable pid-above-the-platform-pid-space' && "$fifteen" == 'unparseable pid-above-the-platform-pid-space' ]]; then
+    pass "lane-lock B3: a 10-digit and a 15-digit corruption now get the SAME verdict [$ten] — the width-dependent inconsistency is gone, and the accepting half of it (which reclaimed) with it"
+  else
+    fail "lane-lock-pid-bound-inconsistent: ten=[$ten] fifteen=[$fifteen] — a corruption that reclaims at one width and refuses at another is the hole this closes"
+  fi
+  above="$(probe_pid $((ceiling + 1)))"
+  at_ceiling="$(probe_pid "$ceiling")"
+  if [[ "$above" == 'unparseable pid-above-the-platform-pid-space' ]]; then
+    pass "lane-lock B3: a pid one past the platform ceiling refuses"
+  else
+    fail "lane-lock-pid-bound-above: [$above]"
+  fi
+  if [[ "$at_ceiling" == "pid $ceiling" ]]; then
+    pass "lane-lock B3 (the other direction): a pid AT the platform ceiling is ACCEPTED — the bound cannot turn a pid a real process could hold into 'malformed', which would wedge the lane"
+  else
+    fail "lane-lock-pid-bound-at-ceiling: [$at_ceiling] — rejecting a legal pid is the same harm pointing the other way"
+  fi
+  unset -f probe_pid
+}
+
+t test_lane_lock_pid_bound_is_the_platform_pid_space
+
+
+# ---------------------------------------------------------------------------
+# THE NUL PROBE'S FALLBACK IS A SECOND IMPLEMENTATION, SO IT IS DIFFERENTIALLY TESTED (#3601).
+#
+# The primary detector is `read -d ''` — a builtin, so no fork and no `PATH` dependency. The `wc`/`tr`
+# byte-count form survives as the FALLBACK for a shell whose `read` rejects `-d`/`-n`, chosen by
+# capability (a `read` that refuses the options exits >1, distinguishable from both "found a NUL" and
+# "reached EOF"). CLAUDE.md's ruling is that a second implementation's correctness is only knowable by
+# differential testing against the original, so both are driven over the SAME inputs here rather than
+# the fallback being assumed unreachable and left uncovered.
+#
+# WHY THE PRIMARY IS NOT THE BYTE-COUNT FORM, MEASURED: `supervisor_lock_publish` calls this parser on
+# EVERY start for its read-back, so with `wc` unavailable a supervisor could not start AT ALL — on a
+# FRESH, uncontended lock — and refused forever with a diagnostic about a read-back that never ran.
+# Turning a missing coreutils tool into "this lane can never start" is the permanent-refusal harm this
+# change exists to remove, so that case is asserted below too.
+# ---------------------------------------------------------------------------
+test_lane_lock_nul_probe_primary_and_fallback_agree() {
+  local d shadow nulf cleanf ovr pv fv
+  d="$(new_case_dir)"
+  common_env "$d"
+  nulf="$d/nul-pid"
+  cleanf="$d/clean-pid"
+  printf '4242\000\n' >"$nulf"
+  printf '4242\n' >"$cleanf"
+  shadow="$d/shadow"
+  mkdir -p "$shadow"
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$shadow/wc"
+  chmod +x "$shadow/wc"
+
+  # ---- (1) THE PRIMARY IS FORK-FREE: with BOTH `wc` and `tr` unavailable it still answers both ways.
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$shadow/tr"
+  chmod +x "$shadow/tr"
+  pv="$(env SUP="$SUPERVISOR" F="$nulf" PATH="$shadow:$PATH" bash -c 'source "$SUP"; printf "%s" "$(supervisor_lock_pid_nul_free "$F")"' 2>/dev/null || true)"
+  fv="$(env SUP="$SUPERVISOR" F="$cleanf" PATH="$shadow:$PATH" bash -c 'source "$SUP"; printf "%s" "$(supervisor_lock_pid_nul_free "$F")"' 2>/dev/null || true)"
+  if [[ "$pv" == 'contains-nul' && "$fv" == 'nul-free' ]]; then
+    pass "lane-lock NUL probe: the primary detector answers correctly with \`wc\` AND \`tr\` both unavailable — it is a builtin, so no verdict here depends on PATH"
+  else
+    fail "lane-lock-nul-primary-forks: nul=[$pv] clean=[$fv] — the primary must not depend on an external command"
+  fi
+
+  # ---- (2) A FRESH START ON SUCH A BOX MUST WORK. This is the wedge the byte-count-as-primary form
+  # measurably caused: the parser runs on every start, for the publish's read-back.
+  local tmp lane lock out rc
+  tmp="$d/tmp"; lane="lane3601nofork$$"
+  mkdir -p "$tmp"
+  lock="$tmp/cqlite-worker-supervisor-$lane.lock"
+  out="$(lane_lock_drive_at "$d" - "$tmp" "$lane" PATH="$shadow:$PATH")"; rc=$?
+  if [[ "$rc" -eq 0 && "$out" == *"ACQUIRED=$lock"* ]]; then
+    pass "lane-lock NUL probe: a FRESH uncontended start still succeeds on a box with neither \`wc\` nor \`tr\` — a missing coreutils tool cannot make this lane unable to start (ruling 2)"
+  else
+    fail "lane-lock-nul-probe-wedges-start: rc=$rc out=[$out] — this is the permanent-refusal harm the primary detector avoids"
+  fi
+
+  # ---- (3) THE FALLBACK, FORCED. `read` is made to look unsupported by a shipped-derived override that
+  # returns >1 from the primary read — the same capability signal a shell without `-d` produces — so the
+  # fallback runs for real rather than being assumed correct.
+  ovr="$d/m-nulfallback.sh"; : >"$ovr"
+  if sv_mutant_override "$ovr" supervisor_lock_pid_nul_free \
+       '  { opened=1; IFS= read -r -d '"'"''"'"' -n "$SUPERVISOR_PID_NUL_SCAN" probe; } 2>/dev/null <"$f" || rrc=$?' \
+       '  opened=1; rrc=2'; then
+    pv="$(env SUP="$SUPERVISOR" OVR="$ovr" F="$nulf" bash -c 'source "$SUP"; source "$OVR"; printf "%s" "$(supervisor_lock_pid_nul_free "$F")"' 2>/dev/null || true)"
+    fv="$(env SUP="$SUPERVISOR" OVR="$ovr" F="$cleanf" bash -c 'source "$SUP"; source "$OVR"; printf "%s" "$(supervisor_lock_pid_nul_free "$F")"' 2>/dev/null || true)"
+    if [[ "$pv" == 'contains-nul' && "$fv" == 'nul-free' ]]; then
+      pass "lane-lock NUL probe DIFFERENTIAL: with the builtin reporting itself unsupported, the byte-count fallback returns the SAME two verdicts over the SAME two files — the second implementation agrees with the first where it can be compared"
+    else
+      fail "lane-lock-nul-fallback-diverges: nul=[$pv] clean=[$fv] — the fallback must agree with the primary, or one of them is wrong"
+    fi
+    # ...and the fallback's own third value: with `wc` gone it must refuse, never report `nul-free`.
+    pv="$(env SUP="$SUPERVISOR" OVR="$ovr" F="$cleanf" PATH="$shadow:$PATH" bash -c 'source "$SUP"; source "$OVR"; printf "%s" "$(supervisor_lock_pid_nul_free "$F")"' 2>/dev/null || true)"
+    if [[ "$pv" == 'could-not-measure'* ]]; then
+      pass "lane-lock NUL probe DIFFERENTIAL: the fallback's failed measurement is [$pv] — three-valued like the primary, so an unmeasurable read is never 'nul-free' in either implementation"
+    else
+      fail "lane-lock-nul-fallback-permissive: [$pv]"
+    fi
+  fi
+
+  rm -rf "$tmp"
+}
+
+t test_lane_lock_nul_probe_primary_and_fallback_agree
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -8148,17 +8148,75 @@ test_lane_lock_pid_bound_is_the_platform_pid_space() {
     fi
   fi
 
-  # ---- (2) THE WIDTH INCONSISTENCY THE BOUND EXISTS FOR. A 10-digit and a 15-digit corruption used to
-  # get OPPOSITE verdicts — the narrower one accepted, probed, reported dead and RECLAIMED. Asserted only
-  # as "the same verdict", so the case stays true on a platform that publishes no bound (where both are
-  # refused by the arithmetic guard, or both accepted) rather than pinning this host's answer.
-  local ten fifteen
+  # ---- (2) THE WIDTH INCONSISTENCY THE BOUND EXISTS FOR. A 10-digit and a 15-digit corruption used to get
+  # OPPOSITE verdicts — the narrower one accepted, probed, reported dead and RECLAIMED.
+  #
+  # THE COMPARISON IS BETWEEN ACCEPT/REJECT CLASSES, NOT BETWEEN VERDICT STRINGS (#3601, roborev job 236
+  # B13). This case compared the two strings EXACTLY while its own comment claimed it "stays true on a
+  # platform that publishes no bound … rather than pinning this host's answer". That claim was FALSE, and
+  # falsifiable without leaving this file: where no bound is published the gate does not apply, both pids
+  # are ACCEPTED, and the two strings then differ by construction (`pid 9999999999` vs
+  # `pid 999999999999999`) — so the case RED on macOS/bash 3.2, a platform this file explicitly supports,
+  # and the first person to run it there would have spent an hour deciding whether they had broken
+  # something. It is the alibi family again — a comment describing a tolerance the code does not have —
+  # and it is fixed here rather than downgraded, because a suite that reds on a supported platform is not
+  # a nit. The property that actually matters is that BOTH WIDTHS LAND IN THE SAME CLASS, and the expected
+  # class is then asserted EXPLICITLY per ceiling branch, which is stronger than either version.
+  pid_verdict_class() {
+    case "$1" in
+      'pid '*)         printf '%s' accepted ;;
+      'unparseable '*) printf '%s' refused ;;
+      *)               printf '%s' unrecognised ;;
+    esac
+  }
+  local ten fifteen ten_class fifteen_class want_class
   ten="$(probe_pid 9999999999)"
   fifteen="$(probe_pid 999999999999999)"
-  if [[ "$ten" == "$fifteen" ]]; then
-    pass "lane-lock B3: a 10-digit and a 15-digit corruption now get the SAME verdict [$ten] — the width-dependent inconsistency is gone, and the accepting half of it (which reclaimed) with it"
+  ten_class="$(pid_verdict_class "$ten")"
+  fifteen_class="$(pid_verdict_class "$fifteen")"
+  if [[ "$ten_class" == "$fifteen_class" && "$ten_class" != unrecognised ]]; then
+    pass "lane-lock B3: a 10-digit and a 15-digit corruption land in the SAME class [$ten_class] — the width-dependent inconsistency is gone, and the accepting half of it (which reclaimed) with it"
   else
-    fail "lane-lock-pid-bound-inconsistent: ten=[$ten] fifteen=[$fifteen] — a corruption that reclaims at one width and refuses at another is the hole this closes"
+    fail "lane-lock-pid-bound-inconsistent: ten=[$ten]($ten_class) fifteen=[$fifteen]($fifteen_class) — a corruption that reclaims at one width and refuses at another is the hole this closes"
+  fi
+  # ...and WHICH class it is, is decided by the ceiling branch, stated rather than left to the host.
+  case "$ceiling" in
+    'authoritative '*) want_class=refused ;;
+    *)                 want_class=accepted ;;
+  esac
+  if [[ "$ten_class" == "$want_class" ]]; then
+    pass "lane-lock B13: with the ceiling [${ceiling%% *}] the expected class for an out-of-range corruption is [$want_class], and that is what both widths got — the case asserts the platform's own consequence instead of this host's string"
+  else
+    fail "lane-lock-pid-bound-class: ceiling=[$ceiling] want=[$want_class] got=[$ten_class] — where a bound IS published an out-of-range pid must be refused; where none is, the gate does not apply and the pid is accepted"
+  fi
+
+  # ---- (2b) THE NO-BOUND BRANCH IS EXERCISED ON THIS HOST TOO, not left to a platform nobody runs the
+  # suite on. `supervisor_pid_space_ceiling` is made to report `unknown` by a shipped-derived override, so
+  # the macOS/no-`/proc` path is measured here: both widths must be ACCEPTED (the gate cannot apply) and
+  # the parser must still reject on its own structural gates.
+  local ovru u_ten u_wide
+  ovru="$d/f-unknown-ceiling.sh"; : >"$ovru"
+  if sv_mutant_override "$ovru" supervisor_pid_space_ceiling \
+       "  printf 'authoritative %s' \"\$((b - 1))\"" \
+       "  printf '%s' 'unknown forced-for-test'"; then
+    probe_pid_ovr() {
+      printf '%s\n' "$1" >"$d/pidfile"
+      env SUP="$SUPERVISOR" OVR="$ovru" F="$d/pidfile" bash -c 'source "$SUP"; source "$OVR"; printf "%s" "$(supervisor_lock_pid_read "$F")"' 2>/dev/null || true
+    }
+    u_ten="$(pid_verdict_class "$(probe_pid_ovr 9999999999)")"
+    u_wide="$(pid_verdict_class "$(probe_pid_ovr 999999999999999)")"
+    if [[ "$u_ten" == accepted && "$u_wide" == accepted ]]; then
+      pass "lane-lock B13: forced onto the no-published-bound path (the macOS shape) both widths are ACCEPTED and consistent — so the case above is correct on a platform without /proc, which is what its comment used to claim without being true"
+    else
+      fail "lane-lock-b13-unknown-branch: ten=[$u_ten] wide=[$u_wide] — with no bound published the gate cannot apply, so both must be accepted"
+    fi
+    # ...and the structural gates still bite on that path, so "the gate does not apply" is not "anything goes".
+    if [[ "$(pid_verdict_class "$(probe_pid_ovr 9999999999999999999999)")" == refused ]]; then
+      pass "lane-lock B13: on the same no-bound path a pid past the arithmetic guard is still REFUSED — an unapplied platform gate is not licence to accept anything"
+    else
+      fail "lane-lock-b13-unknown-unbounded: a 22-digit value must still be refused with no platform bound published"
+    fi
+    unset -f probe_pid_ovr
   fi
 
   # ---- (3) NO INVENTED CONSTANT SURVIVES. The rejected design substituted Linux's PID_MAX_LIMIT
@@ -8189,7 +8247,7 @@ test_lane_lock_pid_bound_is_the_platform_pid_space() {
     fi
   fi
 
-  unset -f probe_pid
+  unset -f probe_pid pid_verdict_class
 }
 
 t test_lane_lock_pid_bound_is_the_platform_pid_space

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -8437,12 +8437,31 @@ test_lane_lock_publish_declines_instead_of_clobbering() {
        '  local tmpf="$SUPERVISOR_LOCK/pid.tmp.$$" state='"''"'
   printf "%s\n" 626262 >"$SUPERVISOR_LOCK/pid" 2>/dev/null || true'; then
     out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")"; rc=$?
-    if [[ "$rc" -ne 0 ]] && [[ "$out" == *"declined to overwrite it and wrote NOTHING"* ]] \
-       && [[ "$out" == *"NOTHING at that path has been modified by this run"* ]] \
+    # THE ASSERTED PROPERTY IS PRESERVATION OF THE HOLDER RECORD, not an absence of modification (#3601,
+    # roborev job 238 B15). The old form required the refusal to say "wrote NOTHING" and "NOTHING at that
+    # path has been modified" — and so it PINNED two claims that were false in detail: the publish writes
+    # its staging file before it tests for an existing `pid`, and the un-create may remove an ownership
+    # marker from that same directory. A test that requires a false claim keeps the claim alive, which is
+    # how the alibi family survives being fixed; so this now asserts what the code actually guarantees.
+    if [[ "$rc" -ne 0 ]] && [[ "$out" == *"declined to publish over it"* ]] \
+       && [[ "$out" == *"is INTACT — it was neither overwritten nor replaced"* ]] \
        && [[ "$out" == *"[pid 626262]"* ]] && [[ "$out" != *"ACQUIRED"* ]]; then
-      pass "lane-lock B11: with a peer's record published into the directory we created, the run refuses, names the record it found, and states it modified nothing"
+      pass "lane-lock B11/B15: with a peer's record published into the directory we created, the run refuses, names the record it found, and claims exactly the preservation it provides — not an absence of modification it does not"
     else
       fail "lane-lock-b11-endtoend: rc=$rc out=[$out]"
+    fi
+    # ...and the claim is not merely WORDED correctly, it is TRUE: the record's bytes are unchanged.
+    if [[ "$(cat "$lock/pid" 2>/dev/null || true)" == "626262" ]]; then
+      pass "lane-lock B15: the holder record is byte-for-byte as the peer left it — the refusal's one load-bearing claim is measured, not asserted"
+    else
+      fail "lane-lock-b15-record-not-preserved: pid=[$(cat "$lock/pid" 2>/dev/null || true)]"
+    fi
+    # NEGATIVE CONTROL for the wording: the refusal must NOT claim the path is untouched, because it is
+    # not. This is the assert that stops the false claim being reintroduced by a well-meaning edit.
+    if [[ "$out" != *"NOTHING at that path has been modified"* ]]; then
+      pass "lane-lock B15: the refusal does NOT claim the path is untouched — it says plainly that it wrote and removed its own scratch entries, because it did"
+    else
+      fail "lane-lock-b15-overclaims: the refusal claims nothing at that path was modified, which is false: a staging file and an ownership marker are written there"
     fi
     if [[ "$(cat "$lock/pid" 2>/dev/null || true)" == "626262" ]]; then
       pass "lane-lock B11: and the peer's record survives the whole refusal path — nothing on the way out removed or rewrote it"

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -7985,11 +7985,15 @@ test_lane_lock_publish_failure_is_named_and_leaves_nothing() {
        '  if ! { printf '"'"'%s\n'"'"' "$$" >"$tmpf"; } 2>/dev/null; then' \
        '  if true; then'; then
     out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")"; rc=$?
+    # B21 retired the confident "FILESYSTEM failure, not contention" here too: this code cannot know which
+    # it was. What B1 is actually about survives unchanged — the refusal is its OWN refusal, it names the
+    # step that failed, and it does not claim a read-back that never ran.
     if [[ "$rc" -ne 0 ]] && [[ "$out" == *"could not record itself in it"* ]] \
-       && [[ "$out" == *"FILESYSTEM failure, not contention"* ]] \
+       && [[ "$out" == *"no byte of it was written"* ]] \
+       && [[ "$out" == *"NOT ESTABLISHED"* ]] \
        && [[ "$out" != *"reading it back did not return our pid"* ]] \
        && [[ "$out" != *"ACQUIRED="* ]]; then
-      pass "lane-lock B1: a publish that never wrote produces its OWN refusal naming a filesystem failure, and does NOT claim a read-back that never ran"
+      pass "lane-lock B1/B21: a publish that never wrote produces its OWN refusal naming the step that failed, does NOT claim a read-back that never ran, and does not assert a cause it cannot establish"
     else
       fail "lane-lock-publish-misdiagnosed: rc=$rc out=[$out] — the refusal must not assert steps that did not run"
     fi
@@ -8072,10 +8076,13 @@ test_lane_lock_failed_reclaim_rename_is_named() {
   out="$(lane_lock_drive_at "$d" - "$ro" "$lane")"; rc=$?
   chmod 0755 "$ro" 2>/dev/null || true
 
+  # B21: "names a filesystem cause" was itself a claim beyond the evidence. What B2 is about survives — the
+  # failure is reported rather than swallowed, and no race is invented.
   if [[ "$rc" -ne 0 ]] && [[ "$out" == *"could not be cleared"* ]] \
-     && [[ "$out" == *"FILESYSTEM failure, not contention"* ]] \
+     && [[ "$out" == *"nothing was cleared and nothing was claimed"* ]] \
+     && [[ "$out" == *"NOT ESTABLISHED"* ]] \
      && [[ "$out" != *"immediately claimed by someone else"* ]]; then
-    pass "lane-lock B2: a reclaim whose rename FAILS says so, names a filesystem cause, and never claims a race that did not happen"
+    pass "lane-lock B2/B21: a reclaim whose rename FAILS says so, states plainly that nothing was cleared or claimed, never invents a race, and does not assert a cause it cannot establish"
   else
     fail "lane-lock-mv-misattributed: rc=$rc out=[$out] — the pre-fix path printed the lost-race refusal plus 're-run this supervisor', which loops"
   fi

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -6930,7 +6930,7 @@ test_lane_lock_holder_pid_is_parsed_before_use() {
   # ones a crash, a truncation or a foreign writer produces — not a curated list of things that happen
   # to fail, but one per rejection reason in `supervisor_lock_pid_read`.
   local staged
-  for shape in EMPTY GARBLED TWOLINE TRAILING ZERO LEADINGZERO OVERLONG NOTAFILE; do
+  for shape in EMPTY GARBLED TWOLINE TRAILING ZERO LEADINGZERO OVERLONG NOTAFILE NUL NULMID; do
     rm -rf "$lock"
     mkdir -p "$lock"
     case "$shape" in
@@ -6942,6 +6942,14 @@ test_lane_lock_holder_pid_is_parsed_before_use() {
       LEADINGZERO) printf '0%s\n' "$dead" >"$lock/pid" ;;
       OVERLONG)    printf '123456789012345\n' >"$lock/pid" ;;
       NOTAFILE)    mkdir -p "$lock/pid" ;;
+      # REAL NUL BYTES, WRITTEN AS BYTES (#3601, roborev job 231) — not a stand-in, because the entire
+      # defect is that a NUL is INVISIBLE to every check that runs on a shell variable. `NUL` is the
+      # dangerous shape: `<dead-pid> NUL LF`, whose NUL-stripped content is a clean, plausible, DEAD pid,
+      # so it passed non-empty + single-line + all-digits + non-zero and the lock was reclaimed. `NULMID`
+      # is the same hazard with the NUL INSIDE the digits, where the value the shell sees is a DIFFERENT
+      # number than the file records.
+      NUL)         printf '%s\000\n' "$dead" >"$lock/pid" ;;
+      NULMID)      printf '%s\000%s\n' "${dead%?}" "${dead#${dead%?}}" >"$lock/pid" ;;
     esac
     staged="$(ls -A "$lock" | tr '\n' ' ')"
     out="$(lane_lock_drive_at "$d" - "$tmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=2 SUPERVISOR_LOCK_PID_WAIT=0.01)"; rc=$?
@@ -6963,7 +6971,7 @@ test_lane_lock_holder_pid_is_parsed_before_use() {
     # for the two shapes that leave content behind, `rmdir` correctly REFUSES, which is the safety
     # property the command was chosen for and is asserted separately below.
     case "$shape" in
-      EMPTY | GARBLED | TWOLINE | TRAILING | ZERO | LEADINGZERO | OVERLONG)
+      EMPTY | GARBLED | TWOLINE | TRAILING | ZERO | LEADINGZERO | OVERLONG | NUL | NULMID)
         rm -f -- "$lock/pid"
         lane_lock_remedy_ok "$shape" "$out" "$lock"
         ;;
@@ -7708,6 +7716,129 @@ test_log_size_unmeasurable_is_not_zero() {
 }
 
 t test_log_size_unmeasurable_is_not_zero
+
+
+
+
+# ---------------------------------------------------------------------------
+# NUL BYTES IN THE PID FILE (#3601, roborev job 231) — the hole in AC1's own guarantee.
+#
+# THE DEFECT, MEASURED BEFORE THE FIX: bash cannot hold a NUL and `read` discards it silently, so a pid
+# file whose BYTES are `<dead-pid> NUL LF` reads back as a clean `<dead-pid>` — non-empty, single line,
+# all decimal digits, non-zero. Every gate in `supervisor_lock_pid_read` passed it, the liveness probe
+# then said `dead`, and the lock was RECLAIMED. That is exactly the outcome AC1 exists to prevent, from
+# exactly the input AC1 is about: a partially-written pid file, which is where NULs come from, because a
+# crash mid-write can leave allocated-but-zeroed bytes.
+#
+# SO THE CHECK CANNOT LIVE IN THE SHELL, and this case asserts that premise rather than assuming it: it
+# first demonstrates that the shell's own view of the file is a clean all-digit pid, and only then that
+# the parser refuses anyway. Without the first half a green here would not show that anything hard was
+# happening.
+#
+# NOT VIA BASH'S WARNING, EITHER. `$(cat …)` on such a file emits `warning: … ignored null byte in
+# input` — on STDERR, which the `2>/dev/null` in use at every one of these sites already suppresses; and
+# keying correctness on bash's message TEXT would be the cargo-status-word defect class (CLAUDE.md
+# #3400). The shipped check measures bytes.
+# ---------------------------------------------------------------------------
+test_lane_lock_nul_bearing_pid_file_refuses() {
+  local d tmp lane lock out rc dead verdict shell_view ovr mout mrc shadow
+  d="$(new_case_dir)"
+  common_env "$d"
+  tmp="$d/tmp"
+  lane="lane3601nul$$"
+  mkdir -p "$tmp"
+  lock="$tmp/cqlite-worker-supervisor-$lane.lock"
+
+  fixture_bg sleep 0.1
+  dead=$FIXTURE_LAST_PID
+  fixture_wait "$dead"
+
+  mkdir -p "$lock"
+  # REAL BYTES. `printf '%s\000\n'` writes an actual NUL; nothing here simulates one, because a simulated
+  # NUL would be visible to the shell and would therefore not reproduce the defect at all.
+  printf '%s\000\n' "$dead" >"$lock/pid"
+  local raw_bytes stripped_bytes
+  raw_bytes="$(wc -c <"$lock/pid" | tr -d '[:space:]')"
+  stripped_bytes="$(tr -d '\000' <"$lock/pid" | wc -c | tr -d '[:space:]')"
+  if [[ "$raw_bytes" -eq $((stripped_bytes + 1)) ]]; then
+    pass "lane-lock NUL PREMISE: the staged pid file really carries a NUL byte — $raw_bytes bytes on disk, $stripped_bytes with NULs stripped"
+  else
+    fail "lane-lock-nul-premise: raw=$raw_bytes stripped=$stripped_bytes — the fixture does not contain a NUL, so this case measures nothing"
+    return 0
+  fi
+  # ...AND THE SHELL CANNOT SEE IT. This is the half that shows why a byte-level check is required.
+  shell_view="$(env F="$lock/pid" bash -c 'IFS= read -r v <"$F"; printf "%s|%s" "$v" "${#v}"' 2>/dev/null || true)"
+  if [[ "$shell_view" == "$dead|${#dead}" ]]; then
+    pass "lane-lock NUL PREMISE: \`read\` hands the shell a CLEAN all-digit pid [$shell_view] — non-empty, single line, all digits, non-zero — so no check running on that value can possibly reject this file"
+  else
+    fail "lane-lock-nul-shell-view: [$shell_view] expected [$dead|${#dead}] — the premise of this case is that the NUL is invisible to the shell"
+  fi
+
+  # ---- (1) THE PARSER REFUSES, WITH ITS OWN NAMED CAUSE, consistent with the other gates.
+  verdict="$(env SUP="$SUPERVISOR" F="$lock/pid" bash -c 'source "$SUP"; printf "%s" "$(supervisor_lock_pid_read "$F")"' 2>/dev/null || true)"
+  if [[ "$verdict" == 'unparseable pid-file-contains-nul' ]]; then
+    pass "lane-lock NUL: the parser reads the FILE'S BYTES and refuses with its own cause [$verdict] — it is \`unparseable\`, never \`dead\`"
+  else
+    fail "lane-lock-nul-accepted: verdict=[$verdict] — a NUL-bearing pid file must not parse as a pid"
+  fi
+
+  # ---- (2) END TO END: refuse, reclaim nothing, leave the lock exactly as found, print the way out.
+  out="$(lane_lock_drive_at "$d" - "$tmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=2 SUPERVISOR_LOCK_PID_WAIT=0.01)"; rc=$?
+  if [[ "$rc" -ne 0 ]] && lane_refusal_ok "$out" && [[ "$out" == *"pid-file-contains-nul"* ]] \
+     && [[ "$out" != *"reclaiming stale lock"* ]] && [[ -f "$lock/pid" ]] \
+     && [[ "$(wc -c <"$lock/pid" | tr -d '[:space:]')" == "$raw_bytes" ]]; then
+    pass "lane-lock NUL: the start REFUSES over a NUL-bearing lock, names the cause, reclaims nothing and leaves the file byte-for-byte as found"
+  else
+    fail "lane-lock-nul-reclaimed: rc=$rc out=[$out] — this is the reclaim-from-a-live-holder path the NUL defect reopened"
+  fi
+  rm -f -- "$lock/pid"
+  lane_lock_remedy_ok "pid-file-contains-nul" "$out" "$lock"
+
+  # ---- (3) THE THIRD VALUE: the NUL check is TWO EXTERNAL COMMANDS, so either can fail, and a failed
+  # measurement must REFUSE rather than report "no NULs found" — the same discipline `log_size` grew in
+  # this change, for the same reason. `wc` is made to fail for real, by a shadow earlier on `PATH`.
+  shadow="$d/shadow"
+  mkdir -p "$shadow"
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$shadow/wc"
+  chmod +x "$shadow/wc"
+  printf '%s\n' "$dead" >"$d/clean-pid"
+  verdict="$(env SUP="$SUPERVISOR" F="$d/clean-pid" PATH="$shadow:$PATH" bash -c 'source "$SUP"; printf "%s" "$(supervisor_lock_pid_read "$F")"' 2>/dev/null || true)"
+  if [[ "$verdict" == 'unparseable pid-file-nul-check-could-not-measure'* ]]; then
+    pass "lane-lock NUL (third value): with the byte count UNMEASURABLE the parser refuses and names the measurement failure [$verdict] — an unmeasurable read is never 'nul-free'"
+  else
+    fail "lane-lock-nul-measurement-collapsed: verdict=[$verdict] — a failed measurement must not become the permissive answer"
+  fi
+  # NON-VACUITY for (3): the SAME clean file parses normally once `wc` works, so the refusal above is the
+  # measurement failing and not the file.
+  verdict="$(env SUP="$SUPERVISOR" F="$d/clean-pid" bash -c 'source "$SUP"; printf "%s" "$(supervisor_lock_pid_read "$F")"' 2>/dev/null || true)"
+  if [[ "$verdict" == "pid $dead" ]]; then
+    pass "lane-lock NUL (third value, non-vacuity): the identical file parses as [$verdict] with a working \`wc\` — so (3) measured the probe's failure, not a bad fixture"
+  else
+    fail "lane-lock-nul-nonvacuity: verdict=[$verdict]"
+  fi
+
+  # ---- (4) MUTANT CONTRAST: the NUL gate removed by ONE literal substitution — its `contains-nul`
+  # verdict joins the accepting branch. Everything else, including the byte measurement itself, is
+  # shipped code, so the contrast isolates the GATE and not the probe.
+  mkdir -p "$lock"
+  printf '%s\000\n' "$dead" >"$lock/pid"
+  ovr="$d/m-nul.sh"; : >"$ovr"
+  mrc=0
+  if sv_mutant_override "$ovr" supervisor_lock_pid_read \
+       '    nul-free) ;;' \
+       '    nul-free | contains-nul) ;;'; then
+    mout="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=2 SUPERVISOR_LOCK_PID_WAIT=0.01)" || mrc=$?
+    if [[ "$mrc" -eq 0 && "$mout" == *"ACQUIRED=$lock"* && "$mout" == *"reclaiming stale lock"* ]]; then
+      pass "lane-lock NUL MUTANT: with the NUL gate removed the SAME byte-for-byte file is ACCEPTED and the lock RECLAIMED — the measured pre-job-231 behaviour, so the refusals above are that gate doing the work"
+    else
+      fail "lane-lock-mutant-nul: rc=$mrc out=[$mout] — the ungated form must be shown to reclaim, or every NUL assert measures nothing"
+    fi
+  fi
+
+  rm -rf "$lock" "$tmp"
+}
+
+t test_lane_lock_nul_bearing_pid_file_refuses
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -7503,8 +7503,11 @@ test_lane_lock_release_only_removes_a_lock_we_still_own() {
   else
     fail "lane-lock-release-deleted-foreign: lock=[$([[ -d "$lock" ]] && echo present || echo GONE)] pid=[$(cat "$lock/pid" 2>/dev/null || true)] — the exit path removed a lock this run did not own"
   fi
-  if [[ "$out" == *"NOT removing"* && "$out" == *"no longer holds this process's pid"* ]]; then
-    pass "lane-lock ownership: and it SAYS so — 'my lock vanished' is otherwise unattributable, so the non-removal is logged rather than silent"
+  # The fixture writes a PARSED foreign pid, so B17's foreign branch is the one that must fire — matched
+  # on the wording that branch now uses (#3601, roborev job 240 B17 reworded this: "no longer holds this
+  # process's pid" was said for unparseable states too, where no holder had been read).
+  if [[ "$out" == *"NOT removing"* && "$out" == *"records holder pid $foreign, not this process"* ]]; then
+    pass "lane-lock ownership: and it SAYS so, naming the holder it read — 'my lock vanished' is otherwise unattributable, so the non-removal is logged rather than silent"
   else
     fail "lane-lock-release-silent: out=[$out]"
   fi

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -8078,43 +8078,110 @@ t test_lane_lock_failed_reclaim_rename_is_named
 # pointing the other way.
 # ---------------------------------------------------------------------------
 test_lane_lock_pid_bound_is_the_platform_pid_space() {
-  local d ceiling verdict f
+  local d verdict raw_max ceiling inclusive
   d="$(new_case_dir)"
   common_env "$d"
-  ceiling="$(env SUP="$SUPERVISOR" bash -c 'source "$SUP"; supervisor_pid_space_ceiling' 2>/dev/null || true)"
-  case "$ceiling" in
-    '' | *[!0123456789]*)
-      fail "lane-lock-pid-ceiling: [$ceiling] — the ceiling must be a decimal number on every platform, from the platform where it publishes one and from the conservative constant where it does not"
-      return 0
-      ;;
-  esac
-  pass "lane-lock B3: the pid-space ceiling resolves to [$ceiling] on this host"
 
   probe_pid() {
     printf '%s\n' "$1" >"$d/pidfile"
     env SUP="$SUPERVISOR" F="$d/pidfile" bash -c 'source "$SUP"; printf "%s" "$(supervisor_lock_pid_read "$F")"' 2>/dev/null || true
   }
-  # The two widths that used to disagree.
-  local ten fifteen above at_ceiling
+
+  ceiling="$(env SUP="$SUPERVISOR" bash -c 'source "$SUPERVISOR"; supervisor_pid_space_ceiling' 2>/dev/null || true)"
+  # THE PROBE IS THREE-VALUED, so the case must handle BOTH of its answers rather than requiring the one
+  # this host happens to give (#3601, roborev job 231 B10). An earlier cut of this case required the
+  # ceiling to parse as a bare number, which on a platform that publishes none would have failed a
+  # CORRECT implementation — and, worse, it asserted a pid EQUAL to the ceiling was accepted, pinning the
+  # off-by-one as correct. That is the #3559 shape (a test pinning wrong behaviour) inside this suite, so
+  # it is fixed here together with the code rather than by moving the boundary.
+  case "$ceiling" in
+    'authoritative '*)
+      inclusive="${ceiling#authoritative }"
+      pass "lane-lock B3/B10: this platform publishes a pid bound; the probe converts it to the INCLUSIVE maximum [$inclusive]"
+      ;;
+    'unknown '*)
+      pass "lane-lock B3/B10: this platform publishes no readable pid bound, so the probe says [$ceiling] — the gate does not apply and, critically, nothing invents a number in its place"
+      ;;
+    *)
+      fail "lane-lock-pid-ceiling: [$ceiling] — the probe must answer 'authoritative <n>' or 'unknown <cause>' and nothing else"
+      unset -f probe_pid
+      return 0
+      ;;
+  esac
+
+  # ---- (1) THE OFF-BY-ONE, MEASURED AGAINST THE PLATFORM'S OWN FILE. `proc(5)` says `pid_max` is the
+  # value at which pids WRAP — one greater than the maximum pid — so `pid_max` itself is not issuable and
+  # must REFUSE, while `pid_max - 1` is a pid a real process can hold and must be ACCEPTED. Both
+  # directions, because a bound that rejects a legal pid would turn live holders into "malformed" and
+  # wedge the lane, which is the same harm inverted.
+  if [[ "$ceiling" == 'authoritative '* ]]; then
+    raw_max="$(cat /proc/sys/kernel/pid_max 2>/dev/null || true)"
+    if [[ "$raw_max" =~ ^[0-9]+$ ]] && [[ "$inclusive" == "$((raw_max - 1))" ]]; then
+      pass "lane-lock B10: the inclusive maximum [$inclusive] is exactly the platform's exclusive wrap point [$raw_max] minus one, as proc(5) defines it"
+    else
+      fail "lane-lock-pid-ceiling-conversion: pid_max=[$raw_max] inclusive=[$inclusive] — the exclusive wrap point must be converted, not used as-is"
+    fi
+    verdict="$(probe_pid "$raw_max")"
+    if [[ "$verdict" == 'unparseable pid-above-the-platform-pid-space' ]]; then
+      pass "lane-lock B10: a pid EQUAL to the exclusive wrap point REFUSES — the value no process can hold no longer parses as a holder pid"
+    else
+      fail "lane-lock-pid-ceiling-offbyone: verdict=[$verdict] for pid_max=$raw_max — this is the one malformed value the pre-B10 boundary let through, and the case that used to assert it was ACCEPTED"
+    fi
+    verdict="$(probe_pid "$inclusive")"
+    if [[ "$verdict" == "pid $inclusive" ]]; then
+      pass "lane-lock B10 (the other direction): the largest pid a process CAN hold is still accepted — the corrected bound rejects nothing legal, so it cannot wedge the lane"
+    else
+      fail "lane-lock-pid-ceiling-rejects-legal: verdict=[$verdict] — rejecting an issuable pid is the same harm pointing the other way"
+    fi
+    verdict="$(probe_pid $((raw_max + 1)))"
+    if [[ "$verdict" == 'unparseable pid-above-the-platform-pid-space' ]]; then
+      pass "lane-lock B3: a pid past the wrap point refuses"
+    else
+      fail "lane-lock-pid-bound-above: [$verdict]"
+    fi
+  fi
+
+  # ---- (2) THE WIDTH INCONSISTENCY THE BOUND EXISTS FOR. A 10-digit and a 15-digit corruption used to
+  # get OPPOSITE verdicts — the narrower one accepted, probed, reported dead and RECLAIMED. Asserted only
+  # as "the same verdict", so the case stays true on a platform that publishes no bound (where both are
+  # refused by the arithmetic guard, or both accepted) rather than pinning this host's answer.
+  local ten fifteen
   ten="$(probe_pid 9999999999)"
   fifteen="$(probe_pid 999999999999999)"
-  if [[ "$ten" == 'unparseable pid-above-the-platform-pid-space' && "$fifteen" == 'unparseable pid-above-the-platform-pid-space' ]]; then
+  if [[ "$ten" == "$fifteen" ]]; then
     pass "lane-lock B3: a 10-digit and a 15-digit corruption now get the SAME verdict [$ten] — the width-dependent inconsistency is gone, and the accepting half of it (which reclaimed) with it"
   else
     fail "lane-lock-pid-bound-inconsistent: ten=[$ten] fifteen=[$fifteen] — a corruption that reclaims at one width and refuses at another is the hole this closes"
   fi
-  above="$(probe_pid $((ceiling + 1)))"
-  at_ceiling="$(probe_pid "$ceiling")"
-  if [[ "$above" == 'unparseable pid-above-the-platform-pid-space' ]]; then
-    pass "lane-lock B3: a pid one past the platform ceiling refuses"
+
+  # ---- (3) NO INVENTED CONSTANT SURVIVES. The rejected design substituted Linux's PID_MAX_LIMIT
+  # wherever `/proc` was absent, which on macOS accepted values 42x the real platform limit and was a
+  # guess about an unmeasured platform presented as a bound. Structural, because no behavioural case on a
+  # Linux host can observe the non-Linux path.
+  local invented
+  invented="$(grep -nE 'SUPERVISOR_PID_MAX_FALLBACK|4194304' "$SUPERVISOR" | grep -vE '^[0-9]+:[[:space:]]*#' || true)"
+  if [[ -z "$invented" ]]; then
+    pass "lane-lock B10 STRUCTURAL: no cross-platform pid ceiling constant exists in the supervisor's code — an unreadable bound yields \`unknown\`, never a number nobody measured (CLAUDE.md #28)"
   else
-    fail "lane-lock-pid-bound-above: [$above]"
+    fail "lane-lock-pid-ceiling-invented: [$invented] — a guessed bound for an unmeasured platform is a no-heuristics violation, not a conservative default"
   fi
-  if [[ "$at_ceiling" == "pid $ceiling" ]]; then
-    pass "lane-lock B3 (the other direction): a pid AT the platform ceiling is ACCEPTED — the bound cannot turn a pid a real process could hold into 'malformed', which would wedge the lane"
-  else
-    fail "lane-lock-pid-bound-at-ceiling: [$at_ceiling] — rejecting a legal pid is the same harm pointing the other way"
+
+  # ---- (4) MUTANT CONTRAST for the conversion: use the exclusive value as if it were inclusive, which
+  # is the pre-B10 spelling, and the wrap-point pid is accepted again.
+  local ovr mverdict
+  ovr="$d/m-ceiling.sh"; : >"$ovr"
+  if [[ "$ceiling" == 'authoritative '* ]] && sv_mutant_override "$ovr" supervisor_pid_space_ceiling \
+       "  printf 'authoritative %s' \"\$((b - 1))\"" \
+       "  printf 'authoritative %s' \"\$b\""; then
+    printf '%s\n' "$raw_max" >"$d/pidfile"
+    mverdict="$(env SUP="$SUPERVISOR" OVR="$ovr" F="$d/pidfile" bash -c 'source "$SUP"; source "$OVR"; printf "%s" "$(supervisor_lock_pid_read "$F")"' 2>/dev/null || true)"
+    if [[ "$mverdict" == "pid $raw_max" ]]; then
+      pass "lane-lock B10 MUTANT: with the exclusive wrap point used as an inclusive maximum the unissuable value $raw_max is ACCEPTED again — so the conversion is what refuses it, and the assert above is not vacuous"
+    else
+      fail "lane-lock-mutant-ceiling: verdict=[$mverdict] — the pre-B10 spelling must be shown to accept the wrap point"
+    fi
   fi
+
   unset -f probe_pid
 }
 

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -8277,6 +8277,119 @@ test_lane_lock_nul_probe_primary_and_fallback_agree() {
 t test_lane_lock_nul_probe_primary_and_fallback_agree
 
 
+
+
+# ---------------------------------------------------------------------------
+# THE PUBLISH DECLINES A PRE-EXISTING HOLDER RECORD RATHER THAN OVERWRITING IT (#3601, job 231 B11).
+#
+# THE DEFECT: publication was not tied to the directory instance this process created. A peer can rename
+# our pid-less directory away, create and publish its OWN lock at the same name, and our forced `mv` then
+# overwrote THAT peer's ownership record — destroying the evidence of who holds the lane, which is
+# strictly worse than failing to start.
+#
+# WHAT IS FIXED HERE AND WHAT IS NOT: the OVERWRITE is refused, so we decline instead of corrupting. The
+# RACE is not closed — test-then-move is not an atomic create-exclusive — and closing it needs
+# serialisation across the whole claim-and-publication operation, which is #3683 together with the
+# reclaim ABA and the release read-then-remove. The asserts below are about the non-destruction only, and
+# the site comment says the same, because a comment claiming more than the code does is the B9 family.
+# ---------------------------------------------------------------------------
+test_lane_lock_publish_declines_instead_of_clobbering() {
+  local d tmp lane lock verdict out rc ovr peer_pid
+  d="$(new_case_dir)"
+  common_env "$d"
+  tmp="$d/tmp"
+  lane="lane3601decl$$"
+  mkdir -p "$tmp"
+  lock="$tmp/cqlite-worker-supervisor-$lane.lock"
+  peer_pid=515151
+
+  # ---- (1) THE SHIPPED PUBLISH against a directory that already carries a record.
+  mkdir -p "$lock"
+  printf '%s\n' "$peer_pid" >"$lock/pid"
+  verdict="$(env SUP="$SUPERVISOR" L="$lock" bash -c 'source "$SUP"; SUPERVISOR_LOCK="$L"; printf "%s" "$(supervisor_lock_publish)"' 2>&1 || true)"
+  if [[ "$verdict" == "declined pid $peer_pid" ]] && [[ "$(cat "$lock/pid" 2>/dev/null || true)" == "$peer_pid" ]]; then
+    pass "lane-lock B11: the publish DECLINES when a holder record already exists [$verdict] and the peer's pid is untouched — it reports the record it found rather than replacing it"
+  else
+    fail "lane-lock-publish-clobbers: verdict=[$verdict] pid=[$(cat "$lock/pid" 2>/dev/null || true)] — a peer's ownership record must never be overwritten"
+  fi
+  # ...and the staging file it wrote on the way is cleaned up, so declining leaves no debris either.
+  if [[ -z "$(ls -A "$lock" 2>/dev/null | grep 'pid\.tmp\.' || true)" ]]; then
+    pass "lane-lock B11: the declined publish removed its own staging file — declining leaves nothing behind"
+  else
+    fail "lane-lock-publish-decline-residue: [$(ls -A "$lock" | tr '\n' ' ')]"
+  fi
+
+  # ---- (2) THE LEGITIMATE CASE IS UNCHANGED: a directory we just created has no `pid`, so the branch is
+  # never taken and the publish succeeds. Without this the assert above is satisfied by code that never
+  # publishes at all.
+  rm -rf "$lock"
+  mkdir -p "$lock"
+  verdict="$(env SUP="$SUPERVISOR" L="$lock" bash -c 'source "$SUP"; SUPERVISOR_LOCK="$L"; printf "%s|%s" "$(supervisor_lock_publish)" "$(cat "$L/pid" 2>/dev/null)"' 2>&1 || true)"
+  if [[ "$verdict" == "ok|"* ]]; then
+    pass "lane-lock B11 NON-VACUITY: an empty lock directory still publishes normally [$verdict] — the non-overwrite costs the legitimate path nothing"
+  else
+    fail "lane-lock-publish-broken: verdict=[$verdict]"
+  fi
+
+  # ---- (3) END TO END: a peer publishes into the directory we created. The refusal must say we wrote
+  # NOTHING, must say the path is untouched, and the peer's record must survive.
+  rm -rf "$lock"
+  ovr="$d/f-peerpub.sh"; : >"$ovr"
+  if sv_mutant_override "$ovr" supervisor_lock_publish \
+       '  local tmpf="$SUPERVISOR_LOCK/pid.tmp.$$" state='"''" \
+       '  local tmpf="$SUPERVISOR_LOCK/pid.tmp.$$" state='"''"'
+  printf "%s\n" 626262 >"$SUPERVISOR_LOCK/pid" 2>/dev/null || true'; then
+    out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")"; rc=$?
+    if [[ "$rc" -ne 0 ]] && [[ "$out" == *"declined to overwrite it and wrote NOTHING"* ]] \
+       && [[ "$out" == *"NOTHING at that path has been modified by this run"* ]] \
+       && [[ "$out" == *"[pid 626262]"* ]] && [[ "$out" != *"ACQUIRED"* ]]; then
+      pass "lane-lock B11: with a peer's record published into the directory we created, the run refuses, names the record it found, and states it modified nothing"
+    else
+      fail "lane-lock-b11-endtoend: rc=$rc out=[$out]"
+    fi
+    if [[ "$(cat "$lock/pid" 2>/dev/null || true)" == "626262" ]]; then
+      pass "lane-lock B11: and the peer's record survives the whole refusal path — nothing on the way out removed or rewrote it"
+    else
+      fail "lane-lock-b11-peer-record-lost: pid=[$(cat "$lock/pid" 2>/dev/null || true)]"
+    fi
+  fi
+
+  # ---- (4) MUTANT CONTRAST: the pre-B11 spelling — the decline branch removed, so the forced rename
+  # overwrites whatever is there. One literal substitution.
+  rm -rf "$lock"
+  mkdir -p "$lock"
+  printf '%s\n' "$peer_pid" >"$lock/pid"
+  ovr="$d/m-clobber.sh"; : >"$ovr"
+  if sv_mutant_override "$ovr" supervisor_lock_publish \
+       '  if [[ -e "$SUPERVISOR_LOCK/pid" || -L "$SUPERVISOR_LOCK/pid" ]]; then' \
+       '  if false; then'; then
+    verdict="$(env SUP="$SUPERVISOR" OVR="$ovr" L="$lock" bash -c 'source "$SUP"; source "$OVR"; SUPERVISOR_LOCK="$L"; printf "%s" "$(supervisor_lock_publish)"' 2>&1 || true)"
+    if [[ "$verdict" == 'ok' ]] && [[ "$(cat "$lock/pid" 2>/dev/null || true)" != "$peer_pid" ]]; then
+      pass "lane-lock B11 MUTANT: with the decline removed the publish reports [$verdict] and the peer's record $peer_pid is GONE, replaced by ours — the measured pre-B11 behaviour, so the assert above is the non-overwrite doing the work"
+    else
+      fail "lane-lock-mutant-clobber: verdict=[$verdict] pid=[$(cat "$lock/pid" 2>/dev/null || true)] — the pre-fix form must be shown to destroy the peer's record"
+    fi
+  fi
+
+  # ---- (5) THE RESIDUAL IS STATED AT THE SITE, IN THE NARROWED-NOT-CLOSED FORM, and does not claim
+  # atomicity. Structural, because no behavioural case can observe a comment — and the comment is the
+  # artifact a reviewer is asked to trust about a race that is still open.
+  local body
+  body="$(sed -n '/^supervisor_lock_publish()/,/^}/p' "$SUPERVISOR")"
+  if [[ "$body" == *'NARROWED, NOT CLOSED'* ]] && [[ "$body" == *'#3683'* ]] \
+     && [[ "$body" == *'NOT bound to the directory instance'* || "$body" == *'NOT bound to the directory'* ]] \
+     && [[ "$body" == *'not equivalent to an atomic'* || "$body" == *'NOT equivalent to an atomic'* ]]; then
+    pass "lane-lock B11: the site states that publication is not bound to the created directory instance, that test-then-move is not atomic, and that closing it is #3683 — the comment claims exactly what the code does"
+  else
+    fail "lane-lock-b11-comment-overclaims: the publish's comment must name the residual and the follow-up; a comment claiming more than the code does is the B9 family"
+  fi
+
+  rm -rf "$lock" "$tmp"
+}
+
+t test_lane_lock_publish_declines_instead_of_clobbering
+
+
 # ---------------------------------------------------------------------------
 # Test 48 (#3549, roborev job 196 F2): THE SUITE LEAVES NO FIXTURE PROCESS BEHIND.
 #

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -8508,6 +8508,90 @@ test_lane_lock_cleanup_outcome_is_verified_not_claimed() {
 t test_lane_lock_cleanup_outcome_is_verified_not_claimed
 
 
+
+
+# ---------------------------------------------------------------------------
+# THE OTHER TWO SITES THE B9 CLASS SWEEP FOUND (#3601, roborev job 231 B9).
+#
+# Neither was in the finding. Both are the same shape: an artifact whose text is not bound to what the run
+# actually observed.
+#
+#   (1) THE LOST-RACE REFUSAL attributed the clearing and the new ownership to specific actors — "a stale
+#       lock was cleared and the name was immediately claimed by someone else" — when all the run observed
+#       is that its own claim found the name taken. It does not know its own rename is what cleared the
+#       lock (a racer may have), and it never read the new holder.
+#   (2) THE RELEASE'S REMOVAL made NO claim, silently: `rm -rf … || true`. The silence is the same problem
+#       one step earlier — a lock left behind by a supervisor that exited cleanly is unattributable, and
+#       the next start has to deal with it. It is self-healing, so it reports rather than escalates.
+# ---------------------------------------------------------------------------
+test_lane_lock_sweep_no_unobserved_attribution() {
+  local d tmp lane lock out rc dead ovr
+  d="$(new_case_dir)"
+  common_env "$d"
+  tmp="$d/tmp"
+  lane="lane3601sweep$$"
+  mkdir -p "$tmp"
+  lock="$tmp/cqlite-worker-supervisor-$lane.lock"
+
+  fixture_bg sleep 0.1
+  dead=$FIXTURE_LAST_PID
+  fixture_wait "$dead"
+
+  # ---- (1) THE LOST-RACE PATH, reached by failing every claim attempt while a genuinely dead holder's
+  # lock is present: the reclaim runs, the claim that follows finds the name unavailable, and this is the
+  # refusal. Fault-injected on `take`'s return, so the refusal text under test is shipped.
+  mkdir -p "$lock"
+  printf '%s\n' "$dead" >"$lock/pid"
+  ovr="$d/f-take.sh"; : >"$ovr"
+  if sv_mutant_override "$ovr" supervisor_lock_take \
+       '  mkdir -- "$SUPERVISOR_LOCK" 2>/dev/null || return 1' \
+       '  return 1'; then
+    out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")"; rc=$?
+    if [[ "$rc" -ne 0 ]] && [[ "$out" == *"taken again before this run could claim it"* ]] \
+       && [[ "$out" == *"both unestablished"* ]] \
+       && [[ "$out" != *"immediately claimed by someone else"* ]] \
+       && [[ "$out" != *"Only one racer can win"* ]]; then
+      pass "lane-lock B9 sweep (lost race): the refusal reports what the run OBSERVED — the name was taken again — and states that who cleared the lock and who holds it now are both unestablished, instead of attributing either"
+    else
+      fail "lane-lock-sweep-lostrace: rc=$rc out=[$out] — the pre-sweep wording attributed a clearing and an ownership this run never established"
+    fi
+  fi
+  rm -rf "$lock"
+
+  # ---- (2) THE RELEASE PATH, with its own removal made to FAIL for real: the lock's parent is made
+  # unwritable after the lock is taken, so the EXIT trap cannot remove it. Derived from the shipped drive
+  # body by one insertion, so the startup path is the ordinary one.
+  local rop body_ro
+  rop="$d/ro-parent"
+  mkdir -p "$rop"
+  body_ro="${SV_DRIVE_BODY/'exit 0'/'chmod 0555 "$2" 2>/dev/null || true; exit 0'}"
+  if [[ "$body_ro" == "$SV_DRIVE_BODY" ]]; then
+    fail "lane-lock-sweep-release-premise: the read-only drive body was not derived from the shipped one"
+  elif ( : >"$rop/.probe" ) 2>/dev/null && { rm -f "$rop/.probe"; chmod 0555 "$rop" 2>/dev/null; ( : >"$rop/.probe2" ) 2>/dev/null; }; then
+    rm -f "$rop/.probe2" 2>/dev/null || true
+    chmod 0755 "$rop" 2>/dev/null || true
+    skip "lane-lock B9 sweep (release): this uid can write a 0555 directory (running as root), so a failed self-removal is not stageable here — unmeasurable on this host rather than passing vacuously"
+  else
+    chmod 0755 "$rop" 2>/dev/null || true
+    out="$( cd "$d" && env -u SUPERVISOR_LOCK TMPDIR="$rop" LANE_ID="$lane" LOCK_CMD="" CLAIM_CMD="" \
+              bash -c "$body_ro" _ "$SUPERVISOR" "$rop" 2>&1 )"; rc=$?
+    chmod 0755 "$rop" 2>/dev/null || true
+    if [[ "$out" == *"ACQUIRED="* ]] && [[ "$out" == *"FAILED to remove our own lock"* ]] \
+       && [[ "$out" == *"next start will find its holder affirmatively dead and reclaim it"* ]]; then
+      pass "lane-lock B9 sweep (release): a self-removal that FAILS is reported, with what happens next — a lock outliving a clean exit is otherwise unattributable, and silence there is the same defect one step earlier"
+    else
+      fail "lane-lock-sweep-release: rc=$rc out=[$out] — the failed removal must be reported rather than swallowed"
+    fi
+    chmod 0755 "$rop" 2>/dev/null || true
+    rm -rf "$rop" 2>/dev/null || true
+  fi
+
+  rm -rf "$tmp"
+}
+
+t test_lane_lock_sweep_no_unobserved_attribution
+
+
 # ---------------------------------------------------------------------------
 # Test 48 (#3549, roborev job 196 F2): THE SUITE LEAVES NO FIXTURE PROCESS BEHIND.
 #

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -5238,9 +5238,9 @@ test_legacy_global_lock_refuses_a_present_lock() {
   # depended on. `kill -0` is deliberately NOT in the list: the per-lane lock and the worker-liveness
   # loop both use it legitimately, and a pattern that reds on correct code is the pattern people learn
   # to waive.
-  revived="$(grep -nE 'supervisor_legacy_lock_state|supervisor_pid_liveness|GLOBIGNORE|pid_max' "$SUPERVISOR" | grep -vE '^[0-9]+:[[:space:]]*#' || true)"
+  revived="$(grep -nE 'supervisor_legacy_lock_state|supervisor_pid_liveness|GLOBIGNORE' "$SUPERVISOR" | grep -vE '^[0-9]+:[[:space:]]*#' || true)"
   if [[ -z "$revived" ]]; then
-    pass "legacy-lock (ruling 2): the classifier, the deleted pid-liveness SYMBOL, the pid_max bound and the glob-state neutralisation are GONE from the supervisor's code"
+    pass "legacy-lock (ruling 2): the classifier, the deleted pid-liveness SYMBOL and the glob-state neutralisation are GONE from the supervisor's code"
   else
     fail "legacy-lock-classifier-resurrected: [$revived] — machinery whose output cannot change the decision is back on the decision path"
   fi
@@ -5252,6 +5252,12 @@ test_legacy_global_lock_refuses_a_present_lock() {
   # read as a name it can be satisfied by a rename, which is the assert that sees nothing. So the
   # durable half is stated over the three functions that ARE the legacy decision: none of them may
   # measure a pid's liveness, by any spelling — no `kill`, and no call to the per-lane probes.
+  #
+  # `pid_max` MOVED OUT OF THE FILE-WIDE NAME LIST FOR THE SAME REASON (#3601, roborev job 231 B3). The
+  # classifier's `/proc/sys/kernel/pid_max` read was deleted because ITS verdict could not change the
+  # decision; the per-lane parser reads the same file to bound a holder pid, where the verdict selects
+  # between refusing and reclaiming. A file-wide ban would have to red on that correct code — the ban
+  # people learn to waive — so what is asserted is the property: the legacy path reads no pid bound.
   local legacy_fn legacy_body legacy_code liveness_on_legacy_path=""
   for legacy_fn in supervisor_legacy_lock_presence supervisor_legacy_lock_refuse supervisor_legacy_lock_guard; do
     legacy_body="$(sed -n "/^$legacy_fn()/,/^}/p" "$SUPERVISOR")"
@@ -5265,12 +5271,12 @@ test_legacy_global_lock_refuses_a_present_lock() {
       fail "legacy-lock-liveness-property-premise: $legacy_fn has no non-comment line"
       break
     fi
-    liveness_on_legacy_path+="$(printf '%s\n' "$legacy_code" | grep -nE 'kill[[:space:]]|supervisor_lock_holder_liveness|supervisor_lock_pid_read' || true)"
+    liveness_on_legacy_path+="$(printf '%s\n' "$legacy_code" | grep -nE 'kill[[:space:]]|supervisor_lock_holder_liveness|supervisor_lock_pid_read|pid_max|/proc/' || true)"
   done
   if [[ -n "$legacy_code" && -z "$liveness_on_legacy_path" ]]; then
-    pass "legacy-lock (ruling 2, as a PROPERTY): no function on the legacy decision path measures a pid's liveness or parses a pid, by any spelling — so the deletion holds even though the capability exists elsewhere in the file for a path where its verdict changes the decision"
+    pass "legacy-lock (ruling 2, as a PROPERTY): no function on the legacy decision path measures a pid's liveness, parses a pid, or reads a platform pid bound, by any spelling — so the deletion holds even though those capabilities exist elsewhere in the file for a path where their verdict changes the decision"
   elif [[ -n "$legacy_code" ]]; then
-    fail "legacy-lock-liveness-on-legacy-path: [$liveness_on_legacy_path] — the legacy guard tests for EXISTENCE and stops; measuring a holder's liveness there is the machinery the ruling removed, whatever it is called"
+    fail "legacy-lock-liveness-on-legacy-path: [$liveness_on_legacy_path] — the legacy guard tests for EXISTENCE and stops; measuring a holder's liveness or reading a pid bound there is the machinery the ruling removed, whatever it is called"
   fi
   # ...AND THE PROBE STILL EXECUTES NO EXTERNAL COMMAND, so none of its verdicts depends on `PATH`.
   # Comment lines are stripped first (the prose legitimately NAMES tools it does not use, and a check
@@ -7528,8 +7534,8 @@ test_lane_lock_publish_is_read_back_before_it_is_trusted() {
   # ---- (2) FORGE A FOREIGN PID INTO THE PUBLISH: the read-back must refuse.
   ovr="$d/m-pub-forge.sh"; : >"$ovr"
   if sv_mutant_override "$ovr" supervisor_lock_publish \
-       '  printf '"'"'%s\n'"'"' "$$" >"$tmpf" 2>/dev/null || return 1' \
-       '  printf '"'"'%s\n'"'"' 424243 >"$tmpf" 2>/dev/null || return 1'; then
+       '  if ! { printf '"'"'%s\n'"'"' "$$" >"$tmpf"; } 2>/dev/null; then' \
+       '  if ! { printf '"'"'%s\n'"'"' 424243 >"$tmpf"; } 2>/dev/null; then'; then
     out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")"; rc=$?
     if [[ "$rc" -ne 0 && "$out" != *"ACQUIRED="* && "$out" == *"could not verify it OWNS it"* ]]; then
       pass "lane-lock publish: when the lock does not read back as ours the run REFUSES and says which step failed — the read-back has teeth"
@@ -7543,7 +7549,7 @@ test_lane_lock_publish_is_read_back_before_it_is_trusted() {
   # could be passing because of the forgery rather than because of the check.
   ovr="$d/m-pub-blind.sh"; : >"$ovr"
   if sv_mutant_override "$ovr" supervisor_lock_publish \
-       '  state="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")" || true' \
+       '  state="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")" || state='"'"'unparseable read-back-aborted'"'"'' \
        '  printf '"'"'%s\n'"'"' 424243 >"$SUPERVISOR_LOCK/pid"; state="pid $$"'; then
     out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")"; rc=$?
     if [[ "$rc" -eq 0 && "$out" == *"ACQUIRED=$lock"* ]]; then
@@ -7815,29 +7821,47 @@ test_lane_lock_nul_bearing_pid_file_refuses() {
   rm -f -- "$lock/pid"
   lane_lock_remedy_ok "pid-file-contains-nul" "$out" "$lock"
 
-  # ---- (3) THE THIRD VALUE: the NUL check is TWO EXTERNAL COMMANDS, so either can fail, and a failed
-  # measurement must REFUSE rather than report "no NULs found" — the same discipline `log_size` grew in
-  # this change, for the same reason. `wc` is made to fail for real, by a shadow earlier on `PATH`.
+  # ---- (3) THE DETECTOR IS FORK-FREE, WHICH IS THE PROPERTY, NOT AN OPTIMISATION. An earlier cut made
+  # the byte-count form the primary and this parser then depended on `wc`/`tr` — and because
+  # `supervisor_lock_publish` calls it on EVERY start for its read-back, a box without `wc` could not
+  # start a supervisor at all. So: with `wc` unavailable the verdict must be UNCHANGED, in both
+  # directions. (The byte-count form's own three-valued failure handling is asserted where that fallback
+  # is forced to run, in the differential case below.)
   shadow="$d/shadow"
   mkdir -p "$shadow"
   printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$shadow/wc"
   chmod +x "$shadow/wc"
   printf '%s\n' "$dead" >"$d/clean-pid"
-  verdict="$(env SUP="$SUPERVISOR" F="$d/clean-pid" PATH="$shadow:$PATH" bash -c 'source "$SUP"; printf "%s" "$(supervisor_lock_pid_read "$F")"' 2>/dev/null || true)"
-  if [[ "$verdict" == 'unparseable pid-file-nul-check-could-not-measure'* ]]; then
-    pass "lane-lock NUL (third value): with the byte count UNMEASURABLE the parser refuses and names the measurement failure [$verdict] — an unmeasurable read is never 'nul-free'"
+  local v_nul_nowc v_clean_nowc
+  v_nul_nowc="$(env SUP="$SUPERVISOR" F="$lock/pid" PATH="$shadow:$PATH" bash -c 'source "$SUP"; printf "%s" "$(supervisor_lock_pid_read "$F")"' 2>/dev/null || true)"
+  v_clean_nowc="$(env SUP="$SUPERVISOR" F="$d/clean-pid" PATH="$shadow:$PATH" bash -c 'source "$SUP"; printf "%s" "$(supervisor_lock_pid_read "$F")"' 2>/dev/null || true)"
+  if [[ "$v_clean_nowc" == "pid $dead" ]]; then
+    pass "lane-lock NUL (fork-free): a clean pid file still parses as [$v_clean_nowc] with \`wc\` unavailable — the detector is a builtin, so a missing coreutils tool cannot stop this lane starting"
   else
-    fail "lane-lock-nul-measurement-collapsed: verdict=[$verdict] — a failed measurement must not become the permissive answer"
+    fail "lane-lock-nul-probe-needs-wc: verdict=[$v_clean_nowc] — the primary detector must not depend on an external command"
   fi
-  # NON-VACUITY for (3): the SAME clean file parses normally once `wc` works, so the refusal above is the
-  # measurement failing and not the file.
-  verdict="$(env SUP="$SUPERVISOR" F="$d/clean-pid" bash -c 'source "$SUP"; printf "%s" "$(supervisor_lock_pid_read "$F")"' 2>/dev/null || true)"
-  if [[ "$verdict" == "pid $dead" ]]; then
-    pass "lane-lock NUL (third value, non-vacuity): the identical file parses as [$verdict] with a working \`wc\` — so (3) measured the probe's failure, not a bad fixture"
+  # ...and the refusing direction is equally unaffected: a broken `wc` must not turn a NUL-bearing file
+  # into an accepted pid either.
+  if [[ "$v_nul_nowc" == 'unparseable pid-file-contains-nul' ]]; then
+    pass "lane-lock NUL (fork-free): and the NUL-bearing file is STILL refused with \`wc\` unavailable [$v_nul_nowc] — being fork-free did not cost the detection"
   else
-    fail "lane-lock-nul-nonvacuity: verdict=[$verdict]"
+    fail "lane-lock-nul-nowc-accepted: verdict=[$v_nul_nowc]"
   fi
-
+  # ---- THE PRIMARY'S OWN THIRD VALUE, at the one state it can actually reach: content longer than the
+  # bounded scan. It is unreachable through `supervisor_lock_pid_read` (the structural gates reject any
+  # such file first), so it is driven at the probe, which is what stops it being dead code a later edit
+  # deletes as unused. `could-not-measure`, never `nul-free`.
+  local big
+  big="$d/big-pid"
+  : >"$big"
+  local i=0
+  while [[ "$i" -lt 130 ]]; do printf '%s' '0123456789012345678901234567890123456789' >>"$big"; i=$((i + 1)); done
+  verdict="$(env SUP="$SUPERVISOR" F="$big" bash -c 'source "$SUP"; printf "%s" "$(supervisor_lock_pid_nul_free "$F")"' 2>/dev/null || true)"
+  if [[ "$verdict" == 'could-not-measure pid-file-longer-than-the-nul-scan-bound' ]]; then
+    pass "lane-lock NUL (third value): content past the bounded scan is [$verdict] — a NUL beyond the bound is UNOBSERVED, and unobserved is never reported as nul-free"
+  else
+    fail "lane-lock-nul-scan-bound: verdict=[$verdict] — a scan that could not see the whole file must say so"
+  fi
   # ---- (4) MUTANT CONTRAST: the NUL gate removed by ONE literal substitution — its `contains-nul`
   # verdict joins the accepting branch. Everything else, including the byte measurement itself, is
   # shipped code, so the contrast isolates the GATE and not the probe.
@@ -8124,10 +8148,17 @@ test_lane_lock_nul_probe_primary_and_fallback_agree() {
   chmod +x "$shadow/wc"
 
   # ---- (1) THE PRIMARY IS FORK-FREE: with BOTH `wc` and `tr` unavailable it still answers both ways.
-  printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$shadow/tr"
-  chmod +x "$shadow/tr"
-  pv="$(env SUP="$SUPERVISOR" F="$nulf" PATH="$shadow:$PATH" bash -c 'source "$SUP"; printf "%s" "$(supervisor_lock_pid_nul_free "$F")"' 2>/dev/null || true)"
-  fv="$(env SUP="$SUPERVISOR" F="$cleanf" PATH="$shadow:$PATH" bash -c 'source "$SUP"; printf "%s" "$(supervisor_lock_pid_nul_free "$F")"' 2>/dev/null || true)"
+  # This is the PROBE called directly, deliberately: `tr` is used all over the supervisor's own startup
+  # (lane-identity sanitisation, the proc probes), so a whole-run drive with `tr` shadowed would fail for
+  # reasons that have nothing to do with this probe and would measure nothing. The whole-run case below
+  # shadows `wc` only, which is the tool the rejected byte-count-as-primary form actually wedged on.
+  local shadow2="$d/shadow2"
+  mkdir -p "$shadow2"
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$shadow2/wc"
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$shadow2/tr"
+  chmod +x "$shadow2/wc" "$shadow2/tr"
+  pv="$(env SUP="$SUPERVISOR" F="$nulf" PATH="$shadow2:$PATH" bash -c 'source "$SUP"; printf "%s" "$(supervisor_lock_pid_nul_free "$F")"' 2>/dev/null || true)"
+  fv="$(env SUP="$SUPERVISOR" F="$cleanf" PATH="$shadow2:$PATH" bash -c 'source "$SUP"; printf "%s" "$(supervisor_lock_pid_nul_free "$F")"' 2>/dev/null || true)"
   if [[ "$pv" == 'contains-nul' && "$fv" == 'nul-free' ]]; then
     pass "lane-lock NUL probe: the primary detector answers correctly with \`wc\` AND \`tr\` both unavailable — it is a builtin, so no verdict here depends on PATH"
   else
@@ -8142,7 +8173,7 @@ test_lane_lock_nul_probe_primary_and_fallback_agree() {
   lock="$tmp/cqlite-worker-supervisor-$lane.lock"
   out="$(lane_lock_drive_at "$d" - "$tmp" "$lane" PATH="$shadow:$PATH")"; rc=$?
   if [[ "$rc" -eq 0 && "$out" == *"ACQUIRED=$lock"* ]]; then
-    pass "lane-lock NUL probe: a FRESH uncontended start still succeeds on a box with neither \`wc\` nor \`tr\` — a missing coreutils tool cannot make this lane unable to start (ruling 2)"
+    pass "lane-lock NUL probe: a FRESH uncontended start still succeeds on a box with no \`wc\` — a missing coreutils tool cannot make this lane unable to start (ruling 2), which the byte-count-as-primary form measurably did"
   else
     fail "lane-lock-nul-probe-wedges-start: rc=$rc out=[$out] — this is the permanent-refusal harm the primary detector avoids"
   fi

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -3775,8 +3775,16 @@ STUBEOF
 # racers only one `mv "$LOCK" "$LOCK.stale.$$"` can succeed against a given
 # stale directory name; the loser's `mv` fails (source already gone) and it
 # falls through to its own `mkdir "$LOCK"`, which fails against the winner's
-# fresh lock, hitting the existing loud "failed to acquire lock" exit path.
+# fresh lock, hitting the loud lost-race exit path.
 # No test function here by design — see comment in acquire_lock() itself.
+# UPDATED (#3601): that exit path is now `supervisor_lock_refuse_lost_race`, which names the cause
+# instead of the pre-#3601 bare "failed to acquire lock", and it is reached only when the name is taken
+# by someone else — a `mkdir` that fails because the PATH cannot hold a lock is diagnosed separately
+# (`test_lane_lock_uncreatable_path_is_not_reported_as_contention`). The reclaim's operands also now
+# terminate option parsing, which `test_lane_lock_option_shaped_tmpdir_starts_normally` drives. The
+# same-instant two-racer interleaving remains untested for the reason above; the interleaving that IS
+# reproducible — a peer holding a PID-LESS lock — is driven with a real competing process by
+# `test_lane_lock_pidless_window_is_never_read_as_dead`.
 
 # ---------------------------------------------------------------------------
 # Test (#2841): the resolved DEFAULT WORKER_CMD (caller does not export one)
@@ -5223,9 +5231,37 @@ test_legacy_global_lock_refuses_a_present_lock() {
   # to waive.
   revived="$(grep -nE 'supervisor_legacy_lock_state|supervisor_pid_liveness|GLOBIGNORE|pid_max' "$SUPERVISOR" | grep -vE '^[0-9]+:[[:space:]]*#' || true)"
   if [[ -z "$revived" ]]; then
-    pass "legacy-lock (ruling 2): the classifier, the pid-liveness probe, the pid_max bound and the glob-state neutralisation are GONE from the supervisor's code"
+    pass "legacy-lock (ruling 2): the classifier, the deleted pid-liveness SYMBOL, the pid_max bound and the glob-state neutralisation are GONE from the supervisor's code"
   else
     fail "legacy-lock-classifier-resurrected: [$revived] — machinery whose output cannot change the decision is back on the decision path"
+  fi
+  # ...AND THE PROPERTY THE NAME CHECK CANNOT SEE (#3601). A NAME BAN IS NOT A PROPERTY ASSERT: the
+  # ruling deleted pid liveness from THIS decision path, not from the file, and #3601 legitimately
+  # rebuilt the capability for the PER-LANE lock — where, unlike here, the verdict selects between
+  # refusing and reclaiming, so it is a guard and not a description generator. Read as a file-wide ban
+  # the assert above would have to red on that correct code, which is the assert people learn to waive;
+  # read as a name it can be satisfied by a rename, which is the assert that sees nothing. So the
+  # durable half is stated over the three functions that ARE the legacy decision: none of them may
+  # measure a pid's liveness, by any spelling — no `kill`, and no call to the per-lane probes.
+  local legacy_fn legacy_body legacy_code liveness_on_legacy_path=""
+  for legacy_fn in supervisor_legacy_lock_presence supervisor_legacy_lock_refuse supervisor_legacy_lock_guard; do
+    legacy_body="$(sed -n "/^$legacy_fn()/,/^}/p" "$SUPERVISOR")"
+    if [[ -z "$legacy_body" || "$legacy_body" != *"$legacy_fn() {"* ]]; then
+      fail "legacy-lock-liveness-property-premise: could not extract $legacy_fn from $SUPERVISOR; the scan below has no subject"
+      legacy_code=""
+      break
+    fi
+    legacy_code="$(printf '%s\n' "$legacy_body" | grep -vE '^[[:space:]]*#' || true)"
+    if [[ -z "$legacy_code" ]]; then
+      fail "legacy-lock-liveness-property-premise: $legacy_fn has no non-comment line"
+      break
+    fi
+    liveness_on_legacy_path+="$(printf '%s\n' "$legacy_code" | grep -nE 'kill[[:space:]]|supervisor_lock_holder_liveness|supervisor_lock_pid_read' || true)"
+  done
+  if [[ -n "$legacy_code" && -z "$liveness_on_legacy_path" ]]; then
+    pass "legacy-lock (ruling 2, as a PROPERTY): no function on the legacy decision path measures a pid's liveness or parses a pid, by any spelling — so the deletion holds even though the capability exists elsewhere in the file for a path where its verdict changes the decision"
+  elif [[ -n "$legacy_code" ]]; then
+    fail "legacy-lock-liveness-on-legacy-path: [$liveness_on_legacy_path] — the legacy guard tests for EXISTENCE and stops; measuring a holder's liveness there is the machinery the ruling removed, whatever it is called"
   fi
   # ...AND THE PROBE STILL EXECUTES NO EXTERNAL COMMAND, so none of its verdicts depends on `PATH`.
   # Comment lines are stripped first (the prose legitimately NAMES tools it does not use, and a check

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -7485,11 +7485,25 @@ t test_lane_lock_publish_is_read_back_before_it_is_trusted
 # is not writable — so the cause is checked before it is attributed to a holder.
 # ---------------------------------------------------------------------------
 test_lane_lock_uncreatable_path_is_not_reported_as_contention() {
-  local d lane out rc
+  local d lane out rc ro
   d="$(new_case_dir)"
   common_env "$d"
   lane="lane3601nopath$$"
-  out="$(lane_lock_drive_at "$d" - "$d/no-such-parent/deeper" "$lane" SUPERVISOR_LOCK_PID_TRIES=2 SUPERVISOR_LOCK_PID_WAIT=0.01)"; rc=$?
+  # THE `TMPDIR` MUST EXIST AND BE SEARCHABLE, AND ONLY THEN UNWRITABLE. An absent container is refused
+  # EARLIER, by the legacy guard's existence probe ("cannot tell" — measured), so it never reaches
+  # `mkdir` and would test the wrong refusal. Read-and-search but not write (0555) is the shape that
+  # reaches the claim and fails there.
+  ro="$d/readonly-tmp"
+  mkdir -p "$ro"
+  chmod 0555 "$ro" 2>/dev/null || true
+  if ( : >"$ro/.probe" ) 2>/dev/null; then
+    rm -f "$ro/.probe" 2>/dev/null || true
+    chmod 0755 "$ro" 2>/dev/null || true
+    skip "lane-lock (uncreatable path): this uid can write a 0555 directory (running as root), so an uncreatable lock path is not stageable here — unmeasurable on this host rather than passing vacuously"
+    return 0
+  fi
+  out="$(lane_lock_drive_at "$d" - "$ro" "$lane" SUPERVISOR_LOCK_PID_TRIES=2 SUPERVISOR_LOCK_PID_WAIT=0.01)"; rc=$?
+  chmod 0755 "$ro" 2>/dev/null || true
   if [[ "$rc" -ne 0 ]] && [[ "$out" == *"could NOT BE CREATED"* ]] \
      && [[ "$out" == *"NOT contention"* ]] && [[ "$out" != *"reclaiming stale lock"* ]] \
      && [[ "$out" != *"already running"* ]]; then
@@ -7500,6 +7514,120 @@ test_lane_lock_uncreatable_path_is_not_reported_as_contention() {
 }
 
 t test_lane_lock_uncreatable_path_is_not_reported_as_contention
+
+
+
+
+# ---------------------------------------------------------------------------
+# `log_size`: A FAILED MEASUREMENT IS NOT A VALUE (#3601, the issue's fourth item).
+#
+# `log_size` returned the EMPTY STRING when `wc` failed, and empty collapses to `0` in the caller's
+# `-eq` comparison — so two UNMEASURABLE reads compared EQUAL and the wedge detector read a healthy,
+# growing log as FROZEN. That is the "an empty probe is not a zero" shape: a measurement that did not
+# happen became the value 0. It was mitigated, not prevented, by the conjoined prompt-signature
+# requirement, which is why it is fixed with the rest of this family rather than left as a landmine.
+#
+# BOTH LEVELS ARE DRIVEN: the probe's own three answers, and the CONSUMER — because a probe returning a
+# sentinel nobody checks is not a fix.
+# ---------------------------------------------------------------------------
+test_log_size_unmeasurable_is_not_zero() {
+  local d shadow out absent present unmeasurable
+  d="$(new_case_dir)"
+  common_env "$d"
+  printf '12345' >"$d/some.log"
+
+  absent="$(env SUP="$SUPERVISOR" F="$d/no-such.log" bash -c 'source "$SUP"; log_size "$F"' 2>/dev/null || true)"
+  present="$(env SUP="$SUPERVISOR" F="$d/some.log" bash -c 'source "$SUP"; log_size "$F"' 2>/dev/null || true)"
+  # `wc` FAILS FOR REAL — a shadow earlier on `PATH`, not a stubbed function — because the defect is
+  # what happens when the external tool this probe depends on cannot answer.
+  shadow="$d/shadow"
+  mkdir -p "$shadow"
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$shadow/wc"
+  chmod +x "$shadow/wc"
+  unmeasurable="$(env SUP="$SUPERVISOR" F="$d/some.log" PATH="$shadow:$PATH" bash -c 'source "$SUP"; log_size "$F"' 2>/dev/null || true)"
+
+  if [[ "$absent" == "0" && "$present" == "5" && "$unmeasurable" == "-1" ]]; then
+    pass "log_size: absent=[0] (a real zero), present=[5] (a real count), unmeasurable=[-1] (a NAMED non-value) — three answers, so a failed measurement can never be mistaken for a byte count"
+  else
+    fail "log-size-collapses: absent=[$absent] present=[$present] unmeasurable=[$unmeasurable] — an unmeasurable read must not come back as an empty string (which \`-eq\` reads as 0) or as any real count"
+  fi
+
+  # ---- THE CONSUMER, BEHAVIOURALLY. Same wedge scenario as the genuine-wedge case (a worker that
+  # prints the prompt signature and then stops), with `wc` shadowed so the size is UNMEASURABLE on every
+  # scan. The wedge must NOT be confirmed: two failed reads are not evidence of a frozen log. Pre-fix
+  # this reported `stuck-on-question` and paged the owner, from a measurement that never happened.
+  local d2 call_ctr jf rc scount acount fcount
+  d2="$(new_case_dir)"
+  common_env "$d2"
+  call_ctr="$d2/calls"
+  write_stuck_then_finalize_stub "$d2/bin/worker.sh" "$call_ctr"
+  export WORKER_CMD="$d2/bin/worker.sh"
+  export MAX_ISSUES=1
+  export BREAKER_N=2
+  export STUCK_POLL_SECS=1
+  export MAX_ITER_SECS=8
+  jf="$JOURNAL_FILE"
+  mkdir -p "$d2/shadow"
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$d2/shadow/wc"
+  chmod +x "$d2/shadow/wc"
+
+  env PATH="$d2/shadow:$PATH" bash "$SUPERVISOR" >"$d2/stdout.log" 2>&1
+  rc=$?
+  scount=$(jline_count "$jf" '"outcome":"stuck-on-question"')
+  acount=$(jline_count "$jf" '"outcome":"abnormal"')
+  fcount=$(jline_count "$jf" '"outcome":"finalized"')
+  if [[ "$rc" -eq 0 && "$scount" -eq 0 && "$acount" -eq 1 && "$fcount" -eq 1 ]]; then
+    pass "log_size CONSUMER: with the byte size UNMEASURABLE on every scan the wedge is NOT confirmed (stuck=0) and the iteration is judged on what IS known (abnormal, then finalize) — two failed reads are not a frozen log"
+  else
+    fail "log-size-consumer-false-wedge: rc=$rc stuck=$scount abnormal=$acount finalized=$fcount (see $jf) — an unmeasurable size must not confirm a wedge"
+  fi
+
+  # ---- MUTANT CONTRAST: the pre-fix probe, restored by one substitution — an unmeasurable read comes
+  # back EMPTY. `-eq` then reads it as 0, both scans agree, and the same run reports a wedge that never
+  # happened. Driven through the probe AND through the consumer, because the empty value is harmless
+  # until something compares it.
+  local ovr mval
+  ovr="$d/m-logsize.sh"; : >"$ovr"
+  if sv_mutant_override "$ovr" log_size \
+       "      printf '%s' '-1'" \
+       "      printf '%s' ''"; then
+    mval="$(env SUP="$SUPERVISOR" OVR="$ovr" F="$d/some.log" PATH="$shadow:$PATH" \
+             bash -c 'source "$SUP"; source "$OVR"; printf "[%s]" "$(log_size "$F")"' 2>/dev/null || true)"
+    if [[ "$mval" == "[]" ]]; then
+      pass "log_size MUTANT: the pre-fix probe returns the EMPTY STRING for an unmeasurable read (mval=$mval) — which \`[[ x -eq y ]]\` reads as 0, so two failures compared equal; the assert above reds on exactly that"
+    else
+      fail "log-size-mutant: mval=[$mval] — the pre-fix form must be shown to return empty"
+    fi
+    # ...and the consumer, with that same pre-fix probe, DOES confirm the false wedge. This is the harm,
+    # measured rather than argued.
+    local d3 jf3 mscount
+    d3="$(new_case_dir)"
+    common_env "$d3"
+    write_stuck_then_finalize_stub "$d3/bin/worker.sh" "$d3/calls"
+    export WORKER_CMD="$d3/bin/worker.sh"
+    export MAX_ISSUES=1
+    export BREAKER_N=2
+    export STUCK_POLL_SECS=1
+    export MAX_ITER_SECS=8
+    jf3="$JOURNAL_FILE"
+    mkdir -p "$d3/shadow"
+    printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$d3/shadow/wc"
+    chmod +x "$d3/shadow/wc"
+    # The supervisor is run with the mutant sourced AFTER it, through the same `bash` entry the ordinary
+    # case uses, so only the probe differs.
+    env PATH="$d3/shadow:$PATH" SUP="$SUPERVISOR" OVR="$ovr" \
+      bash -c 'source "$SUP" 2>/dev/null || true; source "$OVR"; main "$@"' _ >"$d3/stdout.log" 2>&1 || true
+    mscount=$(jline_count "$jf3" '"outcome":"stuck-on-question"')
+    if [[ "$mscount" -ge 1 ]]; then
+      pass "log_size CONSUMER MUTANT: with the pre-fix probe the identical run reports a wedge (stuck=$mscount) from a measurement that never happened — so the consumer assert above is the sentinel doing the work"
+    else
+      fail "log-size-consumer-mutant: stuck=$mscount (see $jf3) — the pre-fix form must be shown to produce the false wedge, or the consumer assert measures nothing"
+    fi
+  fi
+  unset WORKER_CMD
+}
+
+t test_log_size_unmeasurable_is_not_zero
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -8692,11 +8692,34 @@ test_lane_lock_sweep_no_unobserved_attribution() {
     out="$( cd "$d" && env -u SUPERVISOR_LOCK TMPDIR="$rop" LANE_ID="$lane" LOCK_CMD="" CLAIM_CMD="" \
               bash -c "$body_ro" _ "$SUPERVISOR" "$rop" 2>&1 )"; rc=$?
     chmod 0755 "$rop" 2>/dev/null || true
-    if [[ "$out" == *"ACQUIRED="* ]] && [[ "$out" == *"FAILED to remove our own lock"* ]] \
-       && [[ "$out" == *"next start will find its holder affirmatively dead and reclaim it"* ]]; then
-      pass "lane-lock B9 sweep (release): a self-removal that FAILS is reported, with what happens next — a lock outliving a clean exit is otherwise unattributable, and silence there is the same defect one step earlier"
+    # WHAT THIS CASE ACTUALLY PRODUCES IS A PARTIAL REMOVAL, AND IT USED TO PIN THE FALSE CLAIM ABOUT IT
+    # (#3601, roborev job 240 B16). `rm -rf` unlinks CONTENTS before the directory, and those need write
+    # permission on DIFFERENT directories — `<lock>/pid` needs write on `<lock>`, `<lock>` needs write on
+    # its PARENT — so an unwritable parent deletes the pid record and leaves the directory. This case
+    # therefore reaches the pid-less state, and the assert here REQUIRED the log to promise that the next
+    # start would "reclaim it automatically", which is false: a pid-less lock is undecidable and the next
+    # start refuses over it indefinitely. A test that requires a false promise is what keeps the promise
+    # alive, so the state is now measured on disk FIRST and the claim asserted against it.
+    local surviving_pid='no' surviving_dir='no'
+    [[ -d "$rop/cqlite-worker-supervisor-$lane.lock" ]] && surviving_dir='yes'
+    [[ -f "$rop/cqlite-worker-supervisor-$lane.lock/pid" ]] && surviving_pid='yes'
+    if [[ "$surviving_dir" == 'yes' && "$surviving_pid" == 'no' ]]; then
+      pass "lane-lock B16 PREMISE: this case really does produce the PARTIAL removal — the lock directory survives and its pid record is GONE, so the claim below has the state it is about"
     else
-      fail "lane-lock-sweep-release: rc=$rc out=[$out] — the failed removal must be reported rather than swallowed"
+      fail "lane-lock-b16-premise: dir=[$surviving_dir] pid=[$surviving_pid] — the partial-removal state was not staged, so the asserts below would measure something else"
+    fi
+    if [[ "$out" == *"ACQUIRED="* ]] && [[ "$out" == *"PARTIALLY removed our own lock"* ]] \
+       && [[ "$out" == *"will NOT clear itself"* ]] && [[ "$out" == *"ACTION IS NEEDED"* ]] \
+       && [[ "$out" == *"PARENT directory is not writable"* ]]; then
+      pass "lane-lock B16: the partial removal is named as a partial removal, stated NOT to self-clear, flagged as needing action, and the cause an operator must fix (the parent's permissions) is named — because the removal a later refusal prints needs that same permission"
+    else
+      fail "lane-lock-b16-report: rc=$rc out=[$out] — a partial removal must be reported as the wedge it is"
+    fi
+    # NEGATIVE CONTROL: the pre-B16 promise must be ABSENT. This is the assert that stops it returning.
+    if [[ "$out" != *"reclaim it automatically"* ]]; then
+      pass "lane-lock B16: and it does NOT promise automatic reclaim — the promise that pointed away from this wedge is gone"
+    else
+      fail "lane-lock-b16-false-promise: the log still promises the next start will reclaim automatically, which is false for a pid-less lock"
     fi
     chmod 0755 "$rop" 2>/dev/null || true
     rm -rf "$rop" 2>/dev/null || true
@@ -8706,6 +8729,72 @@ test_lane_lock_sweep_no_unobserved_attribution() {
 }
 
 t test_lane_lock_sweep_no_unobserved_attribution
+
+
+# ---------------------------------------------------------------------------
+# "NOT OURS" IS NOT THE SAME FACT AS "SOMEONE ELSE'S" (#3601, roborev job 240 B17).
+#
+# The release reported EVERY state other than its own pid as "Something else owns that name now" —
+# including absent, unreadable, malformed and NUL-bearing records. Those establish only that ownership
+# CANNOT BE VERIFIED. Attributing them to another process names a holder that may not exist and sends an
+# operator looking for it; the DECISION is identical either way (remove nothing), so the wording is the
+# entire content of the finding, which is why it has to be the wording that is true.
+# ---------------------------------------------------------------------------
+test_lane_lock_release_distinguishes_foreign_from_unverifiable() {
+  local d tmp lane out body_steal foreign
+  d="$(new_case_dir)"
+  common_env "$d"
+  tmp="$d/tmp"
+  lane="lane3601b17$$"
+  mkdir -p "$tmp"
+
+  # One drive, derived from the shipped body by a single insertion, that replaces the lock's pid record
+  # with a value the caller chooses just before exiting — so the EXIT trap runs against that state.
+  body_steal="${SV_DRIVE_BODY/'exit 0'/'printf "%s\n" "$2" >"$SUPERVISOR_LOCK/pid"; exit 0'}"
+  if [[ "$body_steal" == "$SV_DRIVE_BODY" ]]; then
+    fail "lane-lock-b17-premise: the steal drive was not derived from the shipped body"
+    return 0
+  fi
+
+  # ---- (1) A PARSED FOREIGN PID: naming another holder is justified, because one was read.
+  foreign=909090
+  out="$( cd "$d" && env -u SUPERVISOR_LOCK TMPDIR="$tmp" LANE_ID="$lane" LOCK_CMD="" CLAIM_CMD="" \
+            bash -c "$body_steal" _ "$SUPERVISOR" "$foreign" 2>&1 )"
+  if [[ "$out" == *"records holder pid $foreign, not this process"* ]] \
+     && [[ "$out" == *"Another holder owns that name"* ]]; then
+    pass "lane-lock B17 (parsed foreign pid): the refusal names the holder it actually read — an attribution backed by a parse is fine, and this is the only branch that may make one"
+  else
+    fail "lane-lock-b17-foreign: out=[$out]"
+  fi
+  rm -rf "$tmp"; mkdir -p "$tmp"
+
+  # ---- (2) AN UNPARSEABLE RECORD: ownership is unverifiable, and that is all that may be said.
+  out="$( cd "$d" && env -u SUPERVISOR_LOCK TMPDIR="$tmp" LANE_ID="$lane" LOCK_CMD="" CLAIM_CMD="" \
+            bash -c "$body_steal" _ "$SUPERVISOR" 'not-a-pid' 2>&1 )"
+  if [[ "$out" == *"could not VERIFY that it owns it"* ]] \
+     && [[ "$out" == *"does NOT establish that another process holds this lock"* ]] \
+     && [[ "$out" == *"left exactly as found"* ]]; then
+    pass "lane-lock B17 (unparseable record): the refusal reports that ownership could not be VERIFIED and says explicitly that this does not establish another holder — the decision is unchanged, only the claim is now true"
+  else
+    fail "lane-lock-b17-unverifiable: out=[$out]"
+  fi
+  # NEGATIVE CONTROL, which is the whole finding: the unparseable branch must not attribute a holder.
+  if [[ "$out" != *"Another holder owns that name"* ]] && [[ "$out" != *"Something else owns that name"* ]]; then
+    pass "lane-lock B17: and it does NOT say another holder owns the name — the attribution that named a process nobody read is gone"
+  else
+    fail "lane-lock-b17-attributes: the unparseable branch still attributes the lock to another holder, which it never established"
+  fi
+  # ...and either way the record is untouched, so the wording change did not come with a behaviour change.
+  if [[ "$(cat "$tmp/cqlite-worker-supervisor-$lane.lock/pid" 2>/dev/null || true)" == 'not-a-pid' ]]; then
+    pass "lane-lock B17: the unverifiable record is left byte-for-byte as found — the decision was always to remove nothing, and it still is"
+  else
+    fail "lane-lock-b17-removed: the unverifiable record was modified or removed"
+  fi
+
+  rm -rf "$tmp"
+}
+
+t test_lane_lock_release_distinguishes_foreign_from_unverifiable
 
 
 

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -7633,8 +7633,12 @@ test_lane_lock_uncreatable_path_is_not_reported_as_contention() {
   fi
   out="$(lane_lock_drive_at "$d" - "$ro" "$lane")"; rc=$?
   chmod 0755 "$ro" 2>/dev/null || true
-  if [[ "$rc" -ne 0 ]] && [[ "$out" == *"could NOT BE CREATED"* ]] \
-     && [[ "$out" == *"NOT contention"* ]] && [[ "$out" != *"reclaiming stale lock"* ]] \
+  # B21 removed the confident "NOT contention": a post-failure existence test cannot establish the cause.
+  # What must survive is the OBSERVATION (nothing is at that name) and the operator's first check (the
+  # parent), which is the half of #3601's AC7 fix that has operator value.
+  if [[ "$rc" -ne 0 ]] && [[ "$out" == *"NOTHING is at that name now"* ]] \
+     && [[ "$out" == *"check the PARENT directory"* ]] && [[ "$out" == *"NOT ESTABLISHED"* ]] \
+     && [[ "$out" != *"reclaiming stale lock"* ]] \
      && [[ "$out" != *"already running"* ]]; then
     pass "lane-lock (uncreatable path): a lock that cannot be created is reported as a PATH problem and explicitly not as contention — no invented stale lock, no invented holder"
   else
@@ -9091,11 +9095,11 @@ test_lane_lock_race_and_io_error_are_not_conflated() {
   export SV_SECOND_TAKE=1
   mkdir -- "$SUPERVISOR_LOCK" 2>/dev/null || return 1'; then
     out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")"; rc=$?
-    if [[ "$rc" -ne 0 ]] && [[ "$out" == *"could NOT BE CREATED"* ]] \
+    if [[ "$rc" -ne 0 ]] && [[ "$out" == *"NOTHING is at that name now"* ]] \
        && [[ "$out" == *"after a stale lock was successfully cleared"* ]] \
-       && [[ "$out" == *"Re-running WITHOUT changing any of that will fail exactly the same way"* ]] \
+       && [[ "$out" == *"ORDER TO TELL THEM APART"* ]] \
        && [[ "$out" != *"taken again before this run could claim it"* ]]; then
-      pass "lane-lock B20: a post-reclaim claim that fails with NOTHING at the name is reported as a PATH failure, says the phase it happened in, and warns that re-running changes nothing — not as a lost race"
+      pass "lane-lock B20/B21: a post-reclaim claim that fails with NOTHING at the name reports that observation and the phase it happened in, and hands the operator both candidate causes in order — never the lost-race story"
     else
       fail "lane-lock-b20-conflated: rc=$rc out=[$out] — reporting a filesystem failure as a lost race sends the operator into a retry loop over a state that cannot resolve"
     fi
@@ -9115,7 +9119,7 @@ test_lane_lock_race_and_io_error_are_not_conflated() {
   mkdir -- "$SUPERVISOR_LOCK" 2>/dev/null || return 1'; then
     out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")"; rc=$?
     if [[ "$rc" -ne 0 ]] && [[ "$out" == *"taken again before this run could claim it"* ]] \
-       && [[ "$out" != *"could NOT BE CREATED"* ]]; then
+       && [[ "$out" != *"NOTHING is at that name now"* ]]; then
       pass "lane-lock B20 NON-VACUITY: when the name IS occupied the same failure is still reported as a lost race — the existence test discriminates, it does not just relabel everything as a path failure"
     else
       fail "lane-lock-b20-nonvacuity: rc=$rc out=[$out] — a genuine race must still read as a race"
@@ -9132,11 +9136,13 @@ test_lane_lock_race_and_io_error_are_not_conflated() {
        '  rm -rf -- "$SUPERVISOR_LOCK"
   if true; then'; then
     out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")"; rc=$?
-    if [[ "$rc" -ne 0 ]] && [[ "$out" == *"ALREADY GONE"* ]] \
-       && [[ "$out" == *"This is CONTENTION, not a filesystem fault"* ]] \
-       && [[ "$out" == *"nothing needs fixing"* ]] \
-       && [[ "$out" != *"This is a FILESYSTEM failure"* ]]; then
-      pass "lane-lock sweep (publish rename): a rename that fails because the directory vanished is reported as CONTENTION with 're-run' as the action — not as a disk problem the operator would go looking for"
+    # B21: the vanished directory is an OBSERVATION and may be reported; the CAUSE may not be claimed from
+    # it, because a peer can remove or recreate that name between the failure and the check either way.
+    if [[ "$rc" -ne 0 ]] && [[ "$out" == *"was GONE when this run looked"* ]] \
+       && [[ "$out" == *"NOT ESTABLISHED"* ]] \
+       && [[ "$out" == *"ORDER TO TELL THEM APART"* ]] \
+       && [[ "$out" != *"This is CONTENTION"* ]] && [[ "$out" != *"This is a FILESYSTEM failure"* ]]; then
+      pass "lane-lock sweep/B21 (publish rename): the vanished directory is reported as what was OBSERVED, the cause is explicitly not established, and the operator gets both candidates in order"
     else
       fail "lane-lock-sweep-rename: rc=$rc out=[$out]"
     fi
@@ -9150,11 +9156,11 @@ test_lane_lock_race_and_io_error_are_not_conflated() {
        '  if { : >"$marker"; } 2>/dev/null; then marker_written=1; fi' \
        '  rm -rf -- "$SUPERVISOR_LOCK" 2>/dev/null || true'; then
     out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")"; rc=$?
-    if [[ "$rc" -ne 0 ]] && [[ "$out" == *"ALREADY GONE"* ]] \
-       && [[ "$out" == *"This is CONTENTION, not a filesystem fault"* ]] \
+    if [[ "$rc" -ne 0 ]] && [[ "$out" == *"was GONE when this run looked"* ]] \
+       && [[ "$out" == *"NOT ESTABLISHED"* ]] \
        && [[ "$out" == *"already gone when it looked"* ]] \
-       && [[ "$out" != *"This is a FILESYSTEM failure"* ]]; then
-      pass "lane-lock sweep (marker write): a marker write that fails because the directory vanished is CONTENTION, and the refusal also states that nothing was left behind — because nothing was there to remove"
+       && [[ "$out" != *"This is CONTENTION"* ]] && [[ "$out" != *"This is a FILESYSTEM failure"* ]]; then
+      pass "lane-lock sweep/B21 (marker write): same at the marker step — the observation is reported, the cause is not claimed, and it still states that nothing was left behind because nothing was there to remove"
     else
       fail "lane-lock-sweep-marker: rc=$rc out=[$out]"
     fi
@@ -9168,10 +9174,18 @@ test_lane_lock_race_and_io_error_are_not_conflated() {
        '  if ! { printf '"'"'%s\n'"'"' "$$" >"$tmpf"; } 2>/dev/null; then' \
        '  if true; then'; then
     out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")" || true
-    if [[ "$out" == *"This is a FILESYSTEM failure"* ]] \
-       && [[ "$out" == *"check free space and mount options"* ]] \
-       && [[ "$out" != *"This is CONTENTION"* ]]; then
-      pass "lane-lock sweep NON-VACUITY: a genuine filesystem failure still reports as one and still sends the operator to df/mount — the nature discriminates both ways"
+    # B21 RETIRED THIS CONTROL'S ORIGINAL PROPERTY, AND THE REPLACEMENT IS THE ONE THAT IS TRUE. It used
+    # to require a genuine filesystem failure to be REPORTED as one — but this code cannot know that it
+    # was one (no errno, and the path's later state cannot decide it), so requiring the confident verdict
+    # was requiring a claim beyond the evidence: a test pinning an overclaim, the shape that kept this
+    # family alive. What must hold instead: the step that failed is named, both candidate causes are
+    # given with the order to check them, and NEITHER is asserted.
+    if [[ "$out" == *"no byte of it was written"* ]] \
+       && [[ "$out" == *"NOT ESTABLISHED"* ]] \
+       && [[ "$out" == *"check the PARENT directory"* ]] \
+       && [[ "$out" == *"CONTENTION: if all of those are clean"* ]] \
+       && [[ "$out" != *"This is a FILESYSTEM failure"* ]] && [[ "$out" != *"This is CONTENTION,"* ]]; then
+      pass "lane-lock B21: a failed write names the STEP that failed, states the cause is not established, and gives both candidates in order — the confident verdict is gone in BOTH directions, not swapped for the other one"
     else
       fail "lane-lock-sweep-nonvacuity: out=[$out]"
     fi
@@ -9200,6 +9214,112 @@ test_lane_lock_race_and_io_error_are_not_conflated() {
 }
 
 t test_lane_lock_race_and_io_error_are_not_conflated
+
+
+
+
+# ---------------------------------------------------------------------------
+# A FAILURE'S CAUSE IS NOT INFERRED FROM THE PATH'S LATER STATE (#3601, roborev job 245 B21).
+#
+# THE TWO DIRECTIONS, INTRODUCED TWO ROUNDS APART, BOTH FROM THE SAME PREDICATE:
+#   * job 244 (B20): `mkdir` fails with EEXIST, the name is present, and the code called it a PATH failure
+#     — contention reported as a disk problem, retry-able state reported as needing repair.
+#   * job 245 (B21): contender A moves the old lock aside; B's operation fails while the name is ABSENT;
+#     A republishes before B reaches the check. B reports a FILESYSTEM fault and sends an operator to
+#     repair permissions on a box that is fine — a disk problem reported where there was contention.
+#
+# A post-failure existence test cannot decide this in either direction, because a peer can remove or
+# recreate that name between the failure and the check. The failing call's errno is the only thing that
+# could, and this script cannot see it; recovering it from `mv`/`mkdir` stderr is locale-dependent guessing
+# dressed as a verdict (the cargo-output-parse class, CLAUDE.md #3400). So the ambiguity is PRESERVED —
+# and made actionable, because "retry versus fix the box" was the sweep's whole value and a shrug would
+# throw it away: the text names both candidates with what to check for each, in order.
+#
+# THE INTERLEAVING IS STAGED FOR REAL — the operation fails while the name is absent and the name is then
+# recreated with a foreign holder record before the code looks, which is exactly A republishing.
+# ---------------------------------------------------------------------------
+test_lane_lock_failure_cause_is_not_inferred_from_later_state() {
+  local d tmp lane lock out rc ovr
+  d="$(new_case_dir)"
+  common_env "$d"
+  tmp="$d/tmp"
+  lane="lane3601cause$$"
+  mkdir -p "$tmp"
+  lock="$tmp/cqlite-worker-supervisor-$lane.lock"
+
+  # ---- (1) THE B21 INTERLEAVING: disappearance, then reappearance, before the check.
+  rm -rf "$lock"
+  ovr="$d/f-gone-then-back.sh"; : >"$ovr"
+  if sv_mutant_override "$ovr" supervisor_lock_publish \
+       '  if ! mv -f -- "$tmpf" "$SUPERVISOR_LOCK/pid" 2>/dev/null; then' \
+       '  rm -rf -- "$SUPERVISOR_LOCK"
+  mkdir -p -- "$SUPERVISOR_LOCK" 2>/dev/null || true
+  printf "%s\n" 424242 >"$SUPERVISOR_LOCK/pid" 2>/dev/null || true
+  if true; then'; then
+    out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")"; rc=$?
+    if [[ "$rc" -ne 0 ]] && [[ "$out" == *"NOT ESTABLISHED"* ]] \
+       && [[ "$out" != *"This is a FILESYSTEM failure"* ]] \
+       && [[ "$out" != *"This is CONTENTION,"* ]]; then
+      pass "lane-lock B21: when the name vanishes and REAPPEARS before the check, the refusal asserts NEITHER cause — the interleaving that made the post-failure existence test report a disk fault over pure contention"
+    else
+      fail "lane-lock-b21-infers-cause: rc=$rc out=[$out] — a cause inferred from the path's later state is wrong in this interleaving whichever way it lands"
+    fi
+    # ...and it is still ACTIONABLE, which is the constraint that makes ambiguity acceptable here.
+    if [[ "$out" == *"ORDER TO TELL THEM APART"* ]] \
+       && [[ "$out" == *"A FILESYSTEM FAULT: check the PARENT directory"* ]] \
+       && [[ "$out" == *"CONTENTION: if all of those are clean"* ]]; then
+      pass "lane-lock B21: and the ambiguity is ACTIONABLE — both candidates are named, each with what to check, in the order to check them; an honest 'one of these two, here is how to tell' rather than a shrug"
+    else
+      fail "lane-lock-b21-unactionable: out=[$out] — going ambiguous without telling the operator how to discriminate gives up the sweep's whole value"
+    fi
+  fi
+
+  # ---- (2) THE PATH IS STILL NAMED FIRST, so #3601's own AC7 value survives the ambiguity: an operator
+  # facing an option-shaped or unwritable TMPDIR is still pointed at the parent before anything else.
+  local ro
+  ro="$d/ro-parent"
+  mkdir -p "$ro"
+  chmod 0555 "$ro" 2>/dev/null || true
+  if ( : >"$ro/.probe" ) 2>/dev/null; then
+    rm -f "$ro/.probe" 2>/dev/null || true
+    chmod 0755 "$ro" 2>/dev/null || true
+    skip "lane-lock B21 (2): this uid can write a 0555 directory (running as root), so an uncreatable lock path is not stageable here"
+  else
+    out="$(lane_lock_drive_at "$d" - "$ro" "$lane")"; rc=$?
+    chmod 0755 "$ro" 2>/dev/null || true
+    if [[ "$rc" -ne 0 ]] && [[ "$out" == *"NOTHING is at that name now"* ]] \
+       && [[ "$out" == *"A FILESYSTEM FAULT: check the PARENT directory"* ]] \
+       && [[ "$out" == *"TMPDIR"* ]]; then
+      pass "lane-lock B21: the uncreatable-path refusal still reports what it OBSERVED and still puts the parent directory and TMPDIR first — the useful half of AC7's fix survives dropping the confident verdict"
+    else
+      fail "lane-lock-b21-lost-ac7-value: rc=$rc out=[$out] — dropping the false claim must not drop the operator's first check"
+    fi
+  fi
+
+  # ---- (3) STRUCTURAL: no site may reintroduce a confident cause. The two emitters are the ONLY place a
+  # cause is described, so a new failure branch cannot quietly assert one — which is how B20 and B21 each
+  # arrived, one branch at a time.
+  local confident
+  confident="$(grep -nE "This is a FILESYSTEM failure|This is CONTENTION|not contention|nature='(filesystem|contention)'" "$SUPERVISOR" | grep -vE '^[0-9]+:[[:space:]]*#' || true)"
+  if [[ -z "$confident" ]]; then
+    pass "lane-lock B21 STRUCTURAL: no code line in the supervisor asserts a failure's cause as contention or filesystem — every site routes through the shared ambiguity emitters, so a new branch cannot claim one by accident"
+  else
+    fail "lane-lock-b21-confident-nature-returned: [$confident] — a cause asserted from a post-failure state check is unsound in both directions"
+  fi
+  # ...and both emitters must actually exist and be used, or (3) passes vacuously on a file that says
+  # nothing at all about causes.
+  local uses
+  uses="$(grep -c 'supervisor_lock_nature_unestablished\|supervisor_lock_nature_actions' "$SUPERVISOR" || true)"
+  if [[ "$uses" -ge 6 ]]; then
+    pass "lane-lock B21 STRUCTURAL: the ambiguity emitters are defined and referenced $uses times — (3) is asserting an absence over a file that does discuss causes, not over silence"
+  else
+    fail "lane-lock-b21-emitters-missing: only $uses reference(s) — the absence assert above would be vacuous"
+  fi
+
+  rm -rf "$tmp"
+}
+
+t test_lane_lock_failure_cause_is_not_inferred_from_later_state
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -9038,6 +9038,164 @@ test_lane_lock_uncreate_is_bound_to_the_created_instance() {
 t test_lane_lock_uncreate_is_bound_to_the_created_instance
 
 
+
+
+# ---------------------------------------------------------------------------
+# A RACE AND AN I/O ERROR MUST NOT SHARE A DIAGNOSTIC (#3601, roborev job 244 B20 + class sweep).
+#
+# THE DEFECT: `supervisor_lock_take` returns 1 when its `mkdir` fails, and `mkdir` fails BOTH because
+# someone else took the name (EEXIST — a race, where re-running is exactly right) and because the path
+# cannot hold a lock (EACCES/ENOSPC/ENOENT — where re-running loops forever over a state that cannot
+# resolve until permissions or disk are fixed). After a SUCCESSFUL rename-aside, every status 1 was
+# reported as a lost race: "a stale lock was cleared and the name was claimed by someone else … re-run
+# this supervisor". On a broken filesystem that tells an operator nothing is wrong and sends them into a
+# retry loop.
+#
+# WHY THIS ONE IS NOT JUST ANOTHER OVERCLAIM: it is #3601'S OWN HEADLINE DEFECT, one branch over. The AC7
+# addendum exists because the pre-fix code "blames the lock rather than the path shape, and an operator
+# goes looking for a stale lock that isn't there". The two facts want OPPOSITE actions — retry versus fix
+# the box — which is what makes conflating them a misdirection rather than an imprecision.
+#
+# THE SWEEP: three sites in this file shared that predicate and did not disambiguate (the post-reclaim
+# take, the publish's rename, the marker write); two others already did (the FIRST take, and the reclaim
+# rename), which is what made the omissions oversights rather than design. All five are asserted here.
+# ---------------------------------------------------------------------------
+test_lane_lock_race_and_io_error_are_not_conflated() {
+  local d tmp lane lock out rc dead ovr
+
+  d="$(new_case_dir)"
+  common_env "$d"
+  tmp="$d/tmp"
+  lane="lane3601conflate$$"
+  mkdir -p "$tmp"
+  lock="$tmp/cqlite-worker-supervisor-$lane.lock"
+
+  fixture_bg sleep 0.1
+  dead=$FIXTURE_LAST_PID
+  fixture_wait "$dead"
+
+  # ---- (1) B20: the SECOND take's mkdir fails while NOTHING is at the name. Fault-injected so only the
+  # second call fails, which is the interleaving the finding describes; the branch under test — the
+  # existence check that picks the refusal — is shipped code.
+  rm -rf "$lock"
+  mkdir -p "$lock"
+  printf '%s\n' "$dead" >"$lock/pid"
+  ovr="$d/f-second-take.sh"; : >"$ovr"
+  if sv_mutant_override "$ovr" supervisor_lock_take \
+       '  mkdir -- "$SUPERVISOR_LOCK" 2>/dev/null || return 1' \
+       '  if [[ -n "${SV_SECOND_TAKE:-}" ]]; then return 1; fi
+  export SV_SECOND_TAKE=1
+  mkdir -- "$SUPERVISOR_LOCK" 2>/dev/null || return 1'; then
+    out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")"; rc=$?
+    if [[ "$rc" -ne 0 ]] && [[ "$out" == *"could NOT BE CREATED"* ]] \
+       && [[ "$out" == *"after a stale lock was successfully cleared"* ]] \
+       && [[ "$out" == *"Re-running WITHOUT changing any of that will fail exactly the same way"* ]] \
+       && [[ "$out" != *"taken again before this run could claim it"* ]]; then
+      pass "lane-lock B20: a post-reclaim claim that fails with NOTHING at the name is reported as a PATH failure, says the phase it happened in, and warns that re-running changes nothing — not as a lost race"
+    else
+      fail "lane-lock-b20-conflated: rc=$rc out=[$out] — reporting a filesystem failure as a lost race sends the operator into a retry loop over a state that cannot resolve"
+    fi
+  fi
+
+  # ---- (2) NON-VACUITY: a real lost race must still be reported as one, or (1) is satisfied by code
+  # that has simply stopped recognising contention. The name is occupied by a LIVE holder at the moment
+  # the second take runs, so the existence check must select the race refusal.
+  rm -rf "$lock"
+  mkdir -p "$lock"
+  printf '%s\n' "$dead" >"$lock/pid"
+  ovr="$d/f-second-take-occupied.sh"; : >"$ovr"
+  if sv_mutant_override "$ovr" supervisor_lock_take \
+       '  mkdir -- "$SUPERVISOR_LOCK" 2>/dev/null || return 1' \
+       '  if [[ -n "${SV_SECOND_TAKE:-}" ]]; then mkdir -p -- "$SUPERVISOR_LOCK" 2>/dev/null || true; printf "%s\n" 313131 >"$SUPERVISOR_LOCK/pid" 2>/dev/null || true; return 1; fi
+  export SV_SECOND_TAKE=1
+  mkdir -- "$SUPERVISOR_LOCK" 2>/dev/null || return 1'; then
+    out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")"; rc=$?
+    if [[ "$rc" -ne 0 ]] && [[ "$out" == *"taken again before this run could claim it"* ]] \
+       && [[ "$out" != *"could NOT BE CREATED"* ]]; then
+      pass "lane-lock B20 NON-VACUITY: when the name IS occupied the same failure is still reported as a lost race — the existence test discriminates, it does not just relabel everything as a path failure"
+    else
+      fail "lane-lock-b20-nonvacuity: rc=$rc out=[$out] — a genuine race must still read as a race"
+    fi
+  fi
+
+  # ---- (3) SWEEP SITE: the publish's RENAME fails because the lock directory vanished under it. That is
+  # contention, and the pre-sweep text called every rename failure a FILESYSTEM failure and sent the
+  # operator to check a disk that is fine.
+  rm -rf "$lock"
+  ovr="$d/f-rename-gone.sh"; : >"$ovr"
+  if sv_mutant_override "$ovr" supervisor_lock_publish \
+       '  if ! mv -f -- "$tmpf" "$SUPERVISOR_LOCK/pid" 2>/dev/null; then' \
+       '  rm -rf -- "$SUPERVISOR_LOCK"
+  if true; then'; then
+    out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")"; rc=$?
+    if [[ "$rc" -ne 0 ]] && [[ "$out" == *"ALREADY GONE"* ]] \
+       && [[ "$out" == *"This is CONTENTION, not a filesystem fault"* ]] \
+       && [[ "$out" == *"nothing needs fixing"* ]] \
+       && [[ "$out" != *"This is a FILESYSTEM failure"* ]]; then
+      pass "lane-lock sweep (publish rename): a rename that fails because the directory vanished is reported as CONTENTION with 're-run' as the action — not as a disk problem the operator would go looking for"
+    else
+      fail "lane-lock-sweep-rename: rc=$rc out=[$out]"
+    fi
+  fi
+
+  # ---- (4) SWEEP SITE: the MARKER write fails because the directory vanished under it. Same predicate,
+  # same two natures, one step earlier.
+  rm -rf "$lock"
+  ovr="$d/f-marker-gone.sh"; : >"$ovr"
+  if sv_mutant_override "$ovr" supervisor_lock_take \
+       '  if ! { : >"$marker"; } 2>/dev/null && [[ ! -d "$SUPERVISOR_LOCK" ]]; then' \
+       '  rm -rf -- "$SUPERVISOR_LOCK"
+  if true; then'; then
+    out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")"; rc=$?
+    if [[ "$rc" -ne 0 ]] && [[ "$out" == *"ALREADY GONE"* ]] \
+       && [[ "$out" == *"This is CONTENTION, not a filesystem fault"* ]] \
+       && [[ "$out" == *"already gone when it looked"* ]] \
+       && [[ "$out" != *"This is a FILESYSTEM failure"* ]]; then
+      pass "lane-lock sweep (marker write): a marker write that fails because the directory vanished is CONTENTION, and the refusal also states that nothing was left behind — because nothing was there to remove"
+    else
+      fail "lane-lock-sweep-marker: rc=$rc out=[$out]"
+    fi
+  fi
+
+  # ---- (5) NON-VACUITY for (3)/(4): a REAL filesystem failure must still read as one. The write fails
+  # with the directory intact, so the nature must be `filesystem` and the action must be to check the box.
+  rm -rf "$lock"
+  ovr="$d/f-write-fs.sh"; : >"$ovr"
+  if sv_mutant_override "$ovr" supervisor_lock_publish \
+       '  if ! { printf '"'"'%s\n'"'"' "$$" >"$tmpf"; } 2>/dev/null; then' \
+       '  if true; then'; then
+    out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")" || true
+    if [[ "$out" == *"This is a FILESYSTEM failure"* ]] \
+       && [[ "$out" == *"check free space and mount options"* ]] \
+       && [[ "$out" != *"This is CONTENTION"* ]]; then
+      pass "lane-lock sweep NON-VACUITY: a genuine filesystem failure still reports as one and still sends the operator to df/mount — the nature discriminates both ways"
+    else
+      fail "lane-lock-sweep-nonvacuity: out=[$out]"
+    fi
+  fi
+
+  # ---- (6) STRUCTURAL: every remedy branch in the publish-failure refusal takes its FIRST ACTION from
+  # the failure's nature rather than hard-coding one. This is what stops a new cleanup branch being added
+  # with "fix the filesystem problem" baked in, which is how sites 3 and 4 came to misdirect.
+  local body hardcoded
+  body="$(sed -n '/^supervisor_lock_refuse_publish_failed()/,/^}/p' "$SUPERVISOR")"
+  if [[ -z "$body" || "$body" != *'supervisor_lock_refuse_publish_failed() {'* ]]; then
+    fail "lane-lock-sweep-structural-premise: could not extract the refusal from $SUPERVISOR"
+  else
+    hardcoded="$(printf '%s\n' "$body" | grep -n 'remedy=' | grep -v 'first_action' || true)"
+    if [[ -z "$hardcoded" ]]; then
+      pass "lane-lock sweep STRUCTURAL: every remedy branch derives its first action from the failure's NATURE — no branch hard-codes an action that could be aimed at the wrong cause"
+    else
+      fail "lane-lock-sweep-hardcoded-remedy: [$hardcoded] — a remedy that names an action without consulting the nature is how a race gets reported as a disk problem"
+    fi
+  fi
+
+  rm -rf "$lock" "$tmp"
+}
+
+t test_lane_lock_race_and_io_error_are_not_conflated
+
+
 # ---------------------------------------------------------------------------
 # Test 48 (#3549, roborev job 196 F2): THE SUITE LEAVES NO FIXTURE PROCESS BEHIND.
 #

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -7832,8 +7832,11 @@ test_lane_lock_nul_bearing_pid_file_refuses() {
   printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$shadow/wc"
   chmod +x "$shadow/wc"
   printf '%s\n' "$dead" >"$d/clean-pid"
+  # Re-staged at a path of its own: the remedy step above deliberately CLEARED the lock, so `$lock/pid`
+  # no longer exists by here and reading it would assert `pid-file-absent` instead of the NUL verdict.
+  printf '%s\000\n' "$dead" >"$d/nul-pid"
   local v_nul_nowc v_clean_nowc
-  v_nul_nowc="$(env SUP="$SUPERVISOR" F="$lock/pid" PATH="$shadow:$PATH" bash -c 'source "$SUP"; printf "%s" "$(supervisor_lock_pid_read "$F")"' 2>/dev/null || true)"
+  v_nul_nowc="$(env SUP="$SUPERVISOR" F="$d/nul-pid" PATH="$shadow:$PATH" bash -c 'source "$SUP"; printf "%s" "$(supervisor_lock_pid_read "$F")"' 2>/dev/null || true)"
   v_clean_nowc="$(env SUP="$SUPERVISOR" F="$d/clean-pid" PATH="$shadow:$PATH" bash -c 'source "$SUP"; printf "%s" "$(supervisor_lock_pid_read "$F")"' 2>/dev/null || true)"
   if [[ "$v_clean_nowc" == "pid $dead" ]]; then
     pass "lane-lock NUL (fork-free): a clean pid file still parses as [$v_clean_nowc] with \`wc\` unavailable — the detector is a builtin, so a missing coreutils tool cannot stop this lane starting"

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -6773,6 +6773,735 @@ t test_legacy_lock_refusals_never_advertise_the_override
 
 
 
+
+
+# ===========================================================================
+# THE PER-LANE LOCK (#3601) — `acquire_lock`'s OWN lock, the one every lane executes on every start.
+#
+# The cases below are the LIVE-PATH half of #3549's defect family. #3549 hardened the legacy
+# COMPATIBILITY guard, whose activation precondition was measurably empty, and recorded these four at
+# the site as out of scope. They are:
+#
+#   1. the holder pid used UNPARSED — an empty, garbled or multi-line `pid` file made `kill -0` fail,
+#      which read as "dead", and the lock was RECLAIMED FROM A LIVE HOLDER;
+#   2. the `mkdir`-then-populate window — a lock observable with NO pid file, which a peer read as a
+#      dead holder;
+#   3. two-valued liveness — `kill -0` fails with EPERM as well as ESRCH, so a live holder owned by
+#      another user read as dead;
+#   4. an "already running (pid N)" refusal asserting an identity it never checked;
+#   5. (addendum) every `TMPDIR`-derived operand missing a `--`, so an option-shaped `TMPDIR` stopped
+#      the lane from starting at all, with a diagnostic that blamed a stale lock instead of the path.
+#
+# MEASURED PRE-FIX, against `origin/main` at `674cffa9d`, so none of this is inferred:
+#   pid-less lock      -> `reclaiming stale lock …(holder pid  not alive)` + ACQUIRED
+#   pid file `not-a-pid` -> `reclaiming stale lock …(holder pid not-a-pid not alive)` + ACQUIRED
+#   pid file `1` (live, EPERM for a non-root uid) -> `…(holder pid 1 not alive)` + ACQUIRED
+#   TMPDIR=-scratch    -> `reclaiming stale lock -scratch/…` then `failed to acquire lock -scratch/…`
+#
+# EVERY CASE CARRIES A MUTANT CONTRAST, and the mutants are DERIVED from the shipped functions by
+# `sv_mutant_override` (one literal substitution, premises checked), so a mutant can never drift into a
+# re-implementation and a green assert can never be a green over code that was never the pre-fix form.
+# ===========================================================================
+
+# lane_lock_drive_at <cwd> <override|-> <tmp> <lane> [VAR=VAL ...] — ONE driver for every per-lane-lock
+# case, derived from the SAME `SV_DRIVE_BODY`/`SV_DRIVE_BODY_OVERRIDE` the legacy-guard cases use, so a
+# case that varies the working directory, the environment, or one function cannot drift into exercising
+# a different startup path than the ordinary case does. `-` for no override.
+#
+# A working directory is a parameter because a RELATIVE — and therefore possibly OPTION-SHAPED — `TMPDIR`
+# is only testable from a chosen cwd. `REPO_ROOT` is resolved from the SUPERVISOR's own location, not
+# from cwd, so moving cwd does not change any other resolution (verified by the pre-existing
+# `legacy_lock_drive_in` cases, which do the same thing).
+lane_lock_drive_at() {
+  local cwd="$1" override="$2" tmp="$3" lane="$4"
+  shift 4
+  if [[ "$override" == '-' ]]; then
+    ( cd "$cwd" && env -u SUPERVISOR_LOCK TMPDIR="$tmp" LANE_ID="$lane" LOCK_CMD="" CLAIM_CMD="" "$@" \
+        bash -c "$SV_DRIVE_BODY" _ "$SUPERVISOR" 2>&1 )
+  else
+    ( cd "$cwd" && env -u SUPERVISOR_LOCK TMPDIR="$tmp" LANE_ID="$lane" LOCK_CMD="" CLAIM_CMD="" "$@" \
+        bash -c "$SV_DRIVE_BODY_OVERRIDE" _ "$SUPERVISOR" "$override" 2>&1 )
+  fi
+}
+
+# A per-lane-lock refusal, told apart from the LEGACY one — an operator and a test both have to be able
+# to tell the two locks apart, which is why `legacy_refusal_ok` asserts the converse.
+lane_refusal_ok() {
+  local out="$1"
+  [[ "$out" == *"worker-supervisor: "* ]] \
+    && [[ "$out" != *"LEGACY GLOBAL supervisor lock"* ]] \
+    && [[ "$out" != *"ACQUIRED="* ]]
+}
+
+# The undecidable refusal must carry ITS REMEDY, and the remedy must be RUNNABLE AS PRINTED. That is
+# #3549 lead ruling 2 in mechanized form: "cannot tell ⇒ refuse" with no way out is a lane blocked by a
+# directory forever, which is broken rather than fail-closed. Asserted per case, not once, because each
+# refusing state builds its own text.
+lane_lock_remedy_ok() {
+  local label="$1" out="$2" lock="$3" bare
+  bare="$(printf '%s\n' "$out" | grep -vE "$SV_DIAG_RE" | grep -v '^$' | head -1)"
+  if [[ "$out" == *"worker-supervisor: remedy — "* ]] && [[ "$bare" == "rmdir -- "* ]]; then
+    pass "lane-lock remedy ($label): the refusal names a remedy and prints exactly one BARE runnable line, and it is the NON-RECURSIVE removal (line=[$bare]) — a refusal with no way out is a permanently blocked lane, not fail-closed"
+  else
+    fail "lane-lock-remedy-missing ($label): bare=[$bare] out=[$out] — every undecidable refusal must print the command that clears the lock"
+    return 0
+  fi
+  # ...AND IT MUST BE RUNNABLE, VERBATIM, AGAINST THE REAL PATH. A remedy that is only prose is what
+  # ruling 2 calls a permanent refusal with extra words.
+  local run_rc=0
+  eval "$bare" 2>/dev/null || run_rc=$?
+  if [[ "$run_rc" -eq 0 && ! -d "$lock" ]]; then
+    pass "lane-lock remedy ($label): the printed line runs VERBATIM and clears the lock — so this refusal is an instruction, not a dead end"
+  else
+    fail "lane-lock-remedy-not-runnable ($label): rc=$run_rc line=[$bare] lock still present=[$([[ -d "$lock" ]] && echo yes || echo no)]"
+  fi
+}
+
+
+# ---------------------------------------------------------------------------
+# AC1 — THE HOLDER PID IS PARSED BEFORE IT IS USED, AND AN UNPARSEABLE PID REFUSES.
+# ---------------------------------------------------------------------------
+test_lane_lock_holder_pid_is_parsed_before_use() {
+  local d tmp lane lock out rc dead shape ovr mout mrc
+  d="$(new_case_dir)"
+  common_env "$d"
+  tmp="$d/tmp"
+  lane="lane3601parse$$"
+  mkdir -p "$tmp"
+  lock="$tmp/cqlite-worker-supervisor-$lane.lock"
+
+  fixture_bg sleep 0.1
+  dead=$FIXTURE_LAST_PID
+  fixture_wait "$dead"
+
+  # ---- (0) THE NON-VACUITY FLOOR, FIRST, BECAUSE EVERY ASSERT BELOW IS A REFUSAL. A suite of
+  # refusals is satisfied by code that refuses unconditionally, and that code is BROKEN (ruling 2: a
+  # guard that never permits work is not fail-closed). So: a WELL-FORMED pid whose process is
+  # affirmatively gone must still be RECLAIMED, automatically, with no operator. This is the stale case
+  # that actually happens on this fleet — a holder killed by -9, an OOM, a reboot.
+  rm -rf "$lock"
+  mkdir -p "$lock"
+  printf '%s\n' "$dead" >"$lock/pid"
+  out="$(lane_lock_drive_at "$d" - "$tmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=2 SUPERVISOR_LOCK_PID_WAIT=0.01)"; rc=$?
+  if [[ "$rc" -eq 0 && "$out" == *"ACQUIRED=$lock"* && "$out" == *"affirmatively DEAD"* ]]; then
+    pass "lane-lock AC1 NON-VACUITY: a well-formed pid whose process is affirmatively gone is still RECLAIMED automatically — the refusals below are decisions, not a guard that always says no"
+  else
+    fail "lane-lock-reclaim-lost: rc=$rc out=[$out] — an affirmatively dead holder must still be reclaimed, or this change has broken the only automated way a stale lock clears"
+  fi
+  rm -rf "$lock"
+
+  # ---- (1) EVERY UNPARSEABLE SHAPE REFUSES, AND LEAVES THE LOCK EXACTLY AS FOUND. The shapes are the
+  # ones a crash, a truncation or a foreign writer produces — not a curated list of things that happen
+  # to fail, but one per rejection reason in `supervisor_lock_pid_read`.
+  local staged
+  for shape in EMPTY GARBLED TWOLINE TRAILING ZERO LEADINGZERO OVERLONG NOTAFILE; do
+    rm -rf "$lock"
+    mkdir -p "$lock"
+    case "$shape" in
+      EMPTY)       : >"$lock/pid" ;;
+      GARBLED)     printf 'not-a-pid\n' >"$lock/pid" ;;
+      TWOLINE)     printf '%s\n%s\n' "$dead" "$dead" >"$lock/pid" ;;
+      TRAILING)    printf '%s x\n' "$dead" >"$lock/pid" ;;
+      ZERO)        printf '0\n' >"$lock/pid" ;;
+      LEADINGZERO) printf '0%s\n' "$dead" >"$lock/pid" ;;
+      OVERLONG)    printf '123456789012345\n' >"$lock/pid" ;;
+      NOTAFILE)    mkdir -p "$lock/pid" ;;
+    esac
+    staged="$(ls -A "$lock" | tr '\n' ' ')"
+    out="$(lane_lock_drive_at "$d" - "$tmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=2 SUPERVISOR_LOCK_PID_WAIT=0.01)"; rc=$?
+    if [[ "$rc" -ne 0 ]] && lane_refusal_ok "$out" \
+       && [[ "$out" == *"could NOT DECIDE"* ]] && [[ "$out" != *"reclaiming stale lock"* ]] \
+       && [[ -d "$lock" ]] && [[ "$(ls -A "$lock" | tr '\n' ' ')" == "$staged" ]]; then
+      pass "lane-lock AC1 ($shape): an unparseable holder pid REFUSES, names the parse verdict, reclaims nothing and leaves the lock byte-for-byte as found"
+    else
+      fail "lane-lock-unparsed-pid ($shape): rc=$rc out=[$out] lock-contents=[$(ls -A "$lock" 2>/dev/null | tr '\n' ' ')] — an unparseable pid must never be read as a dead holder"
+    fi
+    # The cause must NAME the parse verdict, not merely refuse: "cannot tell" and "the holder is there"
+    # are different facts with different remedies (#3549 lead ruling 1).
+    if [[ "$out" == *"unparseable pid-"* ]]; then
+      pass "lane-lock AC1 ($shape): the refusal names WHICH parse rejected the content, so the cause is the probe's verdict and not a bare 'refused'"
+    else
+      fail "lane-lock-unparsed-cause ($shape): out=[$out] — the refusal must name the parse verdict"
+    fi
+    # AND THE WAY OUT (ruling 2). Checked for the shapes whose lock a non-recursive removal can clear —
+    # for the two shapes that leave content behind, `rmdir` correctly REFUSES, which is the safety
+    # property the command was chosen for and is asserted separately below.
+    case "$shape" in
+      EMPTY | GARBLED | TWOLINE | TRAILING | ZERO | LEADINGZERO | OVERLONG)
+        rm -f -- "$lock/pid"
+        lane_lock_remedy_ok "$shape" "$out" "$lock"
+        ;;
+    esac
+  done
+
+  # ---- (2) THE PRINTED REMEDY IS NON-RECURSIVE, AND THAT IS THE SAFETY PROPERTY. With content still in
+  # the lock the printed line must FAIL rather than delete something nobody examined — the opposite of
+  # an `rm -rf`, which would destroy the evidence of the state we could not decide.
+  rm -rf "$lock"
+  mkdir -p "$lock"
+  printf 'not-a-pid\n' >"$lock/pid"
+  out="$(lane_lock_drive_at "$d" - "$tmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=2 SUPERVISOR_LOCK_PID_WAIT=0.01)" || true
+  local bare rmrc=0
+  bare="$(printf '%s\n' "$out" | grep -vE "$SV_DIAG_RE" | grep -v '^$' | head -1)"
+  eval "$bare" 2>/dev/null || rmrc=$?
+  if [[ "$rmrc" -ne 0 && -f "$lock/pid" ]]; then
+    pass "lane-lock AC1 (remedy safety): with content still inside the lock the printed removal REFUSES (rc=$rmrc) and the pid file survives — a mis-paste cannot destroy a holder's record"
+  else
+    fail "lane-lock-remedy-destructive: rc=$rmrc line=[$bare] — the printed remedy deleted contents nobody examined"
+  fi
+
+  # ---- (3) MUTANT CONTRAST: the PRE-FIX semantics, which is exactly "an unparseable pid is a holder
+  # pid, and `kill -0` failing on it means dead". Expressed as ONE substitution in the shipped parse: the
+  # non-digit rejection returns a (known-dead) pid instead of a named refusal. With that, the shipped
+  # decision path reclaims the lock — which is the measured pre-fix behaviour, reproduced from shipped
+  # code rather than from a copy of it.
+  rm -rf "$lock"
+  mkdir -p "$lock"
+  printf 'not-a-pid\n' >"$lock/pid"
+  ovr="$d/m-parse.sh"; : >"$ovr"
+  mrc=0
+  if sv_mutant_override "$ovr" supervisor_lock_pid_read \
+       "      printf '%s' 'unparseable pid-not-all-decimal-digits'" \
+       "      printf '%s' 'pid $dead'"; then
+    mout="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=2 SUPERVISOR_LOCK_PID_WAIT=0.01)" || mrc=$?
+    if [[ "$mrc" -eq 0 && "$mout" == *"ACQUIRED=$lock"* && "$mout" == *"reclaiming stale lock"* ]]; then
+      pass "lane-lock AC1 MUTANT: with the parse's non-digit rejection turned back into a holder pid, the SAME drive RECLAIMS the lock (the measured pre-fix behaviour) — so the refusals above are the parse doing the work, not the harness"
+    else
+      fail "lane-lock-mutant-parse: rc=$mrc out=[$mout] — the pre-fix form must be shown to reclaim, or every AC1 assert measures nothing"
+    fi
+  fi
+  rm -rf "$lock" "$tmp"
+}
+
+t test_lane_lock_holder_pid_is_parsed_before_use
+
+
+# ---------------------------------------------------------------------------
+# AC2 / AC5 — THE PID-LESS WINDOW, DRIVEN WITH A REAL COMPETING PROCESS AND A FORCED INTERLEAVING.
+#
+# The window is `mkdir` (the lock now exists) … `pid` published. A peer arriving inside it saw a lock
+# with no pid file and reclaimed it from a holder that was alive and starting. This case stages that
+# interleaving with an actual second process rather than by argument, in both of its shapes:
+#
+#   (i)  THE HOLDER IS STARTING — pid-less now, published shortly. The arriving run must end up
+#        refusing over the REAL holder pid: the window resolves into a fact, and the fact is "held".
+#   (ii) THE HOLDER DIED INSIDE THE WINDOW — pid-less forever. The arriving run must REFUSE (never
+#        reclaim), because "pid-less" is not evidence of death, and must print the way out.
+#
+# THE DISCRIMINATOR IS PERSISTENCE, NOT DURATION, and that is why (i) and (ii) are BOTH here: a timing
+# heuristic would have to pick a number that is right for one of them and wrong for the other. Case (i)
+# uses a delay well inside the bounded window and case (ii) never publishes at all, so the two are
+# separated by whether the state RESOLVES, not by how long the test waited.
+# ---------------------------------------------------------------------------
+test_lane_lock_pidless_window_is_never_read_as_dead() {
+  local d tmp lane lock out rc peer peerpid ovr mout mrc
+  d="$(new_case_dir)"
+  common_env "$d"
+  tmp="$d/tmp"
+  lane="lane3601window$$"
+  mkdir -p "$tmp"
+  lock="$tmp/cqlite-worker-supervisor-$lane.lock"
+
+  # ---- (i) A REAL PEER HOLDING A PID-LESS LOCK THAT IT THEN PUBLISHES.
+  rm -rf "$lock"
+  fixture_bg bash -c 'mkdir -p "$1"; sleep "$2"; printf "%s\n" "$$" >"$1/pid"; sleep 30' _ "$lock" 0.4
+  peer=$FIXTURE_LAST_PID
+  # Wait for the peer to have CREATED the lock, so the drive genuinely starts inside the window rather
+  # than before it. This is a precondition wait on an observable fact, not a timing guess.
+  local waited=0
+  while [[ ! -d "$lock" && "$waited" -lt 50 ]]; do sleep 0.02; waited=$((waited + 1)); done
+  if [[ -d "$lock" && ! -f "$lock/pid" ]]; then
+    pass "lane-lock AC2 PREMISE (i): the drive below starts with the peer's lock present and PID-LESS — the interleaving is staged, not assumed"
+  else
+    fail "lane-lock-window-premise: lock present=[$([[ -d "$lock" ]] && echo yes || echo no)] pid present=[$([[ -f "$lock/pid" ]] && echo yes || echo no)] — the window was not staged and the assert below has no subject"
+  fi
+  out="$(lane_lock_drive_at "$d" - "$tmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=200 SUPERVISOR_LOCK_PID_WAIT=0.02)"; rc=$?
+  peerpid="$(cat "$lock/pid" 2>/dev/null || true)"
+  if [[ "$rc" -ne 0 ]] && lane_refusal_ok "$out" && [[ "$out" != *"reclaiming stale lock"* ]] \
+     && [[ -d "$lock" ]] && [[ -n "$peerpid" ]] && [[ "$out" == *"already running (pid $peerpid)"* ]]; then
+    pass "lane-lock AC2 (i): a run arriving inside a real peer's PID-LESS window waits the window out, reads the peer's PUBLISHED pid and refuses over it — the peer's lock is untouched and nothing was reclaimed"
+  else
+    fail "lane-lock-window-starting: rc=$rc peerpid=[$peerpid] lock=[$([[ -d "$lock" ]] && echo present || echo GONE)] out=[$out] — a starting holder must never be read as a dead one"
+  fi
+  fixture_kill "$peer"
+  rm -rf "$lock"
+
+  # ---- (ii) THE PID-LESS LOCK THAT NEVER RESOLVES — a holder killed inside its own window. Persistent,
+  # so the verdict is "undecidable", and undecidable REFUSES. The bound is small here on purpose: the
+  # measurement is of PERSISTENCE, so a short bound is sufficient to establish it and the case does not
+  # pay for the long window (i) needs.
+  mkdir -p "$lock"
+  out="$(lane_lock_drive_at "$d" - "$tmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=3 SUPERVISOR_LOCK_PID_WAIT=0.01)"; rc=$?
+  if [[ "$rc" -ne 0 ]] && lane_refusal_ok "$out" && [[ "$out" == *"pid-file-absent"* ]] \
+     && [[ "$out" != *"reclaiming stale lock"* ]] && [[ -d "$lock" ]]; then
+    pass "lane-lock AC2 (ii): a PERSISTENTLY pid-less lock is UNDECIDABLE and refuses — it is never read as stale, and the lock is left as found"
+  else
+    fail "lane-lock-window-persistent: rc=$rc out=[$out] lock=[$([[ -d "$lock" ]] && echo present || echo GONE)]"
+  fi
+  # It must also say how many reads it took, so the refusal reports a MEASUREMENT and not an assumption.
+  if [[ "$out" == *"read(s) over a bounded window"* ]]; then
+    pass "lane-lock AC2 (ii): the refusal states that the verdict came from repeated reads over a bounded window — a measurement of persistence, reported as one"
+  else
+    fail "lane-lock-window-not-reported: out=[$out]"
+  fi
+  lane_lock_remedy_ok "pid-file-absent" "$out" "$lock"
+
+  # ---- (iii) NO `.stale.*` RESIDUE ANYWHERE. A refusal must leave nothing behind it: the reclaim path
+  # renames the lock aside, so a refusal that had touched it would leave that name in the tree.
+  local residue
+  residue="$(find "$tmp" -name '*.stale.*' 2>/dev/null | wc -l | tr -d ' ')"
+  if [[ "$residue" == "0" ]]; then
+    pass "lane-lock AC2: no rename-aside residue exists anywhere under the case TMPDIR after the refusals — a refusing run mutated nothing"
+  else
+    fail "lane-lock-stale-residue: $residue path(s) — a refusal touched a lock it does not own"
+  fi
+
+  # ---- (iv) MUTANT CONTRAST: pid-less read as a dead holder, which IS the pre-fix behaviour (measured:
+  # `reclaiming stale lock … (holder pid  not alive)` + ACQUIRED). One substitution, in the shipped
+  # parse's absent-file branch.
+  rm -rf "$lock"
+  mkdir -p "$lock"
+  local deadpid
+  fixture_bg sleep 0.1
+  deadpid=$FIXTURE_LAST_PID
+  fixture_wait "$deadpid"
+  ovr="$d/m-window.sh"; : >"$ovr"
+  mrc=0
+  if sv_mutant_override "$ovr" supervisor_lock_pid_read \
+       "    printf '%s' 'unparseable pid-file-absent'" \
+       "    printf '%s' 'pid $deadpid'"; then
+    mout="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=3 SUPERVISOR_LOCK_PID_WAIT=0.01)" || mrc=$?
+    if [[ "$mrc" -eq 0 && "$mout" == *"ACQUIRED=$lock"* && "$mout" == *"reclaiming stale lock"* ]]; then
+      pass "lane-lock AC2 MUTANT: with a pid-less lock reported as a (dead) holder pid, the SAME drive RECLAIMS a lock whose holder it never established — the measured pre-fix behaviour, so the refusals above are the probe doing the work"
+    else
+      fail "lane-lock-mutant-window: rc=$mrc out=[$mout] — the pre-fix form must be shown to reclaim"
+    fi
+  fi
+  rm -rf "$lock" "$tmp"
+}
+
+t test_lane_lock_pidless_window_is_never_read_as_dead
+
+
+# ---------------------------------------------------------------------------
+# AC3 — LIVENESS IS THREE-VALUED, AND ONLY AN AFFIRMATIVE `dead` RECLAIMS.
+#
+# THE CASE IS REAL EPERM, NOT A SIMULATION OF IT. `kill -0 1` from a non-root uid fails with EPERM: pid 1
+# EXISTS and is not ours to signal. Pre-fix that failure read as "not alive" and the lock was reclaimed
+# (measured). This is the same errno a live holder owned by ANOTHER USER produces, which is the fleet
+# case the two-valued test could not see.
+# ---------------------------------------------------------------------------
+test_lane_lock_liveness_is_three_valued() {
+  local d tmp lane lock out rc ovr mout mrc live
+  d="$(new_case_dir)"
+  common_env "$d"
+  tmp="$d/tmp"
+  lane="lane3601live$$"
+  mkdir -p "$tmp"
+  lock="$tmp/cqlite-worker-supervisor-$lane.lock"
+
+  # ---- (1) A LIVE HOLDER WE CAN SIGNAL: refuse. The ordinary case, kept as the floor.
+  rm -rf "$lock"; mkdir -p "$lock"
+  fixture_bg sleep 30
+  live=$FIXTURE_LAST_PID
+  printf '%s\n' "$live" >"$lock/pid"
+  out="$(lane_lock_drive_at "$d" - "$tmp" "$lane")"; rc=$?
+  if [[ "$rc" -ne 0 && "$out" == *"already running (pid $live)"* && "$out" != *"reclaiming stale lock"* ]]; then
+    pass "lane-lock AC3 (live, signallable): a live holder refuses and is named"
+  else
+    fail "lane-lock-live-signallable: rc=$rc out=[$out]"
+  fi
+  fixture_kill "$live"
+
+  # ---- (2) A LIVE HOLDER WE CANNOT SIGNAL — REAL EPERM. This is the assert #3601 exists for.
+  if kill -0 1 2>/dev/null; then
+    skip "lane-lock AC3 (EPERM): this uid CAN signal pid 1 (running as root), so no EPERM case is stageable here — the property is unmeasurable on this host rather than passing vacuously"
+  else
+    rm -rf "$lock"; mkdir -p "$lock"
+    printf '1\n' >"$lock/pid"
+    out="$(lane_lock_drive_at "$d" - "$tmp" "$lane")"; rc=$?
+    if [[ "$rc" -ne 0 ]] && [[ "$out" == *"already running (pid 1)"* ]] \
+       && [[ "$out" != *"reclaiming stale lock"* ]] && [[ -f "$lock/pid" ]]; then
+      pass "lane-lock AC3 (EPERM): a holder that EXISTS but is not ours to signal refuses — the errno that a live holder owned by another user produces is no longer read as death"
+    else
+      fail "lane-lock-eperm-reclaimed: rc=$rc out=[$out] — a live, unsignallable holder was read as dead; this is the measured pre-fix defect"
+    fi
+
+    # ---- MUTANT CONTRAST for (2): the pre-fix two-valued test, restored by ONE substitution — any
+    # non-zero `kill -0` means dead. Both of the shipped probe's existence witnesses (procfs, and the
+    # EPERM message) are bypassed by it, so the mutant is the pre-fix decision exactly.
+    ovr="$d/m-live.sh"; : >"$ovr"
+    mrc=0
+    if sv_mutant_override "$ovr" supervisor_lock_holder_liveness \
+         '  if [[ -d /proc/self && -d "/proc/$pid" ]]; then' \
+         '  if [[ "$rc" -ne 0 ]]; then printf "%s" dead; return 0; fi
+  if [[ -d /proc/self && -d "/proc/$pid" ]]; then'; then
+      mout="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")" || mrc=$?
+      if [[ "$mrc" -eq 0 && "$mout" == *"ACQUIRED=$lock"* && "$mout" == *"reclaiming stale lock"* ]]; then
+        pass "lane-lock AC3 MUTANT: with liveness collapsed back to the two-valued \`kill -0\`, the SAME drive RECLAIMS pid 1's lock — a LIVE process's lock, which is the pre-fix behaviour and the harm #3601 fixes"
+      else
+        fail "lane-lock-mutant-live: rc=$mrc out=[$mout] — the two-valued form must be shown to reclaim a live holder's lock"
+      fi
+    fi
+  fi
+
+  # ---- (3) THE PROBE'S THIRD VALUE EXISTS AND REFUSES. A pid `kill` cannot even interpret is neither
+  # live nor dead; `unknown` must refuse, never reclaim. Reached through the probe directly, because the
+  # parse (correctly) rejects such content before `acquire_lock` ever calls the probe — asserting it here
+  # is what stops the third value being unreachable dead code that a later edit deletes as unused.
+  local verdict
+  verdict="$(env SUP="$SUPERVISOR" bash -c 'source "$SUP"; supervisor_lock_holder_liveness "not-a-pid"' 2>/dev/null || true)"
+  if [[ "$verdict" == unknown* ]]; then
+    pass "lane-lock AC3 (third value): a pid the kernel cannot be asked about yields \`$verdict\` — not \`dead\`, so nothing downstream can read an unanswerable probe as a licence to reclaim"
+  else
+    fail "lane-lock-liveness-not-three-valued: verdict=[$verdict] — a probe that cannot answer must say so"
+  fi
+  # ...and the two answerable values, from the same probe, so the three-valued claim is measured whole.
+  verdict="$(env SUP="$SUPERVISOR" bash -c 'source "$SUP"; supervisor_lock_holder_liveness "$$"' 2>/dev/null || true)"
+  if [[ "$verdict" == live ]]; then
+    pass "lane-lock AC3: the probe reports \`live\` for a process that demonstrably exists (its own pid)"
+  else
+    fail "lane-lock-liveness-live: verdict=[$verdict]"
+  fi
+  local dead2
+  fixture_bg sleep 0.1
+  dead2=$FIXTURE_LAST_PID
+  fixture_wait "$dead2"
+  verdict="$(env SUP="$SUPERVISOR" DP="$dead2" bash -c 'source "$SUP"; supervisor_lock_holder_liveness "$DP"' 2>/dev/null || true)"
+  if [[ "$verdict" == dead ]]; then
+    pass "lane-lock AC3: the probe reports \`dead\` for a reaped process — the affirmative verdict the reclaim requires is reachable, so the fix has not made every lock permanent"
+  else
+    fail "lane-lock-liveness-dead: verdict=[$verdict] — without a reachable \`dead\` nothing ever clears a stale lock automatically"
+  fi
+
+  rm -rf "$lock" "$tmp"
+}
+
+t test_lane_lock_liveness_is_three_valued
+
+
+# ---------------------------------------------------------------------------
+# AC4 — THE "ALREADY RUNNING" REFUSAL DOES NOT ASSERT AN IDENTITY IT NEVER CHECKED.
+#
+# It has established that the recorded pid EXISTS. It has NOT established that the process is a
+# supervisor, and pids are REUSED — so a lock abandoned by a dead holder can name a number the kernel
+# has since given to something unrelated. AC4 allows either corroborating the identity or declaring the
+# gap; the gap is declared, because the verdict could not change the decision (`live` refuses whatever
+# the process is) and #3549's ruling on exactly that shape is that such machinery is a description
+# generator on the decision path, not a guard.
+# ---------------------------------------------------------------------------
+test_lane_lock_running_refusal_declares_unverified_identity() {
+  local d tmp lane lock out rc live ovr mout
+  d="$(new_case_dir)"
+  common_env "$d"
+  tmp="$d/tmp"
+  lane="lane3601ident$$"
+  mkdir -p "$tmp"
+  lock="$tmp/cqlite-worker-supervisor-$lane.lock"
+  mkdir -p "$lock"
+  fixture_bg sleep 30
+  live=$FIXTURE_LAST_PID
+  printf '%s\n' "$live" >"$lock/pid"
+
+  out="$(lane_lock_drive_at "$d" - "$tmp" "$lane")"; rc=$?
+  if [[ "$rc" -ne 0 && "$out" == *"already running (pid $live)"* ]]; then
+    pass "lane-lock AC4 PREMISE: the running refusal was reached, so the text below has a subject"
+  else
+    fail "lane-lock-ac4-premise: rc=$rc out=[$out]"
+  fi
+  if [[ "$out" == *"IDENTITY IS NOT VERIFIED"* ]] && [[ "$out" == *"pids are REUSED"* ]]; then
+    pass "lane-lock AC4: the refusal states plainly that it did NOT verify the pid is a supervisor and that pids are reused — the scope is declared in the text an operator reads, which is what stops the message asserting a fact it never established"
+  else
+    fail "lane-lock-ac4-unqualified-identity: out=[$out] — 'another instance is already running (pid N)' with no scope statement asserts an identity the run never checked"
+  fi
+  # The refusal must also hand the operator the read-only line that ANSWERS the question it left open.
+  if [[ "$out" == *"ps -p $live -o pid,ppid,user,lstart,args"* ]]; then
+    pass "lane-lock AC4: it names the read-only command that settles the identity it did not check — the declared gap comes with the way to close it"
+  else
+    fail "lane-lock-ac4-no-identity-probe-offered: out=[$out]"
+  fi
+
+  # ---- MUTANT CONTRAST: the pre-fix wording, restored by one substitution. The assert above must be
+  # shown to red on exactly that text, or it is a green over a string that was never absent.
+  ovr="$d/m-ident.sh"; : >"$ovr"
+  if sv_mutant_override "$ovr" acquire_lock \
+       '        "pid $holder_pid is recorded as this lane'"'"'s lock holder and that process EXISTS (verified: it is signallable, or the kernel reports it exists but is not ours to signal). ITS IDENTITY IS NOT VERIFIED — this run did not check that pid $holder_pid is a worker-supervisor, and pids are REUSED, so a lock abandoned by a dead holder can name a number that now belongs to an unrelated process" \' \
+       '        "another instance is already running (pid $holder_pid)" \'; then
+    mout="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")" || true
+    if [[ "$mout" == *"already running (pid $live)"* ]] && [[ "$mout" != *"IDENTITY IS NOT VERIFIED"* ]]; then
+      pass "lane-lock AC4 MUTANT: with the scope statement removed the refusal still fires and now claims 'another instance' with nothing behind it — so the assert above reds on exactly the pre-fix text"
+    else
+      fail "lane-lock-mutant-ident: out=[$mout] — the pre-fix wording must be shown to lose the scope statement"
+    fi
+  fi
+  fixture_kill "$live"
+  rm -rf "$lock" "$tmp"
+}
+
+t test_lane_lock_running_refusal_declares_unverified_identity
+
+
+# ---------------------------------------------------------------------------
+# AC7 — AN OPTION-SHAPED `TMPDIR` MUST NOT STOP THE LANE FROM STARTING.
+#
+# QUOTING IS NOT OPTION-SAFETY. `"$SUPERVISOR_LOCK"` stops word-splitting and globbing and does nothing
+# about option parsing: `mkdir`, `mv` and `rm` read a leading `-` in an operand as flags whatever quoting
+# produced it. MEASURED pre-fix with `TMPDIR=-scratch`: `reclaiming stale lock -scratch/…` followed by
+# `failed to acquire lock -scratch/…` — the lane cannot start, and the diagnostic blames a stale lock
+# that does not exist, which is the expensive half.
+#
+# BOTH PATHS ARE DRIVEN, because they use different operands: the fresh-claim path (`mkdir`, and the
+# publish's `mv`) and the reclaim path (`mv` aside, `rm -rf`). The pid is read by REDIRECTION, which
+# parses no options at all, so the `cat` the addendum named is gone rather than terminated.
+# ---------------------------------------------------------------------------
+test_lane_lock_option_shaped_tmpdir_starts_normally() {
+  local d optdir opttmp lane lock out rc dead ovr mout mrc
+  d="$(new_case_dir)"
+  common_env "$d"
+  optdir="$d/optshaped"
+  opttmp="-scratch"
+  lane="lane3601opt$$"
+  mkdir -p "$optdir/$opttmp"
+  lock="$optdir/$opttmp/cqlite-worker-supervisor-$lane.lock"
+
+  # ---- (1) THE FRESH CLAIM.
+  rm -rf "$lock"
+  out="$(lane_lock_drive_at "$optdir" - "$opttmp" "$lane")"; rc=$?
+  if [[ "$rc" -eq 0 ]] && [[ "$out" == *"ACQUIRED=$opttmp/cqlite-worker-supervisor-$lane.lock"* ]] \
+     && [[ "$out" == *"LOCKDIR=yes"* ]] && [[ "$out" != *"reclaiming stale lock"* ]] \
+     && [[ "$out" != *"failed to acquire"* ]]; then
+    pass "lane-lock AC7 (fresh claim): with a relative, option-shaped TMPDIR the lock is acquired NORMALLY — no invented stale lock, no refusal"
+  else
+    fail "lane-lock-optshaped-fresh: rc=$rc out=[$out] — an option-shaped TMPDIR must not stop the lane from starting"
+  fi
+
+  # ---- (2) THE RECLAIM PATH, same TMPDIR shape: `mv` aside and `rm -rf` both take the option-shaped
+  # operand, and neither is exercised by (1).
+  fixture_bg sleep 0.1
+  dead=$FIXTURE_LAST_PID
+  fixture_wait "$dead"
+  rm -rf "$lock"
+  mkdir -p "$lock"
+  printf '%s\n' "$dead" >"$lock/pid"
+  out="$(lane_lock_drive_at "$optdir" - "$opttmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=2 SUPERVISOR_LOCK_PID_WAIT=0.01)"; rc=$?
+  if [[ "$rc" -eq 0 && "$out" == *"reclaiming stale lock"* && "$out" == *"LOCKDIR=yes"* ]]; then
+    pass "lane-lock AC7 (reclaim): the rename-aside and removal operands are option-safe too — a genuinely stale lock under an option-shaped TMPDIR is still cleared automatically"
+  else
+    fail "lane-lock-optshaped-reclaim: rc=$rc out=[$out]"
+  fi
+  local residue
+  residue="$(find "$optdir" -name '*.stale.*' 2>/dev/null | wc -l | tr -d ' ')"
+  if [[ "$residue" == "0" ]]; then
+    pass "lane-lock AC7 (reclaim): the renamed-aside copy was removed — the `rm -rf` operand parsed as a path, not as flags"
+  else
+    fail "lane-lock-optshaped-aside-leak: $residue leftover aside path(s) under $optdir — the removal's operand was eaten as an option"
+  fi
+
+  # ---- (3) MUTANT CONTRAST: strip the `--` from the claim's `mkdir`, which is the pre-fix spelling.
+  # Without it the identical case must FAIL, or the `--` in the shipped line is decoration.
+  rm -rf "$lock"
+  ovr="$d/m-opt.sh"; : >"$ovr"
+  mrc=0
+  if sv_mutant_override "$ovr" supervisor_lock_take \
+       '  mkdir -- "$SUPERVISOR_LOCK" 2>/dev/null || return 1' \
+       '  mkdir "$SUPERVISOR_LOCK" 2>/dev/null || return 1'; then
+    mout="$(lane_lock_drive_at "$optdir" "$ovr" "$opttmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=2 SUPERVISOR_LOCK_PID_WAIT=0.01)" || mrc=$?
+    if [[ "$mrc" -ne 0 && "$mout" != *"ACQUIRED="* ]]; then
+      pass "lane-lock AC7 MUTANT: with \`--\` stripped from the claim's mkdir the SAME case FAILS to start (rc=$mrc) — so the terminator is load-bearing, not decoration"
+    else
+      fail "lane-lock-mutant-opt: rc=$mrc out=[$mout] — the pre-fix spelling must be shown to break here"
+    fi
+  fi
+  # ...and the same for the reclaim's `mv`, whose operand (1) and (3) never reach.
+  rm -rf "$lock"
+  mkdir -p "$lock"
+  printf '%s\n' "$dead" >"$lock/pid"
+  ovr="$d/m-opt-mv.sh"; : >"$ovr"
+  mrc=0
+  if sv_mutant_override "$ovr" acquire_lock \
+       '  if mv -f -- "$SUPERVISOR_LOCK" "$SUPERVISOR_LOCK.stale.$$" 2>/dev/null; then' \
+       '  if mv -f "$SUPERVISOR_LOCK" "$SUPERVISOR_LOCK.stale.$$" 2>/dev/null; then'; then
+    mout="$(lane_lock_drive_at "$optdir" "$ovr" "$opttmp" "$lane" SUPERVISOR_LOCK_PID_TRIES=2 SUPERVISOR_LOCK_PID_WAIT=0.01)" || mrc=$?
+    if [[ "$mrc" -ne 0 && "$mout" != *"ACQUIRED="* ]]; then
+      pass "lane-lock AC7 MUTANT (reclaim mv): with \`--\` stripped from the rename-aside the SAME reclaim FAILS (rc=$mrc) — the reclaim path's terminator is load-bearing on its own"
+    else
+      fail "lane-lock-mutant-opt-mv: rc=$mrc out=[$mout]"
+    fi
+  fi
+
+  rm -rf "$optdir"
+}
+
+t test_lane_lock_option_shaped_tmpdir_starts_normally
+
+
+# ---------------------------------------------------------------------------
+# THE OWNERSHIP HALF, FOUND BY THE CALL-SITE SWEEP THIS ISSUE MANDATES (#3601).
+#
+# AC1-AC3 stop us TAKING a lock we do not own. The same defect class points the other way at the same
+# call site and had no acceptance criterion: the EXIT trap was an unconditional
+# `rm -rf "$SUPERVISOR_LOCK"`, so a run that had LOST its lock (a peer running pre-#3601 code reclaims a
+# pid-less lock, which ours is for one rename at startup) deleted the NEW holder's lock on the way out,
+# handing the lane to a third process while the second believed it held exclusion.
+#
+# Both halves are decided by the same ONE observation — does the lock's pid file read back as OUR pid —
+# which is #3549 lead ruling 5 applied: the question "do we hold this lock?" is answered by a single
+# reading rather than by a tuple of pid, liveness and identity agreeing.
+# ---------------------------------------------------------------------------
+test_lane_lock_release_only_removes_a_lock_we_still_own() {
+  local d tmp lane lock out rc ovr mout foreign
+  d="$(new_case_dir)"
+  common_env "$d"
+  tmp="$d/tmp"
+  lane="lane3601own$$"
+  mkdir -p "$tmp"
+  lock="$tmp/cqlite-worker-supervisor-$lane.lock"
+  foreign=424242
+
+  # A drive that acquires the lock and then has the lock STOLEN (its pid file replaced) before exiting,
+  # so the EXIT trap runs against a lock that is no longer ours. Derived from the shipped drive body by
+  # inserting one statement before its exit, so it cannot drift into a different startup path.
+  local body_steal="${SV_DRIVE_BODY/'exit 0'/'printf "%s\n" "$2" >"$SUPERVISOR_LOCK/pid"; exit 0'}"
+  if [[ "$body_steal" != "$SV_DRIVE_BODY" && "$body_steal" == *'"$SUPERVISOR_LOCK/pid"'* ]]; then
+    pass "lane-lock ownership PREMISE: the steal drive is derived from the shipped drive body by one insertion"
+  else
+    fail "lane-lock-steal-drive-premise: [$body_steal]"
+    return 0
+  fi
+
+  rm -rf "$lock"
+  out="$( cd "$d" && env -u SUPERVISOR_LOCK TMPDIR="$tmp" LANE_ID="$lane" LOCK_CMD="" CLAIM_CMD="" \
+            bash -c "$body_steal" _ "$SUPERVISOR" "$foreign" 2>&1 )"; rc=$?
+  if [[ "$rc" -eq 0 && "$out" == *"ACQUIRED=$lock"* ]]; then
+    pass "lane-lock ownership PREMISE: the run acquired the lock, then the lock was taken from it"
+  else
+    fail "lane-lock-ownership-premise: rc=$rc out=[$out]"
+  fi
+  if [[ -d "$lock" ]] && [[ "$(cat "$lock/pid" 2>/dev/null || true)" == "$foreign" ]]; then
+    pass "lane-lock ownership: the EXIT trap left the lock ALONE because it no longer held our pid — a run that lost its lock does not delete the new holder's"
+  else
+    fail "lane-lock-release-deleted-foreign: lock=[$([[ -d "$lock" ]] && echo present || echo GONE)] pid=[$(cat "$lock/pid" 2>/dev/null || true)] — the exit path removed a lock this run did not own"
+  fi
+  if [[ "$out" == *"NOT removing"* && "$out" == *"no longer holds this process's pid"* ]]; then
+    pass "lane-lock ownership: and it SAYS so — 'my lock vanished' is otherwise unattributable, so the non-removal is logged rather than silent"
+  else
+    fail "lane-lock-release-silent: out=[$out]"
+  fi
+
+  # ---- MUTANT CONTRAST: the pre-fix unconditional removal, by one substitution in the shipped release.
+  rm -rf "$lock"
+  ovr="$d/m-release.sh"; : >"$ovr"
+  if sv_mutant_override "$ovr" supervisor_lock_release \
+       '  if [[ "$state" == "pid $$" ]]; then' \
+       '  if true; then'; then
+    local body_steal_ovr="${SV_DRIVE_BODY_OVERRIDE/'exit 0'/'printf "%s\n" "$3" >"$SUPERVISOR_LOCK/pid"; exit 0'}"
+    mout="$( cd "$d" && env -u SUPERVISOR_LOCK TMPDIR="$tmp" LANE_ID="$lane" LOCK_CMD="" CLAIM_CMD="" \
+               bash -c "$body_steal_ovr" _ "$SUPERVISOR" "$ovr" "$foreign" 2>&1 )" || true
+    if [[ "$mout" == *"ACQUIRED=$lock"* ]] && [[ ! -d "$lock" ]]; then
+      pass "lane-lock ownership MUTANT: with the ownership test removed the identical drive DELETES the new holder's lock on exit — so the test above is what protects it"
+    else
+      fail "lane-lock-mutant-release: out=[$mout] lock=[$([[ -d "$lock" ]] && echo present || echo GONE)] — the unconditional removal must be shown to destroy a foreign lock"
+    fi
+  fi
+
+  rm -rf "$lock" "$tmp"
+}
+
+t test_lane_lock_release_only_removes_a_lock_we_still_own
+
+
+# ---------------------------------------------------------------------------
+# THE PUBLISH IS VERIFIED, NOT ASSUMED (#3601, AC2's other half).
+#
+# `mkdir` makes the NAME ours; it does not make the lock ours, because a peer running pre-#3601 code
+# reclaims a pid-less lock and our lock is pid-less for exactly one rename. So the publish READS BACK
+# what it wrote and requires our own pid. The pair of mutants below is what shows the read-back is the
+# thing refusing, and not something else: the first forges a foreign pid into the publish (the shipped
+# read-back must catch it), the second forges the SAME pid and blinds the read-back (it must not).
+# ---------------------------------------------------------------------------
+test_lane_lock_publish_is_read_back_before_it_is_trusted() {
+  local d tmp lane lock ovr out rc
+  d="$(new_case_dir)"
+  common_env "$d"
+  tmp="$d/tmp"
+  lane="lane3601pub$$"
+  mkdir -p "$tmp"
+  lock="$tmp/cqlite-worker-supervisor-$lane.lock"
+
+  # ---- (1) A clean claim publishes OUR pid and leaves no temporary behind: the rename is what makes the
+  # `pid` NAME appear only with complete content, so a `pid.tmp.*` survivor would mean the publish is
+  # back to create-then-write.
+  rm -rf "$lock"
+  local body_keep="${SV_DRIVE_BODY/'exit 0'/'printf "KEPT=%s\n" "$(ls -A "$SUPERVISOR_LOCK" | tr "\n" " ")"; printf "PID=%s\n" "$(<"$SUPERVISOR_LOCK/pid")"; trap - EXIT; exit 0'}"
+  out="$( cd "$d" && env -u SUPERVISOR_LOCK TMPDIR="$tmp" LANE_ID="$lane" LOCK_CMD="" CLAIM_CMD="" \
+            bash -c "$body_keep" _ "$SUPERVISOR" 2>&1 )"; rc=$?
+  if [[ "$rc" -eq 0 && "$out" == *"KEPT=pid "* && "$out" != *"pid.tmp."* ]]; then
+    pass "lane-lock publish: the acquired lock holds exactly one file, \`pid\`, with no staging temporary left behind — the name is published by rename, so a reader never sees it holding partial content"
+  else
+    fail "lane-lock-publish-residue: rc=$rc out=[$out] — a leftover staging file means the publish is not a rename"
+  fi
+  rm -rf "$lock"
+
+  # ---- (2) FORGE A FOREIGN PID INTO THE PUBLISH: the read-back must refuse.
+  ovr="$d/m-pub-forge.sh"; : >"$ovr"
+  if sv_mutant_override "$ovr" supervisor_lock_publish \
+       '  printf '"'"'%s\n'"'"' "$$" >"$tmpf" 2>/dev/null || return 1' \
+       '  printf '"'"'%s\n'"'"' 424243 >"$tmpf" 2>/dev/null || return 1'; then
+    out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")"; rc=$?
+    if [[ "$rc" -ne 0 && "$out" != *"ACQUIRED="* && "$out" == *"could not verify it OWNS it"* ]]; then
+      pass "lane-lock publish: when the lock does not read back as ours the run REFUSES and says which step failed — the read-back has teeth"
+    else
+      fail "lane-lock-publish-unverified: rc=$rc out=[$out] — a lock that does not hold our pid must never be treated as acquired"
+    fi
+  fi
+  rm -rf "$lock"
+
+  # ---- (3) NON-VACUITY: the same forgery with the read-back BLINDED must acquire. Without this, (2)
+  # could be passing because of the forgery rather than because of the check.
+  ovr="$d/m-pub-blind.sh"; : >"$ovr"
+  if sv_mutant_override "$ovr" supervisor_lock_publish \
+       '  state="$(supervisor_lock_pid_read "$SUPERVISOR_LOCK/pid")" || true' \
+       '  printf '"'"'%s\n'"'"' 424243 >"$SUPERVISOR_LOCK/pid"; state="pid $$"'; then
+    out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")"; rc=$?
+    if [[ "$rc" -eq 0 && "$out" == *"ACQUIRED=$lock"* ]]; then
+      pass "lane-lock publish MUTANT: with the read-back blinded the SAME forged publish is accepted and the run starts holding a lock whose pid is someone else's — so (2) is the read-back refusing, not the forgery failing"
+    else
+      fail "lane-lock-mutant-publish: rc=$rc out=[$out] — the blinded form must be shown to accept a foreign lock"
+    fi
+  fi
+
+  rm -rf "$lock" "$tmp"
+}
+
+t test_lane_lock_publish_is_read_back_before_it_is_trusted
+
+
+# ---------------------------------------------------------------------------
+# A FAILED `mkdir` IS NOT EVIDENCE OF CONTENTION (#3601).
+#
+# The addendum's expensive half was the DIAGNOSIS, not the failure: pre-fix, an option-shaped `TMPDIR`
+# produced `reclaiming stale lock …` then `failed to acquire lock …`, sending an operator to hunt a
+# stale lock that did not exist. `mkdir` also fails when the parent is missing, is not a directory, or
+# is not writable — so the cause is checked before it is attributed to a holder.
+# ---------------------------------------------------------------------------
+test_lane_lock_uncreatable_path_is_not_reported_as_contention() {
+  local d lane out rc
+  d="$(new_case_dir)"
+  common_env "$d"
+  lane="lane3601nopath$$"
+  out="$(lane_lock_drive_at "$d" - "$d/no-such-parent/deeper" "$lane" SUPERVISOR_LOCK_PID_TRIES=2 SUPERVISOR_LOCK_PID_WAIT=0.01)"; rc=$?
+  if [[ "$rc" -ne 0 ]] && [[ "$out" == *"could NOT BE CREATED"* ]] \
+     && [[ "$out" == *"NOT contention"* ]] && [[ "$out" != *"reclaiming stale lock"* ]] \
+     && [[ "$out" != *"already running"* ]]; then
+    pass "lane-lock (uncreatable path): a lock that cannot be created is reported as a PATH problem and explicitly not as contention — no invented stale lock, no invented holder"
+  else
+    fail "lane-lock-uncreatable-misdiagnosed: rc=$rc out=[$out] — a failed mkdir must not be attributed to a holder"
+  fi
+}
+
+t test_lane_lock_uncreatable_path_is_not_reported_as_contention
+
+
 # ---------------------------------------------------------------------------
 # Test 48 (#3549, roborev job 196 F2): THE SUITE LEAVES NO FIXTURE PROCESS BEHIND.
 #

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -8750,9 +8750,13 @@ test_lane_lock_sweep_no_unobserved_attribution() {
   mkdir -p "$lock"
   printf '%s\n' "$dead" >"$lock/pid"
   ovr="$d/f-take.sh"; : >"$ovr"
+  # THE NAME MUST BE OCCUPIED FOR THIS TO BE A LOST RACE (#3601, roborev job 244 B20). This override used
+  # to just `return 1`, which after the reclaim left NOTHING at the name — and B20 correctly reports that
+  # as a path failure, not a race. So the fault now also holds the name, which is what a lost race means.
   if sv_mutant_override "$ovr" supervisor_lock_take \
        '  mkdir -- "$SUPERVISOR_LOCK" 2>/dev/null || return 1' \
-       '  return 1'; then
+       '  mkdir -p -- "$SUPERVISOR_LOCK" 2>/dev/null || true
+  return 1'; then
     out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")"; rc=$?
     if [[ "$rc" -ne 0 ]] && [[ "$out" == *"taken again before this run could claim it"* ]] \
        && [[ "$out" == *"both unestablished"* ]] \
@@ -9007,7 +9011,7 @@ test_lane_lock_uncreate_is_bound_to_the_created_instance() {
   local ovrk
   ovrk="$d/f-marker.sh"; : >"$ovrk"
   if sv_mutant_override "$ovrk" supervisor_lock_take \
-       '  if ! { : >"$marker"; } 2>/dev/null; then' \
+       '  if [[ "$marker_written" -eq 0 ]]; then' \
        '  if true; then'; then
     out="$(lane_lock_drive_at "$d" "$ovrk" "$tmp" "$lane")"; rc=$?
     if [[ "$rc" -ne 0 ]] && [[ "$out" == *"did NOT attempt to remove"* ]] \
@@ -9143,9 +9147,8 @@ test_lane_lock_race_and_io_error_are_not_conflated() {
   rm -rf "$lock"
   ovr="$d/f-marker-gone.sh"; : >"$ovr"
   if sv_mutant_override "$ovr" supervisor_lock_take \
-       '  if ! { : >"$marker"; } 2>/dev/null && [[ ! -d "$SUPERVISOR_LOCK" ]]; then' \
-       '  rm -rf -- "$SUPERVISOR_LOCK"
-  if true; then'; then
+       '  if { : >"$marker"; } 2>/dev/null; then marker_written=1; fi' \
+       '  rm -rf -- "$SUPERVISOR_LOCK" 2>/dev/null || true'; then
     out="$(lane_lock_drive_at "$d" "$ovr" "$tmp" "$lane")"; rc=$?
     if [[ "$rc" -ne 0 ]] && [[ "$out" == *"ALREADY GONE"* ]] \
        && [[ "$out" == *"This is CONTENTION, not a filesystem fault"* ]] \
@@ -9182,7 +9185,10 @@ test_lane_lock_race_and_io_error_are_not_conflated() {
   if [[ -z "$body" || "$body" != *'supervisor_lock_refuse_publish_failed() {'* ]]; then
     fail "lane-lock-sweep-structural-premise: could not extract the refusal from $SUPERVISOR"
   else
-    hardcoded="$(printf '%s\n' "$body" | grep -n 'remedy=' | grep -v 'first_action' || true)"
+    # Anchored on an INDENTED assignment, so the function's own `local … remedy='' …` declaration is not
+    # matched — an earlier cut of this guard flagged that line and reported a defect that was not there,
+    # which is this diff's own family showing up in a guard written for it.
+    hardcoded="$(printf '%s\n' "$body" | grep -nE '^ +remedy=' | grep -v 'first_action' || true)"
     if [[ -z "$hardcoded" ]]; then
       pass "lane-lock sweep STRUCTURAL: every remedy branch derives its first action from the failure's NATURE — no branch hard-codes an action that could be aimed at the wrong cause"
     else


### PR DESCRIPTION
Closes #3601

`acquire_lock`'s per-lane supervisor lock carried #3549's defect family on the **live** path — the code every
lane executes on every start. #3549 hardened a compatibility guard whose activation precondition is
measurably empty (zero pre-#3467 supervisors fleet-wide); this fixes the same family where it actually runs.

## Pre-registered stopping trigger (declared on the issue thread BEFORE work began, 02:42Z)

> Ship when roborev returns clean, **or** when the only remaining findings are in a file+class already
> recorded as a known residual. A stopping rule never licenses shipping a finding that (a) discloses across
> a trust boundary, (b) permits execution, or (c) corrupts a measured value.

#3549 took 14 rounds / 21 reviews because the surface regenerated one layer out each time. This diff is
confined to `acquire_lock`, its `supervisor_lock_*` helpers, the `log_size` item the issue authorises, their
cases in the existing `scripts/tests/test_worker_supervisor.sh`, and the scoped-out residual records at
`:1428`/`:1776` that deferred exactly this work. **Two roborev Highs were escalated rather than absorbed**
(see Residuals) — that is the trigger working, not being waived.

## Acceptance criteria

| AC | Landed as |
|---|---|
| **1** pid validated before use; unparseable **refuses** | `supervisor_lock_pid_read` returns `pid <digits>` or `unparseable <named-cause>` across **ten** distinct causes (absent, not-a-regular-file, unreadable, empty, multi-line, non-digit, zero-or-leading-zero, digit-count bound, above the platform pid space, **contains-nul**). Unparseable reclaims nothing and mutates nothing. |
| **2** `mkdir`-then-populate window closed or made safe | Publish is `printf > pid.tmp.$$` then `mv -f -- … pid`, so the `pid` **name** never holds partial content. The residual "name not there yet" window is resolved by a bounded re-read of only the two transient causes, then `unknown ⇒ refuse`. Staging-then-rename was **declined on measurement** (below), i.e. AC2's own sanctioned fallback. |
| **3** three-valued liveness; `unknown` refuses | `supervisor_lock_holder_liveness` → `live\|dead\|unknown`. `dead` requires **affirmative** absence (C-locale `No such process`); EPERM and `/proc/<pid>` are existence witnesses used one-directionally. |
| **4** refusal corroborates identity, or says it is unverified | Option **(b)**: the refusal states `ITS IDENTITY IS NOT VERIFIED … pids are REUSED` and prints a read-only `ps -p N` line. No identity probe, because its verdict cannot change the decision — #3549's own ruling. |
| **5** real pid-less lock, real garbled pid, forced interleaving | All three, with the interleaving **sequenced on a sentinel written by the arriving run's own first pid read** — not a tuned `sleep`, so load changes duration and never ordering. |
| **6** mutant contrast per property | Built by `sv_mutant_override`, which `sed`-extracts the function from the **shipped** file and asserts four premises (extractable, occurrence count, substitution changed something, result parses). |
| **7** `--` on every `TMPDIR`-derived operand | `mkdir --`, `mv -f --` (×2), `rm -f --`, `rm -rf --`, `rmdir --`. The `cat` is **gone**, replaced by a redirection, which parses no options at all. Reproduction confirmed on `origin/main` first: `reclaiming stale lock -scratch/…` → `failed to acquire lock -scratch/…`. |

Plus the issue's item 4: `log_size` now answers three-valued — `[0]` a real zero, `[5]` a real count, `[-1]` a
**named non-value** — and is errexit-safe, so a failing internal pipeline no longer aborts its caller.

## "How does a stale lock get cleared, and by whom?" (answered before the probe was designed, per the lead's ruling 3)

1. **Normal exit** — the holder's own trap removes it. Nobody involved.
2. **Holder killed** (`-9`/OOM/reboot) — the lock survives with a well-formed pid, the next start gets an
   affirmative `dead` and reclaims **automatically**. This is the only case that happens in practice and it
   is untouched. A non-vacuity floor case asserts it still works, so the refusals below are decisions rather
   than a guard that always says no.
3. **The undecidable remainder** (persistently pid-less, unparseable, unanswerable liveness) — refuses, and
   every such refusal prints its remedy **shape-aware**: `rmdir --` for a directory, `rm -f --` for a file or
   dangling symlink (`-L` tested before `-d`, since `-d` follows a link and `rmdir` would `ENOTDIR`), and no
   command at all when nothing is there. `rmdir` is non-recursive, so a mis-paste **cannot** delete a
   holder's record — asserted.

## Measurements that changed the design (rather than confirmed it)

- **`mv -T` is NOT `RENAME_NOREPLACE`.** On GNU coreutils 9.4 it refuses a *non-empty* target but
  **succeeds and replaces an EMPTY target directory** — and an empty target dir is precisely a peer's
  pid-less window, i.e. the exact holder AC2 protects. So staging-then-rename is unavailable on **two**
  independent grounds, portability *and* correctness. The lead prescribed `mkdir`+`mv` in this area once
  before and it produced a High; this is the check that was missing then.
- **The reviewed NUL detector was replaced because the lead's own prescription wedged the lane.** A
  `wc -c` vs `tr -d '\0' | wc -c` byte-count form was built and **measured to refuse a fresh, uncontended
  lock forever** when `wc` is unavailable, because `supervisor_lock_publish` calls the parser on every start
  for its read-back. Primary detector is now `IFS= read -r -d '' -n 4096` — a builtin, no fork, no `PATH`
  dependence, and the NUL is the *delimiter*, so nothing is stripped before it can be observed. The
  byte-count form survives as a capability-selected fallback and, being a second implementation, the two are
  **differentially tested** over the same NUL/clean/unmeasurable inputs with the fallback forced by a
  shipped-derived override rather than assumed unreachable.
- **The platform pid ceiling was a no-heuristics violation, not merely loose.** An earlier cut substituted
  Linux's `PID_MAX_LIMIT` (4194304) wherever `/proc` was unreadable — **a guess about a platform we never
  measured, presented as a bound** (#28). `proc(5)` says the file's value is *one greater than* the maximum
  pid, so the inclusive max is `pid_max - 1`: `4194303` accepts, `4194304` refuses. The probe is now
  `authoritative <n>` / `unknown <cause>`, and `unknown` leaves the gate **unapplied and unclaimed** rather
  than refusing everything. That is sound **only** because this gate is rejection-only — it can turn accept
  into refuse, never the reverse — and it explicitly **does not generalise** to the liveness or NUL probes,
  whose verdicts select the reclaim. Said so at the probe. A structural assert forbids the constant returning.

## Severity re-triage (4 rust-reviewer "nits" promoted to blockers, with the reason for each)

`rust-reviewer` returned **CLEAN — 0 blockers, 9 nits**. "Nit" here means *batch to a follow-up, never a
re-verify round*, and four did not qualify:

1. **A publish that never wrote left an empty lock and a refusal asserting it did.** On ENOSPC or a
   read-only fs the code manufactured the undecidable state itself and wedged the lane, while printing a
   claim about two steps that never ran.
2. **A failed reclaim rename was reported as `refuse_lost_race`** — "cleared and immediately claimed by
   someone else", which did not happen — plus "re-run this supervisor", which loops. Same misdiagnosis
   family as the AC7 addendum this issue fixes. And for a lock *name* that is a file or dangling symlink the
   printed `rmdir --` was not runnable: **a remedy that cannot work is worse than none.**
3. **A 10-digit garbage pid was accepted**, cast to `pid_t`, yielded ESRCH, became an affirmative `dead` and
   **reclaimed** — while a 15-digit one refused. AC1's guarantee, holed in the issue's own direction.
4. **The `log_size` mutant did not share its control's entry point, and a comment claimed it did.** The
   mutant *is* the evidence; if control and mutant differ in more than the probe the contrast isolates
   nothing, and it was the only one of eleven with no premise assert.

roborev's Medium (NUL bytes defeating the parser) was **verified locally before any fix was dispatched** —
`printf '4242\0\n' > f` gives `[4242]` len=4 from both `cat` and `read -r` on bash 5.2.21, and the
all-digits check accepts it. Bash *does* warn (`ignored null byte in input`) but to **stderr**, which the
site's existing `2>/dev/null` suppresses, so the one signal bash offers is silenced by the idiom already in
use. Verifying the finding first is what stops a fix chasing a phantom.

## The recurring defect this diff kept regenerating, and the only thing that held

**Seven instances of one family: an artifact asserting a step that did not run.** `main`'s reclaim comment
vouching for the race it sits on; a mutant comment claiming an entry point it did not share; a refusal
claiming a read-back that never ran; a cleanup diagnostic claiming a removal that may not have happened; a
test pinning a pid-ceiling off-by-one as correct; a test comment claiming it accepted both widths while
comparing exact strings; and a declined-publish diagnostic claiming it "wrote NOTHING" when it writes a
staging file first.

**Two of the seven were introduced by fixes written for the family**, an hour apart, by someone who knew
about it. So it survives careful attention, which is the argument for the **structural comment-claim
asserts** now in the suite: a human re-reading catches instance N; only a test catches the class. That
mechanism is **partial**, not complete — see Residuals.

The B9 fix was therefore dispatched as a **class sweep, not an instance fix**: **17 claim-bearing sites
audited, 4 changed** (1 reported by roborev, 3 the sweep found), 13 checked and left alone as already true.
Three of those four would have shipped had the finding been treated as the single site it named.

## Certification

- **Suite**: 413 total, **413 passed, 0 failed, 0 skipped**, on two consecutive runs (216s / 214s), read
  from the terminal summary line and not from `$?`. Baseline `origin/main`: 278 passed / 195s → **+135
  cases**. Exit-latency assertion measured 1–2s against its `<15s` bound; every fixture group reaped.
- **`--lite`**: PASS, `tree-integrity: PASS`, `tree-start == tree-end`, `dirty: no`, on every round.
- **`--lite` is structurally blind to this diff and must not be read as coverage.** The change is
  shell-only, so lite's blast radius finds no rust package and falls back to `cqlite-core --lib`
  (`agent-gate.sh:12285`, `:12339`); `test_worker_supervisor.sh` appears only at `:11935`/`:11949`, inside
  the full gate's `tooling-tests`. What lite *does* certify here is `roborev-lints` (which mechanizes
  #2642's wall-clock guard, so no new case carries a wall-clock threshold assert in a correctness path) and
  that nothing else broke. **`tooling-tests` in the gate of record is the only gate component that executes
  this diff** — read that component line, not just `RESULT:`.
- **Gate of record**: PENDING. **Declared deviation:** it will be **lead-launched**, not launched inside
  `flow-closer`. A subagent-owned gate dies at a turn boundary leaving only the `RESULT: INCOMPLETE`
  sentinel (#3344/#3246), and #3473's fix for that (PR #3561) is open/unmerged. Launched under
  `systemd-run --user --scope -p OOMPolicy=continue` plus `setsid nohup … disown` — two separate
  protections, and `OOMPolicy` is launch-time only with no retrofit — with a nonced summary path outside the
  worktree (inside trips #2926; shared trips #2874).
- **roborev**: `--agent codex --model gpt-5.6-sol`, the only healthy agent on this box (`claude-code` fails
  `OAuth session expired`). Findings per round: **12 → 3 → 2 → 2** (round 1 = roborev 3 + rust-reviewer 9).
- **`file-size` does not apply**: it selects `'*.rs'` only (`agent-gate.sh:12044`), so no
  `CQLITE_ALLOW_FILE_GROWTH` opt-out is used or needed — which matters, because that opt-out leaves no
  marker in the SUMMARY (#3402).
- **Coordination with #3436** (adjacent lane, machine-local lane lock): measured disjoint — their 17-file
  branch does not touch `scripts/local/worker-supervisor.sh`, and this diff touches neither
  `scripts/agent-gate.sh` (the `tooling-tests` roster already lists the suite) nor `scripts/flow/claim.sh`.
  Noted on both threads.

## Residuals — narrowed, not closed

- **#3683 — reclaim ABA race + release read-then-remove, one root.** Both are **pre-existing on `main`**
  and this change makes them **strictly narrower**: reclaim now requires an affirmative `dead` where `main`
  reclaimed on *any* non-live answer, and release **gained** an ownership check where `main`'s trap was a
  bare `rm -rf` with none at all. Closing them needs serialization across `classify → reclaim → claim` —
  a lock protecting a lock, whose own staleness reopens "how does a stale instance get cleared, and by
  whom?" one level down. Split by lead ruling rather than improvised in a fix round. **Recorded in code at
  all three sites in NARROWED-NOT-CLOSED form, with "do not read this as a guarantee" in those words.**
- **The B12 ownership marker's own absence window is reachable and is not closed.** A peer replacing the
  directory between `mkdir` and the marker write receives our marker in *its* directory. Two bounds, stated
  rather than assured: it is two **adjacent** syscalls with no intervening I/O, where the window it replaces
  spanned an entire publish attempt (write + decline test + rename); and a stale marker cannot alias us,
  because this path is reached only when *our* `mkdir` succeeded, so the directory did not exist a moment
  earlier and cannot already hold an `own.<pid>` from a dead process sharing our pid — **pid reuse cannot
  forge the token for this decision.**
- **The structural comment-claim assert mechanism is partial, and now quantified: 2 of 28 (#3697).**
  Counted in the added code: **28** distinct claim-producing branches (2 `detail=` + 4 `what=` + 7
  `aftermath=`/`remedy=` + 4 `shape_note` + 3 `clear_command` + 4 `log` lines + 4 single-branch refusals),
  excluding call-site wrappers that only pass those through. **2** are covered by a structural,
  reachability-independent claim assert; **1** further branch has a negative control requiring the
  previously-false sentence to be *absent* — because a test that requires a false claim is what keeps the
  claim alive. A further **~23 of 28** are exercised behaviourally, but that figure is **read off the cases,
  not instrumented**, and is explicitly not to be trusted like the 2 and the 28.
  So the mechanism is real, partial, and does **not** generalise to "no branch asserts a step that did not
  run". **#3697** proposes what would: a convention that every operator-facing claim string be produced only
  from a variable assigned by a verified observation, making the binding between *what we say happened* and
  *what we checked happened* machine-checkable. Filed rather than improvised here, and scoped by the standing
  ruling that a guard with known false PASSes is worse than none (#3229/#3283/#3499).
- **The family's full census, for the follow-up's benefit: 11 instances in this one diff across 7 review
  rounds — and 2 of the 11 were introduced by fixes written for the family**, an hour apart, by someone who
  knew about it. Findings per round ran 12 → 3 → 2 → 2 → 2 → 2, i.e. flat rather than converging, which is
  the evidence that re-reading does not close this class and a convention plus a linter is required. A
  characteristic worth recording: when a claim is wrong there is often a **test holding it in place** (one
  case here pinned a false automatic-reclaim promise), so correcting wording without correcting the assert
  leaves the claim recoverable.
- **A supervisor killed inside the marker window leaves `own.<pid>`, so the printed `rmdir` refuses.** A
  debris-aware `rm -f -- <dir>/own.* … && rmdir` was **rejected**: it puts globs in operator-facing text and
  needs glob-state pinning (`GLOBIGNORE`/`nullglob`/`failglob`) — the apparatus #3549 deleted and whose
  revival the suite's guard bans. Enumerating the directory at print time was also rejected (content can
  change between print and paste; it widens hostile-filename surface). The shape note names the case
  instead. This is **not** finding 2 returning: `rmdir` refusing when there is content the operator must
  examine *is* the safety property it was chosen for.
- **The suite header's "Target: <30s total" has been false on `main` for a long time (195s, 6.5× over)** —
  a stale-prose defect in a pre-existing test file, named rather than edited inside this diff. This change
  adds +20s for +135 cases.
- **`worker-supervisor.sh` is over 3000 lines** and wants splitting (#1116). Not gate-enforced for `.sh`;
  real, and its own issue.

