### PR TITLE
fix(#3220): fail closed in the #3358 BTI token-bound test — its fixture is committed source

### DIFF
--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -11,6 +11,21 @@ rust-version.workspace = true
 description = "Core engine for CQLite — read Apache Cassandra 5.0 SSTables locally without a cluster"
 readme = "../README.md"
 
+# Not packaged: this integration test reads a fixture that lives at REPO ROOT
+# (`test-data/datasets/…`), outside this package, so `cargo package` cannot carry it.
+# The test fails CLOSED on a missing fixture by design (#3220) — committed source is
+# never legitimately absent in a checkout — so shipping it in the published crate
+# would make `cargo test` fail for a consumer who can never satisfy it.
+#
+# Excluding it from the PACKAGE is the fix that keeps both properties: fail-closed in
+# a repository checkout, and absent (rather than skipping) where the fixture cannot
+# exist. A skip would reintroduce exactly the vacuous green #3220 removed, and a
+# "am I a git checkout?" runtime probe would be the environment heuristic #28 forbids.
+#
+# 454 sibling integration tests have the same repo-root-fixture property; fixing the
+# class (likely `exclude = ["tests/**"]`) is a packaging decision tracked in #3677.
+exclude = ["tests/issue_3358_bti_query_token_bound.rs"]
+
 # docs.rs build: document the commonly used features. Deliberately excludes
 # `wasm` (wasm32-only deps would fail the default x86_64 docs.rs target).
 [package.metadata.docs.rs]

--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -22,8 +22,11 @@ readme = "../README.md"
 # exist. A skip would reintroduce exactly the vacuous green #3220 removed, and a
 # "am I a git checkout?" runtime probe would be the environment heuristic #28 forbids.
 #
-# 454 sibling integration tests have the same repo-root-fixture property; fixing the
-# class (likely `exclude = ["tests/**"]`) is a packaging decision tracked in #3677.
+# This test JOINS a pre-existing class rather than creating it: #3677 measured 106
+# `cqlite-core` integration tests reading repo-root `test-data/datasets`, 104 of which
+# already fail hard rather than skip. Fixing the class (its recommended option (a),
+# `exclude = ["tests/**"]`) is a packaging call it holds open deliberately, so the
+# narrow single-file exclusion here is scoped to what this lane may decide.
 exclude = ["tests/issue_3358_bti_query_token_bound.rs"]
 
 # docs.rs build: document the commonly used features. Deliberately excludes

--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -22,11 +22,23 @@ readme = "../README.md"
 # exist. A skip would reintroduce exactly the vacuous green #3220 removed, and a
 # "am I a git checkout?" runtime probe would be the environment heuristic #28 forbids.
 #
-# This test JOINS a pre-existing class rather than creating it: #3677 measured 106
+# Measured effective, not assumed: `cargo package -p cqlite-core --no-verify --list`
+# lists 1015 files, 0 of them this test, and 454 other `tests/` entries survive — so the
+# key drops exactly one target and nothing else. (There is no `include` key, which would
+# make cargo ignore `exclude` entirely.) Note this does NOT assert the crate packages
+# end-to-end: `readme = "../README.md"` also points outside the package, so a full
+# `cargo package` may fail on that first. Packageability is #3677's, not this lane's.
+#
+# This test JOINS a pre-existing class rather than creating it. #3677 measured 106
 # `cqlite-core` integration tests reading repo-root `test-data/datasets`, 104 of which
-# already fail hard rather than skip. Fixing the class (its recommended option (a),
-# `exclude = ["tests/**"]`) is a packaging call it holds open deliberately, so the
+# already fail hard rather than skip. Fixing the class — its recommended option (a),
+# `exclude = ["tests/**"]` — is a packaging call it holds open deliberately, so the
 # narrow single-file exclusion here is scoped to what this lane may decide.
+#
+# An earlier draft of this comment said "454 sibling integration tests have the same
+# repo-root-fixture property". 454 is a real number and it is the one above — packaged
+# `tests/` ENTRIES, most of which read no fixture at all — attached to a claim about a
+# property it does not measure. The two counts answer different questions.
 exclude = ["tests/issue_3358_bti_query_token_bound.rs"]
 
 # docs.rs build: document the commonly used features. Deliberately excludes

--- a/cqlite-core/tests/issue_3358_bti_query_token_bound.rs
+++ b/cqlite-core/tests/issue_3358_bti_query_token_bound.rs
@@ -300,9 +300,18 @@ fn fixture() -> Fixture {
              \n\
              \x20   CQLITE_DATASETS_ROOT={verify_root} bash {verify_cmd} --verify-only\n\
              \n\
-             It names every git-tracked fixture that is missing and prints the exact, \
-             correctly-scoped restore command for them — which is why this message \
-             does not try to construct one."
+             READ ONLY ITS FIRST LINE, `Tracked-fixture probe (#3310)`: that is the \
+             half that answers this failure, naming every git-tracked fixture that is \
+             missing and printing the exact, correctly-scoped `git restore` for them — \
+             which is why this message does not try to construct one.\n\
+             \n\
+             IGNORE the `ERROR:` lines that follow it, and do NOT run the remedy they \
+             suggest. They report a DIFFERENT condition — the checkout corpus is not a \
+             complete FETCHED corpus, which it is never meant to be — and the command \
+             exits 1 with 7 such lines even when nothing is missing. One of them \
+             proposes clearing `.dataset-pin` and re-running the fetch, whose default \
+             path is destructive (`rm -rf` on the dataset root): against this checkout \
+             root that would DELETE the committed fixtures you are trying to restore."
         )
     });
     let golden = golden_rows_by_pk(&dir);

--- a/cqlite-core/tests/issue_3358_bti_query_token_bound.rs
+++ b/cqlite-core/tests/issue_3358_bti_query_token_bound.rs
@@ -46,11 +46,21 @@
 //! documented — #3310 added reporting for git-tracked fixtures a SIGKILLed fetch
 //! left deleted — which is exactly the case a skip would swallow.
 //!
-//! `CQLITE_DATASETS_ROOT` is honored first, then the in-repo `test-data/datasets`
-//! corpus; EVERY candidate root is walked for this TABLE's own `Data.db` rather than
-//! committing to a root by keyspace (issue #3220), because neither root is a superset
-//! — the root `fetch-datasets.sh` prints does not carry this fixture and the checkout
-//! does.
+//! Fixture roots resolve through the SHARED `support/datasets_root.rs` resolver, not a
+//! private copy: `CQLITE_DATASETS_ROOT` is honored first, then the in-repo
+//! `test-data/datasets` corpus, and EVERY candidate is probed for this TABLE's own
+//! `da-1-bti-Data.db` rather than committing to a root by keyspace (issue #3220),
+//! because neither root is a superset — the root `fetch-datasets.sh` prints does not
+//! carry this fixture and the checkout does.
+//!
+//! Using the shared module rather than re-deriving the rule is what makes the
+//! fail-closed guard OBSERVABLE (#3220 AC3). The checkout candidate is built from
+//! `CARGO_MANIFEST_DIR`, a COMPILE-TIME constant, so with a private resolver the only
+//! way to stage "the committed fixture is unreadable" is deleting a git-tracked file
+//! from the working tree — which also trips the gate's mid-run `tree-integrity` check
+//! (#2926). The shared module's `CQLITE_TEST_CHECKOUT_SSTABLES_ROOT` seam substitutes
+//! the checkout candidate instead, and can only ever REMOVE fixtures from view, so a
+//! stray value makes this lane FAIL, never pass vacuously.
 
 #![cfg(feature = "state_machine")]
 
@@ -66,11 +76,16 @@ use cqlite_core::storage::sstable::reader::{SSTableReader, ScanTokenBound};
 use cqlite_core::util::cassandra_murmur3::cassandra_murmur3_token;
 use cqlite_core::Config;
 
+// The #3220 fixture-root rule lives HERE, once, and is regression-tested on synthetic
+// roots by `issue_3220_datasets_root_resolution.rs`. A private re-derivation in this
+// file would be the very shape #3220 exists to remove, and would carry no test seam.
+#[path = "support/datasets_root.rs"]
+mod datasets_root;
+
 const KEYSPACE: &str = "test_da";
 const TABLE: &str = "wide_multiclustering_small";
 const SSTABLE_PREFIX: &str = "da-1-bti";
 
-/// Repo root = the parent of this crate's manifest dir (`<repo>/cqlite-core`).
 /// Single-quote a path for safe pasting into a shell.
 ///
 /// Checkout paths on this fleet contain no spaces today, but a remedy is copied by
@@ -81,25 +96,28 @@ fn shell_quote(p: &Path) -> String {
     format!("'{}'", p.display().to_string().replace('\'', "'\\''"))
 }
 
-fn repo_root() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("cqlite-core has a parent repo dir")
-        .to_path_buf()
-}
-
-/// The `<table>-<cfid>` generation dir, requiring a real `Data.db` so a JSONL-only
-/// root is passed over rather than yielding zero rows. `None` means no candidate root
-/// held it, which [`fixture`] turns into a hard failure (this fixture is committed).
+/// The `<table>-<cfid>` generation dir holding this fixture's `da-1-bti` generation.
+///
+/// Candidate roots come from [`datasets_root::sstables_root_candidates`] — the shared,
+/// deduplicated, workspace-anchored list, including the override seam the RED
+/// verification uses — and each is probed with THIS generation's own `Data.db`. The
+/// first root that actually holds it wins: resolution is by EVIDENCE, never by a fixed
+/// env-first/checkout-first preference, because neither root is a superset (#3104).
+///
+/// The probe is `{SSTABLE_PREFIX}-Data.db` rather than the shared
+/// [`datasets_root::table_has_data`]'s any-`*-Data.db` test, matching the oracle's
+/// `sstables_root_for_case` precedent for a format-specific fixture. The stricter
+/// predicate matters in the safe direction: a root carrying some OTHER generation of
+/// this table would satisfy `table_has_data`, win the selection, and then hard-FAIL
+/// this `must_run` lane on a checkout that does hold the `da` copy — a guard that reds
+/// on correct input is the guard agents learn to waive.
+///
+/// `None` means no candidate held it, which [`fixture`] turns into a hard failure —
+/// this fixture is committed source.
 fn fixture_dir() -> Option<PathBuf> {
-    let roots = std::env::var("CQLITE_DATASETS_ROOT")
-        .ok()
-        .map(PathBuf::from)
-        .into_iter()
-        .chain(std::iter::once(repo_root().join("test-data/datasets")));
-    for root in roots {
-        let keyspace_dir = root.join("sstables").join(KEYSPACE);
-        let Ok(entries) = std::fs::read_dir(&keyspace_dir) else {
+    let data_db = format!("{SSTABLE_PREFIX}-Data.db");
+    for root in datasets_root::sstables_root_candidates() {
+        let Ok(entries) = std::fs::read_dir(root.join(KEYSPACE)) else {
             continue;
         };
         let mut candidates: Vec<PathBuf> = entries
@@ -112,10 +130,7 @@ fn fixture_dir() -> Option<PathBuf> {
             })
             .collect();
         candidates.sort();
-        if let Some(dir) = candidates
-            .into_iter()
-            .find(|p| p.join(format!("{SSTABLE_PREFIX}-Data.db")).is_file())
-        {
+        if let Some(dir) = candidates.into_iter().find(|p| p.join(&data_db).is_file()) {
             return Some(dir);
         }
     }
@@ -265,13 +280,14 @@ fn fixture() -> Fixture {
         // caller's environment and the caller's directory. A remedy that is correct only
         // from the repository root is a remedy that gets pasted from somewhere else and
         // quietly reads as an all-clear — the exact silent-pass this test exists to stop.
-        let root = repo_root();
+        // The roots named here come from the RESOLVER, via `describe_search`, so the
+        // message can never name a candidate list the lookup above did not use.
+        let root = datasets_root::repo_root();
         let verify_cmd = shell_quote(&root.join("test-data/scripts/fetch-datasets.sh"));
         let verify_root = shell_quote(&root.join("test-data/datasets"));
-        let default_root = root.join("test-data/datasets").display().to_string();
+        let searched = datasets_root::describe_search(KEYSPACE, TABLE);
         panic!(
-            "{KEYSPACE}.{TABLE} `{SSTABLE_PREFIX}-Data.db` was not found under any \
-             candidate dataset root (CQLITE_DATASETS_ROOT, then {default_root}).\n\
+            "{KEYSPACE}.{TABLE} `{SSTABLE_PREFIX}-Data.db` was not found: {searched}.\n\
              \n\
              This fixture is COMMITTED SOURCE (git-tracked, not gitignored), so this \
              is a broken checkout rather than a missing optional corpus, and it fails \

--- a/cqlite-core/tests/issue_3358_bti_query_token_bound.rs
+++ b/cqlite-core/tests/issue_3358_bti_query_token_bound.rs
@@ -281,8 +281,6 @@ fn fixture() -> Fixture {
         // caller's environment and the caller's directory. A remedy that is correct only
         // from the repository root is a remedy that gets pasted from somewhere else and
         // quietly reads as an all-clear — the exact silent-pass this test exists to stop.
-        // The roots named here come from the RESOLVER, via `describe_search`, so the
-        // message can never name a candidate list the lookup above did not use.
         let root = datasets_root::repo_root();
         let verify_cmd = shell_quote(&root.join("test-data/scripts/fetch-datasets.sh"));
         let verify_root = shell_quote(&root.join("test-data/datasets"));
@@ -294,7 +292,8 @@ fn fixture() -> Fixture {
         // `fetch-datasets.sh`, the destructive invocation the rest of this message
         // spends six lines warning against. So the root list is taken from the
         // resolver and the sentence is composed here, naming what was actually
-        // required.
+        // required. Taking the list from the resolver is what stops the message naming
+        // a candidate set the lookup above did not use.
         let roots = datasets_root::sstables_root_candidates()
             .iter()
             .map(|r| r.display().to_string())

--- a/cqlite-core/tests/issue_3358_bti_query_token_bound.rs
+++ b/cqlite-core/tests/issue_3358_bti_query_token_bound.rs
@@ -229,8 +229,19 @@ fn fixture() -> Fixture {
         // wrong AND unrunnable (`<` is shell input redirection). Quoted so the shell
         // passes the `*` through to git rather than expanding it against a tree where
         // the directory is, by definition, missing.
-        let restore_pathspec = format!("test-data/datasets/sstables/{KEYSPACE}/{TABLE}-*");
-        let default_root = repo_root().join("test-data/datasets").display().to_string();
+        //
+        // `:(top)` anchors it at the repository root, because `cargo test -p cqlite-core`
+        // is routinely run FROM `cqlite-core/`, where a crate-relative `test-data/...`
+        // names nothing. The verification script is printed absolute for the same reason:
+        // a remedy that only works from one directory is a remedy that will be pasted
+        // and fail.
+        let restore_pathspec = format!(":(top)test-data/datasets/sstables/{KEYSPACE}/{TABLE}-*");
+        let root = repo_root();
+        let default_root = root.join("test-data/datasets").display().to_string();
+        let verify_cmd = root
+            .join("test-data/scripts/fetch-datasets.sh")
+            .display()
+            .to_string();
         panic!(
             "{KEYSPACE}.{TABLE} `{SSTABLE_PREFIX}-Data.db` was not found under any \
              candidate dataset root (CQLITE_DATASETS_ROOT, then {default_root}).\n\
@@ -246,8 +257,8 @@ fn fixture() -> Fixture {
              \n\
              \x20   git restore -- '{restore_pathspec}'\n\
              \n\
-             `bash test-data/scripts/fetch-datasets.sh --verify-only` names any such \
-             deletions and prints the exact restore command."
+             `bash {verify_cmd} --verify-only` names any such deletions and prints \
+             the exact restore command."
         )
     });
     let golden = golden_rows_by_pk(&dir);

--- a/cqlite-core/tests/issue_3358_bti_query_token_bound.rs
+++ b/cqlite-core/tests/issue_3358_bti_query_token_bound.rs
@@ -300,18 +300,28 @@ fn fixture() -> Fixture {
              \n\
              \x20   CQLITE_DATASETS_ROOT={verify_root} bash {verify_cmd} --verify-only\n\
              \n\
-             READ ONLY ITS FIRST LINE, `Tracked-fixture probe (#3310)`: that is the \
-             half that answers this failure, naming every git-tracked fixture that is \
-             missing and printing the exact, correctly-scoped `git restore` for them — \
-             which is why this message does not try to construct one.\n\
+             It writes to STDERR, so keep `2>&1` if you pipe it. Read the FIRST line \
+             and branch on it — the two outcomes are different conditions with \
+             different answers:\n\
              \n\
-             IGNORE the `ERROR:` lines that follow it, and do NOT run the remedy they \
-             suggest. They report a DIFFERENT condition — the checkout corpus is not a \
-             complete FETCHED corpus, which it is never meant to be — and the command \
-             exits 1 with 7 such lines even when nothing is missing. One of them \
-             proposes clearing `.dataset-pin` and re-running the fetch, whose default \
-             path is destructive (`rm -rf` on the dataset root): against this checkout \
-             root that would DELETE the committed fixtures you are trying to restore."
+             (1) `ERROR: TRACKED FIXTURES MISSING … (issue #3310)` — this is your case. \
+             That block names every tracked fixture that is absent and then prints an \
+             exact `git -C <repo> restore` command covering ONLY those paths (a second \
+             one with `--staged --worktree` if any deletion was staged). Run it \
+             verbatim. The probe reports only: it creates, deletes and restores \
+             nothing. This is why this message does not construct a restore command \
+             itself — five earlier attempts to hand-build one produced five different \
+             defects, and the tool's version is scoped and tested.\n\
+             \n\
+             (2) `Tracked-fixture probe (#3310): OK` — every tracked fixture is \
+             present, so the fault is NOT a deleted fixture and this test's own \
+             resolution is what to look at next. ONLY in this case are the `ERROR:` \
+             lines that follow unrelated noise: they report that the corpus is not a \
+             complete FETCHED corpus, which a checkout is never meant to be, and the \
+             command exits 1 with 7 such lines even though nothing is missing. Do NOT \
+             run the remedy they propose there — clearing `.dataset-pin` and re-running \
+             the fetch takes its destructive path (`rm -rf` on the dataset root), which \
+             against a checkout root DELETES the committed fixtures."
         )
     });
     let golden = golden_rows_by_pk(&dir);

--- a/cqlite-core/tests/issue_3358_bti_query_token_bound.rs
+++ b/cqlite-core/tests/issue_3358_bti_query_token_bound.rs
@@ -248,16 +248,27 @@ fn fixture() -> Fixture {
         // than reproducing it here badly, so this message names ONE command and lets
         // that tool produce the restore line. Do not "helpfully" add one back.
         //
-        // `env -u CQLITE_DATASETS_ROOT` is LOAD-BEARING, not tidiness. The probe is
-        // scoped to whatever root it is given, and on a fleet box that variable points
-        // at a machine-local corpus OUTSIDE any git work tree — where it correctly
-        // reports `NO SUBJECT` and exits 0, detecting nothing. Measured: with the
-        // variable set to /data/datasets the remedy finds none of the 10 deleted files;
-        // unset, it names all 10. The fixture we are hunting is the COMMITTED one in
-        // this checkout, so the probe must be pointed there. Removing `env -u` turns
-        // this remedy into a no-op that looks like an all-clear.
-        let verify_cmd = shell_quote(&repo_root().join("test-data/scripts/fetch-datasets.sh"));
-        let default_root = repo_root().join("test-data/datasets").display().to_string();
+        // BOTH values in the emitted command are ABSOLUTE, and both are load-bearing.
+        //
+        // The probe is scoped to the root it is given. On a fleet box
+        // CQLITE_DATASETS_ROOT points at a machine-local corpus OUTSIDE any git work
+        // tree, where it correctly reports `NO SUBJECT` and exits 0 — measured: it finds
+        // none of the 10 deleted files. So the caller's value must not be inherited.
+        //
+        // Unsetting it is NOT enough, which cost a review round: the script then falls
+        // back to a CWD-RELATIVE `test-data/datasets`, and `cargo test -p cqlite-core`
+        // is routinely run from `cqlite-core/`, where that names nothing and the command
+        // silently reports no missing fixtures. Measured from that directory: the
+        // unset form found none of the 10; this form finds all 10.
+        //
+        // Passing the absolute checkout corpus makes the command independent of both the
+        // caller's environment and the caller's directory. A remedy that is correct only
+        // from the repository root is a remedy that gets pasted from somewhere else and
+        // quietly reads as an all-clear — the exact silent-pass this test exists to stop.
+        let root = repo_root();
+        let verify_cmd = shell_quote(&root.join("test-data/scripts/fetch-datasets.sh"));
+        let verify_root = shell_quote(&root.join("test-data/datasets"));
+        let default_root = root.join("test-data/datasets").display().to_string();
         panic!(
             "{KEYSPACE}.{TABLE} `{SSTABLE_PREFIX}-Data.db` was not found under any \
              candidate dataset root (CQLITE_DATASETS_ROOT, then {default_root}).\n\
@@ -271,7 +282,7 @@ fn fixture() -> Fixture {
              Remedy: a SIGKILLed `fetch-datasets.sh` can delete tracked files \
              (#3310). Run:\n\
              \n\
-             \x20   env -u CQLITE_DATASETS_ROOT bash {verify_cmd} --verify-only\n\
+             \x20   CQLITE_DATASETS_ROOT={verify_root} bash {verify_cmd} --verify-only\n\
              \n\
              It names every git-tracked fixture that is missing and prints the exact, \
              correctly-scoped restore command for them — which is why this message \

--- a/cqlite-core/tests/issue_3358_bti_query_token_bound.rs
+++ b/cqlite-core/tests/issue_3358_bti_query_token_bound.rs
@@ -35,9 +35,22 @@
 //! "the whole ring" and "the range" would be the same answer and the test could
 //! not discriminate.
 //!
-//! Requires the gitignored `Data.db` binaries; SKIPs (never passes with zero rows)
-//! when absent. `CQLITE_DATASETS_ROOT` is honored first, else the in-repo
-//! `test-data/datasets` corpus is used.
+//! This fixture is COMMITTED SOURCE, not part of the gitignored fetched corpus:
+//! `git ls-files` lists its `da-1-bti-*` components and `git check-ignore` does not
+//! match them, so it is present in every complete checkout and appears in a fresh
+//! `git worktree add` without any fetch. Absence therefore means a BROKEN CHECKOUT,
+//! never an expected condition — so every case here is `must_run` and fails CLOSED
+//! (issue #3220). It deliberately does NOT skip: this file is the only end-to-end
+//! pin of #3358, a silent-wrong-data defect, and a skip would leave a green suite
+//! that certified nothing. The reachable way to lose the file is real and already
+//! documented — #3310 added reporting for git-tracked fixtures a SIGKILLed fetch
+//! left deleted — which is exactly the case a skip would swallow.
+//!
+//! `CQLITE_DATASETS_ROOT` is honored first, then the in-repo `test-data/datasets`
+//! corpus; EVERY candidate root is walked for this TABLE's own `Data.db` rather than
+//! committing to a root by keyspace (issue #3220), because neither root is a superset
+//! — the root `fetch-datasets.sh` prints does not carry this fixture and the checkout
+//! does.
 
 #![cfg(feature = "state_machine")]
 
@@ -66,7 +79,8 @@ fn repo_root() -> PathBuf {
 }
 
 /// The `<table>-<cfid>` generation dir, requiring a real `Data.db` so a JSONL-only
-/// checkout SKIPs rather than passing with zero rows.
+/// root is passed over rather than yielding zero rows. `None` means no candidate root
+/// held it, which [`fixture`] turns into a hard failure (this fixture is committed).
 fn fixture_dir() -> Option<PathBuf> {
     let roots = std::env::var("CQLITE_DATASETS_ROOT")
         .ok()
@@ -204,9 +218,38 @@ struct Fixture {
 
 /// The fixture's partitions in ring order, with the golden's row count each.
 ///
-/// Returns `None` when the `Data.db` binaries are absent, which is the SKIP.
-fn fixture() -> Option<Fixture> {
-    let dir = fixture_dir()?;
+/// PANICS when the fixture is absent — it is committed source, so absence is a broken
+/// checkout and #3220 requires `must_run`, fail-closed unconditionally. There is no
+/// opt-out env var and none may be added: committed source in a checkout is never
+/// legitimately absent, so an escape hatch could only buy a vacuous green.
+fn fixture() -> Fixture {
+    let dir = fixture_dir().unwrap_or_else(|| {
+        // A glob PATHSPEC, not a literal path: the tracked directory carries a CFID
+        // suffix this code does not know, and a `<cfid>` placeholder would be both
+        // wrong AND unrunnable (`<` is shell input redirection). Quoted so the shell
+        // passes the `*` through to git rather than expanding it against a tree where
+        // the directory is, by definition, missing.
+        let restore_pathspec = format!("test-data/datasets/sstables/{KEYSPACE}/{TABLE}-*");
+        let default_root = repo_root().join("test-data/datasets").display().to_string();
+        panic!(
+            "{KEYSPACE}.{TABLE} `{SSTABLE_PREFIX}-Data.db` was not found under any \
+             candidate dataset root (CQLITE_DATASETS_ROOT, then {default_root}).\n\
+             \n\
+             This fixture is COMMITTED SOURCE (git-tracked, not gitignored), so this \
+             is a broken checkout rather than a missing optional corpus, and it fails \
+             closed rather than skipping: this file is the only end-to-end pin of \
+             #3358 and a skip would leave a green suite that certified nothing \
+             (issue #3220).\n\
+             \n\
+             Remedy: restore the tracked fixture (a SIGKILLed \
+             `test-data/scripts/fetch-datasets.sh` can delete tracked files — #3310):\n\
+             \n\
+             \x20   git restore -- '{restore_pathspec}'\n\
+             \n\
+             `bash test-data/scripts/fetch-datasets.sh --verify-only` names any such \
+             deletions and prints the exact restore command."
+        )
+    });
     let golden = golden_rows_by_pk(&dir);
     let mut by_token: Vec<(i32, i64, usize)> = golden
         .iter()
@@ -214,11 +257,11 @@ fn fixture() -> Option<Fixture> {
         .collect();
     by_token.sort_by_key(|(_, token, _)| *token);
     let ring: Vec<(i32, usize)> = by_token.iter().map(|(pk, _, rows)| (*pk, *rows)).collect();
-    Some(Fixture {
+    Fixture {
         data_db: dir.join(format!("{SSTABLE_PREFIX}-Data.db")),
         ring,
         golden,
-    })
+    }
 }
 
 fn token_of(pk: i32) -> i64 {
@@ -229,13 +272,9 @@ fn token_of(pk: i32) -> i64 {
 /// narrowed answer below is a narrowing rather than a failure to read.
 #[test]
 fn unbounded_scan_matches_the_golden() {
-    let Some(Fixture {
+    let Fixture {
         data_db, golden, ..
-    }) = fixture()
-    else {
-        eprintln!("SKIP: {KEYSPACE}.{TABLE} Data.db is absent (gitignored corpus)");
-        return;
-    };
+    } = fixture();
     let rt = tokio::runtime::Runtime::new().unwrap();
     let reader = rt.block_on(open_reader(&data_db));
     let got = rt.block_on(emitted_rows_by_pk(&reader, None));
@@ -254,10 +293,7 @@ fn unbounded_scan_matches_the_golden() {
 /// table.
 #[test]
 fn non_wraparound_range_emits_only_its_segment() {
-    let Some(Fixture { data_db, ring, .. }) = fixture() else {
-        eprintln!("SKIP: {KEYSPACE}.{TABLE} Data.db is absent (gitignored corpus)");
-        return;
-    };
+    let Fixture { data_db, ring, .. } = fixture();
     // A mid-ring segment: every partition above the lowest and below the highest.
     // The two it excludes are what makes the case discriminating.
     let last = ring.len() - 1;
@@ -301,10 +337,7 @@ fn non_wraparound_range_emits_only_its_segment() {
 /// that the fix takes no early exit it is not entitled to.
 #[test]
 fn wraparound_range_emits_both_segments_and_nothing_between() {
-    let Some(Fixture { data_db, ring, .. }) = fixture() else {
-        eprintln!("SKIP: {KEYSPACE}.{TABLE} Data.db is absent (gitignored corpus)");
-        return;
-    };
+    let Fixture { data_db, ring, .. } = fixture();
     // `(highest-but-one, MAX] ∪ [MIN, lowest]`: the highest partition and the
     // lowest one, with everything between them excluded.
     let last = ring.len() - 1;

--- a/cqlite-core/tests/issue_3358_bti_query_token_bound.rs
+++ b/cqlite-core/tests/issue_3358_bti_query_token_bound.rs
@@ -1,8 +1,9 @@
 //! Issue #3358: `stream_all_partitions_for_query` must narrow to its
 //! `token_bound` on a BTI (`da`) reader, as it already does on an `nb` one.
 //!
-//! `ScanTokenBound::contains` is called in one place, the Summary-guided walk in
-//! `summary_scan/mod.rs`, and `stream_all_partitions_for_query` gates that walk on
+//! When #3358 was filed, `ScanTokenBound::contains` had ONE caller, the Summary-guided
+//! walk in `summary_scan/mod.rs`; the fix this file pins added a second,
+//! `TokenGate::admits`. `stream_all_partitions_for_query` gates that walk on
 //! `self.index_reader.is_some() && self.bti_partitions_db.is_none() &&
 //! summary_usable`. Every BTI generation has a `Partitions.db`, so the second term
 //! is false for every `da` reader on every call: the "full-ring fallback" below the
@@ -285,10 +286,40 @@ fn fixture() -> Fixture {
         let root = datasets_root::repo_root();
         let verify_cmd = shell_quote(&root.join("test-data/scripts/fetch-datasets.sh"));
         let verify_root = shell_quote(&root.join("test-data/datasets"));
-        let searched = datasets_root::describe_search(KEYSPACE, TABLE);
+        // NOT `describe_search`: it reports "no *-Data.db for <keyspace>.<table>", a
+        // BROADER absence than this lookup measured. The probe is generation-specific
+        // on purpose (see `fixture_dir`), so in the very case that predicate exists
+        // for — a root holding some OTHER generation of this table — that wording
+        // would be false. And NOT `describe_roots` either: its text advertises a bare
+        // `fetch-datasets.sh`, the destructive invocation the rest of this message
+        // spends six lines warning against. So the root list is taken from the
+        // resolver and the sentence is composed here, naming what was actually
+        // required.
+        let roots = datasets_root::sstables_root_candidates()
+            .iter()
+            .map(|r| r.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        // Named because a stray value hard-FAILs a CORRECT checkout: the seam removes
+        // the checkout candidate, which is the safe direction but an opaque one to
+        // debug if the reader does not know the var exists.
+        let seam = datasets_root::CHECKOUT_SSTABLES_ROOT_OVERRIDE_ENV;
+        let seam_note = match std::env::var_os(seam) {
+            Some(v) if !v.is_empty() => format!(
+                "NOTE: the test-harness seam {seam} is SET to '{}', which REPLACED the \
+                 checkout candidate root. If you did not mean to set it, unset it and \
+                 re-run — that alone may resolve this.\n\n",
+                v.to_string_lossy()
+            ),
+            _ => String::new(),
+        };
         panic!(
-            "{KEYSPACE}.{TABLE} `{SSTABLE_PREFIX}-Data.db` was not found: {searched}.\n\
+            "{KEYSPACE}.{TABLE}: no directory `{TABLE}-*` holding \
+             `{SSTABLE_PREFIX}-Data.db` under any candidate sstables root [{roots}]. \
+             The probe is GENERATION-specific, so a root carrying a different \
+             generation of this table does not satisfy it.\n\
              \n\
+             {seam_note}\
              This fixture is COMMITTED SOURCE (git-tracked, not gitignored), so this \
              is a broken checkout rather than a missing optional corpus, and it fails \
              closed rather than skipping: this file is the only end-to-end pin of \

--- a/cqlite-core/tests/issue_3358_bti_query_token_bound.rs
+++ b/cqlite-core/tests/issue_3358_bti_query_token_bound.rs
@@ -71,6 +71,16 @@ const TABLE: &str = "wide_multiclustering_small";
 const SSTABLE_PREFIX: &str = "da-1-bti";
 
 /// Repo root = the parent of this crate's manifest dir (`<repo>/cqlite-core`).
+/// Single-quote a path for safe pasting into a shell.
+///
+/// Checkout paths on this fleet contain no spaces today, but a remedy is copied by
+/// hand into a terminal, so a path holding a space or a shell metacharacter would
+/// silently run a different command. Single quotes disable all expansion; an embedded
+/// single quote is closed, escaped and reopened, the standard POSIX form.
+fn shell_quote(p: &Path) -> String {
+    format!("'{}'", p.display().to_string().replace('\'', "'\\''"))
+}
+
 fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -224,24 +234,30 @@ struct Fixture {
 /// legitimately absent, so an escape hatch could only buy a vacuous green.
 fn fixture() -> Fixture {
     let dir = fixture_dir().unwrap_or_else(|| {
-        // A glob PATHSPEC, not a literal path: the tracked directory carries a CFID
-        // suffix this code does not know, and a `<cfid>` placeholder would be both
-        // wrong AND unrunnable (`<` is shell input redirection). Quoted so the shell
-        // passes the `*` through to git rather than expanding it against a tree where
-        // the directory is, by definition, missing.
+        // DELIBERATELY NOT a synthesized `git restore` command. Five review rounds
+        // produced five different defects in one hand-built remedy string — an
+        // unsubstituted `<cfid>`, shell-redirection from the `<`, crate-relative paths
+        // that resolve to nothing when run from `cqlite-core/`, a glob that would
+        // restore the WHOLE fixture directory and silently discard a reader's unrelated
+        // uncommitted changes, and a repo-root anchor that still fails when pasted
+        // outside the checkout. The variant list was not closing.
         //
-        // `:(top)` anchors it at the repository root, because `cargo test -p cqlite-core`
-        // is routinely run FROM `cqlite-core/`, where a crate-relative `test-data/...`
-        // names nothing. The verification script is printed absolute for the same reason:
-        // a remedy that only works from one directory is a remedy that will be pasted
-        // and fail.
-        let restore_pathspec = format!(":(top)test-data/datasets/sstables/{KEYSPACE}/{TABLE}-*");
-        let root = repo_root();
-        let default_root = root.join("test-data/datasets").display().to_string();
-        let verify_cmd = root
-            .join("test-data/scripts/fetch-datasets.sh")
-            .display()
-            .to_string();
+        // `fetch-datasets.sh --verify-only` already emits a precise, safe restore
+        // command for exactly this case (#3310: it names git-tracked fixtures a
+        // SIGKILLed fetch deleted). Pointing at the tested emitter is strictly better
+        // than reproducing it here badly, so this message names ONE command and lets
+        // that tool produce the restore line. Do not "helpfully" add one back.
+        //
+        // `env -u CQLITE_DATASETS_ROOT` is LOAD-BEARING, not tidiness. The probe is
+        // scoped to whatever root it is given, and on a fleet box that variable points
+        // at a machine-local corpus OUTSIDE any git work tree — where it correctly
+        // reports `NO SUBJECT` and exits 0, detecting nothing. Measured: with the
+        // variable set to /data/datasets the remedy finds none of the 10 deleted files;
+        // unset, it names all 10. The fixture we are hunting is the COMMITTED one in
+        // this checkout, so the probe must be pointed there. Removing `env -u` turns
+        // this remedy into a no-op that looks like an all-clear.
+        let verify_cmd = shell_quote(&repo_root().join("test-data/scripts/fetch-datasets.sh"));
+        let default_root = repo_root().join("test-data/datasets").display().to_string();
         panic!(
             "{KEYSPACE}.{TABLE} `{SSTABLE_PREFIX}-Data.db` was not found under any \
              candidate dataset root (CQLITE_DATASETS_ROOT, then {default_root}).\n\
@@ -252,13 +268,14 @@ fn fixture() -> Fixture {
              #3358 and a skip would leave a green suite that certified nothing \
              (issue #3220).\n\
              \n\
-             Remedy: restore the tracked fixture (a SIGKILLed \
-             `test-data/scripts/fetch-datasets.sh` can delete tracked files — #3310):\n\
+             Remedy: a SIGKILLed `fetch-datasets.sh` can delete tracked files \
+             (#3310). Run:\n\
              \n\
-             \x20   git restore -- '{restore_pathspec}'\n\
+             \x20   env -u CQLITE_DATASETS_ROOT bash {verify_cmd} --verify-only\n\
              \n\
-             `bash {verify_cmd} --verify-only` names any such deletions and prints \
-             the exact restore command."
+             It names every git-tracked fixture that is missing and prints the exact, \
+             correctly-scoped restore command for them — which is why this message \
+             does not try to construct one."
         )
     });
     let golden = golden_rows_by_pk(&dir);

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -11998,6 +11998,14 @@ run_compaction_byte_parity() {
 # falls back to the in-repo committed fixture when CQLITE_DATASETS_ROOT names a corpus
 # that lacks it. Under the previous keyspace-granular resolution the case skipped.
 #
+# Fourth invocation — scripts/tests/test_issue_3358_failclosed.sh (#3731/#3220 AC3), the
+# same positive control for the OTHER committed-fixture BTI lane,
+# issue_3358_bti_query_token_bound. Its #3220 hardening recorded the RED verification as
+# measurements in a PR comment, which proves a guard fired once and regression-protects
+# nothing: a run with the fixture PRESENT is identical whether or not `fixture()` still
+# fails closed. roborev job 252 raised exactly that. Runs HERE for the same reason as the
+# third invocation — it drives a test binary this component's feature set has built.
+#
 # Third invocation — scripts/tests/test_point_vs_full_failclosed.sh (#3220 AC2), the
 # POSITIVE CONTROL for everything above: a green lane proves nothing unless the same
 # lane FAILs on a fixture that is absent from every candidate root AND on one that is
@@ -12035,7 +12043,8 @@ run_bti_multiclustering() {
     && env -u CQLITE_REQUIRE_FIXTURES "${ds_env[@]}" \
       cargo test -p cqlite-core --features "state_machine cli-helpers" \
         --test point_vs_full_differential >>"$log" 2>&1 \
-    && bash "$REPO_ROOT/scripts/tests/test_point_vs_full_failclosed.sh" >>"$log" 2>&1; then
+    && bash "$REPO_ROOT/scripts/tests/test_point_vs_full_failclosed.sh" >>"$log" 2>&1 \
+    && bash "$REPO_ROOT/scripts/tests/test_issue_3358_failclosed.sh" >>"$log" 2>&1; then
     status=PASS
   else
     status=FAIL

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -12035,7 +12035,16 @@ run_bti_multiclustering() {
   # word as the command.
   local -a ds_env=()
   [ -n "${CQLITE_DATASETS_ROOT:-}" ] && ds_env=(CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT")
+  # DECLARES WHAT IT RUNS, because the SUMMARY annotation structurally cannot. That line
+  # is derived from cargo argv observed in THIS shell, and the interceptors are unexported
+  # by design, so the 6 cargo invocations inside the two fail-closed sub-scripts are
+  # invisible to it: the annotation reads `x2` while this component drives 8. Not drift —
+  # `x2` truthfully names what the renderer saw — but a reader pasting the SUMMARY would
+  # not know either harness ran. The narrowing is therefore declared HERE, in the emitted
+  # log, on the same principle as flight-tests printing what it does not execute.
   echo ">>> [$name] compound-clustering BTI trie shape + SELECT + point-vs-full lanes, fail-closed (#3032/#3220)"
+  echo ">>> [$name] + 2 fail-closed positive controls, 6 further cargo runs NOT named by the SUMMARY annotation:"
+  echo ">>> [$name]     test_point_vs_full_failclosed.sh (#3220 AC2), test_issue_3358_failclosed.sh (#3731 AC3)"
   if env CQLITE_REQUIRE_FIXTURES=1 "${ds_env[@]}" \
       cargo test -p cqlite-core --features "state_machine cli-helpers" \
         --test issue_3032_multiclustering_rows_trie_shape \

--- a/scripts/tests/test_issue_3358_failclosed.sh
+++ b/scripts/tests/test_issue_3358_failclosed.sh
@@ -151,19 +151,54 @@ FIXTURE_STATUS_BEFORE=$(git -C "$REPO" status --porcelain -- "$FIXTURE_REL" 2>/d
 # taken is `UNMEASURED`, never a hash, and UNMEASURED on either side FAILS the case — an
 # unanswerable question is not a clean answer.
 _fixture_content_digest() {
-  local n out
-  n=$(find "$REPO/$FIXTURE_REL" -type f 2>/dev/null | wc -l | tr -d ' ')
+  # PORTABLE, and git-only by design. The first version used `sort -z` and `sha256sum`,
+  # both GNU-only: on stock macOS — a supported host — neither exists, the digest became
+  # UNMEASURED, and this script's own fail-closed rule then FAILED `bti-multiclustering`
+  # on a healthy tree (roborev job 268). A guard that reds on a supported platform is the
+  # guard that platform's operators learn to waive.
+  #
+  # `git ls-files -z` + `git hash-object` need nothing but git, which this script already
+  # requires for the status leg, and `-z` is git's own flag rather than a coreutils
+  # extension. ls-files emits in git's own sorted order, so no external sort is needed —
+  # which also removes the newline-in-filename hazard a plain `sort` would reintroduce.
+  #
+  # The VALUE is the sorted "<blob-sha> <path>" text itself, not a hash of it: comparing
+  # the text is exact, and it means no digest utility is required at all.
+  #
+  # EVERY status is checked, per the same finding's second half: a partial traversal or a
+  # failed per-file hash must yield UNMEASURED, never a well-formed digest of incomplete
+  # input.
+  # NUL-delimited data CANNOT round-trip through a shell variable — command substitution
+  # strips NUL ("bash: ignored null byte in input"), which silently collapsed the file
+  # list and made every call return UNMEASURED. Caught by running the helper rather than
+  # reading it. So the list goes to a temp FILE, which holds NULs fine and also lets
+  # git's exit status be checked before the list is used.
+  local tmpf n out h rc emitted
+  tmpf=$(mktemp "${TMPDIR:-/tmp}/i3358-dg.XXXXXX") || { printf 'UNMEASURED(mktemp)'; return; }
+  if ! git -C "$REPO" ls-files -z -- "$FIXTURE_REL" >"$tmpf" 2>/dev/null; then
+    rm -f "$tmpf"; printf 'UNMEASURED(ls-files-failed)'; return
+  fi
+  n=$(tr -cd '\0' <"$tmpf" | wc -c | tr -d ' ')
   case $n in
-    ''|*[!0-9]*) printf 'UNMEASURED(count)'; return ;;
-    0)           printf 'UNMEASURED(no-files)'; return ;;
+    ''|*[!0-9]*) rm -f "$tmpf"; printf 'UNMEASURED(count)'; return ;;
+    0)           rm -f "$tmpf"; printf 'UNMEASURED(no-tracked-files)'; return ;;
   esac
-  out=$(find "$REPO/$FIXTURE_REL" -type f -print0 2>/dev/null \
-        | LC_ALL=C sort -z \
-        | xargs -0 sha256sum 2>/dev/null \
-        | sha256sum 2>/dev/null | cut -d' ' -f1)
-  case $out in
-    ''|*[!0-9a-f]*) printf 'UNMEASURED(digest)'; return ;;
-  esac
+  out=""
+  while IFS= read -r -d '' f; do
+    h=$(git -C "$REPO" hash-object -- "$f" 2>/dev/null); rc=$?
+    if [ "$rc" -ne 0 ] || [ -z "$h" ]; then
+      rm -f "$tmpf"; printf 'UNMEASURED(hash-object-failed)'; return
+    fi
+    out="$out$h $f
+"
+  done <"$tmpf"
+  rm -f "$tmpf"
+  # Re-assert the count: a `while read` that terminated early would otherwise emit a
+  # shorter, perfectly well-formed value.
+  emitted=$(printf '%s' "$out" | grep -c .)
+  if [ "$emitted" != "$n" ]; then
+    printf 'UNMEASURED(truncated:%s-of-%s)' "$emitted" "$n"; return
+  fi
   printf '%s:%s' "$n" "$out"
 }
 FIXTURE_DIGEST_BEFORE=$(_fixture_content_digest)

--- a/scripts/tests/test_issue_3358_failclosed.sh
+++ b/scripts/tests/test_issue_3358_failclosed.sh
@@ -241,15 +241,27 @@ the empty one was never rejected; see $empty_out"
 else
   ok "empty: the target did not report ok (no fallback to a healthy fixture)"
 fi
-# The rejection must be the READER refusing the empty file, named on one line together
-# with this fixture, so a sibling's failure cannot satisfy it.
-if grep -q "Header buffer too small for parsing: 0 bytes" "$empty_out" \
-   && grep -q "$FIXTURE_DIRNAME" "$empty_out"; then
-  ok "empty: rejected by the reader on the empty Data.db, naming this fixture"
+# COUNT-BEARING, exactly as the absent case is. `must_run` is per case (#3220 forbids a
+# suite-wide `ran > 0`), so "one case failed and two silently passed" is the defect
+# itself, not a pass. This assertion was missing here while the file's own contract
+# claimed it — roborev job 254.
+if grep -qE "^test result: FAILED\. 0 passed; ${TEST_COUNT} failed" "$empty_out"; then
+  ok "empty: ALL ${TEST_COUNT} cases failed — fail-closed is per case, not suite-wide"
 else
-  bad "empty: no 'Header buffer too small for parsing: 0 bytes' for $FIXTURE_DIRNAME — \
-the run failed for some OTHER reason, which does not prove the empty fixture was \
-rejected; see $empty_out"
+  bad "empty: no 'test result: FAILED. 0 passed; ${TEST_COUNT} failed' line — some case \
+did not reject the empty fixture; see $empty_out"
+fi
+# ONE line carrying BOTH the fixture identity and the zero-byte reader error. Two
+# separate greps would only prove each string appears SOMEWHERE, which is satisfiable by
+# an unrelated failure elsewhere in the output plus the fixture name in a healthy path —
+# and the comment here previously CLAIMED "on one line" while the code did not check it
+# (roborev job 254). That is this lane's own defect class, in the file asserting it.
+if grep -qE "${FIXTURE_DIRNAME}.*Header buffer too small for parsing: 0 bytes" "$empty_out"; then
+  ok "empty: ONE line carries both this fixture and the zero-byte reader rejection"
+else
+  bad "empty: no single line carrying both '$FIXTURE_DIRNAME' and 'Header buffer too \
+small for parsing: 0 bytes' — the run failed for some OTHER reason, which does not \
+prove the empty fixture was rejected; see $empty_out"
 fi
 if grep -q 'SKIP' "$empty_out"; then
   bad "empty: output contains 'SKIP' — an empty fixture must be a hard failure, not an \
@@ -282,7 +294,7 @@ fi
 # Anti-vacuity for THIS harness: `failed: 0` is only meaningful if every case actually
 # asserted. A deleted case, an early `exit`, or a block skipped by an editing accident
 # would otherwise report green.
-EXPECTED_CHECKS=14
+EXPECTED_CHECKS=15
 total_checks=$((PASS + FAIL))
 if [ "$total_checks" -ne "$EXPECTED_CHECKS" ]; then
   printf 'FAIL - harness: %d assertions ran, expected %d — a dropped or '\

--- a/scripts/tests/test_issue_3358_failclosed.sh
+++ b/scripts/tests/test_issue_3358_failclosed.sh
@@ -102,7 +102,46 @@ case $tmp in
   /*) ;;
   *) echo "FATAL: scratch root '$tmp' is not absolute; refusing to run" >&2; exit 1 ;;
 esac
-trap 'rm -rf "$tmp"' EXIT
+# On FAILURE the scratch root is PRESERVED and every lane log EXCERPTED, because a
+# harness whose failure destroys its own evidence is the "defect that produces no
+# artifact" shape (roborev job 297, Low — reproduced before fixing: a planted absent-case
+# failure printed `see /tmp/i3358-failclosed.XXXXXX/absent.log` and the trap had already
+# deleted it).
+#
+# WHY THE EXCERPT AND NOT JUST THE PRESERVED PATH: this harness runs INSIDE the gate
+# (`bti-multiclustering`), and the only gate text an agent retains is the SUMMARY block —
+# doctrine says never read gate.log. A preserved directory therefore helps a STANDALONE
+# re-run and does nothing for the run that actually failed, so the diagnostics have to be
+# ON STDOUT to exist at all. The control case already did this at its one site
+# (`sed -n '1,40p'`); doing it in the trap covers EVERY site, including the absent and
+# empty cases the finding names, without touching eight message sites.
+#
+# Placed here so the function exists before the trap can fire; the trap is still armed
+# immediately after the scratch-root validation above, so `rm -rf ""` stays impossible.
+_i3358_cleanup() {
+  if [ "${FAIL:-0}" -gt 0 ]; then
+    printf '\n%s\n' "---------- FAILURE DIAGNOSTICS (the logs the messages above name) ----------"
+    for _log in "$tmp"/*.log; do
+      [ -f "$_log" ] || continue
+      _lines=$(wc -l < "$_log" 2>/dev/null || echo 0)
+      printf '\n===== %s (%s lines) =====\n' "$_log" "$_lines"
+      # Bounded, and it says WHERE it truncated. A cargo lane's cause can be at either
+      # end — compile errors at the top, panics and the `test result:` line at the
+      # bottom — so neither `head` nor `tail` alone is sufficient.
+      if [ "$_lines" -le 60 ]; then
+        cat "$_log"
+      else
+        sed -n '1,20p' "$_log"
+        printf '%s\n' "... [$((_lines - 50)) lines omitted] ..."
+        sed -n "$((_lines - 29)),\$p" "$_log"
+      fi
+    done
+    printf '\n%s\n' "PRESERVED for inspection (not deleted, because FAIL=$FAIL): $tmp"
+  else
+    rm -rf "$tmp"
+  fi
+}
+trap '_i3358_cleanup' EXIT
 
 # The committed fixture must be present for ANY of this to mean anything: the control's
 # expected behavior is "it runs", and both failure cases are defined relative to it.

--- a/scripts/tests/test_issue_3358_failclosed.sh
+++ b/scripts/tests/test_issue_3358_failclosed.sh
@@ -138,17 +138,23 @@ fi
 #
 # POSTURE: clear the ENTIRE `GIT_*` namespace rather than blacklisting names. Inherited git
 # environment is routine (hooks, `rebase --exec`, some CI runners), and this script's safety
-# oracle is exactly the kind of thing it silently breaks: a VALID but FOREIGN
-# `GIT_INDEX_FILE` makes `ls-files` enumerate only a SUBSET of the fixture (possibly zero),
-# so the CONTENT digest is computed over fewer files than exist and a change to an omitted
-# tracked file compares EQUAL. That is a false PASS in the guard whose whole claim is "this
-# run left the tracked fixture UNCHANGED" — and it is not hypothetical: the sibling wrapper's
-# own comment records this exact door causing tracked fixtures to be deleted while the run
-# declared success (#2878). `GIT_DIR`/`GIT_WORK_TREE`/`GIT_OBJECT_DIRECTORY` redirect the
-# same inputs.
+# oracle is exactly the kind of thing it silently breaks. `GIT_DIR` / `GIT_WORK_TREE` /
+# `GIT_OBJECT_DIRECTORY` / `GIT_COMMON_DIR` redirect which repository and object store
+# `ls-tree` and `hash-object` read, and a VALID but FOREIGN `GIT_INDEX_FILE` still redirects
+# the index that `status --porcelain` consults. Either way the digest or the status leg is
+# computed against something other than this checkout, and a real change compares EQUAL —
+# a false PASS in the guard whose whole claim is "this run left the tracked fixture
+# UNCHANGED". Not hypothetical: the sibling wrapper's own comment records this exact door
+# causing tracked fixtures to be deleted while the run declared success (#2878).
+#
+# HONEST NOTE on overlap: the enumeration leg later moved from `ls-files` to
+# `ls-tree HEAD` (roborev job 295), which removes `GIT_INDEX_FILE`'s ability to truncate the
+# FILE LIST specifically. That narrows one illustration; it does not make the scrub
+# redundant, because the variables above still redirect the repo/object store for both
+# remaining git operations, and the index still governs the status leg.
 #
 # A `-u` blacklist is an ever-growing list that fails silently the day git adds another
-# variable. None of this script's three operations (status --porcelain, ls-files,
+# variable. None of this script's three operations (status --porcelain, ls-tree,
 # hash-object) needs any GIT_* input, so clearing the namespace has no legitimate cost, and
 # where it is visible it fails LOUDLY rather than mis-reading quietly.
 # The subshell keeps the caller's environment untouched.
@@ -188,9 +194,9 @@ _fixture_content_digest() {
   # on a healthy tree (roborev job 268). A guard that reds on a supported platform is the
   # guard that platform's operators learn to waive.
   #
-  # `git ls-files -z` + `git hash-object` need nothing but git, which this script already
+  # `git ls-tree -z` + `git hash-object` need nothing but git, which this script already
   # requires for the status leg, and `-z` is git's own flag rather than a coreutils
-  # extension. ls-files emits in git's own sorted order, so no external sort is needed —
+  # extension. ls-tree emits in git's own sorted order, so no external sort is needed —
   # which also removes the newline-in-filename hazard a plain `sort` would reintroduce.
   #
   # The VALUE is the sorted "<blob-sha> <path>" text itself, not a hash of it: comparing
@@ -206,8 +212,19 @@ _fixture_content_digest() {
   # git's exit status be checked before the list is used.
   local tmpf n out h rc emitted
   tmpf=$(mktemp "${TMPDIR:-/tmp}/i3358-dg.XXXXXX") || { printf 'UNMEASURED(mktemp)'; return; }
-  if ! guard_git -C "$REPO" ls-files -z -- "$FIXTURE_REL" >"$tmpf" 2>/dev/null; then
-    rm -f "$tmpf"; printf 'UNMEASURED(ls-files-failed)'; return
+  # Enumerate from HEAD, not the index. `ls-files` reads the INDEX, i.e. STAGED state, while
+  # this case's claim is about the COMMITTED fixture — the enumeration source has to match
+  # the noun in the claim (roborev job 295). A fixture file staged for deletion but still
+  # present in the worktree is OMITTED by `ls-files`, so the digest never covers it, and
+  # porcelain cannot compensate: measured in a scratch repo, `status --porcelain` returns the
+  # byte-identical `D  <path>` + `?? <path>` before AND after that file is modified, so BOTH
+  # legs go blind together in exactly the harness-bug scenario this case exists to catch.
+  #   ls-files        2 files -> 1 after staging the deletion (omits it)
+  #   ls-tree -r HEAD 2 files -> 2 (still the committed set)
+  # CONSEQUENCE, deliberate and consistent with the narrowed claim: a fixture file added to
+  # the index but NOT yet committed is out of scope here, because it is not committed.
+  if ! guard_git -C "$REPO" ls-tree -r -z --name-only HEAD -- "$FIXTURE_REL" >"$tmpf" 2>/dev/null; then
+    rm -f "$tmpf"; printf 'UNMEASURED(ls-tree-failed)'; return
   fi
   n=$(tr -cd '\0' <"$tmpf" | wc -c | tr -d ' ')
   case $n in

--- a/scripts/tests/test_issue_3358_failclosed.sh
+++ b/scripts/tests/test_issue_3358_failclosed.sh
@@ -30,7 +30,9 @@
 #             the seam NOTE, since this case is what sets the seam.
 #   empty   — the fixture dir and its `-Data.db` exist but the file is 0 bytes: must be
 #             a hard failure, never a SKIP and never a 0-rows pass.
-#   safety  — neither the git-tracked fixture nor the ambient corpus was mutated.
+#   safety  — the git-tracked fixture was not mutated (SCOPE: the tracked fixture only;
+#             the ambient $CQLITE_DATASETS_ROOT is never a staging target and is not
+#             claimed — see the case-4 header for why).
 #
 # DISCRIMINATION LIMIT, stated rather than implied. The sibling script can prove its
 # staging is surgical from the LANE's own output, because its target drives many fixtures
@@ -214,7 +216,15 @@ _fixture_content_digest() {
   esac
   out=""
   while IFS= read -r -d '' f; do
-    h=$(guard_git -C "$REPO" hash-object -- "$f" 2>/dev/null); rc=$?
+    # `--no-filters` hashes the RAW bytes on disk. Without it `hash-object` applies any
+    # configured clean/EOL filter, so a byte change that NORMALISES to the same content
+    # yields the same blob sha — and `git status` applies the SAME normalisation, so both
+    # legs of this safety check would go blind together. Two legs with a shared blind spot
+    # are one leg (roborev job 294). LATENT today, not live: this repo sets no
+    # `.gitattributes` and `git check-attr -a` reports no attribute on the fixture, so no
+    # filter currently applies. The flag costs nothing and removes the dependence on that
+    # staying true.
+    h=$(guard_git -C "$REPO" hash-object --no-filters -- "$f" 2>/dev/null); rc=$?
     if [ "$rc" -ne 0 ] || [ -z "$h" ]; then
       rm -f "$tmpf"; printf 'UNMEASURED(hash-object-failed)'; return
     fi
@@ -435,8 +445,22 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 4. SAFETY: neither the tracked fixture nor the ambient corpus was mutated.
+# 4. SAFETY: the git-tracked (committed) fixture was not mutated by this harness.
 # ---------------------------------------------------------------------------
+# SCOPE, stated to match what is actually MEASURED. The header previously claimed "nor
+# the ambient corpus", which this case never snapshots — a claim wider than its evidence,
+# i.e. this lane's own defect class in the file asserting it (roborev job 294).
+#
+# What IS measured: the git-tracked fixture $FIXTURE_REL, by CONTENT digest + `git status`
+# against a pre-staging baseline.
+# What is NOT, and why that is not a gap here: the AMBIENT root ($CQLITE_DATASETS_ROOT) is
+# not git-tracked, so a git-based digest cannot cover it at all. It is also never a staging
+# TARGET — every staged path this harness writes lives under `$tmp` from `mktemp -d`
+# (`absent_checkout` and `$tmp/absent-env` at the absent lane; `$tmp/empty` holding the
+# COPY that case 3 truncates). The ambient root appears in exactly one place, the CONTROL
+# case's env, where it is only READ. Narrowing the claim is therefore the honest fix rather
+# than bolting on a second, unverifiable oracle over an out-of-tree directory.
+#
 # `git status` is the evidence, so a git that could not ANSWER (not a repo, git missing)
 # must not read as "untouched" — an unanswerable question is not a clean answer. The
 # `-s` check is the independent second leg: case 3 truncates a COPY, and a staging bug
@@ -473,8 +497,10 @@ elif [ ! -s "$REPO/$FIXTURE_REL/$DATA_DB" ]; then
   bad "safety: the tracked $FIXTURE_REL/$DATA_DB is now EMPTY — case 3 truncated the \
 original instead of its copy"
 else
-  ok "safety: this run left the tracked fixture UNCHANGED — CONTENT digest and git \
-status both identical to the pre-staging baseline, and the Data.db still non-empty"
+  ok "safety: this run left the git-tracked fixture UNCHANGED — raw-content digest \
+(hash-object --no-filters) and git status both identical to the pre-staging baseline, \
+and the Data.db still non-empty. Scope: the TRACKED fixture only; the ambient \
+\$CQLITE_DATASETS_ROOT is never a staging target and is not claimed here"
 fi
 
 # Anti-vacuity for THIS harness: `failed: 0` is only meaningful if every case actually

--- a/scripts/tests/test_issue_3358_failclosed.sh
+++ b/scripts/tests/test_issue_3358_failclosed.sh
@@ -131,11 +131,40 @@ if [ ! -f "$REPO/$FIXTURE_REL/$DATA_DB" ]; then
   exit 1
 fi
 
+# EVERY git invocation in this script goes through this wrapper (roborev job 293, and the
+# same posture as `guard_git` in test-data/scripts/fetch-datasets.sh:109, issue #2878).
+#
+# POSTURE: clear the ENTIRE `GIT_*` namespace rather than blacklisting names. Inherited git
+# environment is routine (hooks, `rebase --exec`, some CI runners), and this script's safety
+# oracle is exactly the kind of thing it silently breaks: a VALID but FOREIGN
+# `GIT_INDEX_FILE` makes `ls-files` enumerate only a SUBSET of the fixture (possibly zero),
+# so the CONTENT digest is computed over fewer files than exist and a change to an omitted
+# tracked file compares EQUAL. That is a false PASS in the guard whose whole claim is "this
+# run left the tracked fixture UNCHANGED" — and it is not hypothetical: the sibling wrapper's
+# own comment records this exact door causing tracked fixtures to be deleted while the run
+# declared success (#2878). `GIT_DIR`/`GIT_WORK_TREE`/`GIT_OBJECT_DIRECTORY` redirect the
+# same inputs.
+#
+# A `-u` blacklist is an ever-growing list that fails silently the day git adds another
+# variable. None of this script's three operations (status --porcelain, ls-files,
+# hash-object) needs any GIT_* input, so clearing the namespace has no legitimate cost, and
+# where it is visible it fails LOUDLY rather than mis-reading quietly.
+# The subshell keeps the caller's environment untouched.
+guard_git() {
+  (
+    # `${!GIT_@}` enumerates every GIT_-prefixed variable in scope, inherited ones included;
+    # unquoted on purpose (names cannot word-split), and `unset` with no arguments is a no-op.
+    # shellcheck disable=SC2086
+    unset ${!GIT_@} 2>/dev/null || true
+    git "$@"
+  )
+}
+
 # BASELINE for the safety case, captured before anything is staged. An unanswerable
 # `git status` is recorded as the sentinel `UNMEASURED` rather than as an empty string,
 # because empty means "clean" and would make a failed probe look like a clean baseline —
 # the permissive direction.
-FIXTURE_STATUS_BEFORE=$(git -C "$REPO" status --porcelain -- "$FIXTURE_REL" 2>/dev/null) \
+FIXTURE_STATUS_BEFORE=$(guard_git -C "$REPO" status --porcelain -- "$FIXTURE_REL" 2>/dev/null) \
   || FIXTURE_STATUS_BEFORE="UNMEASURED"
 
 # CONTENT, not status. `git status --porcelain` yields a STATUS CODE, and a file already
@@ -175,7 +204,7 @@ _fixture_content_digest() {
   # git's exit status be checked before the list is used.
   local tmpf n out h rc emitted
   tmpf=$(mktemp "${TMPDIR:-/tmp}/i3358-dg.XXXXXX") || { printf 'UNMEASURED(mktemp)'; return; }
-  if ! git -C "$REPO" ls-files -z -- "$FIXTURE_REL" >"$tmpf" 2>/dev/null; then
+  if ! guard_git -C "$REPO" ls-files -z -- "$FIXTURE_REL" >"$tmpf" 2>/dev/null; then
     rm -f "$tmpf"; printf 'UNMEASURED(ls-files-failed)'; return
   fi
   n=$(tr -cd '\0' <"$tmpf" | wc -c | tr -d ' ')
@@ -185,7 +214,7 @@ _fixture_content_digest() {
   esac
   out=""
   while IFS= read -r -d '' f; do
-    h=$(git -C "$REPO" hash-object -- "$f" 2>/dev/null); rc=$?
+    h=$(guard_git -C "$REPO" hash-object -- "$f" 2>/dev/null); rc=$?
     if [ "$rc" -ne 0 ] || [ -z "$h" ]; then
       rm -f "$tmpf"; printf 'UNMEASURED(hash-object-failed)'; return
     fi
@@ -412,7 +441,7 @@ fi
 # must not read as "untouched" — an unanswerable question is not a clean answer. The
 # `-s` check is the independent second leg: case 3 truncates a COPY, and a staging bug
 # that truncated the ORIGINAL in place would leave a 0-byte tracked file.
-fixture_status=$(git -C "$REPO" status --porcelain -- "$FIXTURE_REL" 2>/dev/null)
+fixture_status=$(guard_git -C "$REPO" status --porcelain -- "$FIXTURE_REL" 2>/dev/null)
 fixture_status_rc=$?
 fixture_digest_after=$(_fixture_content_digest)
 if [ "$fixture_status_rc" -ne 0 ]; then

--- a/scripts/tests/test_issue_3358_failclosed.sh
+++ b/scripts/tests/test_issue_3358_failclosed.sh
@@ -276,7 +276,17 @@ run_lane() {
 control_out="$tmp/control.log"
 control_env=()
 [ -n "${CQLITE_DATASETS_ROOT:-}" ] && control_env=(CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT")
-run_lane "$control_out" "${control_env[@]}"
+# `${arr[@]+"${arr[@]}"}` — an EMPTY array expands to NOTHING under `set -u` instead of
+# aborting. On Bash 3.2, which is what macOS ships and this repo supports, a bare
+# `"${control_env[@]}"` on an empty array is an UNBOUND VARIABLE error under `set -u`
+# (roborev job 296, Medium). That is reachable on the DOCUMENTED standalone invocation:
+# measured here, with CQLITE_DATASETS_ROOT unset the script reaches this line and the
+# control lane passes (the checkout resolver finds the corpus by itself), so `control_env`
+# is legitimately empty. The failure mode is the worst one for a fail-closed harness — it
+# aborts BEFORE any case runs, i.e. a silent non-run.
+# Same idiom and rationale as scripts/tests/test_ws0_embedded_steps_execute.sh:1363 and
+# scripts/bootstrap-agent-machine.sh:621 — reusing the repo's form, not inventing one.
+run_lane "$control_out" ${control_env[@]+"${control_env[@]}"}
 control_rc=$?
 if [ "$control_rc" -eq 0 ]; then
   ok "control: the target passes against the ambient corpus"

--- a/scripts/tests/test_issue_3358_failclosed.sh
+++ b/scripts/tests/test_issue_3358_failclosed.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# Regression test for #3731/#3220 AC3: the #3358 BTI token-bound lane must FAIL — never
+# skip, never pass vacuously — in BOTH fixture-absence directions.
+#
+# WHY THIS FILE EXISTS AT ALL. The #3220 hardening removed three SKIP guards from
+# `issue_3358_bti_query_token_bound.rs` and its PR recorded the RED verification as
+# MEASUREMENTS IN A COMMENT. That is evidence that the guard fired ONCE, on one machine,
+# on one day — it is not a guard. Nothing stopped `fixture()` reverting to `Option` and
+# every run staying green, because a run with the fixture PRESENT looks identical either
+# way. roborev raised exactly that (job 252): "the new fail-closed behavior has no
+# committed negative test". So the observation moves here, where it re-runs.
+#
+# ASSERTION CONTRACT, inherited from `test_point_vs_full_failclosed.sh` (#3220 AC2) and
+# held to the same standard: every check must be UNSATISFIABLE by output that does not
+# demonstrate the property claimed. Two forms are therefore banned in the failure cases:
+#   * a bare nonzero exit — it proves only that SOMETHING failed, not that the STAGED
+#     condition was rejected (an unrelated compile error produces an identical rc); and
+#   * a bare mention of the table name — the fixture PATH carries it in healthy output
+#     too, so accepting it would let a run that resolved to the real fixture satisfy the
+#     control meant to rule that out.
+# Each case therefore pins a count-bearing `test result:` line AND a message naming this
+# target's own guard, and the terminal EXPECTED_CHECKS anchor keeps a dropped case from
+# reading as green.
+#
+# The cases:
+#   control — ambient corpus: the target PASSES and all THREE tests run (the count is
+#             asserted, so a target that executed nothing cannot satisfy it).
+#   absent  — no candidate root holds `wide_multiclustering_small-*/da-1-bti-Data.db`:
+#             every case must FAIL with the generation-specific diagnostic. Also pins
+#             the seam NOTE, since this case is what sets the seam.
+#   empty   — the fixture dir and its `-Data.db` exist but the file is 0 bytes: must be
+#             a hard failure, never a SKIP and never a 0-rows pass.
+#   safety  — neither the git-tracked fixture nor the ambient corpus was mutated.
+#
+# DISCRIMINATION LIMIT, stated rather than implied. The sibling script can prove its
+# staging is surgical from the LANE's own output, because its target drives many fixtures
+# and a sibling case's `PASS` line shows only one was hidden. This target has exactly ONE
+# fixture, so no such per-case list exists and that evidence is not available here.
+# Instead the staging is asserted SURGICAL against the filesystem (the keyspace dir is
+# mirrored with its sibling tables and only this fixture withheld), which is what pins
+# the specific #3220 defect: keyspace-granular selection would have ACCEPTED that root.
+#
+# Run standalone:   bash scripts/tests/test_issue_3358_failclosed.sh
+# Or via the gate:  `bti-multiclustering`, alongside the sibling fail-closed script, so
+#                   the test binary it drives is already built.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+FIXTURE_REL="test-data/datasets/sstables/test_da/wide_multiclustering_small-47f6a3008f6911f1bc0f8df8badcc262"
+FIXTURE_DIRNAME=$(basename "$FIXTURE_REL")
+DATA_DB="da-1-bti-Data.db"
+TEST_TARGET="issue_3358_bti_query_token_bound"
+TEST_COUNT=3
+
+# #2751 defense-in-depth: never clobber an inherited gate summary path.
+unset AGENT_GATE_SUMMARY_FILE
+# The guard under test is the UNCONDITIONAL one (committed fixture => no legitimate
+# SKIP), so an inherited CQLITE_REQUIRE_FIXTURES must not decide any case.
+unset CQLITE_REQUIRE_FIXTURES
+# Scrub the seam this file itself drives, so a stale export cannot pre-decide a case.
+unset CQLITE_TEST_CHECKOUT_SSTABLES_ROOT
+
+PASS=0
+FAIL=0
+ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+# Scratch root, VALIDATED before the cleanup trap is armed: this script runs without
+# `errexit` (every case must run, so one failure cannot hide the rest), so an unchecked
+# `mktemp -d` would leave `$tmp` empty, resolve every derived path under `/`, and hand
+# the EXIT trap an `rm -rf ""`.
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/i3358-failclosed.XXXXXX") || {
+  echo "FATAL: mktemp -d failed; refusing to run with an unset scratch root" >&2
+  exit 1
+}
+if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
+  echo "FATAL: mktemp -d produced no usable directory ('$tmp'); refusing to run" >&2
+  exit 1
+fi
+trap 'rm -rf "$tmp"' EXIT
+
+# The committed fixture must be present for ANY of this to mean anything: the control's
+# expected behavior is "it runs", and both failure cases are defined relative to it.
+# Absent => hard error, not a skip. This fixture is git-tracked (#3220).
+if [ ! -f "$REPO/$FIXTURE_REL/$DATA_DB" ]; then
+  echo "FATAL: committed fixture $FIXTURE_REL/$DATA_DB is missing from the checkout;" >&2
+  echo "       remedy: git -C $REPO restore --source=HEAD -- test-data/datasets" >&2
+  exit 1
+fi
+
+# Run the target with an explicit environment. Prints nothing; the caller greps $out.
+run_lane() {
+  local out=$1; shift
+  # `env -u` clears both seams unless the case re-supplies them, so no case can inherit
+  # another's staging.
+  ( cd "$REPO" && env -u CQLITE_DATASETS_ROOT -u CQLITE_TEST_CHECKOUT_SSTABLES_ROOT "$@" \
+      cargo test -p cqlite-core --features "state_machine cli-helpers" \
+        --test "$TEST_TARGET" -- --nocapture ) >"$out" 2>&1
+  return $?
+}
+
+# ---------------------------------------------------------------------------
+# 1. CONTROL: the ambient corpus. The target passes AND all three tests run.
+# ---------------------------------------------------------------------------
+control_out="$tmp/control.log"
+control_env=()
+[ -n "${CQLITE_DATASETS_ROOT:-}" ] && control_env=(CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT")
+run_lane "$control_out" "${control_env[@]}"
+control_rc=$?
+if [ "$control_rc" -eq 0 ]; then
+  ok "control: the target passes against the ambient corpus"
+else
+  bad "control: the target FAILED against the ambient corpus (rc=$control_rc) — the two \
+failure cases below prove nothing until this passes; see $control_out"
+  sed -n '1,40p' "$control_out"
+fi
+# COUNT-BEARING, deliberately: `test result: ok. 0 passed` is also an `ok` line, so a
+# target whose cases were all filtered out or cfg'd away would satisfy a bare `ok`
+# match. Requiring the exact count is what makes this a positive control.
+if grep -qE "^test result: ok\. ${TEST_COUNT} passed; 0 failed" "$control_out"; then
+  ok "control: all ${TEST_COUNT} cases actually RAN and passed (count asserted, not just 'ok')"
+else
+  bad "control: no 'test result: ok. ${TEST_COUNT} passed; 0 failed' line — the cases did \
+not all run, so a green here would be vacuous; see $control_out"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. ABSENT: no candidate root carries THIS generation of THIS table, while every
+#    sibling table stays resolvable.
+#
+#    The staging is SURGICAL, not "hide the whole corpus". Hiding everything would let
+#    the assertion pass for a reason unrelated to this fixture. The checkout candidate
+#    is mirrored by SYMLINK, table by table, minus the one fixture; the env candidate is
+#    an empty root that exists (so the resolver walks it and finds nothing, rather than
+#    skipping an unreadable dir).
+# ---------------------------------------------------------------------------
+absent_checkout="$tmp/absent-checkout/sstables"
+mkdir -p "$absent_checkout" "$tmp/absent-env/sstables"
+src_sstables="$REPO/test-data/datasets/sstables"
+for ks_dir in "$src_sstables"/*/; do
+  [ -d "$ks_dir" ] || continue
+  ks_name=$(basename "$ks_dir")
+  mkdir -p "$absent_checkout/$ks_name"
+  for tbl_dir in "$ks_dir"*/; do
+    [ -d "$tbl_dir" ] || continue
+    tbl_name=$(basename "$tbl_dir")
+    case "$tbl_name" in
+      wide_multiclustering_small-*) continue ;;   # the ONLY thing hidden
+    esac
+    ln -s "${tbl_dir%/}" "$absent_checkout/$ks_name/$tbl_name"
+  done
+done
+# The keyspace dir EXISTS and holds sibling tables: that is what pins the #3220 defect
+# specifically, because keyspace-granular selection would have accepted this root.
+if [ -d "$absent_checkout/test_da" ] \
+   && [ -n "$(ls -A "$absent_checkout/test_da" 2>/dev/null)" ] \
+   && [ ! -e "$absent_checkout/test_da/$FIXTURE_DIRNAME" ]; then
+  ok "absent: staging is surgical (test_da present with sibling tables, fixture hidden)"
+else
+  bad "absent: staging is wrong — test_da must exist with siblings and without the fixture"
+fi
+
+absent_out="$tmp/absent.log"
+run_lane "$absent_out" \
+  CQLITE_DATASETS_ROOT="$tmp/absent-env" \
+  CQLITE_TEST_CHECKOUT_SSTABLES_ROOT="$absent_checkout"
+absent_rc=$?
+if [ "$absent_rc" -ne 0 ]; then
+  ok "absent: the target FAILS when no candidate root holds the fixture (rc=$absent_rc)"
+else
+  bad "absent: the target PASSED with the fixture absent from every candidate root — \
+this is the #3220 silent-skip defect the hardening removed; see $absent_out"
+fi
+# EVERY case must fail, not merely one: `must_run` is per case (#3220 forbids a
+# suite-wide `ran > 0`), so a run where one case failed and two silently skipped would
+# be the very defect this pins. The count is what expresses that.
+if grep -qE "^test result: FAILED\. 0 passed; ${TEST_COUNT} failed" "$absent_out"; then
+  ok "absent: ALL ${TEST_COUNT} cases failed — fail-closed is per case, not suite-wide"
+else
+  bad "absent: no 'test result: FAILED. 0 passed; ${TEST_COUNT} failed' line — some case \
+did not fail-close, or the run failed for an unrelated reason; see $absent_out"
+fi
+# The target's OWN diagnostic, generation-specific. A bare table-name match is banned:
+# healthy output carries it in the fixture path.
+if grep -q "no directory \`wide_multiclustering_small-\*\` holding \`${DATA_DB}\`" "$absent_out"; then
+  ok "absent: the rejection is this target's own generation-specific diagnostic"
+else
+  bad "absent: no 'no directory \`wide_multiclustering_small-*\` holding \`${DATA_DB}\`' \
+line — the failure does not demonstrate THIS guard fired; see $absent_out"
+fi
+# A SKIP must not reappear under any wording. The removed guards printed 'SKIP:'.
+if grep -q 'SKIP' "$absent_out"; then
+  bad "absent: output contains 'SKIP' — a committed fixture must never skip (#3220); \
+see $absent_out"
+else
+  ok "absent: no SKIP anywhere in the output"
+fi
+# The seam NOTE is behavior this lane added: a stray seam value hard-FAILs a CORRECT
+# checkout, which is the safe direction but opaque without it. This case sets the seam,
+# so the note must appear.
+if grep -q "CQLITE_TEST_CHECKOUT_SSTABLES_ROOT is SET to" "$absent_out"; then
+  ok "absent: the diagnostic names the seam that replaced the checkout candidate"
+else
+  bad "absent: the seam NOTE is missing — a stray seam value would hard-FAIL a correct \
+checkout with no hint why; see $absent_out"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. EMPTY: the fixture is present but its Data.db carries no bytes.
+#
+#    This is the direction doctrine warns is SILENT: a zero-length component can make a
+#    read return 0 rows with no error, and "0 == 0" then passes. The fixture is COPIED,
+#    never truncated in place — case 4 re-asserts that.
+# ---------------------------------------------------------------------------
+empty_root="$tmp/empty/sstables/test_da"
+mkdir -p "$empty_root"
+cp -r "$REPO/$FIXTURE_REL" "$empty_root/"
+: > "$empty_root/$FIXTURE_DIRNAME/$DATA_DB"
+if [ -f "$empty_root/$FIXTURE_DIRNAME/$DATA_DB" ] && [ ! -s "$empty_root/$FIXTURE_DIRNAME/$DATA_DB" ]; then
+  ok "empty: staging is right (the copied Data.db exists and is 0 bytes)"
+else
+  bad "empty: staging is wrong — the copied Data.db must exist AND be empty"
+fi
+empty_out="$tmp/empty.log"
+run_lane "$empty_out" CQLITE_DATASETS_ROOT="$tmp/empty"
+empty_rc=$?
+if [ "$empty_rc" -ne 0 ]; then
+  ok "empty: the target FAILS on a present-but-empty fixture (rc=$empty_rc)"
+else
+  bad "empty: the target PASSED against a 0-byte Data.db — a dataset-dependent test \
+must never pass on an empty dataset; see $empty_out"
+fi
+# Rules out the fallback this control exists for: if resolution had reached the HEALTHY
+# checkout fixture, the cases would have PASSED and some sibling would have to supply
+# the nonzero exit.
+if grep -qE "^test result: ok\." "$empty_out"; then
+  bad "empty: a 'test result: ok.' line — resolution fell back to a healthy fixture, so \
+the empty one was never rejected; see $empty_out"
+else
+  ok "empty: the target did not report ok (no fallback to a healthy fixture)"
+fi
+# The rejection must be the READER refusing the empty file, named on one line together
+# with this fixture, so a sibling's failure cannot satisfy it.
+if grep -q "Header buffer too small for parsing: 0 bytes" "$empty_out" \
+   && grep -q "$FIXTURE_DIRNAME" "$empty_out"; then
+  ok "empty: rejected by the reader on the empty Data.db, naming this fixture"
+else
+  bad "empty: no 'Header buffer too small for parsing: 0 bytes' for $FIXTURE_DIRNAME — \
+the run failed for some OTHER reason, which does not prove the empty fixture was \
+rejected; see $empty_out"
+fi
+if grep -q 'SKIP' "$empty_out"; then
+  bad "empty: output contains 'SKIP' — an empty fixture must be a hard failure, not an \
+absence; see $empty_out"
+else
+  ok "empty: the cases did not degrade into a SKIP"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. SAFETY: neither the tracked fixture nor the ambient corpus was mutated.
+# ---------------------------------------------------------------------------
+# `git status` is the evidence, so a git that could not ANSWER (not a repo, git missing)
+# must not read as "untouched" — an unanswerable question is not a clean answer. The
+# `-s` check is the independent second leg: case 3 truncates a COPY, and a staging bug
+# that truncated the ORIGINAL in place would leave a 0-byte tracked file.
+fixture_status=$(git -C "$REPO" status --porcelain -- "$FIXTURE_REL" 2>/dev/null)
+fixture_status_rc=$?
+if [ "$fixture_status_rc" -ne 0 ]; then
+  bad "safety: 'git status' failed (rc=$fixture_status_rc) — the untouched-fixture check \
+has no evidence and must not report green"
+elif [ -n "$fixture_status" ]; then
+  bad "safety: this self-test dirtied the tracked fixture $FIXTURE_REL"
+elif [ ! -s "$REPO/$FIXTURE_REL/$DATA_DB" ]; then
+  bad "safety: the tracked $FIXTURE_REL/$DATA_DB is now EMPTY — case 3 truncated the \
+original instead of its copy"
+else
+  ok "safety: the git-tracked fixture is untouched (git-clean and non-empty)"
+fi
+
+# Anti-vacuity for THIS harness: `failed: 0` is only meaningful if every case actually
+# asserted. A deleted case, an early `exit`, or a block skipped by an editing accident
+# would otherwise report green.
+EXPECTED_CHECKS=14
+total_checks=$((PASS + FAIL))
+if [ "$total_checks" -ne "$EXPECTED_CHECKS" ]; then
+  printf 'FAIL - harness: %d assertions ran, expected %d — a dropped or '\
+'short-circuited case must never read as green (update EXPECTED_CHECKS when '\
+'adding one)\n' "$total_checks" "$EXPECTED_CHECKS"
+  FAIL=$((FAIL + 1))
+fi
+
+printf '\n%s\n' "----------------------------------------"
+printf 'passed: %d  failed: %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/scripts/tests/test_issue_3358_failclosed.sh
+++ b/scripts/tests/test_issue_3358_failclosed.sh
@@ -62,6 +62,14 @@ unset CQLITE_REQUIRE_FIXTURES
 # Scrub the seam this file itself drives, so a stale export cannot pre-decide a case.
 unset CQLITE_TEST_CHECKOUT_SSTABLES_ROOT
 
+# Single-quote a path for safe pasting into a shell, mirroring `shell_quote` in
+# cqlite-core/tests/issue_3358_bti_query_token_bound.rs — same reason, same POSIX form:
+# an embedded single quote is closed, escaped and reopened. Raw single quotes were used
+# here first (roborev job 257), which breaks on a checkout path containing an apostrophe
+# and can turn later path characters into shell syntax when pasted. The Rust side of this
+# lane had already solved it; this mirrors it rather than re-deriving it.
+shell_quote() { printf "'%s'" "${1//\'/\'\\\'\'}"; }
+
 PASS=0
 FAIL=0
 ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
@@ -79,6 +87,19 @@ if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
   echo "FATAL: mktemp -d produced no usable directory ('$tmp'); refusing to run" >&2
   exit 1
 fi
+# ABSOLUTE, before the trap and before anything is staged under it. A relative TMPDIR
+# yields a relative `$tmp`, and `run_lane` does `cd "$REPO"` — so every staged root would
+# resolve against the REPO instead of here, the empty case would miss its staged corpus,
+# fall back to the healthy checkout fixture, and the harness would FAIL a correct tree.
+# A guard that reds on correct input is the guard agents learn to waive.
+tmp=$(cd "$tmp" && pwd) || {
+  echo "FATAL: could not canonicalize the scratch root; refusing to run" >&2
+  exit 1
+}
+case $tmp in
+  /*) ;;
+  *) echo "FATAL: scratch root '$tmp' is not absolute; refusing to run" >&2; exit 1 ;;
+esac
 trap 'rm -rf "$tmp"' EXIT
 
 # The committed fixture must be present for ANY of this to mean anything: the control's
@@ -98,8 +119,8 @@ if [ ! -f "$REPO/$FIXTURE_REL/$DATA_DB" ]; then
   echo "       remedy: run the tracked-fixture probe, which names every missing" >&2
   echo "       git-tracked file and prints a restore command scoped to ONLY those:" >&2
   echo "" >&2
-  echo "         CQLITE_DATASETS_ROOT='$REPO/test-data/datasets' \\" >&2
-  echo "           bash '$REPO/test-data/scripts/fetch-datasets.sh' --verify-only" >&2
+  echo "         CQLITE_DATASETS_ROOT=$(shell_quote "$REPO/test-data/datasets") \\" >&2
+  echo "           bash $(shell_quote "$REPO/test-data/scripts/fetch-datasets.sh") --verify-only" >&2
   echo "" >&2
   echo "       Follow its 'ERROR: TRACKED FIXTURES MISSING ... (issue #3310)' block." >&2
   echo "       If it instead reports 'Tracked-fixture probe (#3310): OK', nothing is" >&2

--- a/scripts/tests/test_issue_3358_failclosed.sh
+++ b/scripts/tests/test_issue_3358_failclosed.sh
@@ -131,6 +131,13 @@ if [ ! -f "$REPO/$FIXTURE_REL/$DATA_DB" ]; then
   exit 1
 fi
 
+# BASELINE for the safety case, captured before anything is staged. An unanswerable
+# `git status` is recorded as the sentinel `UNMEASURED` rather than as an empty string,
+# because empty means "clean" and would make a failed probe look like a clean baseline —
+# the permissive direction.
+FIXTURE_STATUS_BEFORE=$(git -C "$REPO" status --porcelain -- "$FIXTURE_REL" 2>/dev/null) \
+  || FIXTURE_STATUS_BEFORE="UNMEASURED"
+
 # Run the target with an explicit environment. Prints nothing; the caller greps $out.
 run_lane() {
   local out=$1; shift
@@ -225,8 +232,14 @@ did not fail-close, or the run failed for an unrelated reason; see $absent_out"
 fi
 # The target's OWN diagnostic, generation-specific. A bare table-name match is banned:
 # healthy output carries it in the fixture path.
-if grep -q "no directory \`wide_multiclustering_small-\*\` holding \`${DATA_DB}\`" "$absent_out"; then
-  ok "absent: the rejection is this target's own generation-specific diagnostic"
+# PER CASE, not once for the run. A single occurrence satisfied "the guard fired" while
+# two of three cases could have failed for unrelated reasons — the count assert above
+# says three FAILED, not three failed for THIS reason (roborev job 263). Each case panics
+# with this message, so the occurrence count IS the per-case evidence. Measured on a
+# staged absent run: exactly 3, matching `test result: FAILED. 0 passed; 3 failed`.
+absent_diag=$(grep -c "no directory \`wide_multiclustering_small-\*\` holding \`${DATA_DB}\`" "$absent_out")
+if [ "$absent_diag" -ge "$TEST_COUNT" ]; then
+  ok "absent: the generation-specific diagnostic fired for ALL ${TEST_COUNT} cases ($absent_diag occurrences)"
 else
   bad "absent: no 'no directory \`wide_multiclustering_small-*\` holding \`${DATA_DB}\`' \
 line — the failure does not demonstrate THIS guard fired; see $absent_out"
@@ -297,8 +310,11 @@ fi
 # an unrelated failure elsewhere in the output plus the fixture name in a healthy path —
 # and the comment here previously CLAIMED "on one line" while the code did not check it
 # (roborev job 254). That is this lane's own defect class, in the file asserting it.
-if grep -qE "${FIXTURE_DIRNAME}.*Header buffer too small for parsing: 0 bytes" "$empty_out"; then
-  ok "empty: ONE line carries both this fixture and the zero-byte reader rejection"
+# Same per-case requirement, and still same-LINE so the conjunction is real rather than
+# two strings appearing somewhere in the output.
+empty_diag=$(grep -cE "${FIXTURE_DIRNAME}.*Header buffer too small for parsing: 0 bytes" "$empty_out")
+if [ "$empty_diag" -ge "$TEST_COUNT" ]; then
+  ok "empty: the zero-byte rejection fired for ALL ${TEST_COUNT} cases, this fixture named on the same line each time ($empty_diag occurrences)"
 else
   bad "empty: no single line carrying both '$FIXTURE_DIRNAME' and 'Header buffer too \
 small for parsing: 0 bytes' — the run failed for some OTHER reason, which does not \
@@ -323,13 +339,21 @@ fixture_status_rc=$?
 if [ "$fixture_status_rc" -ne 0 ]; then
   bad "safety: 'git status' failed (rc=$fixture_status_rc) — the untouched-fixture check \
 has no evidence and must not report green"
-elif [ -n "$fixture_status" ]; then
-  bad "safety: this self-test dirtied the tracked fixture $FIXTURE_REL"
+elif [ "$fixture_status" != "$FIXTURE_STATUS_BEFORE" ]; then
+  # Compared against the BASELINE, not against clean. Requiring git-clean answered the
+  # wrong question: a reader with a pre-existing uncommitted fixture edit — their own
+  # work, nothing to do with this script — got "this self-test dirtied the tracked
+  # fixture", a false FAIL that also FALSELY ACCUSED this script (roborev job 263). The
+  # property this case owns is a DELTA, "this run changed nothing"; "the tree is clean"
+  # is the gate's own mid-run tree-integrity guard (#2926), not ours.
+  bad "safety: this self-test CHANGED the tracked fixture $FIXTURE_REL \
+(before: '\''${FIXTURE_STATUS_BEFORE:-<clean>}'\'' after: '\''${fixture_status:-<clean>}'\'')"
 elif [ ! -s "$REPO/$FIXTURE_REL/$DATA_DB" ]; then
   bad "safety: the tracked $FIXTURE_REL/$DATA_DB is now EMPTY — case 3 truncated the \
 original instead of its copy"
 else
-  ok "safety: the git-tracked fixture is untouched (git-clean and non-empty)"
+  ok "safety: this run left the tracked fixture UNCHANGED (status identical to the \
+pre-staging baseline, and still non-empty)"
 fi
 
 # Anti-vacuity for THIS harness: `failed: 0` is only meaningful if every case actually

--- a/scripts/tests/test_issue_3358_failclosed.sh
+++ b/scripts/tests/test_issue_3358_failclosed.sh
@@ -85,8 +85,28 @@ trap 'rm -rf "$tmp"' EXIT
 # expected behavior is "it runs", and both failure cases are defined relative to it.
 # Absent => hard error, not a skip. This fixture is git-tracked (#3220).
 if [ ! -f "$REPO/$FIXTURE_REL/$DATA_DB" ]; then
-  echo "FATAL: committed fixture $FIXTURE_REL/$DATA_DB is missing from the checkout;" >&2
-  echo "       remedy: git -C $REPO restore --source=HEAD -- test-data/datasets" >&2
+  echo "FATAL: committed fixture $FIXTURE_REL/$DATA_DB is missing from the checkout." >&2
+  echo "" >&2
+  # DELIBERATELY NOT `git restore -- test-data/datasets`. That pathspec is the WHOLE
+  # corpus directory, so it would also revert a reader's unrelated uncommitted fixture
+  # changes — silent data loss in a message offered as a repair (roborev job 256, High).
+  # It is also, precisely, one of the five defects the panic in
+  # cqlite-core/tests/issue_3358_bti_query_token_bound.rs documents itself as refusing
+  # to reproduce ("a glob that would restore the WHOLE fixture directory"). Same
+  # resolution as there: point at the tested emitter, which scopes the restore to the
+  # files that are actually missing, and do not hand-build one here.
+  echo "       remedy: run the tracked-fixture probe, which names every missing" >&2
+  echo "       git-tracked file and prints a restore command scoped to ONLY those:" >&2
+  echo "" >&2
+  echo "         CQLITE_DATASETS_ROOT='$REPO/test-data/datasets' \\" >&2
+  echo "           bash '$REPO/test-data/scripts/fetch-datasets.sh' --verify-only" >&2
+  echo "" >&2
+  echo "       Follow its 'ERROR: TRACKED FIXTURES MISSING ... (issue #3310)' block." >&2
+  echo "       If it instead reports 'Tracked-fixture probe (#3310): OK', nothing is" >&2
+  echo "       missing: ignore the remaining ERROR: lines (they report an incomplete" >&2
+  echo "       FETCHED corpus, which a checkout is never meant to be) and do NOT run" >&2
+  echo "       the '.dataset-pin' remedy they suggest — it re-runs the destructive" >&2
+  echo "       fetch path against this checkout root." >&2
   exit 1
 fi
 

--- a/scripts/tests/test_issue_3358_failclosed.sh
+++ b/scripts/tests/test_issue_3358_failclosed.sh
@@ -344,6 +344,18 @@ if [ "$total_checks" -ne "$EXPECTED_CHECKS" ]; then
   FAIL=$((FAIL + 1))
 fi
 
+# EMITTED, not merely commented. The header records this limit in source, but a reader
+# sees the RUN: 15 `ok` lines and a `passed:` count convey "everything checked", and a
+# caveat that lives only where a caveat-hunter looks is not a disclosure to the person
+# who needs it. So the narrowing is printed on every run, affirmatively worded, and
+# deliberately NOT an assertion — it is a disclosure, so it must not move PASS/FAIL or
+# the EXPECTED_CHECKS count.
+printf '\n%s\n' "DECLARED LIMIT (1 RECOGNISED): the 'absent' case's staging-is-surgical claim is"
+printf '%s\n' "  evidenced from the FILESYSTEM (keyspace dir mirrored, one fixture withheld), NOT from"
+printf '%s\n' "  this lane's own output. The sibling harness proves it from lane output because its"
+printf '%s\n' "  target drives many fixtures and a sibling case's PASS line shows only one was hidden;"
+printf '%s\n' "  this target has exactly ONE fixture, so that evidence does not exist here."
+
 printf '\n%s\n' "----------------------------------------"
 printf 'passed: %d  failed: %d\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/tests/test_issue_3358_failclosed.sh
+++ b/scripts/tests/test_issue_3358_failclosed.sh
@@ -138,6 +138,36 @@ fi
 FIXTURE_STATUS_BEFORE=$(git -C "$REPO" status --porcelain -- "$FIXTURE_REL" 2>/dev/null) \
   || FIXTURE_STATUS_BEFORE="UNMEASURED"
 
+# CONTENT, not status. `git status --porcelain` yields a STATUS CODE, and a file already
+# ` M` that this script modified AGAIN would keep status ` M` — so a status-only
+# before/after comparison PASSES while the fixture really changed (roborev job 265).
+# Demonstrated: identical porcelain line, different sha256. That is a false PASS in a
+# harness whose whole purpose is refusing vacuous passes, so the status leg is kept and a
+# content leg added beside it.
+#
+# Three-valued on purpose. The file COUNT is part of the value because sha256sum of empty
+# input is itself valid hex, so an empty or vanished fixture directory would otherwise
+# produce a well-formed digest that compares equal to nothing. A digest that cannot be
+# taken is `UNMEASURED`, never a hash, and UNMEASURED on either side FAILS the case — an
+# unanswerable question is not a clean answer.
+_fixture_content_digest() {
+  local n out
+  n=$(find "$REPO/$FIXTURE_REL" -type f 2>/dev/null | wc -l | tr -d ' ')
+  case $n in
+    ''|*[!0-9]*) printf 'UNMEASURED(count)'; return ;;
+    0)           printf 'UNMEASURED(no-files)'; return ;;
+  esac
+  out=$(find "$REPO/$FIXTURE_REL" -type f -print0 2>/dev/null \
+        | LC_ALL=C sort -z \
+        | xargs -0 sha256sum 2>/dev/null \
+        | sha256sum 2>/dev/null | cut -d' ' -f1)
+  case $out in
+    ''|*[!0-9a-f]*) printf 'UNMEASURED(digest)'; return ;;
+  esac
+  printf '%s:%s' "$n" "$out"
+}
+FIXTURE_DIGEST_BEFORE=$(_fixture_content_digest)
+
 # Run the target with an explicit environment. Prints nothing; the caller greps $out.
 run_lane() {
   local out=$1; shift
@@ -336,9 +366,23 @@ fi
 # that truncated the ORIGINAL in place would leave a 0-byte tracked file.
 fixture_status=$(git -C "$REPO" status --porcelain -- "$FIXTURE_REL" 2>/dev/null)
 fixture_status_rc=$?
+fixture_digest_after=$(_fixture_content_digest)
 if [ "$fixture_status_rc" -ne 0 ]; then
   bad "safety: 'git status' failed (rc=$fixture_status_rc) — the untouched-fixture check \
 has no evidence and must not report green"
+elif [ "$FIXTURE_DIGEST_BEFORE" = "${FIXTURE_DIGEST_BEFORE#UNMEASURED}" ] \
+     && [ "$fixture_digest_after" != "${fixture_digest_after#UNMEASURED}" ]; then
+  bad "safety: the fixture CONTENT digest could not be taken after the run \
+($fixture_digest_after) — the unchanged-fixture check has no evidence and must not report \
+green"
+elif [ "$FIXTURE_DIGEST_BEFORE" != "${FIXTURE_DIGEST_BEFORE#UNMEASURED}" ]; then
+  bad "safety: the fixture CONTENT digest could not be taken BEFORE staging \
+($FIXTURE_DIGEST_BEFORE) — no baseline, so nothing can be compared and this must not \
+report green"
+elif [ "$fixture_digest_after" != "$FIXTURE_DIGEST_BEFORE" ]; then
+  bad "safety: this self-test CHANGED the tracked fixture CONTENT $FIXTURE_REL \
+(before: $FIXTURE_DIGEST_BEFORE after: $fixture_digest_after) — a status comparison alone \
+would have missed this"
 elif [ "$fixture_status" != "$FIXTURE_STATUS_BEFORE" ]; then
   # Compared against the BASELINE, not against clean. Requiring git-clean answered the
   # wrong question: a reader with a pre-existing uncommitted fixture edit — their own
@@ -352,8 +396,8 @@ elif [ ! -s "$REPO/$FIXTURE_REL/$DATA_DB" ]; then
   bad "safety: the tracked $FIXTURE_REL/$DATA_DB is now EMPTY — case 3 truncated the \
 original instead of its copy"
 else
-  ok "safety: this run left the tracked fixture UNCHANGED (status identical to the \
-pre-staging baseline, and still non-empty)"
+  ok "safety: this run left the tracked fixture UNCHANGED — CONTENT digest and git \
+status both identical to the pre-staging baseline, and the Data.db still non-empty"
 fi
 
 # Anti-vacuity for THIS harness: `failed: 0` is only meaningful if every case actually

--- a/scripts/tests/test_issue_3358_failclosed.sh
+++ b/scripts/tests/test_issue_3358_failclosed.sh
@@ -309,8 +309,19 @@ else
   bad "absent: no 'no directory \`wide_multiclustering_small-*\` holding \`${DATA_DB}\`' \
 line — the failure does not demonstrate THIS guard fired; see $absent_out"
 fi
-# A SKIP must not reappear under any wording. The removed guards printed 'SKIP:'.
-if grep -q 'SKIP' "$absent_out"; then
+# A SKIP must not reappear under any wording — but the MARKER is what this matches, not
+# the message. A bare `SKIP` substring scan over the whole cargo output false-FAILs a
+# CORRECT run whenever the checkout or TMPDIR path (or an unrelated diagnostic) happens to
+# contain those four letters: e.g. a lane directory named `.../SKIPPED-lane/...` appears in
+# every path cargo prints (roborev job 292, Low). A guard that reds on correct input is the
+# guard agents learn to waive, which is this lane's own subject.
+# `SKIP:` — the marker the removed guards printed (`eprintln!("SKIP: {KEYSPACE}.{TABLE}
+# Data.db is absent (gitignored corpus)")`) — keeps the check wording-AGNOSTIC (anything may
+# follow the colon) while no filesystem path can satisfy it.
+# DECLARED RESIDUAL (1 RECOGNISED): a future skip printed WITHOUT the colon would be missed.
+# That is the deliberate trade — a missed novel spelling is recoverable, a guard nobody
+# trusts is not — and it is declared here rather than left for the next reader to discover.
+if grep -q 'SKIP:' "$absent_out"; then
   bad "absent: output contains 'SKIP' — a committed fixture must never skip (#3220); \
 see $absent_out"
 else
@@ -385,7 +396,9 @@ else
 small for parsing: 0 bytes' — the run failed for some OTHER reason, which does not \
 prove the empty fixture was rejected; see $empty_out"
 fi
-if grep -q 'SKIP' "$empty_out"; then
+# Same marker rule as the absent case above (roborev job 292): match `SKIP:`, never a bare
+# `SKIP` substring, so a checkout/TMPDIR path containing those letters cannot false-FAIL.
+if grep -q 'SKIP:' "$empty_out"; then
   bad "empty: output contains 'SKIP' — an empty fixture must be a hard failure, not an \
 absence; see $empty_out"
 else


### PR DESCRIPTION
## Make the #3358 BTI token-bound test fail CLOSED — its fixture is committed source, not a fetched optional corpus

Follow-up to **#3358** / PR **#3362** (@michaelsembwever's fix, merged), opened per the owner's tightening on that thread: *open the #3220 hardening as a PR, don't merely file it.*

`cqlite-core/tests/issue_3358_bti_query_token_bound.rs` landed with three SKIP guards and a module doc asserting the fixture is *"the gitignored `Data.db` binaries"*. **That premise is factually wrong**, and the guards it justifies are exactly the #3220 defect: the only end-to-end pin of a silent-wrong-data bug can quietly not run, behind a green suite.

### The premise, measured rather than asserted

```
$ git ls-files test-data/datasets/sstables/ | grep -c wide_multiclustering_small
10                                        # incl. da-1-bti-Data.db, Partitions.db, Rows.db, TOC.txt

$ git check-ignore -v .../test_da/wide_multiclustering_small
(no output, exit 1)                       # NO ignore rule matches it
```

The fixture is **git-tracked and not gitignored**. It is present in every complete checkout and appears in a fresh `git worktree add` with no fetch at all. Its absence therefore means a **broken checkout** — never an expected condition — so per #3220 every case must be `must_run` and fail closed.

### Why the root-walking half is load-bearing, not defensive dressing

This is not hypothetical on this fleet. On the box that certified #3362:

```
$ ls /data/datasets/**/wide_multiclustering_small*      # the EXPORTED CQLITE_DATASETS_ROOT
(absent)
$ ls test-data/datasets/sstables/test_da/wide_multiclustering_small-47f6a300…
(present)
```

**Neither root is a superset.** The root `fetch-datasets.sh` prints does not carry this fixture; the checkout does. So a resolver that picks a root by keyspace and commits to it — `root.join(keyspace).is_dir()` — selects `/data/datasets`, fails to find this *table*, and **skips**. That is precisely the #3220 failure mode that let the #3032 case skip silently. Resolution must therefore be per **TABLE**, walking **every** candidate root for that table's own `*-Data.db`, and by **evidence** rather than a fixed env-first/checkout-first preference — any fixed ordering picks wrong for one set of tables.

### What changes

| | Before | After |
|---|---|---|
| Module doc | "Requires the gitignored `Data.db` binaries" | states it is committed source, with the `git ls-files` / `check-ignore` evidence and why absence ⇒ broken checkout |
| `fixture()` | `-> Option<Fixture>`, `None` ⇒ SKIP | `-> Fixture`, panics with a diagnostic naming both candidate roots |
| 3 SKIP guards | silently pass | **removed** — 0 remain |
| Root resolution | by keyspace | per table, every candidate root walked |

There is deliberately **no opt-out env var and none may be added**: committed source in a checkout is never legitimately absent, so an escape hatch could only buy a vacuous green — the same reasoning CLAUDE.md records for the gate's `missing-schemas` check having no bypass.

The one reachable way to genuinely lose the file is real and already handled elsewhere: **#3310** added `--verify-only` reporting for git-tracked fixtures a SIGKILLed fetch left deleted. That is the case a skip would swallow and a panic surfaces.

### Verification

- Patch applied by an **anchor-asserting** script (each anchor asserted present **and unique** before substitution): `PATCHED OK: 6 anchors + 2 call sites; 0 SKIP guards remain`.
- Post-patch grep for `SKIP` / `return None` / skip-guards returns **0** functional hits.
- Test executes and passes against the committed fixture — and, critically, is now **incapable of passing without running**.

Closes the #3220 gap for this file. Does not touch @michaelsembwever's fix; only the test's guard structure and its module doc.

---

## roborev — SIX rounds, clean on the sixth

Final: job **291**, `RESULT: PASS`, `findings: NONE`, `sha-assert: PASS`, `prompt-content: PASS (2/2)`, tokens `input=546440 cached=409088` (genuine review, against the ~18.7k vacuous baseline). Base pinned to the immutable merge sha `b6c10865d`, never the moving ref.

| job | sev | defect | disposition |
|---|---|---|---|
| 284 | Low | remedy printed `…-<cfid>` — an unsubstituted placeholder, and `<` is shell input redirection | fixed |
| 284 | Med | published crate ships a test whose fixture can never exist | fixed (package `exclude`) |
| 286 | Med | (repeat of the above) | resolved by that fix |
| 287 | Low | remedy paths crate-relative → resolve to nothing from `cqlite-core/` | fixed |
| 288 | Med | glob would restore the **whole** fixture dir, silently discarding a reader's uncommitted work | fixed by deletion |
| 288 | Low | `:(top)` anchors a pathspec but selects no repository; unquoted path breaks on spaces | fixed by deletion |
| 289 | Low | unsetting the env var leaves a **cwd-relative** fallback → command silently reports nothing | fixed |
| 291 | — | **findings: NONE** | ✅ |

**The fail-closed behaviour was never in question.** It was RED/GREEN verified every round, including from the awkward `cqlite-core/` working directory. All seven findings landed on the *diagnostic text*.

### Round 5 changed the approach: deleted rather than patched

Five defects in five rounds inside one hand-built `git restore` string is a variant list that will not close. `fetch-datasets.sh --verify-only` **already** emits a precise, correctly-scoped restore command for exactly this case (#3310), so reproducing it inside a panic message was the wrong shape from the start. The string is gone; the message names one command and lets the tested tool produce the restore line. A comment at the call site says so, so nobody adds it back.

### The defect no review found

Having redirected readers to that tool, I tested that it works — and **on the fleet default it does not**. The probe is scoped to whatever root it is given, and `CQLITE_DATASETS_ROOT=/data/datasets` lies outside any git work tree, where it reports `NO SUBJECT` and exits **0**, finding none of the 10 deleted files. Unfixed, the remedy would have been a no-op that reads as an all-clear — the identical silent-pass this PR exists to remove.

Round 6 then showed my first fix for that was incomplete, and that my verification shared the reviewer's blind spot: I had written "executed verbatim" having run the command only from the repo root, never from the directory whose breakage I had just fixed.

### Closing property (not a round count)

The emitted command contains **no relative path and no inherited environment value** — corpus root and script path are both absolute and shell-quoted, so cwd and environment are eliminated by construction. Verified by extracting the string from the panic and **executing it** from three working directories:

```
                      repo root   cqlite-core/   /tmp
unset-env form          reports      NOTHING      —      <- the round-6 defect
this form               reports      reports    reports
```

## Verification summary

| check | result |
|---|---|
| GREEN | 3 tests **run** and pass; zero skips |
| RED (fixture moved out of tree) | all 3 **FAIL** fail-closed, from repo root and from `cqlite-core/` |
| emitted remedy | executed verbatim from 3 cwds; reports all 10 missing tracked files |
| packaging | `cargo package --list`: test **1 → 0**; siblings 455 → 454 (#3677) |
| roborev | job 291 PASS, findings NONE |

---

## ⚠️ NOT READY TO MERGE — the full gate of record is still OWED

What this PR has:

```
==== AGENT-GATE LITE SUMMARY ====
run-id: /tmp/agent-gate.EBkJQt
MODE: lite (FAST ITERATION — NOT the gate of record; full agent-gate.sh must PASS once before merge)
lite-scope: file-size fmt clippy roborev-lints scoped-tests
tree-start: cb910af15b8b dirty: no digest: fd02bee3c55b
tree-end:   cb910af15b8b dirty: no digest: fd02bee3c55b
tree-integrity: PASS
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```

**That block says `MODE: lite` and cannot be read as the gate of record** — its own `lite-scope` line names the five components it ran, and the full set is 36. Per CLAUDE.md a full `AGENT-GATE SUMMARY` must PASS once before merge, and it has not run on this branch.

Auto-merge is therefore **deliberately not armed**. Arming it would be the one-line version of certifying with a lite.


---

# Ownership under #3731 — lane-3731, first review this PR has had

PR opened 05:53Z and untouched for five hours: no gate of record, no C, `refs/claims/issue-3220` empty,
parent #3220 legitimately closed. `required` was green, which is the dangerous shape — every cheap signal
said ready and nothing had certified it. #3731 asks for a **decision**, not for this to merge.

**Decision: fix and merge.** The premise is sound and re-verified independently (`git ls-files` lists all 10
`da-1-bti-*` components; `git check-ignore` matches none), and fail-closed is the right posture. But two
things above were **described rather than asserted**, and one comment asserted a number its own citation
contradicts.

## AC1 — rebase onto current `origin/main`

`main` had moved **12 commits** since the PR was cut. All 5 commits rebased cleanly, no conflicts;
`HEAD..origin/main` = 0. The change still applies.

## AC2 was described, not asserted — and that is what blocked AC3

The module doc stated #3220's per-table rule; the code then re-derived it in a **private** `fixture_dir()`
instead of `support/datasets_root.rs::sstables_root_for_table`, which the AC names by symbol and which **9
sibling targets already use**. Three costs, the third decisive:

1. It re-implements the resolver #3220 exists to centralise — the shape of the original defect, in the file
   whose subject is that defect.
2. It misses the shared version's workspace-`Cargo.toml` root anchoring, candidate dedupe, and
   env-root-only-if-present semantics.
3. **It carries no test seam, so AC3 could not be staged honestly.** The checkout candidate is built from
   `CARGO_MANIFEST_DIR`, a *compile-time* constant, so with a private resolver the only way to hide a
   committed fixture is deleting a git-tracked file from the working tree — which trips the gate's mid-run
   `tree-integrity` check (#2926). `support/datasets_root.rs` documents
   `CQLITE_TEST_CHECKOUT_SSTABLES_ROOT` as existing for precisely this, and it can only ever *remove*
   fixtures from view, so a stray value makes a `must_run` lane FAIL, never pass vacuously.

The probe stays `da-1-bti`-prefix-specific rather than adopting the shared `table_has_data`'s
any-`*-Data.db` test, following `query_semantics_oracle_parity.rs::sstables_root_for_case`'s precedent for
a format-specific fixture. That is the safe direction: a root holding some *other* generation of this table
would satisfy `table_has_data`, win the selection, then hard-FAIL this `must_run` lane on a checkout that
does hold the `da` copy — and a guard that reds on correct input is the guard agents learn to waive.

## AC3 — each guard OBSERVED to fire, in all three directions

The body above claimed the test "is now incapable of passing without running." That was an assertion; below
is the evidence. A guard never observed to fire is not evidence.

| direction | staging | result |
|---|---|---|
| fixture **present** | `CQLITE_DATASETS_ROOT=/data/datasets` | `3 passed; 0 failed; 0 ignored` |
| fixture **absent** from every root | `CQLITE_TEST_CHECKOUT_SSTABLES_ROOT=<empty dir>`, `CQLITE_DATASETS_ROOT` unset | `0 passed; 3 failed` — **FAIL, not SKIP**, each case named individually |
| fixture **present but empty** | fixture copied to a temp root, `da-1-bti-Statistics.db` truncated to 0 bytes | `0 passed; 3 failed` — `Corruption("Failed to load Statistics.db …")`, **not** a 0-row pass |

The GREEN row is itself AC2 evidence, not just a control: `/data/datasets/sstables/test_da` holds **4
tables and not this one**, so all 3 cases passing proves the per-table fall-through to the checkout ran —
the exact shape (`root.join(keyspace).is_dir()` then commit) that let the #3032 case skip silently.

The present-but-empty row is the one doctrine warns is silent: a zero-length `Statistics.db` can make
`SELECT` return 0 rows with no error. Here it raises `Corruption` and fails all three cases.

## Two claims that did not survive being checked

**The `Cargo.toml` comment asserted "454 sibling integration tests" and cited #3677** — whose own
measurement is **106 referencing / 104 already hard-failing / 105 with this one**. The cited issue
contradicted the number citing it. Corrected to #3677's figure, and the one-file scope is now tied to
#3677 deliberately holding the class decision (`exclude = ["tests/**"]`) open as a packaging call.

**The panic's remedy was measured rather than trusted.** Running the exact command it prints, on an intact
tree from the repo root:

```
REAL exit = 1        8 lines, 7 of them ERROR:        line 1 is the only one that answers the question
```

The `Tracked-fixture probe (#3310)` half is correct and genuinely cwd-independent — it stat'ed all 894
git-tracked files under `test-data/datasets` individually and reported OK, from the repo root **and** from
`cqlite-core/`, which is what the absolute-path form was for. The other 7 lines answer a different question
(the checkout corpus is not a complete *fetched* corpus, which it is never meant to be). One of them is
worse than noise: it proposes `rm -f <root>/.dataset-pin && … fetch-datasets.sh`, whose default path is
destructive (`rm -rf` on the dataset root) — against the **checkout** root that deletes the committed
fixtures the reader is trying to restore. The message now names the one line to read and warns off the
rest, with the reason.

`exclude` itself stays, and the orphaned `repo_root` doc comment the diff had left attached to the new
`shell_quote` is reattached.

## Certification

The prior body's roborev evidence (job 291) was bound to `cb910af15`, **superseded by the rebase** and by
the two commits above — inert per #3460. Re-certification at the final head is recorded below.


---

## Review rounds 2–4: the fail-closed guard had no guard, and then its guard broke its own contract

Two more roborev blockers after the first, both genuine, both in code I wrote. Recorded in full because
the pattern is the useful part.

### Round 2 (job 252) — a measurement in a PR is not a guard

*"The new fail-closed behavior has no committed negative test. Existing runs with the fixture present
remain green if `fixture()` later reverts to skipping."*

Correct, and it is this issue's own AC3 one level up. The RED evidence above proved the guard fired
**once**, on one machine, on one day, and lived in a PR comment. A run with the fixture PRESENT is
byte-identical whether `fixture()` returns `Fixture` or `Option<Fixture>` — so nothing would have caught a
revert. A guard never observed to fire is not evidence; a guard observed once and never again is not a
guard.

So the observation moved into **`scripts/tests/test_issue_3358_failclosed.sh`** (15 assertions), modelled
on `test_point_vs_full_failclosed.sh` (#3220 AC2) — same file, same assertion contract, because it is the
same property for the sibling BTI lane. Wired as `bti-multiclustering`'s **fourth invocation**, beside that
sibling and for the same stated reason (the component has already built the binary it drives), with the
component's doctrine comment declaring it so a widened lane is never silent.

Held to the sibling's contract: no check may rest on a bare nonzero exit (an unrelated compile error
produces an identical rc) or a bare table-name match (healthy output carries the table name in the fixture
path). Staging is **surgical** — the keyspace dir is symlink-mirrored with its siblings and only this
fixture withheld — because hiding the whole corpus lets the assertion pass for an unrelated reason, and
because a keyspace dir that EXISTS is what pins the #3220 defect specifically: keyspace-granular selection
would have *accepted* that root.

**Discrimination limit, stated in the file rather than implied.** The sibling proves its staging surgical
from the lane's own output, because its target drives many fixtures and a sibling case's `PASS` line shows
only one was hidden. This target has exactly ONE fixture, so that evidence does not exist here and the
claim is made against the filesystem instead. Naming the weaker evidence beats implying the stronger.

**The contrast that matters** — run in a throwaway `git worktree` with its OWN `CARGO_TARGET_DIR`, because
a shared one serves a stale binary and would have made the measurement meaningless:

| tree | result |
|---|---|
| unmutated | **15 passed / 0 failed** |
| `fixture()` reverted to the pre-#3220 SKIP shape | **9 passed / 5 failed** |

All five failures are the `absent` case, and one names the planted symbol directly
(`output contains 'SKIP'`). A bare red would not have been evidence either — an unrelated breakage
produces an identical exit code. Control and `empty` still passed, so the harness is not simply broken.
Worktree and its target removed; the lane's tree verified clean.

The harness also found two defects in itself on first run, both the anti-vacuity machinery working:
`EXPECTED_CHECKS` was 13 against 14 real assertions (caught by the terminal anchor that exists for exactly
that), and the failure `printf` used a backslash-continuation inside SINGLE quotes — literal there, not a
continuation — leaking a stray `\` into the message. The `bad "…"` calls are unaffected; inside double
quotes the continuation is real. `test_point_vs_full_failclosed.sh` carries the identical construct; left
alone as out of scope and cosmetic.

### Round 3 (job 254) — the harness enforcing the contract violated it

*"The empty-fixture case does not enforce its stated count-bearing contract … separate `grep` calls do not
ensure the error and fixture name occur on the same line as claimed."*

Both true, in the file added one commit earlier to fix round 2:

1. `empty` had **no count assertion** while `absent` required `0 passed; 3 failed`, so one case failing
   while two silently passed satisfied it — a suite-wide `ran > 0` in disguise, the shape #3220 forbids and
   the shape this file's own header says every case is held to.
2. It used **two separate greps** under a comment claiming the rejection was *"named on one line together
   with this fixture"*. Two greps prove each string appears somewhere; they do not prove the conjunction.

**This is the PR's own defect class on its third instance, and its second in my code**: prose asserting
more than the code does. Once in the shipped `Cargo.toml` comment ("454 sibling integration tests"), once
in the panic remedy (read the probe line — in the branch where no probe line exists), once in the harness
built to stop exactly this. Writing a contract in a header comment is not enforcing it, and I wrote the
header.

Both fixed, and both fixes verified to **discriminate** rather than to pass — a constructed log with the
two strings on separate lines and a `2 passed; 1 failed` result:

```
old two-grep form   PASSES on separate lines   <- the false pass, demonstrated
new same-line form  correctly FAILS
new count form      correctly FAILS on '2 passed; 1 failed'
```

A green assertion proves nothing about an assertion's power; the falsifying input does — the same standard
the mutant contrast held the `absent` half to, applied to the half that had not been held to it.

### Certification status

| | |
|---|---|
| `--lite` | **PASS** (`tree-integrity: PASS`) at each head; round 1's FAIL was `tree-mutated-midrun`, my own doing (#2926), not the code's |
| roborev | 3 rounds, **3 blockers found and fixed**; all genuine (243k–427k input, `prompt-content: PASS`, `sha-assert: PASS`) |
| rust-reviewer | blocker (same as roborev round 1) + 4 nits; 3 fixed, 1 deferred to a follow-up at merge |
| gate of record | **NOT YET RUN — blocked on disk**, not on the code |

The gate of record is the one thing outstanding. box1 `/data` has **41G** on `/dev/nvme1n1` against the
**~96–102G** a full gate demonstrably needs here (measured live from a peer lane's running gate), so the
run would ENOSPC rather than certify. Tracked on #3731 as coord request `3731-R1`. **This PR must not merge
until a full `AGENT-GATE SUMMARY` with `RESULT: PASS` and `tree-integrity: PASS` exists at its final head**
— `required` being green is exactly the signal this issue was filed to distrust.


---

## AC3 wiring: DEMONSTRATED in-gate, not asserted

`--only bti-multiclustering` (a PARTIAL run — explicitly *not* the gate of record):

```
bti-multiclustering: PASS (5s)   [test cqlite-core --features state_machine,cli-helpers x2]
RESULT: PARTIAL (--only bti-multiclustering) - does NOT count as the gate
```

**5 seconds looked too fast** for a component running two cargo suites plus two shell harnesses, so the
PASS was not banked. Checked against the component's own log in that run's dir:

```
27 x "ok   - " lines
passed: 12  failed: 0      <- the sibling test_point_vs_full_failclosed.sh
passed: 15  failed: 0      <- this PR's test_issue_3358_failclosed.sh
12 + 15 = 27 ✓
and this harness's distinctive assertions by name: the generation-specific diagnostic,
the seam NOTE, and "ONE line carries both this fixture and the zero-byte reader rejection"
```

So the harness genuinely executes inside the gate component; the 5s is a warm cache, not a skip. A green
component that never reached the code is the failure mode #3522 exists for, and this PR would have shipped
the wiring claim without that check.

### Disclosed limitation this PR introduces: it widens a documented annotation blind spot

The SUMMARY feature-matrix annotation (#3453) is DERIVED from observed cargo argv, and the gate's cargo
interceptors are **unexported by design**, so cargo calls made inside a `bash scripts/tests/…` sub-script
are invisible to it. Measured:

| | |
|---|---|
| cargo invocations `run_bti_multiclustering` makes directly | **2** (observed; annotation reads `x2`) |
| cargo invocations inside its two fail-closed sub-scripts | **6** (3 each — unobserved) |

So `bti-multiclustering`'s annotation says `x2` while the component actually drives 8. That is **not
drift** — `x2` correctly names what the renderer observed, and `test_agent_gate_feature_matrix_annotation.sh`
compares declared against *observed*, so it does not red. And it is **pre-existing**: the sibling harness
already contributed 3 unobserved invocations, and `_fm_component_class`'s own `tooling-tests` carve-out
documents this exact limitation in prose.

But this PR takes the unobserved count from 3 to 6, so the annotation understates the component slightly
more than before. Recorded here rather than left to be rediscovered, because #3453's ruling is that a
pasted SUMMARY should state what it certified — and an annotation that omits sub-script work states less
than the component did. No code change proposed: the design deliberately accepts unobservable sub-script
cargo, and inventing a second mechanism to count it would be the "port is a second implementation" trap
(#3283).

Two hazards checked and ruled out while verifying this:

* **`tooling-tests` does not auto-discover `scripts/tests/*.sh`** — it invokes an explicit named list, so
  the new harness is not silently double-run there without the component's build context.
* **No self-test asserts a roster or count of component invocations**, so adding a fourth invocation to
  `run_bti_multiclustering` registers nothing elsewhere. `COMPONENTS` is unchanged (no new component), and
  `bti-multiclustering` correctly stays out of `DATASET_COMPONENTS` — this fixture is committed, not
  fetched.

## Certification status — AC4 pending on DISK only; #3740 was retracted

**This PR is a DRAFT and stays one until a gate-of-record PASS binds to its head.**

### The #3740 halt was withdrawn, and my "confirmation" of it was not independent

An earlier revision of this section said `binding-rust-tests` FAILs on clean `origin/main` and that AC4/AC6
were *impossible*. That was wrong, and the correction matters more than the claim did.

`agent-gate.sh` applies `-D warnings` **only to clippy**, via a scoped env prefix; `binding-rust-tests` gets
none. My failure came from `RUSTFLAGS=-D warnings` **exported in my session environment** and inherited by
the gate. Measured, same crate, same tree, one variable:

```
WITH    inherited RUSTFLAGS=-D warnings : error: constant MAX_DECOMPRESSED_SIZE is never used   exit=101
WITHOUT (env -u RUSTFLAGS)              : warning: ... Finished                                 exit=0
```

So I reported a "third independent reproduction" of a defect that was my own contaminated environment.
Since every box here is provisioned identically, such a fault reproduces everywhere and each reproduction
*looks* like corroboration while adding no information. #3740 is now P2 — the ungated constant is still
real latent hygiene, and it is not a blocker.

All verification in this PR is run under `env -u RUSTFLAGS -u CARGO_ENCODED_RUSTFLAGS`, both measured rather
than assumed (`RUSTFLAGS` contaminated, `CARGO_ENCODED_RUSTFLAGS` unset).

### What the last gate attempt established, and why it did not certify

The gate of record reached **36 of 37 components with the only red being an artifact of my own
configuration**:

```
bti-multiclustering: PASS 14
  27 ok-lines; passed: 12 failed: 0 (sibling harness) + passed: 15 failed: 0 (this PR's)
  this PR's per-case assertions present, each reporting "(3 occurrences)"
  DECLARED LIMIT emitted

tooling-tests: FAIL 207   <- NOT this diff
```

That FAIL is `scripts/tests/test_bti_perf_scan.sh`: it builds the harness honouring `CARGO_TARGET_DIR`
(`:149`) and then resolves the binary from `$REPO_ROOT/target` (`:158`), with **zero** references to the
variable. I had set `CARGO_TARGET_DIR` outside the worktree to relieve build-filesystem pressure, so the
binary existed somewhere the script never looks. **The run could never have produced `RESULT: PASS`** —
filed as **#3748**, and the configuration is now forbidden fleet-wide for a second, better reason: that
filesystem stores every gate's summary, and an ENOSPC there is silent (`RESULT: INCOMPLETE`, #3041).

**AC3 is therefore demonstrated inside a real gate run**, not only in an `--only` probe: the component
executed, both fail-closed harnesses ran to completion, and every assertion passed.

### Acceptance criteria

| AC | state |
|---|---|
| 1 rebase onto current `origin/main` | **satisfied** — v3 trigger (`merge-base..origin/main` ∩ my files) is **EMPTY**, so gating where I am is correct; reported as *gate of record verified at `<sha>`*, never "certified against main" |
| 2 committed-source distinction asserted, per-table roots, per-case `must_run` | **satisfied** — C intent audit judged the generation-specific-probe reasoning and accepted it |
| 3 RED-verify each guard | **satisfied**, demonstrated in-gate (above) and by a mutant contrast (15/0 unmutated vs 9/5 with `fixture()` reverted, one failure naming the planted symbol) |
| 4 gate of record PASS at final head | **pending on disk** — needs ~100G cold; `/data` has ~40G. Not blocked on code, review, or main |
| 5 roborev clean at certified sha | **satisfied** — job 269, `findings: NONE`, `prompt-content: PASS 4/4`, `sha-assert: PASS`, 605k in / 518k cached, at `981e75972` |
| 6 `premerge-assert` then arm `--auto` | after AC4 |

### Review history, in full

**11 roborev rounds, 5 blockers, all fixed, ending clean.** Plus a rust-reviewer pass (1 blocker, 4 nits)
and a C intent audit that caught a defect roborev had passed over. Nine instances of one class —
*prose asserting more than the code does* — seven in the shipped diff and two in the harness written to
prevent them. Each is recorded in its own commit message with the falsifying measurement, because the
pattern is more useful than the individual fixes.

Follow-ups filed rather than swept in: **#3737** (sibling harness: whole-directory `git restore`, raw-quoted
paths, relative-`TMPDIR` false FAIL), **#3743** (corpus-shape guard misdiagnosis), **#3748** (the
`CARGO_TARGET_DIR` hazard above).
