### PR TITLE
fix(#3414): the gate reports where its slot cap came from, and bootstrap verifies the pin is IN EFFECT

### DIFF
--- a/.agent-ami/profile.yaml
+++ b/.agent-ami/profile.yaml
@@ -60,7 +60,19 @@ verify:
   # read back + delete a throwaway refs/claims/smoke-<commit-sha> ref), not by probing the
   # credential helper: the affected box passed `gh auth status` AND
   # `git ls-remote origin HEAD` and still could not push.
-  run: "bash scripts/bootstrap-agent-machine.sh --fix-credentials --strict"
+  # --fix-gate-pin (issue #3414) is the SECOND narrow repair, added for the same reason and
+  # in the same shape as --fix-credentials above. The single-gate pin
+  # (CQLITE_GATE_MAX_CONCURRENCY=1) has to be PERSISTED where a non-interactive shell reads
+  # it — /etc/environment, read by PAM at session creation — and a launched box gets no
+  # other bootstrap invocation, so without this flag every new instance arrives UNPINNED,
+  # its gates silently resolve the #1825 cap from the default formula and admit co-tenants,
+  # and verify merely reds. That converts a silent defect into a loud one without removing
+  # it, and an alarm that fires on every new box is one people learn to waive. Persisting an
+  # env line is not a toolchain install, so verify stays a verification step — the same
+  # boundary --yes would have crossed. The write is idempotent and NEVER rewrites an existing
+  # value, and the verdict still comes from probing a fresh session, so a box that cannot be
+  # pinned (no passwordless sudo) stays non-passing and --strict still exits 1.
+  run: "bash scripts/bootstrap-agent-machine.sh --fix-credentials --fix-gate-pin --strict"
   expect: "All checks green."
 hooks:
   # Deliberately EMPTY (issue #3369). The credential wiring belongs in verify.run above,

--- a/.gitignore
+++ b/.gitignore
@@ -337,6 +337,12 @@ trino-connector/docker/field-repro-artifacts/
 # repo, and leaving them untracked stamps `dirty: yes` on the certification block.
 .review-*.md
 .followup-*.md
+# Same class, third instance (#3414 gate #7 prep): a stage-C intent audit's verdict file. A
+# spec-auditor writes it MID-RUN, and an untracked-but-not-ignored write while the gate of
+# record is running is `tree-integrity: FAIL (tree-mutated-midrun)` — which is exactly how
+# gate #6 of this branch died. Ignoring it removes the hazard rather than relying on nobody
+# spawning a C agent at the wrong moment.
+.c-audit-*.md
 # Live box-load sampler output (#3248). MUST stay out of the worktree: it is appended
 # every 10s, so an in-tree copy trips the gate tree-integrity check mid-run, and a
 # worktree is deleted at finalize which would destroy a sampler meant to outlive the issue.

--- a/.gitignore
+++ b/.gitignore
@@ -327,6 +327,11 @@ trino-connector/docker/field-repro-artifacts/
 # resume from it, but it is session state, not a repo artifact — never shipped
 # in a PR.
 .drive-issue-state.md
+# Implementer/subagent terminal verdicts, written to disk because subagent reports get
+# dropped (MEMORY.md: "Subagent verdicts need a file"). Same class as the state file
+# above — worktree-local session state, never a repo artifact. Untracked-but-not-ignored
+# would also make every gate in the lane stamp `dirty: yes` on its certification block.
+.impl-*-verdict.md
 # Live box-load sampler output (#3248). MUST stay out of the worktree: it is appended
 # every 10s, so an in-tree copy trips the gate tree-integrity check mid-run, and a
 # worktree is deleted at finalize which would destroy a sampler meant to outlive the issue.

--- a/.gitignore
+++ b/.gitignore
@@ -332,6 +332,11 @@ trino-connector/docker/field-repro-artifacts/
 # above — worktree-local session state, never a repo artifact. Untracked-but-not-ignored
 # would also make every gate in the lane stamp `dirty: yes` on its certification block.
 .impl-*-verdict.md
+# Same class again: a lane's review report and its batched-nit list. Both are inputs to
+# the work, not artifacts of it — shipping them in a PR puts one lane's scratch in the
+# repo, and leaving them untracked stamps `dirty: yes` on the certification block.
+.review-*.md
+.followup-*.md
 # Live box-load sampler output (#3248). MUST stay out of the worktree: it is appended
 # every 10s, so an in-tree copy trips the gate tree-integrity check mid-run, and a
 # worktree is deleted at finalize which would destroy a sampler meant to outlive the issue.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1949,10 +1949,14 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   inherited value — **and `BASH_ENV`/`ENV` with it, since a non-interactive bash SOURCES `$BASH_ENV`
   and that file can re-export the variable just scrubbed** — and reads it back out of a fresh,
   profile-free session, in the same posture as `git-push:`. FIVE verdicts ship and only the first is
-  an `[ok]`: **`VERIFIED`** (visible AND the gate honours the value), **`NOT-HONOURED`** (visible,
-  but the gate discards or clamps it — the remedy is to fix the VALUE, not the presence),
-  **`FAILED`** (not visible), **`UNMEASURED`** (the probe could not run, or the gate could not be
-  consulted about the value), **`OPT-OUT`/`SKIPPED`**. **`VERIFIED` IS SCOPED AND SAYS SO**: it
+  an `[ok]`: **`VERIFIED`** (the system-wide file sets a value, a fresh session sees THAT SAME
+  value, and the gate honours it), **`NOT-SYSTEM-WIDE`** (the session sees a value the file does not
+  set — a sudo- or user-specific override, so ordinary sessions get something else),
+  **`NOT-HONOURED`** (visible, but the gate discards or clamps it — fix the VALUE, not the
+  presence), **`FAILED`** (not visible), **`UNMEASURED`** (the probe could not run, the gate could
+  not be consulted, or the file could not be read/parsed), **`OPT-OUT`/`SKIPPED`**. A **non-Linux**
+  host reports **`NOT-APPLICABLE`** as a second `[ok]`: the mechanism is Linux/`pam_env`-specific,
+  so macOS is scoped OUT rather than supported. **`VERIFIED` IS SCOPED AND SAYS SO**: it
   measures a PAM-created (sudo) session, so a gate launched from a systemd unit or a container
   entrypoint — no PAM in its ancestry, so `/etc/environment` never applies — is NOT covered, and the
   authoritative per-run confirmation stays that gate's own `cpu-budget: max-concurrency=N(pinned)`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1954,9 +1954,16 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   set — a sudo- or user-specific override, so ordinary sessions get something else),
   **`NOT-HONOURED`** (visible, but the gate discards or clamps it — fix the VALUE, not the
   presence), **`FAILED`** (not visible), **`UNMEASURED`** (the probe could not run, the gate could
-  not be consulted, or the file could not be read/parsed), **`OPT-OUT`/`SKIPPED`**. A **non-Linux**
-  host reports **`NOT-APPLICABLE`** as a second `[ok]`: the mechanism is Linux/`pam_env`-specific,
-  so macOS is scoped OUT rather than supported. **`VERIFIED` IS SCOPED AND SAYS SO**: it
+  not be consulted, or the file could not be read/parsed), **`OPT-OUT`/`SKIPPED`**. **`VERIFIED` IS THE ONLY `[ok]`, AND A
+  NON-LINUX HOST DOES NOT GET ONE.** An earlier form emitted `ok "NOT-APPLICABLE"` there — the
+  mechanism is Linux/`pam_env`-specific, so macOS was scoped OUT rather than supported — and that
+  reasoning is still right about the MECHANISM and was wrong about the VERDICT: an `[ok]` is what
+  `--strict` reads, so it **certified an unpinned host**, which is the false-certification shape this
+  whole section exists to remove. A non-Linux host whose session shows a value now reports
+  **`UNMEASURED`** (there is no PAM-read system-wide file to correlate against, so a machine-wide pin
+  cannot be told apart from a user-scoped one), and the per-run authority there is the gate's own
+  `cpu-budget:` token. **Scoping a platform out is not the same as passing it**, and `NOT-APPLICABLE`
+  is emitted nowhere in the script today. **`VERIFIED` IS SCOPED AND SAYS SO**: it
   measures a PAM-created (sudo) session, so a gate launched from a systemd unit or a container
   entrypoint — no PAM in its ancestry, so `/etc/environment` never applies — is NOT covered, and the
   authoritative per-run confirmation stays that gate's own `cpu-budget: max-concurrency=N(pinned)`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -753,8 +753,14 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   Read `N(default)` on a fleet box as **the pin is not provisioned** — `3` and `3 because nothing set
   it` are different operational facts, and the second one is what ran unseen for months. `invalid`
   and `clamped` exist because `${VAR:-dflt}` cannot tell unset from set-empty (`${VAR+set}` can), so a
-  mis-set variable was textually identical to a healthy defaulted box. Fix a `default`/`invalid` box
-  with `bash scripts/bootstrap-agent-machine.sh --yes` and check its `gate-pin:` line.
+  mis-set variable was textually identical to a healthy defaulted box.
+  **THE REMEDY DIFFERS BY TOKEN, and getting that wrong sends an operator in a circle.** A
+  `default` box has NO pin line, so `bash scripts/bootstrap-agent-machine.sh --fix-gate-pin`
+  (or `--yes`) persists one. An `invalid`/`clamped` box ALREADY HAS the line, with a bad value —
+  and bootstrap deliberately never rewrites an existing value (a box running >1 gate on purpose
+  must not be clobbered), so re-running it is a **silent no-op**: fix the VALUE in
+  `/etc/environment` by hand. Bootstrap says the same thing at the same fork, as
+  `gate-pin: NOT-HONOURED`.
 - Every SUMMARY carries an `accelerators:` line (sccache/nextest/lane state, plus a `mold=` token and
   a `perf=` profiling-capability token on Linux hosts, #2859/#3249) — degradation there is
   actionable, not noise. `perf=paranoid-<N>`/`kptr-restricted` means THIS BOX CANNOT BE PROFILED (a
@@ -1940,8 +1946,17 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   given an isolation guarantee the semaphore was not providing. Bootstrap now persists to
   `/etc/environment` (read by PAM at session creation, no interactivity guard; bash itself never
   reads it, login shell or not) and takes its verdict from an AFFIRMATIVE PROBE — it SCRUBS its own
-  inherited value and reads the variable back out of a fresh, profile-free session — reported as
-  `gate-pin: VERIFIED / FAILED / UNMEASURED` in the same posture as `git-push:`. The generalisation,
+  inherited value — **and `BASH_ENV`/`ENV` with it, since a non-interactive bash SOURCES `$BASH_ENV`
+  and that file can re-export the variable just scrubbed** — and reads it back out of a fresh,
+  profile-free session, in the same posture as `git-push:`. FIVE verdicts ship and only the first is
+  an `[ok]`: **`VERIFIED`** (visible AND the gate honours the value), **`NOT-HONOURED`** (visible,
+  but the gate discards or clamps it — the remedy is to fix the VALUE, not the presence),
+  **`FAILED`** (not visible), **`UNMEASURED`** (the probe could not run, or the gate could not be
+  consulted about the value), **`OPT-OUT`/`SKIPPED`**. **`VERIFIED` IS SCOPED AND SAYS SO**: it
+  measures a PAM-created (sudo) session, so a gate launched from a systemd unit or a container
+  entrypoint — no PAM in its ancestry, so `/etc/environment` never applies — is NOT covered, and the
+  authoritative per-run confirmation stays that gate's own `cpu-budget: max-concurrency=N(pinned)`
+  token. The generalisation,
   which is the same one #3369 landed one section over: **presence in a config file and visibility to
   the process that reads it are different facts, and only the second one is a verdict** — so never
   certify a setting by re-reading the file you just wrote, and never let an INHERITED value answer a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -745,6 +745,16 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   differential is re-run under a FAILING shim, where each body must name exactly the one invocation
   it reached — with the short-circuit proved by measurement (strictly fewer invocations than the
   passing run) rather than assumed.
+- **Every SUMMARY's `cpu-budget:` line says WHERE the slot cap came from (#3414):**
+  `max-concurrency=N(pinned|default|invalid|clamped)`, the same idiom as `build-jobs=N(derived|caller)`
+  beside it. `pinned` = a valid `CQLITE_GATE_MAX_CONCURRENCY` >= 1 used verbatim; `default` = the var
+  is UNSET so N is the #1825 formula; `invalid` = it was EMPTY or non-numeric and was silently
+  discarded for the formula; `clamped` = it was a valid integer < 1 and was silently raised to 1.
+  Read `N(default)` on a fleet box as **the pin is not provisioned** — `3` and `3 because nothing set
+  it` are different operational facts, and the second one is what ran unseen for months. `invalid`
+  and `clamped` exist because `${VAR:-dflt}` cannot tell unset from set-empty (`${VAR+set}` can), so a
+  mis-set variable was textually identical to a healthy defaulted box. Fix a `default`/`invalid` box
+  with `bash scripts/bootstrap-agent-machine.sh --yes` and check its `gate-pin:` line.
 - Every SUMMARY carries an `accelerators:` line (sccache/nextest/lane state, plus a `mold=` token and
   a `perf=` profiling-capability token on Linux hosts, #2859/#3249) — degradation there is
   actionable, not noise. `perf=paranoid-<N>`/`kptr-restricted` means THIS BOX CANNOT BE PROFILED (a
@@ -1922,7 +1932,21 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   pins `CQLITE_GATE_MAX_CONCURRENCY=1` (the #1825 cap admits one gate; the per-gate core budget then
   gives it full cores), and every gate derives `CARGO_BUILD_JOBS` + nextest `--test-threads` from its
   slot count and runs under `taskpolicy -c utility`/`nice`, so no manual `pgrep`-serialization is
-  needed. It pre-claims by checking the `refs/claims/issue-<N>` ref (`claim.sh status <N>`) AND any legacy
+  needed. **A PIN THAT IS PRESENT IS NOT A PIN THAT IS IN EFFECT (#3414).** That pin lived in
+  `~/.bashrc` on all three boxes and was in effect on NONE of them: stock Ubuntu `.bashrc` opens
+  with `case $- in *i*) ;; *) return;; esac`, and a gate is launched non-interactively, so every
+  gate resolved N from the #1825 formula (`--slots 3` on 16 cores) while `grep` said the pin was
+  installed — one gate queued 1h31m and was killed with no verdict, and a measurement lane was
+  given an isolation guarantee the semaphore was not providing. Bootstrap now persists to
+  `/etc/environment` (read by PAM at session creation, no interactivity guard; bash itself never
+  reads it, login shell or not) and takes its verdict from an AFFIRMATIVE PROBE — it SCRUBS its own
+  inherited value and reads the variable back out of a fresh, profile-free session — reported as
+  `gate-pin: VERIFIED / FAILED / UNMEASURED` in the same posture as `git-push:`. The generalisation,
+  which is the same one #3369 landed one section over: **presence in a config file and visibility to
+  the process that reads it are different facts, and only the second one is a verdict** — so never
+  certify a setting by re-reading the file you just wrote, and never let an INHERITED value answer a
+  question about a PERSISTED one (bootstrap runs inside an already-pinned session, so an unscrubbed
+  probe would have certified the exact failure it exists to catch). It pre-claims by checking the `refs/claims/issue-<N>` ref (`claim.sh status <N>`) AND any legacy
   `issue-<N>-*` branch. Multiple sessions on ONE machine are now expected, each
   claim-protocol-gated; NEVER N bare sessions without the protocol — and note the claim ref is a
   hard control only *cross-machine* (git arbitrates the push). Locally it is advisory: a session

--- a/docs/development/agent-machine-setup.md
+++ b/docs/development/agent-machine-setup.md
@@ -9,9 +9,21 @@ place, and `gh`/roborev configured so a local gate run predicts CI.
 ```bash
 bash scripts/bootstrap-agent-machine.sh          # check everything; print any install commands
 bash scripts/bootstrap-agent-machine.sh --yes    # also auto-run brew/cargo installs + dataset fetch
-bash scripts/bootstrap-agent-machine.sh --fix-credentials --strict   # image/launcher preflight (#3369):
-                                                 # wire git push credentials ONLY, and exit 1 on any [warn]
+bash scripts/bootstrap-agent-machine.sh --fix-credentials --fix-gate-pin --strict
+                                                 # image/launcher preflight (#3369, #3414): wire git push
+                                                 # credentials AND persist the single-gate pin, then exit 1
+                                                 # on any [warn]. Two narrow repairs, nothing else — no
+                                                 # toolchain installs, so verify stays a verification step.
 ```
+
+**Both repair flags are needed, and omitting `--fix-gate-pin` reproduces #3414.** A launched box
+gets exactly one bootstrap invocation, and `--fix-credentials` alone leaves
+`CQLITE_GATE_MAX_CONCURRENCY` unpersisted — so every gate on that box silently resolves the #1825
+concurrency cap from the default formula and admits co-tenants, which is the defect #3414 exists to
+remove. `--fix-gate-pin` performs section 5b's `/etc/environment` write (idempotent; it never
+rewrites a value someone set deliberately) and the run then VERIFIES it by probing a fresh session.
+Check the `gate-pin:` line in the output, and the gate's own
+`cpu-budget: ... max-concurrency=N(pinned)` on the first summary that box produces.
 
 `--strict` is what the agent-ami profile's `verify.run` uses. Without it the script always
 exits 0 (so it composes into setup scripts) and the ONLY failure signal is the literal

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -36,10 +36,13 @@ gh auth status                                  # must include the 'project' sco
 ```
 
 **On a LAUNCHER-ONBOARDED box the credential step is already done (#3369)** — the agent-ami
-profile's `verify.run` is `bootstrap-agent-machine.sh --fix-credentials --strict`, which runs
-`gh auth setup-git` itself after the token is injected. It is **wired at onboard, not baked into
-the image**, so a hand-built box still needs the line above; the two paths do not conflict, and
-re-running it is idempotent.
+profile's `verify.run` is
+`bootstrap-agent-machine.sh --fix-credentials --fix-gate-pin --strict`, which runs
+`gh auth setup-git` itself after the token is injected **and persists the single-gate pin**
+(`--fix-gate-pin`, #3414 — without it a launched box arrives unpinned and every gate on it resolves
+the #1825 cap from the default formula). It is **wired at onboard, not baked into the image**, so a
+hand-built box still needs the line above; the two paths do not conflict, and re-running it is
+idempotent.
 
 **The `refs/claims/*` preflight is no longer a separate manual step either.** Every bootstrap run
 MEASURES push capability by performing the operation — it invokes `claim.sh smoke` and reports one

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -52,9 +52,22 @@ bash scripts/flow/claim.sh smoke               # same probe the bootstrap runs (
 **The single-gate pin is provisioned and VERIFIED the same way (#3414).** Bootstrap persists
 `CQLITE_GATE_MAX_CONCURRENCY=1` into **`/etc/environment`** under `--yes` — read by PAM's
 `pam_env` at session creation, with no interactivity guard — and then reports one
-`gate-pin: VERIFIED / FAILED / UNMEASURED` line taken from an **affirmative probe**: it scrubs
-its own inherited value and reads the variable back out of a fresh, profile-free session. It is
-never a grep of the file it just wrote. Two facts to keep in mind when you touch this:
+`gate-pin:` line taken from an **affirmative probe**: it scrubs its own inherited value —
+**and `BASH_ENV`/`ENV` with it**, since a non-interactive bash sources `$BASH_ENV` and that file
+could re-export the very variable just removed — then reads the variable back out of a fresh,
+profile-free session. It is never a grep of the file it just wrote. Five verdicts ship, only the
+first an `[ok]`: **`VERIFIED`** (visible AND honoured by the gate), **`NOT-HONOURED`** (visible,
+but the gate discards or clamps the value), **`FAILED`** (not visible), **`UNMEASURED`** (the
+probe could not run, or the gate could not be consulted), **`OPT-OUT`/`SKIPPED`**.
+Three facts to keep in mind when you touch this:
+
+* **`VERIFIED` is SCOPED, and the line says so.** The probe measures a PAM-created (sudo)
+  session, because that is the only session an unprivileged process can create. A gate is not
+  launched through sudo: a supervisor or lane tree started from a systemd unit or a container
+  entrypoint has no PAM in its ancestry, so `/etc/environment` never applies to it. `VERIFIED`
+  therefore means "a PAM-created session here sees a value the gate honours", never "every gate
+  on this box is pinned" — the authoritative per-run confirmation is that gate's own
+  `cpu-budget: max-concurrency=N(pinned)` token.
 
 * **A shell profile is the wrong place and a grep of it is the wrong check.** Stock Ubuntu
   `~/.bashrc` opens with `case $- in *i*) ;; *) return;; esac`, so an export appended there is
@@ -67,8 +80,11 @@ never a grep of the file it just wrote. Two facts to keep in mind when you touch
   overrides the pin; bootstrap leaves the line exactly as it is and verifies effectiveness.
 
 ```bash
-# how to ask the question yourself, the only way that answers it:
-sudo -u "$(id -un)" bash -c 'echo "${CQLITE_GATE_MAX_CONCURRENCY:-UNSET}"'
+# how to ask the question yourself. The scrub and the '-' (NOT ':-') are load-bearing:
+# without the scrub an INHERITED value reads as a healthy pin, and ':-' collapses "unset"
+# with "set but empty" — the exact defect this issue removed from the gate's own resolver.
+env -u CQLITE_GATE_MAX_CONCURRENCY -u BASH_ENV -u ENV \
+  sudo -u "$(id -un)" bash -c 'printf "[%s]\n" "${CQLITE_GATE_MAX_CONCURRENCY-UNSET}"'
 # and what the gate then stamps on its own cpu-budget line:
 #   max-concurrency=1(pinned)   <- provisioned    max-concurrency=3(default) <- NOT provisioned
 ```

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -56,9 +56,14 @@ bash scripts/flow/claim.sh smoke               # same probe the bootstrap runs (
 **and `BASH_ENV`/`ENV` with it**, since a non-interactive bash sources `$BASH_ENV` and that file
 could re-export the very variable just removed — then reads the variable back out of a fresh,
 profile-free session. It is never a grep of the file it just wrote. Five verdicts ship, only the
-first an `[ok]`: **`VERIFIED`** (visible AND honoured by the gate), **`NOT-HONOURED`** (visible,
-but the gate discards or clamps the value), **`FAILED`** (not visible), **`UNMEASURED`** (the
-probe could not run, or the gate could not be consulted), **`OPT-OUT`/`SKIPPED`**.
+first an `[ok]`: **`VERIFIED`** (the file sets a value, the session sees THAT SAME value, and the
+gate honours it), **`NOT-SYSTEM-WIDE`** (the session sees a value the file does not set — a sudo-
+or user-specific override), **`NOT-HONOURED`** (visible, but the gate discards or clamps it),
+**`FAILED`** (not visible), **`UNMEASURED`** (the probe could not run, the gate could not be
+consulted, or the file could not be read/parsed), **`OPT-OUT`/`SKIPPED`**. On a **non-Linux** host
+the verdict is **`NOT-APPLICABLE`**, a second `[ok]`: `/etc/environment` + `pam_env` is a Linux
+mechanism, so macOS is scoped out rather than supported (no launchd equivalent is shipped — there
+is no Mac on this fleet to verify one against).
 Three facts to keep in mind when you touch this:
 
 * **`VERIFIED` is SCOPED, and the line says so.** The probe measures a PAM-created (sudo)

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -63,10 +63,16 @@ first an `[ok]`: **`VERIFIED`** (the file sets a value, the session sees THAT SA
 gate honours it), **`NOT-SYSTEM-WIDE`** (the session sees a value the file does not set — a sudo-
 or user-specific override), **`NOT-HONOURED`** (visible, but the gate discards or clamps it),
 **`FAILED`** (not visible), **`UNMEASURED`** (the probe could not run, the gate could not be
-consulted, or the file could not be read/parsed), **`OPT-OUT`/`SKIPPED`**. On a **non-Linux** host
-the verdict is **`NOT-APPLICABLE`**, a second `[ok]`: `/etc/environment` + `pam_env` is a Linux
-mechanism, so macOS is scoped out rather than supported (no launchd equivalent is shipped — there
-is no Mac on this fleet to verify one against).
+consulted, or the file could not be read/parsed), **`OPT-OUT`/`SKIPPED`**. `VERIFIED` is the ONLY `[ok]`.
+
+On a **non-Linux** host there is no `[ok]`. `/etc/environment` + `pam_env` is a Linux mechanism, so
+macOS is scoped out rather than supported (no launchd equivalent is shipped — there is no Mac on
+this fleet to verify one against). An earlier form reported `NOT-APPLICABLE` as a second `[ok]`
+here; that was right about the mechanism and wrong about the verdict, because `--strict` reads the
+`[ok]` and so **certified an unpinned host**. Such a host now reports **`UNMEASURED`** when a value
+is visible — with no system-wide file to correlate against, a machine-wide pin cannot be told apart
+from a user-scoped one — and the per-run authority is the gate's own `cpu-budget:` token.
+`NOT-APPLICABLE` is emitted nowhere in the script today.
 Three facts to keep in mind when you touch this:
 
 * **`VERIFIED` is SCOPED, and the line says so.** The probe measures a PAM-created (sudo)

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -49,6 +49,30 @@ of `git-push: VERIFIED` / `FAILED` / `UNMEASURED`. Run the probe by hand only wh
 bash scripts/flow/claim.sh smoke               # same probe the bootstrap runs (see below)
 ```
 
+**The single-gate pin is provisioned and VERIFIED the same way (#3414).** Bootstrap persists
+`CQLITE_GATE_MAX_CONCURRENCY=1` into **`/etc/environment`** under `--yes` — read by PAM's
+`pam_env` at session creation, with no interactivity guard — and then reports one
+`gate-pin: VERIFIED / FAILED / UNMEASURED` line taken from an **affirmative probe**: it scrubs
+its own inherited value and reads the variable back out of a fresh, profile-free session. It is
+never a grep of the file it just wrote. Two facts to keep in mind when you touch this:
+
+* **A shell profile is the wrong place and a grep of it is the wrong check.** Stock Ubuntu
+  `~/.bashrc` opens with `case $- in *i*) ;; *) return;; esac`, so an export appended there is
+  never reached by the non-interactive shells that launch gates. All three fleet boxes carried
+  the export and **none** of them had it in effect; every gate resolved the #1825 cap from the
+  default formula (`--slots 3` on a 16-core box) while the pin looked installed. Bootstrap still
+  appends to the profile for interactive convenience, but that append can only ever print
+  `[info]`.
+* **An existing value is never rewritten.** A box deliberately running >1 concurrent gate
+  overrides the pin; bootstrap leaves the line exactly as it is and verifies effectiveness.
+
+```bash
+# how to ask the question yourself, the only way that answers it:
+sudo -u "$(id -un)" bash -c 'echo "${CQLITE_GATE_MAX_CONCURRENCY:-UNSET}"'
+# and what the gate then stamps on its own cpu-budget line:
+#   max-concurrency=1(pinned)   <- provisioned    max-concurrency=3(default) <- NOT provisioned
+```
+
 **Cost and residual of the automatic probe.** Every bootstrap run — laptop runs included — makes two
 extra network round trips and CREATES AND DELETES a transient `refs/claims/smoke-<commit-sha>` ref on the
 shared origin. A cleanup delete that exits nonzero now FAILS the probe

--- a/docs/development/gate-ops.md
+++ b/docs/development/gate-ops.md
@@ -373,9 +373,14 @@ Running many sessions/worktrees at once used to let ~15 full gates hit the CPU a
   < 1 and was silently raised to 1. `3` and `3 because nothing set it` are different
   operational facts: the whole fleet ran at `N=3` for months with the pin present in
   `~/.bashrc` and invisible to every non-interactive shell (stock Ubuntu `.bashrc` returns
-  early when not interactive), and no artifact said so. Provision the pin with
-  `bash scripts/bootstrap-agent-machine.sh --yes`, whose `gate-pin:` line VERIFIES it by
-  probing a fresh profile-free PAM session rather than by grepping the file it wrote.
+  early when not interactive), and no artifact said so.
+- **The remedy differs by token.** `default` = no pin line at all, so
+  `bash scripts/bootstrap-agent-machine.sh --fix-gate-pin` (or `--yes`) persists one into
+  `/etc/environment`, and its `gate-pin:` line VERIFIES the result by probing a fresh
+  profile-free PAM session rather than by grepping the file it wrote. `invalid`/`clamped` =
+  the line is ALREADY there with a bad value, and bootstrap never rewrites an existing value,
+  so re-running it is a **silent no-op** — fix the VALUE by hand. Bootstrap reports that fork
+  as `gate-pin: NOT-HONOURED`.
 - **SIGKILL-safe stale-slot reaping**: each slot is an `fcntl.flock` held by a background daemon (`scripts/lib/gate_slot_daemon.py`) whose lock fd is NOT inherited by the gate's `cargo`/`nextest` children, so a killed gate releases its slot within one poll — no permanent leak/deadlock.
 - Works **across worktrees** (shared slot dir) and composes with `AGENT_GATE_JOBS` (per-gate) + `sccache`. The cap bounds the *worst case*; those cut average load / per-compile time.
 

--- a/docs/development/gate-ops.md
+++ b/docs/development/gate-ops.md
@@ -366,6 +366,16 @@ Running many sessions/worktrees at once used to let ~15 full gates hit the CPU a
 
 - **`--lite` and `--only` runs are EXEMPT** (never queued): `--lite` is cheap, and `--only` PARTIAL runs are used by nested tooling self-tests (capping them could self-deadlock the queue).
 - **N** defaults to `max(2, floor((ncpu-2)/4))`; override with `CQLITE_GATE_MAX_CONCURRENCY`.
+- **Every SUMMARY says WHERE N came from (issue #3414)**: the `cpu-budget:` line stamps
+  `max-concurrency=N(pinned|default|invalid|clamped)` — `pinned` = the env var held a valid
+  integer >= 1, `default` = it was UNSET so N is the formula, `invalid` = it was empty or
+  non-numeric and was silently discarded for the formula, `clamped` = it was a valid integer
+  < 1 and was silently raised to 1. `3` and `3 because nothing set it` are different
+  operational facts: the whole fleet ran at `N=3` for months with the pin present in
+  `~/.bashrc` and invisible to every non-interactive shell (stock Ubuntu `.bashrc` returns
+  early when not interactive), and no artifact said so. Provision the pin with
+  `bash scripts/bootstrap-agent-machine.sh --yes`, whose `gate-pin:` line VERIFIES it by
+  probing a fresh profile-free PAM session rather than by grepping the file it wrote.
 - **SIGKILL-safe stale-slot reaping**: each slot is an `fcntl.flock` held by a background daemon (`scripts/lib/gate_slot_daemon.py`) whose lock fd is NOT inherited by the gate's `cargo`/`nextest` children, so a killed gate releases its slot within one poll — no permanent leak/deadlock.
 - Works **across worktrees** (shared slot dir) and composes with `AGENT_GATE_JOBS` (per-gate) + `sccache`. The cap bounds the *worst case*; those cut average load / per-compile time.
 

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1281,7 +1281,16 @@ _gate_resolve_max_concurrency() {
     v="${CQLITE_GATE_MAX_CONCURRENCY}"
     case "$v" in
       ''|*[!0-9]*) v=$dflt; src=invalid ;;
-      *)           if [ "$v" -lt 1 ]; then v=1; src=clamped; else src=pinned; fi ;;
+      # BASE-10 EXPLICITLY (roborev job 331, Medium). The case above admits any digit-only
+      # string, so `08` reached the arithmetic below — where bash reads a leading zero as
+      # OCTAL and `08`/`09` are not valid octal. Measured before the fix:
+      #   CQLITE_GATE_MAX_CONCURRENCY=08 -> "line 1301: 08: value too great for base"
+      # i.e. the gate ERRORED OUT rather than resolving a cap, which is worse than either
+      # mis-classifying it or refusing it. `10#` forces base 10, and `v` is normalised so
+      # every downstream consumer (cores-per-gate, build-jobs, test-threads) gets a clean
+      # decimal — the SUMMARY then reports the value actually honoured, e.g. `8(pinned)`.
+      *)           v=$(( 10#$v ))
+                   if [ "$v" -lt 1 ]; then v=1; src=clamped; else src=pinned; fi ;;
     esac
   fi
   GATE_MAX_CONCURRENCY="$v"

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1263,9 +1263,11 @@ accelerators_line() {
 # so. Four states, because two more fall straight out of the resolver:
 #   pinned  — the env var is set to a valid integer >= 1 and is used verbatim
 #   default — the env var is UNSET, so N is the #1825 formula max(2,(ncpu-2)/4)
-#   invalid — the env var is set to a non-numeric or EMPTY value; it is SILENTLY
-#             discarded for the formula (a mis-set tmux/systemd/CI var reads
-#             exactly like a healthy defaulted box unless we say so)
+#   invalid — the env var is set to a value that cannot be used as a cap: EMPTY,
+#             non-numeric, or a digit string too large to represent (19+ digits,
+#             roborev job 332). It is SILENTLY discarded for the formula (a mis-set
+#             tmux/systemd/CI var reads exactly like a healthy defaulted box unless
+#             we say so)
 #   clamped — the env var is set to a valid integer < 1 (e.g. 0) and is silently
 #             raised to 1
 # `${VAR+set}` — NOT `${VAR:-}` — is what separates unset from set-but-empty:
@@ -1274,7 +1276,7 @@ accelerators_line() {
 _gate_resolve_max_concurrency() {
   local dflt=$(( ( _ncpu - 2 ) / 4 ))
   [ "$dflt" -lt 2 ] && dflt=2
-  local v src
+  local v src sig
   if [ -z "${CQLITE_GATE_MAX_CONCURRENCY+set}" ]; then
     v=$dflt; src=default
   else
@@ -1289,8 +1291,31 @@ _gate_resolve_max_concurrency() {
       # mis-classifying it or refusing it. `10#` forces base 10, and `v` is normalised so
       # every downstream consumer (cores-per-gate, build-jobs, test-threads) gets a clean
       # decimal — the SUMMARY then reports the value actually honoured, e.g. `8(pinned)`.
-      *)           v=$(( 10#$v ))
-                   if [ "$v" -lt 1 ]; then v=1; src=clamped; else src=pinned; fi ;;
+      *)           # AN UPPER BOUND CHECKED BY DIGIT COUNT, BEFORE ANY ARITHMETIC (roborev
+                   # job 332). `10#$v` on a digit string bash cannot represent WRAPS
+                   # SILENTLY, and the wrap was reported as a pin. Measured before the fix:
+                   #   ...=99999999999999999999 -> max-concurrency=7766279631452241919(pinned)
+                   #   ...=9223372036854775808  -> max-concurrency=1(clamped)
+                   # The first is the damaging one: the SUMMARY AFFIRMS a pin at a value
+                   # nobody set, which inverts the one property this token exists to carry.
+                   # The second mislabels an unusable value as a deliberate 0.
+                   #
+                   # The bound is a DIGIT COUNT, not a comparison against INT64_MAX, because
+                   # it must be decided WITHOUT the arithmetic that is the defect: any
+                   # <=18-digit decimal is < 9.22e18 and always fits, so 19+ digits is
+                   # refused. That refuses a handful of representable 19-digit values too —
+                   # deliberately, since a 19-digit slot cap is a mis-set variable by any
+                   # measure, and `invalid` (silently discarded, use the formula) is the
+                   # correct answer for one. A lexical compare against INT64_MAX would be
+                   # exact but locale-dependent on digit collation; a length test is not.
+                   sig="$v"
+                   while [ "${#sig}" -gt 1 ] && [ "${sig#0}" != "$sig" ]; do sig="${sig#0}"; done
+                   if [ "${#sig}" -gt 18 ]; then
+                     v=$dflt; src=invalid
+                   else
+                     v=$(( 10#$sig ))
+                     if [ "$v" -lt 1 ]; then v=1; src=clamped; else src=pinned; fi
+                   fi ;;
     esac
   fi
   GATE_MAX_CONCURRENCY="$v"

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1246,18 +1246,53 @@ accelerators_line() {
 #                         core-tests long pole.
 # A caller who exports CARGO_BUILD_JOBS is respected verbatim (never overridden).
 
-# _gate_max_concurrency: resolve N from the #1825 default formula + the
-# CQLITE_GATE_MAX_CONCURRENCY override. Defined early (issue #2640) because the
-# core-budget derivation below needs it before any cargo runs; the #1825 cap's
-# acquire_gate_slot consumes the SAME function further down (single source).
-_gate_max_concurrency() {
+# _gate_resolve_max_concurrency: resolve N — and WHERE N CAME FROM — ONCE, into
+# GATE_MAX_CONCURRENCY + GATE_MAX_CONCURRENCY_SOURCE. Resolved early (issue #2640)
+# because the core-budget derivation below needs it before any cargo runs; the
+# #1825 cap's acquire_gate_slot and the SUMMARY's cpu-budget line both READ THESE
+# GLOBALS through _gate_max_concurrency, so the value the slot semaphore enforces
+# and the value the pasted SUMMARY reports are STRUCTURALLY the same value — a
+# second, independently-recomputing resolver could disagree with the first.
+#
+# THE SOURCE TOKEN IS THE POINT (issue #3414). `max-concurrency=3` alone does not
+# say whether this box was PINNED at 3 or merely DEFAULTED there because nothing
+# set the variable, and those are different operational facts: the fleet ran for
+# months with the pin present in ~/.bashrc but invisible to every non-interactive
+# shell (Ubuntu's stock .bashrc returns early when not interactive), so every gate
+# silently resolved N from the formula, admitted co-tenants, and no artifact said
+# so. Four states, because two more fall straight out of the resolver:
+#   pinned  — the env var is set to a valid integer >= 1 and is used verbatim
+#   default — the env var is UNSET, so N is the #1825 formula max(2,(ncpu-2)/4)
+#   invalid — the env var is set to a non-numeric or EMPTY value; it is SILENTLY
+#             discarded for the formula (a mis-set tmux/systemd/CI var reads
+#             exactly like a healthy defaulted box unless we say so)
+#   clamped — the env var is set to a valid integer < 1 (e.g. 0) and is silently
+#             raised to 1
+# `${VAR+set}` — NOT `${VAR:-}` — is what separates unset from set-but-empty:
+# the `:-` form collapses them onto one answer, which is precisely how an empty
+# value would have gone on reading as `default`.
+_gate_resolve_max_concurrency() {
   local dflt=$(( ( _ncpu - 2 ) / 4 ))
   [ "$dflt" -lt 2 ] && dflt=2
-  local v="${CQLITE_GATE_MAX_CONCURRENCY:-$dflt}"
-  case "$v" in *[!0-9]*|'') v=$dflt ;; esac
-  [ "$v" -lt 1 ] && v=1
-  printf '%s' "$v"
+  local v src
+  if [ -z "${CQLITE_GATE_MAX_CONCURRENCY+set}" ]; then
+    v=$dflt; src=default
+  else
+    v="${CQLITE_GATE_MAX_CONCURRENCY}"
+    case "$v" in
+      ''|*[!0-9]*) v=$dflt; src=invalid ;;
+      *)           if [ "$v" -lt 1 ]; then v=1; src=clamped; else src=pinned; fi ;;
+    esac
+  fi
+  GATE_MAX_CONCURRENCY="$v"
+  GATE_MAX_CONCURRENCY_SOURCE="$src"
 }
+_gate_resolve_max_concurrency
+
+# _gate_max_concurrency: the SINGLE accessor for the resolved N. Kept as a function
+# so every existing call site (acquire_gate_slot, the core budget, the cpu-budget
+# line) keeps reading one resolution rather than recomputing its own.
+_gate_max_concurrency() { printf '%s' "$GATE_MAX_CONCURRENCY"; }
 
 # _gate_cores_per_gate: the fair-share core count for THIS gate = max(1, ncpu/N).
 _gate_cores_per_gate() {
@@ -1283,8 +1318,14 @@ fi
 # cpu_budget_line: machine-checkable one-liner stamped into every SUMMARY block,
 # so per-gate CPU throttling (or its absence) is visible in the pasted block, not
 # just scrollback (#2640). Names the wrapper (nice/taskpolicy/none), the resolved
-# machine-wide concurrency N, the derived per-gate cores, and the build-jobs +
-# test-threads the gate actually used.
+# machine-wide concurrency N **and where N came from** (#3414), the derived
+# per-gate cores, and the build-jobs + test-threads the gate actually used.
+#
+# max-concurrency carries its source in parentheses — the same idiom as
+# build-jobs=N(derived|caller) beside it — so a pasted SUMMARY distinguishes a box
+# that was PINNED at N from one that merely DEFAULTED there (and from one whose pin
+# is invalid or was clamped). It is deliberately here and NOT on `accelerators:`:
+# the cap already lives on this line, and two spellings of one fact is drift.
 #
 # The `cpu-budget:` line is a space-delimited `key=value`-per-token line, so the
 # wrapper field MUST be a SINGLE token: AGENT_GATE_WRAPPER holds the full command
@@ -1292,12 +1333,14 @@ fi
 # otherwise inject stray `-c`/`utility`/`-n`/`10` tokens between wrapper= and the
 # next key and break any positional/space-splitting parser. Emit only the tool
 # name (first word) here; the full command stays in AGENT_GATE_WRAPPER for the
-# re-exec (issue #2640).
+# re-exec (issue #2640). The same rule binds every field added later: the #3414
+# source token is `max-concurrency=1(pinned)` with NO space inside the parens, for
+# exactly the reason the wrapper field is truncated.
 cpu_budget_line() {
   local _wrapper_tok="${AGENT_GATE_WRAPPER:-none}"
   _wrapper_tok="${_wrapper_tok%% *}"   # first word only: "taskpolicy -c utility" -> "taskpolicy"
-  printf 'cpu-budget: wrapper=%s ncpu=%s max-concurrency=%s cores-per-gate=%s build-jobs=%s(%s) test-threads=%s' \
-    "$_wrapper_tok" "$_ncpu" "$(_gate_max_concurrency)" \
+  printf 'cpu-budget: wrapper=%s ncpu=%s max-concurrency=%s(%s) cores-per-gate=%s build-jobs=%s(%s) test-threads=%s' \
+    "$_wrapper_tok" "$_ncpu" "$GATE_MAX_CONCURRENCY" "$GATE_MAX_CONCURRENCY_SOURCE" \
     "$GATE_CORES_PER_GATE" "${CARGO_BUILD_JOBS:-unset}" "${CARGO_BUILD_JOBS_SOURCE:-unknown}" \
     "$GATE_TEST_THREADS"
 }

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -2189,7 +2189,15 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   fi
 
   # ---- (1) persist. Reported with info/warn ONLY — a write is never the verdict ----
-  if [ ! -e "$PIN_ENV_FILE" ]; then
+  # AND ONLY ON LINUX (#3414 final roborev). The verdict half already treats a non-Linux
+  # host as unmanaged, but this block still APPENDED to /etc/environment whenever that file
+  # happened to exist and --yes/--fix-gate-pin was passed — mutating a system file that the
+  # platform's own session mechanism does not consume. Writing to a file nobody reads is not
+  # a harmless no-op; it is an unrequested change to host state that will outlive the run.
+  if [ "$PIN_PLATFORM_UNMANAGED" = 1 ]; then
+    PIN_PERSIST_NOTE="not persisted (no PAM-read system-wide env file on $PLATFORM)"
+    info "not touching $PIN_ENV_FILE on this $PLATFORM host — pam_env is a Linux mechanism and this platform does not consume that file, so writing it would change host state for nothing"
+  elif [ ! -e "$PIN_ENV_FILE" ]; then
     PIN_PERSIST_NOTE="no $PIN_ENV_FILE on this host"
     info "no $PIN_ENV_FILE on this $PLATFORM host — there is no PAM-read system-wide env file to persist the pin into"
   elif [ -L "$PIN_ENV_FILE" ]; then

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -1977,7 +1977,27 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   # then fail in the measurement.
   PIN_ROOT=()
   PIN_PRIV_STATE=unknown
+  # Initialised HERE, above the first thing that can set it: the non-root name check below
+  # records a subject note, and an initialisation further down would blank it (the note
+  # would vanish and the state would degrade to a bare no-identity).
+  PIN_PROBE_SUBJECT_NOTE=""
+  # AND THE NAME MUST MAP BACK TO $EUID (#3414 roborev round 9). `id -un` is a PATH lookup
+  # against NSS, and both halves can lie: a shadowed or malformed `id`, or a stale NSS
+  # mapping, can name an account that is NOT the one we are running as. The name is then
+  # handed to `sudo -n -u`, so the probe would open a session for a DIFFERENT account and
+  # report its PAM environment as ours — the wrong-subject defect the root branch below
+  # already guards, on the path nobody thought to guard because it looked like it was just
+  # asking who we are. $EUID is the authority (shell-set, no fork, unshadowable); the name
+  # is a label for the messages and is only usable once it resolves back to that uid.
+  # A mismatch is UNMEASURED, never a guess between two disagreeing sources.
   PIN_SELF_USER=$(id -un 2>/dev/null || true)
+  if [ -n "$PIN_SELF_USER" ]; then
+    pin_name_uid=$(id -u "$PIN_SELF_USER" 2>/dev/null || echo none)
+    if [ "$pin_name_uid" != "$PIN_EUID" ]; then
+      PIN_PROBE_SUBJECT_NOTE="'id -un' answered '$PIN_SELF_USER', which resolves to uid $pin_name_uid rather than this process's EUID $PIN_EUID — a shadowed 'id' or a stale NSS mapping, so probing that name would answer about the wrong account"
+      PIN_SELF_USER=""
+    fi
+  fi
   PIN_SELF_UID="$PIN_EUID"   # one source: resolved before the seam guard, which needs it
   # UNDER `sudo bash bootstrap …` THE ANSWER TO `id -un` IS root, WHICH IS THE WRONG
   # SUBJECT (#3414 roborev round 5). Gates run as the agent account, and the two genuinely
@@ -1998,7 +2018,6 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   # (root invoking sudo tells us nothing new), and if a username is present it must resolve
   # to that same uid. Anything absent or inconsistent is UNMEASURED — never a fall back to
   # answering about root, and never a guess between two disagreeing sources.
-  PIN_PROBE_SUBJECT_NOTE=""
   if [ "$PIN_EUID" = 0 ]; then
     pin_sudo_uid="${SUDO_UID-}"
     case "$pin_sudo_uid" in ''|*[!0-9]*) pin_sudo_uid="" ;; esac

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -2365,6 +2365,7 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
     # session type the probe could open. What it does NOT buy is a launch path with no
     # PAM in its ancestry at all — that residual is real and is stated, not implied.
     info "scope: measured through a PAM-created (sudo) session against the line in $PIN_ENV_FILE. Whether the service stacks a gate is actually launched from also read that file is NOT checked here — and a process tree created WITHOUT PAM (a systemd unit, a container entrypoint) never has it applied at all"
+    info "scope: pam_env reads $PIN_ENV_FILE at SESSION CREATION, so this verdict is about FUTURE sessions. THIS shell, and every process already descended from it — including workers a launcher started before now — do NOT have the pin and will not until their sessions are recreated. A gate launched by such a worker still resolves the #1825 cap from the formula (#3728)"
     info "the authoritative per-run confirmation is the gate's own SUMMARY line:  cpu-budget: ... max-concurrency=N(pinned)   (N(default) there means that gate did not see the pin)"
     [ -n "$PIN_PROBE_SUBJECT_NOTE" ] && info "subject: $PIN_PROBE_SUBJECT_NOTE"
   }

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -2256,126 +2256,9 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
     # every PAM stack (sshd, login, su, sudo), so the claim is not limited to the one
     # session type the probe could open. What it does NOT buy is a launch path with no
     # PAM in its ancestry at all — that residual is real and is stated, not implied.
-    info "scope: the line is in $PIN_ENV_FILE and the sshd/login session stacks were CHECKED to read it, so the claim is not limited to the sudo session probed — but a process tree created WITHOUT PAM, a systemd unit or a container entrypoint, never has it applied, so this does not prove every gate on this box is pinned"
+    info "scope: measured through a PAM-created (sudo) session against the line in $PIN_ENV_FILE. Whether the service stacks a gate is actually launched from also read that file is NOT checked here — and a process tree created WITHOUT PAM (a systemd unit, a container entrypoint) never has it applied at all"
     info "the authoritative per-run confirmation is the gate's own SUMMARY line:  cpu-budget: ... max-concurrency=N(pinned)   (N(default) there means that gate did not see the pin)"
     [ -n "$PIN_PROBE_SUBJECT_NOTE" ] && info "subject: $PIN_PROBE_SUBJECT_NOTE"
-    [ -n "$PIN_PAM_UNCHECKED" ] && info "unchecked: $PIN_PAM_UNCHECKED — those service stacks could not be read, so this run says nothing about them either way"
-  }
-
-  # pin_pam_services_missing_readenv: the sshd/login session stacks that do NOT read
-  # $PIN_ENV_FILE. Echoes the offending service names, empty when none.
-  #
-  # A WEAKEN-ONLY SIGNAL, AND THAT IS WHAT MAKES CONSULTING CONFIG LEGITIMATE HERE
-  # (#3414 roborev round 5). Reading configuration to CREATE a positive verdict is the
-  # proxy reasoning this whole issue exists to remove — a file saying pam_env is loaded is
-  # not evidence that a session got the value, exactly as a line in ~/.bashrc was not. But
-  # the converse is sound: if the stack a gate's session is actually created by does not
-  # read the file at all, then a SUDO-verified pin is not evidence about that session. So
-  # this may only ever DOWNGRADE a would-be VERIFIED and can never produce one. Same
-  # asymmetry as the negative-probe rule above: an unmeasurable or absent half may weaken
-  # a positive claim and may never strengthen one.
-  #
-  # THE PREDICATE IS MEASURED, NOT GUESSED. `readenv` DEFAULTS TO ON (pam_env(8): "By
-  # default this option is on"), so a BARE `pam_env.so` reads the file and only an
-  # explicit `readenv=0` disables it — requiring the literal `readenv=1` would flag this
-  # very box, whose /etc/pam.d/sshd carries a bare `pam_env.so`, and weaken a correctly
-  # configured machine. A line with an explicit `envfile=` pointing somewhere ELSE (sshd
-  # and login both carry one for /etc/default/locale) is likewise not evidence for this
-  # file. So: a session line invoking pam_env.so, without readenv=0, and either without an
-  # envfile= or with one naming $PIN_ENV_FILE.
-  #
-  # A service whose config is ABSENT is not a gap — a box with no sshd needs no sshd
-  # stack. A service whose config is present but UNREADABLE is recorded as unchecked
-  # (PIN_PAM_UNCHECKED) rather than treated as missing: "cannot tell" must not manufacture
-  # a downgrade any more than it may manufacture a pass.
-  #
-  # THE DIRECTORY IS OVERRIDABLE ONLY INSIDE AN ALREADY-VALIDATED SEAM, and deliberately
-  # not by a switch of its own. `CQLITE_BOOTSTRAP_PAM_DIR` is honoured ONLY when
-  # PIN_ENV_FILE_IS_SEAM is 1 — i.e. when the env-file seam has already passed test-mode,
-  # absolute-path, not-production and NOT-ROOT validation — so it adds no new reachable
-  # surface and cannot be set independently of that gate. It matters that this is the
-  # direction it is: pointing the check at a directory that looks healthy could SUPPRESS a
-  # downgrade, and suppressing a downgrade is how a VERIFIED gets manufactured. Tying it
-  # to the seam keeps that reachable only where the section is already non-production.
-  PIN_PAM_DIR=/etc/pam.d
-  if [ "$PIN_ENV_FILE_IS_SEAM" = 1 ] && [ -n "${CQLITE_BOOTSTRAP_PAM_DIR:-}" ]; then
-    case "$CQLITE_BOOTSTRAP_PAM_DIR" in
-      /etc/pam.d) : ;;                      # never the production directory
-      /*) [ -d "$CQLITE_BOOTSTRAP_PAM_DIR" ] && PIN_PAM_DIR="$CQLITE_BOOTSTRAP_PAM_DIR" ;;
-    esac
-  fi
-  # pin_pam_effective_lines <service-file>: the service file PLUS one level of @include.
-  #
-  # A DISTRIBUTION MAY FACTOR pam_env INTO THE COMMON STACK. Both /etc/pam.d/sshd and
-  # /etc/pam.d/login here carry `@include common-session`, and a predicate reading only the
-  # service file would report "no pam_env" on any distro that puts it there — weakening a
-  # correctly configured box, which is the red-on-correct-input shape this lane has hit
-  # four times. Measured on THIS box: common-session carries no pam_env line, so following
-  # the include changes nothing here; it is done for the distros where it would.
-  #
-  # ONE LEVEL, NOT RECURSIVE, and the not-found diagnostic SAYS SO — an absence you did not
-  # fully search for is not an absence, so the limit is declared rather than papered over.
-  pin_pam_effective_lines() {
-    local f="$1" inc
-    cat "$f" 2>/dev/null
-    while IFS= read -r inc; do
-      [ -n "$inc" ] || continue
-      case "$inc" in /*) : ;; *) inc="$PIN_PAM_DIR/$inc" ;; esac
-      [ -r "$inc" ] && cat "$inc" 2>/dev/null
-    done <<EOF
-$(awk '/^[[:space:]]*@include[[:space:]]+/ { print $2 }' "$f" 2>/dev/null)
-EOF
-  }
-
-  #
-  # RESULTS COME BACK IN GLOBALS AND THIS IS CALLED DIRECTLY, NEVER IN `$( )` (#3414
-  # roborev round 6). It used to be invoked as `pin_pam_gap=$(pin_pam_services_...)`, and
-  # `$( )` FORKS — so the PIN_PAM_UNCHECKED assignment happened in a subshell and was
-  # discarded. An UNREADABLE service config then reached VERIFIED *and* the scope note
-  # claimed the stacks had been checked: a false positive plus a false statement about
-  # what was measured, which is worse than either alone.
-  #
-  # THIS IS NOT A NEW LESSON, IT IS AN EXISTING ONE REPRODUCED ONE FILE OVER. CLAUDE.md
-  # already carries it for the gate's cargo-output parse sites — "read by redirection,
-  # never a pipe: a piped `while read` runs in a subshell and its verdict is discarded".
-  # That doctrine was written about agent-gate.sh, but it is a property of the SHELL, not
-  # of that file: `$( )` and `|` both fork, and a verdict assigned inside either does not
-  # survive. Said here because the next person reaches for `$( )` reflexively too.
-  #
-  # The rule this file now follows: a function that ECHOES its result may be used in a
-  # substitution or a pipe (the output IS the payload — pin_gate_source_for,
-  # pin_strip_pam_quotes, pin_pam_effective_lines); a function that ASSIGNS must be called
-  # directly. Swept at the time of this fix: this was the only assigner being substituted.
-  PIN_PAM_UNCHECKED=""
-  PIN_PAM_GAP=""
-  pin_pam_services_missing_readenv() {
-    local svc f missing=""
-    PIN_PAM_UNCHECKED=""
-    PIN_PAM_GAP=""
-    for svc in sshd login; do
-      f="$PIN_PAM_DIR/$svc"
-      [ -e "$f" ] || continue
-      if [ ! -r "$f" ]; then
-        PIN_PAM_UNCHECKED="${PIN_PAM_UNCHECKED:+$PIN_PAM_UNCHECKED }$svc"
-        continue
-      fi
-      # `envfile=` REDIRECTS WHICH FILE IS READ, so a pam_env line is evidence about ours
-      # only if it does not point elsewhere. Both service files here carry a second
-      # pam_env line with envfile=/etc/default/locale — that one reads the locale file and
-      # must not count, or a stack whose ONLY pam_env line was the locale one would read
-      # as pinned when it is not. sshd still qualifies, via its bare line alone.
-      if ! pin_pam_effective_lines "$f" | awk -v envfile="$PIN_ENV_FILE" '
-            /^[[:space:]]*#/ { next }
-            $1 == "session" && /pam_env\.so/ {
-              if ($0 ~ /readenv=0/) next
-              if ($0 ~ /envfile=/) { if ($0 !~ ("envfile=" envfile "([[:space:]]|$)")) next }
-              found = 1
-            }
-            END { exit(found ? 0 : 1) }' 2>/dev/null; then
-        missing="${missing:+$missing }$svc"
-      fi
-    done
-    PIN_PAM_GAP="$missing"
   }
 
   # pin_value_remedy: the remedy for a VISIBLE but NOT-HONOURED value. Shared by both
@@ -2540,27 +2423,8 @@ EOF
               if [ "$PIN_FILE_VALUE" = "$pin_probe_seen" ]; then
                 # Called DIRECTLY: see the note on the function — a substitution here
                 # forks, and both of its result globals would be lost with the fork.
-                pin_pam_services_missing_readenv
-                pin_pam_gap="$PIN_PAM_GAP"
-                if [ -n "$pin_pam_gap" ]; then
-                  # WEAKEN ONLY. Both affirmative halves hold, but the session stacks a
-                  # gate is actually created by do not read this file, so what was
-                  # measured through sudo is not evidence about them.
-                  warn "gate-pin: NOT-SYSTEM-WIDE ($PIN_ENV_FILE sets CQLITE_GATE_MAX_CONCURRENCY=$PIN_FILE_VALUE and a sudo session sees it, but the PAM stack for [$pin_pam_gap] does NOT read $PIN_ENV_FILE — sessions created by those services, which is how gates are launched, will not get it)"
-                  info "add a session-stage 'pam_env.so' (readenv defaults to on) to $PIN_PAM_DIR/{$(printf '%s' "$pin_pam_gap" | tr ' ' ',')}, then re-run"
-                  info "searched each service file plus ONE level of @include; a pam_env buried deeper than that would not have been seen, so confirm by hand before rewriting a stack"
-                  info "the sudo-session result above is real but does not generalise; the per-run authority stays the gate's own cpu-budget: max-concurrency=N(...) token"
-                elif [ -n "$PIN_PAM_UNCHECKED" ]; then
-                  # NOT a gap and NOT a clean check. The stacks that decide whether this
-                  # generalises could not be read, so the scope the VERIFIED text would
-                  # claim was never established — and claiming it was is the half of this
-                  # finding that is worse than the false positive.
-                  warn "gate-pin: UNMEASURED ($PIN_ENV_FILE sets CQLITE_GATE_MAX_CONCURRENCY=$PIN_FILE_VALUE and a sudo session sees it, but the PAM stack for [$PIN_PAM_UNCHECKED] could not be READ — whether sessions created by those services get it is UNKNOWN)"
-                  info "the sudo-session result above is real but its scope is unestablished; the per-run authority stays the gate's own cpu-budget: max-concurrency=N(...) token"
-                else
                 ok "gate-pin: VERIFIED ($PIN_ENV_FILE sets CQLITE_GATE_MAX_CONCURRENCY=$PIN_FILE_VALUE AND a fresh PAM-created, profile-free session sees that SAME value, which the gate HONOURS verbatim — max-concurrency=$pin_probe_seen(pinned); this run's own value, BASH_ENV and ENV were scrubbed first)"
                 pin_scope_note
-                fi
               else
                 warn "gate-pin: NOT-SYSTEM-WIDE ($PIN_ENV_FILE sets CQLITE_GATE_MAX_CONCURRENCY='$PIN_FILE_VALUE' but this session sees '$pin_probe_seen' — a sudo- or user-specific source is OVERRIDING the system-wide file, so ordinary PAM sessions get the file's value and the gate will act on THAT, not on the one measured here)"
                 info "fix the VALUE in $PIN_ENV_FILE (bootstrap never rewrites an existing value), or remove the per-user/sudoers override so the two agree"

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -2521,6 +2521,26 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   # persisted value of `abc` would then get a `(pinned)` answer from an oracle that never
   # saw `abc`. Fixing the probe and leaving the oracle open is fixing one instance of a
   # class; the value check above is the belt to this braces, and vice versa.
+  # pin_canon_decimal: the gate's leading-zero normalisation, MIRRORED here — and that is a
+  # SECOND IMPLEMENTATION, which this repo is right to be suspicious of (roborev job 333).
+  # Two reasons it is the lesser evil, and the mechanism that keeps it honest:
+  #   * The alternative the finding also offered — have the oracle echo its INPUT back — is a
+  #     change to the `cpu-budget:` line's CONTRACT, which is a published gate surface that
+  #     other readers parse. Widening it to serve one caller is the bigger coupling.
+  #   * The drift check below exists to catch the oracle answering about a DIFFERENT value, so
+  #     it cannot be expressed without comparing against our input; asking the oracle to
+  #     canonicalise our input for us is circular.
+  # ANTI-DRIFT IS A TEST, NOT A COMMENT: the suite runs the REAL gate for `08` and requires
+  # bootstrap to reach VERIFIED, so if the gate's normalisation rule ever changes this reds.
+  pin_canon_decimal() {
+    local c="$1"
+    case "$c" in
+      ''|*[!0-9]*) printf '%s' "$c"; return 0 ;;
+    esac
+    while [ "${#c}" -gt 1 ] && [ "${c#0}" != "$c" ]; do c="${c#0}"; done
+    printf '%s' "$c"
+  }
+
   pin_gate_source_for() {
     local v="$1" line tok n
     [ -r "$GATE" ] || return 1
@@ -2587,7 +2607,11 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
       info "the bad value is NOT coming from $PIN_ENV_FILE — that file sets CQLITE_GATE_MAX_CONCURRENCY='$PIN_FILE_VALUE' while this session sees '$pin_probe_seen', so a sudo- or user-specific source (a sudoers env_file, ~/.pam_environment, a launcher-injected env) is OVERRIDING it"
       info "fix or remove THAT override — editing $PIN_ENV_FILE would change a value that is already being ignored"
     elif [ "$PIN_FILE_HAS_LINE" = yes ]; then
-      info "fix the VALUE (not the presence) — edit the CQLITE_GATE_MAX_CONCURRENCY line in $PIN_ENV_FILE to a positive integer; bootstrap deliberately never rewrites an existing value"
+      # "A POSITIVE INTEGER" IS ADVICE AN OVERSIZED VALUE HAS ALREADY TAKEN (roborev job
+      # 333). `99999999999999999999` IS a positive integer and is still refused, so the
+      # unqualified remedy sends that operator to re-read a line they will find nothing
+      # wrong with. The bound is stated where the remedy is, not only in the diagnosis.
+      info "fix the VALUE (not the presence) — edit the CQLITE_GATE_MAX_CONCURRENCY line in $PIN_ENV_FILE to a positive decimal integer of at most 18 digits (a larger one is refused even though it is positive); bootstrap deliberately never rewrites an existing value"
     else
       info "the value is visible but is NOT coming from $PIN_ENV_FILE — find and fix whatever sets it (a systemd unit, the image, a launcher-injected env), then re-run"
     fi
@@ -2705,7 +2729,16 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
       # answered about something else — the BASH_ENV-pollution shape above, or any future
       # way the two could drift. Demote it to the same non-answer as an unconsultable gate
       # rather than trusting the suffix.
-      if [ "$pin_gate_src" = pinned ] && [ "$pin_gate_n" != "$pin_probe_seen" ]; then
+      # COMPARED AS CANONICAL DECIMALS, NOT AS RAW STRINGS (roborev job 333, Medium). The
+      # gate NORMALISES a valid leading-zero pin (`08` -> `8(pinned)`), so a raw string
+      # compare read `8` != `08` and demoted a CORRECTLY PERSISTED `08` to UNMEASURED —
+      # `--strict` red on a properly pinned box, i.e. the guard that reds on correct input,
+      # which is the guard agents learn to waive. Introduced by this branch's own octal fix:
+      # normalisation was added to the gate and this comparison was not told about it.
+      # Canonicalising BOTH sides keeps the drift check intact — an oracle answering about a
+      # different value still differs after normalisation.
+      if [ "$pin_gate_src" = pinned ] \
+         && [ "$(pin_canon_decimal "$pin_gate_n")" != "$(pin_canon_decimal "$pin_probe_seen")" ]; then
         pin_gate_src=""
       fi
       case "$pin_gate_src" in
@@ -2808,7 +2841,18 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
           # Its OWN verdict, not FAILED: the pin is present and visible, so "persist the
           # pin" is the wrong remedy and would send the operator to a file that already
           # has a line in it. What is wrong is the VALUE.
-          warn "gate-pin: NOT-HONOURED (a fresh session sees CQLITE_GATE_MAX_CONCURRENCY='$pin_probe_seen', but the gate DISCARDS it — it is empty or non-numeric — and falls back to the #1825 default formula, stamping max-concurrency=N(invalid))"
+          # THE CAUSE IS NAMED FROM THE VALUE, because `invalid` covers more than it used
+          # to (roborev job 333). This branch widened it to include a digit string too
+          # large to represent, and the diagnosis still said "empty or non-numeric" — so an
+          # oversized value was told it was non-numeric and handed a "use a positive
+          # integer" remedy it already satisfied. A remedy the operator has already
+          # complied with is worse than none: it stops them looking.
+          case "$pin_probe_seen" in
+            '') pin_invalid_why="it is EMPTY" ;;
+            *[!0-9]*) pin_invalid_why="it is not a plain decimal integer" ;;
+            *) pin_invalid_why="it is a decimal integer too large to use as a slot cap (more than 18 significant digits)" ;;
+          esac
+          warn "gate-pin: NOT-HONOURED (a fresh session sees CQLITE_GATE_MAX_CONCURRENCY='$pin_probe_seen', but the gate DISCARDS it — $pin_invalid_why — and falls back to the #1825 default formula, stamping max-concurrency=N(invalid))"
           pin_value_remedy
           ;;
         clamped)

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -1890,11 +1890,22 @@ fi
 # macOS persistence (a launchd equivalent) is deliberately NOT implemented: there is no
 # Mac on this fleet, so it could not be verified, and an unverifiable persistence path is
 # worse than a documented gap. macOS is SCOPED OUT here, not supported.
+# THE MECHANISM IS LINUX-SPECIFIC; THE REQUIREMENT IS NOT (#3414 final roborev). An
+# earlier form emitted `ok "NOT-APPLICABLE"` here unconditionally, which let `--strict`
+# CERTIFY AN UNPINNED non-Linux host: no /etc/environment exists to persist into, so the
+# section declared inapplicability and passed — while every gate on that box resolved the
+# #1825 cap from the formula. Inapplicability of the PERSISTENCE step was standing in for
+# absence of the REQUIREMENT, which is this issue's own defect wearing a platform label.
+#
+# So the platform no longer earns an exemption; it earns a NARROWER QUESTION. We cannot
+# ask "is it in the system env file" (there is none), but "does a fresh session see a
+# value the GATE HONOURS" is platform-independent and is the fact that matters. That is
+# decided below, in the same probe the Linux path uses, minus the file-correlation half.
+PIN_PLATFORM_UNMANAGED=0
 if [ "$PIN_SECTION_OK" = 1 ] && [ "$PLATFORM" != linux ]; then
-  ok "gate-pin: NOT-APPLICABLE (the single-gate pin is persisted in /etc/environment and read by PAM's pam_env — a Linux mechanism; $PLATFORM has no equivalent here, so there is nothing to verify rather than something failing)"
-  info "on this platform the per-run authority is the gate's own SUMMARY line:  cpu-budget: ... max-concurrency=N(pinned)   (N(default) means that gate resolved the #1825 cap from the formula)"
-  info "to cap gates here, export CQLITE_GATE_MAX_CONCURRENCY in whatever this host's session-startup mechanism is; bootstrap does not manage it"
-  PIN_SECTION_OK=0
+  PIN_PLATFORM_UNMANAGED=1
+  info "gate-pin: no PAM-read system-wide env file on this $PLATFORM host, so bootstrap does not MANAGE the pin here — but it still VERIFIES it: the probe below asks whether a fresh session sees a value the gate honours"
+  info "to cap gates here, export CQLITE_GATE_MAX_CONCURRENCY in whatever this host's session-startup mechanism is"
 fi
 
 # Effective privilege, resolved BEFORE the seam guard because the guard now depends on it.
@@ -2504,6 +2515,18 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
           # non-passing" (the probe is ALWAYS sudo-scoped, so that reds every box's
           # onboarding forever — an always-firing alarm is one people learn to waive,
           # which is the same reason the fleet does not just let verify red).
+          # ON A PLATFORM WITH NO PAM-READ SYSTEM FILE, the file half does not exist and
+          # asking for it would manufacture a permanent failure on a correctly-pinned host
+          # — the red-on-correct-input shape refused elsewhere in this section. The
+          # remaining question is still affirmative and still platform-independent: a fresh
+          # scrubbed session sees a value, and the GATE HONOURS it. That is a narrower
+          # claim than the Linux verdict and is worded as one; it is NOT an exemption, and
+          # an unpinned host still lands in the non-passing branch below (#3414 final
+          # roborev — the earlier `NOT-APPLICABLE` ok certified exactly that host).
+          if [ "${PIN_PLATFORM_UNMANAGED:-0}" = 1 ]; then
+            ok "gate-pin: VERIFIED-NO-SYSTEM-FILE (a fresh, profile-free session on this $PLATFORM host sees CQLITE_GATE_MAX_CONCURRENCY=$pin_probe_seen and the gate HONOURS it verbatim — max-concurrency=$pin_probe_seen(pinned); this run's own value, BASH_ENV and ENV were scrubbed first. There is no PAM-read system-wide file here, so this does NOT establish the pin is system-wide — only that a fresh session gets it)"
+            pin_scope_note
+          else
           case "$PIN_FILE_HAS_LINE" in
             yes)
               # STRING equality on the raw effective value, deliberately not a numeric
@@ -2539,6 +2562,7 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
               fi
               ;;
           esac
+          fi
           ;;
         invalid)
           # Its OWN verdict, not FAILED: the pin is present and visible, so "persist the

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -2304,6 +2304,29 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
       /*) [ -d "$CQLITE_BOOTSTRAP_PAM_DIR" ] && PIN_PAM_DIR="$CQLITE_BOOTSTRAP_PAM_DIR" ;;
     esac
   fi
+  # pin_pam_effective_lines <service-file>: the service file PLUS one level of @include.
+  #
+  # A DISTRIBUTION MAY FACTOR pam_env INTO THE COMMON STACK. Both /etc/pam.d/sshd and
+  # /etc/pam.d/login here carry `@include common-session`, and a predicate reading only the
+  # service file would report "no pam_env" on any distro that puts it there — weakening a
+  # correctly configured box, which is the red-on-correct-input shape this lane has hit
+  # four times. Measured on THIS box: common-session carries no pam_env line, so following
+  # the include changes nothing here; it is done for the distros where it would.
+  #
+  # ONE LEVEL, NOT RECURSIVE, and the not-found diagnostic SAYS SO — an absence you did not
+  # fully search for is not an absence, so the limit is declared rather than papered over.
+  pin_pam_effective_lines() {
+    local f="$1" inc
+    cat "$f" 2>/dev/null
+    while IFS= read -r inc; do
+      [ -n "$inc" ] || continue
+      case "$inc" in /*) : ;; *) inc="$PIN_PAM_DIR/$inc" ;; esac
+      [ -r "$inc" ] && cat "$inc" 2>/dev/null
+    done <<EOF
+$(awk '/^[[:space:]]*@include[[:space:]]+/ { print $2 }' "$f" 2>/dev/null)
+EOF
+  }
+
   PIN_PAM_UNCHECKED=""
   pin_pam_services_missing_readenv() {
     local svc f missing=""
@@ -2314,14 +2337,19 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
         PIN_PAM_UNCHECKED="${PIN_PAM_UNCHECKED:+$PIN_PAM_UNCHECKED }$svc"
         continue
       fi
-      if ! awk -v envfile="$PIN_ENV_FILE" '
+      # `envfile=` REDIRECTS WHICH FILE IS READ, so a pam_env line is evidence about ours
+      # only if it does not point elsewhere. Both service files here carry a second
+      # pam_env line with envfile=/etc/default/locale — that one reads the locale file and
+      # must not count, or a stack whose ONLY pam_env line was the locale one would read
+      # as pinned when it is not. sshd still qualifies, via its bare line alone.
+      if ! pin_pam_effective_lines "$f" | awk -v envfile="$PIN_ENV_FILE" '
             /^[[:space:]]*#/ { next }
             $1 == "session" && /pam_env\.so/ {
               if ($0 ~ /readenv=0/) next
               if ($0 ~ /envfile=/) { if ($0 !~ ("envfile=" envfile "([[:space:]]|$)")) next }
               found = 1
             }
-            END { exit(found ? 0 : 1) }' "$f" 2>/dev/null; then
+            END { exit(found ? 0 : 1) }' 2>/dev/null; then
         missing="${missing:+$missing }$svc"
       fi
     done
@@ -2494,7 +2522,8 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
                   # gate is actually created by do not read this file, so what was
                   # measured through sudo is not evidence about them.
                   warn "gate-pin: NOT-SYSTEM-WIDE ($PIN_ENV_FILE sets CQLITE_GATE_MAX_CONCURRENCY=$PIN_FILE_VALUE and a sudo session sees it, but the PAM stack for [$pin_pam_gap] does NOT read $PIN_ENV_FILE — sessions created by those services, which is how gates are launched, will not get it)"
-                  info "add a session-stage 'pam_env.so' (readenv defaults to on) to /etc/pam.d/{$(printf '%s' "$pin_pam_gap" | tr ' ' ',')}, then re-run"
+                  info "add a session-stage 'pam_env.so' (readenv defaults to on) to $PIN_PAM_DIR/{$(printf '%s' "$pin_pam_gap" | tr ' ' ',')}, then re-run"
+                  info "searched each service file plus ONE level of @include; a pam_env buried deeper than that would not have been seen, so confirm by hand before rewriting a stack"
                   info "the sudo-session result above is real but does not generalise; the per-run authority stays the gate's own cpu-budget: max-concurrency=N(...) token"
                 else
                 ok "gate-pin: VERIFIED ($PIN_ENV_FILE sets CQLITE_GATE_MAX_CONCURRENCY=$PIN_FILE_VALUE AND a fresh PAM-created, profile-free session sees that SAME value, which the gate HONOURS verbatim — max-concurrency=$pin_probe_seen(pinned); this run's own value, BASH_ENV and ENV were scrubbed first)"

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -2251,6 +2251,27 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   # pin_scope_note: what VERIFIED does NOT cover. Printed with the verdict, not buried in
   # a doc, because an unqualified VERIFIED reads as "gates on this box are pinned" and the
   # probe cannot see a gate launched from a non-PAM parent (#3414 review B2).
+  # pin_scope_note: what VERIFIED does and does NOT cover.
+  #
+  # A CHECK USED TO LIVE HERE AND WAS DELETED ON PURPOSE (#3414 round 7). It parsed
+  # /etc/pam.d/{sshd,login} and downgraded a would-be VERIFIED when those stacks did not
+  # appear to read this file. Do not helpfully reintroduce it. Four reasons it went:
+  #   * it accumulated two defects in two review rounds, both invisible on the happy path
+  #     (its result assigned inside `$( )` so an unreadable config silently passed; then a
+  #     substring match on `pam_env.so` that a comment or another module's args satisfied);
+  #   * IT WAS CONFIG INSPECTION STANDING IN FOR RUNTIME BEHAVIOUR — reading a file to
+  #     infer what a session will receive is the proxy reasoning this whole section exists
+  #     to remove, and it was only ever admissible because it could not create a pass;
+  #   * what it approximated is measured DIRECTLY, every run, by the gate itself:
+  #     `cpu-budget: max-concurrency=N(pinned)` is the actual resolved cap of the actual
+  #     gate, not an inference about one;
+  #   * the only remaining fix was to make anything unparseable WEAKEN — but a weaken is
+  #     non-passing, non-passing fails --strict, and --strict is what verify.run uses, so a
+  #     PAM layout we could not parse would have failed ONBOARDING for that box. Exactly
+  #     one layout has ever been validated.
+  # The residual it addressed is therefore DOCUMENTED, not measured, and the honest text
+  # below says so. Settling it needs a runtime probe of the real launch path, not a better
+  # parser.
   pin_scope_note() {
     # What the correlation DOES buy: the line is in the system-wide file pam_env reads in
     # every PAM stack (sshd, login, su, sudo), so the claim is not limited to the one

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -2222,7 +2222,14 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
            | ${PIN_ROOT[@]+"${PIN_ROOT[@]}"} tee "$PIN_ENV_FILE" >/dev/null 2>&1 \
          && ${PIN_ROOT[@]+"${PIN_ROOT[@]}"} chmod 0644 "$PIN_ENV_FILE" 2>/dev/null; then
       PIN_FILE_HAS_LINE=yes; PIN_FILE_VALUE="$PIN_ENV_VALUE"
-      info "CREATED $PIN_ENV_FILE (root:root 0644) carrying '$PIN_ENV_LINE' — pam_env reads it at session creation, so NEW sessions pick it up"
+      # REPORT WHAT IT ACTUALLY IS, read back — not what the write intended. An earlier
+      # draft of this line asserted "root:root 0644" unconditionally, which is false
+      # wherever the write was unprivileged (the test seam forces PIN_ROOT empty, so the
+      # file belongs to the invoking user). A message claiming an ownership it did not
+      # establish is the same presence-for-fact substitution this section exists to remove,
+      # in the section's own output.
+      pin_made=$(ls -ld -- "$PIN_ENV_FILE" 2>/dev/null | awk '{print $1" "$3":"$4}')
+      info "CREATED $PIN_ENV_FILE (${pin_made:-mode/owner unreadable}) carrying '$PIN_ENV_LINE' — pam_env reads it at session creation, so NEW sessions pick it up"
     else
       PIN_PERSIST_NOTE="could not create $PIN_ENV_FILE"
       warn "gate-pin: could not create $PIN_ENV_FILE — the pin was NOT persisted"

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -1968,6 +1968,44 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   # write" true IN CODE rather than merely by construction.
   if [ "$PIN_ENV_FILE_IS_SEAM" = 1 ]; then PIN_ROOT=(); PIN_WRITE_PRIV=1; fi
 
+  # pin_strip_pam_quotes <raw>: reproduce pam_env's own de-quoting, so the value compared
+  # below is the value a session actually RECEIVES.
+  #
+  # STRIPPING QUOTES IS READING THE FILE'S FORMAT; NORMALISING THE VALUE IS REINTERPRETING
+  # IT. The first is mandatory, the second is forbidden. Without this, a legitimately
+  # quoted line — `CQLITE_GATE_MAX_CONCURRENCY="1"`, and quoting IS the convention in this
+  # file, which opens with `PATH="/usr/local/sbin:..."` — parses as `"1"`, the session
+  # reports `1`, and a correctly-pinned box gets a non-passing verdict: red on correct
+  # input, produced by the fix for a false green. But ` 1 ` must still mismatch `1`,
+  # because the gate genuinely discards the former; that asymmetry is why the gate is
+  # asked rather than second-guessed.
+  #
+  # THE RULE IS MEASURED, NOT ASSUMED (pam 1.5.3-5ubuntu5.7, this fleet's platform), by
+  # writing shapes into the real /etc/environment and reading them back out of a fresh
+  # session. It is NOT "a matched pair": a LEADING quote is stripped whether or not it is
+  # closed, and single quotes behave like double ones — the symmetry this was told not to
+  # assume, checked rather than guessed:
+  #     "1"  -> 1        '1' -> 1        1   -> 1        "a b"  -> a b
+  #     "1   -> 1        '1  -> 1        1"  -> 1"       a"b    -> a"b
+  #     ""   -> (empty)  "   -> (empty)  " 1 " -> ` 1 `  ""1""  -> "1"
+  # i.e. drop a leading `"` or `'`, then drop a trailing one of the SAME kind if present.
+  #
+  # WHY A WRONG ANSWER HERE IS SAFE IN THE DIRECTION THAT MATTERS: the session side of the
+  # comparison is pam_env's OWN output, so any disagreement between this parser and a
+  # different pam build moves the two values APART, never together. Over-stripping and
+  # under-stripping both yield a non-passing verdict; neither can manufacture a VERIFIED.
+  pin_strip_pam_quotes() {
+    local v="$1" q
+    case "$v" in
+      '"'*) q='"' ;;
+      "'"*) q="'" ;;
+      *) printf '%s' "$v"; return 0 ;;
+    esac
+    v=${v#?}
+    case "$v" in *"$q") v=${v%?} ;; esac
+    printf '%s' "$v"
+  }
+
   # Does the file ALREADY carry a pin line? Read ONCE, here, because two very different
   # boxes reach the FAILED verdict below and they need different remedies: a box with no
   # line (persist it) and a box whose line is present yet invisible to a fresh session
@@ -2008,7 +2046,7 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
       # gate, re-created in the parser that checks it.
       pin_file_raw=$(sed -n 's/^[[:space:]]*CQLITE_GATE_MAX_CONCURRENCY[[:space:]]*=/VAL:/p' "$PIN_ENV_FILE" 2>/dev/null | tail -1)
       case "$pin_file_raw" in
-        VAL:*) PIN_FILE_VALUE=${pin_file_raw#VAL:}; PIN_FILE_HAS_LINE=yes ;;
+        VAL:*) PIN_FILE_VALUE=$(pin_strip_pam_quotes "${pin_file_raw#VAL:}"); PIN_FILE_HAS_LINE=yes ;;
         *)     PIN_FILE_HAS_LINE=unparseable ;;
       esac
     else

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -2121,6 +2121,20 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   esac
   if [ -n "$PROFILE" ] && [ -f "$PROFILE" ] && grep -q 'CQLITE_GATE_MAX_CONCURRENCY' "$PROFILE" 2>/dev/null; then
     info "$PROFILE already carries the export — INTERACTIVE shells only (stock ~/.bashrc returns early for non-interactive ones), so it says nothing about the shell a gate runs in"
+  elif [ "$PIN_FILE_HAS_LINE" = yes ]; then
+    # SKIPPED, DELIBERATELY, when the system-wide file already carries a value (#3414
+    # roborev round 4). The append hardcodes `=1`, so on a box deliberately pinned to 4
+    # it would MANUFACTURE a divergence between two mechanisms on the same machine —
+    # this issue's own subject, created by the tool that exists to remove it.
+    #
+    # Skipping rather than deriving the value, for a reason stronger than "the profile is
+    # only convenience": /etc/environment is read by PAM at SESSION CREATION, which
+    # applies to interactive login shells too, so on such a box the interactive shell
+    # ALREADY receives the system-wide value — a profile export could only OVERRIDE it,
+    # handing interactive shells 1 while every non-interactive one gets 4. Deriving the
+    # value instead would agree today and go stale the moment someone edits
+    # /etc/environment, manufacturing the same divergence later and more quietly.
+    info "not touching $PROFILE — $PIN_ENV_FILE already sets CQLITE_GATE_MAX_CONCURRENCY=$PIN_FILE_VALUE, and PAM delivers that to interactive shells too; appending a hardcoded '=$PIN_ENV_VALUE' here could only override it"
   elif [ "$AUTO_YES" = 1 ] && [ -n "$PROFILE" ]; then
     if printf '%s\n' "$EXPORT_LINE" >>"$PROFILE" 2>/dev/null; then
       info "appended the export to $PROFILE for INTERACTIVE shells (convenience only — the verdict below comes from the session probe, not from this file)"
@@ -2141,17 +2155,31 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   # #1825 slot logic so it creates no run directory and takes no slot. If the gate cannot
   # be consulted the answer is UNKNOWN, never an assumed `pinned` — a positive verdict
   # requires an affirmative measurement.
+  # Echoes "<source>:<resolved-N>" (e.g. `pinned:1`), or rc 1 if the gate could not be
+  # consulted. BOTH halves are returned because the SOURCE TOKEN ALONE CANNOT TELL YOU THE
+  # ORACLE WAS REASONING ABOUT YOUR VALUE (#3414 roborev round 4): `pinned` says only that
+  # *something* was a valid pin, and the caller must check that the N the gate resolved is
+  # the value we handed it.
+  #
+  # BASH_ENV AND ENV ARE SCRUBBED HERE TOO, and this is the same hole closed for the probe
+  # in round 2, sitting one call site over. This launches a FRESH NON-INTERACTIVE bash,
+  # which SOURCES $BASH_ENV before running anything — so on a box whose sudoers lacks
+  # env_reset an inherited BASH_ENV could export a valid integer into the ORACLE's shell,
+  # overriding the `CQLITE_GATE_MAX_CONCURRENCY="$v"` set on this very command line. A
+  # persisted value of `abc` would then get a `(pinned)` answer from an oracle that never
+  # saw `abc`. Fixing the probe and leaving the oracle open is fixing one instance of a
+  # class; the value check above is the belt to this braces, and vice versa.
   pin_gate_source_for() {
-    local v="$1" line tok
+    local v="$1" line tok n
     [ -r "$GATE" ] || return 1
-    line=$(bounded 30 env CQLITE_GATE_MAX_CONCURRENCY="$v" CQLITE_GATE_NO_NICE=1 \
+    line=$(bounded 30 env -u BASH_ENV -u ENV CQLITE_GATE_MAX_CONCURRENCY="$v" CQLITE_GATE_NO_NICE=1 \
              bash "$GATE" --cpu-budget 2>/dev/null | grep -E '^cpu-budget: ' | head -1)
     [ -n "$line" ] || return 1
     # The line is space-delimited key=value tokens; max-concurrency=N(source) is ONE of
     # them, which is exactly why that token carries no spaces.
     tok=$(printf '%s\n' "$line" | tr ' ' '\n' | sed -n 's/^max-concurrency=//p' | head -1)
     case "$tok" in
-      *"("*")") tok=${tok#*(}; printf '%s' "${tok%)}" ;;
+      *"("*")") n=${tok%%(*}; tok=${tok#*(}; printf '%s:%s' "${tok%)}" "$n" ;;
       *) return 1 ;;
     esac
   }
@@ -2282,7 +2310,16 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
       # pin in name only, and certifying it here would be this issue's own shape one
       # level further out — presence of a VISIBLE value standing in for a value that has
       # EFFECT. So the gate is asked what it will actually do with it.
-      pin_gate_src=$(pin_gate_source_for "$pin_probe_seen") || pin_gate_src=""
+      pin_gate_out=$(pin_gate_source_for "$pin_probe_seen") || pin_gate_out=""
+      pin_gate_src=${pin_gate_out%%:*}
+      pin_gate_n=${pin_gate_out#*:}
+      # A `pinned` token whose N is NOT the value we handed the oracle means the oracle
+      # answered about something else — the BASH_ENV-pollution shape above, or any future
+      # way the two could drift. Demote it to the same non-answer as an unconsultable gate
+      # rather than trusting the suffix.
+      if [ "$pin_gate_src" = pinned ] && [ "$pin_gate_n" != "$pin_probe_seen" ]; then
+        pin_gate_src=""
+      fi
       case "$pin_gate_src" in
         pinned)
           # TWO AFFIRMATIVE HALVES, AND NEITHER SUFFICES ALONE (#3414 roborev round 2).

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -2327,9 +2327,31 @@ $(awk '/^[[:space:]]*@include[[:space:]]+/ { print $2 }' "$f" 2>/dev/null)
 EOF
   }
 
+  #
+  # RESULTS COME BACK IN GLOBALS AND THIS IS CALLED DIRECTLY, NEVER IN `$( )` (#3414
+  # roborev round 6). It used to be invoked as `pin_pam_gap=$(pin_pam_services_...)`, and
+  # `$( )` FORKS — so the PIN_PAM_UNCHECKED assignment happened in a subshell and was
+  # discarded. An UNREADABLE service config then reached VERIFIED *and* the scope note
+  # claimed the stacks had been checked: a false positive plus a false statement about
+  # what was measured, which is worse than either alone.
+  #
+  # THIS IS NOT A NEW LESSON, IT IS AN EXISTING ONE REPRODUCED ONE FILE OVER. CLAUDE.md
+  # already carries it for the gate's cargo-output parse sites — "read by redirection,
+  # never a pipe: a piped `while read` runs in a subshell and its verdict is discarded".
+  # That doctrine was written about agent-gate.sh, but it is a property of the SHELL, not
+  # of that file: `$( )` and `|` both fork, and a verdict assigned inside either does not
+  # survive. Said here because the next person reaches for `$( )` reflexively too.
+  #
+  # The rule this file now follows: a function that ECHOES its result may be used in a
+  # substitution or a pipe (the output IS the payload — pin_gate_source_for,
+  # pin_strip_pam_quotes, pin_pam_effective_lines); a function that ASSIGNS must be called
+  # directly. Swept at the time of this fix: this was the only assigner being substituted.
   PIN_PAM_UNCHECKED=""
+  PIN_PAM_GAP=""
   pin_pam_services_missing_readenv() {
     local svc f missing=""
+    PIN_PAM_UNCHECKED=""
+    PIN_PAM_GAP=""
     for svc in sshd login; do
       f="$PIN_PAM_DIR/$svc"
       [ -e "$f" ] || continue
@@ -2353,7 +2375,7 @@ EOF
         missing="${missing:+$missing }$svc"
       fi
     done
-    printf '%s' "$missing"
+    PIN_PAM_GAP="$missing"
   }
 
   # pin_value_remedy: the remedy for a VISIBLE but NOT-HONOURED value. Shared by both
@@ -2516,7 +2538,10 @@ EOF
               # free to disagree with the gate — the thing avoided by asking the gate what
               # it honours instead of re-deriving its rules.
               if [ "$PIN_FILE_VALUE" = "$pin_probe_seen" ]; then
-                pin_pam_gap=$(pin_pam_services_missing_readenv)
+                # Called DIRECTLY: see the note on the function — a substitution here
+                # forks, and both of its result globals would be lost with the fork.
+                pin_pam_services_missing_readenv
+                pin_pam_gap="$PIN_PAM_GAP"
                 if [ -n "$pin_pam_gap" ]; then
                   # WEAKEN ONLY. Both affirmative halves hold, but the session stacks a
                   # gate is actually created by do not read this file, so what was
@@ -2525,6 +2550,13 @@ EOF
                   info "add a session-stage 'pam_env.so' (readenv defaults to on) to $PIN_PAM_DIR/{$(printf '%s' "$pin_pam_gap" | tr ' ' ',')}, then re-run"
                   info "searched each service file plus ONE level of @include; a pam_env buried deeper than that would not have been seen, so confirm by hand before rewriting a stack"
                   info "the sudo-session result above is real but does not generalise; the per-run authority stays the gate's own cpu-budget: max-concurrency=N(...) token"
+                elif [ -n "$PIN_PAM_UNCHECKED" ]; then
+                  # NOT a gap and NOT a clean check. The stacks that decide whether this
+                  # generalises could not be read, so the scope the VERIFIED text would
+                  # claim was never established — and claiming it was is the half of this
+                  # finding that is worse than the false positive.
+                  warn "gate-pin: UNMEASURED ($PIN_ENV_FILE sets CQLITE_GATE_MAX_CONCURRENCY=$PIN_FILE_VALUE and a sudo session sees it, but the PAM stack for [$PIN_PAM_UNCHECKED] could not be READ — whether sessions created by those services get it is UNKNOWN)"
+                  info "the sudo-session result above is real but its scope is unestablished; the per-run authority stays the gate's own cpu-budget: max-concurrency=N(...) token"
                 else
                 ok "gate-pin: VERIFIED ($PIN_ENV_FILE sets CQLITE_GATE_MAX_CONCURRENCY=$PIN_FILE_VALUE AND a fresh PAM-created, profile-free session sees that SAME value, which the gate HONOURS verbatim — max-concurrency=$pin_probe_seen(pinned); this run's own value, BASH_ENV and ENV were scrubbed first)"
                 pin_scope_note

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -2257,17 +2257,33 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   # pin_create_mode_ok stays as verification: setting a umask is an instruction, and this
   # section's whole rule is that an instruction is not a measurement.
   pin_create_env_file() {
+    # THE CREATE AND THE WRITE ARE SEPARATE STEPS SO THEIR FAILURES ARE DISTINGUISHABLE
+    # (roborev job 321, Medium). Collapsing them and then asking `[ -e "$FILE" ]` cannot tell
+    # SOMEONE ELSE'S file from OUR OWN partially-written one — both exist — and the two
+    # dispositions are opposite: leave someone else's alone, roll our own back. Getting it
+    # wrong falsely blamed a concurrent writer AND left a truncated assignment that a later
+    # run would read as an existing pin and decline to repair.
+    #   exit 4 = exclusive create refused, i.e. the file already existed  -> LOST RACE
+    #   exit 5 = we created it and the write then failed                  -> OUR partial file
+    local pin_child_rc
     ${PIN_ROOT[@]+"${PIN_ROOT[@]}"} bash -c '
       umask 022
-      set -C
-      printf "%s\n%s\n" "$1" "$2" > "$3"
-    ' _ "$PIN_ENV_COMMENT" "$PIN_ENV_LINE" "$PIN_ENV_FILE" 2>/dev/null || {
-      # O_EXCL refuses when the file APPEARED between the caller's `[ ! -e ]` and here, which
-      # is a LOST RACE and not a failure — distinguished from a genuine write error so the
-      # caller can refresh its cache instead of reporting a broken box.
-      [ -e "$PIN_ENV_FILE" ] && { pin_create_rc=3; return 3; }
+      f="$3"
+      ( set -C; : > "$f" ) 2>/dev/null || exit 4
+      printf "%s\n%s\n" "$1" "$2" > "$f" 2>/dev/null || exit 5
+    ' _ "$PIN_ENV_COMMENT" "$PIN_ENV_LINE" "$PIN_ENV_FILE" 2>/dev/null
+    pin_child_rc=$?
+    if [ "$pin_child_rc" = 4 ]; then pin_create_rc=3; return 3; fi
+    if [ "$pin_child_rc" != 0 ]; then
+      # OUR file, incomplete. Roll it back for the same reason pin_create_mode_ok does: a
+      # reported failure must match the filesystem, or the next run inherits it as a pin.
+      if ${PIN_ROOT[@]+"${PIN_ROOT[@]}"} rm -f "$PIN_ENV_FILE" 2>/dev/null && [ ! -e "$PIN_ENV_FILE" ]; then
+        PIN_CREATE_RESIDUE="the write failed after the file was created (rc $pin_child_rc); the incomplete file was REMOVED"
+      else
+        PIN_CREATE_RESIDUE="the write failed after the file was created (rc $pin_child_rc) AND the incomplete file could not be removed — inspect $PIN_ENV_FILE by hand"
+      fi
       pin_create_rc=1; return 1
-    }
+    fi
     pin_create_mode_ok "$PIN_ENV_FILE"; pin_create_rc=$?; return "$pin_create_rc"
   }
 

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -2289,7 +2289,13 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
       # destination correct BY CONSTRUCTION — `ln` links the inode, so it carries this mode
       # from the instant it appears — and removes the need for any rollback at all.
       chmod 0644 "$t" 2>/dev/null || true
-      [ "$(stat -c %a "$t" 2>/dev/null)" = 644 ] || { rm -f "$t" 2>/dev/null; exit 6; }
+      # PORTABLE MODE READ (roborev job 330, Medium). `stat -c` is GNU-only; BSD/macOS `stat`
+      # rejects it. The PRODUCTION path is Linux-gated, but the TEST SEAM stubs `uname` to
+      # simulate Linux while linking the HOST copy of `stat`, so on a macOS host this check would
+      # fail-closed (exit 6) and the create would never happen — a break that the Linux-only
+      # justification does not cover. GNU first, BSD fallback; `stat -f %Lp` is the BSD spelling.
+      _pm=$(stat -c %a "$t" 2>/dev/null || stat -f %Lp "$t" 2>/dev/null)
+      [ "$_pm" = 644 ] || { rm -f "$t" 2>/dev/null; exit 6; }
       ln "$t" "$f" 2>/dev/null || { rm -f "$t" 2>/dev/null; exit 4; }
       rm -f "$t" 2>/dev/null
     ' _ "$PIN_ENV_COMMENT" "$PIN_ENV_LINE" "$PIN_ENV_FILE" 2>/dev/null

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -72,8 +72,10 @@
 #      #3414 defect and session-only certifies a pin that may reach sudo sessions alone,
 #      and the file's VALUE must EQUAL the session's (presence alone let a file saying
 #      `abc` pass while a per-user override supplied `1`). NON-LINUX hosts report an
-#      explicit, non-failing NOT-APPLICABLE: the mechanism is Linux/pam_env-specific, so
-#      macOS is scoped out rather than supported. `--yes` persists it, and
+#      a NARROWER question, never an exemption: there is no PAM-read system-wide file to
+#      correlate against, so the file half is dropped and the verdict is the scoped
+#      VERIFIED-NO-SYSTEM-FILE — but an unpinned non-Linux host is still NON-PASSING. An
+#      unconditional `ok` there let `--strict` certify an unpinned Mac. `--yes` persists it, and
 #      so does the narrow `--fix-gate-pin` that `.agent-ami/profile.yaml`'s verify.run
 #      passes, so a freshly launched box is PINNED rather than merely reported unpinned.
 #      PAM reads /etc/environment at session creation, so the probe in the SAME run sees

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -2165,6 +2165,25 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   # absence of evidence, and reporting it as a contradiction would invent one.
   PIN_FILE_HAS_LINE=unknown
   PIN_FILE_VALUE=""
+  # pin_read_env_file: THE ONE PARSER, callable again (roborev job 319, Medium). It used to
+  # run inline, exactly once, at the top of the section — so every later decision read a
+  # snapshot taken before the writes. That was fine while this run was the only writer; it
+  # stopped being fine when the create and append learned to LOSE a race (jobs 314/316),
+  # because a lost race leaves the cache saying "no line" about a file that now HAS one, and
+  # two things downstream act on that stale answer: the shell-profile fallback appends a
+  # hardcoded `=1` — manufacturing the 1-vs-4 divergence 11ai exists to prevent — and the
+  # verdict compares the session against an empty PIN_FILE_VALUE and reports NOT-SYSTEM-WIDE
+  # about a correctly pinned box.
+  #
+  # Factored rather than re-implemented at the call sites: a second parse is a second place
+  # for the sentinel/quote/last-wins rules to drift, and those rules are the subtle part.
+  pin_read_env_file() {
+  # Reset to the SAME default the one-shot version started from (:2166), not to empty: an
+  # unreadable or symlinked file assigns nothing below, and `unknown` is the value the
+  # "uncorrelatable file" verdict keys on. Resetting to "" silently disabled that branch —
+  # caught by the existing case, which is the argument for making the function reproduce the
+  # original initial state rather than an intuitive-looking blank one.
+  PIN_FILE_HAS_LINE=unknown; PIN_FILE_VALUE=""
   if [ ! -e "$PIN_ENV_FILE" ]; then
     PIN_FILE_HAS_LINE=absent-file
   elif [ ! -L "$PIN_ENV_FILE" ] && [ -r "$PIN_ENV_FILE" ]; then
@@ -2187,6 +2206,8 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
       PIN_FILE_HAS_LINE=no
     fi
   fi
+  }
+  pin_read_env_file
 
   PIN_CREATE_RESIDUE=""
   # pin_append_env_file: CHECK-AND-APPEND under a lock, re-reading inside it (roborev job
@@ -2240,8 +2261,14 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
       umask 022
       set -C
       printf "%s\n%s\n" "$1" "$2" > "$3"
-    ' _ "$PIN_ENV_COMMENT" "$PIN_ENV_LINE" "$PIN_ENV_FILE" 2>/dev/null || return 1
-    pin_create_mode_ok "$PIN_ENV_FILE"
+    ' _ "$PIN_ENV_COMMENT" "$PIN_ENV_LINE" "$PIN_ENV_FILE" 2>/dev/null || {
+      # O_EXCL refuses when the file APPEARED between the caller's `[ ! -e ]` and here, which
+      # is a LOST RACE and not a failure — distinguished from a genuine write error so the
+      # caller can refresh its cache instead of reporting a broken box.
+      [ -e "$PIN_ENV_FILE" ] && { pin_create_rc=3; return 3; }
+      pin_create_rc=1; return 1
+    }
+    pin_create_mode_ok "$PIN_ENV_FILE"; pin_create_rc=$?; return "$pin_create_rc"
   }
 
   # pin_create_mode_ok: establish 0644 on a JUST-CREATED env file and CONFIRM it by reading
@@ -2310,6 +2337,11 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
       # in the section's own output.
       pin_made=$(ls -ld -- "$PIN_ENV_FILE" 2>/dev/null | awk '{print $1" "$3":"$4}')
       info "CREATED $PIN_ENV_FILE (${pin_made:-mode/owner unreadable}) carrying '$PIN_ENV_LINE' — pam_env reads it at session creation, so NEW sessions pick it up"
+    elif [ "${pin_create_rc:-}" = 3 ]; then
+      # RACED, and the contract wins — same disposition as the append's lost race.
+      pin_read_env_file
+      PIN_PERSIST_NOTE="not persisted (another writer created $PIN_ENV_FILE first)"
+      info "$PIN_ENV_FILE was created by something else while this run was working — left EXACTLY as it is, and re-read, so the verdict and the profile decision below use what the file NOW says rather than the snapshot taken before the race"
     elif [ -n "$PIN_CREATE_RESIDUE" ]; then
       # THE FAILURE REPORT MUST MATCH THE FILESYSTEM (roborev job 311, Low). The write is
       # two steps — content then mode — so a `tee` that succeeded followed by a mode that
@@ -2365,6 +2397,7 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
       # RACED, and the contract wins. Reported as the left-alone case rather than as a
       # failure: nothing is wrong with the box, and the file now holds someone else's
       # deliberate value.
+      pin_read_env_file
       PIN_PERSIST_NOTE="not persisted (a concurrent writer added a CQLITE_GATE_MAX_CONCURRENCY line first)"
       info "$PIN_ENV_FILE gained a CQLITE_GATE_MAX_CONCURRENCY line while this run was working — left EXACTLY as it is, because appending ours would land LAST and pam_env takes the last assignment, silently overriding a value someone else chose"
     elif [ "$pin_append_rc" = 0 ]; then

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -2286,13 +2286,22 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
     pin_child_rc=$?
     if [ "$pin_child_rc" = 4 ]; then pin_create_rc=3; return 3; fi
     if [ "$pin_child_rc" != 0 ]; then
-      # OUR file, incomplete. Roll it back for the same reason pin_create_mode_ok does: a
-      # reported failure must match the filesystem, or the next run inherits it as a pin.
-      if ${PIN_ROOT[@]+"${PIN_ROOT[@]}"} rm -f "$PIN_ENV_FILE" 2>/dev/null && [ ! -e "$PIN_ENV_FILE" ]; then
-        PIN_CREATE_RESIDUE="the write failed after the file was created (rc $pin_child_rc); the incomplete file was REMOVED"
-      else
-        PIN_CREATE_RESIDUE="the write failed after the file was created (rc $pin_child_rc) AND the incomplete file could not be removed — inspect $PIN_ENV_FILE by hand"
-      fi
+      # NEVER TOUCH THE DESTINATION ON A PRE-LINK FAILURE (roborev job 328, Medium). This
+      # branch used to `rm -f "$PIN_ENV_FILE"` unconditionally, which was DESTRUCTIVE and
+      # defeated the very no-clobber guarantee the temp+`ln` rewrite exists for: exit 5 means
+      # the TEMP write failed, i.e. `ln` never ran and the destination was NEVER ours — so if
+      # a concurrent provisioner created /etc/environment during our write, we deleted THEIR
+      # file and called it our own cleanup.
+      #
+      # The child already removes its own temp on every failure path, and there is NO child
+      # exit where `ln` SUCCEEDED and we then failed (a successful `ln` falls through to
+      # rc=0). Therefore the parent never needs to remove the destination here, and the
+      # correct disposition is: report, and touch NOTHING.
+      #
+      # pin_create_mode_ok's rollback is a DIFFERENT case and stays: it runs only after `ln`
+      # succeeded, and `ln` is atomic and fails if the destination exists, so the inode it
+      # removes is provably the one THIS invocation created.
+      PIN_CREATE_RESIDUE="the staging write failed (rc $pin_child_rc) before $PIN_ENV_FILE was linked; nothing was written there and the temporary was removed by the child"
       pin_create_rc=1; return 1
     fi
     pin_create_mode_ok "$PIN_ENV_FILE"; pin_create_rc=$?; return "$pin_create_rc"

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -62,8 +62,11 @@
 #      into /etc/environment — which PAM reads at SESSION CREATION, with no
 #      interactivity guard — and takes its VERDICT from an AFFIRMATIVE PROBE of a
 #      fresh, profile-free session, never from a grep of the file it just wrote.
-#      Three-valued on one greppable `gate-pin:` line: VERIFIED / FAILED /
-#      UNMEASURED, with UNMEASURED a [warn] (same posture as `git-push:`).
+#      VISIBILITY IS ONLY HALF THE QUESTION: a value the gate does not HONOUR is a pin
+#      in name only, so the gate itself is then asked (via its `--cpu-budget` hook,
+#      never a re-derivation of its rules) what it will do with the value. One
+#      greppable `gate-pin:` line: VERIFIED / NOT-HONOURED / FAILED / UNMEASURED, and
+#      only VERIFIED is an [ok] (same posture as `git-push:`).
 #   6. Health check: run the gate's fmt component and print its authoritative
 #      `accelerators:` line.
 #
@@ -1887,6 +1890,22 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   # write" true IN CODE rather than merely by construction.
   if [ "$PIN_ENV_FILE_IS_SEAM" = 1 ]; then PIN_ROOT=(); PIN_WRITE_PRIV=1; fi
 
+  # Does the file ALREADY carry a pin line? Read ONCE, here, because two very different
+  # boxes reach the FAILED verdict below and they need different remedies: a box with no
+  # line (persist it) and a box whose line is present yet invisible to a fresh session
+  # (a PAM condition — re-running with --yes finds the line already there and changes
+  # NOTHING, so an operator told to do that just loops).
+  PIN_FILE_HAS_LINE=unknown
+  if [ ! -e "$PIN_ENV_FILE" ]; then
+    PIN_FILE_HAS_LINE=absent-file
+  elif [ ! -L "$PIN_ENV_FILE" ] && [ -r "$PIN_ENV_FILE" ]; then
+    if grep -Eq '^[[:space:]]*CQLITE_GATE_MAX_CONCURRENCY[[:space:]]*=' "$PIN_ENV_FILE" 2>/dev/null; then
+      PIN_FILE_HAS_LINE=yes
+    else
+      PIN_FILE_HAS_LINE=no
+    fi
+  fi
+
   # ---- (1) persist. Reported with info/warn ONLY — a write is never the verdict ----
   if [ ! -e "$PIN_ENV_FILE" ]; then
     PIN_PERSIST_NOTE="no $PIN_ENV_FILE on this host"
@@ -1897,7 +1916,7 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   elif [ ! -r "$PIN_ENV_FILE" ]; then
     PIN_PERSIST_NOTE="$PIN_ENV_FILE is unreadable"
     warn "gate-pin: cannot read $PIN_ENV_FILE — cannot tell whether the pin is already there, so nothing was written (a blind append could duplicate or contradict an existing line)"
-  elif grep -Eq '^[[:space:]]*CQLITE_GATE_MAX_CONCURRENCY[[:space:]]*=' "$PIN_ENV_FILE" 2>/dev/null; then
+  elif [ "$PIN_FILE_HAS_LINE" = yes ]; then
     info "$PIN_ENV_FILE already carries a CQLITE_GATE_MAX_CONCURRENCY line — left EXACTLY as it is (a box deliberately running >1 concurrent gate overrides the pin; bootstrap never rewrites an existing value)"
   elif [ "$AUTO_YES" != 1 ]; then
     PIN_PERSIST_NOTE="not persisted (no --yes)"
@@ -1925,6 +1944,7 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
     # nothing already there is disturbed.
     if printf '%s%s\n%s\n' "$pin_prefix" "$PIN_ENV_COMMENT" "$PIN_ENV_LINE" \
          | ${PIN_ROOT[@]+"${PIN_ROOT[@]}"} tee -a "$PIN_ENV_FILE" >/dev/null 2>&1; then
+      PIN_FILE_HAS_LINE=yes
       info "appended '$PIN_ENV_LINE' to $PIN_ENV_FILE — PAM reads it at session creation, so NEW sessions pick it up with no reboot and no re-login"
     else
       PIN_PERSIST_NOTE="the append to $PIN_ENV_FILE failed"
@@ -1952,6 +1972,43 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
       info "could not append to $PROFILE (interactive convenience only) — add by hand: $EXPORT_LINE"
     fi
   fi
+
+  # pin_gate_source_for <value>: what the GATE will do with <value>, echoed as its own
+  # source token (`pinned` / `default` / `invalid` / `clamped`); rc 1 if the gate could
+  # not be consulted.
+  #
+  # ASK THE GATE, DO NOT RE-DERIVE ITS RULES HERE. A copy of the resolver would be a
+  # SECOND IMPLEMENTATION, and a second implementation's correctness is only knowable by
+  # differential testing against the original (CLAUDE.md's #3283 lesson, learned from a
+  # bash port of a Go function that was tested against a MODEL of Go rather than Go). The
+  # original is one `--cpu-budget` call away: measured 0.4s, and it exits before the
+  # #1825 slot logic so it creates no run directory and takes no slot. If the gate cannot
+  # be consulted the answer is UNKNOWN, never an assumed `pinned` — a positive verdict
+  # requires an affirmative measurement.
+  pin_gate_source_for() {
+    local v="$1" line tok
+    [ -r "$GATE" ] || return 1
+    line=$(bounded 30 env CQLITE_GATE_MAX_CONCURRENCY="$v" CQLITE_GATE_NO_NICE=1 \
+             bash "$GATE" --cpu-budget 2>/dev/null | grep -E '^cpu-budget: ' | head -1)
+    [ -n "$line" ] || return 1
+    # The line is space-delimited key=value tokens; max-concurrency=N(source) is ONE of
+    # them, which is exactly why that token carries no spaces.
+    tok=$(printf '%s\n' "$line" | tr ' ' '\n' | sed -n 's/^max-concurrency=//p' | head -1)
+    case "$tok" in
+      *"("*")") tok=${tok#*(}; printf '%s' "${tok%)}" ;;
+      *) return 1 ;;
+    esac
+  }
+
+  # pin_value_remedy: the remedy for a VISIBLE but NOT-HONOURED value. Shared by both
+  # not-honoured branches so neither can silently lose it.
+  pin_value_remedy() {
+    if [ "$PIN_FILE_HAS_LINE" = yes ]; then
+      info "fix the VALUE (not the presence) — edit the CQLITE_GATE_MAX_CONCURRENCY line in $PIN_ENV_FILE to a positive integer; bootstrap deliberately never rewrites an existing value"
+    else
+      info "the value is visible but is NOT coming from $PIN_ENV_FILE — find and fix whatever sets it (a systemd unit, the image, a launcher-injected env), then re-run"
+    fi
+  }
 
   # ---- (2) THE VERDICT: an affirmative probe of a fresh, profile-free session ----
   #
@@ -1990,23 +2047,71 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
     warn "gate-pin: UNMEASURED (sudo works but will not run a command as '$PIN_SELF_USER', so no probe session could be opened — pin visibility is UNKNOWN, not ok)"
   else
     pin_probe_rc=0
+    # TWO markers, because SET-BUT-EMPTY and UNSET are different facts with different
+    # consequences — the gate DISCARDS an empty value for its default formula and stamps
+    # `(invalid)`, which is a misconfigured box, not an unprovisioned one. `${VAR+1}`
+    # separates them; `${VAR-}` alone cannot, and collapsing them here would put the
+    # `:-` defect this issue removed from the gate back into the tool that verifies it.
     pin_probe_out=$(bounded "$PIN_PROBE_BOUND" env -u CQLITE_GATE_MAX_CONCURRENCY \
       sudo -n -u "$PIN_SELF_USER" \
-      bash -c 'printf "cqlite-gate-pin-probe=%s\n" "${CQLITE_GATE_MAX_CONCURRENCY-}"' 2>/dev/null) || pin_probe_rc=$?
-    # Anchored on our own marker at line start, and the value is read from the FIRST
+      bash -c 'printf "cqlite-gate-pin-probe-set=%s\ncqlite-gate-pin-probe=%s\n" "${CQLITE_GATE_MAX_CONCURRENCY+1}" "${CQLITE_GATE_MAX_CONCURRENCY-}"' 2>/dev/null) || pin_probe_rc=$?
+    # Anchored on our own markers at line start, and each value is read from the FIRST
     # matching line: the probe's stdout can also carry a shell's own noise, and a
     # verdict decided by an unanchored match would be decided by whatever else printed.
+    pin_probe_set=$(printf '%s\n' "$pin_probe_out" | sed -n 's/^cqlite-gate-pin-probe-set=//p' | head -1)
     pin_probe_seen=$(printf '%s\n' "$pin_probe_out" | sed -n 's/^cqlite-gate-pin-probe=//p' | head -1)
     if [ "$pin_probe_rc" = 124 ] || [ "$pin_probe_rc" = 137 ]; then
       warn "gate-pin: UNMEASURED (the probe exceeded its ${PIN_PROBE_BOUND}s bound and was killed — pin visibility is UNKNOWN, not ok)"
-    elif ! printf '%s\n' "$pin_probe_out" | grep -q '^cqlite-gate-pin-probe='; then
-      warn "gate-pin: UNMEASURED (the probe session produced no cqlite-gate-pin-probe= line, rc=$pin_probe_rc — pin visibility is UNKNOWN, not ok)"
-    elif [ -n "$pin_probe_seen" ]; then
-      ok "gate-pin: VERIFIED (a fresh profile-free session sees CQLITE_GATE_MAX_CONCURRENCY=$pin_probe_seen; this run's own value was scrubbed first, so it came from the system env file via PAM, not from inheritance)"
+    elif ! printf '%s\n' "$pin_probe_out" | grep -q '^cqlite-gate-pin-probe-set='; then
+      warn "gate-pin: UNMEASURED (the probe session produced no cqlite-gate-pin-probe-set= line, rc=$pin_probe_rc — pin visibility is UNKNOWN, not ok)"
+    elif [ -n "$pin_probe_set" ]; then
+      # VISIBLE. That is only HALF the question: a value the gate does not HONOUR is a
+      # pin in name only, and certifying it here would be this issue's own shape one
+      # level further out — presence of a VISIBLE value standing in for a value that has
+      # EFFECT. So the gate is asked what it will actually do with it.
+      pin_gate_src=$(pin_gate_source_for "$pin_probe_seen") || pin_gate_src=""
+      case "$pin_gate_src" in
+        pinned)
+          ok "gate-pin: VERIFIED (a fresh profile-free session sees CQLITE_GATE_MAX_CONCURRENCY=$pin_probe_seen and the gate HONOURS it verbatim — max-concurrency=$pin_probe_seen(pinned); this run's own value was scrubbed first, so it came from the system env file via PAM, not from inheritance)"
+          ;;
+        invalid)
+          # Its OWN verdict, not FAILED: the pin is present and visible, so "persist the
+          # pin" is the wrong remedy and would send the operator to a file that already
+          # has a line in it. What is wrong is the VALUE.
+          warn "gate-pin: NOT-HONOURED (a fresh session sees CQLITE_GATE_MAX_CONCURRENCY='$pin_probe_seen', but the gate DISCARDS it — it is empty or non-numeric — and falls back to the #1825 default formula, stamping max-concurrency=N(invalid))"
+          pin_value_remedy
+          ;;
+        clamped)
+          warn "gate-pin: NOT-HONOURED (a fresh session sees CQLITE_GATE_MAX_CONCURRENCY='$pin_probe_seen', but the gate silently raises it to 1, stamping max-concurrency=1(clamped) — the cap you asked for is not the cap you get)"
+          pin_value_remedy
+          ;;
+        *)
+          # Visibility WAS measured; honouring was not. Not a pass: the sole oracle for
+          # the second half could not be consulted.
+          warn "gate-pin: UNMEASURED (a fresh session sees CQLITE_GATE_MAX_CONCURRENCY='$pin_probe_seen', but $GATE could not be consulted to confirm the gate HONOURS that value — half the question is unanswered, which is not ok)"
+          ;;
+      esac
     else
+      # NOT VISIBLE. Two different boxes, two different remedies — split on a fact we
+      # already read above rather than printing one remedy and hoping.
       warn "gate-pin: FAILED (a fresh profile-free session does NOT see CQLITE_GATE_MAX_CONCURRENCY — every non-interactive gate on this box will resolve the #1825 cap from the default formula and admit co-tenants, #3414)"
-      [ -n "$PIN_PERSIST_NOTE" ] && info "nothing was persisted this run: $PIN_PERSIST_NOTE"
-      info "fix:  bash scripts/bootstrap-agent-machine.sh --yes   (appends '$PIN_ENV_LINE' to /etc/environment)"
+      case "$PIN_FILE_HAS_LINE" in
+        yes)
+          info "the pin IS in $PIN_ENV_FILE and a fresh session still does not see it — this is a PAM condition, NOT a missing pin"
+          info "re-running with --yes will NOT help: it finds the line already present and changes nothing"
+          info "check the session stack reads it:  grep -n pam_env /etc/pam.d/sudo /etc/pam.d/login /etc/pam.d/sshd   (each needs 'pam_env.so readenv=1')"
+          ;;
+        absent-file)
+          # No remedy that names a file this host does not have (the ruling on #3414's
+          # residual 4): telling a Mac to re-run --yes to append to /etc/environment is
+          # advice that cannot work on the box it is printed for.
+          info "this $PLATFORM host has no $PIN_ENV_FILE, so bootstrap has nowhere to persist it — set CQLITE_GATE_MAX_CONCURRENCY=1 in this host's own session-startup mechanism (launchd/systemd/the image), NOT in a shell profile"
+          ;;
+        *)
+          [ -n "$PIN_PERSIST_NOTE" ] && info "nothing was persisted this run: $PIN_PERSIST_NOTE"
+          info "fix:  bash scripts/bootstrap-agent-machine.sh --yes   (appends '$PIN_ENV_LINE' to $PIN_ENV_FILE)"
+          ;;
+      esac
       info "the gate reports the same fact on its cpu-budget line as max-concurrency=N(default) instead of N(pinned)"
     fi
   fi

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -2047,20 +2047,40 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
     [ -n "$PIN_PROBE_SUBJECT_NOTE" ] && PIN_PRIV_STATE=invoker-unresolvable
   elif ! have sudo; then
     PIN_PRIV_STATE=no-sudo-binary
-  elif ! bounded 10 sudo -n true >/dev/null 2>&1; then
-    PIN_PRIV_STATE=sudo-needs-password
-  elif ! bounded 10 sudo -n -u "$PIN_SELF_USER" true >/dev/null 2>&1; then
-    PIN_PRIV_STATE=sudo-runas-denied
+  elif [ -z "$TIMEOUT_BIN" ]; then
+    # THE BOUND IS CHECKED BEFORE THE FIRST PROBE, NOT AFTER (#3414 roborev round 10).
+    # `bounded` DEGRADES TO RUNNING THE COMMAND DIRECTLY when no timeout utility exists,
+    # and both sudo probes used to execute ABOVE the later no-timeout guard — so on a host
+    # with neither `timeout` nor `gtimeout` a stalled sudo/PAM/NSS lookup hung bootstrap
+    # indefinitely WHILE THE CODE CLAIMED IT REFUSES UNBOUNDED SESSION PROBING. The false
+    # claim is the worse half: a comment asserting a safety property the code does not
+    # have is worse than not having it, because it stops the next person checking.
+    PIN_PRIV_STATE=no-timeout-binary
   else
-    PIN_PRIV_STATE=sudo-nopasswd
+    # ROOT-WRITE PERMISSION AND SESSION-PROBE PERMISSION ARE INDEPENDENT FACTS, and gating
+    # the probe on the WRITE one was a false red (#3414 roborev round 10). `sudo -n true`
+    # asks "may I run ANYTHING as root"; the probe needs only "may I open a session as
+    # MYSELF". A host granting the second but not the first — a narrowly-scoped sudoers
+    # rule, or a box already correctly pinned — was reported sudo-needs-password and
+    # failed --strict on a legitimately configured machine.
+    #
+    # This finishes a split started two rounds ago: PIN_WRITE_PRIV was separated from
+    # PIN_PRIV_STATE in USE, but their ACQUISITION stayed entangled, so the weaker
+    # permission still depended on the stronger one being granted first.
+    if bounded 10 sudo -n -u "$PIN_SELF_USER" true >/dev/null 2>&1; then
+      PIN_PRIV_STATE=sudo-nopasswd
+    else
+      PIN_PRIV_STATE=sudo-runas-denied
+    fi
   fi
-  # WRITE privilege and PROBE capability are separate facts: a root shell with no sudo
-  # binary can persist the pin but cannot open a probe session, and saying so is more
-  # useful than collapsing both into one state.
+  # WRITE privilege: a SEPARATE question, asked separately and only where persistence is
+  # attempted. A root shell with no sudo binary can persist but cannot probe; a box that
+  # permits the runas-self session but not unrestricted root can probe but not persist.
+  # Neither fact implies the other, so neither is derived from the other's answer.
   PIN_WRITE_PRIV=0
   if [ "$PIN_SELF_UID" = 0 ]; then
     PIN_WRITE_PRIV=1; PIN_ROOT=()
-  elif [ "$PIN_PRIV_STATE" = sudo-nopasswd ]; then
+  elif have sudo && [ -n "$TIMEOUT_BIN" ] && bounded 10 sudo -n true >/dev/null 2>&1; then
     PIN_WRITE_PRIV=1; PIN_ROOT=(sudo -n)
   fi
   # Test mode never runs a PRIVILEGED write; the sandbox file belongs to the invoking
@@ -2386,8 +2406,8 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   # is NOT tolerated is running it UNBOUNDED: hanging the fleet's provisioning entry
   # point is worse than an unmeasured verdict.
   PIN_PROBE_BOUND=20
-  if [ -z "$TIMEOUT_BIN" ]; then
-    warn "gate-pin: UNMEASURED (no timeout/gtimeout on PATH — refusing to run an UNBOUNDED session probe during bootstrap)"
+  if [ "$PIN_PRIV_STATE" = no-timeout-binary ] || [ -z "$TIMEOUT_BIN" ]; then
+    warn "gate-pin: UNMEASURED (no timeout/gtimeout on PATH — refusing to run an UNBOUNDED session probe during bootstrap; NOTHING was probed)"
     info "install GNU coreutils so the probe can be bounded (macOS: brew install coreutils), then re-run"
   elif [ "$PIN_PRIV_STATE" = invoker-unresolvable ]; then
     warn "gate-pin: UNMEASURED ($PIN_PROBE_SUBJECT_NOTE — refusing to answer about the wrong user)"
@@ -2398,11 +2418,9 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
     warn "gate-pin: UNMEASURED (no 'sudo' on this box, so no fresh PAM session can be created — pin visibility is UNKNOWN, not ok)"
     info "check by hand:  env -u CQLITE_GATE_MAX_CONCURRENCY -u BASH_ENV -u ENV sudo -u \"\$(id -un)\" bash -c 'printf \"[%s]\\n\" \"\${CQLITE_GATE_MAX_CONCURRENCY-UNSET}\"'"
     info "(the scrub and the '-' — not ':-' — are load-bearing: without them an INHERITED value, or a set-but-EMPTY one, reads as a healthy pin, which is the defect this section exists to remove)"
-  elif [ "$PIN_PRIV_STATE" = sudo-needs-password ]; then
-    warn "gate-pin: UNMEASURED (sudo needs a password here and bootstrap probes with 'sudo -n', which never prompts — pin visibility is UNKNOWN, not ok)"
-    info "authenticate first, then re-run:  sudo -v && bash scripts/bootstrap-agent-machine.sh --yes"
   elif [ "$PIN_PRIV_STATE" = sudo-runas-denied ]; then
-    warn "gate-pin: UNMEASURED (sudo works but will not run a command as '$PIN_SELF_USER', so no probe session could be opened — pin visibility is UNKNOWN, not ok)"
+    warn "gate-pin: UNMEASURED (sudo will not open a session as '$PIN_SELF_USER' without a password, so no probe session could be created — pin visibility is UNKNOWN, not ok)"
+    info "this needs only a session as YOURSELF, not root — authenticate once and re-run:  sudo -v && bash scripts/bootstrap-agent-machine.sh"
   else
     pin_probe_rc=0
     # TWO markers, because SET-BUT-EMPTY and UNSET are different facts with different

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -2790,8 +2790,13 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
               ;;
             *)
               warn "gate-pin: NOT-SYSTEM-WIDE (a fresh session sees CQLITE_GATE_MAX_CONCURRENCY=$pin_probe_seen and the gate would honour it, but there is NO CQLITE_GATE_MAX_CONCURRENCY line in $PIN_ENV_FILE — so it is reaching this session from a sudo- or user-specific source (a sudoers env_file, ~/.pam_environment) and gates launched outside that source get nothing)"
-              if [ "$PIN_FILE_HAS_LINE" = absent-file ]; then
+              if [ "$PIN_FILE_HAS_LINE" = absent-file ] && [ "$PIN_PLATFORM_UNMANAGED" = 1 ]; then
+                # UNMANAGED PLATFORM only — on Linux the absent file is creatable, so the
+                # remedy below is the true one (roborev job 332; see the absent-file arm
+                # of the FAILED table for the full reasoning).
                 info "this $PLATFORM host has no $PIN_ENV_FILE, so there is no system-wide file to correlate against — set CQLITE_GATE_MAX_CONCURRENCY=1 in this host's own session-startup mechanism (launchd/systemd/the image)"
+              elif [ "$PIN_FILE_HAS_LINE" = absent-file ]; then
+                info "fix:  bash scripts/bootstrap-agent-machine.sh --fix-gate-pin   (this $PLATFORM host has no $PIN_ENV_FILE yet — the flag CREATES it carrying '$PIN_ENV_LINE', which every PAM session reads; the per-user source stays as it is)"
               else
                 info "fix:  bash scripts/bootstrap-agent-machine.sh --fix-gate-pin   (persists '$PIN_ENV_LINE' to $PIN_ENV_FILE, which every PAM session reads — the per-user source stays as it is)"
               fi
@@ -2834,7 +2839,22 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
           # No remedy that names a file this host does not have (the ruling on #3414's
           # residual 4): telling a Mac to re-run --yes to append to /etc/environment is
           # advice that cannot work on the box it is printed for.
-          info "this $PLATFORM host has no $PIN_ENV_FILE, so bootstrap has nowhere to persist it — set CQLITE_GATE_MAX_CONCURRENCY=1 in this host's own session-startup mechanism (launchd/systemd/the image), NOT in a shell profile"
+          #
+          # BUT THAT RULING IS ABOUT AN UNMANAGED PLATFORM, AND APPLYING IT TO EVERY
+          # ABSENT FILE MADE IT FALSE ON LINUX (roborev job 332). "The file is missing" and
+          # "this platform has no such file" are DIFFERENT STATES: on Linux the missing
+          # file is CREATED by --fix-gate-pin (the persist path above says so in its own
+          # message), so "nowhere to persist it" sent an operator on a minimal Linux
+          # image to hand-edit systemd while a working remedy sat one flag away. A false
+          # remedy costs more than a missing one, because it stops them looking.
+          #
+          # The VERDICT was already scoped on platform rather than on file presence (the
+          # test suite asserts exactly that); this scopes the REMEDY the same way.
+          if [ "$PIN_PLATFORM_UNMANAGED" = 1 ]; then
+            info "this $PLATFORM host has no $PIN_ENV_FILE, so bootstrap has nowhere to persist it — set CQLITE_GATE_MAX_CONCURRENCY=1 in this host's own session-startup mechanism (launchd/systemd/the image), NOT in a shell profile"
+          else
+            info "fix:  bash scripts/bootstrap-agent-machine.sh --fix-gate-pin   (this $PLATFORM host has no $PIN_ENV_FILE yet — the flag CREATES it carrying '$PIN_ENV_LINE', and pam_env reads it at session creation; --yes does it too)"
+          fi
           ;;
         *)
           [ -n "$PIN_PERSIST_NOTE" ] && info "nothing was persisted this run: $PIN_PERSIST_NOTE"

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -69,7 +69,11 @@
 #      UNMEASURED, and only VERIFIED is an [ok] (same posture as `git-push:`). VERIFIED
 #      requires BOTH halves — the line present in the system-wide file AND a fresh
 #      session that sees a value the gate honours — because file-only was the original
-#      #3414 defect and session-only certifies a pin that may reach sudo sessions alone. `--yes` persists it, and
+#      #3414 defect and session-only certifies a pin that may reach sudo sessions alone,
+#      and the file's VALUE must EQUAL the session's (presence alone let a file saying
+#      `abc` pass while a per-user override supplied `1`). NON-LINUX hosts report an
+#      explicit, non-failing NOT-APPLICABLE: the mechanism is Linux/pam_env-specific, so
+#      macOS is scoped out rather than supported. `--yes` persists it, and
 #      so does the narrow `--fix-gate-pin` that `.agent-ami/profile.yaml`'s verify.run
 #      passes, so a freshly launched box is PINNED rather than merely reported unpinned.
 #      PAM reads /etc/environment at session creation, so the probe in the SAME run sees
@@ -1856,12 +1860,40 @@ PIN_PERSIST_NOTE=""
 # trailing `# ...` would become part of the value. Whole-line comments are skipped, so
 # the rationale goes on its own line above it.
 PIN_ENV_COMMENT='# cqlite: one full gate per box, full cores (issues #2640/#3414)'
-PIN_ENV_LINE='CQLITE_GATE_MAX_CONCURRENCY=1'
+PIN_ENV_VALUE='1'
+PIN_ENV_LINE="CQLITE_GATE_MAX_CONCURRENCY=$PIN_ENV_VALUE"
 EXPORT_LINE='export CQLITE_GATE_MAX_CONCURRENCY=1  # cqlite: one full gate per box, full cores (issue #2640)'
 
 if [ "$SKIP_GATE_PIN" = 1 ]; then
   warn "gate-pin: OPT-OUT ($SKIP_GATE_PIN_HOW) — the pin was NOT persisted and its visibility was NOT measured"
   info "this run cannot certify that a non-interactive shell sees CQLITE_GATE_MAX_CONCURRENCY; drop the opt-out to measure it"
+  PIN_SECTION_OK=0
+fi
+
+# PLATFORM SCOPING, EXPLICIT AND NOT INFERRED FROM FILE ABSENCE (#3414 roborev round 3).
+# /etc/environment + pam_env is a Linux mechanism. Requiring the file for VERIFIED made a
+# correctly-configured Mac PERMANENTLY non-passing under --strict — red on correct input,
+# which is the shape this lane has now refused three times: an alarm that always fires is
+# one people learn to waive, and it would have made `verify.run` unusable on any non-Linux
+# host rather than merely unverified.
+#
+# Scoped on $PLATFORM, deliberately NOT on "is /etc/environment missing?", because those
+# are different facts with opposite correct answers: a Mac has no such file BY DESIGN,
+# while a LINUX box without one is a genuine anomaly that must stay non-passing. Folding
+# them together would trade a false red for a false green.
+#
+# Reported as an explicit NON-FAILING verdict rather than silence: this repo's rule for
+# the CI tier registry is that absence is an error while inapplicability must be reported
+# as an explicit success, and the same reasoning applies to a provisioning check — a
+# section that simply prints nothing is indistinguishable from one that did not run.
+#
+# macOS persistence (a launchd equivalent) is deliberately NOT implemented: there is no
+# Mac on this fleet, so it could not be verified, and an unverifiable persistence path is
+# worse than a documented gap. macOS is SCOPED OUT here, not supported.
+if [ "$PIN_SECTION_OK" = 1 ] && [ "$PLATFORM" != linux ]; then
+  ok "gate-pin: NOT-APPLICABLE (the single-gate pin is persisted in /etc/environment and read by PAM's pam_env — a Linux mechanism; $PLATFORM has no equivalent here, so there is nothing to verify rather than something failing)"
+  info "on this platform the per-run authority is the gate's own SUMMARY line:  cpu-budget: ... max-concurrency=N(pinned)   (N(default) means that gate resolved the #1825 cap from the formula)"
+  info "to cap gates here, export CQLITE_GATE_MAX_CONCURRENCY in whatever this host's session-startup mechanism is; bootstrap does not manage it"
   PIN_SECTION_OK=0
 fi
 
@@ -1941,12 +1973,44 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   # line (persist it) and a box whose line is present yet invisible to a fresh session
   # (a PAM condition — re-running with --yes finds the line already there and changes
   # NOTHING, so an operator told to do that just loops).
+  #
+  # AND IT CAPTURES THE VALUE, NOT JUST THE PRESENCE OF A LINE (#3414 roborev round 3).
+  # THIS IS THE FOURTH INSTANCE OF THIS ISSUE'S OWN DEFECT IN THIS LANE, and it was inside
+  # the correlation added to fix the third: presence is a PROXY for the fact that matters,
+  # exactly as "the export is in ~/.bashrc" was. Concretely — the file holds
+  # `CQLITE_GATE_MAX_CONCURRENCY=abc`, a sudoers env_file or ~/.pam_environment supplies
+  # `1`, both halves of the file-AND-session conjunction are satisfied, the verdict is
+  # VERIFIED — and every ordinary PAM session receives `abc`, which the gate discards for
+  # its default formula and stamps N(invalid). The verdict must therefore compare VALUES.
+  #
+  # Parsed the way pam_env reads the file, because a second, subtly-different parser here
+  # would be the same class of bug one layer down:
+  #   * whole-line `#` comments are skipped;
+  #   * NO inline-comment stripping — pam_env takes a trailing `# …` as part of the value,
+  #     which is precisely why this section's own append puts its comment on its own line;
+  #   * the LAST assignment wins if a file somehow carries two.
+  # An assignment we cannot parse is UNMEASURED, never a mismatch: a parse failure is an
+  # absence of evidence, and reporting it as a contradiction would invent one.
   PIN_FILE_HAS_LINE=unknown
+  PIN_FILE_VALUE=""
   if [ ! -e "$PIN_ENV_FILE" ]; then
     PIN_FILE_HAS_LINE=absent-file
   elif [ ! -L "$PIN_ENV_FILE" ] && [ -r "$PIN_ENV_FILE" ]; then
     if grep -Eq '^[[:space:]]*CQLITE_GATE_MAX_CONCURRENCY[[:space:]]*=' "$PIN_ENV_FILE" 2>/dev/null; then
-      PIN_FILE_HAS_LINE=yes
+      # `sed -n 's/…//p' | tail -1` = last assignment wins. The pattern anchors at line
+      # start (so a `#`-commented line cannot match) and stops at the FIRST `=`, taking
+      # everything after it verbatim — no trimming, no comment stripping.
+      # A SENTINEL PREFIX, because an EMPTY capture and a FAILED capture are otherwise the
+      # same string: `CQLITE_GATE_MAX_CONCURRENCY=` is a legitimate (empty, gate-invalid)
+      # value, while sed producing nothing means the parse failed. Without the marker the
+      # `unparseable` branch is unreachable and an unparseable file would silently report
+      # an empty value — the unset-vs-set-empty conflation this issue removed from the
+      # gate, re-created in the parser that checks it.
+      pin_file_raw=$(sed -n 's/^[[:space:]]*CQLITE_GATE_MAX_CONCURRENCY[[:space:]]*=/VAL:/p' "$PIN_ENV_FILE" 2>/dev/null | tail -1)
+      case "$pin_file_raw" in
+        VAL:*) PIN_FILE_VALUE=${pin_file_raw#VAL:}; PIN_FILE_HAS_LINE=yes ;;
+        *)     PIN_FILE_HAS_LINE=unparseable ;;
+      esac
     else
       PIN_FILE_HAS_LINE=no
     fi
@@ -1962,7 +2026,10 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   elif [ ! -r "$PIN_ENV_FILE" ]; then
     PIN_PERSIST_NOTE="$PIN_ENV_FILE is unreadable"
     warn "gate-pin: cannot read $PIN_ENV_FILE — cannot tell whether the pin is already there, so nothing was written (a blind append could duplicate or contradict an existing line)"
-  elif [ "$PIN_FILE_HAS_LINE" = yes ]; then
+  elif [ "$PIN_FILE_HAS_LINE" = yes ] || [ "$PIN_FILE_HAS_LINE" = unparseable ]; then
+    # `unparseable` counts as PRESENT for the append decision even though its value could
+    # not be read: grep DID match a line, so appending would leave the file with two
+    # assignments and pam_env would silently take the last one.
     info "$PIN_ENV_FILE already carries a CQLITE_GATE_MAX_CONCURRENCY line — left EXACTLY as it is (a box deliberately running >1 concurrent gate overrides the pin; bootstrap never rewrites an existing value)"
   elif [ "$AUTO_YES" != 1 ] && [ "$FIX_GATE_PIN" != 1 ]; then
     PIN_PERSIST_NOTE="not persisted (neither --yes nor --fix-gate-pin)"
@@ -1990,7 +2057,12 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
     # nothing already there is disturbed.
     if printf '%s%s\n%s\n' "$pin_prefix" "$PIN_ENV_COMMENT" "$PIN_ENV_LINE" \
          | ${PIN_ROOT[@]+"${PIN_ROOT[@]}"} tee -a "$PIN_ENV_FILE" >/dev/null 2>&1; then
+      # BOTH halves of the cached parse must move together. Setting only HAS_LINE left
+      # PIN_FILE_VALUE at its pre-write value (empty), so the value comparison below
+      # compared the session against what the file said BEFORE the append and reported a
+      # mismatch on a box this very run had just pinned correctly. Caught by 11q/11u.
       PIN_FILE_HAS_LINE=yes
+      PIN_FILE_VALUE="$PIN_ENV_VALUE"
       info "appended '$PIN_ENV_LINE' to $PIN_ENV_FILE — PAM reads it at session creation, so NEW sessions pick it up with no reboot and no re-login"
     else
       PIN_PERSIST_NOTE="the append to $PIN_ENV_FILE failed"
@@ -2199,8 +2271,22 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
           # which is the same reason the fleet does not just let verify red).
           case "$PIN_FILE_HAS_LINE" in
             yes)
-              ok "gate-pin: VERIFIED ($PIN_ENV_FILE carries the line AND a fresh PAM-created, profile-free session sees CQLITE_GATE_MAX_CONCURRENCY=$pin_probe_seen, which the gate HONOURS verbatim — max-concurrency=$pin_probe_seen(pinned); this run's own value, BASH_ENV and ENV were scrubbed first)"
-              pin_scope_note
+              # STRING equality on the raw effective value, deliberately not a numeric
+              # one. `1`, `01` and `1 ` are different strings and the gate's own resolver
+              # already treats them differently (a trailing space matches `*[!0-9]*` and
+              # is discarded as invalid). Normalising here would be a SECOND classifier
+              # free to disagree with the gate — the thing avoided by asking the gate what
+              # it honours instead of re-deriving its rules.
+              if [ "$PIN_FILE_VALUE" = "$pin_probe_seen" ]; then
+                ok "gate-pin: VERIFIED ($PIN_ENV_FILE sets CQLITE_GATE_MAX_CONCURRENCY=$PIN_FILE_VALUE AND a fresh PAM-created, profile-free session sees that SAME value, which the gate HONOURS verbatim — max-concurrency=$pin_probe_seen(pinned); this run's own value, BASH_ENV and ENV were scrubbed first)"
+                pin_scope_note
+              else
+                warn "gate-pin: NOT-SYSTEM-WIDE ($PIN_ENV_FILE sets CQLITE_GATE_MAX_CONCURRENCY='$PIN_FILE_VALUE' but this session sees '$pin_probe_seen' — a sudo- or user-specific source is OVERRIDING the system-wide file, so ordinary PAM sessions get the file's value and the gate will act on THAT, not on the one measured here)"
+                info "fix the VALUE in $PIN_ENV_FILE (bootstrap never rewrites an existing value), or remove the per-user/sudoers override so the two agree"
+              fi
+              ;;
+            unparseable)
+              warn "gate-pin: UNMEASURED (a fresh session sees CQLITE_GATE_MAX_CONCURRENCY=$pin_probe_seen and the gate would honour it, but the CQLITE_GATE_MAX_CONCURRENCY assignment in $PIN_ENV_FILE could not be PARSED, so it cannot be compared against what the session saw)"
               ;;
             unknown)
               # Half the evidence is unreadable, so the correlation cannot be made. Not a

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -2189,6 +2189,39 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   fi
 
   PIN_CREATE_RESIDUE=""
+  # pin_append_env_file: CHECK-AND-APPEND under a lock, re-reading inside it (roborev job
+  # 316, Medium). The caller's "is a line already there" fact is read ~150 lines earlier, and
+  # the append was a bare `tee -a`, so a value added in between — a provisioner setting a
+  # DELIBERATE `=4`, or a peer bootstrap on the same box — was silently overridden, because
+  # pam_env takes the LAST assignment. That breaks this script's own stated contract that it
+  # never rewrites an existing value, and two concurrent runs also produced DUPLICATE lines.
+  #
+  # `flock` serialises against every cooperating writer (both bootstrap runs take it), and
+  # the re-read INSIDE the lock shrinks the window to the locked region. Exit 3 means
+  # someone else won and we must not write.
+  #
+  # RESIDUAL, DECLARED: flock is ADVISORY, so a writer using a plain `>>` and no lock can
+  # still interleave. That is not closable from here — it needs cooperation from the other
+  # writer — and it is strictly better than the unlocked version it replaces. Where flock is
+  # absent the same body runs unlocked, which still buys the re-read: losing the lock is a
+  # weaker guarantee, not a reason to skip the check.
+  pin_append_env_file() {
+    local -a pin_lock=()
+    command -v flock >/dev/null 2>&1 && pin_lock=(flock "$PIN_ENV_FILE")
+    ${PIN_ROOT[@]+"${PIN_ROOT[@]}"} ${pin_lock[@]+"${pin_lock[@]}"} bash -c '
+      f="$1"; comment="$2"; line="$3"
+      if grep -Eq "^[[:space:]]*CQLITE_GATE_MAX_CONCURRENCY[[:space:]]*=" "$f" 2>/dev/null; then
+        exit 3
+      fi
+      prefix=""
+      # A file whose last byte is not a newline would otherwise have our KEY=VALUE welded
+      # onto its final line, and pam_env would read the result as one malformed entry.
+      if [ -s "$f" ] && [ -n "$(tail -c 1 "$f" 2>/dev/null)" ]; then prefix="
+"; fi
+      printf "%s%s\n%s\n" "$prefix" "$comment" "$line" >> "$f"
+    ' _ "$PIN_ENV_FILE" "$PIN_ENV_COMMENT" "$PIN_ENV_LINE" 2>/dev/null
+  }
+
   # pin_create_env_file: CREATE-IF-ABSENT, atomically (roborev job 314, Medium). The
   # `[ ! -e "$PIN_ENV_FILE" ]` test in the caller and the write are two separate steps, and
   # the write used to be a TRUNCATING `tee` — so a file created in between, by cloud-init, a
@@ -2324,15 +2357,17 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
     # onto its final line, and pam_env would read the result as one malformed entry.
     # Prepend a newline in that case only; the append happens at most once per box, so
     # this can never accumulate blank lines.
-    pin_prefix=""
-    if [ -s "$PIN_ENV_FILE" ] && [ -n "$(tail -c 1 "$PIN_ENV_FILE" 2>/dev/null)" ]; then
-      pin_prefix=$'\n'
-    fi
     # Appended at the END, after any managed marker block the image owner put in the
     # file (this fleet's images carry a `# >>> agent-ami worker auth >>>` block), so
     # nothing already there is disturbed.
-    if printf '%s%s\n%s\n' "$pin_prefix" "$PIN_ENV_COMMENT" "$PIN_ENV_LINE" \
-         | ${PIN_ROOT[@]+"${PIN_ROOT[@]}"} tee -a "$PIN_ENV_FILE" >/dev/null 2>&1; then
+    pin_append_env_file; pin_append_rc=$?
+    if [ "$pin_append_rc" = 3 ]; then
+      # RACED, and the contract wins. Reported as the left-alone case rather than as a
+      # failure: nothing is wrong with the box, and the file now holds someone else's
+      # deliberate value.
+      PIN_PERSIST_NOTE="not persisted (a concurrent writer added a CQLITE_GATE_MAX_CONCURRENCY line first)"
+      info "$PIN_ENV_FILE gained a CQLITE_GATE_MAX_CONCURRENCY line while this run was working — left EXACTLY as it is, because appending ours would land LAST and pam_env takes the last assignment, silently overriding a value someone else chose"
+    elif [ "$pin_append_rc" = 0 ]; then
       # BOTH halves of the cached parse must move together. Setting only HAS_LINE left
       # PIN_FILE_VALUE at its pre-write value (empty), so the value comparison below
       # compared the session against what the file said BEFORE the append and reported a

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -2198,8 +2198,35 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
     PIN_PERSIST_NOTE="not persisted (no PAM-read system-wide env file on $PLATFORM)"
     info "not touching $PIN_ENV_FILE on this $PLATFORM host — pam_env is a Linux mechanism and this platform does not consume that file, so writing it would change host state for nothing"
   elif [ ! -e "$PIN_ENV_FILE" ]; then
-    PIN_PERSIST_NOTE="no $PIN_ENV_FILE on this host"
-    info "no $PIN_ENV_FILE on this $PLATFORM host — there is no PAM-read system-wide env file to persist the pin into"
+    # CREATE IT ON LINUX WHEN AUTHORISED (#3414 final roborev). Refusing here meant a
+    # MINIMAL Linux install — where /etc/environment simply does not ship — could never be
+    # repaired: --fix-gate-pin declined, the probe found no pin, and --strict failed that
+    # box's onboarding FOREVER. A repair flag that cannot repair the one case it exists for
+    # is the "red on correct input" shape inverted: the box is fixable and we refuse to fix
+    # it. pam_env consumes the file once it exists, so creating it is the repair.
+    #
+    # Created with the ownership and mode pam_env expects and every other consumer assumes:
+    # root:root 0644. Explicitly NOT 0600 — this file is read by PAM for every login
+    # session, and a mode nothing else on the box uses is its own trap. Guarded the same way
+    # the append is: only under an explicit authorisation, only with write privilege, and
+    # only at the literal production path (the seam forces PIN_ROOT empty, and the invariant
+    # below still refuses a privileged write to a non-production path).
+    if [ "$AUTO_YES" != 1 ] && [ "$FIX_GATE_PIN" != 1 ]; then
+      PIN_PERSIST_NOTE="no $PIN_ENV_FILE and no authorisation to create it"
+      info "no $PIN_ENV_FILE on this $PLATFORM host — pass --yes or --fix-gate-pin and it will be CREATED (root:root 0644) so pam_env can consume it"
+    elif [ "$PIN_WRITE_PRIV" != 1 ]; then
+      PIN_PERSIST_NOTE="no $PIN_ENV_FILE and no privilege to create it ($PIN_PRIV_STATE)"
+      warn "gate-pin: $PIN_ENV_FILE does not exist and this run cannot create it ($PIN_PRIV_STATE) — the pin was NOT persisted"
+      info "create it as root:  printf '%s\n' '$PIN_ENV_COMMENT' '$PIN_ENV_LINE' > $PIN_ENV_FILE && chmod 0644 $PIN_ENV_FILE"
+    elif printf '%s\n%s\n' "$PIN_ENV_COMMENT" "$PIN_ENV_LINE" \
+           | ${PIN_ROOT[@]+"${PIN_ROOT[@]}"} tee "$PIN_ENV_FILE" >/dev/null 2>&1 \
+         && ${PIN_ROOT[@]+"${PIN_ROOT[@]}"} chmod 0644 "$PIN_ENV_FILE" 2>/dev/null; then
+      PIN_FILE_HAS_LINE=yes; PIN_FILE_VALUE="$PIN_ENV_VALUE"
+      info "CREATED $PIN_ENV_FILE (root:root 0644) carrying '$PIN_ENV_LINE' — pam_env reads it at session creation, so NEW sessions pick it up"
+    else
+      PIN_PERSIST_NOTE="could not create $PIN_ENV_FILE"
+      warn "gate-pin: could not create $PIN_ENV_FILE — the pin was NOT persisted"
+    fi
   elif [ -L "$PIN_ENV_FILE" ]; then
     PIN_PERSIST_NOTE="$PIN_ENV_FILE is a SYMLINK"
     warn "gate-pin: $PIN_ENV_FILE is a SYMLINK — refusing a privileged write that would follow it; nothing was persisted"

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -1900,7 +1900,16 @@ fi
 # Effective privilege, resolved BEFORE the seam guard because the guard now depends on it.
 # Unknown is treated as privileged (fail closed): a seam that steers a write must not be
 # admitted because we could not establish who we are.
-PIN_EUID=$(id -u 2>/dev/null || true)
+# `$EUID` — Bash's own readonly — NEVER a PATH-resolved `id` (#3414 roborev round 8, HIGH).
+# The privilege decision gates a seam that can steer a ROOT `tee -a` at an arbitrary
+# absolute path, so a shadowed or merely MALFORMED `id` (a busybox variant, a broken PATH)
+# makes a root invocation look unprivileged and reopens the round-5 High through a
+# different door. A malformed `id` is an ACCIDENT, not an attack, which is what puts this
+# inside the threat model rather than in the invoker-controls-the-process category.
+# A nonnumeric value is treated as UNKNOWN, never as "not root": the guards below read an
+# empty PIN_EUID as privileged, so an unreadable identity fails closed. Also one fewer fork.
+PIN_EUID="${EUID-}"
+case "$PIN_EUID" in ''|*[!0-9]*) PIN_EUID="" ;; esac
 
 if [ "$PIN_SECTION_OK" = 1 ] && [ -n "${CQLITE_BOOTSTRAP_ENV_FILE:-}" ] \
    && { [ "$PIN_EUID" = 0 ] || [ -z "$PIN_EUID" ]; }; then
@@ -1981,19 +1990,36 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   # silent fall back to root: falling back would answer a question about the wrong user
   # and report it as if it were the right one, which is the substitution this whole
   # section exists to stop.
+  # SUDO_UID IS THE AUTHORITY AND SUDO_USER MUST AGREE WITH IT (#3414 roborev round 8).
+  # Trusting the NAME alone accepts stale or inconsistent metadata — `SUDO_UID=1000
+  # SUDO_USER=root` would probe root and could report VERIFIED while the agent account has
+  # a different PAM environment, which is the wrong-subject defect this retarget exists to
+  # fix, wearing the retarget's own clothes. So: a validated NUMERIC SUDO_UID, NONZERO
+  # (root invoking sudo tells us nothing new), and if a username is present it must resolve
+  # to that same uid. Anything absent or inconsistent is UNMEASURED — never a fall back to
+  # answering about root, and never a guess between two disagreeing sources.
   PIN_PROBE_SUBJECT_NOTE=""
   if [ "$PIN_EUID" = 0 ]; then
-    pin_invoker="${SUDO_USER:-}"
-    if [ -z "$pin_invoker" ] && [ -n "${SUDO_UID:-}" ]; then
-      pin_invoker=$(id -un "$SUDO_UID" 2>/dev/null || true)
-    fi
-    if [ -n "$pin_invoker" ]; then
-      if id -u "$pin_invoker" >/dev/null 2>&1; then
-        PIN_SELF_USER="$pin_invoker"
-        PIN_PROBE_SUBJECT_NOTE="probed as '$pin_invoker' (the account that invoked sudo), not root — root's session is not the one a gate runs in"
-      else
+    pin_sudo_uid="${SUDO_UID-}"
+    case "$pin_sudo_uid" in ''|*[!0-9]*) pin_sudo_uid="" ;; esac
+    pin_sudo_name="${SUDO_USER-}"
+    if [ -z "$pin_sudo_uid" ]; then
+      PIN_SELF_USER=""
+      PIN_PROBE_SUBJECT_NOTE="running as root with no usable SUDO_UID (absent or non-numeric), so the account a gate would run as is unknown"
+    elif [ "$pin_sudo_uid" = 0 ]; then
+      PIN_SELF_USER=""
+      PIN_PROBE_SUBJECT_NOTE="SUDO_UID is 0, so sudo was invoked BY root — that tells us nothing about the account a gate runs as"
+    else
+      pin_resolved=$(id -un "$pin_sudo_uid" 2>/dev/null || true)
+      if [ -z "$pin_resolved" ]; then
         PIN_SELF_USER=""
-        PIN_PROBE_SUBJECT_NOTE="sudo named invoker '$pin_invoker', which does not resolve to an account"
+        PIN_PROBE_SUBJECT_NOTE="SUDO_UID $pin_sudo_uid does not resolve to an account"
+      elif [ -n "$pin_sudo_name" ] && [ "$(id -u "$pin_sudo_name" 2>/dev/null || echo none)" != "$pin_sudo_uid" ]; then
+        PIN_SELF_USER=""
+        PIN_PROBE_SUBJECT_NOTE="INCONSISTENT sudo metadata — SUDO_USER '$pin_sudo_name' does not resolve to SUDO_UID $pin_sudo_uid, so which account to probe is ambiguous and neither answer would be trustworthy"
+      else
+        PIN_SELF_USER="$pin_resolved"
+        PIN_PROBE_SUBJECT_NOTE="probed as '$pin_resolved' (uid $pin_sudo_uid, the account that invoked sudo), not root — root's session is not the one a gate runs in"
       fi
     fi
   fi
@@ -2199,6 +2225,14 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
     # value instead would agree today and go stale the moment someone edits
     # /etc/environment, manufacturing the same divergence later and more quietly.
     info "not touching $PROFILE — $PIN_ENV_FILE already sets CQLITE_GATE_MAX_CONCURRENCY=$PIN_FILE_VALUE, and PAM delivers that to interactive shells too; appending a hardcoded '=$PIN_ENV_VALUE' here could only override it"
+  elif [ "$PIN_FILE_HAS_LINE" != no ] && [ "$PIN_FILE_HAS_LINE" != absent-file ]; then
+    # UNREADABLE IS NOT ABSENT (#3414 roborev round 8). The skip above keys on a value
+    # having been FOUND; this branch catches the states where we could not tell — an
+    # unreadable file, or a line we could not parse. Appending the hardcoded `=1` there
+    # would recreate exactly the divergence the skip exists to prevent, because the file we
+    # could not read may already pin 4. An unmeasurable state must not inherit the
+    # permissive branch: append only where absence was AFFIRMATIVELY established.
+    info "not touching $PROFILE — could not determine what $PIN_ENV_FILE sets ($PIN_FILE_HAS_LINE), and appending a hardcoded '=$PIN_ENV_VALUE' could contradict a value that is already there"
   elif [ "$AUTO_YES" = 1 ] && [ -n "$PROFILE" ]; then
     if printf '%s\n' "$EXPORT_LINE" >>"$PROFILE" 2>/dev/null; then
       info "appended the export to $PROFILE — the FALLBACK for interactive shells on a box with no system-wide value; it is not the verdict, which comes from the session probe below"
@@ -2337,8 +2371,8 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
     warn "gate-pin: UNMEASURED (no timeout/gtimeout on PATH — refusing to run an UNBOUNDED session probe during bootstrap)"
     info "install GNU coreutils so the probe can be bounded (macOS: brew install coreutils), then re-run"
   elif [ "$PIN_PRIV_STATE" = invoker-unresolvable ]; then
-    warn "gate-pin: UNMEASURED ($PIN_PROBE_SUBJECT_NOTE, and root's own session is NOT the subject a gate runs in — refusing to answer about the wrong user)"
-    info "re-run as the agent account, or fix SUDO_USER/SUDO_UID so the invoking account can be resolved"
+    warn "gate-pin: UNMEASURED ($PIN_PROBE_SUBJECT_NOTE — refusing to answer about the wrong user)"
+    info "re-run as the agent account itself, which needs no sudo metadata to be trusted"
   elif [ "$PIN_PRIV_STATE" = no-identity ]; then
     warn "gate-pin: UNMEASURED ('id -un' reported no identity, so there is no user to open a probe session as — pin visibility is UNKNOWN, not ok)"
   elif [ "$PIN_PRIV_STATE" = no-sudo-binary ]; then

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -2109,10 +2109,15 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
     fi
   fi
 
-  # The shell-profile export is kept for INTERACTIVE convenience only — a human who
-  # opens a terminal and runs the gate by hand. It is reported with `info`, NEVER `ok`:
-  # a profile line is precisely the artifact whose presence certified nothing for
-  # months, and letting it produce a success verdict anywhere would reintroduce #3414.
+  # The shell-profile export is the FALLBACK for a box where no system-wide value could be
+  # established — that is the only state in which it adds anything, and the branches below
+  # are ordered to say so. It is NOT merely "interactive convenience": PAM applies
+  # /etc/environment to interactive login shells too, so where a system-wide value exists
+  # this file is redundant at best and an override at worst (see the skip branch).
+  #
+  # It is reported with `info`, NEVER `ok`, whichever branch runs: a profile line is
+  # precisely the artifact whose presence certified nothing for months, and letting it
+  # produce a success verdict anywhere would reintroduce #3414.
   PROFILE=""
   case "${SHELL:-}" in
     */zsh) PROFILE="$HOME/.zshrc" ;;
@@ -2137,9 +2142,9 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
     info "not touching $PROFILE — $PIN_ENV_FILE already sets CQLITE_GATE_MAX_CONCURRENCY=$PIN_FILE_VALUE, and PAM delivers that to interactive shells too; appending a hardcoded '=$PIN_ENV_VALUE' here could only override it"
   elif [ "$AUTO_YES" = 1 ] && [ -n "$PROFILE" ]; then
     if printf '%s\n' "$EXPORT_LINE" >>"$PROFILE" 2>/dev/null; then
-      info "appended the export to $PROFILE for INTERACTIVE shells (convenience only — the verdict below comes from the session probe, not from this file)"
+      info "appended the export to $PROFILE — the FALLBACK for interactive shells on a box with no system-wide value; it is not the verdict, which comes from the session probe below"
     else
-      info "could not append to $PROFILE (interactive convenience only) — add by hand: $EXPORT_LINE"
+      info "could not append to $PROFILE (the interactive fallback; the system-wide pin is what a gate reads) — add by hand: $EXPORT_LINE"
     fi
   fi
 

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -2138,6 +2138,31 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
     # verdict decided by an unanchored match would be decided by whatever else printed.
     pin_probe_set=$(printf '%s\n' "$pin_probe_out" | sed -n 's/^cqlite-gate-pin-probe-set=//p' | head -1)
     pin_probe_seen=$(printf '%s\n' "$pin_probe_out" | sed -n 's/^cqlite-gate-pin-probe=//p' | head -1)
+    # THE VERDICT IS A CONJUNCTION OF TWO MEASUREMENTS, NEVER A FILE-STATE PRECEDENCE
+    # THAT OVERRIDES THE PROBE (#3414, lead ruling). Written out because getting the
+    # asymmetry backwards is easy and would silently undo an earlier ruling in this same
+    # issue:
+    #
+    #   session sees value | /etc/environment line        | verdict
+    #   -------------------|------------------------------|--------------------------
+    #   NO                 | anything — present, absent,   | FAILED. "Not visible" is an
+    #                      | unreadable, or no such file   | AFFIRMATIVE measurement;
+    #                      |                              | nothing about the file can
+    #                      |                              | rescue or worsen it. The file
+    #                      |                              | state picks only the REMEDY
+    #                      |                              | TEXT below, never the verdict.
+    #   yes                | present                      | VERIFIED (still subject to the
+    #                      |                              | gate-honours check)
+    #   yes                | verified absent (readable)   | NOT-SYSTEM-WIDE
+    #   yes                | unreadable / undeterminable  | UNMEASURED — the attribution
+    #                      |                              | half genuinely was not measured
+    #
+    # THE RULE THIS ENCODES, which came up three separate times in #3414: AN UNMEASURABLE
+    # HALF MAY ONLY EVER WEAKEN A POSITIVE CLAIM; IT MAY NEVER SOFTEN A NEGATIVE ONE.
+    # UNMEASURED earns its place by blocking a VERIFIED we cannot support — not by
+    # excusing a FAILED we have already established. Collapsing every unreadable-file case
+    # to UNMEASURED would downgrade a real FAILED to "could not measure", which is the
+    # discard-a-measurement error already ruled against for the unwritable-file case.
     if [ "$pin_probe_rc" = 124 ] || [ "$pin_probe_rc" = 137 ]; then
       warn "gate-pin: UNMEASURED (the probe exceeded its ${PIN_PROBE_BOUND}s bound and was killed — pin visibility is UNKNOWN, not ok)"
     elif ! printf '%s\n' "$pin_probe_out" | grep -q '^cqlite-gate-pin-probe-set='; then
@@ -2213,6 +2238,9 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
       # NOT VISIBLE. Two different boxes, two different remedies — split on a fact we
       # already read above rather than printing one remedy and hoping.
       warn "gate-pin: FAILED (a fresh profile-free session does NOT see CQLITE_GATE_MAX_CONCURRENCY — every non-interactive gate on this box will resolve the #1825 cap from the default formula and admit co-tenants, #3414)"
+      # The verdict is ALREADY emitted, unconditionally, above. What follows selects the
+      # REMEDY only — two different boxes reach FAILED and need different next steps, but
+      # no file state can turn this verdict into anything else (see the table above).
       case "$PIN_FILE_HAS_LINE" in
         yes)
           info "the pin IS in $PIN_ENV_FILE and a fresh session still does not see it — this is a PAM condition, NOT a missing pin"

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -1897,6 +1897,33 @@ if [ "$PIN_SECTION_OK" = 1 ] && [ "$PLATFORM" != linux ]; then
   PIN_SECTION_OK=0
 fi
 
+# Effective privilege, resolved BEFORE the seam guard because the guard now depends on it.
+# Unknown is treated as privileged (fail closed): a seam that steers a write must not be
+# admitted because we could not establish who we are.
+PIN_EUID=$(id -u 2>/dev/null || true)
+
+if [ "$PIN_SECTION_OK" = 1 ] && [ -n "${CQLITE_BOOTSTRAP_ENV_FILE:-}" ] \
+   && { [ "$PIN_EUID" = 0 ] || [ -z "$PIN_EUID" ]; }; then
+  # THE SEAM IS REFUSED OUTRIGHT UNDER ROOT (#3414 roborev round 5, HIGH).
+  #
+  # THIS IS THE SIXTH INSTANCE OF THIS ISSUE'S OWN DEFECT IN THIS LANE, AND IT WAS INSIDE
+  # THE SAFETY GUARD ITSELF. The invariant below used to read `${#PIN_ROOT[@]} -gt 0`,
+  # i.e. "are we going through sudo" — a PROXY for the fact that matters, which is
+  # EFFECTIVE PRIVILEGE. When bootstrap is itself EUID 0, PIN_ROOT is empty and the
+  # `tee -a` is privileged anyway, so "no env var can ever steer a PRIVILEGED write" was
+  # FALSE under root: CQLITE_BOOTSTRAP_ENV_FILE could aim a root write at any absolute
+  # path. Presence of a sudo prefix stood in for being privileged exactly as presence in
+  # ~/.bashrc stood in for a gate seeing the pin.
+  #
+  # Refused rather than made safe: dropping to a validated UID would put MORE machinery
+  # in the privileged path, and the seam exists precisely to avoid privileged writes. The
+  # cost is real and accepted — the section cannot be exercised through the seam as root,
+  # so a test that needs it must SKIP (counted), never report ok.
+  warn "gate-pin: SKIPPED (CQLITE_BOOTSTRAP_ENV_FILE is set and this process is root or of unknown identity — refusing a seam that could steer a PRIVILEGED write at an env-chosen path)"
+  info "the seam is for unprivileged self-tests only; run them as a normal user"
+  PIN_SECTION_OK=0
+fi
+
 if [ "$PIN_SECTION_OK" = 1 ] && [ -n "${CQLITE_BOOTSTRAP_ENV_FILE:-}" ]; then
   # TEST-ONLY SEAM — fail-closed, with NO production fallback (the #3249 lesson: a test
   # seam that degrades to the real path certifies the real path by accident). It exists
@@ -1942,9 +1969,37 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   PIN_ROOT=()
   PIN_PRIV_STATE=unknown
   PIN_SELF_USER=$(id -un 2>/dev/null || true)
-  PIN_SELF_UID=$(id -u 2>/dev/null || true)
+  PIN_SELF_UID="$PIN_EUID"   # one source: resolved before the seam guard, which needs it
+  # UNDER `sudo bash bootstrap …` THE ANSWER TO `id -un` IS root, WHICH IS THE WRONG
+  # SUBJECT (#3414 roborev round 5). Gates run as the agent account, and the two genuinely
+  # diverge: a per-user `~/.pam_environment` on that account, or a sudoers rule that
+  # supplies a value only for root's sessions, both make root's session say VERIFIED while
+  # the account that matters gets something else. So when we are root and sudo told us who
+  # invoked us, probe THAT account.
+  #
+  # The name is VALIDATED before use, and an unresolvable one is UNMEASURED rather than a
+  # silent fall back to root: falling back would answer a question about the wrong user
+  # and report it as if it were the right one, which is the substitution this whole
+  # section exists to stop.
+  PIN_PROBE_SUBJECT_NOTE=""
+  if [ "$PIN_EUID" = 0 ]; then
+    pin_invoker="${SUDO_USER:-}"
+    if [ -z "$pin_invoker" ] && [ -n "${SUDO_UID:-}" ]; then
+      pin_invoker=$(id -un "$SUDO_UID" 2>/dev/null || true)
+    fi
+    if [ -n "$pin_invoker" ]; then
+      if id -u "$pin_invoker" >/dev/null 2>&1; then
+        PIN_SELF_USER="$pin_invoker"
+        PIN_PROBE_SUBJECT_NOTE="probed as '$pin_invoker' (the account that invoked sudo), not root — root's session is not the one a gate runs in"
+      else
+        PIN_SELF_USER=""
+        PIN_PROBE_SUBJECT_NOTE="sudo named invoker '$pin_invoker', which does not resolve to an account"
+      fi
+    fi
+  fi
   if [ -z "$PIN_SELF_USER" ]; then
     PIN_PRIV_STATE=no-identity
+    [ -n "$PIN_PROBE_SUBJECT_NOTE" ] && PIN_PRIV_STATE=invoker-unresolvable
   elif ! have sudo; then
     PIN_PRIV_STATE=no-sudo-binary
   elif ! bounded 10 sudo -n true >/dev/null 2>&1; then
@@ -2076,9 +2131,13 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
     PIN_PERSIST_NOTE="no privilege to write $PIN_ENV_FILE ($PIN_PRIV_STATE)"
     warn "gate-pin: cannot write $PIN_ENV_FILE ($PIN_PRIV_STATE) — the pin was NOT persisted"
     info "add these two lines as root:  $PIN_ENV_COMMENT / $PIN_ENV_LINE"
-  elif [ "${#PIN_ROOT[@]}" -gt 0 ] && [ "$PIN_ENV_FILE" != /etc/environment ]; then
-    # INVARIANT, enforced rather than argued. The seam forces PIN_ROOT empty above, so
-    # this can only fire if that coupling is ever broken by a later edit.
+  elif { [ "$PIN_EUID" = 0 ] || [ -z "$PIN_EUID" ] || [ "${#PIN_ROOT[@]}" -gt 0 ]; } \
+       && [ "$PIN_ENV_FILE" != /etc/environment ]; then
+    # INVARIANT, enforced rather than argued — and keyed on EFFECTIVE PRIVILEGE, not on
+    # the presence of a sudo prefix (#3414 roborev round 5). `${#PIN_ROOT[@]} -gt 0` alone
+    # was a proxy: under EUID 0 the array is empty and the write is privileged regardless,
+    # so the old form could not fire on the one path where it mattered most. An unknown
+    # EUID counts as privileged, because a guard that abstains is not a guard.
     PIN_PERSIST_NOTE="internal invariant refused the write"
     warn "gate-pin: INTERNAL — refusing a PRIVILEGED write to a non-production path ($PIN_ENV_FILE)"
   else
@@ -2197,8 +2256,76 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
     # every PAM stack (sshd, login, su, sudo), so the claim is not limited to the one
     # session type the probe could open. What it does NOT buy is a launch path with no
     # PAM in its ancestry at all — that residual is real and is stated, not implied.
-    info "scope: the line is in $PIN_ENV_FILE, which pam_env reads for EVERY PAM-created session (sshd, login, su, sudo) — but a process tree created WITHOUT PAM, a systemd unit or a container entrypoint, never has it applied, so this does not prove every gate on this box is pinned"
+    info "scope: the line is in $PIN_ENV_FILE and the sshd/login session stacks were CHECKED to read it, so the claim is not limited to the sudo session probed — but a process tree created WITHOUT PAM, a systemd unit or a container entrypoint, never has it applied, so this does not prove every gate on this box is pinned"
     info "the authoritative per-run confirmation is the gate's own SUMMARY line:  cpu-budget: ... max-concurrency=N(pinned)   (N(default) there means that gate did not see the pin)"
+    [ -n "$PIN_PROBE_SUBJECT_NOTE" ] && info "subject: $PIN_PROBE_SUBJECT_NOTE"
+    [ -n "$PIN_PAM_UNCHECKED" ] && info "unchecked: $PIN_PAM_UNCHECKED — those service stacks could not be read, so this run says nothing about them either way"
+  }
+
+  # pin_pam_services_missing_readenv: the sshd/login session stacks that do NOT read
+  # $PIN_ENV_FILE. Echoes the offending service names, empty when none.
+  #
+  # A WEAKEN-ONLY SIGNAL, AND THAT IS WHAT MAKES CONSULTING CONFIG LEGITIMATE HERE
+  # (#3414 roborev round 5). Reading configuration to CREATE a positive verdict is the
+  # proxy reasoning this whole issue exists to remove — a file saying pam_env is loaded is
+  # not evidence that a session got the value, exactly as a line in ~/.bashrc was not. But
+  # the converse is sound: if the stack a gate's session is actually created by does not
+  # read the file at all, then a SUDO-verified pin is not evidence about that session. So
+  # this may only ever DOWNGRADE a would-be VERIFIED and can never produce one. Same
+  # asymmetry as the negative-probe rule above: an unmeasurable or absent half may weaken
+  # a positive claim and may never strengthen one.
+  #
+  # THE PREDICATE IS MEASURED, NOT GUESSED. `readenv` DEFAULTS TO ON (pam_env(8): "By
+  # default this option is on"), so a BARE `pam_env.so` reads the file and only an
+  # explicit `readenv=0` disables it — requiring the literal `readenv=1` would flag this
+  # very box, whose /etc/pam.d/sshd carries a bare `pam_env.so`, and weaken a correctly
+  # configured machine. A line with an explicit `envfile=` pointing somewhere ELSE (sshd
+  # and login both carry one for /etc/default/locale) is likewise not evidence for this
+  # file. So: a session line invoking pam_env.so, without readenv=0, and either without an
+  # envfile= or with one naming $PIN_ENV_FILE.
+  #
+  # A service whose config is ABSENT is not a gap — a box with no sshd needs no sshd
+  # stack. A service whose config is present but UNREADABLE is recorded as unchecked
+  # (PIN_PAM_UNCHECKED) rather than treated as missing: "cannot tell" must not manufacture
+  # a downgrade any more than it may manufacture a pass.
+  #
+  # THE DIRECTORY IS OVERRIDABLE ONLY INSIDE AN ALREADY-VALIDATED SEAM, and deliberately
+  # not by a switch of its own. `CQLITE_BOOTSTRAP_PAM_DIR` is honoured ONLY when
+  # PIN_ENV_FILE_IS_SEAM is 1 — i.e. when the env-file seam has already passed test-mode,
+  # absolute-path, not-production and NOT-ROOT validation — so it adds no new reachable
+  # surface and cannot be set independently of that gate. It matters that this is the
+  # direction it is: pointing the check at a directory that looks healthy could SUPPRESS a
+  # downgrade, and suppressing a downgrade is how a VERIFIED gets manufactured. Tying it
+  # to the seam keeps that reachable only where the section is already non-production.
+  PIN_PAM_DIR=/etc/pam.d
+  if [ "$PIN_ENV_FILE_IS_SEAM" = 1 ] && [ -n "${CQLITE_BOOTSTRAP_PAM_DIR:-}" ]; then
+    case "$CQLITE_BOOTSTRAP_PAM_DIR" in
+      /etc/pam.d) : ;;                      # never the production directory
+      /*) [ -d "$CQLITE_BOOTSTRAP_PAM_DIR" ] && PIN_PAM_DIR="$CQLITE_BOOTSTRAP_PAM_DIR" ;;
+    esac
+  fi
+  PIN_PAM_UNCHECKED=""
+  pin_pam_services_missing_readenv() {
+    local svc f missing=""
+    for svc in sshd login; do
+      f="$PIN_PAM_DIR/$svc"
+      [ -e "$f" ] || continue
+      if [ ! -r "$f" ]; then
+        PIN_PAM_UNCHECKED="${PIN_PAM_UNCHECKED:+$PIN_PAM_UNCHECKED }$svc"
+        continue
+      fi
+      if ! awk -v envfile="$PIN_ENV_FILE" '
+            /^[[:space:]]*#/ { next }
+            $1 == "session" && /pam_env\.so/ {
+              if ($0 ~ /readenv=0/) next
+              if ($0 ~ /envfile=/) { if ($0 !~ ("envfile=" envfile "([[:space:]]|$)")) next }
+              found = 1
+            }
+            END { exit(found ? 0 : 1) }' "$f" 2>/dev/null; then
+        missing="${missing:+$missing }$svc"
+      fi
+    done
+    printf '%s' "$missing"
   }
 
   # pin_value_remedy: the remedy for a VISIBLE but NOT-HONOURED value. Shared by both
@@ -2255,6 +2382,9 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   if [ -z "$TIMEOUT_BIN" ]; then
     warn "gate-pin: UNMEASURED (no timeout/gtimeout on PATH — refusing to run an UNBOUNDED session probe during bootstrap)"
     info "install GNU coreutils so the probe can be bounded (macOS: brew install coreutils), then re-run"
+  elif [ "$PIN_PRIV_STATE" = invoker-unresolvable ]; then
+    warn "gate-pin: UNMEASURED ($PIN_PROBE_SUBJECT_NOTE, and root's own session is NOT the subject a gate runs in — refusing to answer about the wrong user)"
+    info "re-run as the agent account, or fix SUDO_USER/SUDO_UID so the invoking account can be resolved"
   elif [ "$PIN_PRIV_STATE" = no-identity ]; then
     warn "gate-pin: UNMEASURED ('id -un' reported no identity, so there is no user to open a probe session as — pin visibility is UNKNOWN, not ok)"
   elif [ "$PIN_PRIV_STATE" = no-sudo-binary ]; then
@@ -2358,8 +2488,18 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
               # free to disagree with the gate — the thing avoided by asking the gate what
               # it honours instead of re-deriving its rules.
               if [ "$PIN_FILE_VALUE" = "$pin_probe_seen" ]; then
+                pin_pam_gap=$(pin_pam_services_missing_readenv)
+                if [ -n "$pin_pam_gap" ]; then
+                  # WEAKEN ONLY. Both affirmative halves hold, but the session stacks a
+                  # gate is actually created by do not read this file, so what was
+                  # measured through sudo is not evidence about them.
+                  warn "gate-pin: NOT-SYSTEM-WIDE ($PIN_ENV_FILE sets CQLITE_GATE_MAX_CONCURRENCY=$PIN_FILE_VALUE and a sudo session sees it, but the PAM stack for [$pin_pam_gap] does NOT read $PIN_ENV_FILE — sessions created by those services, which is how gates are launched, will not get it)"
+                  info "add a session-stage 'pam_env.so' (readenv defaults to on) to /etc/pam.d/{$(printf '%s' "$pin_pam_gap" | tr ' ' ',')}, then re-run"
+                  info "the sudo-session result above is real but does not generalise; the per-run authority stays the gate's own cpu-budget: max-concurrency=N(...) token"
+                else
                 ok "gate-pin: VERIFIED ($PIN_ENV_FILE sets CQLITE_GATE_MAX_CONCURRENCY=$PIN_FILE_VALUE AND a fresh PAM-created, profile-free session sees that SAME value, which the gate HONOURS verbatim — max-concurrency=$pin_probe_seen(pinned); this run's own value, BASH_ENV and ENV were scrubbed first)"
                 pin_scope_note
+                fi
               else
                 warn "gate-pin: NOT-SYSTEM-WIDE ($PIN_ENV_FILE sets CQLITE_GATE_MAX_CONCURRENCY='$PIN_FILE_VALUE' but this session sees '$pin_probe_seen' — a sudo- or user-specific source is OVERRIDING the system-wide file, so ordinary PAM sessions get the file's value and the gate will act on THAT, not on the one measured here)"
                 info "fix the VALUE in $PIN_ENV_FILE (bootstrap never rewrites an existing value), or remove the per-user/sudoers override so the two agree"

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -2269,8 +2269,19 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
     ${PIN_ROOT[@]+"${PIN_ROOT[@]}"} bash -c '
       umask 022
       f="$3"
-      ( set -C; : > "$f" ) 2>/dev/null || exit 4
-      printf "%s\n%s\n" "$1" "$2" > "$f" 2>/dev/null || exit 5
+      # ATOMIC CREATE *WITH CONTENT*, via a hard link (roborev job 323, Medium). The previous
+      # form created the file exclusively and THEN wrote it, which reopened the very window it
+      # was meant to close: another writer appending between the two steps had its content
+      # erased by the truncating write, so the create was "atomic" only in the sense that
+      # nothing else could CREATE it. Writing the content into a temporary in the SAME
+      # directory and then `ln`-ing it into place makes the file appear complete or not at
+      # all — `ln` fails if the destination exists, so exclusivity and completeness are the
+      # same operation instead of two.
+      t="$f.cqlite-pin.$$"
+      rm -f "$t" 2>/dev/null
+      printf "%s\n%s\n" "$1" "$2" > "$t" 2>/dev/null || { rm -f "$t" 2>/dev/null; exit 5; }
+      ln "$t" "$f" 2>/dev/null || { rm -f "$t" 2>/dev/null; exit 4; }
+      rm -f "$t" 2>/dev/null
     ' _ "$PIN_ENV_COMMENT" "$PIN_ENV_LINE" "$PIN_ENV_FILE" 2>/dev/null
     pin_child_rc=$?
     if [ "$pin_child_rc" = 4 ]; then pin_create_rc=3; return 3; fi

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -65,8 +65,11 @@
 #      VISIBILITY IS ONLY HALF THE QUESTION: a value the gate does not HONOUR is a pin
 #      in name only, so the gate itself is then asked (via its `--cpu-budget` hook,
 #      never a re-derivation of its rules) what it will do with the value. One
-#      greppable `gate-pin:` line: VERIFIED / NOT-HONOURED / FAILED / UNMEASURED, and
-#      only VERIFIED is an [ok] (same posture as `git-push:`). `--yes` persists it, and
+#      greppable `gate-pin:` line: VERIFIED / NOT-SYSTEM-WIDE / NOT-HONOURED / FAILED /
+#      UNMEASURED, and only VERIFIED is an [ok] (same posture as `git-push:`). VERIFIED
+#      requires BOTH halves — the line present in the system-wide file AND a fresh
+#      session that sees a value the gate honours — because file-only was the original
+#      #3414 defect and session-only certifies a pin that may reach sudo sessions alone. `--yes` persists it, and
 #      so does the narrow `--fix-gate-pin` that `.agent-ami/profile.yaml`'s verify.run
 #      passes, so a freshly launched box is PINNED rather than merely reported unpinned.
 #      PAM reads /etc/environment at session creation, so the probe in the SAME run sees
@@ -2047,7 +2050,11 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   # a doc, because an unqualified VERIFIED reads as "gates on this box are pinned" and the
   # probe cannot see a gate launched from a non-PAM parent (#3414 review B2).
   pin_scope_note() {
-    info "scope: this measured a PAM-created (sudo) session. A process tree created WITHOUT PAM — a systemd unit, a container entrypoint — never has $PIN_ENV_FILE applied, so this does NOT prove every gate on this box is pinned"
+    # What the correlation DOES buy: the line is in the system-wide file pam_env reads in
+    # every PAM stack (sshd, login, su, sudo), so the claim is not limited to the one
+    # session type the probe could open. What it does NOT buy is a launch path with no
+    # PAM in its ancestry at all — that residual is real and is stated, not implied.
+    info "scope: the line is in $PIN_ENV_FILE, which pam_env reads for EVERY PAM-created session (sshd, login, su, sudo) — but a process tree created WITHOUT PAM, a systemd unit or a container entrypoint, never has it applied, so this does not prove every gate on this box is pinned"
     info "the authoritative per-run confirmation is the gate's own SUMMARY line:  cpu-budget: ... max-concurrency=N(pinned)   (N(default) there means that gate did not see the pin)"
   }
 
@@ -2143,14 +2150,47 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
       pin_gate_src=$(pin_gate_source_for "$pin_probe_seen") || pin_gate_src=""
       case "$pin_gate_src" in
         pinned)
-          # The text says what was MEASURED and nothing more. It used to assert the value
-          # "came from the system env file via PAM, not from inheritance" — the second
-          # half is establishable (this run's value, BASH_ENV and ENV were all scrubbed),
-          # the FIRST half is not: ~/.pam_environment or a sudoers env_file satisfies the
-          # observation identically. Claiming an attribution the probe cannot make is the
-          # proxy-for-a-fact shape this whole section exists to remove.
-          ok "gate-pin: VERIFIED (a PAM-created, profile-free session sees CQLITE_GATE_MAX_CONCURRENCY=$pin_probe_seen and the gate HONOURS it verbatim — max-concurrency=$pin_probe_seen(pinned); this run's own value, BASH_ENV and ENV were scrubbed first, so it is not inherited from this shell)"
-          pin_scope_note
+          # TWO AFFIRMATIVE HALVES, AND NEITHER SUFFICES ALONE (#3414 roborev round 2).
+          # Scoping the TEXT to "a sudo session" while leaving the VERDICT an `ok` still
+          # certified onboarding green: zero warnings => "All checks green." => verify.run
+          # passes, on a box where the value might reach ONLY sudo sessions (a sudoers
+          # `env_file`, `~/.pam_environment`) while every gate launched outside sudo gets
+          # nothing. A verdict that passes while its own text says it might not hold is a
+          # contradiction, not a caveat.
+          #
+          # So the probe is CORRELATED WITH THE FILE, using the read already taken to
+          # decide the append — no second probe:
+          #   file line + session sees it  => VERIFIED, and that is well-founded for ANY
+          #     PAM-created session (sshd, login, su — pam_env reads /etc/environment in
+          #     all of those stacks, not just sudo's), not merely for the one we opened.
+          #   session sees it, no file line => the value comes from something sudo- or
+          #     user-specific; it is NOT a system-wide pin. Non-passing.
+          # File-only was the ORIGINAL #3414 defect and session-only is this finding, so
+          # requiring both is the smallest honest verdict. Two fixes the reviewer offered
+          # are deliberately NOT taken: "verify through the actual gate launch path"
+          # (bootstrap cannot know that path) and "keep any sudo-scoped result
+          # non-passing" (the probe is ALWAYS sudo-scoped, so that reds every box's
+          # onboarding forever — an always-firing alarm is one people learn to waive,
+          # which is the same reason the fleet does not just let verify red).
+          case "$PIN_FILE_HAS_LINE" in
+            yes)
+              ok "gate-pin: VERIFIED ($PIN_ENV_FILE carries the line AND a fresh PAM-created, profile-free session sees CQLITE_GATE_MAX_CONCURRENCY=$pin_probe_seen, which the gate HONOURS verbatim — max-concurrency=$pin_probe_seen(pinned); this run's own value, BASH_ENV and ENV were scrubbed first)"
+              pin_scope_note
+              ;;
+            unknown)
+              # Half the evidence is unreadable, so the correlation cannot be made. Not a
+              # pass: a positive verdict requires an affirmative measurement of BOTH halves.
+              warn "gate-pin: UNMEASURED (a fresh session sees CQLITE_GATE_MAX_CONCURRENCY=$pin_probe_seen and the gate would honour it, but $PIN_ENV_FILE could not be READ, so it cannot be confirmed the value is a system-wide pin rather than a sudo- or user-specific one)"
+              ;;
+            *)
+              warn "gate-pin: NOT-SYSTEM-WIDE (a fresh session sees CQLITE_GATE_MAX_CONCURRENCY=$pin_probe_seen and the gate would honour it, but there is NO CQLITE_GATE_MAX_CONCURRENCY line in $PIN_ENV_FILE — so it is reaching this session from a sudo- or user-specific source (a sudoers env_file, ~/.pam_environment) and gates launched outside that source get nothing)"
+              if [ "$PIN_FILE_HAS_LINE" = absent-file ]; then
+                info "this $PLATFORM host has no $PIN_ENV_FILE, so there is no system-wide file to correlate against — set CQLITE_GATE_MAX_CONCURRENCY=1 in this host's own session-startup mechanism (launchd/systemd/the image)"
+              else
+                info "fix:  bash scripts/bootstrap-agent-machine.sh --fix-gate-pin   (persists '$PIN_ENV_LINE' to $PIN_ENV_FILE, which every PAM session reads — the per-user source stays as it is)"
+              fi
+              ;;
+          esac
           ;;
         invalid)
           # Its OWN verdict, not FAILED: the pin is present and visible, so "persist the

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -2189,6 +2189,28 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   fi
 
   PIN_CREATE_RESIDUE=""
+  # pin_create_env_file: CREATE-IF-ABSENT, atomically (roborev job 314, Medium). The
+  # `[ ! -e "$PIN_ENV_FILE" ]` test in the caller and the write are two separate steps, and
+  # the write used to be a TRUNCATING `tee` — so a file created in between, by cloud-init, a
+  # provisioning run or a peer agent on the same box, was silently OVERWRITTEN and whatever
+  # it held was destroyed. On a fleet that runs bootstrap on several lanes per box that is a
+  # live race, not a theoretical one.
+  #
+  # `set -C` (noclobber) opens with O_EXCL, so the KERNEL arbitrates and a loser writes
+  # nothing — the same reason the claim protocol pushes a ref instead of checking for one.
+  # `umask 022` establishes the mode AT CREATION instead of chmod-ing afterwards, which also
+  # closes the window where the file briefly exists at a mode nobody chose. The readback in
+  # pin_create_mode_ok stays as verification: setting a umask is an instruction, and this
+  # section's whole rule is that an instruction is not a measurement.
+  pin_create_env_file() {
+    ${PIN_ROOT[@]+"${PIN_ROOT[@]}"} bash -c '
+      umask 022
+      set -C
+      printf "%s\n%s\n" "$1" "$2" > "$3"
+    ' _ "$PIN_ENV_COMMENT" "$PIN_ENV_LINE" "$PIN_ENV_FILE" 2>/dev/null || return 1
+    pin_create_mode_ok "$PIN_ENV_FILE"
+  }
+
   # pin_create_mode_ok: establish 0644 on a JUST-CREATED env file and CONFIRM it by reading
   # the mode BACK. chmod's exit status answers a different question than "is the mode
   # right": a chmod that fails on a file already at 0644 is harmless, and one that reports
@@ -2245,9 +2267,7 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
       PIN_PERSIST_NOTE="no $PIN_ENV_FILE and no privilege to create it ($PIN_PRIV_STATE)"
       warn "gate-pin: $PIN_ENV_FILE does not exist and this run cannot create it ($PIN_PRIV_STATE) — the pin was NOT persisted"
       info "create it as root:  printf '%s\n' '$PIN_ENV_COMMENT' '$PIN_ENV_LINE' > $PIN_ENV_FILE && chmod 0644 $PIN_ENV_FILE"
-    elif printf '%s\n%s\n' "$PIN_ENV_COMMENT" "$PIN_ENV_LINE" \
-           | ${PIN_ROOT[@]+"${PIN_ROOT[@]}"} tee "$PIN_ENV_FILE" >/dev/null 2>&1 \
-         && pin_create_mode_ok "$PIN_ENV_FILE"; then
+    elif pin_create_env_file; then
       PIN_FILE_HAS_LINE=yes; PIN_FILE_VALUE="$PIN_ENV_VALUE"
       # REPORT WHAT IT ACTUALLY IS, read back — not what the write intended. An earlier
       # draft of this line asserted "root:root 0644" unconditionally, which is false

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -66,7 +66,11 @@
 #      in name only, so the gate itself is then asked (via its `--cpu-budget` hook,
 #      never a re-derivation of its rules) what it will do with the value. One
 #      greppable `gate-pin:` line: VERIFIED / NOT-HONOURED / FAILED / UNMEASURED, and
-#      only VERIFIED is an [ok] (same posture as `git-push:`).
+#      only VERIFIED is an [ok] (same posture as `git-push:`). `--yes` persists it, and
+#      so does the narrow `--fix-gate-pin` that `.agent-ami/profile.yaml`'s verify.run
+#      passes, so a freshly launched box is PINNED rather than merely reported unpinned.
+#      PAM reads /etc/environment at session creation, so the probe in the SAME run sees
+#      what the write just persisted — no reboot and no re-login.
 #   6. Health check: run the gate's fmt component and print its authoritative
 #      `accelerators:` line.
 #
@@ -88,6 +92,16 @@
 #                                                      #   withholds "All checks green." and can
 #                                                      #   never buy a vacuous green. For offline
 #                                                      #   boxes and hermetic self-tests.
+#   bash scripts/bootstrap-agent-machine.sh --fix-gate-pin     # persist the single-gate pin
+#                                                      #   (section 5b's /etc/environment write)
+#                                                      #   WITHOUT --yes, and nothing else — the
+#                                                      #   sibling of --fix-credentials, and what
+#                                                      #   .agent-ami/profile.yaml's verify.run
+#                                                      #   uses so a freshly launched box is
+#                                                      #   PINNED rather than merely reported
+#                                                      #   unpinned. Needs privilege; when it
+#                                                      #   cannot persist, the section stays
+#                                                      #   non-passing (never an [ok]).
 #   bash scripts/bootstrap-agent-machine.sh --skip-gate-pin    # skip ONLY section 5b (the
 #                                                      #   single-gate pin: the /etc/environment
 #                                                      #   write AND the PAM-session visibility
@@ -128,6 +142,20 @@ SKIP_GATE_PIN_HOW=""
 if [ "${CQLITE_BOOTSTRAP_SKIP_GATE_PIN:-0}" = 1 ]; then
   SKIP_GATE_PIN=1; SKIP_GATE_PIN_HOW="CQLITE_BOOTSTRAP_SKIP_GATE_PIN=1"
 fi
+# --fix-gate-pin (issue #3414): perform section 5b's /etc/environment write WITHOUT --yes,
+# and nothing else. A SIBLING of --fix-credentials, deliberately not a widening of it:
+# that flag documents itself as running section 3b's auto-fix "and NOTHING else", and
+# quietly making that false is the drift this codebase pays for later. Same one-flag-per-
+# subject rule --skip-push-probe / --skip-smoke / --skip-gate-pin already follow.
+#
+# WHY A REPAIR FLAG AT ALL. `.agent-ami/profile.yaml`'s verify.run is the only bootstrap
+# invocation a launcher-onboarded box ever gets, and it does not pass --yes. Without this
+# flag a fresh box is left UNPINNED and verify merely reds — which converts #3414's silent
+# defect into a loud one without removing it, and a verify that reds on every new box is an
+# alarm people learn to waive. Persisting env wiring is not a toolchain install, so verify
+# stays a verification step rather than becoming an installer — the same reasoning that
+# justified --fix-credentials.
+FIX_GATE_PIN=0
 FIX_CREDENTIALS=0
 STRICT=0
 for arg in "$@"; do
@@ -136,6 +164,7 @@ for arg in "$@"; do
     --skip-smoke) SKIP_SMOKE=1 ;;
     --skip-push-probe) SKIP_PUSH_PROBE=1 ;;
     --skip-gate-pin) SKIP_GATE_PIN=1; SKIP_GATE_PIN_HOW="--skip-gate-pin" ;;
+    --fix-gate-pin) FIX_GATE_PIN=1 ;;
     --fix-credentials) FIX_CREDENTIALS=1 ;;
     --strict) STRICT=1 ;;
     -h|--help)
@@ -147,6 +176,20 @@ for arg in "$@"; do
     *) echo "bootstrap: unknown arg: $arg (try --help)" >&2; exit 2 ;;
   esac
 done
+
+# Contradictory intents must not resolve silently — "I told it to fix the pin and it
+# skipped the section" is exactly the class of quiet surprise this issue is about.
+# An EXPLICIT --skip-gate-pin beside --fix-gate-pin is a usage error; the ENV opt-out is
+# the weaker signal, so an explicit --fix-gate-pin overrides it (a harness exporting
+# CQLITE_BOOTSTRAP_SKIP_GATE_PIN=1 must not be able to neuter a caller's explicit repair).
+# Resolved here, after the loop, so flag ORDER cannot change the outcome.
+if [ "$FIX_GATE_PIN" = 1 ] && [ "$SKIP_GATE_PIN" = 1 ]; then
+  if [ "$SKIP_GATE_PIN_HOW" = "--skip-gate-pin" ]; then
+    echo "bootstrap: --skip-gate-pin and --fix-gate-pin are contradictory (try --help)" >&2
+    exit 2
+  fi
+  SKIP_GATE_PIN=0; SKIP_GATE_PIN_HOW=""
+fi
 
 # ---- OS + package-manager detection ----
 OS=$(uname -s)
@@ -1918,9 +1961,9 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
     warn "gate-pin: cannot read $PIN_ENV_FILE — cannot tell whether the pin is already there, so nothing was written (a blind append could duplicate or contradict an existing line)"
   elif [ "$PIN_FILE_HAS_LINE" = yes ]; then
     info "$PIN_ENV_FILE already carries a CQLITE_GATE_MAX_CONCURRENCY line — left EXACTLY as it is (a box deliberately running >1 concurrent gate overrides the pin; bootstrap never rewrites an existing value)"
-  elif [ "$AUTO_YES" != 1 ]; then
-    PIN_PERSIST_NOTE="not persisted (no --yes)"
-    info "persist the pin:  bash scripts/bootstrap-agent-machine.sh --yes   (appends '$PIN_ENV_LINE' to $PIN_ENV_FILE)"
+  elif [ "$AUTO_YES" != 1 ] && [ "$FIX_GATE_PIN" != 1 ]; then
+    PIN_PERSIST_NOTE="not persisted (neither --yes nor --fix-gate-pin)"
+    info "persist the pin:  bash scripts/bootstrap-agent-machine.sh --fix-gate-pin   (appends '$PIN_ENV_LINE' to $PIN_ENV_FILE; --yes does it too)"
   elif [ "$PIN_WRITE_PRIV" != 1 ]; then
     PIN_PERSIST_NOTE="no privilege to write $PIN_ENV_FILE ($PIN_PRIV_STATE)"
     warn "gate-pin: cannot write $PIN_ENV_FILE ($PIN_PRIV_STATE) — the pin was NOT persisted"
@@ -2098,7 +2141,7 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
       case "$PIN_FILE_HAS_LINE" in
         yes)
           info "the pin IS in $PIN_ENV_FILE and a fresh session still does not see it — this is a PAM condition, NOT a missing pin"
-          info "re-running with --yes will NOT help: it finds the line already present and changes nothing"
+          info "re-running with --yes / --fix-gate-pin will NOT help: either finds the line already present and changes nothing"
           info "check the session stack reads it:  grep -n pam_env /etc/pam.d/sudo /etc/pam.d/login /etc/pam.d/sshd   (each needs 'pam_env.so readenv=1')"
           ;;
         absent-file)
@@ -2109,7 +2152,7 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
           ;;
         *)
           [ -n "$PIN_PERSIST_NOTE" ] && info "nothing was persisted this run: $PIN_PERSIST_NOTE"
-          info "fix:  bash scripts/bootstrap-agent-machine.sh --yes   (appends '$PIN_ENV_LINE' to $PIN_ENV_FILE)"
+          info "fix:  bash scripts/bootstrap-agent-machine.sh --fix-gate-pin   (appends '$PIN_ENV_LINE' to $PIN_ENV_FILE; --yes does it too)"
           ;;
       esac
       info "the gate reports the same fact on its cpu-budget line as max-concurrency=N(default) instead of N(pinned)"

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -71,11 +71,12 @@
 #      session that sees a value the gate honours — because file-only was the original
 #      #3414 defect and session-only certifies a pin that may reach sudo sessions alone,
 #      and the file's VALUE must EQUAL the session's (presence alone let a file saying
-#      `abc` pass while a per-user override supplied `1`). NON-LINUX hosts report an
-#      a NARROWER question, never an exemption: there is no PAM-read system-wide file to
-#      correlate against, so the file half is dropped and the verdict is the scoped
-#      VERIFIED-NO-SYSTEM-FILE — but an unpinned non-Linux host is still NON-PASSING. An
-#      unconditional `ok` there let `--strict` certify an unpinned Mac. `--yes` persists it, and
+#      `abc` pass while a per-user override supplied `1`). NON-LINUX hosts get UNMEASURED
+#      and never a success: with no PAM-read system-wide file there is nothing to correlate
+#      the session value against, so a machine-wide pin cannot be told apart from a sudo-
+#      or user-scoped one that ordinary gate processes never see. No verdict that reports a
+#      state is available there, so none is given. `verify.run` runs on Linux, so nothing
+#      on this fleet regresses. `--yes` persists it, and
 #      so does the narrow `--fix-gate-pin` that `.agent-ami/profile.yaml`'s verify.run
 #      passes, so a freshly launched box is PINNED rather than merely reported unpinned.
 #      PAM reads /etc/environment at session creation, so the probe in the SAME run sees
@@ -2526,8 +2527,26 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
           # an unpinned host still lands in the non-passing branch below (#3414 final
           # roborev — the earlier `NOT-APPLICABLE` ok certified exactly that host).
           if [ "${PIN_PLATFORM_UNMANAGED:-0}" = 1 ]; then
-            ok "gate-pin: VERIFIED-NO-SYSTEM-FILE (a fresh, profile-free session on this $PLATFORM host sees CQLITE_GATE_MAX_CONCURRENCY=$pin_probe_seen and the gate HONOURS it verbatim — max-concurrency=$pin_probe_seen(pinned); this run's own value, BASH_ENV and ENV were scrubbed first. There is no PAM-read system-wide file here, so this does NOT establish the pin is system-wide — only that a fresh session gets it)"
-            pin_scope_note
+            # NO SUCCESS VERDICT IS AVAILABLE HERE, SO NONE IS GIVEN (#3414 roborev round
+            # 14). With no PAM-read system-wide file there is nothing to correlate the
+            # session value against — and that correlation is exactly how the Linux path
+            # tells a machine-wide pin from a sudo- or user-scoped one (a sudoers
+            # `env_file`, `~/.pam_environment`). The problem is not merely unsolved here,
+            # it is UNSOLVABLE with the machinery this section has.
+            #
+            # So every verdict that reports a state either over-claims or permanently reds:
+            # an `ok` certifies a host whose ordinary gate processes may be unpinned, and a
+            # FAILED asserts an absence nothing established. The honest third answer is that
+            # the measurement could not be taken, cause named. "Could not measure" is a
+            # different statement from "wrong", and it is the true one — so this is NOT the
+            # red-on-correct-input shape refused elsewhere in this section.
+            #
+            # SECOND GUARD ON THIS BRANCH REPLACED RATHER THAN PATCHED, after the PAM
+            # weaken-signal. Introduced round 11, amended round 13, defective again round
+            # 14; the pre-committed trigger for that pattern is deletion, and it applies to
+            # a verdict the LEAD introduced exactly as it applied to the PAM signal.
+            warn "gate-pin: UNMEASURED (a fresh, profile-free session on this $PLATFORM host sees CQLITE_GATE_MAX_CONCURRENCY=$pin_probe_seen and the gate would HONOUR it — but this platform has no PAM-read system-wide file to compare it against, so a machine-wide pin cannot be told apart from a sudo- or user-scoped one that ordinary gate processes never see)"
+            info "on this platform the per-run authority is the gate's own SUMMARY line:  cpu-budget: ... max-concurrency=N(pinned)   (N(default) means that gate did not see the pin)"
           else
           case "$PIN_FILE_HAS_LINE" in
             yes)

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -2254,8 +2254,9 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   # nothing — the same reason the claim protocol pushes a ref instead of checking for one.
   # `umask 022` establishes the mode AT CREATION instead of chmod-ing afterwards, which also
   # closes the window where the file briefly exists at a mode nobody chose. The readback in
-  # pin_create_mode_ok stays as verification: setting a umask is an instruction, and this
-  # section's whole rule is that an instruction is not a measurement.
+  # The mode is VERIFIED, not merely instructed: setting a umask/chmod is an instruction, and
+  # this section's whole rule is that an instruction is not a measurement. The verification now
+  # happens on the STAGED file before `ln` (job 329) rather than on the destination after it.
   pin_create_env_file() {
     # THE CREATE AND THE WRITE ARE SEPARATE STEPS SO THEIR FAILURES ARE DISTINGUISHABLE
     # (roborev job 321, Medium). Collapsing them and then asking `[ -e "$FILE" ]` cannot tell
@@ -2280,11 +2281,26 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
       t="$f.cqlite-pin.$$"
       rm -f "$t" 2>/dev/null
       printf "%s\n%s\n" "$1" "$2" > "$t" 2>/dev/null || { rm -f "$t" 2>/dev/null; exit 5; }
+      # ESTABLISH AND VERIFY THE MODE ON THE *TEMP*, BEFORE LINKING (roborev job 329, Medium).
+      # This used to be a post-`ln` read-back with a rollback that removed the DESTINATION BY
+      # PATHNAME, which is a destructive race: `ln` succeeding proves the inode is ours AT
+      # LINK TIME, not at REMOVE time, so a provisioner that unlinked and replaced the file in
+      # between had ITS replacement deleted by our rollback. Verifying here makes the
+      # destination correct BY CONSTRUCTION — `ln` links the inode, so it carries this mode
+      # from the instant it appears — and removes the need for any rollback at all.
+      chmod 0644 "$t" 2>/dev/null || true
+      [ "$(stat -c %a "$t" 2>/dev/null)" = 644 ] || { rm -f "$t" 2>/dev/null; exit 6; }
       ln "$t" "$f" 2>/dev/null || { rm -f "$t" 2>/dev/null; exit 4; }
       rm -f "$t" 2>/dev/null
     ' _ "$PIN_ENV_COMMENT" "$PIN_ENV_LINE" "$PIN_ENV_FILE" 2>/dev/null
     pin_child_rc=$?
     if [ "$pin_child_rc" = 4 ]; then pin_create_rc=3; return 3; fi
+    if [ "$pin_child_rc" = 6 ]; then
+      # Mode could not be established ON THE STAGED FILE, so nothing was ever linked. The
+      # destination is untouched by construction — there is no rollback to get wrong.
+      PIN_CREATE_RESIDUE="0644 could not be established on the staged file, so $PIN_ENV_FILE was never created; the temporary was removed by the child"
+      pin_create_rc=1; return 1
+    fi
     if [ "$pin_child_rc" != 0 ]; then
       # NEVER TOUCH THE DESTINATION ON A PRE-LINK FAILURE (roborev job 328, Medium). This
       # branch used to `rm -f "$PIN_ENV_FILE"` unconditionally, which was DESTRUCTIVE and
@@ -2298,47 +2314,22 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
       # rc=0). Therefore the parent never needs to remove the destination here, and the
       # correct disposition is: report, and touch NOTHING.
       #
-      # pin_create_mode_ok's rollback is a DIFFERENT case and stays: it runs only after `ln`
-      # succeeded, and `ln` is atomic and fails if the destination exists, so the inode it
-      # removes is provably the one THIS invocation created.
+      # AND THERE IS NO OTHER ROLLBACK LEFT TO GET WRONG. An earlier revision kept a post-`ln`
+      # mode rollback here on the argument that `ln` proves the inode is ours — true at LINK
+      # time, FALSE at REMOVE time, which is the destructive race job 329 found. The mode is
+      # now verified on the staged file before linking, so no rollback exists at all.
       PIN_CREATE_RESIDUE="the staging write failed (rc $pin_child_rc) before $PIN_ENV_FILE was linked; nothing was written there and the temporary was removed by the child"
       pin_create_rc=1; return 1
     fi
-    pin_create_mode_ok "$PIN_ENV_FILE"; pin_create_rc=$?; return "$pin_create_rc"
+    pin_create_rc=0; return 0
   }
 
-  # pin_create_mode_ok: establish 0644 on a JUST-CREATED env file and CONFIRM it by reading
-  # the mode BACK. chmod's exit status answers a different question than "is the mode
-  # right": a chmod that fails on a file already at 0644 is harmless, and one that reports
-  # success is still worth confirming — the same affirmative-measurement rule this whole
-  # section is built on, applied to its own write.
-  #
-  # Where the mode cannot be established (or cannot be READ, which is indistinguishable
-  # from wrong for our purposes) the partial file is REMOVED. That is the fail-closed
-  # direction and it costs nothing: the file did not exist a moment ago, so deleting it
-  # restores the state the run started in, whereas LEAVING it makes the next run read a
-  # present CQLITE_GATE_MAX_CONCURRENCY line and treat the pin as persisted at a permission
-  # nothing chose. Linux-only path — the caller is behind PIN_PLATFORM_UNMANAGED — so
-  # `stat -c` is the right spelling here and needs no BSD fallback.
-  pin_create_mode_ok() {
-    local f="$1" mode
-    ${PIN_ROOT[@]+"${PIN_ROOT[@]}"} chmod 0644 "$f" 2>/dev/null || true
-    mode=$(${PIN_ROOT[@]+"${PIN_ROOT[@]}"} stat -c %a "$f" 2>/dev/null || stat -c %a "$f" 2>/dev/null)
-    if [ "$mode" = 644 ]; then PIN_CREATE_RESIDUE=""; return 0; fi
-    if ${PIN_ROOT[@]+"${PIN_ROOT[@]}"} rm -f "$f" 2>/dev/null && [ ! -e "$f" ]; then
-      PIN_CREATE_RESIDUE="mode came out ${mode:-unreadable}, not 0644 — the partial file was REMOVED so the next run creates it cleanly instead of inheriting it"
-    else
-      PIN_CREATE_RESIDUE="mode came out ${mode:-unreadable}, not 0644, AND the partial file could not be removed — it still carries the pin line; chmod 0644 or delete $f by hand"
-    fi
-    return 1
-  }
-
-  # ---- (1) persist. Reported with info/warn ONLY — a write is never the verdict ----
-  # AND ONLY ON LINUX (#3414 final roborev). The verdict half already treats a non-Linux
-  # host as unmanaged, but this block still APPENDED to /etc/environment whenever that file
-  # happened to exist and --yes/--fix-gate-pin was passed — mutating a system file that the
-  # platform's own session mechanism does not consume. Writing to a file nobody reads is not
-  # a harmless no-op; it is an unrequested change to host state that will outlive the run.
+  # pin_create_mode_ok WAS HERE AND IS DELETED (roborev job 329, Medium). It read the mode
+  # back AFTER `ln` and, on a mismatch, removed the DESTINATION BY PATHNAME — a destructive
+  # race, because `ln` proves the inode is ours at LINK time and not at REMOVE time. The mode
+  # is now established and verified on the TEMP before linking, so the destination is correct
+  # from the instant it exists and there is nothing to roll back. Removing the rollback
+  # removes the race; narrowing it would only have made the window smaller.
   if [ "$PIN_PLATFORM_UNMANAGED" = 1 ]; then
     PIN_PERSIST_NOTE="not persisted (no PAM-read system-wide env file on $PLATFORM)"
     info "not touching $PIN_ENV_FILE on this $PLATFORM host — pam_env is a Linux mechanism and this platform does not consume that file, so writing it would change host state for nothing"

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -2043,6 +2043,14 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
     esac
   }
 
+  # pin_scope_note: what VERIFIED does NOT cover. Printed with the verdict, not buried in
+  # a doc, because an unqualified VERIFIED reads as "gates on this box are pinned" and the
+  # probe cannot see a gate launched from a non-PAM parent (#3414 review B2).
+  pin_scope_note() {
+    info "scope: this measured a PAM-created (sudo) session. A process tree created WITHOUT PAM — a systemd unit, a container entrypoint — never has $PIN_ENV_FILE applied, so this does NOT prove every gate on this box is pinned"
+    info "the authoritative per-run confirmation is the gate's own SUMMARY line:  cpu-budget: ... max-concurrency=N(pinned)   (N(default) there means that gate did not see the pin)"
+  }
+
   # pin_value_remedy: the remedy for a VISIBLE but NOT-HONOURED value. Shared by both
   # not-honoured branches so neither can silently lose it.
   pin_value_remedy() {
@@ -2063,11 +2071,30 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   # is belt, not braces, since a box without env_reset would pass an inherited value
   # straight through.
   #
-  # NO `-i`. With no profile file read, a value that comes back can only have come from
-  # PAM, so the probe ATTRIBUTES as well as detects. Negative control, run by hand on
-  # the box this was written on: a variable exported in the parent shell but absent
-  # from /etc/environment reads UNSET through this probe, while the persisted pin
-  # reads 1.
+  # BASH_ENV AND ENV ARE SCRUBBED FOR THE SAME REASON, and they are the hole that
+  # "belt, not braces" actually admits (#3414 review). A NON-INTERACTIVE bash SOURCES
+  # $BASH_ENV before running its command — so on a box whose sudoers lacks env_reset an
+  # inherited BASH_ENV survives into the probe, that file can `export
+  # CQLITE_GATE_MAX_CONCURRENCY=1`, and the probe reports the box pinned with NOTHING in
+  # /etc/environment. Scrubbing the variable while leaving the mechanism that can
+  # re-inject it is not a scrub. (`ENV` is POSIX sh's equivalent, scrubbed with it.)
+  #
+  # NO `-i`, so no PROFILE file is read (`~/.bash_profile`, `~/.bashrc`, `/etc/profile`)
+  # — which is the point, since those are exactly the files #3414 showed a gate never
+  # reads. Note the claim is "no profile file", NOT "no file at all": with BASH_ENV and
+  # ENV scrubbed the remaining sources are the session's own (pam_env's /etc/environment
+  # and ~/.pam_environment, a sudoers env_file). Negative control, run by hand on the box
+  # this was written on: a variable exported in the parent shell but absent from
+  # /etc/environment reads UNSET through this probe, while the persisted pin reads 1.
+  #
+  # WHAT THIS PROBE DOES **NOT** COVER, stated here because the verdict text says it too
+  # (#3414 review B2). It measures a PAM-CREATED session, because `sudo` is the only way
+  # to create one unprivileged. A gate is NOT launched through sudo, and a process tree
+  # created WITHOUT PAM — a systemd unit, a container entrypoint — never has
+  # /etc/environment applied to it at all. So VERIFIED means "a PAM-created session on
+  # this box sees a value the gate honours", never "every gate on this box is pinned".
+  # The authoritative per-run confirmation is the gate's OWN `cpu-budget:
+  # max-concurrency=N(pinned)` token, which reports what that gate actually resolved.
   #
   # The bound may degrade to SIGTERM-only (a `timeout` without --kill-after) — tolerated
   # HERE, unlike the §3b push probe, because this probe is LOCAL, NON-MUTATING and
@@ -2082,7 +2109,8 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
     warn "gate-pin: UNMEASURED ('id -un' reported no identity, so there is no user to open a probe session as — pin visibility is UNKNOWN, not ok)"
   elif [ "$PIN_PRIV_STATE" = no-sudo-binary ]; then
     warn "gate-pin: UNMEASURED (no 'sudo' on this box, so no fresh PAM session can be created — pin visibility is UNKNOWN, not ok)"
-    info "check by hand from a session that reads no profile:  sudo -u <you> bash -c 'echo \${CQLITE_GATE_MAX_CONCURRENCY:-UNSET}'"
+    info "check by hand:  env -u CQLITE_GATE_MAX_CONCURRENCY -u BASH_ENV -u ENV sudo -u \"\$(id -un)\" bash -c 'printf \"[%s]\\n\" \"\${CQLITE_GATE_MAX_CONCURRENCY-UNSET}\"'"
+    info "(the scrub and the '-' — not ':-' — are load-bearing: without them an INHERITED value, or a set-but-EMPTY one, reads as a healthy pin, which is the defect this section exists to remove)"
   elif [ "$PIN_PRIV_STATE" = sudo-needs-password ]; then
     warn "gate-pin: UNMEASURED (sudo needs a password here and bootstrap probes with 'sudo -n', which never prompts — pin visibility is UNKNOWN, not ok)"
     info "authenticate first, then re-run:  sudo -v && bash scripts/bootstrap-agent-machine.sh --yes"
@@ -2095,7 +2123,7 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
     # `(invalid)`, which is a misconfigured box, not an unprovisioned one. `${VAR+1}`
     # separates them; `${VAR-}` alone cannot, and collapsing them here would put the
     # `:-` defect this issue removed from the gate back into the tool that verifies it.
-    pin_probe_out=$(bounded "$PIN_PROBE_BOUND" env -u CQLITE_GATE_MAX_CONCURRENCY \
+    pin_probe_out=$(bounded "$PIN_PROBE_BOUND" env -u CQLITE_GATE_MAX_CONCURRENCY -u BASH_ENV -u ENV \
       sudo -n -u "$PIN_SELF_USER" \
       bash -c 'printf "cqlite-gate-pin-probe-set=%s\ncqlite-gate-pin-probe=%s\n" "${CQLITE_GATE_MAX_CONCURRENCY+1}" "${CQLITE_GATE_MAX_CONCURRENCY-}"' 2>/dev/null) || pin_probe_rc=$?
     # Anchored on our own markers at line start, and each value is read from the FIRST
@@ -2115,7 +2143,14 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
       pin_gate_src=$(pin_gate_source_for "$pin_probe_seen") || pin_gate_src=""
       case "$pin_gate_src" in
         pinned)
-          ok "gate-pin: VERIFIED (a fresh profile-free session sees CQLITE_GATE_MAX_CONCURRENCY=$pin_probe_seen and the gate HONOURS it verbatim — max-concurrency=$pin_probe_seen(pinned); this run's own value was scrubbed first, so it came from the system env file via PAM, not from inheritance)"
+          # The text says what was MEASURED and nothing more. It used to assert the value
+          # "came from the system env file via PAM, not from inheritance" — the second
+          # half is establishable (this run's value, BASH_ENV and ENV were all scrubbed),
+          # the FIRST half is not: ~/.pam_environment or a sudoers env_file satisfies the
+          # observation identically. Claiming an attribution the probe cannot make is the
+          # proxy-for-a-fact shape this whole section exists to remove.
+          ok "gate-pin: VERIFIED (a PAM-created, profile-free session sees CQLITE_GATE_MAX_CONCURRENCY=$pin_probe_seen and the gate HONOURS it verbatim — max-concurrency=$pin_probe_seen(pinned); this run's own value, BASH_ENV and ENV were scrubbed first, so it is not inherited from this shell)"
+          pin_scope_note
           ;;
         invalid)
           # Its OWN verdict, not FAILED: the pin is present and visible, so "persist the
@@ -2143,6 +2178,7 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
           info "the pin IS in $PIN_ENV_FILE and a fresh session still does not see it — this is a PAM condition, NOT a missing pin"
           info "re-running with --yes / --fix-gate-pin will NOT help: either finds the line already present and changes nothing"
           info "check the session stack reads it:  grep -n pam_env /etc/pam.d/sudo /etc/pam.d/login /etc/pam.d/sshd   (each needs 'pam_env.so readenv=1')"
+          info "and re-check by hand:  env -u CQLITE_GATE_MAX_CONCURRENCY -u BASH_ENV -u ENV sudo -u \"\$(id -un)\" bash -c 'printf \"[%s]\\n\" \"\${CQLITE_GATE_MAX_CONCURRENCY-UNSET}\"'"
           ;;
         absent-file)
           # No remedy that names a file this host does not have (the ruling on #3414's

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -2188,6 +2188,33 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
     fi
   fi
 
+  PIN_CREATE_RESIDUE=""
+  # pin_create_mode_ok: establish 0644 on a JUST-CREATED env file and CONFIRM it by reading
+  # the mode BACK. chmod's exit status answers a different question than "is the mode
+  # right": a chmod that fails on a file already at 0644 is harmless, and one that reports
+  # success is still worth confirming — the same affirmative-measurement rule this whole
+  # section is built on, applied to its own write.
+  #
+  # Where the mode cannot be established (or cannot be READ, which is indistinguishable
+  # from wrong for our purposes) the partial file is REMOVED. That is the fail-closed
+  # direction and it costs nothing: the file did not exist a moment ago, so deleting it
+  # restores the state the run started in, whereas LEAVING it makes the next run read a
+  # present CQLITE_GATE_MAX_CONCURRENCY line and treat the pin as persisted at a permission
+  # nothing chose. Linux-only path — the caller is behind PIN_PLATFORM_UNMANAGED — so
+  # `stat -c` is the right spelling here and needs no BSD fallback.
+  pin_create_mode_ok() {
+    local f="$1" mode
+    ${PIN_ROOT[@]+"${PIN_ROOT[@]}"} chmod 0644 "$f" 2>/dev/null || true
+    mode=$(${PIN_ROOT[@]+"${PIN_ROOT[@]}"} stat -c %a "$f" 2>/dev/null || stat -c %a "$f" 2>/dev/null)
+    if [ "$mode" = 644 ]; then PIN_CREATE_RESIDUE=""; return 0; fi
+    if ${PIN_ROOT[@]+"${PIN_ROOT[@]}"} rm -f "$f" 2>/dev/null && [ ! -e "$f" ]; then
+      PIN_CREATE_RESIDUE="mode came out ${mode:-unreadable}, not 0644 — the partial file was REMOVED so the next run creates it cleanly instead of inheriting it"
+    else
+      PIN_CREATE_RESIDUE="mode came out ${mode:-unreadable}, not 0644, AND the partial file could not be removed — it still carries the pin line; chmod 0644 or delete $f by hand"
+    fi
+    return 1
+  }
+
   # ---- (1) persist. Reported with info/warn ONLY — a write is never the verdict ----
   # AND ONLY ON LINUX (#3414 final roborev). The verdict half already treats a non-Linux
   # host as unmanaged, but this block still APPENDED to /etc/environment whenever that file
@@ -2220,7 +2247,7 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
       info "create it as root:  printf '%s\n' '$PIN_ENV_COMMENT' '$PIN_ENV_LINE' > $PIN_ENV_FILE && chmod 0644 $PIN_ENV_FILE"
     elif printf '%s\n%s\n' "$PIN_ENV_COMMENT" "$PIN_ENV_LINE" \
            | ${PIN_ROOT[@]+"${PIN_ROOT[@]}"} tee "$PIN_ENV_FILE" >/dev/null 2>&1 \
-         && ${PIN_ROOT[@]+"${PIN_ROOT[@]}"} chmod 0644 "$PIN_ENV_FILE" 2>/dev/null; then
+         && pin_create_mode_ok "$PIN_ENV_FILE"; then
       PIN_FILE_HAS_LINE=yes; PIN_FILE_VALUE="$PIN_ENV_VALUE"
       # REPORT WHAT IT ACTUALLY IS, read back — not what the write intended. An earlier
       # draft of this line asserted "root:root 0644" unconditionally, which is false
@@ -2230,6 +2257,17 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
       # in the section's own output.
       pin_made=$(ls -ld -- "$PIN_ENV_FILE" 2>/dev/null | awk '{print $1" "$3":"$4}')
       info "CREATED $PIN_ENV_FILE (${pin_made:-mode/owner unreadable}) carrying '$PIN_ENV_LINE' — pam_env reads it at session creation, so NEW sessions pick it up"
+    elif [ -n "$PIN_CREATE_RESIDUE" ]; then
+      # THE FAILURE REPORT MUST MATCH THE FILESYSTEM (roborev job 311, Low). The write is
+      # two steps — content then mode — so a `tee` that succeeded followed by a mode that
+      # could not be established used to take this branch and say "NOT persisted" while
+      # leaving a POPULATED file behind. The next run then reads a present
+      # CQLITE_GATE_MAX_CONCURRENCY line, treats the pin as already persisted, and never
+      # repairs the mode: one run's reported failure becomes the next run's silent success
+      # at a permission nothing chose. So the residue is rolled back, and where it cannot
+      # be, that is stated rather than folded into the generic message.
+      PIN_PERSIST_NOTE="could not create $PIN_ENV_FILE ($PIN_CREATE_RESIDUE)"
+      warn "gate-pin: could not create $PIN_ENV_FILE — the pin was NOT persisted ($PIN_CREATE_RESIDUE)"
     else
       PIN_PERSIST_NOTE="could not create $PIN_ENV_FILE"
       warn "gate-pin: could not create $PIN_ENV_FILE — the pin was NOT persisted"
@@ -2408,6 +2446,7 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
     # PAM in its ancestry at all — that residual is real and is stated, not implied.
     info "scope: measured through a PAM-created (sudo) session against the line in $PIN_ENV_FILE. Whether the service stacks a gate is actually launched from also read that file is NOT checked here — and a process tree created WITHOUT PAM (a systemd unit, a container entrypoint) never has it applied at all"
     info "scope: pam_env reads $PIN_ENV_FILE at SESSION CREATION, so this verdict is about FUTURE sessions. THIS shell, and every process already descended from it — including workers a launcher started before now — do NOT have the pin and will not until their sessions are recreated. A gate launched by such a worker still resolves the #1825 cap from the formula (#3728)"
+    info "scope: VERIFIED asserts that the file SETS this value and a fresh session SEES that same value — it does NOT prove the file is where the session got it. If this box also sets CQLITE_GATE_MAX_CONCURRENCY to the same value from a sudoers env_file or ~/.pam_environment, an $PIN_ENV_FILE that no PAM stack actually loads would still read VERIFIED. Agreement is measured; provenance is not (#3728)"
     info "the authoritative per-run confirmation is the gate's own SUMMARY line:  cpu-budget: ... max-concurrency=N(pinned)   (N(default) there means that gate did not see the pin)"
     [ -n "$PIN_PROBE_SUBJECT_NOTE" ] && info "subject: $PIN_PROBE_SUBJECT_NOTE"
   }
@@ -2415,7 +2454,18 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   # pin_value_remedy: the remedy for a VISIBLE but NOT-HONOURED value. Shared by both
   # not-honoured branches so neither can silently lose it.
   pin_value_remedy() {
-    if [ "$PIN_FILE_HAS_LINE" = yes ]; then
+    if [ "$PIN_FILE_HAS_LINE" = yes ] && [ "$PIN_FILE_VALUE" != "$pin_probe_seen" ]; then
+      # COMPARE BEFORE PRESCRIBING (roborev job 311, Low). The enclosing `case` dispatches
+      # on the GATE's classification of what the SESSION saw, which says nothing about
+      # where that value came from. So a box whose system file is CORRECT (`=1`) but whose
+      # session is overridden by a sudoers env_file or ~/.pam_environment holding `abc`
+      # lands here, and the unconditional branch below sent the operator to edit a file
+      # that is already right — they find nothing wrong and re-run into the same verdict.
+      # That is the #3414 defect one level down: a remedy keyed on a verdict rather than on
+      # the fact that decides between two remedies.
+      info "the bad value is NOT coming from $PIN_ENV_FILE — that file sets CQLITE_GATE_MAX_CONCURRENCY='$PIN_FILE_VALUE' while this session sees '$pin_probe_seen', so a sudo- or user-specific source (a sudoers env_file, ~/.pam_environment, a launcher-injected env) is OVERRIDING it"
+      info "fix or remove THAT override — editing $PIN_ENV_FILE would change a value that is already being ignored"
+    elif [ "$PIN_FILE_HAS_LINE" = yes ]; then
       info "fix the VALUE (not the presence) — edit the CQLITE_GATE_MAX_CONCURRENCY line in $PIN_ENV_FILE to a positive integer; bootstrap deliberately never rewrites an existing value"
     else
       info "the value is visible but is NOT coming from $PIN_ENV_FILE — find and fix whatever sets it (a systemd unit, the image, a launcher-injected env), then re-run"

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -58,6 +58,12 @@
 #      machine's configured agent (commonly codex via .roborev.toml); we warn
 #      only if the local config is broken, never prescribe an agent.
 #   5. Datasets present + CQLITE_DATASETS_ROOT guidance.
+#   5b. Single-gate pin (issues #2640/#3414). Persists CQLITE_GATE_MAX_CONCURRENCY=1
+#      into /etc/environment — which PAM reads at SESSION CREATION, with no
+#      interactivity guard — and takes its VERDICT from an AFFIRMATIVE PROBE of a
+#      fresh, profile-free session, never from a grep of the file it just wrote.
+#      Three-valued on one greppable `gate-pin:` line: VERIFIED / FAILED /
+#      UNMEASURED, with UNMEASURED a [warn] (same posture as `git-push:`).
 #   6. Health check: run the gate's fmt component and print its authoritative
 #      `accelerators:` line.
 #
@@ -79,6 +85,16 @@
 #                                                      #   withholds "All checks green." and can
 #                                                      #   never buy a vacuous green. For offline
 #                                                      #   boxes and hermetic self-tests.
+#   bash scripts/bootstrap-agent-machine.sh --skip-gate-pin    # skip ONLY section 5b (the
+#                                                      #   single-gate pin: the /etc/environment
+#                                                      #   write AND the PAM-session visibility
+#                                                      #   probe). Same posture as
+#                                                      #   --skip-push-probe: it emits
+#                                                      #   `gate-pin: OPT-OUT` as a [warn], so it
+#                                                      #   can never buy a vacuous green.
+#                                                      #   CQLITE_BOOTSTRAP_SKIP_GATE_PIN=1 is the
+#                                                      #   env spelling, for harnesses that drive
+#                                                      #   bootstrap on a fixed command line.
 #   bash scripts/bootstrap-agent-machine.sh --skip-smoke   # skip the final GATE run (section 6).
 #                                                      #   DISTINCT from --skip-push-probe: this
 #                                                      #   one is about the gate fmt smoke, that
@@ -95,6 +111,20 @@ SKIP_SMOKE=0
 # --skip-smoke: --skip-smoke skips the GATE fmt run in section 6 and has nothing to do
 # with git. Two different subjects, two different flags (issue #3369).
 SKIP_PUSH_PROBE=0
+# --skip-gate-pin / CQLITE_BOOTSTRAP_SKIP_GATE_PIN=1 (issue #3414): skip section 5b
+# entirely — no /etc/environment write and no PAM session probe. A THIRD subject, so a
+# third switch, exactly as --skip-push-probe is separate from --skip-smoke. It is LOUD
+# and NON-PASSING (a `gate-pin: OPT-OUT` [warn]), so it withholds "All checks green."
+# and --strict still exits 1: an opt-out that returned `ok` would be a switch for buying
+# a vacuous green, which is the failure mode this whole section exists to remove. The
+# env spelling exists because the sibling self-suites drive bootstrap on fixed command
+# lines they cannot easily grow an argument on; both spellings take the same code path
+# and print the same non-passing verdict, and the message names which one was used.
+SKIP_GATE_PIN=0
+SKIP_GATE_PIN_HOW=""
+if [ "${CQLITE_BOOTSTRAP_SKIP_GATE_PIN:-0}" = 1 ]; then
+  SKIP_GATE_PIN=1; SKIP_GATE_PIN_HOW="CQLITE_BOOTSTRAP_SKIP_GATE_PIN=1"
+fi
 FIX_CREDENTIALS=0
 STRICT=0
 for arg in "$@"; do
@@ -102,6 +132,7 @@ for arg in "$@"; do
     --yes|-y) AUTO_YES=1 ;;
     --skip-smoke) SKIP_SMOKE=1 ;;
     --skip-push-probe) SKIP_PUSH_PROBE=1 ;;
+    --skip-gate-pin) SKIP_GATE_PIN=1; SKIP_GATE_PIN_HOW="--skip-gate-pin" ;;
     --fix-credentials) FIX_CREDENTIALS=1 ;;
     --strict) STRICT=1 ;;
     -h|--help)
@@ -1734,33 +1765,251 @@ info "  export CQLITE_DATASETS_ROOT=$MAIN_DATASETS"
 info "  Worktrees lack the gitignored Data.db binaries — always aim CQLITE_DATASETS_ROOT"
 info "  at the main checkout (above), NOT a worktree's own test-data/datasets."
 
-# ---- 5b. Single-gate default: one full gate per box (issue #2640) ----
-# One worker per machine (#1930) runs its full gates serially, so the DEFAULT
-# posture is a SINGLE full gate at a time. Pin CQLITE_GATE_MAX_CONCURRENCY=1 in the
-# shell profile so (a) the #1825 machine-wide cap admits exactly one full gate and
-# (b) the #2640 per-gate core budget hands that sole gate the FULL core count —
-# no CPU oversubscription, no manual pgrep-serialization. A machine that
-# deliberately wants >1 concurrent gate overrides the export.
-hdr "Single-gate default (CQLITE_GATE_MAX_CONCURRENCY=1, issue #2640)"
-PROFILE=""
-case "${SHELL:-}" in
-  */zsh) PROFILE="$HOME/.zshrc" ;;
-  */bash) PROFILE="$HOME/.bashrc" ;;
-  *) PROFILE="${ENV:-$HOME/.profile}" ;;
-esac
+# ---- 5b. Single-gate pin: one full gate per box (issues #2640 / #3414) ----
+# The #1825 machine-wide cap admits N concurrent full gates, and the #2640 per-gate
+# core budget derives each gate's core share from the SAME N — so pinning
+# CQLITE_GATE_MAX_CONCURRENCY=1 admits exactly one full gate and hands it the FULL core
+# count: no CPU oversubscription, no manual pgrep-serialization. A machine that
+# deliberately wants >1 concurrent gate overrides the pin, and bootstrap NEVER rewrites
+# an existing value.
+#
+# WHY THIS SECTION WAS REBUILT (issue #3414). It used to append the export to the shell
+# PROFILE and then report `ok` from a GREP OF THAT PROFILE — or, worse, from the value
+# it had INHERITED from its own caller. Both are PROXIES, and both were wrong on every
+# box in the fleet at once: Ubuntu's stock ~/.bashrc opens with
+# `case $- in *i*) ;; *) return;; esac`, so a line appended to it is never reached by
+# the non-interactive shells that actually launch gates (a script, a `bash -c`, a
+# detached `setsid`, a subagent). Measured: `ssh <box> 'echo $CQLITE_GATE_MAX_CONCURRENCY'`
+# printed UNSET on all three boxes whose profiles held the export; every gate therefore
+# resolved N=3 from the #1825 formula, and the live slot daemon's own argv said
+# `--slots 3` while an isolation guarantee had been given to a measurement lane on the
+# strength of the cap. PRESENCE IN A CONFIG FILE AND VISIBILITY TO THE PROCESS THAT
+# READS IT ARE DIFFERENT FACTS, and only the second one matters.
+#
+# So this section does two separable things, and only the second one can produce a
+# success verdict:
+#   (1) PERSIST where a non-interactive shell provably reads it — /etc/environment,
+#       read by PAM's pam_env at SESSION CREATION (`/etc/pam.d/sudo`, `/etc/pam.d/sshd`
+#       and `/etc/pam.d/login` all carry `pam_env.so readenv=1`), with no interactivity
+#       guard anywhere in the path. bash itself NEVER reads that file — measured,
+#       `env -i bash -c` AND `env -i bash -lc` both report UNSET — which is exactly why
+#       no shell-file check can answer this question, login shell or not.
+#   (2) PROBE a fresh, profile-free session and report what it actually saw.
+hdr "Single-gate pin (CQLITE_GATE_MAX_CONCURRENCY, issues #2640/#3414)"
+
+# The PRODUCTION persistence target, written as a LITERAL here. The privileged write
+# below can never name anything else (see the seam guard and the invariant assert).
+PIN_ENV_FILE=/etc/environment
+PIN_ENV_FILE_IS_SEAM=0
+PIN_SECTION_OK=1
+PIN_PERSIST_NOTE=""
+# NO INLINE COMMENT ON THE VALUE LINE: pam_env parses `KEY=VALUE` literally, so a
+# trailing `# ...` would become part of the value. Whole-line comments are skipped, so
+# the rationale goes on its own line above it.
+PIN_ENV_COMMENT='# cqlite: one full gate per box, full cores (issues #2640/#3414)'
+PIN_ENV_LINE='CQLITE_GATE_MAX_CONCURRENCY=1'
 EXPORT_LINE='export CQLITE_GATE_MAX_CONCURRENCY=1  # cqlite: one full gate per box, full cores (issue #2640)'
-if [ -n "${CQLITE_GATE_MAX_CONCURRENCY:-}" ]; then
-  ok "CQLITE_GATE_MAX_CONCURRENCY already set to '${CQLITE_GATE_MAX_CONCURRENCY}' in this environment"
-elif [ -n "$PROFILE" ] && [ -f "$PROFILE" ] && grep -q 'CQLITE_GATE_MAX_CONCURRENCY' "$PROFILE" 2>/dev/null; then
-  ok "CQLITE_GATE_MAX_CONCURRENCY already pinned in $PROFILE"
-elif [ "$AUTO_YES" = 1 ] && [ -n "$PROFILE" ]; then
-  printf '%s\n' "$EXPORT_LINE" >>"$PROFILE" \
-    && ok "pinned CQLITE_GATE_MAX_CONCURRENCY=1 in $PROFILE (re-source or open a new shell)" \
-    || warn "could not append to $PROFILE — add manually: $EXPORT_LINE"
-else
-  warn "CQLITE_GATE_MAX_CONCURRENCY not pinned — one full gate per box is the default posture (#2640)"
-  info "add to ${PROFILE:-your shell profile}:  $EXPORT_LINE"
-  info "(re-run with --yes to auto-append)"
+
+if [ "$SKIP_GATE_PIN" = 1 ]; then
+  warn "gate-pin: OPT-OUT ($SKIP_GATE_PIN_HOW) — the pin was NOT persisted and its visibility was NOT measured"
+  info "this run cannot certify that a non-interactive shell sees CQLITE_GATE_MAX_CONCURRENCY; drop the opt-out to measure it"
+  PIN_SECTION_OK=0
+fi
+
+if [ "$PIN_SECTION_OK" = 1 ] && [ -n "${CQLITE_BOOTSTRAP_ENV_FILE:-}" ]; then
+  # TEST-ONLY SEAM — fail-closed, with NO production fallback (the #3249 lesson: a test
+  # seam that degrades to the real path certifies the real path by accident). It exists
+  # so the self-tests can drive this section's DECISIONS without a privileged write to
+  # the real /etc/environment, including when a suite happens to run as root. Two
+  # properties keep it from being a hole of its own:
+  #   * it is inert unless CQLITE_BOOTSTRAP_TEST_MODE=1, and a seam set WITHOUT the
+  #     marker SKIPS the section rather than falling back, and
+  #   * under the marker the write is UNPRIVILEGED (PIN_ROOT is forced empty below), so
+  #     no environment variable can ever steer a PRIVILEGED write at a path of its
+  #     choosing — the privileged branch only ever names the literal /etc/environment.
+  if [ "${CQLITE_BOOTSTRAP_TEST_MODE:-0}" != 1 ]; then
+    warn "gate-pin: SKIPPED (CQLITE_BOOTSTRAP_ENV_FILE is set without CQLITE_BOOTSTRAP_TEST_MODE=1) — refusing to persist the pin at an env-chosen path"
+    PIN_SECTION_OK=0
+  else
+    case "$CQLITE_BOOTSTRAP_ENV_FILE" in
+      /etc/environment)
+        warn "gate-pin: SKIPPED (the test seam may not name the production /etc/environment)"
+        PIN_SECTION_OK=0 ;;
+      /*)
+        if [ -L "$CQLITE_BOOTSTRAP_ENV_FILE" ]; then
+          warn "gate-pin: SKIPPED (the test seam path is a SYMLINK — a write would follow it)"
+          PIN_SECTION_OK=0
+        elif [ ! -d "$(dirname "$CQLITE_BOOTSTRAP_ENV_FILE")" ]; then
+          warn "gate-pin: SKIPPED (the test seam's parent directory does not exist)"
+          PIN_SECTION_OK=0
+        else
+          PIN_ENV_FILE="$CQLITE_BOOTSTRAP_ENV_FILE"; PIN_ENV_FILE_IS_SEAM=1
+        fi ;;
+      *)
+        warn "gate-pin: SKIPPED (CQLITE_BOOTSTRAP_ENV_FILE must be an ABSOLUTE path)"
+        PIN_SECTION_OK=0 ;;
+    esac
+  fi
+fi
+
+if [ "$PIN_SECTION_OK" = 1 ]; then
+  # Privilege, resolved the same way section 2c resolves it: NON-INTERACTIVELY, so no
+  # code path here can ever sit on a password prompt on an unattended worker. The
+  # runas target of the AVAILABILITY probe is the same as the runas target of the real
+  # probe, so a box whose sudoers permits root-but-not-self cannot look available and
+  # then fail in the measurement.
+  PIN_ROOT=()
+  PIN_PRIV_STATE=unknown
+  PIN_SELF_USER=$(id -un 2>/dev/null || true)
+  PIN_SELF_UID=$(id -u 2>/dev/null || true)
+  if [ -z "$PIN_SELF_USER" ]; then
+    PIN_PRIV_STATE=no-identity
+  elif ! have sudo; then
+    PIN_PRIV_STATE=no-sudo-binary
+  elif ! bounded 10 sudo -n true >/dev/null 2>&1; then
+    PIN_PRIV_STATE=sudo-needs-password
+  elif ! bounded 10 sudo -n -u "$PIN_SELF_USER" true >/dev/null 2>&1; then
+    PIN_PRIV_STATE=sudo-runas-denied
+  else
+    PIN_PRIV_STATE=sudo-nopasswd
+  fi
+  # WRITE privilege and PROBE capability are separate facts: a root shell with no sudo
+  # binary can persist the pin but cannot open a probe session, and saying so is more
+  # useful than collapsing both into one state.
+  PIN_WRITE_PRIV=0
+  if [ "$PIN_SELF_UID" = 0 ]; then
+    PIN_WRITE_PRIV=1; PIN_ROOT=()
+  elif [ "$PIN_PRIV_STATE" = sudo-nopasswd ]; then
+    PIN_WRITE_PRIV=1; PIN_ROOT=(sudo -n)
+  fi
+  # Test mode never runs a PRIVILEGED write; the sandbox file belongs to the invoking
+  # user. Forcing PIN_ROOT empty is what makes "no env var can steer a privileged
+  # write" true IN CODE rather than merely by construction.
+  if [ "$PIN_ENV_FILE_IS_SEAM" = 1 ]; then PIN_ROOT=(); PIN_WRITE_PRIV=1; fi
+
+  # ---- (1) persist. Reported with info/warn ONLY — a write is never the verdict ----
+  if [ ! -e "$PIN_ENV_FILE" ]; then
+    PIN_PERSIST_NOTE="no $PIN_ENV_FILE on this host"
+    info "no $PIN_ENV_FILE on this $PLATFORM host — there is no PAM-read system-wide env file to persist the pin into"
+  elif [ -L "$PIN_ENV_FILE" ]; then
+    PIN_PERSIST_NOTE="$PIN_ENV_FILE is a SYMLINK"
+    warn "gate-pin: $PIN_ENV_FILE is a SYMLINK — refusing a privileged write that would follow it; nothing was persisted"
+  elif [ ! -r "$PIN_ENV_FILE" ]; then
+    PIN_PERSIST_NOTE="$PIN_ENV_FILE is unreadable"
+    warn "gate-pin: cannot read $PIN_ENV_FILE — cannot tell whether the pin is already there, so nothing was written (a blind append could duplicate or contradict an existing line)"
+  elif grep -Eq '^[[:space:]]*CQLITE_GATE_MAX_CONCURRENCY[[:space:]]*=' "$PIN_ENV_FILE" 2>/dev/null; then
+    info "$PIN_ENV_FILE already carries a CQLITE_GATE_MAX_CONCURRENCY line — left EXACTLY as it is (a box deliberately running >1 concurrent gate overrides the pin; bootstrap never rewrites an existing value)"
+  elif [ "$AUTO_YES" != 1 ]; then
+    PIN_PERSIST_NOTE="not persisted (no --yes)"
+    info "persist the pin:  bash scripts/bootstrap-agent-machine.sh --yes   (appends '$PIN_ENV_LINE' to $PIN_ENV_FILE)"
+  elif [ "$PIN_WRITE_PRIV" != 1 ]; then
+    PIN_PERSIST_NOTE="no privilege to write $PIN_ENV_FILE ($PIN_PRIV_STATE)"
+    warn "gate-pin: cannot write $PIN_ENV_FILE ($PIN_PRIV_STATE) — the pin was NOT persisted"
+    info "add these two lines as root:  $PIN_ENV_COMMENT / $PIN_ENV_LINE"
+  elif [ "${#PIN_ROOT[@]}" -gt 0 ] && [ "$PIN_ENV_FILE" != /etc/environment ]; then
+    # INVARIANT, enforced rather than argued. The seam forces PIN_ROOT empty above, so
+    # this can only fire if that coupling is ever broken by a later edit.
+    PIN_PERSIST_NOTE="internal invariant refused the write"
+    warn "gate-pin: INTERNAL — refusing a PRIVILEGED write to a non-production path ($PIN_ENV_FILE)"
+  else
+    # A file whose last byte is not a newline would otherwise have our KEY=VALUE welded
+    # onto its final line, and pam_env would read the result as one malformed entry.
+    # Prepend a newline in that case only; the append happens at most once per box, so
+    # this can never accumulate blank lines.
+    pin_prefix=""
+    if [ -s "$PIN_ENV_FILE" ] && [ -n "$(tail -c 1 "$PIN_ENV_FILE" 2>/dev/null)" ]; then
+      pin_prefix=$'\n'
+    fi
+    # Appended at the END, after any managed marker block the image owner put in the
+    # file (this fleet's images carry a `# >>> agent-ami worker auth >>>` block), so
+    # nothing already there is disturbed.
+    if printf '%s%s\n%s\n' "$pin_prefix" "$PIN_ENV_COMMENT" "$PIN_ENV_LINE" \
+         | ${PIN_ROOT[@]+"${PIN_ROOT[@]}"} tee -a "$PIN_ENV_FILE" >/dev/null 2>&1; then
+      info "appended '$PIN_ENV_LINE' to $PIN_ENV_FILE — PAM reads it at session creation, so NEW sessions pick it up with no reboot and no re-login"
+    else
+      PIN_PERSIST_NOTE="the append to $PIN_ENV_FILE failed"
+      warn "gate-pin: the append to $PIN_ENV_FILE FAILED — the pin was NOT persisted"
+      info "add these two lines as root:  $PIN_ENV_COMMENT / $PIN_ENV_LINE"
+    fi
+  fi
+
+  # The shell-profile export is kept for INTERACTIVE convenience only — a human who
+  # opens a terminal and runs the gate by hand. It is reported with `info`, NEVER `ok`:
+  # a profile line is precisely the artifact whose presence certified nothing for
+  # months, and letting it produce a success verdict anywhere would reintroduce #3414.
+  PROFILE=""
+  case "${SHELL:-}" in
+    */zsh) PROFILE="$HOME/.zshrc" ;;
+    */bash) PROFILE="$HOME/.bashrc" ;;
+    *) PROFILE="${ENV:-$HOME/.profile}" ;;
+  esac
+  if [ -n "$PROFILE" ] && [ -f "$PROFILE" ] && grep -q 'CQLITE_GATE_MAX_CONCURRENCY' "$PROFILE" 2>/dev/null; then
+    info "$PROFILE already carries the export — INTERACTIVE shells only (stock ~/.bashrc returns early for non-interactive ones), so it says nothing about the shell a gate runs in"
+  elif [ "$AUTO_YES" = 1 ] && [ -n "$PROFILE" ]; then
+    if printf '%s\n' "$EXPORT_LINE" >>"$PROFILE" 2>/dev/null; then
+      info "appended the export to $PROFILE for INTERACTIVE shells (convenience only — the verdict below comes from the session probe, not from this file)"
+    else
+      info "could not append to $PROFILE (interactive convenience only) — add by hand: $EXPORT_LINE"
+    fi
+  fi
+
+  # ---- (2) THE VERDICT: an affirmative probe of a fresh, profile-free session ----
+  #
+  # THE SCRUB IS THE LOAD-BEARING PART. Bootstrap normally runs inside a session that
+  # already inherited the value, so an UNSCRUBBED probe returns it on a box where
+  # nothing is persisted at all — the same false positive as the old profile grep, one
+  # level up, and it would certify the very failure this section exists to catch.
+  # `env -u` removes it from the process handed to sudo; sudoers' `Defaults env_reset`
+  # is belt, not braces, since a box without env_reset would pass an inherited value
+  # straight through.
+  #
+  # NO `-i`. With no profile file read, a value that comes back can only have come from
+  # PAM, so the probe ATTRIBUTES as well as detects. Negative control, run by hand on
+  # the box this was written on: a variable exported in the parent shell but absent
+  # from /etc/environment reads UNSET through this probe, while the persisted pin
+  # reads 1.
+  #
+  # The bound may degrade to SIGTERM-only (a `timeout` without --kill-after) — tolerated
+  # HERE, unlike the §3b push probe, because this probe is LOCAL, NON-MUTATING and
+  # `sudo -n` never prompts, so there is nothing for a wedged child to hold open. What
+  # is NOT tolerated is running it UNBOUNDED: hanging the fleet's provisioning entry
+  # point is worse than an unmeasured verdict.
+  PIN_PROBE_BOUND=20
+  if [ -z "$TIMEOUT_BIN" ]; then
+    warn "gate-pin: UNMEASURED (no timeout/gtimeout on PATH — refusing to run an UNBOUNDED session probe during bootstrap)"
+    info "install GNU coreutils so the probe can be bounded (macOS: brew install coreutils), then re-run"
+  elif [ "$PIN_PRIV_STATE" = no-identity ]; then
+    warn "gate-pin: UNMEASURED ('id -un' reported no identity, so there is no user to open a probe session as — pin visibility is UNKNOWN, not ok)"
+  elif [ "$PIN_PRIV_STATE" = no-sudo-binary ]; then
+    warn "gate-pin: UNMEASURED (no 'sudo' on this box, so no fresh PAM session can be created — pin visibility is UNKNOWN, not ok)"
+    info "check by hand from a session that reads no profile:  sudo -u <you> bash -c 'echo \${CQLITE_GATE_MAX_CONCURRENCY:-UNSET}'"
+  elif [ "$PIN_PRIV_STATE" = sudo-needs-password ]; then
+    warn "gate-pin: UNMEASURED (sudo needs a password here and bootstrap probes with 'sudo -n', which never prompts — pin visibility is UNKNOWN, not ok)"
+    info "authenticate first, then re-run:  sudo -v && bash scripts/bootstrap-agent-machine.sh --yes"
+  elif [ "$PIN_PRIV_STATE" = sudo-runas-denied ]; then
+    warn "gate-pin: UNMEASURED (sudo works but will not run a command as '$PIN_SELF_USER', so no probe session could be opened — pin visibility is UNKNOWN, not ok)"
+  else
+    pin_probe_rc=0
+    pin_probe_out=$(bounded "$PIN_PROBE_BOUND" env -u CQLITE_GATE_MAX_CONCURRENCY \
+      sudo -n -u "$PIN_SELF_USER" \
+      bash -c 'printf "cqlite-gate-pin-probe=%s\n" "${CQLITE_GATE_MAX_CONCURRENCY-}"' 2>/dev/null) || pin_probe_rc=$?
+    # Anchored on our own marker at line start, and the value is read from the FIRST
+    # matching line: the probe's stdout can also carry a shell's own noise, and a
+    # verdict decided by an unanchored match would be decided by whatever else printed.
+    pin_probe_seen=$(printf '%s\n' "$pin_probe_out" | sed -n 's/^cqlite-gate-pin-probe=//p' | head -1)
+    if [ "$pin_probe_rc" = 124 ] || [ "$pin_probe_rc" = 137 ]; then
+      warn "gate-pin: UNMEASURED (the probe exceeded its ${PIN_PROBE_BOUND}s bound and was killed — pin visibility is UNKNOWN, not ok)"
+    elif ! printf '%s\n' "$pin_probe_out" | grep -q '^cqlite-gate-pin-probe='; then
+      warn "gate-pin: UNMEASURED (the probe session produced no cqlite-gate-pin-probe= line, rc=$pin_probe_rc — pin visibility is UNKNOWN, not ok)"
+    elif [ -n "$pin_probe_seen" ]; then
+      ok "gate-pin: VERIFIED (a fresh profile-free session sees CQLITE_GATE_MAX_CONCURRENCY=$pin_probe_seen; this run's own value was scrubbed first, so it came from the system env file via PAM, not from inheritance)"
+    else
+      warn "gate-pin: FAILED (a fresh profile-free session does NOT see CQLITE_GATE_MAX_CONCURRENCY — every non-interactive gate on this box will resolve the #1825 cap from the default formula and admit co-tenants, #3414)"
+      [ -n "$PIN_PERSIST_NOTE" ] && info "nothing was persisted this run: $PIN_PERSIST_NOTE"
+      info "fix:  bash scripts/bootstrap-agent-machine.sh --yes   (appends '$PIN_ENV_LINE' to /etc/environment)"
+      info "the gate reports the same fact on its cpu-budget line as max-concurrency=N(default) instead of N(pinned)"
+    fi
+  fi
 fi
 
 # ---- 5c. Notification channel (ntfy) — issue #3119 ----

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -4614,7 +4614,20 @@ fi
 # 1465c. The component-level dataset SKIP must declare the leak-lane state, or a skipped
 #        component leaves NO `node-bindings-leak-lane:` line and "no line" becomes
 #        ambiguous between "it ran" and "this gate predates the line".
-if printf '%s' "$nll_component" | grep -q '_node_leak_lane_note SKIP-OPTOUT'; then
+# SIGPIPE-FREE MATCH, DELIBERATELY NOT `printf | grep -q` (#3685). Measured at this site:
+#        `printf '%s' "$nll_component" | grep -q PATTERN` under this suite's `set -uo pipefail`
+#        returned **rc=141** in 30 of 80 runs (37.5%) — `grep -q` exits at the first match, closing
+#        the read end, and whichever of `printf`'s write(2) calls lands after that gets EPIPE. Over
+#        those 80 runs `rc=1` occurred ZERO times: the note was present EVERY time, so the pipeline
+#        was inverting a TRUE assertion into a FAIL. It red two consecutive gates of record on an
+#        identical tree digest (#3414) before the mechanism was found.
+#
+#        DANGER HEURISTIC for the other ~200 sites in #3685 — large variable x EARLY match. Here the
+#        data is 34,397 bytes (it FITS a 65,536-byte pipe, so this is syscall interleaving, NOT
+#        buffer exhaustion) and the first match is at byte 3,372, so grep discards 31,025 bytes it
+#        never reads: near-maximal exposure. A pattern near the END of its data is nearly safe.
+#        `[[ ]]` glob measured 0/80 on the identical variable and load. Only THIS site is changed.
+if [[ $nll_component == *'_node_leak_lane_note SKIP-OPTOUT'* ]]; then
   ok "1465-skip-declares: the #3522 opt-out SKIP branch writes the SKIP-OPTOUT note"
 else
   bad "1465-skip-declares: the opt-out SKIP branch does not declare the leak-lane state"

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -4721,7 +4721,18 @@ fi
 nll_comp_v1=$(sed -n '/^run_node_bindings() {/,/^}$/p' "$GATE")
 nll_leakfile_v1="$SCRIPT_DIR/../../bindings/node/__test__/leak-paths.test.js"
 nll_v1_ok=1
-printf '%s' "$nll_comp_v1" | grep -q 'leak_strict_env=(-u CQLITE_LEAK_BUDGET_RELAX)' \
+# SIGPIPE-FREE MATCH (#3685), second and LAST measured-dangerous site in this file. The
+# `printf | grep -q` form here false-FAILed 12/40 (30%): the data is 34,397 bytes and this
+# pattern sits at byte 6,331, so `grep -q` exits having DISCARDED 28,066 bytes and whichever
+# of printf's write(2) calls lands after that gets EPIPE -> rc=141 -> a FAIL on a TRUE
+# assertion. It is why `1465-gate-strict` red 1-in-3 suite runs even after L4618 was fixed.
+#        SORT KEY for #3685's other sites is BYTES DISCARDED, not "early match" — the
+#        discarded count IS the race window. Measured here: 305-byte data at 14% => 0/40
+#        (too small to race); 34,397-byte data at 93%/98% => 0/40 (only ~2.5KB discarded);
+#        34,397 at 18%/10% => 30%/37.5%. Small OR late is safe; only large AND early fires.
+#        `grep -c` sites below are SAFE by construction — a count reads all input, so there
+#        is no early exit to race. Only the two `grep -q` sites needed changing.
+[[ $nll_comp_v1 == *'leak_strict_env=(-u CQLITE_LEAK_BUDGET_RELAX)'* ]] \
   || { nll_v1_ok=0; echo "  node-bindings does not declare the strict leak-budget env"; }
 # every `env` that launches node in this component must carry the unset array
 nll_env_launches=$(printf '%s\n' "$nll_comp_v1" | grep -cE '^[[:space:]]*if (! )?env ')

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -2609,12 +2609,17 @@ else
   #      must be the probe's VERIFIED verdict. Any future `ok` added for a file write,
   #      a profile grep or an inherited value reds this immediately.
   pin_section=$(awk '/^# ---- 5b\./,/^# ---- 5c\./' "$BOOTSTRAP")
+  # TWO success verdicts now, and both are ENUMERATED rather than merely counted: the
+  # probe's VERIFIED, and the non-Linux NOT-APPLICABLE (an explicit inapplicability, which
+  # must be an [ok] so a correctly-configured Mac is not permanently non-passing). Naming
+  # them is what keeps this a real guard — a bare count of 2 would let a third `ok` in as
+  # soon as someone removed one of these.
   pin_ok_total=$(printf '%s\n' "$pin_section" | grep -cE '^[[:space:]]*ok "' || true)
-  pin_ok_verified=$(printf '%s\n' "$pin_section" | grep -cE '^[[:space:]]*ok "gate-pin: VERIFIED' || true)
-  if [ -n "$pin_section" ] && [ "${pin_ok_total:-0}" = 1 ] && [ "${pin_ok_verified:-0}" = 1 ]; then
-    ok "gate-pin: section 5b's ONLY success verdict is the probe's VERIFIED line"
+  pin_ok_named=$(printf '%s\n' "$pin_section" | grep -cE '^[[:space:]]*ok "gate-pin: (VERIFIED|NOT-APPLICABLE)' || true)
+  if [ -n "$pin_section" ] && [ "${pin_ok_total:-0}" = 2 ] && [ "${pin_ok_named:-0}" = 2 ]; then
+    ok "gate-pin: section 5b's ONLY success verdicts are VERIFIED and NOT-APPLICABLE"
   else
-    bad "gate-pin: section 5b has ${pin_ok_total:-0} ok() call(s), ${pin_ok_verified:-0} of them the probe verdict"
+    bad "gate-pin: section 5b has ${pin_ok_total:-0} ok() call(s), ${pin_ok_named:-0} of them a named verdict"
   fi
 
   # 11j. The OPT-OUT is loud and NON-PASSING: a switch that returned `ok` would be a
@@ -2968,11 +2973,14 @@ else
   #      UNMEASURED. Asserted across all three file states in one loop, because the
   #      individual cases (11w absent, 11z2 present, 11s2 unreadable) each check one row
   #      and none of them states the INVARIANT that binds the three.
-  for pin_row in absent present unreadable; do
+  for pin_row in absent present mismatched unreadable; do
     envf_r5="$tmp/pin-env-r5-$pin_row"
     case "$pin_row" in
       absent)     : >"$envf_r5" ;;
       present)    printf 'CQLITE_GATE_MAX_CONCURRENCY=1\n' >"$envf_r5" ;;
+      # `mismatched` joined the loop with the value check (roborev round 3): the new
+      # comparison must not become a way for file state to soften a negative either.
+      mismatched) printf 'CQLITE_GATE_MAX_CONCURRENCY=abc\n' >"$envf_r5" ;;
       unreadable) printf 'CQLITE_GATE_MAX_CONCURRENCY=1\n' >"$envf_r5"; chmod 0000 "$envf_r5" ;;
     esac
     if [ "$pin_row" = unreadable ] && [ "$(id -u)" = 0 ]; then
@@ -2989,6 +2997,70 @@ else
       printf '%s\n' "$out_r5" | grep -i 'gate-pin' | head -2
     fi
   done
+
+  # 11aa. THE FILE'S VALUE MUST EQUAL THE SESSION'S, not merely exist (issue #3414 roborev
+  #      round 3 — the FOURTH instance of this issue's own defect in this lane, and it was
+  #      inside the correlation added to fix the third). File says `abc`, a sudo- or
+  #      user-specific source supplies `1`: both halves of "line present AND session sees
+  #      it" hold, so the old check said VERIFIED — while every ordinary PAM session gets
+  #      `abc`, which the gate discards for its default formula and stamps N(invalid).
+  envf_aa="$tmp/pin-env-aa"; printf 'CQLITE_GATE_MAX_CONCURRENCY=abc\n' >"$envf_aa"
+  out_aa=$(runpin "$pinroot" "$shims_one" "$envf_aa" HOME="$pin_home_plain")   # session sees 1
+  if printf '%s' "$out_aa" | grep -q 'gate-pin: NOT-SYSTEM-WIDE' \
+     && ! printf '%s' "$out_aa" | grep -qE '\[ok\].*gate-pin' \
+     && printf '%s' "$out_aa" | grep -q "OVERRIDING the system-wide file"; then
+    ok "gate-pin: a file value the session does NOT match is not VERIFIED (presence is not the predicate)"
+  else
+    bad "gate-pin: a file/session VALUE mismatch was certified"
+    printf '%s\n' "$out_aa" | grep -i 'gate-pin' | head -3
+  fi
+
+  # 11ab. ...and the equality is a STRING comparison, deliberately not a numeric one. The
+  #      gate's own resolver discards `1 ` (trailing space matches *[!0-9]*), so treating
+  #      it as equal to `1` here would make bootstrap certify a value the gate rejects —
+  #      a second classifier disagreeing with the one that decides, which is the thing
+  #      pin_gate_source_for exists to avoid.
+  envf_ab="$tmp/pin-env-ab"; printf 'CQLITE_GATE_MAX_CONCURRENCY=1 \n' >"$envf_ab"
+  out_ab=$(runpin "$pinroot" "$shims_one" "$envf_ab" HOME="$pin_home_plain")
+  if ! printf '%s' "$out_ab" | grep -qE '\[ok\].*gate-pin'; then
+    ok "gate-pin: '1 ' in the file is not equal to '1' in the session (string equality, as the gate resolves it)"
+  else
+    bad "gate-pin: a value the gate would DISCARD was normalised into a match"
+    printf '%s\n' "$out_ab" | grep -i 'gate-pin' | head -2
+  fi
+
+  # 11ac. NON-LINUX IS AN EXPLICIT, NON-FAILING INAPPLICABILITY (roborev round 3). The
+  #      mechanism is /etc/environment + pam_env, which is Linux-specific, so requiring
+  #      the file made a correctly-configured Mac permanently fail --strict — red on
+  #      correct input, the shape refused three times in this lane. It must be an [ok]
+  #      (so --strict can pass), it must SAY it is inapplicable rather than going silent,
+  #      and it must name the per-run authority.
+  shims_mac="$tmp/pin-shims-mac"; mkpinshims "$shims_mac" 1
+  mk_stub "$shims_mac" uname 'echo Darwin'
+  envf_ac="$tmp/pin-env-ac"; : >"$envf_ac"
+  out_ac=$(runpin "$pinroot" "$shims_mac" "$envf_ac" HOME="$pin_home_plain")
+  if printf '%s' "$out_ac" | grep -qE '\[ok\].*gate-pin: NOT-APPLICABLE' \
+     && printf '%s' "$out_ac" | grep -q 'max-concurrency=N(pinned)' \
+     && ! printf '%s' "$out_ac" | grep -qE '\[warn\].*gate-pin'; then
+    ok "gate-pin: a non-Linux host reports explicit NOT-APPLICABLE as an [ok], never a warn"
+  else
+    bad "gate-pin: a non-Linux host was not reported as an explicit, non-failing inapplicability"
+    printf '%s\n' "$out_ac" | grep -i 'gate-pin' | head -3
+  fi
+
+  # 11ad. ...and the scoping is on PLATFORM, not on "the file is missing". A LINUX box
+  #      with no /etc/environment is a genuine anomaly and must stay non-passing; folding
+  #      it into 11ac's branch would trade a false red for a false green. Same input as
+  #      11ac (no env file) with the only difference being the platform.
+  envf_ad="$tmp/pin-env-ad-missing"; rm -f "$envf_ad"
+  out_ad=$(runpin "$pinroot" "$shims_one" "$envf_ad" HOME="$pin_home_plain")
+  if ! printf '%s' "$out_ad" | grep -qE '\[ok\].*gate-pin' \
+     && ! printf '%s' "$out_ad" | grep -q 'NOT-APPLICABLE'; then
+    ok "gate-pin: a LINUX box with no system env file stays non-passing (scoped by platform, not by file absence)"
+  else
+    bad "gate-pin: a Linux anomaly was excused as a platform inapplicability"
+    printf '%s\n' "$out_ad" | grep -i 'gate-pin' | head -2
+  fi
 
   # 11k. The test seam is FAIL-CLOSED and has NO production fallback: set without its
   #      marker, or relative, it SKIPS the section rather than silently persisting to

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -3231,10 +3231,19 @@ else
   # The PAM weaken-signal was DELETED (#3414 round 7 ruling), so the note no longer claims
   # the service stacks were checked — it now states that they are NOT checked here. That
   # is the whole point of the deletion: the note must not assert a scope nothing measured.
+  # AND IT MUST DISCLOSE THE TEMPORAL HALF (#3728). pam_env reads the file at SESSION
+  # CREATION, so a VERIFIED verdict is about FUTURE sessions: this shell and everything
+  # already descended from it — including workers a launcher started earlier — do not have
+  # the pin until their sessions are recreated. That was disclosed in the PR body and in
+  # #3728 and NOWHERE IN THE EMITTED LINE, which is the only place an operator reads. A
+  # caveat that lives where only a caveat-hunter looks is not a disclosure; asserted here
+  # so a later edit cannot drop it silently.
   if printf '%s' "$out_x" | grep -q 'is NOT checked here' \
      && printf '%s' "$out_x" | grep -q 'created WITHOUT PAM' \
+     && printf '%s' "$out_x" | grep -q 'SESSION CREATION' \
+     && printf '%s' "$out_x" | grep -q 'already descended from it' \
      && printf '%s' "$out_x" | grep -q 'max-concurrency=N(pinned)'; then
-    ok "gate-pin: the scope note states what it did NOT check and names the gate's token as authority"
+    ok "gate-pin: the scope note states what it did NOT check, that the verdict covers FUTURE sessions only, and names the gate's token as authority"
   else
     bad "gate-pin: the scope note does not match the correlated verdict"
     printf '%s\n' "$out_x" | grep -iA 3 'gate-pin: VERIFIED' | head -4

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -3460,21 +3460,37 @@ else
   fi
 
   # 11aj. ...but where NO system-wide value can be established the append still happens,
-  #      so 11ai cannot pass against a build that simply stopped writing profiles. The
-  #      reachable state is a MISSING system env file: bootstrap writes nothing there, so
-  #      PAM delivers nothing, and the profile is the only lever left. (A box that merely
-  #      STARTS empty is not this case — `--yes` persists into it and the append is then
-  #      correctly skipped, because PAM now delivers the value to interactive shells too.
-  #      I discovered that by writing this case the obvious way first and watching it
-  #      fail, which is the distinction worth recording here.)
+  #      so 11ai cannot pass against a build that simply stopped writing profiles.
+  #
+  #      THE STATE HAS TO BE AN UNWRITABLE ENV FILE, NOT A MISSING ONE — and this case's
+  #      premise was invalidated by THIS BRANCH. A missing file used to qualify, because
+  #      bootstrap refused to create one, so PAM delivered nothing and the profile was the
+  #      only lever left. `--fix-gate-pin`/`--yes` now CREATE it, so on a missing file
+  #      bootstrap establishes the system-wide value and then CORRECTLY skips the profile
+  #      (that skip is 11ai's whole point). Measured: the run emits `CREATED <file>
+  #      carrying CQLITE_GATE_MAX_CONCURRENCY=1` and then `not touching <profile>`.
+  #      A file that EXISTS but cannot be written is still genuinely unestablishable —
+  #      `the append to <file> FAILED — the pin was NOT persisted` — so the profile is
+  #      once again the only lever, and the case tests what it claims to.
+  #
+  #      (A box that merely STARTS empty is not this case either — `--yes` persists into
+  #      it and the append is correctly skipped for the same reason. I discovered that by
+  #      writing this case the obvious way first and watching it fail.)
   pin_home_aj="$tmp/pin-home-aj"; mkdir -p "$pin_home_aj/.cargo"; : >"$pin_home_aj/.bashrc"
-  envf_aj="$tmp/pin-env-aj-missing"; rm -f "$envf_aj"
+  envf_aj="$tmp/pin-env-aj-ro"; printf '# no pin here\n' >"$envf_aj"; chmod 0444 "$envf_aj"
   out_aj=$(runpin "$pinroot" "$shims_none" "$envf_aj" HOME="$pin_home_aj" SHELL=/bin/bash --yes)
+  chmod 0644 "$envf_aj" 2>/dev/null || true
   if grep -q '^export CQLITE_GATE_MAX_CONCURRENCY=1' "$pin_home_aj/.bashrc"; then
-    ok "gate-pin: on a box with no system-wide value the profile append still happens"
+    ok "gate-pin: on a box where no system-wide value CAN be established the profile append still happens"
   else
     bad "gate-pin: the profile append stopped happening even with no system-wide value (11ai would pass vacuously)"
+    # DUMP THE SCRIPT OUTPUT, not just the profile: this case previously printed only
+    # `.bashrc`, so when the premise above went stale the failure could not show WHY the
+    # append was skipped, and it was misdiagnosed as a flake in unrelated code. A failure
+    # diagnostic must carry the evidence its own assertion turns on (#3758 nit 7).
     cat "$pin_home_aj/.bashrc"
+    printf '%s\n' "$out_aj" | grep -iE 'CREATED|not touching|NOT persisted|gate-pin:' | head -8
+    echo "  env-file: mode=$(stat -c %a "$envf_aj" 2>/dev/null) content=[$(cat "$envf_aj" 2>/dev/null | tr '\n' '|')]"
   fi
 
   # 11ak. THE SEAM MUST NOT STEER A ROOT-PRIVILEGED WRITE (issue #3414 roborev round 5,

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -60,7 +60,24 @@ skip() { printf 'skip - %s\n' "$1"; SKIPS=$((SKIPS + 1)); }
 # That is not hypothetical: it is what happened 40 minutes earlier with the cargo config.
 # Even the tmpdir matters — created as root it is litter the invoking user cannot remove.
 # So the decline precedes everything, and the only host contact above it is now none.
-if [ "$(id -u)" = 0 ]; then
+#
+# AND IT ASKS BASH, NOT `id` (#3414 roborev round 9). The production guard was moved to the
+# readonly $EUID because `id` can be missing, shadowed or malformed; this decline is a
+# SAFETY gate, so the same argument applies with more force — an `id` that fails here does
+# not merely misreport, it lets the suite continue AS ROOT past the one check whose purpose
+# is to stop exactly that. $EUID is set by the shell itself, needs no PATH lookup and no
+# fork, and cannot be shadowed. A missing or non-numeric value FAILS CLOSED: unable to tell
+# is not permission to proceed.
+pin_suite_euid="${EUID-}"
+case "$pin_suite_euid" in
+  ''|*[!0-9]*)
+    printf 'bad  - THE ENTIRE SUITE: cannot determine the effective UID (EUID=%s). Refusing to run: this suite must not execute as root, and a shell that cannot answer that question cannot be trusted to have declined.\n' "${pin_suite_euid:-<unset>}"
+    echo
+    echo "PASS=$PASS FAIL=$((FAIL + 1)) SKIP=$SKIPS"
+    echo "DECLINED: EUID is unavailable, so root could not be ruled out. Run under bash." >&2
+    exit 1 ;;
+esac
+if [ "$pin_suite_euid" = 0 ]; then
   skip "THE ENTIRE SUITE: it drives bootstrap through a test seam that is REFUSED under root (#3414 finding S), so every sandboxed invocation gains a warning and the green-path assertions cannot run. Re-run as an unprivileged user."
   echo
   echo "PASS=$PASS FAIL=$FAIL SKIP=$SKIPS"

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -2362,7 +2362,21 @@ mkpinshims() {
     bin=$(type -P "$t" 2>/dev/null) || continue
     [ -n "$bin" ] && ln -sf "$bin" "$dir/$t" 2>/dev/null || true
   done
-  if [ "$val" = "-" ]; then
+  if [ "${val#file:}" != "$val" ]; then
+    # PAM STAND-IN: read the env file AT SESSION CREATION, exactly as pam_env does, so a
+    # write performed earlier in the same bootstrap run is visible to this probe. Presence
+    # of the line and its VALUE are separated (grep vs sed) so a present-but-empty line
+    # injects an empty value rather than being treated as absent — the distinction the
+    # gate's (invalid) classification turns on.
+    mk_stub "$dir" sudo "while [ \"\${1:-}\" = \"-n\" ]; do shift; done
+if [ \"\${1:-}\" = \"-u\" ]; then shift 2; fi
+pam_file='${val#file:}'
+if [ -f \"\$pam_file\" ] && grep -Eq '^[[:space:]]*CQLITE_GATE_MAX_CONCURRENCY[[:space:]]*=' \"\$pam_file\"; then
+  pam_val=\$(sed -n 's/^[[:space:]]*CQLITE_GATE_MAX_CONCURRENCY[[:space:]]*=//p' \"\$pam_file\" | head -1)
+  exec env CQLITE_GATE_MAX_CONCURRENCY=\"\$pam_val\" \"\$@\"
+fi
+exec \"\$@\""
+  elif [ "$val" = "-" ]; then
     mk_stub "$dir" sudo 'while [ "${1:-}" = "-n" ]; do shift; done
 if [ "${1:-}" = "-u" ]; then shift 2; fi
 exec "$@"'
@@ -2646,6 +2660,123 @@ else
     printf '%s\n' "$out_p" | grep -i 'gate-pin\|nowhere\|fix:' | head -4
   fi
 
+  # 11q. PERSIST-THEN-PROBE WITHIN ONE RUN — the property `verify.run` depends on.
+  #      `--fix-gate-pin` writes the env file and the probe then opens a NEW session, which
+  #      reads that file at session creation, so a box that starts unpinned must come out
+  #      of the SAME invocation VERIFIED — no --yes, no re-login, no second run. If this
+  #      does not hold, putting the flag in .agent-ami/profile.yaml's verify.run buys
+  #      nothing. The `sudo` shim here stands in for pam_env by reading the file, so the
+  #      case exercises the ORDERING rather than a canned answer.
+  envf_q="$tmp/pin-env-q"; : >"$envf_q"
+  shims_pam_q="$tmp/pin-shims-pam-q"; mkpinshims "$shims_pam_q" "file:$envf_q"
+  out_q=$(runpin "$pinroot" "$shims_pam_q" "$envf_q" HOME="$pin_home_plain" --fix-gate-pin)
+  if printf '%s' "$out_q" | grep -q 'gate-pin: VERIFIED' \
+     && grep -q '^CQLITE_GATE_MAX_CONCURRENCY=1$' "$envf_q"; then
+    ok "gate-pin: --fix-gate-pin persists AND the same run's probe then sees it (no --yes, no re-login)"
+  else
+    bad "gate-pin: persist-then-probe did not close within one run"
+    printf '%s\n' "$out_q" | grep -i 'gate-pin' | head -3
+    cat "$envf_q"
+  fi
+
+  # 11r. The NEGATIVE twin of 11q, so it cannot pass for the wrong reason: with the SAME
+  #      pam-stand-in shim and no repair flag, an unpinned box must still come out FAILED.
+  #      Without this, 11q would also pass against a shim that injects unconditionally.
+  envf_r="$tmp/pin-env-r"; : >"$envf_r"
+  shims_pam_r="$tmp/pin-shims-pam-r"; mkpinshims "$shims_pam_r" "file:$envf_r"
+  out_r=$(runpin "$pinroot" "$shims_pam_r" "$envf_r" HOME="$pin_home_plain")
+  if printf '%s' "$out_r" | grep -q 'gate-pin: FAILED' \
+     && ! printf '%s' "$out_r" | grep -qE '\[ok\].*gate-pin' \
+     && [ ! -s "$envf_r" ]; then
+    ok "gate-pin: without a repair flag the same unpinned box stays FAILED and nothing is written"
+  else
+    bad "gate-pin: the no-flag twin did not stay FAILED (or wrote without being asked)"
+    printf '%s\n' "$out_r" | grep -i 'gate-pin' | head -3
+  fi
+
+  # 11s. --fix-gate-pin must stay NON-PASSING on a box it cannot certify. An onboarding
+  #      instance without passwordless sudo has to red loudly — that is the whole point of
+  #      putting the flag behind --strict in verify.run, and `--strict` keys off exactly
+  #      this: a [warn] rather than an [ok].
+  #
+  #      It deliberately does NOT also assert "wrote nothing". Under the test seam the
+  #      write is forced UNPRIVILEGED (that is what makes "no env var can steer a
+  #      PRIVILEGED write" true), so a broken `sudo` cannot stop the sandbox write and the
+  #      file-emptiness half would be asserting a property of the seam, not of the code.
+  #      The refuse-to-persist path is covered behaviourally by 11s2 below instead.
+  envf_s="$tmp/pin-env-s"; : >"$envf_s"
+  out_s=$(runpin "$pinroot" "$shims_pw" "$envf_s" HOME="$pin_home_plain" --fix-gate-pin)
+  if ! printf '%s' "$out_s" | grep -qE '\[ok\].*gate-pin' \
+     && printf '%s' "$out_s" | grep -qE '\[warn\].*gate-pin:'; then
+    ok "gate-pin: --fix-gate-pin on a box it cannot certify stays non-passing (so --strict exits 1)"
+  else
+    bad "gate-pin: --fix-gate-pin reported ok on a box without passwordless sudo"
+    printf '%s\n' "$out_s" | grep -i 'gate-pin' | head -3
+  fi
+
+  # 11s2. ...and a genuine COULD-NOT-PERSIST condition refuses the write, says why, and
+  #      still does not pass. An unreadable env file is the one such condition reachable
+  #      through the seam: bootstrap will not append blind, because it cannot tell whether
+  #      a line is already there and a blind append could duplicate or contradict it.
+  #      Root can read a 0000 file, so the case would assert nothing as root — skipped
+  #      rather than silently inverted.
+  if [ "$(id -u)" = 0 ]; then
+    ok "SKIP gate-pin unreadable-env-file case (running as root: 0000 is still readable)"
+  else
+    envf_s2="$tmp/pin-env-s2"; printf 'FOO=bar\n' >"$envf_s2"; chmod 0000 "$envf_s2"
+    # shims_none (a session that injects nothing) is the right stand-in here: the append
+    # was refused, so the box IS unpinned and the probe must say so. Using a shim bound to
+    # some OTHER case's file would report that file's pin and green this case for a reason
+    # that has nothing to do with it.
+    out_s2=$(runpin "$pinroot" "$shims_none" "$envf_s2" HOME="$pin_home_plain" --fix-gate-pin)
+    chmod 0644 "$envf_s2"
+    if printf '%s' "$out_s2" | grep -q 'cannot read' \
+       && printf '%s' "$out_s2" | grep -q 'gate-pin: FAILED' \
+       && ! printf '%s' "$out_s2" | grep -qE '\[ok\].*gate-pin' \
+       && [ "$(cat "$envf_s2")" = "FOO=bar" ]; then
+      ok "gate-pin: an unreadable env file refuses the append, says why, and does not pass"
+    else
+      bad "gate-pin: an unreadable env file was appended to blind (or still passed)"
+      printf '%s\n' "$out_s2" | grep -i 'gate-pin\|cannot read' | head -3
+      cat "$envf_s2"
+    fi
+  fi
+
+  # 11t. Contradictory intents do not resolve silently: an explicit --skip-gate-pin beside
+  #      --fix-gate-pin is a usage error, and flag ORDER must not change that.
+  #      The MESSAGE is asserted too, not just the exit code: an unrecognised flag also
+  #      exits 2, so a bare rc check would pass against a build that never learned
+  #      --fix-gate-pin at all — a vacuous green in the exact place this case exists.
+  for pin_order in "--skip-gate-pin --fix-gate-pin" "--fix-gate-pin --skip-gate-pin"; do
+    # shellcheck disable=SC2086
+    pin_t_out=$(env PATH="$shims_one" HOME="$pin_home_plain" CARGO_HOME="$tmp/pin-cargo" \
+      CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="$tmp/pin-env-t" \
+      timeout -s KILL 120 bash "$pinroot/scripts/bootstrap-agent-machine.sh" \
+        --skip-smoke $pin_order 2>&1)
+    pin_t_rc=$?
+    if [ "$pin_t_rc" -eq 2 ] && printf '%s' "$pin_t_out" | grep -q 'contradictory'; then
+      ok "gate-pin: '$pin_order' is a usage error naming the contradiction, whatever the order"
+    else
+      bad "gate-pin: '$pin_order' did not exit 2 naming the contradiction (rc=$pin_t_rc)"
+      printf '%s\n' "$pin_t_out" | head -2
+    fi
+  done
+
+  # 11u. ...but the weaker ENV opt-out yields to an explicit --fix-gate-pin, so a harness
+  #      that exports CQLITE_BOOTSTRAP_SKIP_GATE_PIN=1 cannot neuter a caller's repair.
+  envf_u="$tmp/pin-env-u"; : >"$envf_u"
+  shims_pam_u="$tmp/pin-shims-pam-u"; mkpinshims "$shims_pam_u" "file:$envf_u"
+  out_u=$(runpin "$pinroot" "$shims_pam_u" "$envf_u" HOME="$pin_home_plain" \
+    CQLITE_BOOTSTRAP_SKIP_GATE_PIN=1 --fix-gate-pin)
+  if printf '%s' "$out_u" | grep -q 'gate-pin: VERIFIED' \
+     && ! printf '%s' "$out_u" | grep -q 'gate-pin: OPT-OUT'; then
+    ok "gate-pin: an explicit --fix-gate-pin overrides the weaker env opt-out"
+  else
+    bad "gate-pin: the env opt-out neutered an explicit --fix-gate-pin"
+    printf '%s\n' "$out_u" | grep -i 'gate-pin' | head -3
+  fi
+
+
   # 11k. The test seam is FAIL-CLOSED and has NO production fallback: set without its
   #      marker, or relative, it SKIPS the section rather than silently persisting to
   #      the real /etc/environment (the #3249 lesson — a seam that degrades to the
@@ -2669,6 +2800,21 @@ else
     printf '%s\n' "$out_k" | grep -i 'gate-pin' | head -2
     printf '%s\n' "$out_k2" | grep -i 'gate-pin' | head -2
   fi
+fi
+
+# 11v. THE COUPLING THAT MOTIVATES THE FLAG. --fix-gate-pin exists because a launched box's
+#      ONLY bootstrap invocation is .agent-ami/profile.yaml's verify.run. If that command
+#      string ever loses the flag, every new instance silently arrives unpinned again and
+#      nothing else in this suite would notice — the flag would still work perfectly and be
+#      called by nobody.
+pin_profile="$SCRIPT_DIR/../../.agent-ami/profile.yaml"
+if [ ! -r "$pin_profile" ]; then
+  bad "gate-pin: .agent-ami/profile.yaml is not readable — cannot check verify.run carries --fix-gate-pin"
+elif grep -E '^[[:space:]]*run:.*bootstrap-agent-machine\.sh' "$pin_profile" | grep -q -- '--fix-gate-pin'; then
+  ok "gate-pin: .agent-ami/profile.yaml's verify.run persists the pin on a launched box (--fix-gate-pin)"
+else
+  bad "gate-pin: verify.run no longer passes --fix-gate-pin — launched boxes will arrive UNPINNED"
+  grep -nE '^[[:space:]]*run:.*bootstrap-agent-machine\.sh' "$pin_profile" | head -2
 fi
 
 echo

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -3789,18 +3789,25 @@ exec env CQLITE_GATE_MAX_CONCURRENCY=1 "$@"'
     echo "  file-exists=$([ -e "$envf_bc" ] && echo yes || echo no) content=[$(cat "$envf_bc" 2>/dev/null | tr '\n' '|')]"
   fi
 
-  # 11bh. TWO CONCURRENT RUNS MUST PRODUCE ONE LINE, NOT TWO (roborev job 316, Medium). The
-  #      append was a bare `tee -a` decided from a check taken ~150 lines earlier, so two
-  #      bootstraps on the same box — the standing model since #3393 is several lanes per box
-  #      — both saw "no line" and both appended, leaving DUPLICATE assignments that pam_env
-  #      resolves by taking the last.
+  # 11bh. AN INVARIANT GUARD, EXPLICITLY *NOT* A DISCRIMINATOR FOR THE LOCK. Two concurrent
+  #      runs must leave exactly ONE CQLITE_GATE_MAX_CONCURRENCY line, because pam_env
+  #      resolves duplicates by taking the last.
   #
-  #      This is the one half of that fix a test can actually schedule, and it is deterministic
-  #      in its OUTCOME rather than its timing: whichever run takes the flock first appends,
-  #      and the other re-reads INSIDE the lock, sees the line and declines. So the assertion
-  #      is on the count, never on which run won. (The other half — a NON-cooperating writer
-  #      using a plain `>>` — is declared uncovered at 11bg above: flock is advisory, and no
-  #      test can inject a write between another implementation's check and its append.)
+  #      MEASURED, and stated because the first version of this comment claimed the opposite:
+  #      this case passes against the pre-lock bootstrap TOO (RED run: PASS=199 FAIL=0, with
+  #      the sanity checks confirming 11bh present and `pin_append_env_file` absent). Two
+  #      runs started together do enough work before their append that one finishes before
+  #      the other reads, so the unlocked implementation serialises by luck and the duplicate
+  #      state never materialises. The case therefore pins the INVARIANT — useful against a
+  #      future change that reintroduces duplicates in a way that does race — and evidences
+  #      NOTHING about job 316's lock.
+  #
+  #      That makes THREE consecutive failed attempts to discriminate a concurrency fix in
+  #      this script (11bg's umask, this case's duplicate count, and the O_EXCL race itself).
+  #      The generalisation is worth more than the cases: a fix that narrows a WINDOW is not
+  #      observable from a harness that cannot schedule the window, and a test that passes
+  #      either way is indistinguishable from coverage until you run it against the defect.
+  #      Both concurrency fixes are DECLARED UNCOVERED — see the note at 11bg.
   envf_bh="$tmp/pin-env-bh"; : >"$envf_bh"
   runpin "$pinroot" "$shims_one" "$envf_bh" HOME="$tmp/pin-home-bh1" --fix-gate-pin >/dev/null 2>&1 &
   pin_bh1=$!
@@ -3809,7 +3816,7 @@ exec env CQLITE_GATE_MAX_CONCURRENCY=1 "$@"'
   wait "$pin_bh1" 2>/dev/null; wait "$pin_bh2" 2>/dev/null
   bh_lines=$(grep -cE '^[[:space:]]*CQLITE_GATE_MAX_CONCURRENCY[[:space:]]*=' "$envf_bh" 2>/dev/null)
   if [ "$bh_lines" = 1 ]; then
-    ok "gate-pin: two concurrent runs leave exactly ONE CQLITE_GATE_MAX_CONCURRENCY line (the loser re-reads inside the lock and declines)"
+    ok "gate-pin: two concurrent runs leave exactly ONE CQLITE_GATE_MAX_CONCURRENCY line (invariant guard; passes with and without the lock)"
   else
     bad "gate-pin: concurrent runs left $bh_lines CQLITE_GATE_MAX_CONCURRENCY lines (pam_env would take the last)"
     cat "$envf_bh"

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -503,7 +503,7 @@ mk_hermetic_bin() {
   local dir="$1" t p
   mkdir -p "$dir"
   for t in bash dirname mktemp grep cp cat sed awk mkdir rm ln mv touch chmod \
-           head tail tr sort cut wc stat env git find xargs basename date sleep expr \
+           head tail tr sort cut wc stat env git find xargs basename date sleep expr flock \
            timeout gtimeout; do   # BOTH: stock macOS has only gtimeout (GNU coreutils)
     p=$(type -P "$t" 2>/dev/null) || continue
     [ -n "$p" ] && ln -sf "$p" "$dir/$t" 2>/dev/null || true
@@ -3787,6 +3787,32 @@ exec env CQLITE_GATE_MAX_CONCURRENCY=1 "$@"'
     bad "gate-pin: the failed create left a residue, or did not report rolling it back"
     printf '%s\n' "$out_bc" | grep -iE 'gate-pin|CREATED|REMOVED|persisted' | head -4
     echo "  file-exists=$([ -e "$envf_bc" ] && echo yes || echo no) content=[$(cat "$envf_bc" 2>/dev/null | tr '\n' '|')]"
+  fi
+
+  # 11bh. TWO CONCURRENT RUNS MUST PRODUCE ONE LINE, NOT TWO (roborev job 316, Medium). The
+  #      append was a bare `tee -a` decided from a check taken ~150 lines earlier, so two
+  #      bootstraps on the same box — the standing model since #3393 is several lanes per box
+  #      — both saw "no line" and both appended, leaving DUPLICATE assignments that pam_env
+  #      resolves by taking the last.
+  #
+  #      This is the one half of that fix a test can actually schedule, and it is deterministic
+  #      in its OUTCOME rather than its timing: whichever run takes the flock first appends,
+  #      and the other re-reads INSIDE the lock, sees the line and declines. So the assertion
+  #      is on the count, never on which run won. (The other half — a NON-cooperating writer
+  #      using a plain `>>` — is declared uncovered at 11bg above: flock is advisory, and no
+  #      test can inject a write between another implementation's check and its append.)
+  envf_bh="$tmp/pin-env-bh"; : >"$envf_bh"
+  runpin "$pinroot" "$shims_one" "$envf_bh" HOME="$tmp/pin-home-bh1" --fix-gate-pin >/dev/null 2>&1 &
+  pin_bh1=$!
+  runpin "$pinroot" "$shims_one" "$envf_bh" HOME="$tmp/pin-home-bh2" --fix-gate-pin >/dev/null 2>&1 &
+  pin_bh2=$!
+  wait "$pin_bh1" 2>/dev/null; wait "$pin_bh2" 2>/dev/null
+  bh_lines=$(grep -cE '^[[:space:]]*CQLITE_GATE_MAX_CONCURRENCY[[:space:]]*=' "$envf_bh" 2>/dev/null)
+  if [ "$bh_lines" = 1 ]; then
+    ok "gate-pin: two concurrent runs leave exactly ONE CQLITE_GATE_MAX_CONCURRENCY line (the loser re-reads inside the lock and declines)"
+  else
+    bad "gate-pin: concurrent runs left $bh_lines CQLITE_GATE_MAX_CONCURRENCY lines (pam_env would take the last)"
+    cat "$envf_bh"
   fi
 
   # 11bg WAS HERE AND WAS DELETED, because it passed against the defect it was written for

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -3609,6 +3609,31 @@ else
   printf '%s\n' "$pin_skip_offenders"
 fi
 
+# --- 13b. THE TRIPWIRE MUST BE ABLE TO FIRE (#3414 roborev round 10) -------------------
+# Case 14 asserts the guard found nothing. That is a claim about the WORLD, and on its own
+# it is satisfied equally by a guard that works and by a guard that is blind — exactly the
+# absence-of-a-bad-signal shape this issue keeps returning to. Nothing in this suite
+# legitimately touches the shared file, so the guard's ability to DETECT is otherwise never
+# exercised: a plant that neutered it left the suite green.
+#
+# So the guard is self-tested against a STAND-IN file, never the real one: point
+# PIN_SHARED_CARGO at a throwaway, have the wrapped command mutate it, and require a
+# violation to be recorded.
+pin_guard_probe="$tmp/guard-selftest-target"; printf 'x\n' >"$pin_guard_probe"
+pin_guard_log="$tmp/guard-selftest-violations.log"; : >"$pin_guard_log"
+PIN_SHARED_CARGO="$pin_guard_probe" PIN_SHARED_VIOLATIONS="$pin_guard_log" \
+  "$PIN_BS" -c 'printf "mutated\n" >>"$1"' _ "$pin_guard_probe" >/dev/null 2>&1
+pin_guard_clean="$tmp/guard-selftest-clean.log"; : >"$pin_guard_clean"
+PIN_SHARED_CARGO="$pin_guard_probe" PIN_SHARED_VIOLATIONS="$pin_guard_clean" \
+  "$PIN_BS" -c 'true' >/dev/null 2>&1
+if [ -s "$pin_guard_log" ] && [ ! -s "$pin_guard_clean" ]; then
+  ok "host hygiene: the tripwire DETECTS a mutation across a wrapped invocation (and stays quiet without one)"
+else
+  bad "host hygiene: the tripwire cannot fire — case 14's 'nothing touched it' would be vacuous"
+  printf '  mutating run recorded: %s bytes; clean run recorded: %s bytes\n' \
+    "$(wc -c <"$pin_guard_log")" "$(wc -c <"$pin_guard_clean")"
+fi
+
 # --- 14. THIS SUITE MUST NOT TOUCH SHARED HOST STATE -----------------------------------
 # Asserted affirmatively rather than by inspection, because the reach is easy to
 # reintroduce (a new case that sets HOME and forgets CARGO_HOME, or a `sudo` invocation

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -208,13 +208,34 @@ mkdir -p "$tmp/help-home/.cargo"
 # Portable and non-fatal: `git` may be absent or this may not be a checkout, in which case
 # the stamp says UNKNOWN rather than pretending. It never fails the suite on its own —
 # the point is that the log can be read, not that the tree must be still.
+# A COUNT IS NOT A DIGEST (#3414 final roborev, finding CC). The first version recorded
+# HEAD plus the NUMBER of dirty paths — unchanged by editing an already-dirty file, and
+# unchanged by swapping one dirty path for another. So it would have reported STABLE across
+# exactly the shared-worktree edit it was built to expose, and BOTH incidents that motivated
+# it began with a file that was ALREADY modified: the instrument was blind to its own
+# founding case.
+#
+# The stamp now carries a digest of the actual content — porcelain status plus the
+# working-tree AND index diffs. `git hash-object` rather than `md5sum`/`shasum`: git is
+# already a hard requirement two lines up, while `md5sum` is GNU-only, and this suite has
+# already shipped one GNU-only probe that broke off Linux. A digest that cannot be computed
+# prints UNKNOWN, never an empty string — two empty digests compare EQUAL, which is the
+# false-STABLE all over again.
 pin_tree_id() {
+  local head dig
   if command -v git >/dev/null 2>&1 && git -C "$SCRIPT_DIR" rev-parse --git-dir >/dev/null 2>&1; then
-    printf '%s dirty=%s' \
-      "$(git -C "$SCRIPT_DIR" rev-parse --short HEAD 2>/dev/null || printf 'UNKNOWN')" \
-      "$(git -C "$SCRIPT_DIR" status --porcelain 2>/dev/null | wc -l | tr -d ' ')"
+    head=$(git -C "$SCRIPT_DIR" rev-parse --short HEAD 2>/dev/null || printf 'UNKNOWN')
+    dig=$( { git -C "$SCRIPT_DIR" status --porcelain 2>/dev/null
+             git -C "$SCRIPT_DIR" diff 2>/dev/null
+             git -C "$SCRIPT_DIR" diff --cached 2>/dev/null
+           } | git hash-object --stdin 2>/dev/null )
+    case "$dig" in
+      ?*) dig=$(printf '%s' "$dig" | cut -c1-12) ;;
+      *)  dig=UNKNOWN ;;
+    esac
+    printf '%s worktree=%s' "$head" "$dig"
   else
-    printf 'UNKNOWN dirty=UNKNOWN'
+    printf 'UNKNOWN worktree=UNKNOWN'
   fi
 }
 PIN_TREE_START=$(pin_tree_id)
@@ -2836,9 +2857,9 @@ else
   # them is what keeps this a real guard — a bare count of 2 would let a third `ok` in as
   # soon as someone removed one of these.
   pin_ok_total=$(printf '%s\n' "$pin_section" | grep -cE '^[[:space:]]*ok "' || true)
-  pin_ok_named=$(printf '%s\n' "$pin_section" | grep -cE '^[[:space:]]*ok "gate-pin: (VERIFIED|NOT-APPLICABLE)' || true)
+  pin_ok_named=$(printf '%s\n' "$pin_section" | grep -cE '^[[:space:]]*ok "gate-pin: (VERIFIED|VERIFIED-NO-SYSTEM-FILE)' || true)
   if [ -n "$pin_section" ] && [ "${pin_ok_total:-0}" = 2 ] && [ "${pin_ok_named:-0}" = 2 ]; then
-    ok "gate-pin: section 5b's ONLY success verdicts are VERIFIED and NOT-APPLICABLE"
+    ok "gate-pin: section 5b's ONLY success verdicts are VERIFIED and VERIFIED-NO-SYSTEM-FILE"
   else
     bad "gate-pin: section 5b has ${pin_ok_total:-0} ok() call(s), ${pin_ok_named:-0} of them a named verdict"
   fi
@@ -3257,23 +3278,41 @@ else
     printf '%s\n' "$out_ab" | grep -i 'gate-pin' | head -2
   fi
 
-  # 11ac. NON-LINUX IS AN EXPLICIT, NON-FAILING INAPPLICABILITY (roborev round 3). The
-  #      mechanism is /etc/environment + pam_env, which is Linux-specific, so requiring
-  #      the file made a correctly-configured Mac permanently fail --strict — red on
-  #      correct input, the shape refused three times in this lane. It must be an [ok]
-  #      (so --strict can pass), it must SAY it is inapplicable rather than going silent,
-  #      and it must name the per-run authority.
+  # 11ac. A NON-LINUX HOST IS ASKED A NARROWER QUESTION, NOT EXEMPTED FROM IT (#3414 final
+  #      roborev, finding BB). The earlier contract emitted `ok "NOT-APPLICABLE"` on every
+  #      non-Linux host unconditionally, so `--strict` CERTIFIED AN UNPINNED MAC:
+  #      inapplicability of the PERSISTENCE STEP stood in for absence of the REQUIREMENT —
+  #      this issue's own defect wearing a platform label, in code a full gate had passed.
+  #
+  #      BOTH DIRECTIONS are asserted, and the second is the one that matters, because it
+  #      is the case the old code got wrong: a non-Linux host that sees an honoured pin
+  #      earns the scoped `ok`; one that sees nothing must be NON-PASSING.
   shims_mac="$tmp/pin-shims-mac"; mkpinshims "$shims_mac" 1
   mk_stub "$shims_mac" uname 'echo Darwin'
   envf_ac="$tmp/pin-env-ac"; : >"$envf_ac"
   out_ac=$(runpin "$pinroot" "$shims_mac" "$envf_ac" HOME="$pin_home_plain")
-  if printf '%s' "$out_ac" | grep -qE '\[ok\].*gate-pin: NOT-APPLICABLE' \
-     && printf '%s' "$out_ac" | grep -q 'max-concurrency=N(pinned)' \
+  if printf '%s' "$out_ac" | grep -qE '\[ok\].*gate-pin: VERIFIED-NO-SYSTEM-FILE' \
+     && printf '%s' "$out_ac" | grep -q 'does NOT establish the pin is system-wide' \
      && ! printf '%s' "$out_ac" | grep -qE '\[warn\].*gate-pin'; then
-    ok "gate-pin: a non-Linux host reports explicit NOT-APPLICABLE as an [ok], never a warn"
+    ok "gate-pin: a non-Linux host WITH an honoured pin gets the scoped ok, worded to claim less"
   else
-    bad "gate-pin: a non-Linux host was not reported as an explicit, non-failing inapplicability"
+    bad "gate-pin: a non-Linux host with a good pin was not reported with the scoped verdict"
     printf '%s\n' "$out_ac" | grep -i 'gate-pin' | head -3
+  fi
+
+  # 11ac2. THE CASE THE OLD CONTRACT GOT WRONG: a non-Linux host whose fresh session sees
+  #      NOTHING must be NON-PASSING. Under the previous code this host got an unconditional
+  #      `ok`, so `--strict` exited 0 and certified a machine on which no gate is pinned.
+  shims_mac_none="$tmp/pin-shims-mac-none"; mkpinshims "$shims_mac_none" -
+  mk_stub "$shims_mac_none" uname 'echo Darwin'
+  envf_ac2="$tmp/pin-env-ac2"; : >"$envf_ac2"
+  out_ac2=$(runpin "$pinroot" "$shims_mac_none" "$envf_ac2" HOME="$pin_home_plain")
+  if ! printf '%s' "$out_ac2" | grep -qE '\[ok\].*gate-pin' \
+     && printf '%s' "$out_ac2" | grep -qE '\[warn\].*gate-pin'; then
+    ok "gate-pin: an UNPINNED non-Linux host is NON-PASSING — no platform exemption certifies it"
+  else
+    bad "gate-pin: an unpinned non-Linux host was certified (the finding-BB defect)"
+    printf '%s\n' "$out_ac2" | grep -i 'gate-pin' | head -3
   fi
 
   # 11ad. ...and the scoping is on PLATFORM, not on "the file is missing". A LINUX box
@@ -3283,7 +3322,7 @@ else
   envf_ad="$tmp/pin-env-ad-missing"; rm -f "$envf_ad"
   out_ad=$(runpin "$pinroot" "$shims_one" "$envf_ad" HOME="$pin_home_plain")
   if ! printf '%s' "$out_ad" | grep -qE '\[ok\].*gate-pin' \
-     && ! printf '%s' "$out_ad" | grep -q 'NOT-APPLICABLE'; then
+     && ! printf '%s' "$out_ad" | grep -qE 'NOT-APPLICABLE|VERIFIED-NO-SYSTEM-FILE'; then
     ok "gate-pin: a LINUX box with no system env file stays non-passing (scoped by platform, not by file absence)"
   else
     bad "gate-pin: a Linux anomaly was excused as a platform inapplicability"

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -2472,7 +2472,13 @@ runpin() {
 }
 
 pinroot="$tmp/pin-root"
-if ! mknotifyroot "$pinroot" good; then
+# THE SEAM IS REFUSED UNDER ROOT BY DESIGN (#3414 roborev round 5, HIGH), so this entire
+# block is unexercisable as root. Reported as ONE counted `skip` rather than an `ok`:
+# announcing a skip through ok() was round 2's finding, and reintroducing it inside the
+# block that fixed it would be galling. The capability loss is accepted, not worked around.
+if [ "$(id -u)" = 0 ]; then
+  skip "gate-pin: the ENTIRE block (the test seam is refused under root, so section 5b cannot be driven here)"
+elif ! mknotifyroot "$pinroot" good; then
   bad "gate-pin: could not stage the bootstrap tree"
 elif ! cp "$SCRIPT_DIR/../agent-gate.sh" "$pinroot/scripts/agent-gate.sh"; then
   # The verdict asks the GATE what it will do with the probed value (rather than
@@ -2955,10 +2961,14 @@ else
   #      the sudo session the probe opened — while still naming the residual it cannot
   #      cover. A note that under-claims after the correlation is as wrong as one that
   #      over-claimed before it.
-  if printf '%s' "$out_x" | grep -q 'pam_env reads for EVERY PAM-created session' \
+  # The claim STRENGTHENED with the weaken-only PAM check (roborev round 5): the note used
+  # to assert that pam_env reads the file in every stack; it now says those stacks were
+  # CHECKED. Asserting the checked wording is the point — the earlier phrasing was a
+  # statement about PAM in general, this one is a statement about THIS box.
+  if printf '%s' "$out_x" | grep -q 'session stacks were CHECKED to read it' \
      && printf '%s' "$out_x" | grep -q 'created WITHOUT PAM' \
      && printf '%s' "$out_x" | grep -q 'max-concurrency=N(pinned)'; then
-    ok "gate-pin: the scope note claims the correlated scope and still names the no-PAM residual"
+    ok "gate-pin: the scope note claims the CHECKED scope and still names the no-PAM residual"
   else
     bad "gate-pin: the scope note does not match the correlated verdict"
     printf '%s\n' "$out_x" | grep -iA 3 'gate-pin: VERIFIED' | head -4
@@ -3165,6 +3175,116 @@ else
   else
     bad "gate-pin: the profile append stopped happening even with no system-wide value (11ai would pass vacuously)"
     cat "$pin_home_aj/.bashrc"
+  fi
+
+  # 11ak. THE SEAM MUST NOT STEER A ROOT-PRIVILEGED WRITE (issue #3414 roborev round 5,
+  #      HIGH — the SIXTH instance of this issue's defect, and it was inside the safety
+  #      guard). The old invariant tested `${#PIN_ROOT[@]} -gt 0`, i.e. "are we going
+  #      through sudo" — a proxy for EFFECTIVE PRIVILEGE. Under EUID 0 the array is empty
+  #      and `tee -a` is privileged anyway, so an env var could aim a root write at any
+  #      absolute path. Asserted at the level the guard now uses: a real root invocation
+  #      with the seam set must REFUSE, not write.
+  pin_seam_probe="$tmp/pin-seam-root-target"; rm -f "$pin_seam_probe"
+  if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+    out_ak=$(sudo -n env CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="$pin_seam_probe" \
+      timeout -s KILL 120 bash "$pinroot/scripts/bootstrap-agent-machine.sh" \
+        --skip-smoke --skip-push-probe --yes 2>&1)
+    if printf '%s' "$out_ak" | grep -q 'gate-pin: SKIPPED' \
+       && printf '%s' "$out_ak" | grep -q 'PRIVILEGED write' \
+       && [ ! -e "$pin_seam_probe" ]; then
+      ok "gate-pin: a ROOT run with the seam set refuses and writes nothing to the env-chosen path"
+    else
+      bad "gate-pin: the seam was honoured under root (a privileged write could be steered)"
+      printf '%s\n' "$out_ak" | grep -i 'gate-pin' | head -2
+      ls -l "$pin_seam_probe" 2>/dev/null
+    fi
+    sudo -n rm -f "$pin_seam_probe" 2>/dev/null || true
+  else
+    skip "gate-pin root-seam refusal (no passwordless sudo here to stage a real root invocation)"
+  fi
+
+  # 11al. ...and the guard keys on EFFECTIVE PRIVILEGE, not on the sudo-prefix array.
+  #      Structural, because the behavioural case above needs root to run at all and a
+  #      future edit could revert the predicate while every unprivileged case still passes.
+  if grep -q 'PIN_EUID" = 0 \] || \[ -z "\$PIN_EUID" \] || \[ "\${#PIN_ROOT\[@\]}" -gt 0' "$BOOTSTRAP"; then
+    ok "gate-pin: the privileged-write invariant tests EUID, not merely the presence of a sudo prefix"
+  else
+    bad "gate-pin: the privileged-write invariant is back to keying on PIN_ROOT alone"
+  fi
+
+  # 11am. THE PROBE SUBJECT IS THE ACCOUNT THAT WILL RUN GATES (roborev round 5). Under
+  #      `sudo bash bootstrap`, `id -un` is root — the wrong subject, since a per-user
+  #      ~/.pam_environment on the agent account diverges from root's session. An
+  #      invoker sudo names but that does not resolve is UNMEASURED, never a silent fall
+  #      back to answering about root.
+  if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+    out_am=$(sudo -n env SUDO_USER=cqlite-no-such-account-3414 \
+      timeout -s KILL 120 bash "$pinroot/scripts/bootstrap-agent-machine.sh" \
+        --skip-smoke --skip-push-probe 2>&1)
+    if printf '%s' "$out_am" | grep -qE '\[warn\].*gate-pin: UNMEASURED' \
+       && printf '%s' "$out_am" | grep -q 'does not resolve to an account' \
+       && ! printf '%s' "$out_am" | grep -qE '\[ok\].*gate-pin'; then
+      ok "gate-pin: an unresolvable sudo invoker is UNMEASURED, never answered about root instead"
+    else
+      bad "gate-pin: an unresolvable invoker fell back to probing the wrong user"
+      printf '%s\n' "$out_am" | grep -i 'gate-pin' | head -2
+    fi
+    out_an=$(sudo -n env SUDO_USER="$(id -un)" \
+      timeout -s KILL 120 bash "$pinroot/scripts/bootstrap-agent-machine.sh" \
+        --skip-smoke --skip-push-probe 2>&1)
+    if printf '%s' "$out_an" | grep -q "the account that invoked sudo"; then
+      ok "gate-pin: a resolvable sudo invoker becomes the probe subject, and the run says so"
+    else
+      bad "gate-pin: the sudo invoker was not adopted as the probe subject"
+      printf '%s\n' "$out_an" | grep -i 'gate-pin\|subject' | head -2
+    fi
+  else
+    skip "gate-pin sudo-invocation-mode cases (no passwordless sudo here)"
+  fi
+
+  # 11ao. PAM CONFIG IS A WEAKEN-ONLY SIGNAL (roborev round 5). If the sshd/login stacks
+  #      do not read the env file, a sudo-verified pin says nothing about the sessions
+  #      gates are launched from — so it DOWNGRADES. It may never create a VERIFIED, which
+  #      is what makes consulting config legitimate at all here.
+  #
+  #      The predicate is MEASURED, not guessed: pam_env's `readenv` DEFAULTS TO ON
+  #      (pam_env(8): "By default this option is on"), so a BARE `pam_env.so` reads the
+  #      file — requiring a literal `readenv=1` would flag this very box, whose
+  #      /etc/pam.d/sshd carries a bare one, and weaken a correct machine.
+  pin_pamd_ok="$tmp/pin-pamd-ok"; pin_pamd_gap="$tmp/pin-pamd-gap"
+  mkdir -p "$pin_pamd_ok" "$pin_pamd_gap"
+  printf 'session required pam_env.so\n'            >"$pin_pamd_ok/sshd"     # bare == reads it
+  printf 'session required pam_env.so readenv=1\n'  >"$pin_pamd_ok/login"
+  printf 'session required pam_unix.so\n'           >"$pin_pamd_gap/sshd"    # no pam_env
+  printf 'session required pam_env.so readenv=1\n'  >"$pin_pamd_gap/login"
+  envf_ao="$tmp/pin-env-ao"; printf 'CQLITE_GATE_MAX_CONCURRENCY=1\n' >"$envf_ao"
+  out_ao_ok=$(runpin "$pinroot" "$shims_one" "$envf_ao" HOME="$pin_home_plain" \
+    CQLITE_BOOTSTRAP_PAM_DIR="$pin_pamd_ok")
+  out_ao_gap=$(runpin "$pinroot" "$shims_one" "$envf_ao" HOME="$pin_home_plain" \
+    CQLITE_BOOTSTRAP_PAM_DIR="$pin_pamd_gap")
+  if printf '%s' "$out_ao_ok" | grep -qE '\[ok\].*gate-pin: VERIFIED' \
+     && printf '%s' "$out_ao_gap" | grep -q 'gate-pin: NOT-SYSTEM-WIDE' \
+     && printf '%s' "$out_ao_gap" | grep -q 'does NOT read' \
+     && ! printf '%s' "$out_ao_gap" | grep -qE '\[ok\].*gate-pin'; then
+    ok "gate-pin: a service stack that does not read the env file DOWNGRADES a would-be VERIFIED"
+  else
+    bad "gate-pin: the PAM-config signal did not weaken (or a bare pam_env.so was misread as a gap)"
+    printf '%s\n' "$out_ao_ok"  | grep -i 'gate-pin' | head -1
+    printf '%s\n' "$out_ao_gap" | grep -i 'gate-pin' | head -1
+  fi
+
+  # 11ap. ...and it is WEAKEN-ONLY: config alone must never CREATE a VERIFIED. A healthy
+  #      pam.d with the pin NOT visible to the session stays FAILED. Without this, 11ao's
+  #      positive half would pass against an implementation that let config decide.
+  envf_ap="$tmp/pin-env-ap"; printf 'CQLITE_GATE_MAX_CONCURRENCY=1\n' >"$envf_ap"
+  out_ap=$(runpin "$pinroot" "$shims_none" "$envf_ap" HOME="$pin_home_plain" \
+    CQLITE_BOOTSTRAP_PAM_DIR="$pin_pamd_ok")
+  if printf '%s' "$out_ap" | grep -q 'gate-pin: FAILED' \
+     && ! printf '%s' "$out_ap" | grep -qE '\[ok\].*gate-pin'; then
+    ok "gate-pin: a healthy PAM config cannot CREATE a VERIFIED when the session sees nothing"
+  else
+    bad "gate-pin: config was allowed to manufacture a positive verdict"
+    printf '%s\n' "$out_ap" | grep -i 'gate-pin' | head -2
   fi
 
   # 11k. The test seam is FAIL-CLOSED and has NO production fallback: set without its

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -92,6 +92,67 @@ if [ "$pin_suite_euid" = 0 ]; then
   exit 1
 fi
 
+# The sandbox and the shared-state guard are created BEFORE the first case, because the
+# guard wraps every bootstrap invocation and case 2 (`--help`) is one of them. Creating it
+# later left that invocation calling an undefined "$PIN_BS" — coverage that reads as
+# complete while one call site silently is not, which is the shape this guard exists for.
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/bootstrap-test.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT
+
+# Baseline for the hermeticity assertion at the end of the suite. Captured as
+# mode+mtime+content so a rewrite is caught even if it happens to restore the bytes.
+PIN_SHARED_CARGO=/usr/local/cargo/config.toml
+pin_shared_cargo_state() {
+  [ -e "$PIN_SHARED_CARGO" ] || { printf 'absent'; return 0; }
+  printf '%s %s %s' "$(stat -c '%a' "$PIN_SHARED_CARGO" 2>/dev/null)" \
+                    "$(stat -c '%Y' "$PIN_SHARED_CARGO" 2>/dev/null)" \
+                    "$(md5sum "$PIN_SHARED_CARGO" 2>/dev/null | cut -d' ' -f1)"
+}
+PIN_SHARED_CARGO_BEFORE=$(pin_shared_cargo_state)
+
+# --- ATTRIBUTABLE, NOT MERELY DETECTED (#3414 roborev round 10) ------------------------
+# The tripwire used to snapshot the shared file around the WHOLE suite, so ANY concurrent
+# writer — a peer lane's bootstrap, an administrator, or a human at a prompt — made it FAIL
+# claiming this suite mutated the file. That is not hypothetical: the lead ran bootstrap by
+# hand mid-session and moved that file's mode and mtime; had the suite been running, its
+# tripwire would have blamed itself for someone else's shell.
+#
+# NOT weakened to a notice — a guard that cannot red cannot catch the reintroduced reach it
+# exists for. Made ATTRIBUTABLE instead: every bootstrap invocation this suite makes goes
+# through the guard below, which snapshots immediately either side of THAT invocation. A
+# change observed across a known invocation is attributable to it; a change observed across
+# 188 cases and several minutes is not.
+#
+# A SCRIPT, not a shell function, because several call sites run under `timeout`, which
+# execs a binary and cannot invoke a function. Violations are appended to a FILE rather
+# than a variable for the same reason plus one more: several invocations run inside `$( )`,
+# and a variable assigned in a subshell is discarded — the exact defect round 6 found one
+# directory over. A file survives both.
+export PIN_SHARED_VIOLATIONS="$tmp/shared-state-violations.log"
+: >"$PIN_SHARED_VIOLATIONS"
+PIN_BS="$tmp/pin-bs-guard"
+cat >"$PIN_BS" <<'PINBS'
+#!/usr/bin/env bash
+# pin-bs-guard <bootstrap-path> [args...] — run one bootstrap invocation and record any
+# change to the shared cargo config across THAT invocation. stdout/stderr and the exit
+# status pass through untouched: callers capture output and assert on rc.
+_st() {
+  [ -e "$PIN_SHARED_CARGO" ] || { printf 'absent'; return 0; }
+  printf '%s %s %s' "$(stat -c '%a' "$PIN_SHARED_CARGO" 2>/dev/null)"                     "$(stat -c '%Y' "$PIN_SHARED_CARGO" 2>/dev/null)"                     "$(md5sum "$PIN_SHARED_CARGO" 2>/dev/null | cut -d' ' -f1)"
+}
+_before=$(_st)
+bash "$@"
+_rc=$?
+_after=$(_st)
+[ "$_before" = "$_after" ] || printf 'invocation: %s
+  before: %s
+  after:  %s
+'   "$*" "$_before" "$_after" >>"$PIN_SHARED_VIOLATIONS"
+exit $_rc
+PINBS
+chmod +x "$PIN_BS"
+export PIN_SHARED_CARGO
+
 # --- 1. syntax check (bash -n) ---
 if bash -n "$BOOTSTRAP" 2>/dev/null; then
   ok "bootstrap script parses (bash -n)"
@@ -100,7 +161,7 @@ else
 fi
 
 # --- 2. --help exits 0 and prints usage ---
-help_out=$(bash "$BOOTSTRAP" --help 2>&1); help_rc=$?
+help_out=$("$PIN_BS" "$BOOTSTRAP" --help 2>&1); help_rc=$?
 if [ "$help_rc" -eq 0 ] && printf '%s' "$help_out" | grep -q "bootstrap"; then
   ok "--help exits 0 and prints usage"
 else
@@ -110,8 +171,6 @@ fi
 # --- 3. Pure-check run must NOT install. Shadow brew/cargo/roborev with a tripwire
 #        on PATH so ANY install attempt is recorded, then assert nothing ran an
 #        install subcommand. ---
-tmp=$(mktemp -d "${TMPDIR:-/tmp}/bootstrap-test.XXXXXX")
-trap 'rm -rf "$tmp"' EXIT
 tripwire="$tmp/tripwire.log"
 : >"$tripwire"
 
@@ -169,16 +228,6 @@ export CQLITE_BOOTSTRAP_ENV_FILE="$tmp/etc-environment"
 export CARGO_HOME="$tmp/cargo-home"
 mkdir -p "$CARGO_HOME"
 
-# Baseline for the hermeticity assertion at the end of the suite. Captured as
-# mode+mtime+content so a rewrite is caught even if it happens to restore the bytes.
-PIN_SHARED_CARGO=/usr/local/cargo/config.toml
-pin_shared_cargo_state() {
-  [ -e "$PIN_SHARED_CARGO" ] || { printf 'absent'; return 0; }
-  printf '%s %s %s' "$(stat -c '%a' "$PIN_SHARED_CARGO" 2>/dev/null)" \
-                    "$(stat -c '%Y' "$PIN_SHARED_CARGO" 2>/dev/null)" \
-                    "$(md5sum "$PIN_SHARED_CARGO" 2>/dev/null | cut -d' ' -f1)"
-}
-PIN_SHARED_CARGO_BEFORE=$(pin_shared_cargo_state)
 
 # --- REAL-ORIGIN isolation for the push probe (issue #3369) ----------------
 # Section 3b now MEASURES push capability by actually pushing a throwaway
@@ -229,7 +278,7 @@ host_home="$tmp/host-home"; mkdir -p "$host_home/.cargo"
 
 # Run with the shims FIRST on PATH, default mode (no --yes), skipping the smoke.
 run_out=$(PATH="$tmp:$PATH" HOME="$host_home" CARGO_HOME="$host_home/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1); run_rc=$?
+  "$PIN_BS" "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1); run_rc=$?
 
 if [ "$run_rc" -eq 0 ]; then
   ok "default (no --yes) run exits 0"
@@ -260,7 +309,7 @@ done
 # Reset the tripwire so the no-install assertion below reflects ONLY this run.
 : >"$tripwire"
 guard_out=$(PATH="$tmp:/usr/bin:/bin" HOME="$host_home" CARGO_HOME="$host_home/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
+  "$PIN_BS" "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
 if printf '%s' "$guard_out" | grep -Eq "install sccache:|sccache MISSING"; then
   ok "missing accelerator prints install guidance (does not auto-install)"
 else
@@ -348,7 +397,7 @@ stub_net "$stubA"
 mk_stub "$stubA" mold '[ "$1" = --version ] && echo "mold 2.4.0"; exit 0'
 mk_stub "$stubA" cc 'exit 0'
 outA=$(PATH="$stubA:$PATH" HOME="$sbA" CARGO_HOME="$sbA/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
+  "$PIN_BS" "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
 cfgA="$sbA/.cargo/config.toml"
 if printf '%s' "$outA" | grep -q "Link accelerator: mold"; then
   ok "mold: Linux run emits the mold section"
@@ -376,7 +425,7 @@ fi
 #     identical to the first run.
 firstA=$(cat "$cfgA")
 PATH="$stubA:$PATH" HOME="$sbA" CARGO_HOME="$sbA/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe >/dev/null 2>&1
+  "$PIN_BS" "$BOOTSTRAP" --skip-smoke --skip-push-probe >/dev/null 2>&1
 secondA=$(cat "$cfgA")
 if [ "$(count_begin "$cfgA")" = 1 ] && [ "$firstA" = "$secondA" ]; then
   ok "mold: re-run idempotent (exactly one block, file byte-identical)"
@@ -389,7 +438,7 @@ sbC=$(mktemp -d "$tmp/moldC.XXXXXX"); mkdir -p "$sbC/.cargo"
 cfgC="$sbC/.cargo/config.toml"
 printf '[build]\njobs = 7\n\n[net]\nretry = 9\n' >"$cfgC"
 PATH="$stubA:$PATH" HOME="$sbC" CARGO_HOME="$sbC/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe >/dev/null 2>&1
+  "$PIN_BS" "$BOOTSTRAP" --skip-smoke --skip-push-probe >/dev/null 2>&1
 if grep -qx 'jobs = 7' "$cfgC" && grep -qx 'retry = 9' "$cfgC" \
    && grep -qx '\[build\]' "$cfgC" && grep -qx '\[net\]' "$cfgC" \
    && grep -q '^# BEGIN cqlite-mold' "$cfgC"; then
@@ -401,7 +450,7 @@ fi
 # Idempotent even with user content present.
 firstC=$(cat "$cfgC")
 PATH="$stubA:$PATH" HOME="$sbC" CARGO_HOME="$sbC/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe >/dev/null 2>&1
+  "$PIN_BS" "$BOOTSTRAP" --skip-smoke --skip-push-probe >/dev/null 2>&1
 if [ "$firstC" = "$(cat "$cfgC")" ] && [ "$(count_begin "$cfgC")" = 1 ]; then
   ok "mold: re-run with user content stays byte-identical (one block)"
 else
@@ -416,7 +465,7 @@ mk_stub "$stubD" mold 'exit 0'
 mk_stub "$stubD" cc 'exit 1'
 mk_stub "$stubD" clang 'exit 1'
 outD=$(PATH="$stubD:$PATH" HOME="$sbD" CARGO_HOME="$sbD/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
+  "$PIN_BS" "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
 if printf '%s' "$outD" | grep -q "link probe FAILED" \
    && [ ! -f "$sbD/.cargo/config.toml" ]; then
   ok "mold: failed link probe warns and writes no linker config"
@@ -433,7 +482,7 @@ mk_stub "$stubE" mold 'exit 0'
 mk_stub "$stubE" cc 'exit 1'
 mk_stub "$stubE" clang 'exit 0'
 PATH="$stubE:$PATH" HOME="$sbE" CARGO_HOME="$sbE/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe >/dev/null 2>&1
+  "$PIN_BS" "$BOOTSTRAP" --skip-smoke --skip-push-probe >/dev/null 2>&1
 cfgE="$sbE/.cargo/config.toml"
 if [ -f "$cfgE" ] && [ "$(grep -c '^linker = "clang"' "$cfgE")" = 2 ]; then
   ok "mold: clang-only probe writes linker = \"clang\" for both triples"
@@ -449,7 +498,7 @@ stub_net "$stubF"
 mk_stub "$stubF" mold '[ "$1" = --version ] && echo "mold 2.4.0"; exit 0'
 mk_stub "$stubF" cc 'exit 0'
 outF=$(PATH="$stubF:$PATH" HOME="$sbF" CARGO_HOME="$sbF/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
+  "$PIN_BS" "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
 if ! printf '%s' "$outF" | grep -q "Link accelerator: mold" \
    && [ ! -f "$sbF/.cargo/config.toml" ]; then
   ok "mold: Darwin performs no mold detection/config (no-op)"
@@ -466,7 +515,7 @@ mk_hermetic_bin "$stubG"
 tripG="$stubG/tripwire.log"; : >"$tripG"
 mk_stub "$stubG" apt-get "echo \"apt-get \$*\" >>\"$tripG\"; exit 0"
 outG=$(PATH="$stubG" HOME="$sbG" CARGO_HOME="$sbG/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
+  "$PIN_BS" "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
 if printf '%s' "$outG" | grep -q "mold MISSING" \
    && printf '%s' "$outG" | grep -q "install mold:.*apt-get install -y mold" \
    && [ ! -s "$tripG" ] \
@@ -482,7 +531,7 @@ fi
 sbH=$(mktemp -d "$tmp/moldH.XXXXXX"); stubH="$tmp/stubH"
 mk_hermetic_bin "$stubH"
 outH=$(PATH="$stubH" HOME="$sbH" CARGO_HOME="$sbH/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
+  "$PIN_BS" "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
 if printf '%s' "$outH" | grep -q "no supported package manager" \
    && [ ! -f "$sbH/.cargo/config.toml" ]; then
   ok "mold: missing + no package manager warns and writes no config"
@@ -497,7 +546,7 @@ fi
 sbJ=$(mktemp -d "$tmp/moldJ.XXXXXX"); mkdir -p "$sbJ/.cargo"
 printf '[net]\nretry = 4\n' >"$sbJ/.cargo/config"
 PATH="$stubA:$PATH" HOME="$sbJ" CARGO_HOME="$sbJ/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe >/dev/null 2>&1
+  "$PIN_BS" "$BOOTSTRAP" --skip-smoke --skip-push-probe >/dev/null 2>&1
 if grep -q '^# BEGIN cqlite-mold' "$sbJ/.cargo/config" \
    && grep -qx 'retry = 4' "$sbJ/.cargo/config" \
    && [ ! -f "$sbJ/.cargo/config.toml" ]; then
@@ -516,7 +565,7 @@ cfgK="$sbK/.cargo/config.toml"
 printf '[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "target-cpu=native"]\n' >"$cfgK"
 beforeK=$(cat "$cfgK")
 outK=$(PATH="$stubA:$PATH" HOME="$sbK" CARGO_HOME="$sbK/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
+  "$PIN_BS" "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
 if printf '%s' "$outK" | grep -q "existing \[target" \
    && [ "$beforeK" = "$(cat "$cfgK")" ] \
    && ! grep -q '^# BEGIN cqlite-mold' "$cfgK"; then
@@ -533,7 +582,7 @@ printf '[net]\nretry = 1\n' >"$sbL/.cargo/config"
 printf '[net]\nretry = 2\n' >"$sbL/.cargo/config.toml"
 tomlL_before=$(cat "$sbL/.cargo/config.toml")
 PATH="$stubA:$PATH" HOME="$sbL" CARGO_HOME="$sbL/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe >/dev/null 2>&1
+  "$PIN_BS" "$BOOTSTRAP" --skip-smoke --skip-push-probe >/dev/null 2>&1
 if grep -q '^# BEGIN cqlite-mold' "$sbL/.cargo/config" \
    && ! grep -q '^# BEGIN cqlite-mold' "$sbL/.cargo/config.toml" \
    && [ "$tomlL_before" = "$(cat "$sbL/.cargo/config.toml")" ]; then
@@ -550,7 +599,7 @@ cfgM="$sbM/.cargo/config.toml"
 printf '[build]\nrustflags = ["-C", "target-cpu=native"]\n' >"$cfgM"
 beforeM=$(cat "$cfgM")
 outM=$(PATH="$stubA:$PATH" HOME="$sbM" CARGO_HOME="$sbM/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
+  "$PIN_BS" "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
 if printf '%s' "$outM" | grep -q "existing \[build\] rustflags" \
    && [ "$beforeM" = "$(cat "$cfgM")" ] \
    && ! grep -q '^# BEGIN cqlite-mold' "$cfgM"; then
@@ -575,7 +624,7 @@ mk_stub "$stubN" sudo 'exec "$@"'   # passthrough so `sudo apt-get …` runs the
 apt_body='installed=0; for a in "$@"; do [ "$a" = mold ] && installed=1; done; if [ "$installed" = 1 ]; then printf "#!/usr/bin/env bash\n[ \"\$1\" = --version ] && echo \"mold 2.4.0\"\nexit 0\n" > "'"$stubN/mold"'"; chmod +x "'"$stubN/mold"'"; fi; exit 0'
 mk_stub "$stubN" apt-get "$apt_body"
 PATH="$stubN" HOME="$sbN" CARGO_HOME="$sbN/.cargo" \
-  bash "$nrepo/scripts/bootstrap-agent-machine.sh" --yes --skip-smoke >/dev/null 2>&1
+  "$PIN_BS" "$nrepo/scripts/bootstrap-agent-machine.sh" --yes --skip-smoke >/dev/null 2>&1
 if grep -q '^# BEGIN cqlite-mold' "$sbN/.cargo/config.toml" 2>/dev/null; then
   ok "mold: --yes installs mold then wires the managed block in the same run"
 else
@@ -594,7 +643,7 @@ printf '[registries.example]\nindex = "sparse+https://example.invalid/"\n' >"$re
 repo_before=$(cat "$repo_cfg")
 sbI=$(mktemp -d "$tmp/moldI.XXXXXX"); mkdir -p "$sbI/.cargo"
 PATH="$stubA:$PATH" HOME="$sbI" CARGO_HOME="$sbI/.cargo" \
-  bash "$fakerepo/scripts/bootstrap-agent-machine.sh" --skip-smoke >/dev/null 2>&1
+  "$PIN_BS" "$fakerepo/scripts/bootstrap-agent-machine.sh" --skip-smoke >/dev/null 2>&1
 if [ "$repo_before" = "$(cat "$repo_cfg")" ] \
    && grep -q '^# BEGIN cqlite-mold' "$sbI/.cargo/config.toml"; then
   ok "mold: repo-committed .cargo/config.toml untouched; block written to per-machine CARGO_HOME"
@@ -644,7 +693,7 @@ mk_hermetic_bin "$stub7a"
 repo7a="$tmp/repo7a"; mk_fake_repo "$repo7a" "https://github.com/pmcfadin/cqlite.git"
 gc7a="$sb7a/gitconfig"   # deliberately absent
 out7a=$(PATH="$stub7a" HOME="$sb7a" CARGO_HOME="$sb7a/.cargo" GIT_CONFIG_GLOBAL="$gc7a" \
-  GH_TOKEN="" GITHUB_TOKEN="" bash "$repo7a/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+  GH_TOKEN="" GITHUB_TOKEN="" "$PIN_BS" "$repo7a/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
 if printf '%s' "$out7a" | grep -q "git push credentials"; then
   ok "cred: bootstrap emits the git-credential section"
 else
@@ -681,7 +730,7 @@ exit 0"   # setup-git succeeds but wires nothing; `auth token` answers as real g
 repo7b="$tmp/repo7b"; mk_fake_repo "$repo7b" "https://github.com/pmcfadin/cqlite.git"
 gc7b="$sb7b/gitconfig"
 out7b=$(PATH="$stub7b" HOME="$sb7b" CARGO_HOME="$sb7b/.cargo" GIT_CONFIG_GLOBAL="$gc7b" \
-  GH_TOKEN="$FAKE_TOKEN" bash "$repo7b/scripts/bootstrap-agent-machine.sh" --yes --skip-smoke 2>&1)
+  GH_TOKEN="$FAKE_TOKEN" "$PIN_BS" "$repo7b/scripts/bootstrap-agent-machine.sh" --yes --skip-smoke 2>&1)
 if grep -q "auth setup-git" "$gh7b_log"; then
   ok "cred: --yes prefers 'gh auth setup-git' first"
 else
@@ -730,7 +779,7 @@ exit 0'
 repo7c="$tmp/repo7c"; mk_fake_repo "$repo7c" "https://github.com/pmcfadin/cqlite.git"
 gc7c="$sb7c/gitconfig"
 out7c=$(PATH="$stub7c" HOME="$sb7c" CARGO_HOME="$sb7c/.cargo" GIT_CONFIG_GLOBAL="$gc7c" \
-  GH_TOKEN="$FAKE_TOKEN" bash "$repo7c/scripts/bootstrap-agent-machine.sh" --yes --skip-smoke 2>&1)
+  GH_TOKEN="$FAKE_TOKEN" "$PIN_BS" "$repo7c/scripts/bootstrap-agent-machine.sh" --yes --skip-smoke 2>&1)
 if [ -f "$gc7c" ] && grep -q 'gh-stub' "$gc7c" && ! grep -q 'x-access-token' "$gc7c" \
    && printf '%s' "$out7c" | grep -q "gh auth setup-git"; then
   ok "cred: a working 'gh auth setup-git' is preferred; no \$GH_TOKEN fallback added"
@@ -746,7 +795,7 @@ mk_hermetic_bin "$stub7d"
 repo7d="$tmp/repo7d"; mk_fake_repo "$repo7d" "git@github.com:pmcfadin/cqlite.git"
 gc7d="$sb7d/gitconfig"
 out7d=$(PATH="$stub7d" HOME="$sb7d" CARGO_HOME="$sb7d/.cargo" GIT_CONFIG_GLOBAL="$gc7d" \
-  GH_TOKEN="$FAKE_TOKEN" bash "$repo7d/scripts/bootstrap-agent-machine.sh" --yes --skip-smoke 2>&1)
+  GH_TOKEN="$FAKE_TOKEN" "$PIN_BS" "$repo7d/scripts/bootstrap-agent-machine.sh" --yes --skip-smoke 2>&1)
 if printf '%s' "$out7d" | grep -qi "SSH" \
    && ! { [ -f "$gc7d" ] && grep -q 'x-access-token' "$gc7d"; }; then
   ok "cred: SSH origin reported as its own credential path; no helper written"
@@ -789,7 +838,7 @@ if ! grep -q 'x-access-token' "$gc7g" 2>/dev/null; then
   bad "cred: 7g precondition FAILED — no helper installed, the warn below would be vacuous"
 fi
 out7g=$(PATH="$stub7g" HOME="$sb7g" CARGO_HOME="$sb7g/.cargo" GIT_CONFIG_GLOBAL="$gc7g" \
-  GH_TOKEN="" GITHUB_TOKEN="" bash "$repo7g/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+  GH_TOKEN="" GITHUB_TOKEN="" "$PIN_BS" "$repo7g/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
 if printf '%s' "$out7g" | grep -q "\[warn\].*git push has NO credentials" \
    && ! printf '%s' "$out7g" | grep -Eq '\[ok\].*git push credentials resolve'; then
   ok "cred: helper present but GH_TOKEN unset -> WARN (a declining helper is not a credential)"
@@ -819,7 +868,7 @@ else
   bad "cred: (precondition) expected git to accept an empty password line"
 fi
 out7ge=$(PATH="$stub7ge" HOME="$sb7ge" CARGO_HOME="$sb7ge/.cargo" GIT_CONFIG_GLOBAL="$gc7ge" \
-  GH_TOKEN="" GITHUB_TOKEN="" bash "$repo7ge/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+  GH_TOKEN="" GITHUB_TOKEN="" "$PIN_BS" "$repo7ge/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
 if printf '%s' "$out7ge" | grep -q "\[warn\].*git push has NO credentials" \
    && ! printf '%s' "$out7ge" | grep -Eq '\[ok\].*git push credentials resolve'; then
   ok "cred: a helper answering with an EMPTY password is not accepted as a credential"
@@ -886,7 +935,7 @@ if [ -n "$TIMEOUT_BIN_TEST" ]; then
   git config --file "$gc7h" --add 'credential.https://github.com.helper' '!f(){ sleep 120; };f'
   rc7h=0
   "$TIMEOUT_BIN_TEST" 60 env PATH="$stub7h" HOME="$sb7h" CARGO_HOME="$sb7h/.cargo" GIT_CONFIG_GLOBAL="$gc7h" \
-    GH_TOKEN="" bash "$repo7h/scripts/bootstrap-agent-machine.sh" --skip-smoke >/dev/null 2>&1 || rc7h=$?
+    GH_TOKEN="" "$PIN_BS" "$repo7h/scripts/bootstrap-agent-machine.sh" --skip-smoke >/dev/null 2>&1 || rc7h=$?
   if [ "$rc7h" -ne 124 ]; then
     ok "cred: a hanging credential helper is bounded — bootstrap still completes (rc=$rc7h)"
   else
@@ -906,7 +955,7 @@ if [ -n "$TIMEOUT_BIN_TEST" ]; then
   rc7hm=0
   "$TIMEOUT_BIN_TEST" 60 env PATH="$stub7hm" HOME="$sb7hm" CARGO_HOME="$sb7hm/.cargo" \
     GIT_CONFIG_GLOBAL="$gc7hm" GH_TOKEN="" \
-    bash "$repo7hm/scripts/bootstrap-agent-machine.sh" --skip-smoke >/dev/null 2>&1 || rc7hm=$?
+    "$PIN_BS" "$repo7hm/scripts/bootstrap-agent-machine.sh" --skip-smoke >/dev/null 2>&1 || rc7hm=$?
   if [ "$rc7hm" -ne 124 ]; then
     ok "cred: the hang bound also applies on a gtimeout-only (macOS-shaped) host (rc=$rc7hm)"
   else
@@ -927,10 +976,10 @@ repo7e="$tmp/repo7e"; mk_fake_repo "$repo7e" "https://github.com/pmcfadin/cqlite
 gc7e="$sb7e/gitconfig"
 for _ in 1 2; do
   PATH="$stub7e" HOME="$sb7e" CARGO_HOME="$sb7e/.cargo" GIT_CONFIG_GLOBAL="$gc7e" \
-    GH_TOKEN="$FAKE_TOKEN" bash "$repo7e/scripts/bootstrap-agent-machine.sh" --yes --skip-smoke >/dev/null 2>&1
+    GH_TOKEN="$FAKE_TOKEN" "$PIN_BS" "$repo7e/scripts/bootstrap-agent-machine.sh" --yes --skip-smoke >/dev/null 2>&1
 done
 out7e=$(PATH="$stub7e" HOME="$sb7e" CARGO_HOME="$sb7e/.cargo" GIT_CONFIG_GLOBAL="$gc7e" \
-  GH_TOKEN="$FAKE_TOKEN" bash "$repo7e/scripts/bootstrap-agent-machine.sh" --yes --skip-smoke 2>&1)
+  GH_TOKEN="$FAKE_TOKEN" "$PIN_BS" "$repo7e/scripts/bootstrap-agent-machine.sh" --yes --skip-smoke 2>&1)
 helper_count=$(grep -c 'x-access-token' "$gc7e" 2>/dev/null); helper_count="${helper_count:-0}"
 if [ "$helper_count" = 1 ]; then
   ok "cred: repeated --yes runs keep exactly one credential helper (idempotent)"
@@ -957,7 +1006,7 @@ repo7i="$tmp/repo7i"; mk_fake_repo "$repo7i" "https://github.com/pmcfadin/cqlite
 git -C "$repo7i" config --local --add 'credential.https://github.com.helper' \
   '!f(){ test "$1" = get || exit 0; echo username=x; echo password=local-only-secret; };f'
 out7i=$(PATH="$stub7i" HOME="$sb7i" CARGO_HOME="$sb7i/.cargo" GIT_CONFIG_GLOBAL="$sb7i/gitconfig" \
-  GH_TOKEN="" bash "$repo7i/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+  GH_TOKEN="" "$PIN_BS" "$repo7i/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
 if printf '%s' "$out7i" | grep -q 'REPO-LOCAL scope only'; then
   ok "cred: repo-local-scope note fires for a HOST-SCOPED local helper"
 else
@@ -1104,7 +1153,7 @@ run_push() {
     GIT_CONFIG_GLOBAL="$gc" GIT_CONFIG_NOSYSTEM=1 CLAIM_MACHINE=push-probe-test \
     CODEX_NOTIFY_WEBHOOK='https://ntfy.example.com/t' \
     CQLITE_PROJECT_OWNER=pmcfadin CQLITE_PROJECT_NUMBER=1 \
-    bash "$repo/scripts/bootstrap-agent-machine.sh" --skip-smoke "$@" 2>&1) || push_rc=$?
+    "$PIN_BS" "$repo/scripts/bootstrap-agent-machine.sh" --skip-smoke "$@" 2>&1) || push_rc=$?
 }
 # ANSI colour is stripped with a printf-built ESC, not a `\x1b` escape: BSD sed (the
 # fleet's macOS hosts) does not understand \x1b and would silently match nothing.
@@ -1509,7 +1558,7 @@ if [ -n "$TIMEOUT_KILL_TEST" ]; then
     CARGO_HOME="$repo7pm/.home/.cargo" GIT_CONFIG_GLOBAL="$gc7pm" GIT_CONFIG_NOSYSTEM=1 \
     CLAIM_MACHINE=push-probe-test CODEX_NOTIFY_WEBHOOK='https://ntfy.example.com/t' \
     CQLITE_PROJECT_OWNER=pmcfadin CQLITE_PROJECT_NUMBER=1 \
-    bash "$repo7pm/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1) || hang_rc=$?
+    "$PIN_BS" "$repo7pm/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1) || hang_rc=$?
   hang_elapsed=$(( $(date +%s) - hang_start ))
   # rc 124 OR 137 both mean the OUTER ceiling fired (137 = the watchdog had to SIGKILL
   # bootstrap itself), i.e. the inner bound failed to bound. Either is a failure here.
@@ -1896,7 +1945,7 @@ fi
 #   git push probe vs the gate fmt run) and the name similarity is a live hazard, so
 #   both must be documented and each must skip only its own thing. 7p-a ran with
 #   --skip-smoke ALONE and still probed; 7p-d ran with BOTH and skipped only the probe.
-push_help=$(bash "$BOOTSTRAP" --help 2>&1)
+push_help=$("$PIN_BS" "$BOOTSTRAP" --help 2>&1)
 if printf '%s' "$push_help" | grep -q -- '--skip-push-probe' \
    && printf '%s' "$push_help" | grep -q -- '--skip-smoke' \
    && printf '%s' "$push_help" | grep -q -- '--fix-credentials' \
@@ -2012,7 +2061,7 @@ run_board_case() {
   repo="$tmp/repo-board-$name"; mk_fake_repo "$repo" "https://github.com/pmcfadin/cqlite.git"
   BOARD_OUT=$(PATH="$stub" HOME="$sb" CARGO_HOME="$sb/.cargo" GIT_CONFIG_GLOBAL="$sb/gitconfig" \
     CQLITE_PROJECT_ACCOUNT=tester CQLITE_PROJECT_NUMBER=1 \
-    GH_TOKEN="" bash "$repo/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+    GH_TOKEN="" "$PIN_BS" "$repo/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
 }
 
 # run_board_auth_case <name> <auth-status-body> [env...] -> BOARD_OUT/BOARD_LOG
@@ -2043,7 +2092,7 @@ EOF
   # override would silently do nothing and the case would assert against the default.
   BOARD_OUT=$(PATH="$stub" HOME="$sb" CARGO_HOME="$sb/.cargo" GIT_CONFIG_GLOBAL="$sb/gitconfig" \
     CQLITE_PROJECT_NUMBER=1 \
-    GH_TOKEN="" env "$@" bash "$repo/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+    GH_TOKEN="" env "$@" "$PIN_BS" "$repo/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
 }
 
 # 8a. THE false-OK case: `project` scope present, `read:org` missing, `gh project`
@@ -2225,7 +2274,7 @@ log8i="$tmp/gh8i.log"; : >"$log8i"; state8i="$tmp/gh8i.state"
 mk_switch_gh "$stub8i" "$log8i" "$state8i" other-emu pmcfadin   # EMU active at start
 repo8i="$tmp/repo8i"; mk_fake_repo "$repo8i" "https://github.com/pmcfadin/cqlite.git"
 out8i=$(PATH="$stub8i" HOME="$sb8i" CARGO_HOME="$sb8i/.cargo" GIT_CONFIG_GLOBAL="$sb8i/gitconfig" \
-  CQLITE_PROJECT_NUMBER=1 GH_TOKEN="" bash "$repo8i/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+  CQLITE_PROJECT_NUMBER=1 GH_TOKEN="" "$PIN_BS" "$repo8i/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
 if grep -q -- 'auth switch --user pmcfadin' "$log8i"; then
   ok "board: switches to CQLITE_PROJECT_ACCOUNT before probing (mirrors flow-board)"
 else
@@ -2252,7 +2301,7 @@ log8j="$tmp/gh8j.log"; : >"$log8j"; state8j="$tmp/gh8j.state"
 mk_switch_gh "$stub8j" "$log8j" "$state8j" other-emu pmcfadin
 repo8j="$tmp/repo8j"; mk_fake_repo "$repo8j" "https://github.com/pmcfadin/cqlite.git"
 out8j=$(PATH="$stub8j" HOME="$sb8j" CARGO_HOME="$sb8j/.cargo" GIT_CONFIG_GLOBAL="$sb8j/gitconfig" \
-  CQLITE_PROJECT_NUMBER=1 GH_TOKEN="$FAKE_TOKEN" bash "$repo8j/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+  CQLITE_PROJECT_NUMBER=1 GH_TOKEN="$FAKE_TOKEN" "$PIN_BS" "$repo8j/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
 if ! grep -q -- 'auth switch' "$log8j" && [ "$(cat "$state8j")" = other-emu ]; then
   ok "board: an env token suppresses the switch entirely (no pointless host mutation)"
 else
@@ -2289,7 +2338,7 @@ EOF
 chmod +x "$stub8k/gh"
 repo8k="$tmp/repo8k"; mk_fake_repo "$repo8k" "https://github.com/pmcfadin/cqlite.git"
 out8k=$(PATH="$stub8k" HOME="$sb8k" CARGO_HOME="$sb8k/.cargo" GIT_CONFIG_GLOBAL="$sb8k/gitconfig" \
-  CQLITE_PROJECT_ACCOUNT=tester GH_TOKEN="" bash "$repo8k/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+  CQLITE_PROJECT_ACCOUNT=tester GH_TOKEN="" "$PIN_BS" "$repo8k/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
 if printf '%s' "$out8k" | grep -Eq '\[ok\].*board #.*reachable'; then
   bad "board: unexported CQLITE_PROJECT_NUMBER still produced a green 'reachable' verdict"
 elif printf '%s' "$out8k" | grep -q 'CQLITE_PROJECT_NUMBER is NOT exported'; then
@@ -2384,7 +2433,7 @@ fi
 # reported value must name the HOST only.
 redact_out=$(PATH="$tmp:$PATH" HOME="$host_home" CARGO_HOME="$host_home/.cargo" \
   CODEX_NOTIFY_WEBHOOK='https://alice:s3cr3t-token@ntfy.example.com/private-topic' \
-  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
+  "$PIN_BS" "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
 if printf '%s' "$redact_out" | grep -q 'notify target configured' \
    && ! printf '%s' "$redact_out" | grep -qE 's3cr3t-token|alice:'; then
   ok "notify: URL userinfo is redacted from the reported target"
@@ -2435,7 +2484,7 @@ MUT
 runnotifyroot() { # runnotifyroot <dir> [env assignments...]
   local dir="$1"; shift
   env PATH="$tmp:$PATH" HOME="$host_home" CARGO_HOME="$host_home/.cargo" "$@" \
-    timeout -s KILL 300 bash "$dir/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1
+    timeout -s KILL 300 "$PIN_BS" "$dir/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1
 }
 
 # (b) POSITIVE twin: a healthy wrapper must be reported VERIFIED.
@@ -2566,7 +2615,7 @@ runpin() {
     PATH="$shims" CARGO_HOME="$tmp/pin-cargo" \
     CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="$envfile" \
     ${pin_env[@]+"${pin_env[@]}"} \
-    timeout -s KILL 300 bash "$root/scripts/bootstrap-agent-machine.sh" \
+    timeout -s KILL 300 "$PIN_BS" "$root/scripts/bootstrap-agent-machine.sh" \
       --skip-smoke ${pin_flags[@]+"${pin_flags[@]}"} 2>&1
 }
 
@@ -2641,9 +2690,9 @@ else
   out_d=$(runpin "$pinroot" "$shims_pw" "$envf_d" HOME="$pin_home_plain" \
     CQLITE_GATE_MAX_CONCURRENCY=7)
   if printf '%s' "$out_d" | grep -qE '\[warn\].*gate-pin: UNMEASURED' \
-     && printf '%s' "$out_d" | grep -q 'sudo needs a password' \
+     && printf '%s' "$out_d" | grep -q 'will not open a session as' \
      && ! printf '%s' "$out_d" | grep -qE '\[ok\].*gate-pin'; then
-    ok "gate-pin: passwordless sudo unavailable => UNMEASURED as a [warn], with its own cause"
+    ok "gate-pin: a sudo that cannot open a self-session => UNMEASURED as a [warn], with its own cause"
   else
     bad "gate-pin: a password-requiring sudo did not report UNMEASURED-as-a-warn"
     printf '%s\n' "$out_d" | grep -i 'gate-pin' | head -3
@@ -2732,7 +2781,7 @@ else
   envf_j="$tmp/pin-env-j"; : >"$envf_j"
   out_j=$(env PATH="$shims_one" HOME="$pin_home_plain" CARGO_HOME="$tmp/pin-cargo" \
     CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="$envf_j" \
-    timeout -s KILL 300 bash "$pinroot/scripts/bootstrap-agent-machine.sh" \
+    timeout -s KILL 300 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
       --skip-smoke --skip-gate-pin 2>&1)
   if printf '%s' "$out_j" | grep -qE '\[warn\].*gate-pin: OPT-OUT' \
      && ! printf '%s' "$out_j" | grep -qE '\[ok\].*gate-pin'; then
@@ -2921,7 +2970,7 @@ else
     # shellcheck disable=SC2086
     pin_t_out=$(env PATH="$shims_one" HOME="$pin_home_plain" CARGO_HOME="$tmp/pin-cargo" \
       CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="$tmp/pin-env-t" \
-      timeout -s KILL 120 bash "$pinroot/scripts/bootstrap-agent-machine.sh" \
+      timeout -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
         --skip-smoke $pin_order 2>&1)
     pin_t_rc=$?
     if [ "$pin_t_rc" -eq 2 ] && printf '%s' "$pin_t_out" | grep -q 'contradictory'; then
@@ -3295,7 +3344,7 @@ else
   if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
     out_ak=$(sudo -n env CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="$pin_seam_probe" \
       HOME="$pin_root_sandbox" CARGO_HOME="$pin_root_sandbox/.cargo" \
-      timeout -s KILL 120 bash "$pinroot/scripts/bootstrap-agent-machine.sh" \
+      timeout -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
         --skip-smoke --skip-push-probe --yes 2>&1)
     if printf '%s' "$out_ak" | grep -q 'gate-pin: SKIPPED' \
        && printf '%s' "$out_ak" | grep -q 'PRIVILEGED write' \
@@ -3329,7 +3378,7 @@ else
   if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
     out_am=$(sudo -n env SUDO_USER=cqlite-no-such-account-3414 \
       HOME="$pin_root_sandbox" CARGO_HOME="$pin_root_sandbox/.cargo" \
-      timeout -s KILL 120 bash "$pinroot/scripts/bootstrap-agent-machine.sh" \
+      timeout -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
         --skip-smoke --skip-push-probe 2>&1)
     if printf '%s' "$out_am" | grep -qE '\[warn\].*gate-pin: UNMEASURED' \
        && printf '%s' "$out_am" | grep -qE 'does not resolve to an account|INCONSISTENT sudo metadata' \
@@ -3341,7 +3390,7 @@ else
     fi
     out_an=$(sudo -n env SUDO_USER="$(id -un)" \
       HOME="$pin_root_sandbox" CARGO_HOME="$pin_root_sandbox/.cargo" \
-      timeout -s KILL 120 bash "$pinroot/scripts/bootstrap-agent-machine.sh" \
+      timeout -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
         --skip-smoke --skip-push-probe 2>&1)
     if printf '%s' "$out_an" | grep -q "the account that invoked sudo"; then
       ok "gate-pin: a resolvable sudo invoker becomes the probe subject, and the run says so"
@@ -3369,7 +3418,7 @@ else
     out_at=$(sudo -n env PATH="$pin_liar:$PATH" \
       CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="$pin_liar_target" \
       HOME="$pin_root_sandbox" CARGO_HOME="$pin_root_sandbox/.cargo" \
-      timeout -s KILL 120 bash "$pinroot/scripts/bootstrap-agent-machine.sh" \
+      timeout -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
         --skip-smoke --skip-push-probe --yes 2>&1)
     if printf '%s' "$out_at" | grep -q 'gate-pin: SKIPPED' && [ ! -e "$pin_liar_target" ]; then
       ok "gate-pin: a lying 'id' on PATH cannot make a ROOT run look unprivileged (the decision reads \$EUID)"
@@ -3386,7 +3435,7 @@ else
     #      wrong-subject defect the retarget exists to fix, wearing the retarget's clothes.
     out_au=$(sudo -n env SUDO_UID=1000 SUDO_USER=root \
       HOME="$pin_root_sandbox" CARGO_HOME="$pin_root_sandbox/.cargo" \
-      timeout -s KILL 120 bash "$pinroot/scripts/bootstrap-agent-machine.sh" \
+      timeout -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
         --skip-smoke --skip-push-probe 2>&1)
     if printf '%s' "$out_au" | grep -qE '\[warn\].*gate-pin: UNMEASURED' \
        && printf '%s' "$out_au" | grep -q 'INCONSISTENT sudo metadata' \
@@ -3400,7 +3449,7 @@ else
     # 11av. ...and root invoking sudo (SUDO_UID=0) tells us nothing about a gate's account.
     out_av=$(sudo -n env SUDO_UID=0 SUDO_USER=root \
       HOME="$pin_root_sandbox" CARGO_HOME="$pin_root_sandbox/.cargo" \
-      timeout -s KILL 120 bash "$pinroot/scripts/bootstrap-agent-machine.sh" \
+      timeout -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
         --skip-smoke --skip-push-probe 2>&1)
     if printf '%s' "$out_av" | grep -qE '\[warn\].*gate-pin: UNMEASURED' \
        && printf '%s' "$out_av" | grep -q 'sudo was invoked BY root'; then
@@ -3446,10 +3495,10 @@ else
   out_k=$(env -u CQLITE_BOOTSTRAP_TEST_MODE \
     PATH="$shims_one" HOME="$pin_home_plain" CARGO_HOME="$tmp/pin-cargo" \
     CQLITE_BOOTSTRAP_ENV_FILE="$envf_k" \
-    timeout -s KILL 300 bash "$pinroot/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+    timeout -s KILL 300 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
   out_k2=$(env PATH="$shims_one" HOME="$pin_home_plain" CARGO_HOME="$tmp/pin-cargo" \
     CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="relative/env" \
-    timeout -s KILL 300 bash "$pinroot/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+    timeout -s KILL 300 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
   if printf '%s' "$out_k" | grep -q 'gate-pin: SKIPPED' \
      && printf '%s' "$out_k2" | grep -q 'gate-pin: SKIPPED' \
      && ! printf '%s' "$out_k" | grep -qE '\[ok\].*gate-pin'; then
@@ -3507,12 +3556,21 @@ fi
 # reintroduce (a new case that sets HOME and forgets CARGO_HOME, or a `sudo` invocation
 # where the exported value is dropped by env_reset) and the cost lands on OTHER lanes as
 # unexplained red gates, which is the worst possible place for it to surface.
+# ATTRIBUTED, not inferred: this reports only changes observed across one of THIS suite's
+# own bootstrap invocations. A concurrent external writer no longer reds it, and a
+# reintroduced reach still does — with the offending invocation named.
 pin_shared_cargo_after=$(pin_shared_cargo_state)
-if [ "$pin_shared_cargo_after" = "$PIN_SHARED_CARGO_BEFORE" ]; then
-  ok "host hygiene: $PIN_SHARED_CARGO is untouched by this suite (mode+mtime+content unchanged)"
+if [ ! -s "$PIN_SHARED_VIOLATIONS" ]; then
+  ok "host hygiene: no bootstrap invocation in this suite touched $PIN_SHARED_CARGO"
+  if [ "$pin_shared_cargo_after" != "$PIN_SHARED_CARGO_BEFORE" ]; then
+    # Deliberately an `info`, not a `bad`: the file moved while the suite ran but NOT
+    # across any invocation of ours, so it was someone else — a peer lane, an admin, a
+    # human at a prompt. Reporting it is useful; blaming ourselves for it is the defect.
+    info "note: $PIN_SHARED_CARGO changed during this run but NOT across any of our invocations — another writer on this box (before: $PIN_SHARED_CARGO_BEFORE / after: $pin_shared_cargo_after)"
+  fi
 else
-  bad "host hygiene: this suite MUTATED the shared $PIN_SHARED_CARGO — it breaks cargo for every other user on the box"
-  printf '  before: %s\n  after:  %s\n' "$PIN_SHARED_CARGO_BEFORE" "$pin_shared_cargo_after"
+  bad "host hygiene: a bootstrap invocation in THIS suite mutated the shared $PIN_SHARED_CARGO — it breaks cargo for every other user on the box"
+  cat "$PIN_SHARED_VIOLATIONS"
 fi
 
 # --- 15. THE THREE GREEN-PATH CASES MUST HAVE RUN, BY NAME (#3414 roborev round 7) -----

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -3696,6 +3696,33 @@ exec env CQLITE_GATE_MAX_CONCURRENCY=1 "$@"'
   #      marker, or relative, it SKIPS the section rather than silently persisting to
   #      the real /etc/environment (the #3249 lesson — a seam that degrades to the
   #      production path certifies the production path by accident).
+  # 11ba. A MISSING env file is CREATED under authorisation, and NOT created without it
+  #      (#3414 final roborev). Before this, --fix-gate-pin declined to create the file, so a
+  #      MINIMAL Linux install — where /etc/environment does not ship — could never be
+  #      repaired and failed --strict onboarding forever: a repair flag that cannot repair the
+  #      one case it exists for. BOTH directions are asserted because a repair that fires
+  #      unasked is as wrong as one that never fires, and the create path was previously
+  #      verified BY HAND only, which is the gap this case closes.
+  envf_ba="$tmp/pin-env-ba"; rm -f "$envf_ba"
+  out_ba=$(env PATH="$shims_one" HOME="$pin_home_plain" CARGO_HOME="$tmp/pin-cargo" \
+    CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="$envf_ba" \
+    timeout -s KILL 300 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" --skip-smoke --fix-gate-pin 2>&1)
+  ba_created=0; [ -s "$envf_ba" ] && grep -q '^CQLITE_GATE_MAX_CONCURRENCY=1$' "$envf_ba" && ba_created=1
+  envf_bb="$tmp/pin-env-bb"; rm -f "$envf_bb"
+  out_bb=$(env PATH="$shims_one" HOME="$pin_home_plain" CARGO_HOME="$tmp/pin-cargo" \
+    CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="$envf_bb" \
+    timeout -s KILL 300 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+  if [ "$ba_created" = 1 ] \
+     && printf '%s' "$out_ba" | grep -q 'CREATED' \
+     && [ ! -e "$envf_bb" ] \
+     && printf '%s' "$out_bb" | grep -q 'will be CREATED'; then
+    ok "gate-pin: a MISSING env file is created under --fix-gate-pin (with the pin in it), and is NOT created without authorisation — which SAYS it would be"
+  else
+    bad "gate-pin: the create path is wrong (created=$ba_created, unauthorised-file-exists=$([ -e "$envf_bb" ] && echo yes || echo no))"
+    printf '%s\n' "$out_ba" | grep -iE 'CREATED|gate-pin' | head -2
+    printf '%s\n' "$out_bb" | grep -iE 'CREATED|gate-pin' | head -2
+  fi
+
   envf_k="$tmp/pin-env-k"; : >"$envf_k"
   # `-u CQLITE_BOOTSTRAP_TEST_MODE` is the point of this half: the marker is exported
   # suite-wide for host safety, and the case is about a seam set WITHOUT it.

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -252,6 +252,17 @@ pin_tree_id() {
     # shared-worktree edit. IGNORED paths stay excluded on purpose (`--exclude-standard`):
     # this lane's own scratch — the verdict file, the follow-up list — changes constantly
     # and hashing it would make every run report MOVED, which is the alarm nobody reads.
+    # ...AND THE ENUMERATION IS ROOTED AT THE WORKTREE TOP, NOT AT $SCRIPT_DIR (roborev
+    # job 332). `git ls-files` defaults to the CURRENT DIRECTORY, so `-C "$SCRIPT_DIR"`
+    # hashed untracked contents only under `scripts/tests` — an untracked file anywhere
+    # else could change content and still digest STABLE. That is the SAME silent-omission
+    # class as the `xargs -r` defect above, one axis over: portability there, SCOPE here,
+    # and in both the digest still LOOKS like it covered them. `status --porcelain` is
+    # repo-wide already, so the NAME of such a file was never the gap — only its CONTENT.
+    # Measured cost on this lane: 0 untracked non-ignored files, 0.017s.
+    local top
+    top=$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null) || top="$SCRIPT_DIR"
+    [ -n "$top" ] || top="$SCRIPT_DIR"
     dig=$( { git -C "$SCRIPT_DIR" status --porcelain 2>/dev/null
              git -C "$SCRIPT_DIR" diff 2>/dev/null
              git -C "$SCRIPT_DIR" diff --cached 2>/dev/null
@@ -262,8 +273,8 @@ pin_tree_id() {
              # omission inside an integrity digest is the worst possible failure mode:
              # the digest still LOOKS like it covered them.
              while IFS= read -r -d "" _u; do
-               git -C "$SCRIPT_DIR" hash-object -- "$_u" 2>/dev/null
-             done < <(git -C "$SCRIPT_DIR" ls-files --others --exclude-standard -z 2>/dev/null)
+               git -C "$top" hash-object -- "$_u" 2>/dev/null
+             done < <(git -C "$top" ls-files --others --exclude-standard -z 2>/dev/null)
            } | git hash-object --stdin 2>/dev/null )
     case "$dig" in
       ?*) dig=$(printf '%s' "$dig" | cut -c1-12) ;;
@@ -3021,18 +3032,46 @@ else
     printf '%s\n' "$out_o" | grep -i 'gate-pin\|pam_env\|fix:' | head -4
   fi
 
-  # 11p. ...and the ABSENT-file box (a Mac has no /etc/environment) is not handed a
-  #      remedy naming a file it does not have. A remedy that cannot work on the box it
-  #      is printed for costs a cycle before the operator learns that.
+  # 11p. ...and the ABSENT-file box is not handed a remedy naming a file it does not
+  #      have. A remedy that cannot work on the box it is printed for costs a cycle
+  #      before the operator learns that.
+  #
+  #      THIS CASE USED TO ASSERT THE WRONG HALF (roborev job 332). It ran on the
+  #      suite's own LINUX host with the env file merely MISSING, and required the
+  #      message "has nowhere to persist it" — which is a MAC's message. On Linux the
+  #      missing file is CREATED by --fix-gate-pin, so the case was PINNING A FALSE
+  #      DIAGNOSTIC in place: it simulated a Mac by removing a file, and "the file is
+  #      absent" is not "this platform has no such file". Split in two, one per state,
+  #      because a single case cannot distinguish them by construction.
+  #
+  #      11p covers the LINUX absent file: creatable, so the remedy must NAME the flag
+  #      that creates it and must NOT claim there is nowhere to persist it.
   envf_p="$tmp/pin-env-p-missing"; rm -f "$envf_p"
   out_p=$(runpin "$pinroot" "$shims_none" "$envf_p" HOME="$pin_home_plain")
   if printf '%s' "$out_p" | grep -q 'gate-pin: FAILED' \
-     && printf '%s' "$out_p" | grep -q 'has nowhere to persist it' \
-     && ! printf '%s' "$out_p" | grep -q 'fix:  bash scripts/bootstrap-agent-machine.sh --yes'; then
-    ok "gate-pin: a host with no system env file is not told to re-run --yes against it"
+     && [[ $out_p == *'--fix-gate-pin'* ]] \
+     && [[ $out_p != *'has nowhere to persist it'* ]]; then
+    ok "gate-pin: a LINUX box with no env file is pointed at --fix-gate-pin, which creates it — not told there is nowhere to persist"
   else
-    bad "gate-pin: the absent-env-file box got a remedy that cannot work there"
+    bad "gate-pin: the absent-env-file Linux box got the unmanaged-platform remedy (job 332)"
     printf '%s\n' "$out_p" | grep -i 'gate-pin\|nowhere\|fix:' | head -4
+  fi
+
+  # 11p2. ...and the UNMANAGED-PLATFORM box keeps the original ruling: no remedy naming a
+  #      file the platform does not have. Same missing file as 11p; the ONLY difference is
+  #      `uname`, which is what makes this the state 11p is not. Without this half the fix
+  #      above could have deleted the Mac message entirely and still passed.
+  shims_mac_p="$tmp/pin-shims-mac-p"; mkpinshims "$shims_mac_p" -
+  mk_stub "$shims_mac_p" uname 'echo Darwin'
+  envf_p2="$tmp/pin-env-p2-missing"; rm -f "$envf_p2"
+  out_p2=$(runpin "$pinroot" "$shims_mac_p" "$envf_p2" HOME="$pin_home_plain")
+  if [[ $out_p2 != *'--fix-gate-pin   (this'* ]] \
+     && [[ $out_p2 != *'fix:  bash scripts/bootstrap-agent-machine.sh --yes'* ]] \
+     && ! printf '%s' "$out_p2" | grep -qE '\[ok\].*gate-pin'; then
+    ok "gate-pin: an unmanaged-platform box with no env file is never pointed at a file its platform does not read"
+  else
+    bad "gate-pin: the unmanaged-platform box was handed a create-the-file remedy"
+    printf '%s\n' "$out_p2" | grep -i 'gate-pin\|nowhere\|fix:' | head -4
   fi
 
   # 11q. PERSIST-THEN-PROBE WITHIN ONE RUN — the property `verify.run` depends on.
@@ -4133,6 +4172,49 @@ if [ -z "$pin_decline_bad" ] && grep -qE '^  exit 1$' "$0"; then
   ok "suite hygiene: the wholesale-decline path exits NONZERO (a declined suite is not a passing suite)"
 else
   bad "suite hygiene: a wholesale decline exits 0 — the gate reads only exit status, so it would certify a suite that ran nothing"
+fi
+
+# THE DIGEST SEES UNTRACKED CONTENT ANYWHERE IN THE WORKTREE, NOT JUST UNDER scripts/tests
+# (roborev job 332). `git ls-files` defaults to the CURRENT DIRECTORY, so the enumeration
+# used to be confined to $SCRIPT_DIR and an untracked file elsewhere could change content
+# while the digest reported STABLE — the same silent-omission class as the `xargs -r`
+# defect, one axis over.
+#
+# THE CASE HAS TO CREATE ITS OWN SUBJECT: this lane has ZERO untracked non-ignored files
+# (measured), so on this tree the fixed and unfixed forms are INDISTINGUISHABLE and a case
+# that merely called pin_tree_id twice would pass either way. It therefore plants a file at
+# the WORKTREE TOP (outside $SCRIPT_DIR, which is the whole point), mutates it, and removes
+# it — then asserts the digest RETURNED to its original value, which is what proves the
+# case cannot destabilise the run's own start/end comparison below. If the case dies before
+# cleanup the leftover file flips tree-integrity to MOVED, i.e. it fails LOUDLY rather than
+# quietly poisoning the verdict.
+# THE PROBE NAME MUST NOT BE GITIGNORED, AND THE FIRST ONE WAS. `.gitignore:79` carries
+# `*.tmp`, so a `…-$$.tmp` probe was excluded by `--exclude-standard` — the case would have
+# taken the `skip` branch on EVERY run, silently, which is a vacuous case wearing a skip's
+# clothes. Caught by the guard below rather than by the suite passing, which is the only
+# reason it is not still there. `.txt` is not matched by any rule in this repository; the
+# guard stays, because a future .gitignore rule could make it so.
+pin_dig_top="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)"
+pin_dig_probe="$pin_dig_top/pin-digest-probe-$$.txt"
+if [ -n "$pin_dig_top" ] && [ -d "$pin_dig_top" ] && ! git check-ignore -q "$pin_dig_probe" 2>/dev/null; then
+  pin_dig_before=$(pin_tree_id)
+  printf 'a\n' > "$pin_dig_probe" 2>/dev/null
+  pin_dig_added=$(pin_tree_id)
+  printf 'b\n' > "$pin_dig_probe" 2>/dev/null
+  pin_dig_edited=$(pin_tree_id)
+  rm -f "$pin_dig_probe"
+  pin_dig_after=$(pin_tree_id)
+  if [ "$pin_dig_added" != "$pin_dig_before" ] \
+     && [ "$pin_dig_edited" != "$pin_dig_added" ] \
+     && [ "$pin_dig_after" = "$pin_dig_before" ]; then
+    ok "suite hygiene: the tree digest sees a CONTENT change to an untracked file outside scripts/tests (and the probe restored the tree)"
+  else
+    bad "suite hygiene: an untracked file outside scripts/tests changed content and the digest did not move (job 332)"
+    printf '  before=%s added=%s edited=%s after=%s\n' \
+      "$pin_dig_before" "$pin_dig_added" "$pin_dig_edited" "$pin_dig_after"
+  fi
+else
+  skip "suite hygiene: cannot plant a NON-IGNORED untracked probe at the worktree top (digest scope unverified — an ignored probe would make this case vacuous)"
 fi
 
 PIN_TREE_END=$(pin_tree_id)

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -3373,6 +3373,51 @@ else
     bad "gate-pin: the gap diagnostic asserts an absence without naming how far it looked"
   fi
 
+  # 11ar. AN UNREADABLE PAM STACK MUST NOT REACH VERIFIED (issue #3414 roborev round 6).
+  #      pin_pam_services_missing_readenv was called inside `$( )`, which FORKS — so its
+  #      PIN_PAM_UNCHECKED assignment happened in a subshell and was discarded. An
+  #      unreadable service config then produced VERIFIED *and* a scope note claiming the
+  #      stacks had been checked: a false positive plus a false statement about what was
+  #      measured. Only this branch loses the signal — the happy path works — which is why
+  #      it survived six review rounds, and why the case is written against the branch
+  #      rather than against the function.
+  #
+  #      Root can read a 0000 file, so as root the case would assert nothing.
+  if [ "$(id -u)" = 0 ]; then
+    skip "gate-pin unreadable-PAM-stack case (running as root: 0000 is still readable)"
+  else
+    pin_pamd_unread="$tmp/pin-pamd-unread"; mkdir -p "$pin_pamd_unread"
+    printf 'session required pam_env.so\n' >"$pin_pamd_unread/sshd"
+    printf 'session required pam_env.so\n' >"$pin_pamd_unread/login"
+    chmod 0000 "$pin_pamd_unread/sshd"
+    envf_ar="$tmp/pin-env-ar"; printf 'CQLITE_GATE_MAX_CONCURRENCY=1\n' >"$envf_ar"
+    out_ar=$(runpin "$pinroot" "$shims_one" "$envf_ar" HOME="$pin_home_plain" \
+      CQLITE_BOOTSTRAP_PAM_DIR="$pin_pamd_unread")
+    chmod 0644 "$pin_pamd_unread/sshd"
+    if printf '%s' "$out_ar" | grep -qE '\[warn\].*gate-pin: UNMEASURED' \
+       && printf '%s' "$out_ar" | grep -q 'could not be READ' \
+       && ! printf '%s' "$out_ar" | grep -qE '\[ok\].*gate-pin' \
+       && ! printf '%s' "$out_ar" | grep -q 'were CHECKED to read it'; then
+      ok "gate-pin: an UNREADABLE PAM stack is UNMEASURED, and the run does not claim the stacks were checked"
+    else
+      bad "gate-pin: an unreadable PAM stack reached a verdict it had not earned (subshell swallowed the signal?)"
+      printf '%s\n' "$out_ar" | grep -i 'gate-pin\|CHECKED' | head -3
+    fi
+  fi
+
+  # 11as. STRUCTURAL, and it is the half that generalises: a function whose purpose is to
+  #      SET a variable must be called directly, never in `$( )` or downstream of `|`,
+  #      because both fork and the assignment does not survive. CLAUDE.md already carries
+  #      this for the gate's cargo-output parse sites; it is a property of the shell, not
+  #      of that file. A future edit could reintroduce the substitution while 11ar still
+  #      passed on a readable box, so the call shape is asserted directly.
+  if grep -qE '^\s*pin_pam_services_missing_readenv$' "$BOOTSTRAP" \
+     && ! grep -qE '\$\(pin_pam_services_missing_readenv' "$BOOTSTRAP"; then
+    ok "gate-pin: the PAM check is called directly, not in a subshell that would discard its globals"
+  else
+    bad "gate-pin: the PAM check is back inside a command substitution — its result globals are lost"
+  fi
+
   # 11k. The test seam is FAIL-CLOSED and has NO production fallback: set without its
   #      marker, or relative, it SKIPS the section rather than silently persisting to
   #      the real /etc/environment (the #3249 lesson — a seam that degrades to the

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -3765,14 +3765,20 @@ exec env CQLITE_GATE_MAX_CONCURRENCY=1 "$@"'
   #      the mode — one run's reported failure becoming the next run's silent success at a
   #      permission nothing chose.
   #
-  #      `chmod` is STUBBED TO FAIL rather than removed from the PATH, so the case models
-  #      exactly one thing going wrong. `umask 077` forces `tee` to create 0600, so the mode
-  #      genuinely cannot reach 0644 — set explicitly rather than inherited, or the case
-  #      would silently stop testing anything on a runner whose ambient umask is 022.
-  shims_nochmod="$tmp/pin-shims-nochmod"; mkpinshims "$shims_nochmod" 1
-  mk_stub "$shims_nochmod" chmod 'exit 1'
+  #      DRIVEN THROUGH ITS ORACLE, and the reason is the third instance of premise-staleness
+  #      in this block. The first version stubbed `chmod` to fail and forced `umask 077` so
+  #      `tee` created 0600. The job-314 fix then made the create atomic — one privileged
+  #      `bash -c` with `umask 022` and `set -C` — which establishes 0644 AT CREATION, so a
+  #      failing chmod can no longer produce a wrong mode and that route to the state is
+  #      closed. The rollback branch is still LIVE in production (a default ACL or an odd
+  #      filesystem can yield a mode the readback rejects), so it is exercised by making the
+  #      readback itself report a non-0644 mode. Stubbing `stat` is only possible because
+  #      mk_stub now removes the hermetic symlink first — before that, this stub would have
+  #      silently not installed and the case would have passed against the real `stat`.
+  shims_badstat="$tmp/pin-shims-badstat"; mkpinshims "$shims_badstat" 1
+  mk_stub "$shims_badstat" stat 'echo 600'
   envf_bc="$tmp/pin-env-bc"; rm -f "$envf_bc"
-  out_bc=$( (umask 077; runpin "$pinroot" "$shims_nochmod" "$envf_bc" HOME="$pin_home_plain" --fix-gate-pin) )
+  out_bc=$(runpin "$pinroot" "$shims_badstat" "$envf_bc" HOME="$pin_home_plain" --fix-gate-pin)
   if [ ! -e "$envf_bc" ] \
      && printf '%s' "$out_bc" | grep -q 'the pin was NOT persisted' \
      && printf '%s' "$out_bc" | grep -q 'was REMOVED'; then
@@ -3781,6 +3787,22 @@ exec env CQLITE_GATE_MAX_CONCURRENCY=1 "$@"'
     bad "gate-pin: the failed create left a residue, or did not report rolling it back"
     printf '%s\n' "$out_bc" | grep -iE 'gate-pin|CREATED|REMOVED|persisted' | head -4
     echo "  file-exists=$([ -e "$envf_bc" ] && echo yes || echo no) content=[$(cat "$envf_bc" 2>/dev/null | tr '\n' '|')]"
+  fi
+
+  # 11bg. THE MODE IS ESTABLISHED AT CREATION, NOT INHERITED FROM THE CALLER (roborev job
+  #      314, Medium). The create used to be truncating `tee` followed by `chmod`, so the
+  #      file briefly existed at whatever the invoking shell's umask gave it. It is now one
+  #      privileged `bash -c` setting `umask 022` before the redirect, so a caller running
+  #      under a restrictive umask must STILL get 0644 — asserted by running under 077,
+  #      which is the value that would produce 0600 if the caller's umask still decided.
+  envf_bg="$tmp/pin-env-bg"; rm -f "$envf_bg"
+  out_bg=$( (umask 077; runpin "$pinroot" "$shims_one" "$envf_bg" HOME="$pin_home_plain" --fix-gate-pin) )
+  bg_mode=$(stat -c %a "$envf_bg" 2>/dev/null)
+  if [ "$bg_mode" = 644 ] && grep -q '^CQLITE_GATE_MAX_CONCURRENCY=1$' "$envf_bg"; then
+    ok "gate-pin: a created env file comes out 0644 even under a restrictive caller umask (mode set at creation, not inherited)"
+  else
+    bad "gate-pin: the created env file took the caller's umask (mode=${bg_mode:-unreadable})"
+    printf '%s\n' "$out_bg" | grep -iE 'CREATED|gate-pin:' | head -3
   fi
 
   # 11bd. A REMEDY MUST BE CHOSEN BY THE FACT THAT DISCRIMINATES IT (roborev job 311, Low).

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -155,8 +155,19 @@ cat >"$PIN_BS" <<'PINBS'
 # here. That is a different defect (a hardcoded destination rather than an unsandboxed
 # caller), and claiming this guard covers it would be the false-assurance shape this whole
 # branch is about. #3673 is where a destination-side guard belongs.
+# FAIL CLOSED ON AN UNUSABLE SANDBOX ROOT, FIRST. Without this the patterns below read
+# `"$PIN_SANDBOX_ROOT"/*`, which with an empty root degenerates to `/*` and matches EVERY
+# absolute path — so the guard would silently permit everything it exists to catch. That is
+# the permissive-branch-on-an-unmeasured-input shape, inside the guard written to catch that
+# shape (#3414, lead self-review). An unusable root is a violation in its own right, never a
+# pass: unable to tell is not permission.
 _v=""
-case "${CARGO_HOME-}" in
+case "${PIN_SANDBOX_ROOT-}" in
+  '') _v="PIN_SANDBOX_ROOT is unset, so the sandbox test would match every absolute path — refusing to certify this invocation" ;;
+  /*) ;;
+  *) _v="PIN_SANDBOX_ROOT='$PIN_SANDBOX_ROOT' is not an absolute path, so the sandbox test is meaningless" ;;
+esac
+[ -n "$_v" ] || case "${CARGO_HOME-}" in
   '') _v="CARGO_HOME is unset, so bootstrap would resolve \${HOME}/.cargo — on this fleet HOME-derived or /etc/environment-derived paths reach the SHARED root-owned config" ;;
   "$PIN_SANDBOX_ROOT"/*) ;;
   *) _v="CARGO_HOME='$CARGO_HOME' is outside the suite sandbox ($PIN_SANDBOX_ROOT)" ;;
@@ -3656,12 +3667,19 @@ PIN_SHARED_VIOLATIONS="$pin_guard_out" HOME="$tmp/sb-selftest" CARGO_HOME=/usr/l
 pin_guard_clean="$tmp/guard-selftest-clean.log"; : >"$pin_guard_clean"
 PIN_SHARED_VIOLATIONS="$pin_guard_clean" HOME="$tmp/sb-selftest" CARGO_HOME="$tmp/sb-selftest/.cargo" \
   "$PIN_BS" -c 'true' >/dev/null 2>&1
-if [ -s "$pin_guard_log" ] && [ -s "$pin_guard_out" ] && [ ! -s "$pin_guard_clean" ]; then
-  ok "host hygiene: the guard FIRES on an unset CARGO_HOME and on one outside the sandbox, and stays quiet on a sandboxed pair"
+# ...and the guard's OWN unmeasured-input case: with PIN_SANDBOX_ROOT unset the sandbox
+# patterns would degenerate to `/*` and match every absolute path, so a guard that did not
+# fail closed here would silently permit everything it exists to catch. Planted with an
+# otherwise-PERFECTLY-SANDBOXED pair, so the only thing under test is the missing root.
+pin_guard_noroot="$tmp/guard-selftest-noroot.log"; : >"$pin_guard_noroot"
+PIN_SHARED_VIOLATIONS="$pin_guard_noroot" HOME="$tmp/sb-selftest" CARGO_HOME="$tmp/sb-selftest/.cargo" \
+  env -u PIN_SANDBOX_ROOT "$PIN_BS" -c 'true' >/dev/null 2>&1
+if [ -s "$pin_guard_log" ] && [ -s "$pin_guard_out" ] && [ -s "$pin_guard_noroot" ] && [ ! -s "$pin_guard_clean" ]; then
+  ok "host hygiene: the guard FIRES on an unset CARGO_HOME, on one outside the sandbox, and on an unusable PIN_SANDBOX_ROOT; and stays quiet on a sandboxed pair"
 else
   bad "host hygiene: the input guard cannot fire (or fires unconditionally) — case 14 would be vacuous"
-  printf '  unset: %s bytes; outside: %s bytes; sandboxed: %s bytes\n' \
-    "$(wc -c <"$pin_guard_log")" "$(wc -c <"$pin_guard_out")" "$(wc -c <"$pin_guard_clean")"
+  printf '  unset: %s bytes; outside: %s bytes; no-root: %s bytes; sandboxed: %s bytes\n' \
+    "$(wc -c <"$pin_guard_log")" "$(wc -c <"$pin_guard_out")" "$(wc -c <"$pin_guard_noroot")" "$(wc -c <"$pin_guard_clean")"
 fi
 
 # --- 14. THIS SUITE MUST NOT TOUCH SHARED HOST STATE -----------------------------------
@@ -3678,6 +3696,39 @@ if [ ! -s "$PIN_SHARED_VIOLATIONS" ]; then
 else
   bad "host hygiene: a bootstrap invocation in THIS suite ran with an UNSANDBOXED CARGO_HOME or HOME, so it could reach the shared $PIN_SHARED_CARGO — that breaks cargo for every other user on the box"
   cat "$PIN_SHARED_VIOLATIONS"
+fi
+
+# --- 14b. GUARD COVERAGE AS A COUNT, NOT A CLAIM (#3414 roborev round 11) --------------
+# Case 14 says no invocation escaped the sandbox. That is only as strong as the number of
+# invocations actually routed THROUGH the guard: an unwrapped one is invisible to it, so a
+# guard covering 49 of 50 sites reports exactly the same green as one covering 50. "Routed
+# the direct calls through the wrapper" is a sentence that was true the day it was written
+# and unverifiable afterwards; a count is checkable on every run.
+#
+# Measured from this file's own source: every line that launches bootstrap must do so via
+# "$PIN_BS". Excluded, and each for a stated reason rather than by convenience — `bash -n`
+# is a syntax check that never executes the script, and a match inside single quotes is a
+# grep PATTERN in an assertion about bootstrap's OUTPUT, not an invocation.
+pin_cov_total=0; pin_cov_wrapped=0; pin_cov_missing=""
+while IFS= read -r pin_cov_line; do
+  case "$pin_cov_line" in
+    *"bash -n "*) continue ;;
+    *"'"*"bootstrap-agent-machine.sh"*"'"*) continue ;;
+  esac
+  pin_cov_total=$((pin_cov_total + 1))
+  case "$pin_cov_line" in
+    *'"$PIN_BS"'*) pin_cov_wrapped=$((pin_cov_wrapped + 1)) ;;
+    *) pin_cov_missing="${pin_cov_missing:+$pin_cov_missing
+}  ${pin_cov_line#"${pin_cov_line%%[![:space:]]*}"}" ;;
+  esac
+done <<EOF
+$(grep -nE '(^|[^-a-zA-Z0-9_])bash [^|;]*bootstrap-agent-machine\.sh|"\$PIN_BS" "\$(BOOTSTRAP|[A-Za-z_][A-Za-z0-9_]*)' "$0" || true)
+EOF
+if [ "$pin_cov_total" -gt 0 ] && [ -z "$pin_cov_missing" ]; then
+  ok "host hygiene: guard coverage is $pin_cov_wrapped/$pin_cov_total bootstrap invocations — none unwrapped"
+else
+  bad "host hygiene: guard coverage is $pin_cov_wrapped/$pin_cov_total — an unwrapped invocation is INVISIBLE to case 14, which would still report green:"
+  printf '%s\n' "$pin_cov_missing"
 fi
 
 # --- 15. THE THREE GREEN-PATH CASES MUST HAVE RUN, BY NAME (#3414 roborev round 7) -----

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -36,6 +36,45 @@ $1"; }
 # instead, by the base_warns assertion in block 7p.
 skip() { printf 'skip - %s\n' "$1"; SKIPS=$((SKIPS + 1)); }
 
+# --- THIS SUITE IS NOT RUNNABLE AS ROOT, AND SAYS SO UP FRONT (#3414 roborev round 7) --
+# OUR OWN REGRESSION, and the second time these three cases have been silently disabled.
+# Round 5 made the test seam refuse under EUID 0 (finding S, a real privilege-escalation
+# hole). But the refusal is a [warn], and it fires for EVERY sandboxed invocation, so under
+# root `base_warns` becomes 2, the baseline assertion below fails, and the three green-path
+# cases print `skip` — the exact three that round 2's finding was about. We unskipped them,
+# then re-skipped them four rounds later by fixing something else.
+#
+# Refused UP FRONT rather than per-case: the alternative is threading privilege-dropping
+# through test setup, which is how the seam came to need a root guard in the first place. A
+# suite that declares "not runnable as root" is honest and cheap; one that runs 190 cases
+# of which an unpredictable subset are silently meaningless is neither.
+#
+# COUNTED, never an `ok` — round 2's finding, and this file now has a hygiene case that
+# forbids announcing a skip through ok() anyway.
+#
+# AND IT IS THE FIRST THING THAT RUNS, BEFORE `mktemp -d` AND BEFORE ANY CASE (#3414
+# roborev round 8, lead caution). The manual check that this suite declines under root is
+# itself run with `sudo`, so anything executing above the decline would run AS ROOT — and
+# a single line up there that resolves CARGO_HOME from /etc/environment, or writes outside
+# its own tmpdir, would make the check for a safety property the thing that violates it.
+# That is not hypothetical: it is what happened 40 minutes earlier with the cargo config.
+# Even the tmpdir matters — created as root it is litter the invoking user cannot remove.
+# So the decline precedes everything, and the only host contact above it is now none.
+if [ "$(id -u)" = 0 ]; then
+  skip "THE ENTIRE SUITE: it drives bootstrap through a test seam that is REFUSED under root (#3414 finding S), so every sandboxed invocation gains a warning and the green-path assertions cannot run. Re-run as an unprivileged user."
+  echo
+  echo "PASS=$PASS FAIL=$FAIL SKIP=$SKIPS"
+  # NONZERO, and this is the THIRD LEVEL at which this same shape has been caught (#3414
+  # roborev round 8). Round 2 found a CASE counted as a pass; round 4 found `ok "SKIP …"`;
+  # round 7's fix for those turned it into a SUITE-level version — the gate checks only
+  # exit status, so `exit 0` here reported `tooling-tests` green having executed nothing at
+  # all, including every regression this branch added. A declined suite is not a passing
+  # suite. The gate runs as an unprivileged user, so the normal path never reaches this and
+  # the cost is zero; running it as root becomes a loud failure instead of a silent green.
+  echo "DECLINED: this suite executed NOTHING and is exiting NONZERO so no caller can read it as a pass." >&2
+  exit 1
+fi
+
 # --- 1. syntax check (bash -n) ---
 if bash -n "$BOOTSTRAP" 2>/dev/null; then
   ok "bootstrap script parses (bash -n)"
@@ -87,35 +126,6 @@ export CQLITE_BOOTSTRAP_TEST_MODE=1
 export CQLITE_BOOTSTRAP_ENV_FILE="$tmp/etc-environment"
 : >"$CQLITE_BOOTSTRAP_ENV_FILE"
 
-# --- THIS SUITE IS NOT RUNNABLE AS ROOT, AND SAYS SO UP FRONT (#3414 roborev round 7) --
-# OUR OWN REGRESSION, and the second time these three cases have been silently disabled.
-# Round 5 made the test seam refuse under EUID 0 (finding S, a real privilege-escalation
-# hole). But the refusal is a [warn], and it fires for EVERY sandboxed invocation, so under
-# root `base_warns` becomes 2, the baseline assertion below fails, and the three green-path
-# cases print `skip` — the exact three that round 2's finding was about. We unskipped them,
-# then re-skipped them four rounds later by fixing something else.
-#
-# Refused UP FRONT rather than per-case: the alternative is threading privilege-dropping
-# through test setup, which is how the seam came to need a root guard in the first place. A
-# suite that declares "not runnable as root" is honest and cheap; one that runs 190 cases
-# of which an unpredictable subset are silently meaningless is neither.
-#
-# COUNTED, never an `ok` — round 2's finding, and this file now has a hygiene case that
-# forbids announcing a skip through ok() anyway.
-if [ "$(id -u)" = 0 ]; then
-  skip "THE ENTIRE SUITE: it drives bootstrap through a test seam that is REFUSED under root (#3414 finding S), so every sandboxed invocation gains a warning and the green-path assertions cannot run. Re-run as an unprivileged user."
-  echo
-  echo "PASS=$PASS FAIL=$FAIL SKIP=$SKIPS"
-  # NONZERO, and this is the THIRD LEVEL at which this same shape has been caught (#3414
-  # roborev round 8). Round 2 found a CASE counted as a pass; round 4 found `ok "SKIP …"`;
-  # round 7's fix for those turned it into a SUITE-level version — the gate checks only
-  # exit status, so `exit 0` here reported `tooling-tests` green having executed nothing at
-  # all, including every regression this branch added. A declined suite is not a passing
-  # suite. The gate runs as an unprivileged user, so the normal path never reaches this and
-  # the cost is zero; running it as root becomes a loud failure instead of a silent green.
-  echo "DECLINED: this suite executed NOTHING and is exiting NONZERO so no caller can read it as a pass." >&2
-  exit 1
-fi
 
 # --- CARGO_HOME isolation: THIS SUITE WAS BREAKING cargo FOR THE WHOLE BOX ---------
 # The mold section writes `${CARGO_HOME:-$HOME/.cargo}/config.toml`, and on this fleet

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -179,7 +179,26 @@ if [ -z "$_v" ]; then
     *) _v="HOME='$HOME' is outside the suite sandbox ($PIN_SANDBOX_ROOT)" ;;
   esac
 fi
-[ -z "$_v" ] || printf 'invocation: %s\n  unsandboxed input: %s\n' "$*" "$_v" >>"$PIN_SHARED_VIOLATIONS"
+if [ -n "$_v" ]; then
+  printf 'invocation: %s\n  unsandboxed input: %s\n' "$*" "$_v" >>"$PIN_SHARED_VIOLATIONS"
+  # AND REFUSE TO RUN (roborev job 321, Medium). Recording a violation and then executing
+  # anyway lets the damage land BEFORE the suite reports it — and the damage is not
+  # hypothetical: an unsandboxed run on this box left /usr/local/cargo/config.toml root-owned
+  # 0600 and broke cargo for every other lane, three times (#3673). A guard that observes but
+  # does not stop is a log, not a guard. The violation is still recorded, so case 14 reports
+  # it exactly as before; what changes is that bootstrap never runs.
+  printf 'FATAL: refusing to run bootstrap with unsandboxed input: %s\n' "$_v" >&2
+  # IF THIS FIRES ON A SUDO INVOCATION, THE CAUSE IS ALMOST CERTAINLY env_reset, NOT A REAL
+  # UNSANDBOXED INPUT. sudo repopulates the environment from /etc/environment, so
+  # PIN_SANDBOX_ROOT and PIN_SHARED_VIOLATIONS — both exported by the suite — do NOT survive
+  # the boundary, and the guard then fail-closes on an unusable sandbox root while the actual
+  # HOME/CARGO_HOME it was handed are perfectly sandboxed. Every `sudo -n env` call site
+  # therefore re-passes BOTH vars explicitly. Measured when this refusal was added: 6 root
+  # cases broke at once, and the same env_reset drop had ALSO been silently discarding every
+  # violation record from a sudo invocation (`>>""`), so that half of the guard had never
+  # worked across the boundary at all.
+  exit 97
+fi
 bash "$@"
 exit $?
 PINBS
@@ -3525,7 +3544,7 @@ else
   pin_root_sandbox="$tmp/pin-root-sandbox"; mkdir -p "$pin_root_sandbox/.cargo"
   pin_seam_probe="$tmp/pin-seam-root-target"; rm -f "$pin_seam_probe"
   if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
-    out_ak=$(sudo -n env CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="$pin_seam_probe" \
+    out_ak=$(sudo -n env PIN_SANDBOX_ROOT="$PIN_SANDBOX_ROOT" PIN_SHARED_VIOLATIONS="$PIN_SHARED_VIOLATIONS" CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="$pin_seam_probe" \
       HOME="$pin_root_sandbox" CARGO_HOME="$pin_root_sandbox/.cargo" \
       timeout -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
         --skip-smoke --skip-push-probe --yes 2>&1)
@@ -3559,7 +3578,7 @@ else
   #      invoker sudo names but that does not resolve is UNMEASURED, never a silent fall
   #      back to answering about root.
   if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
-    out_am=$(sudo -n env SUDO_USER=cqlite-no-such-account-3414 \
+    out_am=$(sudo -n env PIN_SANDBOX_ROOT="$PIN_SANDBOX_ROOT" PIN_SHARED_VIOLATIONS="$PIN_SHARED_VIOLATIONS" SUDO_USER=cqlite-no-such-account-3414 \
       HOME="$pin_root_sandbox" CARGO_HOME="$pin_root_sandbox/.cargo" \
       timeout -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
         --skip-smoke --skip-push-probe 2>&1)
@@ -3571,7 +3590,7 @@ else
       bad "gate-pin: an unresolvable invoker fell back to probing the wrong user"
       printf '%s\n' "$out_am" | grep -i 'gate-pin' | head -2
     fi
-    out_an=$(sudo -n env SUDO_USER="$(id -un)" \
+    out_an=$(sudo -n env PIN_SANDBOX_ROOT="$PIN_SANDBOX_ROOT" PIN_SHARED_VIOLATIONS="$PIN_SHARED_VIOLATIONS" SUDO_USER="$(id -un)" \
       HOME="$pin_root_sandbox" CARGO_HOME="$pin_root_sandbox/.cargo" \
       timeout -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
         --skip-smoke --skip-push-probe 2>&1)
@@ -3598,7 +3617,7 @@ else
     pin_liar="$tmp/pin-liar-bin"; mkdir -p "$pin_liar"
     printf '#!/usr/bin/env bash\necho 1000\n' >"$pin_liar/id"; chmod +x "$pin_liar/id"
     pin_liar_target="$tmp/pin-liar-target"; rm -f "$pin_liar_target"
-    out_at=$(sudo -n env PATH="$pin_liar:$PATH" \
+    out_at=$(sudo -n env PIN_SANDBOX_ROOT="$PIN_SANDBOX_ROOT" PIN_SHARED_VIOLATIONS="$PIN_SHARED_VIOLATIONS" PATH="$pin_liar:$PATH" \
       CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="$pin_liar_target" \
       HOME="$pin_root_sandbox" CARGO_HOME="$pin_root_sandbox/.cargo" \
       timeout -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
@@ -3616,7 +3635,7 @@ else
     #      accepts stale metadata — `SUDO_UID=1000 SUDO_USER=root` would probe root and
     #      could report VERIFIED while the agent account differs, which is the
     #      wrong-subject defect the retarget exists to fix, wearing the retarget's clothes.
-    out_au=$(sudo -n env SUDO_UID=1000 SUDO_USER=root \
+    out_au=$(sudo -n env PIN_SANDBOX_ROOT="$PIN_SANDBOX_ROOT" PIN_SHARED_VIOLATIONS="$PIN_SHARED_VIOLATIONS" SUDO_UID=1000 SUDO_USER=root \
       HOME="$pin_root_sandbox" CARGO_HOME="$pin_root_sandbox/.cargo" \
       timeout -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
         --skip-smoke --skip-push-probe 2>&1)
@@ -3630,7 +3649,7 @@ else
     fi
 
     # 11av. ...and root invoking sudo (SUDO_UID=0) tells us nothing about a gate's account.
-    out_av=$(sudo -n env SUDO_UID=0 SUDO_USER=root \
+    out_av=$(sudo -n env PIN_SANDBOX_ROOT="$PIN_SANDBOX_ROOT" PIN_SHARED_VIOLATIONS="$PIN_SHARED_VIOLATIONS" SUDO_UID=0 SUDO_USER=root \
       HOME="$pin_root_sandbox" CARGO_HOME="$pin_root_sandbox/.cargo" \
       timeout -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
         --skip-smoke --skip-push-probe 2>&1)

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -81,6 +81,42 @@ export CQLITE_BOOTSTRAP_TEST_MODE=1
 export CQLITE_BOOTSTRAP_ENV_FILE="$tmp/etc-environment"
 : >"$CQLITE_BOOTSTRAP_ENV_FILE"
 
+# --- CARGO_HOME isolation: THIS SUITE WAS BREAKING cargo FOR THE WHOLE BOX ---------
+# The mold section writes `${CARGO_HOME:-$HOME/.cargo}/config.toml`, and on this fleet
+# /etc/environment sets CARGO_HOME=/usr/local/cargo — root-owned and SHARED BY EVERY
+# USER. So every bootstrap invocation here rewrote the machine-wide cargo config, and a
+# peer lane took three spurious red clusters from `could not load Cargo configuration ...
+# Permission denied` while it sat root-owned mode 600.
+#
+# TWO HALVES OF THE CAUSE, both worth recording. The hazard is OLD — that section has
+# always written $CARGO_HOME — but this suite makes **37 bootstrap invocations**, so what
+# was "occasionally, when someone runs the suite" became constant. We did not introduce
+# the bug; we crossed a threshold on someone else's latent one, and a tooling test that
+# mutates shared host state is a fleet-wide false-red generator whatever it asserts —
+# including inside a gate of record, where it voids a 20-minute certification and invites
+# misattribution to the diff under test.
+#
+# Sandboxed rather than restored-afterwards: a restore leaves a window in which peers red,
+# does not survive a killed run, and still clobbers whatever the real file legitimately
+# holds. The sibling suite test_perf_capability_bootstrap.sh already pairs
+# CARGO_HOME with its sandbox HOME per invocation; this is the same fact from a second
+# channel, so a case added later that sets HOME and forgets CARGO_HOME is still contained.
+# NOTE the export does NOT cover `sudo` invocations — sudoers' env_reset drops it — so
+# those must pass CARGO_HOME explicitly on the command line; see the root cases in block 11.
+export CARGO_HOME="$tmp/cargo-home"
+mkdir -p "$CARGO_HOME"
+
+# Baseline for the hermeticity assertion at the end of the suite. Captured as
+# mode+mtime+content so a rewrite is caught even if it happens to restore the bytes.
+PIN_SHARED_CARGO=/usr/local/cargo/config.toml
+pin_shared_cargo_state() {
+  [ -e "$PIN_SHARED_CARGO" ] || { printf 'absent'; return 0; }
+  printf '%s %s %s' "$(stat -c '%a' "$PIN_SHARED_CARGO" 2>/dev/null)" \
+                    "$(stat -c '%Y' "$PIN_SHARED_CARGO" 2>/dev/null)" \
+                    "$(md5sum "$PIN_SHARED_CARGO" 2>/dev/null | cut -d' ' -f1)"
+}
+PIN_SHARED_CARGO_BEFORE=$(pin_shared_cargo_state)
+
 # --- REAL-ORIGIN isolation for the push probe (issue #3369) ----------------
 # Section 3b now MEASURES push capability by actually pushing a throwaway
 # refs/claims/smoke-<commit-sha> ref (scripts/flow/claim.sh smoke). Every case that runs
@@ -3184,9 +3220,15 @@ else
   #      and `tee -a` is privileged anyway, so an env var could aim a root write at any
   #      absolute path. Asserted at the level the guard now uses: a real root invocation
   #      with the seam set must REFUSE, not write.
+  # A sandbox for the ROOT invocations below. It must be cleaned with sudo, because root
+  # writing here leaves root-owned files that the suite's own `rm -rf "$tmp"` trap (running
+  # as the invoking user) cannot remove — a leak of the same shape as the one being fixed,
+  # one directory over.
+  pin_root_sandbox="$tmp/pin-root-sandbox"; mkdir -p "$pin_root_sandbox/.cargo"
   pin_seam_probe="$tmp/pin-seam-root-target"; rm -f "$pin_seam_probe"
   if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
     out_ak=$(sudo -n env CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="$pin_seam_probe" \
+      HOME="$pin_root_sandbox" CARGO_HOME="$pin_root_sandbox/.cargo" \
       timeout -s KILL 120 bash "$pinroot/scripts/bootstrap-agent-machine.sh" \
         --skip-smoke --skip-push-probe --yes 2>&1)
     if printf '%s' "$out_ak" | grep -q 'gate-pin: SKIPPED' \
@@ -3199,6 +3241,7 @@ else
       ls -l "$pin_seam_probe" 2>/dev/null
     fi
     sudo -n rm -f "$pin_seam_probe" 2>/dev/null || true
+    sudo -n rm -rf "$pin_root_sandbox" 2>/dev/null || true; mkdir -p "$pin_root_sandbox/.cargo"
   else
     skip "gate-pin root-seam refusal (no passwordless sudo here to stage a real root invocation)"
   fi
@@ -3219,6 +3262,7 @@ else
   #      back to answering about root.
   if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
     out_am=$(sudo -n env SUDO_USER=cqlite-no-such-account-3414 \
+      HOME="$pin_root_sandbox" CARGO_HOME="$pin_root_sandbox/.cargo" \
       timeout -s KILL 120 bash "$pinroot/scripts/bootstrap-agent-machine.sh" \
         --skip-smoke --skip-push-probe 2>&1)
     if printf '%s' "$out_am" | grep -qE '\[warn\].*gate-pin: UNMEASURED' \
@@ -3230,6 +3274,7 @@ else
       printf '%s\n' "$out_am" | grep -i 'gate-pin' | head -2
     fi
     out_an=$(sudo -n env SUDO_USER="$(id -un)" \
+      HOME="$pin_root_sandbox" CARGO_HOME="$pin_root_sandbox/.cargo" \
       timeout -s KILL 120 bash "$pinroot/scripts/bootstrap-agent-machine.sh" \
         --skip-smoke --skip-push-probe 2>&1)
     if printf '%s' "$out_an" | grep -q "the account that invoked sudo"; then
@@ -3351,6 +3396,19 @@ if [ -z "$pin_skip_offenders" ]; then
 else
   bad "suite hygiene: a SKIP is announced through ok(), so it counts as a PASS and not as a skip:"
   printf '%s\n' "$pin_skip_offenders"
+fi
+
+# --- 14. THIS SUITE MUST NOT TOUCH SHARED HOST STATE -----------------------------------
+# Asserted affirmatively rather than by inspection, because the reach is easy to
+# reintroduce (a new case that sets HOME and forgets CARGO_HOME, or a `sudo` invocation
+# where the exported value is dropped by env_reset) and the cost lands on OTHER lanes as
+# unexplained red gates, which is the worst possible place for it to surface.
+pin_shared_cargo_after=$(pin_shared_cargo_state)
+if [ "$pin_shared_cargo_after" = "$PIN_SHARED_CARGO_BEFORE" ]; then
+  ok "host hygiene: $PIN_SHARED_CARGO is untouched by this suite (mode+mtime+content unchanged)"
+else
+  bad "host hygiene: this suite MUTATED the shared $PIN_SHARED_CARGO — it breaks cargo for every other user on the box"
+  printf '  before: %s\n  after:  %s\n' "$PIN_SHARED_CARGO_BEFORE" "$pin_shared_cargo_after"
 fi
 
 echo

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -192,6 +192,34 @@ export PIN_SANDBOX_ROOT
 # reasoned it is harmless is how a guard's coverage erodes into a claim. No exemptions.
 mkdir -p "$tmp/help-home/.cargo"
 
+# --- TREE IDENTITY, STAMPED AT BOTH ENDS (#3414, shared-worktree incident) -------------
+# This suite is run by more than one actor against ONE shared worktree, and a run that
+# spans an edit CANNOT BE ATTRIBUTED — its failures may belong to the tree it started on,
+# the tree it ended on, or neither. That is not hypothetical twice over: a run died with a
+# parse error at a line nobody had touched (bash was still reading the file as it changed),
+# and separately a `FAIL=1` followed by four clean runs was read as an intermittent case
+# when it was actually one measurement across a moving tree.
+#
+# Neither was visible in the log. The mtime forensics that found them are not something the
+# next reader will think to do, so the run now SAYS what tree it ran on, at both ends, in
+# the same shape agent-gate.sh uses (tree-start / tree-end / tree-integrity). A moving tree
+# then shows up as itself instead of as a flaky case.
+#
+# Portable and non-fatal: `git` may be absent or this may not be a checkout, in which case
+# the stamp says UNKNOWN rather than pretending. It never fails the suite on its own —
+# the point is that the log can be read, not that the tree must be still.
+pin_tree_id() {
+  if command -v git >/dev/null 2>&1 && git -C "$SCRIPT_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+    printf '%s dirty=%s' \
+      "$(git -C "$SCRIPT_DIR" rev-parse --short HEAD 2>/dev/null || printf 'UNKNOWN')" \
+      "$(git -C "$SCRIPT_DIR" status --porcelain 2>/dev/null | wc -l | tr -d ' ')"
+  else
+    printf 'UNKNOWN dirty=UNKNOWN'
+  fi
+}
+PIN_TREE_START=$(pin_tree_id)
+printf 'tree-start: %s\n' "$PIN_TREE_START"
+
 # --- 1. syntax check (bash -n) ---
 if bash -n "$BOOTSTRAP" 2>/dev/null; then
   ok "bootstrap script parses (bash -n)"
@@ -3768,6 +3796,17 @@ if [ -z "$pin_decline_bad" ] && grep -qE '^  exit 1$' "$0"; then
   ok "suite hygiene: the wholesale-decline path exits NONZERO (a declined suite is not a passing suite)"
 else
   bad "suite hygiene: a wholesale decline exits 0 — the gate reads only exit status, so it would certify a suite that ran nothing"
+fi
+
+PIN_TREE_END=$(pin_tree_id)
+printf 'tree-end:   %s\n' "$PIN_TREE_END"
+if [ "$PIN_TREE_START" = "$PIN_TREE_END" ]; then
+  printf 'tree-integrity: STABLE\n'
+else
+  # Reported, not failed: the run may still be entirely valid. What it must not do is look
+  # like a clean measurement of one tree when it spanned two.
+  printf 'tree-integrity: MOVED (%s -> %s) — this run spanned an edit; do not attribute its verdicts to either tree without re-running on a still one\n' \
+    "$PIN_TREE_START" "$PIN_TREE_END"
 fi
 
 echo

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -101,14 +101,11 @@ trap 'rm -rf "$tmp"' EXIT
 
 # Baseline for the hermeticity assertion at the end of the suite. Captured as
 # mode+mtime+content so a rewrite is caught even if it happens to restore the bytes.
+# Named only for the diagnostic below; never stat'd or hashed. The GNU-only `stat -c` /
+# `md5sum` snapshot that used to live here is gone with the shared-state observation it
+# served (#3414 roborev round 11) — those probes yield empty fields on macOS, where this
+# suite runs as part of a MANDATORY gate component.
 PIN_SHARED_CARGO=/usr/local/cargo/config.toml
-pin_shared_cargo_state() {
-  [ -e "$PIN_SHARED_CARGO" ] || { printf 'absent'; return 0; }
-  printf '%s %s %s' "$(stat -c '%a' "$PIN_SHARED_CARGO" 2>/dev/null)" \
-                    "$(stat -c '%Y' "$PIN_SHARED_CARGO" 2>/dev/null)" \
-                    "$(md5sum "$PIN_SHARED_CARGO" 2>/dev/null | cut -d' ' -f1)"
-}
-PIN_SHARED_CARGO_BEFORE=$(pin_shared_cargo_state)
 
 # --- ATTRIBUTABLE, NOT MERELY DETECTED (#3414 roborev round 10) ------------------------
 # The tripwire used to snapshot the shared file around the WHOLE suite, so ANY concurrent
@@ -133,25 +130,51 @@ export PIN_SHARED_VIOLATIONS="$tmp/shared-state-violations.log"
 PIN_BS="$tmp/pin-bs-guard"
 cat >"$PIN_BS" <<'PINBS'
 #!/usr/bin/env bash
-# pin-bs-guard <bootstrap-path> [args...] — run one bootstrap invocation and record any
-# change to the shared cargo config across THAT invocation. stdout/stderr and the exit
-# status pass through untouched: callers capture output and assert on rc.
-_st() {
-  [ -e "$PIN_SHARED_CARGO" ] || { printf 'absent'; return 0; }
-  printf '%s %s %s' "$(stat -c '%a' "$PIN_SHARED_CARGO" 2>/dev/null)"                     "$(stat -c '%Y' "$PIN_SHARED_CARGO" 2>/dev/null)"                     "$(md5sum "$PIN_SHARED_CARGO" 2>/dev/null | cut -d' ' -f1)"
-}
-_before=$(_st)
+# pin-bs-guard <bootstrap-path> [args...] — run one bootstrap invocation with its
+# HOST-REACHING INPUTS asserted, and record a violation if they are not sandboxed.
+# stdout/stderr and the exit status pass through untouched: callers capture output and
+# assert on rc.
+#
+# ASSERTS THE INPUTS, DOES NOT OBSERVE THE OUTPUT (#3414 roborev round 11). The previous
+# form snapshotted the SHARED /usr/local/cargo/config.toml either side of each invocation.
+# That was already attributable in the common case — a change outside every invocation
+# window was reported as another writer's, not ours — but it had two defects it could not
+# shed: an external write landing INSIDE one of our windows was still recorded as ours (a
+# narrower race is a smaller race, not attribution), and `stat -c`/`md5sum` are GNU-only,
+# so on macOS both probes yield empty fields, the mutation self-test cannot detect its own
+# deliberate write, and a MANDATORY gate component fails on that platform.
+#
+# The property we actually need is "no invocation can reach the shared path". Bootstrap
+# resolves its cargo config as `${CARGO_HOME:-$HOME/.cargo}/config.toml`, so if BOTH
+# CARGO_HOME and HOME point inside the suite sandbox, that path is unreachable BY
+# CONSTRUCTION — no window, no race, no platform-specific probe, and nothing another
+# writer on the box can affect. So assert the inputs.
+#
+# HONEST RESIDUAL, stated because input-assertion does not cover it: a future bootstrap
+# edit that writes an ABSOLUTE path while ignoring CARGO_HOME/HOME would not be caught
+# here. That is a different defect (a hardcoded destination rather than an unsandboxed
+# caller), and claiming this guard covers it would be the false-assurance shape this whole
+# branch is about. #3673 is where a destination-side guard belongs.
+_v=""
+case "${CARGO_HOME-}" in
+  '') _v="CARGO_HOME is unset, so bootstrap would resolve \${HOME}/.cargo — on this fleet HOME-derived or /etc/environment-derived paths reach the SHARED root-owned config" ;;
+  "$PIN_SANDBOX_ROOT"/*) ;;
+  *) _v="CARGO_HOME='$CARGO_HOME' is outside the suite sandbox ($PIN_SANDBOX_ROOT)" ;;
+esac
+if [ -z "$_v" ]; then
+  case "${HOME-}" in
+    '') _v="HOME is unset" ;;
+    "$PIN_SANDBOX_ROOT"/*) ;;
+    *) _v="HOME='$HOME' is outside the suite sandbox ($PIN_SANDBOX_ROOT)" ;;
+  esac
+fi
+[ -z "$_v" ] || printf 'invocation: %s\n  unsandboxed input: %s\n' "$*" "$_v" >>"$PIN_SHARED_VIOLATIONS"
 bash "$@"
-_rc=$?
-_after=$(_st)
-[ "$_before" = "$_after" ] || printf 'invocation: %s
-  before: %s
-  after:  %s
-'   "$*" "$_before" "$_after" >>"$PIN_SHARED_VIOLATIONS"
-exit $_rc
+exit $?
 PINBS
 chmod +x "$PIN_BS"
-export PIN_SHARED_CARGO
+PIN_SANDBOX_ROOT="$tmp"
+export PIN_SANDBOX_ROOT
 
 # --- 1. syntax check (bash -n) ---
 if bash -n "$BOOTSTRAP" 2>/dev/null; then
@@ -3616,22 +3639,24 @@ fi
 # legitimately touches the shared file, so the guard's ability to DETECT is otherwise never
 # exercised: a plant that neutered it left the suite green.
 #
-# So the guard is self-tested against a STAND-IN file, never the real one: point
-# PIN_SHARED_CARGO at a throwaway, have the wrapped command mutate it, and require a
-# violation to be recorded.
-pin_guard_probe="$tmp/guard-selftest-target"; printf 'x\n' >"$pin_guard_probe"
+# So the guard is self-tested by PLANTING THE DEFECT IT EXISTS FOR — an invocation whose
+# CARGO_HOME is not sandboxed — into a throwaway violations log. Both directions, because
+# a guard that fires unconditionally is as useless as one that never fires.
 pin_guard_log="$tmp/guard-selftest-violations.log"; : >"$pin_guard_log"
-PIN_SHARED_CARGO="$pin_guard_probe" PIN_SHARED_VIOLATIONS="$pin_guard_log" \
-  "$PIN_BS" -c 'printf "mutated\n" >>"$1"' _ "$pin_guard_probe" >/dev/null 2>&1
-pin_guard_clean="$tmp/guard-selftest-clean.log"; : >"$pin_guard_clean"
-PIN_SHARED_CARGO="$pin_guard_probe" PIN_SHARED_VIOLATIONS="$pin_guard_clean" \
+PIN_SHARED_VIOLATIONS="$pin_guard_log" HOME="$tmp/sb-selftest" \
+  env -u CARGO_HOME "$PIN_BS" -c 'true' >/dev/null 2>&1
+pin_guard_out="$tmp/guard-selftest-outside.log"; : >"$pin_guard_out"
+PIN_SHARED_VIOLATIONS="$pin_guard_out" HOME="$tmp/sb-selftest" CARGO_HOME=/usr/local/cargo \
   "$PIN_BS" -c 'true' >/dev/null 2>&1
-if [ -s "$pin_guard_log" ] && [ ! -s "$pin_guard_clean" ]; then
-  ok "host hygiene: the tripwire DETECTS a mutation across a wrapped invocation (and stays quiet without one)"
+pin_guard_clean="$tmp/guard-selftest-clean.log"; : >"$pin_guard_clean"
+PIN_SHARED_VIOLATIONS="$pin_guard_clean" HOME="$tmp/sb-selftest" CARGO_HOME="$tmp/sb-selftest/.cargo" \
+  "$PIN_BS" -c 'true' >/dev/null 2>&1
+if [ -s "$pin_guard_log" ] && [ -s "$pin_guard_out" ] && [ ! -s "$pin_guard_clean" ]; then
+  ok "host hygiene: the guard FIRES on an unset CARGO_HOME and on one outside the sandbox, and stays quiet on a sandboxed pair"
 else
-  bad "host hygiene: the tripwire cannot fire — case 14's 'nothing touched it' would be vacuous"
-  printf '  mutating run recorded: %s bytes; clean run recorded: %s bytes\n' \
-    "$(wc -c <"$pin_guard_log")" "$(wc -c <"$pin_guard_clean")"
+  bad "host hygiene: the input guard cannot fire (or fires unconditionally) — case 14 would be vacuous"
+  printf '  unset: %s bytes; outside: %s bytes; sandboxed: %s bytes\n' \
+    "$(wc -c <"$pin_guard_log")" "$(wc -c <"$pin_guard_out")" "$(wc -c <"$pin_guard_clean")"
 fi
 
 # --- 14. THIS SUITE MUST NOT TOUCH SHARED HOST STATE -----------------------------------
@@ -3639,20 +3664,14 @@ fi
 # reintroduce (a new case that sets HOME and forgets CARGO_HOME, or a `sudo` invocation
 # where the exported value is dropped by env_reset) and the cost lands on OTHER lanes as
 # unexplained red gates, which is the worst possible place for it to surface.
-# ATTRIBUTED, not inferred: this reports only changes observed across one of THIS suite's
-# own bootstrap invocations. A concurrent external writer no longer reds it, and a
-# reintroduced reach still does — with the offending invocation named.
-pin_shared_cargo_after=$(pin_shared_cargo_state)
+# ATTRIBUTED BY CONSTRUCTION, not inferred and not observed: the guard asserts each
+# invocation's CARGO_HOME and HOME are inside the sandbox, which makes the shared path
+# unreachable for bootstrap's `${CARGO_HOME:-$HOME/.cargo}` resolution. No external writer
+# can affect this verdict, and it needs no GNU-only probe, so it holds on macOS too.
 if [ ! -s "$PIN_SHARED_VIOLATIONS" ]; then
-  ok "host hygiene: no bootstrap invocation in this suite touched $PIN_SHARED_CARGO"
-  if [ "$pin_shared_cargo_after" != "$PIN_SHARED_CARGO_BEFORE" ]; then
-    # Deliberately an `info`, not a `bad`: the file moved while the suite ran but NOT
-    # across any invocation of ours, so it was someone else — a peer lane, an admin, a
-    # human at a prompt. Reporting it is useful; blaming ourselves for it is the defect.
-    info "note: $PIN_SHARED_CARGO changed during this run but NOT across any of our invocations — another writer on this box (before: $PIN_SHARED_CARGO_BEFORE / after: $pin_shared_cargo_after)"
-  fi
+  ok "host hygiene: every bootstrap invocation in this suite ran with sandboxed CARGO_HOME and HOME, so the shared cargo config was unreachable"
 else
-  bad "host hygiene: a bootstrap invocation in THIS suite mutated the shared $PIN_SHARED_CARGO — it breaks cargo for every other user on the box"
+  bad "host hygiene: a bootstrap invocation in THIS suite ran with an UNSANDBOXED CARGO_HOME or HOME, so it could reach the shared $PIN_SHARED_CARGO — that breaks cargo for every other user on the box"
   cat "$PIN_SHARED_VIOLATIONS"
 fi
 

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -3062,6 +3062,38 @@ else
     printf '%s\n' "$out_ad" | grep -i 'gate-pin' | head -2
   fi
 
+  # 11ae. A QUOTED-BUT-CORRECT FILE MUST STILL VERIFY (issue #3414, lead correction).
+  #      pam_env strips surrounding quotes, and quoting IS the convention in this file —
+  #      /etc/environment on this fleet opens with PATH="/usr/local/sbin:...". Comparing
+  #      the RAW string would make `CQLITE_GATE_MAX_CONCURRENCY="1"` parse as `"1"` while
+  #      the session reports `1`, and a properly pinned box would get a non-passing
+  #      verdict: red on correct input, produced by the fix for a false green. Both quote
+  #      kinds, because pam was MEASURED to treat them alike rather than assumed to.
+  for pin_q in '"1"' "'1'" '"1' '1'; do
+    envf_ae="$tmp/pin-env-ae"; printf 'CQLITE_GATE_MAX_CONCURRENCY=%s\n' "$pin_q" >"$envf_ae"
+    out_ae=$(runpin "$pinroot" "$shims_one" "$envf_ae" HOME="$pin_home_plain")
+    if printf '%s' "$out_ae" | grep -qE '\[ok\].*gate-pin: VERIFIED'; then
+      ok "gate-pin: a file value written as $pin_q still VERIFIES (pam_env's quoting is read, not reinterpreted)"
+    else
+      bad "gate-pin: a correctly-pinned box written as $pin_q was reported non-passing"
+      printf '%s\n' "$out_ae" | grep -i 'gate-pin' | head -2
+    fi
+  done
+
+  # 11af. ...and de-quoting must not become normalisation. The INTERIOR is untouched, so a
+  #      quoted `" 1 "` still mismatches a session reporting `1` — the gate discards ` 1 `
+  #      (it matches *[!0-9]*), so calling them equal here would certify a value the gate
+  #      rejects. This is the line between reading the file's format and reinterpreting
+  #      its content, and it is the half a future "just trim it" refactor would erase.
+  envf_af="$tmp/pin-env-af"; printf 'CQLITE_GATE_MAX_CONCURRENCY=" 1 "\n' >"$envf_af"
+  out_af=$(runpin "$pinroot" "$shims_one" "$envf_af" HOME="$pin_home_plain")
+  if ! printf '%s' "$out_af" | grep -qE '\[ok\].*gate-pin'; then
+    ok "gate-pin: de-quoting leaves the interior alone — a quoted ' 1 ' still mismatches '1'"
+  else
+    bad "gate-pin: de-quoting slid into normalisation and certified a value the gate discards"
+    printf '%s\n' "$out_af" | grep -i 'gate-pin' | head -2
+  fi
+
   # 11k. The test seam is FAIL-CLOSED and has NO production fallback: set without its
   #      marker, or relative, it SKIPS the section rather than silently persisting to
   #      the real /etc/environment (the #3249 lesson — a seam that degrades to the

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -16,8 +16,14 @@ BOOTSTRAP="$SCRIPT_DIR/../bootstrap-agent-machine.sh"
 PASS=0
 FAIL=0
 SKIPS=0
-ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
-bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+# Every case name that actually REPORTED. Case 15 reads this rather than re-deriving what
+# "should" have run: the question is whether a case executed, and the only evidence of that
+# is that it announced a verdict.
+PIN_RAN_CASES=""
+ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); PIN_RAN_CASES="$PIN_RAN_CASES
+$1"; }
+bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); PIN_RAN_CASES="$PIN_RAN_CASES
+$1"; }
 # SKIPS ARE NEITHER PASS NOR FAIL, so they must be COUNTED and REPORTED (issue #3414
 # review B1). Three end-to-end cases silently became skips when section 5b started adding
 # one warning to every sandbox, and the suite still said FAIL=0 — including the case whose
@@ -80,6 +86,28 @@ export GIT_CONFIG_NOSYSTEM=1
 export CQLITE_BOOTSTRAP_TEST_MODE=1
 export CQLITE_BOOTSTRAP_ENV_FILE="$tmp/etc-environment"
 : >"$CQLITE_BOOTSTRAP_ENV_FILE"
+
+# --- THIS SUITE IS NOT RUNNABLE AS ROOT, AND SAYS SO UP FRONT (#3414 roborev round 7) --
+# OUR OWN REGRESSION, and the second time these three cases have been silently disabled.
+# Round 5 made the test seam refuse under EUID 0 (finding S, a real privilege-escalation
+# hole). But the refusal is a [warn], and it fires for EVERY sandboxed invocation, so under
+# root `base_warns` becomes 2, the baseline assertion below fails, and the three green-path
+# cases print `skip` — the exact three that round 2's finding was about. We unskipped them,
+# then re-skipped them four rounds later by fixing something else.
+#
+# Refused UP FRONT rather than per-case: the alternative is threading privilege-dropping
+# through test setup, which is how the seam came to need a root guard in the first place. A
+# suite that declares "not runnable as root" is honest and cheap; one that runs 190 cases
+# of which an unpredictable subset are silently meaningless is neither.
+#
+# COUNTED, never an `ok` — round 2's finding, and this file now has a hygiene case that
+# forbids announcing a skip through ok() anyway.
+if [ "$(id -u)" = 0 ]; then
+  skip "THE ENTIRE SUITE: it drives bootstrap through a test seam that is REFUSED under root (#3414 finding S), so every sandboxed invocation gains a warning and the green-path assertions cannot run. Re-run as an unprivileged user."
+  echo
+  echo "PASS=$PASS FAIL=$FAIL SKIP=$SKIPS"
+  exit 0
+fi
 
 # --- CARGO_HOME isolation: THIS SUITE WAS BREAKING cargo FOR THE WHOLE BOX ---------
 # The mold section writes `${CARGO_HOME:-$HOME/.cargo}/config.toml`, and on this fleet
@@ -3495,6 +3523,27 @@ if [ "$pin_shared_cargo_after" = "$PIN_SHARED_CARGO_BEFORE" ]; then
 else
   bad "host hygiene: this suite MUTATED the shared $PIN_SHARED_CARGO — it breaks cargo for every other user on the box"
   printf '  before: %s\n  after:  %s\n' "$PIN_SHARED_CARGO_BEFORE" "$pin_shared_cargo_after"
+fi
+
+# --- 15. THE THREE GREEN-PATH CASES MUST HAVE RUN, BY NAME (#3414 roborev round 7) -----
+# They have now been silently disabled TWICE by unrelated changes — once when section 5b
+# started warning in every sandbox (round 4), once when the seam began refusing under root
+# (round 7). Both times the suite reported FAIL=0 and both times the skip count was the
+# only trace. The baseline assertion at :1102 catches the CAUSE, and case 13 catches skips
+# announced as passes; this catches the EFFECT directly, keyed on the case names, because
+# the two prior recurrences arrived through different causes and a third will too.
+pin_mustrun_missing=""
+for pin_mustrun in \
+  "push: VERIFIED yields 'All checks green.' and --strict exits 0 (zero warnings)" \
+  "push: AC1+AC3 end to end" \
+  "push: the refusal is exactly ONE warning and names the host"; do
+  printf '%s\n' "$PIN_RAN_CASES" | grep -qF -- "$pin_mustrun" \
+    || pin_mustrun_missing="${pin_mustrun_missing:+$pin_mustrun_missing; }$pin_mustrun"
+done
+if [ -z "$pin_mustrun_missing" ]; then
+  ok "suite: the three green-path cases RAN (not skipped by a warning-count drift)"
+else
+  bad "suite: green-path case(s) did not run — silently disabled again: $pin_mustrun_missing"
 fi
 
 echo

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -15,8 +15,20 @@ BOOTSTRAP="$SCRIPT_DIR/../bootstrap-agent-machine.sh"
 
 PASS=0
 FAIL=0
+SKIPS=0
 ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
 bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+# SKIPS ARE NEITHER PASS NOR FAIL, so they must be COUNTED and REPORTED (issue #3414
+# review B1). Three end-to-end cases silently became skips when section 5b started adding
+# one warning to every sandbox, and the suite still said FAIL=0 — including the case whose
+# own comment records that its absence "let a defect through with 102 tests green". A
+# total that cannot distinguish "ran and passed" from "did not run" is the proxy-for-a-fact
+# shape this issue exists to remove, so the tail now prints SKIP= alongside PASS/FAIL.
+# Deliberately NOT a failure in itself: some skips here are honest reports about the HOST
+# (no timeout that accepts --kill-after), and a suite that reds on correct input is one
+# agents learn to waive. The DRIFT that silently disables cases is caught at its root
+# instead, by the base_warns assertion in block 7p.
+skip() { printf 'skip - %s\n' "$1"; SKIPS=$((SKIPS + 1)); }
 
 # --- 1. syntax check (bash -n) ---
 if bash -n "$BOOTSTRAP" 2>/dev/null; then
@@ -802,7 +814,7 @@ if [ -n "$TIMEOUT_BIN_TEST" ]; then
     bad "cred: bootstrap HUNG on a gtimeout-only host — the bound is inert on macOS"
   fi
 else
-  echo "skip - cred: hanging-helper guard needs timeout/gtimeout (neither on this host)"
+  skip "cred: hanging-helper guard needs timeout/gtimeout (neither on this host)"
 fi
 
 # 7e. Re-running --yes must not STACK a second copy of the helper. Bootstrap is
@@ -883,6 +895,16 @@ mk_push_repo() {
   mkdir -p "$dir/scripts/lib" "$dir/test-data/datasets/sstables/ks/tbl" "$dir/.home/.cargo"
   cp "$SCRIPT_DIR/../lib/gate-notify.sh" "$dir/scripts/lib/gate-notify.sh"
   cp "$SCRIPT_DIR/../perf-capability.sh" "$dir/scripts/perf-capability.sh"
+  # agent-gate.sh is staged for SECTION 5b, not for the push probe (issue #3414 review B1).
+  # 5b's verdict asks the gate what it will do with the probed value, so a sandbox without
+  # it yields `gate-pin: UNMEASURED` — one extra [warn] in EVERY case built on this helper,
+  # which pushed base_warns from 1 to 2 and silently turned three end-to-end assertions
+  # below (the absolute-green, AC1+AC3 exit-0, and one-warning cases) into `skip`s. Skips
+  # are neither pass nor fail, so the suite stayed at FAIL=0 while the case whose own
+  # comment records that its absence "let a defect through with 102 tests green" stopped
+  # running. Staging it here plus the pinned `sudo` shim in mk_push_bin makes 5b contribute
+  # ZERO warnings deterministically — on a pinned host and an unpinned one alike.
+  cp "$SCRIPT_DIR/../agent-gate.sh" "$dir/scripts/agent-gate.sh"
   : >"$dir/test-data/datasets/sstables/ks/tbl/nb-1-big-Data.db"
 }
 
@@ -945,6 +967,17 @@ mk_push_bin() {
   mk_stub "$dir" cargo-nextest 'exit 0'
   mk_stub "$dir" cargo 'exit 0'
   mk_stub "$dir" roborev 'exit 0'
+  # A `sudo` that stands in for a PAM session on a PINNED box (issue #3414 review B1).
+  # Without it these sandboxes fall through to the REAL sudo and the REAL /etc/environment,
+  # so section 5b's verdict — and therefore the warning count every case here measures —
+  # would depend on whether the HOST running the suite happens to be pinned. That is the
+  # host-dependence this file removes everywhere else (GIT_CONFIG_GLOBAL, the board env,
+  # the datasets stub); 5b is simply the newest place it could leak in. Section 3b never
+  # invokes sudo and the perf section is skipped here (`uname` reports Darwin), so this
+  # shim's only subject is 5b.
+  mk_stub "$dir" sudo 'while [ "${1:-}" = "-n" ]; do shift; done
+if [ "${1:-}" = "-u" ]; then shift 2; fi
+exec env CQLITE_GATE_MAX_CONCURRENCY=1 "$@"'
   mk_push_gh "$dir" "$setup"
 }
 
@@ -1013,6 +1046,20 @@ fi
 # Absolute-green assertions need the sandbox to be otherwise-warning-free. MEASURE that
 # (baseline = exactly the one OPT-OUT warning) instead of assuming it: an exotic host
 # that warns for its own reasons must not produce a mystery red here.
+# THE BASELINE ITSELF IS AN ASSERTION (issue #3414 review B1). The three cases below are
+# guarded on `base_warns -eq 1` and print a `skip` otherwise — which is correct as a safety
+# net but SILENT as a signal: when section 5b began emitting an extra warning in every
+# sandbox, base_warns went 1 -> 2, all three stopped running, and the suite still reported
+# FAIL=0. Asserting the baseline catches that drift at its cause instead of letting it
+# disable assertions one by one. If this reds, a section has started warning in the clean
+# sandbox; find it before touching the cases below.
+if [ "$base_warns" -eq 1 ]; then
+  ok "push: the clean sandbox costs exactly ONE warning (the opt-out) — the exit-0/green cases below can run"
+else
+  bad "push: sandbox baseline drifted to $base_warns warnings — the three end-to-end cases below will SKIP, not fail"
+  push_plain "$out7pd" | grep -E '^[[:space:]]+\[warn\] ' | head -4
+fi
+
 if [ "$base_warns" -eq 1 ]; then
   if push_green "$out7pa" && [ "$rc7pa" -eq 0 ]; then
     ok "push: VERIFIED yields 'All checks green.' and --strict exits 0 (zero warnings)"
@@ -1021,7 +1068,7 @@ if [ "$base_warns" -eq 1 ]; then
     push_verdict "$out7pa"
   fi
 else
-  echo "skip - push: absolute-green assertions need an otherwise-clean sandbox (baseline=$base_warns warnings)"
+  skip "push: absolute-green assertions need an otherwise-clean sandbox (baseline=$base_warns warnings)"
   printf '%s' "$out7pd" | grep -F '[warn]' | sed 's/\x1b\[[0-9;]*m//g' | head -5
 fi
 
@@ -1221,7 +1268,7 @@ if [ "$base_warns" -eq 1 ]; then
     push_plain "$out7pj" | grep -E '\[warn\]' | head -5
   fi
 else
-  echo "skip - push: AC1+AC3 exit-0 assertion needs an otherwise-clean sandbox (baseline=$base_warns warnings)"
+  skip "push: AC1+AC3 exit-0 assertion needs an otherwise-clean sandbox (baseline=$base_warns warnings)"
 fi
 
 # 7p-k. AN UNSUCCESSFUL CLEANUP DELETE (#3369 blocker 2). `cmd_smoke` used to emit SMOKE-OK — text and
@@ -1368,7 +1415,7 @@ else
   # Deliberately SKIP rather than run unbounded: this fixture ignores SIGTERM, so without
   # a hard-kill-capable watchdog the case could hang the gate forever. A skip that says
   # so is honest; a case that can hang is not.
-  echo "skip - push: bound-escalation guard needs a timeout/gtimeout accepting --kill-after (its fixture ignores SIGTERM)"
+  skip "push: bound-escalation guard needs a timeout/gtimeout accepting --kill-after (its fixture ignores SIGTERM)"
 fi
 
 # 7p-n. SSH REMOTES GET SSH ADVICE (#3369 review). `gh auth setup-git` configures an
@@ -1477,7 +1524,7 @@ if [ -n "$TIMEOUT_BIN_TEST" ]; then
     push_plain "$out7po" | grep -E 'git-push|kill-after' | head -4
   fi
 else
-  echo "skip - push: --kill-after fallback case needs a real timeout/gtimeout to delegate to"
+  skip "push: --kill-after fallback case needs a real timeout/gtimeout to delegate to"
 fi
 
 # 7p-p. A REMOTE WITH SEVERAL PUSH URLs (#3369 review). `git push <remote>` writes to
@@ -1664,7 +1711,7 @@ if [ "$base_warns" -eq 1 ]; then
     push_plain "$out7pr" | grep -E '^[[:space:]]+\[warn\] ' | head -4
   fi
 else
-  echo "skip - push: one-warning assertion needs an otherwise-clean sandbox (baseline=$base_warns warnings)"
+  skip "push: one-warning assertion needs an otherwise-clean sandbox (baseline=$base_warns warnings)"
 fi
 
 # (ii) POSITIVE CONTROL: the SAME sandbox and the SAME fallback path, the ONLY change being
@@ -1733,7 +1780,7 @@ if [ "$divergence" -eq 0 ] && [ "$green_runs" -ge 1 ] && [ "$nongreen_runs" -ge 
 elif [ "$divergence" -ne 0 ]; then
   bad "push: --strict and the 'All checks green.' string DIVERGED (see the divergence lines above)"
 else
-  echo "skip - push: divergence check needs both directions (green=$green_runs nongreen=$nongreen_runs on this host)"
+  skip "push: divergence check needs both directions (green=$green_runs nongreen=$nongreen_runs on this host)"
 fi
 
 # 7p-h. FLAG HYGIENE. --skip-push-probe and --skip-smoke are different subjects (the
@@ -2150,7 +2197,7 @@ if [ -n "$jqp" ]; then
     printf '%s\n' "$out8k" | grep -i "PROJECT_NUMBER"
   fi
 else
-  echo "skip - board: title discovery needs jq (absent on this host)"
+  skip "board: title discovery needs jq (absent on this host)"
 fi
 
 # 8k-ii: not discoverable -> point at setup-project-board.sh, still no green.
@@ -2777,6 +2824,60 @@ else
   fi
 
 
+  # 11w. BASH_ENV MUST NOT BE ABLE TO FORGE A PIN (issue #3414 roborev, Medium).
+  #      A NON-INTERACTIVE bash sources $BASH_ENV before running its command. On a box
+  #      whose sudoers lacks `Defaults env_reset` an inherited BASH_ENV survives into the
+  #      probe, and that file can `export CQLITE_GATE_MAX_CONCURRENCY` — so scrubbing the
+  #      variable while leaving the mechanism that re-injects it is not a scrub, and the
+  #      run reports VERIFIED with nothing persisted anywhere. The `-` shim models exactly
+  #      that box: it strips sudo's flags and execs, passing the environment straight
+  #      through, which is what a missing env_reset does.
+  pin_bashenv="$tmp/pin-bashenv.sh"
+  printf 'export CQLITE_GATE_MAX_CONCURRENCY=9\n' >"$pin_bashenv"
+  envf_w="$tmp/pin-env-w"; : >"$envf_w"
+  out_w=$(runpin "$pinroot" "$shims_none" "$envf_w" HOME="$pin_home_plain" \
+    BASH_ENV="$pin_bashenv")
+  if printf '%s' "$out_w" | grep -q 'gate-pin: FAILED' \
+     && ! printf '%s' "$out_w" | grep -qE '\[ok\].*gate-pin' \
+     && ! printf '%s' "$out_w" | grep -q 'CQLITE_GATE_MAX_CONCURRENCY=9'; then
+    ok "gate-pin: a BASH_ENV file exporting the pin cannot forge VERIFIED (BASH_ENV is scrubbed)"
+  else
+    bad "gate-pin: BASH_ENV injected a pin the box does not have"
+    printf '%s\n' "$out_w" | grep -i 'gate-pin' | head -3
+  fi
+
+  # 11x. ...and its POSITIVE twin, so 11w cannot pass against a probe that is simply
+  #      broken: the same shim and the same BASH_ENV file, but with the pin genuinely
+  #      persisted, must still reach VERIFIED. Without this, deleting the probe entirely
+  #      would green 11w.
+  envf_x="$tmp/pin-env-x"; printf 'CQLITE_GATE_MAX_CONCURRENCY=1\n' >"$envf_x"
+  shims_pam_x="$tmp/pin-shims-pam-x"; mkpinshims "$shims_pam_x" "file:$envf_x"
+  out_x=$(runpin "$pinroot" "$shims_pam_x" "$envf_x" HOME="$pin_home_plain" \
+    BASH_ENV="$pin_bashenv")
+  if printf '%s' "$out_x" | grep -q 'gate-pin: VERIFIED' \
+     && printf '%s' "$out_x" | grep -q 'max-concurrency=1(pinned)'; then
+    ok "gate-pin: scrubbing BASH_ENV does not break a genuinely pinned box"
+  else
+    bad "gate-pin: the BASH_ENV scrub broke the positive path"
+    printf '%s\n' "$out_x" | grep -i 'gate-pin' | head -3
+  fi
+
+  # 11y. VERIFIED STATES ITS OWN SCOPE (issue #3414 review B2). The probe measures a
+  #      PAM-created sudo session; a gate launched from a systemd unit or a container
+  #      entrypoint has no PAM in its ancestry and never has /etc/environment applied, so
+  #      an unqualified VERIFIED reads as a guarantee the probe cannot give. The verdict
+  #      must therefore carry the limit AND name the gate's own cpu-budget token as the
+  #      authoritative per-run confirmation — and must not re-assert the attribution it
+  #      cannot establish ("came from the system env file").
+  if printf '%s' "$out_x" | grep -q 'does NOT prove every gate on this box is pinned' \
+     && printf '%s' "$out_x" | grep -q 'max-concurrency=N(pinned)' \
+     && ! printf '%s' "$out_x" | grep -q 'came from the system env file'; then
+    ok "gate-pin: VERIFIED states what it did NOT measure and names cpu-budget as authoritative"
+  else
+    bad "gate-pin: VERIFIED claims more than the probe measured (missing scope note?)"
+    printf '%s\n' "$out_x" | grep -iA 2 'gate-pin: VERIFIED' | head -4
+  fi
+
   # 11k. The test seam is FAIL-CLOSED and has NO production fallback: set without its
   #      marker, or relative, it SKIPS the section rather than silently persisting to
   #      the real /etc/environment (the #3249 lesson — a seam that degrades to the
@@ -2818,5 +2919,5 @@ else
 fi
 
 echo
-echo "PASS=$PASS FAIL=$FAIL"
+echo "PASS=$PASS FAIL=$FAIL SKIP=$SKIPS"
 [ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -3789,21 +3789,22 @@ exec env CQLITE_GATE_MAX_CONCURRENCY=1 "$@"'
     echo "  file-exists=$([ -e "$envf_bc" ] && echo yes || echo no) content=[$(cat "$envf_bc" 2>/dev/null | tr '\n' '|')]"
   fi
 
-  # 11bg. THE MODE IS ESTABLISHED AT CREATION, NOT INHERITED FROM THE CALLER (roborev job
-  #      314, Medium). The create used to be truncating `tee` followed by `chmod`, so the
-  #      file briefly existed at whatever the invoking shell's umask gave it. It is now one
-  #      privileged `bash -c` setting `umask 022` before the redirect, so a caller running
-  #      under a restrictive umask must STILL get 0644 — asserted by running under 077,
-  #      which is the value that would produce 0600 if the caller's umask still decided.
-  envf_bg="$tmp/pin-env-bg"; rm -f "$envf_bg"
-  out_bg=$( (umask 077; runpin "$pinroot" "$shims_one" "$envf_bg" HOME="$pin_home_plain" --fix-gate-pin) )
-  bg_mode=$(stat -c %a "$envf_bg" 2>/dev/null)
-  if [ "$bg_mode" = 644 ] && grep -q '^CQLITE_GATE_MAX_CONCURRENCY=1$' "$envf_bg"; then
-    ok "gate-pin: a created env file comes out 0644 even under a restrictive caller umask (mode set at creation, not inherited)"
-  else
-    bad "gate-pin: the created env file took the caller's umask (mode=${bg_mode:-unreadable})"
-    printf '%s\n' "$out_bg" | grep -iE 'CREATED|gate-pin:' | head -3
-  fi
+  # 11bg WAS HERE AND WAS DELETED, because it passed against the defect it was written for
+  #      — the vacuous-case class this block keeps finding, produced this time by me.
+  #      It asserted that a create under `umask 077` still comes out 0644, intending to pin
+  #      the job-314 fix's "mode established AT CREATION" half. RED-verified against the
+  #      pre-fix bootstrap: PASS=199 FAIL=0 — it did not discriminate. The old code was
+  #      `tee` (0600 under that umask) followed by a real `chmod 0644` that SUCCEEDS, so both
+  #      implementations end at 0644. The difference exists only in the window BETWEEN the
+  #      two steps, which is exactly as unobservable from the CLI as the O_EXCL race.
+  #
+  #      Both halves of that fix are therefore DECLARED UNCOVERED rather than faked: an
+  #      implementation-neutral test would have to inject a file between the caller's
+  #      `[ ! -e ]` test and the write, and the two implementations share NO step there — so
+  #      any test that could fire would be pinning the implementation, not the property. The
+  #      remaining option is a source grep for `set -C`, which is nit 5's antipattern
+  #      (#3758). The reachable halves ARE covered: 11ba (create happens / does not without
+  #      authorisation) and 11bc (rollback when the mode cannot be confirmed).
 
   # 11bd. A REMEDY MUST BE CHOSEN BY THE FACT THAT DISCRIMINATES IT (roborev job 311, Low).
   #      The verdict `case` dispatches on the GATE's classification of what the SESSION saw,

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -434,11 +434,29 @@ fi
 mk_stub() {
   # mk_stub <dir> <name> <body>
   local dir="$1" name="$2" body="$3"
+  # REMOVE FIRST — never write THROUGH the path. mk_hermetic_bin populates these same dirs
+  # with SYMLINKS to the real tools, and `cat >` FOLLOWS a symlink, so stubbing a name that
+  # is ALSO hermetically linked has two failure modes and neither is visible: where the link
+  # target is not writable (a root-owned /usr/bin tool, and the suite runs unprivileged) the
+  # redirect fails, no stub is installed, and every case relying on it passes VACUOUSLY
+  # against the REAL tool; where the target IS writable it TRUNCATES THE REAL BINARY.
+  # Measured when this bit: `chmod` is the one name in both sets, the stub never installed,
+  # and case 11bc read the real chmod's success as its own.
+  rm -f "$dir/$name"
   cat >"$dir/$name" <<EOF
 #!/usr/bin/env bash
 $body
 EOF
   chmod +x "$dir/$name"
+  # AND FAIL LOUDLY. A harness that cannot install a stub does not produce a failing case,
+  # it produces a PASSING one that tested nothing — the exact shape this suite exists to
+  # refuse, so it aborts rather than reporting a verdict it did not earn.
+  if [ -L "$dir/$name" ] || [ ! -f "$dir/$name" ] || [ ! -x "$dir/$name" ]; then
+    printf 'FATAL: mk_stub could not install a real stub at %s/%s (symlink=%s file=%s exec=%s) — refusing to run cases that would pass vacuously against the real tool\n' \
+      "$dir" "$name" "$([ -L "$dir/$name" ] && echo yes || echo no)" \
+      "$([ -f "$dir/$name" ] && echo yes || echo no)" "$([ -x "$dir/$name" ] && echo yes || echo no)" >&2
+    exit 1
+  fi
 }
 # count_begin <file>: number of managed-block BEGIN markers. grep -c already prints
 # a count (0 on no match) AND exits 1 — a `|| echo 0` would DOUBLE-print "0\n0", so

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -3094,6 +3094,79 @@ else
     printf '%s\n' "$out_af" | grep -i 'gate-pin' | head -2
   fi
 
+  # 11ag. THE GATE ORACLE MUST NOT BE POLLUTABLE EITHER (issue #3414 roborev round 4).
+  #      The oracle launches its own fresh non-interactive bash to ask the gate what it
+  #      honours, and a non-interactive bash SOURCES $BASH_ENV — so the hole closed for
+  #      the probe in round 2 was still open one call site over. Persisted value `abc`,
+  #      a valid `1` injected through BASH_ENV: the oracle answers `1(pinned)` about a
+  #      value it never saw, and the run certifies a box whose gates will stamp
+  #      N(invalid). Two independent defences now: the scrub, and the requirement that
+  #      the oracle's resolved N equal the value actually probed.
+  pin_bashenv_v="$tmp/pin-bashenv-valid.sh"
+  printf 'export CQLITE_GATE_MAX_CONCURRENCY=1\n' >"$pin_bashenv_v"
+  envf_ag="$tmp/pin-env-ag"; printf 'CQLITE_GATE_MAX_CONCURRENCY=abc\n' >"$envf_ag"
+  shims_ag="$tmp/pin-shims-ag"; mkpinshims "$shims_ag" abc     # session genuinely sees abc
+  out_ag=$(runpin "$pinroot" "$shims_ag" "$envf_ag" HOME="$pin_home_plain" \
+    BASH_ENV="$pin_bashenv_v")
+  if ! printf '%s' "$out_ag" | grep -qE '\[ok\].*gate-pin' \
+     && printf '%s' "$out_ag" | grep -q 'gate-pin: NOT-HONOURED'; then
+    ok "gate-pin: a BASH_ENV-injected valid value cannot make the ORACLE certify an invalid pin"
+  else
+    bad "gate-pin: the gate oracle was polluted into certifying a value it never saw"
+    printf '%s\n' "$out_ag" | grep -i 'gate-pin' | head -3
+  fi
+
+  # 11ah. ...and the SOURCE TOKEN ALONE is not the check: the oracle's resolved N must be
+  #      the value we handed it. A `(pinned)` suffix says only that *something* was a
+  #      valid pin. Asserted structurally as well as behaviourally, because a future edit
+  #      could drop the N comparison while every behavioural case above still passes —
+  #      the scrub alone would cover them.
+  if grep -q 'pin_gate_n" != "\$pin_probe_seen' "$BOOTSTRAP" \
+     && grep -q 'bounded 30 env -u BASH_ENV -u ENV' "$BOOTSTRAP"; then
+    ok "gate-pin: the oracle is scrubbed AND its resolved N is compared, not just its source token"
+  else
+    bad "gate-pin: the oracle check lost its scrub or its resolved-value comparison"
+  fi
+
+  # 11ai. THE PROFILE APPEND MUST NOT MANUFACTURE A DIVERGENCE (issue #3414 roborev
+  #      round 4). On a box deliberately pinned to 4, appending a hardcoded `export …=1`
+  #      to the shell profile gives interactive shells 1 while every non-interactive one
+  #      gets 4 — this issue's own subject, created by the tool that exists to remove it.
+  #      It is SKIPPED rather than value-derived because PAM already delivers the
+  #      system-wide value to interactive login shells, so the append could only override
+  #      it, and a derived value would go stale on the next edit of the env file.
+  pin_home_ai="$tmp/pin-home-ai"; mkdir -p "$pin_home_ai/.cargo"; : >"$pin_home_ai/.bashrc"
+  envf_ai="$tmp/pin-env-ai"; printf 'CQLITE_GATE_MAX_CONCURRENCY=4\n' >"$envf_ai"
+  shims_ai="$tmp/pin-shims-ai"; mkpinshims "$shims_ai" 4
+  out_ai=$(runpin "$pinroot" "$shims_ai" "$envf_ai" HOME="$pin_home_ai" SHELL=/bin/bash --yes)
+  if ! grep -q 'CQLITE_GATE_MAX_CONCURRENCY' "$pin_home_ai/.bashrc" \
+     && printf '%s' "$out_ai" | grep -q 'not touching' \
+     && printf '%s' "$out_ai" | grep -qE '\[ok\].*gate-pin: VERIFIED'; then
+    ok "gate-pin: --yes on a box pinned to 4 leaves the profile alone (no manufactured 1-vs-4 divergence)"
+  else
+    bad "gate-pin: the profile append manufactured a divergence with the system-wide value"
+    printf '%s\n' "$out_ai" | grep -i 'gate-pin\|profile\|not touching' | head -3
+    cat "$pin_home_ai/.bashrc"
+  fi
+
+  # 11aj. ...but where NO system-wide value can be established the append still happens,
+  #      so 11ai cannot pass against a build that simply stopped writing profiles. The
+  #      reachable state is a MISSING system env file: bootstrap writes nothing there, so
+  #      PAM delivers nothing, and the profile is the only lever left. (A box that merely
+  #      STARTS empty is not this case — `--yes` persists into it and the append is then
+  #      correctly skipped, because PAM now delivers the value to interactive shells too.
+  #      I discovered that by writing this case the obvious way first and watching it
+  #      fail, which is the distinction worth recording here.)
+  pin_home_aj="$tmp/pin-home-aj"; mkdir -p "$pin_home_aj/.cargo"; : >"$pin_home_aj/.bashrc"
+  envf_aj="$tmp/pin-env-aj-missing"; rm -f "$envf_aj"
+  out_aj=$(runpin "$pinroot" "$shims_none" "$envf_aj" HOME="$pin_home_aj" SHELL=/bin/bash --yes)
+  if grep -q '^export CQLITE_GATE_MAX_CONCURRENCY=1' "$pin_home_aj/.bashrc"; then
+    ok "gate-pin: on a box with no system-wide value the profile append still happens"
+  else
+    bad "gate-pin: the profile append stopped happening even with no system-wide value (11ai would pass vacuously)"
+    cat "$pin_home_aj/.bashrc"
+  fi
+
   # 11k. The test seam is FAIL-CLOSED and has NO production fallback: set without its
   #      marker, or relative, it SKIPS the section rather than silently persisting to
   #      the real /etc/environment (the #3249 lesson — a seam that degrades to the

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -3739,6 +3739,85 @@ exec env CQLITE_GATE_MAX_CONCURRENCY=1 "$@"'
     printf '%s\n' "$out_bb" | grep -iE 'CREATED|gate-pin' | head -2
   fi
 
+  # 11bc. THE CREATE IS TWO STEPS, AND ITS FAILURE MUST NOT LEAVE A POPULATED FILE
+  #      (roborev job 311, Low). Content-then-mode: a `tee` that succeeded followed by a
+  #      mode that could not be established took the failure branch, reported "the pin was
+  #      NOT persisted", and left the pin line on disk. The NEXT run then reads a present
+  #      CQLITE_GATE_MAX_CONCURRENCY line, treats the pin as persisted, and never repairs
+  #      the mode — one run's reported failure becoming the next run's silent success at a
+  #      permission nothing chose.
+  #
+  #      `chmod` is STUBBED TO FAIL rather than removed from the PATH, so the case models
+  #      exactly one thing going wrong. `umask 077` forces `tee` to create 0600, so the mode
+  #      genuinely cannot reach 0644 — set explicitly rather than inherited, or the case
+  #      would silently stop testing anything on a runner whose ambient umask is 022.
+  shims_nochmod="$tmp/pin-shims-nochmod"; mkpinshims "$shims_nochmod" 1
+  mk_stub "$shims_nochmod" chmod 'exit 1'
+  envf_bc="$tmp/pin-env-bc"; rm -f "$envf_bc"
+  out_bc=$( (umask 077; runpin "$pinroot" "$shims_nochmod" "$envf_bc" HOME="$pin_home_plain" --fix-gate-pin) )
+  if [ ! -e "$envf_bc" ] \
+     && printf '%s' "$out_bc" | grep -q 'the pin was NOT persisted' \
+     && printf '%s' "$out_bc" | grep -q 'was REMOVED'; then
+    ok "gate-pin: a create whose mode cannot be established rolls the partial file back and says so (nothing populated for the next run to inherit)"
+  else
+    bad "gate-pin: the failed create left a residue, or did not report rolling it back"
+    printf '%s\n' "$out_bc" | grep -iE 'gate-pin|CREATED|REMOVED|persisted' | head -4
+    echo "  file-exists=$([ -e "$envf_bc" ] && echo yes || echo no) content=[$(cat "$envf_bc" 2>/dev/null | tr '\n' '|')]"
+  fi
+
+  # 11bd. A REMEDY MUST BE CHOSEN BY THE FACT THAT DISCRIMINATES IT (roborev job 311, Low).
+  #      The verdict `case` dispatches on the GATE's classification of what the SESSION saw,
+  #      which says nothing about WHERE that value came from. So a box whose system file is
+  #      CORRECT (`=1`) but whose session is overridden by a per-user `abc` reached the
+  #      not-honoured branch and was told to "fix the VALUE in <file>" — a file that is
+  #      already right. The operator finds nothing wrong and re-runs into the same verdict.
+  #      This is #3414's own subject one level down: a remedy keyed on a verdict rather than
+  #      on the fact that decides between two remedies.
+  envf_bd="$tmp/pin-env-bd"; printf 'CQLITE_GATE_MAX_CONCURRENCY=1\n' >"$envf_bd"
+  shims_bd="$tmp/pin-shims-bd"; mkpinshims "$shims_bd" abc
+  out_bd=$(runpin "$pinroot" "$shims_bd" "$envf_bd" HOME="$pin_home_plain")
+  if printf '%s' "$out_bd" | grep -q 'gate-pin: NOT-HONOURED' \
+     && printf '%s' "$out_bd" | grep -q 'is OVERRIDING it' \
+     && ! printf '%s' "$out_bd" | grep -q 'fix the VALUE (not the presence)'; then
+    ok "gate-pin: a bad SESSION value over a CORRECT system file is diagnosed as an override, not as a bad file"
+  else
+    bad "gate-pin: the override case was handed the edit-the-system-file remedy"
+    printf '%s\n' "$out_bd" | grep -iE 'gate-pin:|OVERRIDING|fix the VALUE' | head -4
+  fi
+
+  # 11be. THE NEGATIVE TWIN, so 11bd cannot pass by suppressing the remedy outright: where
+  #      the system file REALLY holds the bad value, "edit the VALUE in that file" is the
+  #      correct advice and must survive.
+  envf_be="$tmp/pin-env-be"; printf 'CQLITE_GATE_MAX_CONCURRENCY=abc\n' >"$envf_be"
+  out_be=$(runpin "$pinroot" "$shims_bd" "$envf_be" HOME="$pin_home_plain")
+  if printf '%s' "$out_be" | grep -q 'gate-pin: NOT-HONOURED' \
+     && printf '%s' "$out_be" | grep -q 'fix the VALUE (not the presence)' \
+     && ! printf '%s' "$out_be" | grep -q 'is OVERRIDING it'; then
+    ok "gate-pin: where the system file really holds the bad value, the edit-the-file remedy survives"
+  else
+    bad "gate-pin: the genuine bad-file case lost its remedy to the override branch"
+    printf '%s\n' "$out_be" | grep -iE 'gate-pin:|OVERRIDING|fix the VALUE' | head -4
+  fi
+
+  # 11bf. VERIFIED DISCLOSES WHAT IT MEASURED (roborev job 311, Medium). Matching values do
+  #      not prove the session got the value FROM the system file: a box that also sets it
+  #      from a sudoers env_file or ~/.pam_environment to the same value would read VERIFIED
+  #      with an /etc/environment no PAM stack loads. That cannot be settled without either
+  #      inspecting PAM config (deleted in round 7 — config inspection standing in for
+  #      runtime behaviour) or perturbing a live system file, so the CLAIM is scoped in the
+  #      output instead of being overstated. Asserted because an unstated limit is
+  #      indistinguishable from one nobody noticed.
+  envf_bf="$tmp/pin-env-bf"; : >"$envf_bf"
+  shims_bf="$tmp/pin-shims-bf"; mkpinshims "$shims_bf" "file:$envf_bf"
+  out_bf=$(runpin "$pinroot" "$shims_bf" "$envf_bf" HOME="$pin_home_plain" --fix-gate-pin)
+  if printf '%s' "$out_bf" | grep -q 'gate-pin: VERIFIED' \
+     && printf '%s' "$out_bf" | grep -q 'Agreement is measured; provenance is not'; then
+    ok "gate-pin: VERIFIED states that it measured agreement and NOT provenance (the alternate-source residual is disclosed with the verdict)"
+  else
+    bad "gate-pin: VERIFIED did not disclose the agreement-vs-provenance limit"
+    printf '%s\n' "$out_bf" | grep -iE 'VERIFIED|provenance|scope:' | head -4
+  fi
+
   envf_k="$tmp/pin-env-k"; : >"$envf_k"
   # `-u CQLITE_BOOTSTRAP_TEST_MODE` is the point of this half: the marker is exported
   # suite-wide for host safety, and the case is about a seam set WITHOUT it.

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -3332,6 +3332,47 @@ else
     printf '%s\n' "$out_ap" | grep -i 'gate-pin' | head -2
   fi
 
+  # 11aq. TWO WAYS THE WEAKEN-SIGNAL COULD MISREAD A STACK (issue #3414, lead refinement).
+  #      (a) `envfile=` REDIRECTS which file is read, so a pam_env line pointing at
+  #          /etc/default/locale — both real service files here carry one — is not
+  #          evidence about ours. A stack whose ONLY pam_env line was that would otherwise
+  #          read as pinned when it is not.
+  #      (b) A distro may factor pam_env into the COMMON stack via `@include`; both real
+  #          files carry `@include common-session`. Reading only the service file would
+  #          report "no pam_env" there and weaken a correct box — the red-on-correct-input
+  #          shape, for the fifth time. One level is followed; deeper is not, and the
+  #          diagnostic says so rather than asserting an absence it did not establish.
+  pin_pamd_inc="$tmp/pin-pamd-inc"; pin_pamd_loc="$tmp/pin-pamd-loc"
+  mkdir -p "$pin_pamd_inc" "$pin_pamd_loc"
+  printf '@include common-session\n'                                  >"$pin_pamd_inc/sshd"
+  printf 'session required pam_env.so\n'                              >"$pin_pamd_inc/common-session"
+  printf 'session required pam_env.so\n'                              >"$pin_pamd_inc/login"
+  printf 'session required pam_env.so envfile=/etc/default/locale\n'  >"$pin_pamd_loc/sshd"
+  printf 'session required pam_env.so\n'                              >"$pin_pamd_loc/login"
+  envf_aq="$tmp/pin-env-aq"; printf 'CQLITE_GATE_MAX_CONCURRENCY=1\n' >"$envf_aq"
+  out_aq_inc=$(runpin "$pinroot" "$shims_one" "$envf_aq" HOME="$pin_home_plain" \
+    CQLITE_BOOTSTRAP_PAM_DIR="$pin_pamd_inc")
+  out_aq_loc=$(runpin "$pinroot" "$shims_one" "$envf_aq" HOME="$pin_home_plain" \
+    CQLITE_BOOTSTRAP_PAM_DIR="$pin_pamd_loc")
+  if printf '%s' "$out_aq_inc" | grep -qE '\[ok\].*gate-pin: VERIFIED'; then
+    ok "gate-pin: pam_env reached only through @include is found (one level), not read as absent"
+  else
+    bad "gate-pin: a stack that loads pam_env via @include was wrongly weakened"
+    printf '%s\n' "$out_aq_inc" | grep -i 'gate-pin' | head -2
+  fi
+  if printf '%s' "$out_aq_loc" | grep -q 'gate-pin: NOT-SYSTEM-WIDE' \
+     && ! printf '%s' "$out_aq_loc" | grep -qE '\[ok\].*gate-pin'; then
+    ok "gate-pin: a pam_env line whose envfile= names ANOTHER file is not evidence for ours"
+  else
+    bad "gate-pin: an envfile=-redirected pam_env line was counted as reading our file"
+    printf '%s\n' "$out_aq_loc" | grep -i 'gate-pin' | head -2
+  fi
+  if printf '%s' "$out_aq_loc" | grep -q 'ONE level of @include'; then
+    ok "gate-pin: the gap diagnostic declares its own search limit (one @include level)"
+  else
+    bad "gate-pin: the gap diagnostic asserts an absence without naming how far it looked"
+  fi
+
   # 11k. The test seam is FAIL-CLOSED and has NO production fallback: set without its
   #      marker, or relative, it SKIPS the section rather than silently persisting to
   #      the real /etc/environment (the #3249 lesson — a seam that degrades to the

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -2771,7 +2771,7 @@ runpin() {
     PATH="$shims" CARGO_HOME="$tmp/pin-cargo" \
     CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="$envfile" \
     ${pin_env[@]+"${pin_env[@]}"} \
-    timeout -s KILL 300 "$PIN_BS" "$root/scripts/bootstrap-agent-machine.sh" \
+    "${TIMEOUT_BIN_TEST:-timeout}" -s KILL 300 "$PIN_BS" "$root/scripts/bootstrap-agent-machine.sh" \
       --skip-smoke ${pin_flags[@]+"${pin_flags[@]}"} 2>&1
 }
 
@@ -2940,7 +2940,7 @@ else
   envf_j="$tmp/pin-env-j"; : >"$envf_j"
   out_j=$(env PATH="$shims_one" HOME="$pin_home_plain" CARGO_HOME="$tmp/pin-cargo" \
     CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="$envf_j" \
-    timeout -s KILL 300 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
+    "${TIMEOUT_BIN_TEST:-timeout}" -s KILL 300 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
       --skip-smoke --skip-gate-pin 2>&1)
   if printf '%s' "$out_j" | grep -qE '\[warn\].*gate-pin: OPT-OUT' \
      && ! printf '%s' "$out_j" | grep -qE '\[ok\].*gate-pin'; then
@@ -3129,7 +3129,7 @@ else
     # shellcheck disable=SC2086
     pin_t_out=$(env PATH="$shims_one" HOME="$pin_home_plain" CARGO_HOME="$tmp/pin-cargo" \
       CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="$tmp/pin-env-t" \
-      timeout -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
+      "${TIMEOUT_BIN_TEST:-timeout}" -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
         --skip-smoke $pin_order 2>&1)
     pin_t_rc=$?
     if [ "$pin_t_rc" -eq 2 ] && printf '%s' "$pin_t_out" | grep -q 'contradictory'; then
@@ -3546,7 +3546,7 @@ else
   if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
     out_ak=$(sudo -n env PIN_SANDBOX_ROOT="$PIN_SANDBOX_ROOT" PIN_SHARED_VIOLATIONS="$PIN_SHARED_VIOLATIONS" CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="$pin_seam_probe" \
       HOME="$pin_root_sandbox" CARGO_HOME="$pin_root_sandbox/.cargo" \
-      timeout -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
+      "${TIMEOUT_BIN_TEST:-timeout}" -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
         --skip-smoke --skip-push-probe --yes 2>&1)
     if printf '%s' "$out_ak" | grep -q 'gate-pin: SKIPPED' \
        && printf '%s' "$out_ak" | grep -q 'PRIVILEGED write' \
@@ -3580,7 +3580,7 @@ else
   if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
     out_am=$(sudo -n env PIN_SANDBOX_ROOT="$PIN_SANDBOX_ROOT" PIN_SHARED_VIOLATIONS="$PIN_SHARED_VIOLATIONS" SUDO_USER=cqlite-no-such-account-3414 \
       HOME="$pin_root_sandbox" CARGO_HOME="$pin_root_sandbox/.cargo" \
-      timeout -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
+      "${TIMEOUT_BIN_TEST:-timeout}" -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
         --skip-smoke --skip-push-probe 2>&1)
     if printf '%s' "$out_am" | grep -qE '\[warn\].*gate-pin: UNMEASURED' \
        && printf '%s' "$out_am" | grep -qE 'does not resolve to an account|INCONSISTENT sudo metadata' \
@@ -3592,7 +3592,7 @@ else
     fi
     out_an=$(sudo -n env PIN_SANDBOX_ROOT="$PIN_SANDBOX_ROOT" PIN_SHARED_VIOLATIONS="$PIN_SHARED_VIOLATIONS" SUDO_USER="$(id -un)" \
       HOME="$pin_root_sandbox" CARGO_HOME="$pin_root_sandbox/.cargo" \
-      timeout -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
+      "${TIMEOUT_BIN_TEST:-timeout}" -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
         --skip-smoke --skip-push-probe 2>&1)
     if printf '%s' "$out_an" | grep -q "the account that invoked sudo"; then
       ok "gate-pin: a resolvable sudo invoker becomes the probe subject, and the run says so"
@@ -3620,7 +3620,7 @@ else
     out_at=$(sudo -n env PIN_SANDBOX_ROOT="$PIN_SANDBOX_ROOT" PIN_SHARED_VIOLATIONS="$PIN_SHARED_VIOLATIONS" PATH="$pin_liar:$PATH" \
       CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="$pin_liar_target" \
       HOME="$pin_root_sandbox" CARGO_HOME="$pin_root_sandbox/.cargo" \
-      timeout -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
+      "${TIMEOUT_BIN_TEST:-timeout}" -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
         --skip-smoke --skip-push-probe --yes 2>&1)
     if printf '%s' "$out_at" | grep -q 'gate-pin: SKIPPED' && [ ! -e "$pin_liar_target" ]; then
       ok "gate-pin: a lying 'id' on PATH cannot make a ROOT run look unprivileged (the decision reads \$EUID)"
@@ -3637,7 +3637,7 @@ else
     #      wrong-subject defect the retarget exists to fix, wearing the retarget's clothes.
     out_au=$(sudo -n env PIN_SANDBOX_ROOT="$PIN_SANDBOX_ROOT" PIN_SHARED_VIOLATIONS="$PIN_SHARED_VIOLATIONS" SUDO_UID=1000 SUDO_USER=root \
       HOME="$pin_root_sandbox" CARGO_HOME="$pin_root_sandbox/.cargo" \
-      timeout -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
+      "${TIMEOUT_BIN_TEST:-timeout}" -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
         --skip-smoke --skip-push-probe 2>&1)
     if printf '%s' "$out_au" | grep -qE '\[warn\].*gate-pin: UNMEASURED' \
        && printf '%s' "$out_au" | grep -q 'INCONSISTENT sudo metadata' \
@@ -3651,7 +3651,7 @@ else
     # 11av. ...and root invoking sudo (SUDO_UID=0) tells us nothing about a gate's account.
     out_av=$(sudo -n env PIN_SANDBOX_ROOT="$PIN_SANDBOX_ROOT" PIN_SHARED_VIOLATIONS="$PIN_SHARED_VIOLATIONS" SUDO_UID=0 SUDO_USER=root \
       HOME="$pin_root_sandbox" CARGO_HOME="$pin_root_sandbox/.cargo" \
-      timeout -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
+      "${TIMEOUT_BIN_TEST:-timeout}" -s KILL 120 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" \
         --skip-smoke --skip-push-probe 2>&1)
     if printf '%s' "$out_av" | grep -qE '\[warn\].*gate-pin: UNMEASURED' \
        && printf '%s' "$out_av" | grep -q 'sudo was invoked BY root'; then
@@ -3759,12 +3759,12 @@ exec env CQLITE_GATE_MAX_CONCURRENCY=1 "$@"'
   envf_ba="$tmp/pin-env-ba"; rm -f "$envf_ba"
   out_ba=$(env PATH="$shims_one" HOME="$pin_home_plain" CARGO_HOME="$tmp/pin-cargo" \
     CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="$envf_ba" \
-    timeout -s KILL 300 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" --skip-smoke --fix-gate-pin 2>&1)
+    "${TIMEOUT_BIN_TEST:-timeout}" -s KILL 300 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" --skip-smoke --fix-gate-pin 2>&1)
   ba_created=0; [ -s "$envf_ba" ] && grep -q '^CQLITE_GATE_MAX_CONCURRENCY=1$' "$envf_ba" && ba_created=1
   envf_bb="$tmp/pin-env-bb"; rm -f "$envf_bb"
   out_bb=$(env PATH="$shims_one" HOME="$pin_home_plain" CARGO_HOME="$tmp/pin-cargo" \
     CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="$envf_bb" \
-    timeout -s KILL 300 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+    "${TIMEOUT_BIN_TEST:-timeout}" -s KILL 300 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
   if [ "$ba_created" = 1 ] \
      && printf '%s' "$out_ba" | grep -q 'CREATED' \
      && [ ! -e "$envf_bb" ] \
@@ -3957,10 +3957,10 @@ exec env CQLITE_GATE_MAX_CONCURRENCY=1 "$@"'
   out_k=$(env -u CQLITE_BOOTSTRAP_TEST_MODE \
     PATH="$shims_one" HOME="$pin_home_plain" CARGO_HOME="$tmp/pin-cargo" \
     CQLITE_BOOTSTRAP_ENV_FILE="$envf_k" \
-    timeout -s KILL 300 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+    "${TIMEOUT_BIN_TEST:-timeout}" -s KILL 300 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
   out_k2=$(env PATH="$shims_one" HOME="$pin_home_plain" CARGO_HOME="$tmp/pin-cargo" \
     CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="relative/env" \
-    timeout -s KILL 300 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+    "${TIMEOUT_BIN_TEST:-timeout}" -s KILL 300 "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
   if printf '%s' "$out_k" | grep -q 'gate-pin: SKIPPED' \
      && printf '%s' "$out_k2" | grep -q 'gate-pin: SKIPPED' \
      && ! printf '%s' "$out_k" | grep -qE '\[ok\].*gate-pin'; then

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -3093,6 +3093,73 @@ else
     cat "$envf_q"
   fi
 
+  # 11q4. AN OVERSIZED VALUE IS NOT "NON-NUMERIC", AND MUST NOT BE TOLD IT IS (roborev job
+  #      333, Low). This branch widened `invalid` to include a digit string too large to
+  #      represent, and the diagnosis still read "it is empty or non-numeric" while the
+  #      remedy said "use a positive integer" — advice `99999999999999999999` HAS ALREADY
+  #      TAKEN. A remedy the operator already complies with is worse than none: they find
+  #      nothing wrong and re-run into the same verdict. Both halves are asserted, because
+  #      naming the cause while leaving the remedy unqualified fixes only the visible half.
+  envf_q4="$tmp/pin-env-q4"; printf 'CQLITE_GATE_MAX_CONCURRENCY=99999999999999999999\n' >"$envf_q4"
+  shims_pam_q4="$tmp/pin-shims-pam-q4"; mkpinshims "$shims_pam_q4" "file:$envf_q4"
+  out_q4=$(runpin "$pinroot" "$shims_pam_q4" "$envf_q4" HOME="$pin_home_plain")
+  if printf '%s' "$out_q4" | grep -q 'gate-pin: NOT-HONOURED' \
+     && [[ $out_q4 == *'too large to use as a slot cap'* ]] \
+     && [[ $out_q4 != *'it is not a plain decimal integer'* ]] \
+     && [[ $out_q4 == *'at most 18 digits'* ]]; then
+    ok "gate-pin: an oversized pin is diagnosed BY SIZE and its remedy states the 18-digit bound (not 'use a positive integer')"
+  else
+    bad "gate-pin: an oversized pin was diagnosed as non-numeric or given advice it already satisfies (job 333)"
+    printf '%s\n' "$out_q4" | grep -i 'gate-pin\|fix the VALUE' | head -4
+  fi
+
+  # 11q2. A VALID LEADING-ZERO PIN MUST REACH VERIFIED (roborev job 333, Medium). The gate
+  #      NORMALISES `08` -> `8(pinned)`; bootstrap compared that normalised N against the RAW
+  #      session value, so `8` != `08` demoted a CORRECTLY PERSISTED pin to UNMEASURED and
+  #      `--strict` red on a properly pinned box. Introduced by this branch's own octal fix:
+  #      normalisation was added to the gate and this comparison was not told about it.
+  #
+  #      THIS CASE IS ALSO THE ANTI-DRIFT MECHANISM for the canonicaliser bootstrap now
+  #      mirrors from the gate. `$pinroot` carries the REAL agent-gate.sh (copied above), so
+  #      if the gate's normalisation rule ever changes, this reds rather than the two rules
+  #      silently diverging. That is why it is worth a case and not a comment.
+  envf_q2="$tmp/pin-env-q2"; printf 'CQLITE_GATE_MAX_CONCURRENCY=08\n' >"$envf_q2"
+  shims_pam_q2="$tmp/pin-shims-pam-q2"; mkpinshims "$shims_pam_q2" "file:$envf_q2"
+  out_q2=$(runpin "$pinroot" "$shims_pam_q2" "$envf_q2" HOME="$pin_home_plain")
+  if printf '%s' "$out_q2" | grep -q 'gate-pin: VERIFIED' \
+     && ! printf '%s' "$out_q2" | grep -q 'gate-pin: UNMEASURED'; then
+    ok "gate-pin: a valid leading-zero pin (08) reaches VERIFIED — the gate's normalisation is not read as oracle drift"
+  else
+    bad "gate-pin: a correctly persisted 08 was not VERIFIED (job 333 — raw-vs-normalised compare)"
+    printf '%s\n' "$out_q2" | grep -i 'gate-pin' | head -3
+  fi
+
+  # 11q3. ...and the drift check it must NOT break: the whole point of comparing against our
+  #      input is to catch an oracle answering about a DIFFERENT value. Canonicalising both
+  #      sides preserves that, and this asserts it — otherwise 11q2 could have been "fixed"
+  #      by deleting the comparison, which would pass 11q2 and silently remove a guard.
+  #      `08` and `9` are both valid and both pinned, so only the COMPARISON distinguishes
+  #      them: the session-visible value is 08 while a BASH_ENV-style pollution makes the
+  #      oracle answer 9, and that must NOT read VERIFIED.
+  envf_q3="$tmp/pin-env-q3"; printf 'CQLITE_GATE_MAX_CONCURRENCY=08\n' >"$envf_q3"
+  shims_pam_q3="$tmp/pin-shims-pam-q3"; mkpinshims "$shims_pam_q3" "file:$envf_q3"
+  # a gate whose cpu-budget line always answers 9(pinned), whatever it was handed
+  cat > "$shims_pam_q3/../pin-fake-gate.sh" <<'FAKEGATE'
+#!/usr/bin/env bash
+echo "cpu-budget: wrapper=none ncpu=16 max-concurrency=9(pinned) cores-per-gate=1 build-jobs=1(derived) test-threads=1"
+FAKEGATE
+  chmod +x "$shims_pam_q3/../pin-fake-gate.sh" 2>/dev/null
+  pinroot_q3="$tmp/pin-root-q3"; mkdir -p "$pinroot_q3/scripts"
+  cp "$pinroot/scripts/bootstrap-agent-machine.sh" "$pinroot_q3/scripts/" 2>/dev/null
+  cp "$shims_pam_q3/../pin-fake-gate.sh" "$pinroot_q3/scripts/agent-gate.sh" 2>/dev/null
+  out_q3=$(runpin "$pinroot_q3" "$shims_pam_q3" "$envf_q3" HOME="$pin_home_plain")
+  if ! printf '%s' "$out_q3" | grep -q 'gate-pin: VERIFIED'; then
+    ok "gate-pin: an oracle answering about a DIFFERENT value is still refused — canonicalising did not delete the drift check"
+  else
+    bad "gate-pin: the drift check was lost — a gate answering 9(pinned) for a session showing 08 read VERIFIED"
+    printf '%s\n' "$out_q3" | grep -i 'gate-pin' | head -3
+  fi
+
   # 11r. The NEGATIVE twin of 11q, so it cannot pass for the wrong reason: with the SAME
   #      pam-stand-in shim and no repair flag, an unpinned box must still come out FAILED.
   #      Without this, 11q would also pass against a shim that injects unconditionally.
@@ -3507,7 +3574,16 @@ else
   #      valid pin. Asserted structurally as well as behaviourally, because a future edit
   #      could drop the N comparison while every behavioural case above still passes —
   #      the scrub alone would cover them.
-  if grep -q 'pin_gate_n" != "\$pin_probe_seen' "$BOOTSTRAP" \
+  #
+  #      THE NEEDLE MOVED WITH THE COMPARISON (roborev job 333). It used to be the literal
+  #      `pin_gate_n" != "$pin_probe_seen`, which the canonical-decimal fix replaced — the
+  #      comparison is still there and still compares the resolved N against the probed
+  #      value, now with both sides normalised so the gate's own `08`->`8` does not read as
+  #      drift. This guard CORRECTLY RED when the expression changed, which is what a
+  #      structural guard is for; it is updated rather than deleted, and it still fails if
+  #      the comparison is removed altogether. A structural needle is a claim about source
+  #      text and decays exactly like a comment: when you change the expression, come here.
+  if grep -Fq '[ "$(pin_canon_decimal "$pin_gate_n")" != "$(pin_canon_decimal "$pin_probe_seen")" ]' "$BOOTSTRAP" \
      && grep -q 'bounded 30 env -u BASH_ENV -u ENV' "$BOOTSTRAP"; then
     ok "gate-pin: the oracle is scrubbed AND its resolved N is compared, not just its source token"
   else

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -3485,6 +3485,64 @@ else
     fi
   fi
 
+  # 11ax. NO TIMEOUT UTILITY => NO PROBE RUNS AT ALL (issue #3414 roborev round 10).
+  #      `bounded` degrades to running the command DIRECTLY when neither timeout nor
+  #      gtimeout exists, and both sudo probes used to execute ABOVE the no-timeout guard —
+  #      so a stalled sudo/PAM/NSS lookup hung bootstrap indefinitely while the code
+  #      CLAIMED it refuses unbounded session probing. Asserting the verdict alone would
+  #      not have caught it: the verdict was already correct, and only the ORDER was wrong.
+  #      So this counts sudo invocations with a recording shim — the fact that distinguishes
+  #      "refused" from "ran it anyway and then said it refused".
+  pin_nt="$tmp/pin-no-timeout"; mkdir -p "$pin_nt"
+  for pin_t in bash env grep sed awk head tail tr cut wc stat mktemp dirname basename cat \
+               cp mv rm mkdir chmod ln find date id uname nproc tee sort xargs expr sleep; do
+    pin_tp=$(type -P "$pin_t" 2>/dev/null) || continue
+    [ -n "$pin_tp" ] && ln -sf "$pin_tp" "$pin_nt/$pin_t" 2>/dev/null || true
+  done
+  pin_nt_trip="$tmp/pin-no-timeout-sudo.log"; : >"$pin_nt_trip"
+  mk_stub "$pin_nt" sudo "echo \"sudo \$*\" >>\"$pin_nt_trip\"; exit 0"
+  envf_ax="$tmp/pin-env-ax"; printf 'CQLITE_GATE_MAX_CONCURRENCY=1\n' >"$envf_ax"
+  # NOT through runpin: that wraps the invocation in `timeout`, which this case has
+  # deliberately removed from PATH, so bootstrap would never launch and the assertion would
+  # fail for the harness's reason rather than the code's. The outer timeout is invoked by
+  # ABSOLUTE path so the bound on the test itself survives while bootstrap's OWN PATH still
+  # has none — which is the condition under test.
+  pin_ax_timeout=$(command -v timeout 2>/dev/null || true)
+  out_ax=$(env PATH="$pin_nt" HOME="$pin_home_plain" CARGO_HOME="$tmp/pin-cargo"     CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="$envf_ax"     ${pin_ax_timeout:+"$pin_ax_timeout" -s KILL 120}     "$PIN_BS" "$pinroot/scripts/bootstrap-agent-machine.sh" --skip-smoke --skip-push-probe 2>&1)
+  if printf '%s' "$out_ax" | grep -qE '\[warn\].*gate-pin: UNMEASURED' \
+     && printf '%s' "$out_ax" | grep -q 'NOTHING was probed' \
+     && [ ! -s "$pin_nt_trip" ]; then
+    ok "gate-pin: with no timeout utility the section refuses AND invokes sudo zero times"
+  else
+    bad "gate-pin: a probe ran unbounded (or the refusal was not reported): $(wc -l <"$pin_nt_trip") sudo call(s)"
+    printf '%s\n' "$out_ax" | grep -i 'gate-pin' | head -2
+    cat "$pin_nt_trip"
+  fi
+
+  # 11ay. A BOX THAT PERMITS THE SELF-SESSION BUT NOT UNRESTRICTED ROOT MUST STILL BE
+  #      MEASURED (roborev round 10). Probe capability was gated on `sudo -n true`
+  #      succeeding as ROOT, but that asks "may I run ANYTHING as root" while the probe
+  #      needs only "may I open a session as MYSELF". A narrowly-scoped sudoers rule — or a
+  #      box already correctly pinned — was reported sudo-needs-password and failed
+  #      --strict on a legitimately configured machine.
+  pin_ab="$tmp/pin-shims-selfonly"; mkpinshims "$pin_ab" 1
+  mk_stub "$pin_ab" sudo 'args="$*"
+case "$args" in
+  "-n true")  exit 1 ;;                 # root execution DENIED
+esac
+while [ "${1:-}" = "-n" ]; do shift; done
+if [ "${1:-}" = "-u" ]; then shift 2; fi
+exec env CQLITE_GATE_MAX_CONCURRENCY=1 "$@"'
+  envf_ay="$tmp/pin-env-ay"; printf 'CQLITE_GATE_MAX_CONCURRENCY=1\n' >"$envf_ay"
+  out_ay=$(runpin "$pinroot" "$pin_ab" "$envf_ay" HOME="$pin_home_plain")
+  if printf '%s' "$out_ay" | grep -qE '\[ok\].*gate-pin: VERIFIED' \
+     && ! printf '%s' "$out_ay" | grep -q 'needs a password'; then
+    ok "gate-pin: root execution denied but the self-session permitted still MEASURES (no false red)"
+  else
+    bad "gate-pin: a box permitting the self-session was failed for lacking unrestricted root"
+    printf '%s\n' "$out_ay" | grep -i 'gate-pin' | head -2
+  fi
+
   # 11k. The test seam is FAIL-CLOSED and has NO production fallback: set without its
   #      marker, or relative, it SKIPS the section rather than silently persisting to
   #      the real /etc/environment (the #3249 lesson — a seam that degrades to the

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -2403,6 +2403,11 @@ runpin() {
 pinroot="$tmp/pin-root"
 if ! mknotifyroot "$pinroot" good; then
   bad "gate-pin: could not stage the bootstrap tree"
+elif ! cp "$SCRIPT_DIR/../agent-gate.sh" "$pinroot/scripts/agent-gate.sh"; then
+  # The verdict asks the GATE what it will do with the probed value (rather than
+  # re-deriving the gate's rules inside bootstrap), so the throwaway tree needs a real
+  # agent-gate.sh. A tree WITHOUT one is its own case — 11m below.
+  bad "gate-pin: could not stage agent-gate.sh into the bootstrap tree"
 else
   mkdir -p "$tmp/pin-cargo"
   pin_home_plain="$tmp/pin-home-plain"; mkdir -p "$pin_home_plain/.cargo"
@@ -2554,6 +2559,91 @@ else
   else
     bad "gate-pin: the opt-out did not report as a non-passing OPT-OUT"
     printf '%s\n' "$out_j" | grep -i 'gate-pin' | head -3
+  fi
+
+  # 11l. VISIBLE IS NOT HONOURED. A value the gate DISCARDS (non-numeric/empty) or
+  #      silently CLAMPS (<1) is a pin in name only: bootstrap would be certifying a cap
+  #      the gate does not apply, while the gate's own summary says (invalid)/(clamped)
+  #      for the same box. That is this issue's shape one level further out, so it gets
+  #      its own non-passing verdict — never VERIFIED, and never the bare FAILED, whose
+  #      remedy ("persist the pin") is wrong for a pin that is already there.
+  for pin_case in "abc:DISCARDS" "0:silently raises it to 1"; do
+    pin_val=${pin_case%%:*}; pin_expect=${pin_case#*:}
+    shims_nh="$tmp/pin-shims-nh-$pin_val"; mkpinshims "$shims_nh" "$pin_val"
+    envf_nh="$tmp/pin-env-nh-$pin_val"; printf 'CQLITE_GATE_MAX_CONCURRENCY=%s\n' "$pin_val" >"$envf_nh"
+    out_nh=$(runpin "$pinroot" "$shims_nh" "$envf_nh" HOME="$pin_home_plain")
+    if printf '%s' "$out_nh" | grep -q 'gate-pin: NOT-HONOURED' \
+       && printf '%s' "$out_nh" | grep -q "$pin_expect" \
+       && ! printf '%s' "$out_nh" | grep -qE '\[ok\].*gate-pin'; then
+      ok "gate-pin: a visible '$pin_val' the gate does not honour is NOT-HONOURED, never VERIFIED"
+    else
+      bad "gate-pin: a visible-but-not-honoured '$pin_val' was not surfaced"
+      printf '%s\n' "$out_nh" | grep -i 'gate-pin' | head -3
+    fi
+  done
+
+  # 11m. A value >= 1 is VERIFIED whatever the number: a box deliberately running >1
+  #      concurrent gate is legitimate and bootstrap correctly never rewrites it, so the
+  #      verdict is "visible AND honoured", not "equal to 1". Without this, 11l would
+  #      also pass against a section that only ever accepts the literal 1.
+  shims_four="$tmp/pin-shims-four"; mkpinshims "$shims_four" 4
+  envf_m="$tmp/pin-env-m"; printf 'CQLITE_GATE_MAX_CONCURRENCY=4\n' >"$envf_m"
+  out_m=$(runpin "$pinroot" "$shims_four" "$envf_m" HOME="$pin_home_plain")
+  if printf '%s' "$out_m" | grep -q 'gate-pin: VERIFIED' \
+     && printf '%s' "$out_m" | grep -q 'max-concurrency=4(pinned)'; then
+    ok "gate-pin: a deliberate override >1 is VERIFIED and reported as the cap the gate will apply"
+  else
+    bad "gate-pin: a legitimate >1 override was not VERIFIED"
+    printf '%s\n' "$out_m" | grep -i 'gate-pin' | head -3
+  fi
+
+  # 11n. THE HONOURING ORACLE IS NOT OPTIONAL. With no agent-gate.sh to consult, the
+  #      second half of the question is unanswered — that must be UNMEASURED, never an
+  #      assumed pass. (A positive verdict requires an affirmative measurement.)
+  nogate="$tmp/pin-root-nogate"
+  if mknotifyroot "$nogate" good; then
+    envf_n="$tmp/pin-env-n"; printf 'CQLITE_GATE_MAX_CONCURRENCY=1\n' >"$envf_n"
+    out_n=$(runpin "$nogate" "$shims_one" "$envf_n" HOME="$pin_home_plain")
+    if printf '%s' "$out_n" | grep -qE '\[warn\].*gate-pin: UNMEASURED' \
+       && printf '%s' "$out_n" | grep -q 'could not be consulted to confirm' \
+       && ! printf '%s' "$out_n" | grep -qE '\[ok\].*gate-pin'; then
+      ok "gate-pin: a visible pin whose honouring could NOT be checked is UNMEASURED, not VERIFIED"
+    else
+      bad "gate-pin: an unconsultable gate still produced a verdict about honouring"
+      printf '%s\n' "$out_n" | grep -i 'gate-pin' | head -3
+    fi
+  else
+    bad "gate-pin: could not stage the gate-less bootstrap tree"
+  fi
+
+  # 11o. THE PAM CASE. The pin IS in the file and a fresh session still does not see it.
+  #      That is not a missing pin, and `--yes` cannot fix it — it finds the line already
+  #      present and changes nothing, so an operator handed the persist remedy loops.
+  #      The two boxes that reach FAILED must be told apart.
+  envf_o="$tmp/pin-env-o"; printf 'CQLITE_GATE_MAX_CONCURRENCY=1\n' >"$envf_o"
+  out_o=$(runpin "$pinroot" "$shims_none" "$envf_o" HOME="$pin_home_plain")
+  if printf '%s' "$out_o" | grep -q 'gate-pin: FAILED' \
+     && printf '%s' "$out_o" | grep -q 'this is a PAM condition, NOT a missing pin' \
+     && printf '%s' "$out_o" | grep -q 'pam_env' \
+     && ! printf '%s' "$out_o" | grep -q 'fix:  bash scripts/bootstrap-agent-machine.sh --yes'; then
+    ok "gate-pin: a present-but-invisible pin is diagnosed as a PAM condition, not handed the persist remedy"
+  else
+    bad "gate-pin: the two FAILED boxes were not told apart"
+    printf '%s\n' "$out_o" | grep -i 'gate-pin\|pam_env\|fix:' | head -4
+  fi
+
+  # 11p. ...and the ABSENT-file box (a Mac has no /etc/environment) is not handed a
+  #      remedy naming a file it does not have. A remedy that cannot work on the box it
+  #      is printed for costs a cycle before the operator learns that.
+  envf_p="$tmp/pin-env-p-missing"; rm -f "$envf_p"
+  out_p=$(runpin "$pinroot" "$shims_none" "$envf_p" HOME="$pin_home_plain")
+  if printf '%s' "$out_p" | grep -q 'gate-pin: FAILED' \
+     && printf '%s' "$out_p" | grep -q 'has nowhere to persist it' \
+     && ! printf '%s' "$out_p" | grep -q 'fix:  bash scripts/bootstrap-agent-machine.sh --yes'; then
+    ok "gate-pin: a host with no system env file is not told to re-run --yes against it"
+  else
+    bad "gate-pin: the absent-env-file box got a remedy that cannot work there"
+    printf '%s\n' "$out_p" | grep -i 'gate-pin\|nowhere\|fix:' | head -4
   fi
 
   # 11k. The test seam is FAIL-CLOSED and has NO production fallback: set without its

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -2999,6 +2999,32 @@ else
   grep -nE '^[[:space:]]*run:.*bootstrap-agent-machine\.sh' "$pin_profile" | head -2
 fi
 
+# --- 13. NO SKIP MAY BE ANNOUNCED THROUGH ok() (issue #3414 roborev round 2) ----------
+# The finding was one `ok "SKIP ..."` — an announcement that incremented PASS and left the
+# skip count at 0, i.e. a skip reported as a pass, sitting inside the accounting added the
+# round before to expose exactly that. The sweep found a second instance in a sibling
+# suite. "If one existed, more may" is the durable half of that finding, so it is a check
+# rather than a one-time grep: this scans EVERY suite, so a new one cannot join the habit.
+#
+# The pattern separates an ANNOUNCEMENT from an ASSERTION ABOUT skips: `ok "SKIP …"` and
+# `ok "skip …"` are announcements, while `ok "skip-routing: …"` / `ok "skip-worktree: …"`
+# are real passing assertions whose subject happens to be skipping. Matching the former
+# and sparing the latter is why this keys on the delimiter after the word, not the word.
+# Also asserted host-independently: the root-only case that motivated it never executes on
+# an unprivileged host, so a behavioural test could not have covered it here at all.
+# COMMENT LINES ARE EXCLUDED, and that is not incidental: the paragraph above QUOTES the
+# offending form to explain it, so without this filter the check reds on its own
+# documentation — the artifact describing a rule becoming a violation of it. Filter on the
+# first non-space character of the matched line, after grep's `file:line:` prefix.
+pin_skip_offenders=$(grep -rnE '(^|[^_[:alnum:]])ok "(SKIP|skip)([[:space:]"]|$)' \
+  "$SCRIPT_DIR" 2>/dev/null | grep -vE '^[^:]*:[0-9]+:[[:space:]]*#' | head -5)
+if [ -z "$pin_skip_offenders" ]; then
+  ok "suite hygiene: no test announces a SKIP through ok() (a skip must never increment PASS)"
+else
+  bad "suite hygiene: a SKIP is announced through ok(), so it counts as a PASS and not as a skip:"
+  printf '%s\n' "$pin_skip_offenders"
+fi
+
 echo
 echo "PASS=$PASS FAIL=$FAIL SKIP=$SKIPS"
 [ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -106,7 +106,15 @@ if [ "$(id -u)" = 0 ]; then
   skip "THE ENTIRE SUITE: it drives bootstrap through a test seam that is REFUSED under root (#3414 finding S), so every sandboxed invocation gains a warning and the green-path assertions cannot run. Re-run as an unprivileged user."
   echo
   echo "PASS=$PASS FAIL=$FAIL SKIP=$SKIPS"
-  exit 0
+  # NONZERO, and this is the THIRD LEVEL at which this same shape has been caught (#3414
+  # roborev round 8). Round 2 found a CASE counted as a pass; round 4 found `ok "SKIP …"`;
+  # round 7's fix for those turned it into a SUITE-level version — the gate checks only
+  # exit status, so `exit 0` here reported `tooling-tests` green having executed nothing at
+  # all, including every regression this branch added. A declined suite is not a passing
+  # suite. The gate runs as an unprivileged user, so the normal path never reaches this and
+  # the cost is zero; running it as root becomes a loud failure instead of a silent green.
+  echo "DECLINED: this suite executed NOTHING and is exiting NONZERO so no caller can read it as a pass." >&2
+  exit 1
 fi
 
 # --- CARGO_HOME isolation: THIS SUITE WAS BREAKING cargo FOR THE WHOLE BOX ---------
@@ -3297,7 +3305,7 @@ else
       timeout -s KILL 120 bash "$pinroot/scripts/bootstrap-agent-machine.sh" \
         --skip-smoke --skip-push-probe 2>&1)
     if printf '%s' "$out_am" | grep -qE '\[warn\].*gate-pin: UNMEASURED' \
-       && printf '%s' "$out_am" | grep -q 'does not resolve to an account' \
+       && printf '%s' "$out_am" | grep -qE 'does not resolve to an account|INCONSISTENT sudo metadata' \
        && ! printf '%s' "$out_am" | grep -qE '\[ok\].*gate-pin'; then
       ok "gate-pin: an unresolvable sudo invoker is UNMEASURED, never answered about root instead"
     else
@@ -3316,6 +3324,89 @@ else
     fi
   else
     skip "gate-pin sudo-invocation-mode cases (no passwordless sudo here)"
+  fi
+
+  # 11at. THE PRIVILEGE DECISION MUST NOT GO THROUGH A PATH-RESOLVED BINARY (issue #3414
+  #      roborev round 8, HIGH). It used to call `id -u`, so a shadowed or merely MALFORMED
+  #      `id` — a busybox variant, a broken PATH — made a ROOT invocation look
+  #      unprivileged, and the seam then steered a root `tee -a` at an arbitrary absolute
+  #      path: the round-5 High reopened through a different door. Bash's readonly $EUID
+  #      cannot be shadowed and costs no fork.
+  #
+  #      Driven as a REAL root invocation with a lying `id` first on PATH, because that is
+  #      the only way to distinguish "we read $EUID" from "we read a binary that agreed".
+  if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+    pin_liar="$tmp/pin-liar-bin"; mkdir -p "$pin_liar"
+    printf '#!/usr/bin/env bash\necho 1000\n' >"$pin_liar/id"; chmod +x "$pin_liar/id"
+    pin_liar_target="$tmp/pin-liar-target"; rm -f "$pin_liar_target"
+    out_at=$(sudo -n env PATH="$pin_liar:$PATH" \
+      CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="$pin_liar_target" \
+      HOME="$pin_root_sandbox" CARGO_HOME="$pin_root_sandbox/.cargo" \
+      timeout -s KILL 120 bash "$pinroot/scripts/bootstrap-agent-machine.sh" \
+        --skip-smoke --skip-push-probe --yes 2>&1)
+    if printf '%s' "$out_at" | grep -q 'gate-pin: SKIPPED' && [ ! -e "$pin_liar_target" ]; then
+      ok "gate-pin: a lying 'id' on PATH cannot make a ROOT run look unprivileged (the decision reads \$EUID)"
+    else
+      bad "gate-pin: a shadowed 'id' defeated the root guard — the seam steered a privileged write"
+      printf '%s\n' "$out_at" | grep -i 'gate-pin' | head -2
+      ls -l "$pin_liar_target" 2>/dev/null
+    fi
+    sudo -n rm -f "$pin_liar_target" 2>/dev/null || true
+
+    # 11au. SUDO_USER MUST AGREE WITH SUDO_UID (roborev round 8). Trusting the NAME alone
+    #      accepts stale metadata — `SUDO_UID=1000 SUDO_USER=root` would probe root and
+    #      could report VERIFIED while the agent account differs, which is the
+    #      wrong-subject defect the retarget exists to fix, wearing the retarget's clothes.
+    out_au=$(sudo -n env SUDO_UID=1000 SUDO_USER=root \
+      HOME="$pin_root_sandbox" CARGO_HOME="$pin_root_sandbox/.cargo" \
+      timeout -s KILL 120 bash "$pinroot/scripts/bootstrap-agent-machine.sh" \
+        --skip-smoke --skip-push-probe 2>&1)
+    if printf '%s' "$out_au" | grep -qE '\[warn\].*gate-pin: UNMEASURED' \
+       && printf '%s' "$out_au" | grep -q 'INCONSISTENT sudo metadata' \
+       && ! printf '%s' "$out_au" | grep -qE '\[ok\].*gate-pin'; then
+      ok "gate-pin: SUDO_USER disagreeing with SUDO_UID is UNMEASURED, not a probe of the wrong account"
+    else
+      bad "gate-pin: inconsistent sudo metadata was trusted"
+      printf '%s\n' "$out_au" | grep -i 'gate-pin' | head -2
+    fi
+
+    # 11av. ...and root invoking sudo (SUDO_UID=0) tells us nothing about a gate's account.
+    out_av=$(sudo -n env SUDO_UID=0 SUDO_USER=root \
+      HOME="$pin_root_sandbox" CARGO_HOME="$pin_root_sandbox/.cargo" \
+      timeout -s KILL 120 bash "$pinroot/scripts/bootstrap-agent-machine.sh" \
+        --skip-smoke --skip-push-probe 2>&1)
+    if printf '%s' "$out_av" | grep -qE '\[warn\].*gate-pin: UNMEASURED' \
+       && printf '%s' "$out_av" | grep -q 'sudo was invoked BY root'; then
+      ok "gate-pin: SUDO_UID=0 is UNMEASURED — root invoking sudo says nothing about a gate's account"
+    else
+      bad "gate-pin: SUDO_UID=0 was treated as a usable probe subject"
+      printf '%s\n' "$out_av" | grep -i 'gate-pin' | head -2
+    fi
+    sudo -n rm -rf "$pin_root_sandbox" 2>/dev/null || true; mkdir -p "$pin_root_sandbox/.cargo"
+  else
+    skip "gate-pin privilege-source and sudo-metadata cases (no passwordless sudo here)"
+  fi
+
+  # 11aw. UNREADABLE IS NOT ABSENT for the profile append (roborev round 8). The Q fix
+  #      keyed on a value having been FOUND, so an unreadable or unparseable env file fell
+  #      through to appending the hardcoded `=1` — and if that file already pins 4, we
+  #      silently create the divergence Q existed to prevent. An unmeasurable state must
+  #      not inherit the permissive branch.
+  if [ "$(id -u)" = 0 ]; then
+    skip "gate-pin unreadable-file profile-append case (running as root: 0000 is still readable)"
+  else
+    pin_home_aw="$tmp/pin-home-aw"; mkdir -p "$pin_home_aw/.cargo"; : >"$pin_home_aw/.bashrc"
+    envf_aw="$tmp/pin-env-aw"; printf 'CQLITE_GATE_MAX_CONCURRENCY=4\n' >"$envf_aw"; chmod 0000 "$envf_aw"
+    out_aw=$(runpin "$pinroot" "$shims_none" "$envf_aw" HOME="$pin_home_aw" SHELL=/bin/bash --yes)
+    chmod 0644 "$envf_aw"
+    if ! grep -q 'CQLITE_GATE_MAX_CONCURRENCY' "$pin_home_aw/.bashrc" \
+       && printf '%s' "$out_aw" | grep -q 'could not determine what'; then
+      ok "gate-pin: an UNREADABLE env file does not get the hardcoded profile export (unreadable is not absent)"
+    else
+      bad "gate-pin: an unreadable env file fell through to the append, recreating the divergence Q removed"
+      printf '%s\n' "$out_aw" | grep -i 'not touching\|could not determine' | head -2
+      cat "$pin_home_aw/.bashrc"
+    fi
   fi
 
   # 11k. The test seam is FAIL-CLOSED and has NO production fallback: set without its
@@ -3416,6 +3507,24 @@ if [ -z "$pin_mustrun_missing" ]; then
   ok "suite: the three green-path cases RAN (not skipped by a warning-count drift)"
 else
   bad "suite: green-path case(s) did not run — silently disabled again: $pin_mustrun_missing"
+fi
+
+# --- 16. A WHOLESALE DECLINE MUST NOT EXIT 0 (#3414 roborev round 8) -------------------
+# Third instance of one shape (case-level pass, `ok "SKIP"`, then suite-level), so it is a
+# check rather than a fixed comment. STRUCTURAL, and the limit is stated rather than
+# implied: a behavioural test would mean re-running this suite as root FROM INSIDE ITSELF,
+# which is recursive and minutes long, so what is asserted here is that every wholesale
+# `skip`-then-exit path exits nonzero. The behavioural half is a one-off manual check under
+# `sudo`, recorded in the lane verdict file — a structural grep must not be read as a
+# behavioural guarantee.
+pin_decline_bad=$(awk '
+  /^  skip "THE ENTIRE SUITE/ { seen = NR }
+  seen && NR > seen && NR <= seen + 8 && /^  exit 0$/ { print NR }
+' "$0")
+if [ -z "$pin_decline_bad" ] && grep -qE '^  exit 1$' "$0"; then
+  ok "suite hygiene: the wholesale-decline path exits NONZERO (a declined suite is not a passing suite)"
+else
+  bad "suite hygiene: a wholesale decline exits 0 — the gate reads only exit status, so it would certify a suite that ran nothing"
 fi
 
 echo

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -2959,6 +2959,37 @@ else
     printf '%s\n' "$out_x" | grep -iA 3 'gate-pin: VERIFIED' | head -4
   fi
 
+  # 11z5. THE NEGATIVE ROW IS INDEPENDENT OF FILE STATE (issue #3414, lead ruling). The
+  #      verdict is a conjunction of two measurements, not a file-state precedence: when
+  #      the session does NOT see the value, that is an affirmative measurement and the
+  #      verdict is FAILED whatever the file says — present, absent, or unreadable. The
+  #      rule is that an unmeasurable half may weaken a POSITIVE claim but may never
+  #      soften a NEGATIVE one, so an unreadable file must not downgrade a real FAILED to
+  #      UNMEASURED. Asserted across all three file states in one loop, because the
+  #      individual cases (11w absent, 11z2 present, 11s2 unreadable) each check one row
+  #      and none of them states the INVARIANT that binds the three.
+  for pin_row in absent present unreadable; do
+    envf_r5="$tmp/pin-env-r5-$pin_row"
+    case "$pin_row" in
+      absent)     : >"$envf_r5" ;;
+      present)    printf 'CQLITE_GATE_MAX_CONCURRENCY=1\n' >"$envf_r5" ;;
+      unreadable) printf 'CQLITE_GATE_MAX_CONCURRENCY=1\n' >"$envf_r5"; chmod 0000 "$envf_r5" ;;
+    esac
+    if [ "$pin_row" = unreadable ] && [ "$(id -u)" = 0 ]; then
+      skip "gate-pin negative-row invariant, unreadable file (running as root: 0000 is still readable)"
+      continue
+    fi
+    out_r5=$(runpin "$pinroot" "$shims_none" "$envf_r5" HOME="$pin_home_plain")
+    chmod 0644 "$envf_r5" 2>/dev/null || true
+    if printf '%s' "$out_r5" | grep -q 'gate-pin: FAILED' \
+       && ! printf '%s' "$out_r5" | grep -qE 'gate-pin: (UNMEASURED|NOT-SYSTEM-WIDE|VERIFIED)'; then
+      ok "gate-pin: session-cannot-see-it => FAILED with the env file $pin_row (file state cannot soften a negative)"
+    else
+      bad "gate-pin: file state '$pin_row' changed a NEGATIVE probe's verdict"
+      printf '%s\n' "$out_r5" | grep -i 'gate-pin' | head -2
+    fi
+  done
+
   # 11k. The test seam is FAIL-CLOSED and has NO production fallback: set without its
   #      marker, or relative, it SKIPS the section rather than silently persisting to
   #      the real /etc/environment (the #3249 lesson — a seam that degrades to the

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -905,6 +905,15 @@ mk_push_repo() {
   # running. Staging it here plus the pinned `sudo` shim in mk_push_bin makes 5b contribute
   # ZERO warnings deterministically — on a pinned host and an unpinned one alike.
   cp "$SCRIPT_DIR/../agent-gate.sh" "$dir/scripts/agent-gate.sh"
+  # A PER-SANDBOX system env file carrying the pin, pointed at by run_push. Section 5b's
+  # VERIFIED now requires BOTH the file line and a session that sees it (roborev round 2),
+  # so without this the sandboxes would take the new NOT-SYSTEM-WIDE branch, base_warns
+  # would go back to 2, and the three end-to-end cases would silently skip again — the
+  # round-4 defect returning through the round-5 fix. Per-sandbox rather than the
+  # suite-wide seam ALSO removes an order-dependence that was already latent: the shared
+  # file is appended to by whichever earlier `--yes` case runs first, so what these cases
+  # measured depended on suite ordering.
+  printf 'CQLITE_GATE_MAX_CONCURRENCY=1\n' >"$dir/etc-environment"
   : >"$dir/test-data/datasets/sstables/ks/tbl/nb-1-big-Data.db"
 }
 
@@ -992,6 +1001,7 @@ run_push() {
   local repo="$1" bin="$2" gc="$3"; shift 3
   push_rc=0
   push_out=$(PATH="$bin:$PATH" HOME="$repo/.home" CARGO_HOME="$repo/.home/.cargo" \
+    CQLITE_BOOTSTRAP_ENV_FILE="$repo/etc-environment" \
     GIT_CONFIG_GLOBAL="$gc" GIT_CONFIG_NOSYSTEM=1 CLAIM_MACHINE=push-probe-test \
     CODEX_NOTIFY_WEBHOOK='https://ntfy.example.com/t' \
     CQLITE_PROJECT_OWNER=pmcfadin CQLITE_PROJECT_NUMBER=1 \
@@ -2768,7 +2778,10 @@ else
   #      Root can read a 0000 file, so the case would assert nothing as root — skipped
   #      rather than silently inverted.
   if [ "$(id -u)" = 0 ]; then
-    ok "SKIP gate-pin unreadable-env-file case (running as root: 0000 is still readable)"
+    # Through `skip`, NOT `ok` (#3414 roborev round 2): an `ok` here increments PASS and
+    # leaves SKIP unchanged — a skip counted as a pass, sitting inside the very accounting
+    # added to expose that.
+    skip "gate-pin unreadable-env-file case (running as root: 0000 is still readable)"
   else
     envf_s2="$tmp/pin-env-s2"; printf 'FOO=bar\n' >"$envf_s2"; chmod 0000 "$envf_s2"
     # shims_none (a session that injects nothing) is the right stand-in here: the append
@@ -2869,13 +2882,81 @@ else
   #      must therefore carry the limit AND name the gate's own cpu-budget token as the
   #      authoritative per-run confirmation — and must not re-assert the attribution it
   #      cannot establish ("came from the system env file").
-  if printf '%s' "$out_x" | grep -q 'does NOT prove every gate on this box is pinned' \
-     && printf '%s' "$out_x" | grep -q 'max-concurrency=N(pinned)' \
-     && ! printf '%s' "$out_x" | grep -q 'came from the system env file'; then
-    ok "gate-pin: VERIFIED states what it did NOT measure and names cpu-budget as authoritative"
+  # Scoped to the ATTRIBUTION half; the scope-note WORDING is 11z4's subject, so the two
+  # cases do not both red on one rewording. What must never come back is the claim the
+  # probe cannot establish — that the value "came from the system env file" — since
+  # ~/.pam_environment or a sudoers env_file satisfies the observation identically. (What
+  # licenses the system-wide claim now is the FILE correlation, not the probe.)
+  if ! printf '%s' "$out_x" | grep -q 'came from the system env file' \
+     && printf '%s' "$out_x" | grep -q 'max-concurrency=N(pinned)'; then
+    ok "gate-pin: VERIFIED does not re-assert the unestablishable attribution, and names cpu-budget as authoritative"
   else
-    bad "gate-pin: VERIFIED claims more than the probe measured (missing scope note?)"
+    bad "gate-pin: VERIFIED claims an attribution the probe cannot make (or dropped the cpu-budget pointer)"
     printf '%s\n' "$out_x" | grep -iA 2 'gate-pin: VERIFIED' | head -4
+  fi
+
+  # 11z. VERIFIED REQUIRES BOTH HALVES (issue #3414 roborev round 2). A session that sees
+  #      the value while the system-wide file does NOT carry the line means the value is
+  #      arriving from something sudo- or user-specific (a sudoers env_file,
+  #      ~/.pam_environment) — real for the session bootstrap opened, absent for every
+  #      gate launched outside it. Scoping the TEXT was not enough: the verdict was still
+  #      an `ok`, so zero warnings still bought "All checks green." and verify.run still
+  #      passed on such a box.
+  envf_z="$tmp/pin-env-z"; : >"$envf_z"          # file has NO pin line ...
+  out_z=$(runpin "$pinroot" "$shims_one" "$envf_z" HOME="$pin_home_plain")   # ... session DOES see one
+  if printf '%s' "$out_z" | grep -q 'gate-pin: NOT-SYSTEM-WIDE' \
+     && ! printf '%s' "$out_z" | grep -qE '\[ok\].*gate-pin' \
+     && printf '%s' "$out_z" | grep -q 'sudo- or user-specific source'; then
+    ok "gate-pin: a session-visible value with NO line in the system env file is NOT-SYSTEM-WIDE, never VERIFIED"
+  else
+    bad "gate-pin: a sudo-only value was certified as a system-wide pin"
+    printf '%s\n' "$out_z" | grep -i 'gate-pin' | head -3
+  fi
+
+  # 11z2. ...and the file half alone is not enough either, which is the ORIGINAL #3414
+  #      defect: the line is in the file but no session sees it. Asserting both directions
+  #      is what makes "neither half suffices" a tested property rather than a comment.
+  #      (11b/11q already cover the both-halves-present positive.)
+  envf_z2="$tmp/pin-env-z2"; printf 'CQLITE_GATE_MAX_CONCURRENCY=1\n' >"$envf_z2"
+  out_z2=$(runpin "$pinroot" "$shims_none" "$envf_z2" HOME="$pin_home_plain")
+  if printf '%s' "$out_z2" | grep -q 'gate-pin: FAILED' \
+     && ! printf '%s' "$out_z2" | grep -qE '\[ok\].*gate-pin'; then
+    ok "gate-pin: the file half ALONE is not VERIFIED either (the original #3414 defect)"
+  else
+    bad "gate-pin: a file line with no session visibility was treated as a pin"
+    printf '%s\n' "$out_z2" | grep -i 'gate-pin' | head -3
+  fi
+
+  # 11z3. An UNREADABLE system env file cannot be correlated, so the run has only half the
+  #      evidence the verdict requires — UNMEASURED, never VERIFIED. Root can read a 0000
+  #      file, so the case would assert nothing there.
+  if [ "$(id -u)" = 0 ]; then
+    skip "gate-pin uncorrelatable-file case (running as root: 0000 is still readable)"
+  else
+    envf_z3="$tmp/pin-env-z3"; printf 'CQLITE_GATE_MAX_CONCURRENCY=1\n' >"$envf_z3"; chmod 0000 "$envf_z3"
+    out_z3=$(runpin "$pinroot" "$shims_one" "$envf_z3" HOME="$pin_home_plain")
+    chmod 0644 "$envf_z3"
+    if printf '%s' "$out_z3" | grep -qE '\[warn\].*gate-pin: UNMEASURED' \
+       && printf '%s' "$out_z3" | grep -q 'could not be READ' \
+       && ! printf '%s' "$out_z3" | grep -qE '\[ok\].*gate-pin'; then
+      ok "gate-pin: an unreadable system env file cannot be correlated => UNMEASURED, not VERIFIED"
+    else
+      bad "gate-pin: an uncorrelatable file still produced a verdict about system-wide scope"
+      printf '%s\n' "$out_z3" | grep -i 'gate-pin' | head -3
+    fi
+  fi
+
+  # 11z4. The scope note must now claim the CORRELATED scope — every PAM stack, not just
+  #      the sudo session the probe opened — while still naming the residual it cannot
+  #      cover. A note that under-claims after the correlation is as wrong as one that
+  #      over-claimed before it.
+  if printf '%s' "$out_x" | grep -q 'pam_env reads for EVERY PAM-created session' \
+     && printf '%s' "$out_x" | grep -q 'created WITHOUT PAM' \
+     && printf '%s' "$out_x" | grep -q 'max-concurrency=N(pinned)'; then
+    ok "gate-pin: the scope note claims the correlated scope and still names the no-PAM residual"
+  else
+    bad "gate-pin: the scope note does not match the correlated verdict"
+    printf '%s\n' "$out_x" | grep -iA 3 'gate-pin: VERIFIED' | head -4
   fi
 
   # 11k. The test seam is FAIL-CLOSED and has NO production fallback: set without its

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -3784,6 +3784,14 @@ exec env CQLITE_GATE_MAX_CONCURRENCY=1 "$@"'
   #      the mode — one run's reported failure becoming the next run's silent success at a
   #      permission nothing chose.
   #
+  #      RE-ANCHORED AGAIN (roborev job 329): the post-`ln` read-back-and-rollback this case
+  #      used to drive HAS BEEN DELETED, because removing the destination by pathname was a
+  #      destructive race (`ln` proves the inode is ours at LINK time, not at REMOVE time). The
+  #      mode is now established and verified on the TEMP *before* linking, so the observable
+  #      changed: on a mode failure the destination is NEVER CREATED rather than created-then-
+  #      removed. The assertion is the same shape — destination absent + failure reported — for
+  #      a materially better reason.
+  #
   #      DRIVEN THROUGH ITS ORACLE, and the reason is the third instance of premise-staleness
   #      in this block. The first version stubbed `chmod` to fail and forced `umask 077` so
   #      `tee` created 0600. The job-314 fix then made the create atomic — one privileged
@@ -3800,8 +3808,8 @@ exec env CQLITE_GATE_MAX_CONCURRENCY=1 "$@"'
   out_bc=$(runpin "$pinroot" "$shims_badstat" "$envf_bc" HOME="$pin_home_plain" --fix-gate-pin)
   if [ ! -e "$envf_bc" ] \
      && printf '%s' "$out_bc" | grep -q 'the pin was NOT persisted' \
-     && printf '%s' "$out_bc" | grep -q 'was REMOVED'; then
-    ok "gate-pin: a create whose mode cannot be established rolls the partial file back and says so (nothing populated for the next run to inherit)"
+     && printf '%s' "$out_bc" | grep -q 'never created'; then
+    ok "gate-pin: a create whose mode cannot be established on the STAGED file never links it, so the destination is untouched (nothing to roll back, hence no rollback race)"
   else
     bad "gate-pin: the failed create left a residue, or did not report rolling it back"
     printf '%s\n' "$out_bc" | grep -iE 'gate-pin|CREATED|REMOVED|persisted' | head -4

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -236,8 +236,15 @@ pin_tree_id() {
     dig=$( { git -C "$SCRIPT_DIR" status --porcelain 2>/dev/null
              git -C "$SCRIPT_DIR" diff 2>/dev/null
              git -C "$SCRIPT_DIR" diff --cached 2>/dev/null
-             git -C "$SCRIPT_DIR" ls-files --others --exclude-standard -z 2>/dev/null \
-               | xargs -0 -r git -C "$SCRIPT_DIR" hash-object -- 2>/dev/null
+             # PORTABLE NUL loop, not `xargs -0 -r` (#3414 final roborev). `-r`
+             # (--no-run-if-empty) is GNU-only and BSD/macOS xargs REJECTS it, so on a
+             # supported macOS host the whole untracked-contents branch failed silently
+             # and edits to already-untracked files were reported STABLE. A silent
+             # omission inside an integrity digest is the worst possible failure mode:
+             # the digest still LOOKS like it covered them.
+             while IFS= read -r -d "" _u; do
+               git -C "$SCRIPT_DIR" hash-object -- "$_u" 2>/dev/null
+             done < <(git -C "$SCRIPT_DIR" ls-files --others --exclude-standard -z 2>/dev/null)
            } | git hash-object --stdin 2>/dev/null )
     case "$dig" in
       ?*) dig=$(printf '%s' "$dig" | cut -c1-12) ;;

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -176,6 +176,11 @@ chmod +x "$PIN_BS"
 PIN_SANDBOX_ROOT="$tmp"
 export PIN_SANDBOX_ROOT
 
+# `--help` gets a sandbox like every other invocation. It exits before any section and so
+# cannot write — but the guard asserts INPUTS, and excusing an invocation because we
+# reasoned it is harmless is how a guard's coverage erodes into a claim. No exemptions.
+mkdir -p "$tmp/help-home/.cargo"
+
 # --- 1. syntax check (bash -n) ---
 if bash -n "$BOOTSTRAP" 2>/dev/null; then
   ok "bootstrap script parses (bash -n)"
@@ -184,7 +189,7 @@ else
 fi
 
 # --- 2. --help exits 0 and prints usage ---
-help_out=$("$PIN_BS" "$BOOTSTRAP" --help 2>&1); help_rc=$?
+help_out=$(env HOME="$tmp/help-home" CARGO_HOME="$tmp/help-home/.cargo" "$PIN_BS" "$BOOTSTRAP" --help 2>&1); help_rc=$?
 if [ "$help_rc" -eq 0 ] && printf '%s' "$help_out" | grep -q "bootstrap"; then
   ok "--help exits 0 and prints usage"
 else
@@ -1968,7 +1973,7 @@ fi
 #   git push probe vs the gate fmt run) and the name similarity is a live hazard, so
 #   both must be documented and each must skip only its own thing. 7p-a ran with
 #   --skip-smoke ALONE and still probed; 7p-d ran with BOTH and skipped only the probe.
-push_help=$("$PIN_BS" "$BOOTSTRAP" --help 2>&1)
+push_help=$(env HOME="$tmp/help-home" CARGO_HOME="$tmp/help-home/.cargo" "$PIN_BS" "$BOOTSTRAP" --help 2>&1)
 if printf '%s' "$push_help" | grep -q -- '--skip-push-probe' \
    && printf '%s' "$push_help" | grep -q -- '--skip-smoke' \
    && printf '%s' "$push_help" | grep -q -- '--fix-credentials' \

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -225,9 +225,19 @@ pin_tree_id() {
   local head dig
   if command -v git >/dev/null 2>&1 && git -C "$SCRIPT_DIR" rev-parse --git-dir >/dev/null 2>&1; then
     head=$(git -C "$SCRIPT_DIR" rev-parse --short HEAD 2>/dev/null || printf 'UNKNOWN')
+    # UNTRACKED CONTENTS ARE HASHED TOO (#3414 roborev round 14, finding EE). `git status
+    # --porcelain` NAMES an untracked file; `git diff` omits its CONTENT — so editing an
+    # already-untracked file left the digest unchanged and reported STABLE. The lead
+    # preferred narrowing the claim to tracked files; I covered them instead, because the
+    # hole is closable in one line and a narrower claim would still have missed a real
+    # shared-worktree edit. IGNORED paths stay excluded on purpose (`--exclude-standard`):
+    # this lane's own scratch — the verdict file, the follow-up list — changes constantly
+    # and hashing it would make every run report MOVED, which is the alarm nobody reads.
     dig=$( { git -C "$SCRIPT_DIR" status --porcelain 2>/dev/null
              git -C "$SCRIPT_DIR" diff 2>/dev/null
              git -C "$SCRIPT_DIR" diff --cached 2>/dev/null
+             git -C "$SCRIPT_DIR" ls-files --others --exclude-standard -z 2>/dev/null \
+               | xargs -0 -r git -C "$SCRIPT_DIR" hash-object -- 2>/dev/null
            } | git hash-object --stdin 2>/dev/null )
     case "$dig" in
       ?*) dig=$(printf '%s' "$dig" | cut -c1-12) ;;
@@ -239,7 +249,7 @@ pin_tree_id() {
   fi
 }
 PIN_TREE_START=$(pin_tree_id)
-printf 'tree-start: %s\n' "$PIN_TREE_START"
+printf 'tree-start: %s  (worktree digest covers tracked diffs + untracked contents; ignored paths excluded)\n' "$PIN_TREE_START"
 
 # --- 1. syntax check (bash -n) ---
 if bash -n "$BOOTSTRAP" 2>/dev/null; then
@@ -1207,7 +1217,21 @@ EOF
 mk_push_bin() {
   local dir="$1" setup="${2:-:}"
   mkdir -p "$dir"
-  mk_stub "$dir" uname 'echo Darwin'
+  # LINUX, plus a perf stub — changed by finding DD (#3414 round 14). This sandbox reported
+  # Darwin purely to skip the Linux-only perf section. But DD made a non-Linux host
+  # permanently NON-PASSING (with no system-wide file there is nothing to correlate a
+  # session value against), so Darwin now costs a gate-pin warn instead: `base_warns` went
+  # 1 -> 2 and the three green-path cases silently skipped for the FOURTH time. Measured
+  # both ways before choosing — Darwin: gate-pin warns; Linux: gate-pin passes and only the
+  # perf section warns. So the sandbox becomes Linux and the one section that made Darwin
+  # attractive is satisfied directly. It also makes the green-path cases MORE meaningful:
+  # "this box certifies green" is now a Linux-only claim, so they must model a Linux box.
+  mk_stub "$dir" uname 'echo Linux'
+  # perf stat is invoked with CSV output, so the stub emits `<count>,,cycles` on stderr as
+  # the real one does — a human-formatted row parses as no-cycles-row (verified against the
+  # shipped awk rather than guessed).
+  mk_stub "$dir" perf 'case "$*" in *stat*) echo "1234567,,cycles" >&2 ;; esac
+exit 0'
   mk_stub "$dir" sccache 'exit 0'
   mk_stub "$dir" cargo-nextest 'exit 0'
   mk_stub "$dir" cargo 'exit 0'
@@ -2857,9 +2881,12 @@ else
   # them is what keeps this a real guard — a bare count of 2 would let a third `ok` in as
   # soon as someone removed one of these.
   pin_ok_total=$(printf '%s\n' "$pin_section" | grep -cE '^[[:space:]]*ok "' || true)
-  pin_ok_named=$(printf '%s\n' "$pin_section" | grep -cE '^[[:space:]]*ok "gate-pin: (VERIFIED|VERIFIED-NO-SYSTEM-FILE)' || true)
-  if [ -n "$pin_section" ] && [ "${pin_ok_total:-0}" = 2 ] && [ "${pin_ok_named:-0}" = 2 ]; then
-    ok "gate-pin: section 5b's ONLY success verdicts are VERIFIED and VERIFIED-NO-SYSTEM-FILE"
+  pin_ok_named=$(printf '%s\n' "$pin_section" | grep -cE '^[[:space:]]*ok "gate-pin: VERIFIED [(]' || true)
+  # ONE success verdict again (#3414 round 14): the non-Linux `ok` was deleted, because on a
+  # platform with no system-wide file to correlate against no verdict that reports a state
+  # is available. A second `ok` reappearing here means someone re-added an exemption.
+  if [ -n "$pin_section" ] && [ "${pin_ok_total:-0}" = 1 ] && [ "${pin_ok_named:-0}" = 1 ]; then
+    ok "gate-pin: section 5b's ONLY success verdict is VERIFIED (no platform exemption)"
   else
     bad "gate-pin: section 5b has ${pin_ok_total:-0} ok() call(s), ${pin_ok_named:-0} of them a named verdict"
   fi
@@ -3291,12 +3318,12 @@ else
   mk_stub "$shims_mac" uname 'echo Darwin'
   envf_ac="$tmp/pin-env-ac"; : >"$envf_ac"
   out_ac=$(runpin "$pinroot" "$shims_mac" "$envf_ac" HOME="$pin_home_plain")
-  if printf '%s' "$out_ac" | grep -qE '\[ok\].*gate-pin: VERIFIED-NO-SYSTEM-FILE' \
-     && printf '%s' "$out_ac" | grep -q 'does NOT establish the pin is system-wide' \
-     && ! printf '%s' "$out_ac" | grep -qE '\[warn\].*gate-pin'; then
-    ok "gate-pin: a non-Linux host WITH an honoured pin gets the scoped ok, worded to claim less"
+  if printf '%s' "$out_ac" | grep -qE '\[warn\].*gate-pin: UNMEASURED' \
+     && printf '%s' "$out_ac" | grep -q 'no PAM-read system-wide file to compare it against' \
+     && ! printf '%s' "$out_ac" | grep -qE '\[ok\].*gate-pin'; then
+    ok "gate-pin: a non-Linux host with a session-visible pin is UNMEASURED, never certified"
   else
-    bad "gate-pin: a non-Linux host with a good pin was not reported with the scoped verdict"
+    bad "gate-pin: a non-Linux host was given a verdict its platform cannot support"
     printf '%s\n' "$out_ac" | grep -i 'gate-pin' | head -3
   fi
 
@@ -3309,7 +3336,7 @@ else
   out_ac2=$(runpin "$pinroot" "$shims_mac_none" "$envf_ac2" HOME="$pin_home_plain")
   if ! printf '%s' "$out_ac2" | grep -qE '\[ok\].*gate-pin' \
      && printf '%s' "$out_ac2" | grep -qE '\[warn\].*gate-pin'; then
-    ok "gate-pin: an UNPINNED non-Linux host is NON-PASSING — no platform exemption certifies it"
+    ok "gate-pin: an UNPINNED non-Linux host is also NON-PASSING — no platform exemption certifies it"
   else
     bad "gate-pin: an unpinned non-Linux host was certified (the finding-BB defect)"
     printf '%s\n' "$out_ac2" | grep -i 'gate-pin' | head -3

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -3808,6 +3808,38 @@ exec env CQLITE_GATE_MAX_CONCURRENCY=1 "$@"'
     echo "  file-exists=$([ -e "$envf_bc" ] && echo yes || echo no) content=[$(cat "$envf_bc" 2>/dev/null | tr '\n' '|')]"
   fi
 
+  # 11bi. A PRE-LINK FAILURE MUST NOT TOUCH THE DESTINATION (roborev job 328, Medium — a
+  #      DESTRUCTIVE defect I introduced with the temp+`ln` rewrite). Exit 5 means the STAGING
+  #      write failed, so `ln` never ran and the destination was NEVER ours. The branch used to
+  #      `rm -f "$PIN_ENV_FILE"` unconditionally, so a provisioner that created
+  #      /etc/environment during our write had ITS file deleted by our "cleanup" — defeating
+  #      the exact no-clobber guarantee the rewrite exists for.
+  #
+  #      DRIVEN BY A READ-ONLY DIRECTORY, which is the one schedulable way to reach exit 5 from
+  #      the CLI: the destination is absent (so the create branch IS entered) and the temp
+  #      write then fails with EACCES.
+  #
+  #      WHAT THIS CASE CANNOT DO, stated rather than implied: it cannot schedule the RACE
+  #      itself. Entering the create branch requires the destination to be absent, and a peer
+  #      creating it mid-write is not something a test can time. So this asserts the reachable
+  #      half — the failure is reported and NOTHING is written or removed at the destination —
+  #      and the unreachable half rests on the code carrying no destination-`rm` on that path
+  #      at all, which is a structural property of a branch that now has none.
+  pin_ro_dir="$tmp/pin-ro-dir"; rm -rf "$pin_ro_dir"; mkdir -p "$pin_ro_dir"
+  envf_bi="$pin_ro_dir/env"; rm -f "$envf_bi"
+  chmod 0555 "$pin_ro_dir"
+  out_bi=$(runpin "$pinroot" "$shims_one" "$envf_bi" HOME="$pin_home_plain" --fix-gate-pin)
+  chmod 0755 "$pin_ro_dir" 2>/dev/null || true
+  if printf '%s' "$out_bi" | grep -q 'the pin was NOT persisted' \
+     && printf '%s' "$out_bi" | grep -q 'before .* was linked' \
+     && [ ! -e "$envf_bi" ]; then
+    ok "gate-pin: a staging-write failure reports itself and writes NOTHING at the destination (no destructive cleanup of a path that was never ours)"
+  else
+    bad "gate-pin: the pre-link failure path did not report cleanly, or touched the destination"
+    printf '%s\n' "$out_bi" | grep -iE 'gate-pin|staging|persisted|CREATED' | head -4
+    echo "  dest exists=$([ -e "$envf_bi" ] && echo yes || echo no)"
+  fi
+
   # 11bh. AN INVARIANT GUARD, EXPLICITLY *NOT* A DISCRIMINATOR FOR THE LOCK. Two concurrent
   #      runs must leave exactly ONE CQLITE_GATE_MAX_CONCURRENCY line, because pam_env
   #      resolves duplicates by taking the last.

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -3029,10 +3029,13 @@ else
   # to assert that pam_env reads the file in every stack; it now says those stacks were
   # CHECKED. Asserting the checked wording is the point — the earlier phrasing was a
   # statement about PAM in general, this one is a statement about THIS box.
-  if printf '%s' "$out_x" | grep -q 'session stacks were CHECKED to read it' \
+  # The PAM weaken-signal was DELETED (#3414 round 7 ruling), so the note no longer claims
+  # the service stacks were checked — it now states that they are NOT checked here. That
+  # is the whole point of the deletion: the note must not assert a scope nothing measured.
+  if printf '%s' "$out_x" | grep -q 'is NOT checked here' \
      && printf '%s' "$out_x" | grep -q 'created WITHOUT PAM' \
      && printf '%s' "$out_x" | grep -q 'max-concurrency=N(pinned)'; then
-    ok "gate-pin: the scope note claims the CHECKED scope and still names the no-PAM residual"
+    ok "gate-pin: the scope note states what it did NOT check and names the gate's token as authority"
   else
     bad "gate-pin: the scope note does not match the correlated verdict"
     printf '%s\n' "$out_x" | grep -iA 3 'gate-pin: VERIFIED' | head -4
@@ -3313,137 +3316,6 @@ else
     fi
   else
     skip "gate-pin sudo-invocation-mode cases (no passwordless sudo here)"
-  fi
-
-  # 11ao. PAM CONFIG IS A WEAKEN-ONLY SIGNAL (roborev round 5). If the sshd/login stacks
-  #      do not read the env file, a sudo-verified pin says nothing about the sessions
-  #      gates are launched from — so it DOWNGRADES. It may never create a VERIFIED, which
-  #      is what makes consulting config legitimate at all here.
-  #
-  #      The predicate is MEASURED, not guessed: pam_env's `readenv` DEFAULTS TO ON
-  #      (pam_env(8): "By default this option is on"), so a BARE `pam_env.so` reads the
-  #      file — requiring a literal `readenv=1` would flag this very box, whose
-  #      /etc/pam.d/sshd carries a bare one, and weaken a correct machine.
-  pin_pamd_ok="$tmp/pin-pamd-ok"; pin_pamd_gap="$tmp/pin-pamd-gap"
-  mkdir -p "$pin_pamd_ok" "$pin_pamd_gap"
-  printf 'session required pam_env.so\n'            >"$pin_pamd_ok/sshd"     # bare == reads it
-  printf 'session required pam_env.so readenv=1\n'  >"$pin_pamd_ok/login"
-  printf 'session required pam_unix.so\n'           >"$pin_pamd_gap/sshd"    # no pam_env
-  printf 'session required pam_env.so readenv=1\n'  >"$pin_pamd_gap/login"
-  envf_ao="$tmp/pin-env-ao"; printf 'CQLITE_GATE_MAX_CONCURRENCY=1\n' >"$envf_ao"
-  out_ao_ok=$(runpin "$pinroot" "$shims_one" "$envf_ao" HOME="$pin_home_plain" \
-    CQLITE_BOOTSTRAP_PAM_DIR="$pin_pamd_ok")
-  out_ao_gap=$(runpin "$pinroot" "$shims_one" "$envf_ao" HOME="$pin_home_plain" \
-    CQLITE_BOOTSTRAP_PAM_DIR="$pin_pamd_gap")
-  if printf '%s' "$out_ao_ok" | grep -qE '\[ok\].*gate-pin: VERIFIED' \
-     && printf '%s' "$out_ao_gap" | grep -q 'gate-pin: NOT-SYSTEM-WIDE' \
-     && printf '%s' "$out_ao_gap" | grep -q 'does NOT read' \
-     && ! printf '%s' "$out_ao_gap" | grep -qE '\[ok\].*gate-pin'; then
-    ok "gate-pin: a service stack that does not read the env file DOWNGRADES a would-be VERIFIED"
-  else
-    bad "gate-pin: the PAM-config signal did not weaken (or a bare pam_env.so was misread as a gap)"
-    printf '%s\n' "$out_ao_ok"  | grep -i 'gate-pin' | head -1
-    printf '%s\n' "$out_ao_gap" | grep -i 'gate-pin' | head -1
-  fi
-
-  # 11ap. ...and it is WEAKEN-ONLY: config alone must never CREATE a VERIFIED. A healthy
-  #      pam.d with the pin NOT visible to the session stays FAILED. Without this, 11ao's
-  #      positive half would pass against an implementation that let config decide.
-  envf_ap="$tmp/pin-env-ap"; printf 'CQLITE_GATE_MAX_CONCURRENCY=1\n' >"$envf_ap"
-  out_ap=$(runpin "$pinroot" "$shims_none" "$envf_ap" HOME="$pin_home_plain" \
-    CQLITE_BOOTSTRAP_PAM_DIR="$pin_pamd_ok")
-  if printf '%s' "$out_ap" | grep -q 'gate-pin: FAILED' \
-     && ! printf '%s' "$out_ap" | grep -qE '\[ok\].*gate-pin'; then
-    ok "gate-pin: a healthy PAM config cannot CREATE a VERIFIED when the session sees nothing"
-  else
-    bad "gate-pin: config was allowed to manufacture a positive verdict"
-    printf '%s\n' "$out_ap" | grep -i 'gate-pin' | head -2
-  fi
-
-  # 11aq. TWO WAYS THE WEAKEN-SIGNAL COULD MISREAD A STACK (issue #3414, lead refinement).
-  #      (a) `envfile=` REDIRECTS which file is read, so a pam_env line pointing at
-  #          /etc/default/locale — both real service files here carry one — is not
-  #          evidence about ours. A stack whose ONLY pam_env line was that would otherwise
-  #          read as pinned when it is not.
-  #      (b) A distro may factor pam_env into the COMMON stack via `@include`; both real
-  #          files carry `@include common-session`. Reading only the service file would
-  #          report "no pam_env" there and weaken a correct box — the red-on-correct-input
-  #          shape, for the fifth time. One level is followed; deeper is not, and the
-  #          diagnostic says so rather than asserting an absence it did not establish.
-  pin_pamd_inc="$tmp/pin-pamd-inc"; pin_pamd_loc="$tmp/pin-pamd-loc"
-  mkdir -p "$pin_pamd_inc" "$pin_pamd_loc"
-  printf '@include common-session\n'                                  >"$pin_pamd_inc/sshd"
-  printf 'session required pam_env.so\n'                              >"$pin_pamd_inc/common-session"
-  printf 'session required pam_env.so\n'                              >"$pin_pamd_inc/login"
-  printf 'session required pam_env.so envfile=/etc/default/locale\n'  >"$pin_pamd_loc/sshd"
-  printf 'session required pam_env.so\n'                              >"$pin_pamd_loc/login"
-  envf_aq="$tmp/pin-env-aq"; printf 'CQLITE_GATE_MAX_CONCURRENCY=1\n' >"$envf_aq"
-  out_aq_inc=$(runpin "$pinroot" "$shims_one" "$envf_aq" HOME="$pin_home_plain" \
-    CQLITE_BOOTSTRAP_PAM_DIR="$pin_pamd_inc")
-  out_aq_loc=$(runpin "$pinroot" "$shims_one" "$envf_aq" HOME="$pin_home_plain" \
-    CQLITE_BOOTSTRAP_PAM_DIR="$pin_pamd_loc")
-  if printf '%s' "$out_aq_inc" | grep -qE '\[ok\].*gate-pin: VERIFIED'; then
-    ok "gate-pin: pam_env reached only through @include is found (one level), not read as absent"
-  else
-    bad "gate-pin: a stack that loads pam_env via @include was wrongly weakened"
-    printf '%s\n' "$out_aq_inc" | grep -i 'gate-pin' | head -2
-  fi
-  if printf '%s' "$out_aq_loc" | grep -q 'gate-pin: NOT-SYSTEM-WIDE' \
-     && ! printf '%s' "$out_aq_loc" | grep -qE '\[ok\].*gate-pin'; then
-    ok "gate-pin: a pam_env line whose envfile= names ANOTHER file is not evidence for ours"
-  else
-    bad "gate-pin: an envfile=-redirected pam_env line was counted as reading our file"
-    printf '%s\n' "$out_aq_loc" | grep -i 'gate-pin' | head -2
-  fi
-  if printf '%s' "$out_aq_loc" | grep -q 'ONE level of @include'; then
-    ok "gate-pin: the gap diagnostic declares its own search limit (one @include level)"
-  else
-    bad "gate-pin: the gap diagnostic asserts an absence without naming how far it looked"
-  fi
-
-  # 11ar. AN UNREADABLE PAM STACK MUST NOT REACH VERIFIED (issue #3414 roborev round 6).
-  #      pin_pam_services_missing_readenv was called inside `$( )`, which FORKS — so its
-  #      PIN_PAM_UNCHECKED assignment happened in a subshell and was discarded. An
-  #      unreadable service config then produced VERIFIED *and* a scope note claiming the
-  #      stacks had been checked: a false positive plus a false statement about what was
-  #      measured. Only this branch loses the signal — the happy path works — which is why
-  #      it survived six review rounds, and why the case is written against the branch
-  #      rather than against the function.
-  #
-  #      Root can read a 0000 file, so as root the case would assert nothing.
-  if [ "$(id -u)" = 0 ]; then
-    skip "gate-pin unreadable-PAM-stack case (running as root: 0000 is still readable)"
-  else
-    pin_pamd_unread="$tmp/pin-pamd-unread"; mkdir -p "$pin_pamd_unread"
-    printf 'session required pam_env.so\n' >"$pin_pamd_unread/sshd"
-    printf 'session required pam_env.so\n' >"$pin_pamd_unread/login"
-    chmod 0000 "$pin_pamd_unread/sshd"
-    envf_ar="$tmp/pin-env-ar"; printf 'CQLITE_GATE_MAX_CONCURRENCY=1\n' >"$envf_ar"
-    out_ar=$(runpin "$pinroot" "$shims_one" "$envf_ar" HOME="$pin_home_plain" \
-      CQLITE_BOOTSTRAP_PAM_DIR="$pin_pamd_unread")
-    chmod 0644 "$pin_pamd_unread/sshd"
-    if printf '%s' "$out_ar" | grep -qE '\[warn\].*gate-pin: UNMEASURED' \
-       && printf '%s' "$out_ar" | grep -q 'could not be READ' \
-       && ! printf '%s' "$out_ar" | grep -qE '\[ok\].*gate-pin' \
-       && ! printf '%s' "$out_ar" | grep -q 'were CHECKED to read it'; then
-      ok "gate-pin: an UNREADABLE PAM stack is UNMEASURED, and the run does not claim the stacks were checked"
-    else
-      bad "gate-pin: an unreadable PAM stack reached a verdict it had not earned (subshell swallowed the signal?)"
-      printf '%s\n' "$out_ar" | grep -i 'gate-pin\|CHECKED' | head -3
-    fi
-  fi
-
-  # 11as. STRUCTURAL, and it is the half that generalises: a function whose purpose is to
-  #      SET a variable must be called directly, never in `$( )` or downstream of `|`,
-  #      because both fork and the assignment does not survive. CLAUDE.md already carries
-  #      this for the gate's cargo-output parse sites; it is a property of the shell, not
-  #      of that file. A future edit could reintroduce the substitution while 11ar still
-  #      passed on a readable box, so the call shape is asserted directly.
-  if grep -qE '^\s*pin_pam_services_missing_readenv$' "$BOOTSTRAP" \
-     && ! grep -qE '\$\(pin_pam_services_missing_readenv' "$BOOTSTRAP"; then
-    ok "gate-pin: the PAM check is called directly, not in a subshell that would discard its globals"
-  else
-    bad "gate-pin: the PAM check is back inside a command substitution — its result globals are lost"
   fi
 
   # 11k. The test seam is FAIL-CLOSED and has NO production fallback: set without its

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -56,6 +56,19 @@ export GIT_CONFIG_GLOBAL="$tmp/global-gitconfig"
 export GIT_CONFIG_NOSYSTEM=1
 : >"$GIT_CONFIG_GLOBAL"
 
+# --- /etc/environment isolation for the single-gate pin (issue #3414) -------
+# Section 5b persists CQLITE_GATE_MAX_CONCURRENCY into /etc/environment under --yes,
+# and several cases below run bootstrap with --yes. Without this the suite's verdict
+# would depend on the host's real system env file — and, on a root-run box, would
+# MUTATE it. The section's test seam redirects the write into this sandbox and, under
+# the required CQLITE_BOOTSTRAP_TEST_MODE marker, makes that write UNPRIVILEGED, so no
+# case here can reach a privileged write at all. Exported ONCE, like GIT_CONFIG_GLOBAL
+# above, so a case added later inherits the isolation without remembering to opt in;
+# the pin cases below override the FILE per case and leave the marker alone.
+export CQLITE_BOOTSTRAP_TEST_MODE=1
+export CQLITE_BOOTSTRAP_ENV_FILE="$tmp/etc-environment"
+: >"$CQLITE_BOOTSTRAP_ENV_FILE"
+
 # --- REAL-ORIGIN isolation for the push probe (issue #3369) ----------------
 # Section 3b now MEASURES push capability by actually pushing a throwaway
 # refs/claims/smoke-<commit-sha> ref (scripts/flow/claim.sh smoke). Every case that runs
@@ -2318,6 +2331,249 @@ if mknotifyroot "$tmp/notify-notarget" good; then
   fi
 else
   bad "notify no-target: could not stage the tree"
+fi
+
+# --- 11. Single-gate pin: the VERDICT is a session PROBE, not a file read (#3414) ---
+# The defect this closes, in the section's own words: it reported `ok` from a GREP of
+# the shell profile it had just written, or from the value it had INHERITED from its
+# own caller. Both were true on every fleet box at once while NO gate could see the
+# pin — Ubuntu's stock ~/.bashrc returns early for non-interactive shells — so every
+# gate resolved the #1825 cap from the default formula and admitted co-tenants.
+#
+# These cases assert the VERDICT, in the shape case 10 above established: a NEGATIVE
+# that the old code would have passed, its POSITIVE twin, and the degraded states that
+# must warn rather than pass. The probe's fresh PAM session is stood in for by a `sudo`
+# PATH shim, so nothing here needs sudo, root, or the host's real /etc/environment.
+
+# mkpinshims <dir> <persisted-value|-> : a hermetic PATH whose `sudo` stands in for a
+# fresh, profile-free session. `-` = a box where NOTHING is persisted system-wide, so
+# the session starts from exactly the environment it was handed and injects nothing —
+# which is what makes it able to catch a bootstrap that forgot to scrub its own
+# inherited value. A value = a box where the pin IS persisted: the session injects it,
+# as pam_env would from /etc/environment.
+mkpinshims() {
+  local dir="$1" val="$2" t bin
+  mk_hermetic_bin "$dir"
+  # mk_hermetic_bin links the coreutils the mold/cred cases need; the pin section also
+  # needs `id` (to name the probe's runas user), `tee` (the append) and `true` (the
+  # `sudo -n true` availability probe — the shim EXECs it, and on a hermetic PATH a
+  # missing /usr/bin/true makes that probe look like a sudo that needs a password).
+  for t in id tee true; do
+    bin=$(type -P "$t" 2>/dev/null) || continue
+    [ -n "$bin" ] && ln -sf "$bin" "$dir/$t" 2>/dev/null || true
+  done
+  if [ "$val" = "-" ]; then
+    mk_stub "$dir" sudo 'while [ "${1:-}" = "-n" ]; do shift; done
+if [ "${1:-}" = "-u" ]; then shift 2; fi
+exec "$@"'
+  else
+    mk_stub "$dir" sudo "while [ \"\${1:-}\" = \"-n\" ]; do shift; done
+if [ \"\${1:-}\" = \"-u\" ]; then shift 2; fi
+exec env CQLITE_GATE_MAX_CONCURRENCY=$val \"\$@\""
+  fi
+}
+
+# runpin <root-dir> <shim-dir> <env-file> [NAME=VALUE...] [--flag...] — one bootstrap
+# run. NAME=VALUE arguments become environment; anything starting with `-` becomes a
+# bootstrap flag. HOME is per-call so a case can control what the shell profile says.
+#
+# CQLITE_GATE_MAX_CONCURRENCY IS SCRUBBED FROM EVERY CALL, and a case that wants it set
+# passes it explicitly: this suite runs on fleet boxes that export the pin, so an
+# inherited value would otherwise decide 11b's verdict instead of the case's own input.
+# `env` applies its `-u` options before the NAME=VALUE assignments, so passing it still
+# works.
+runpin() {
+  local root="$1" shims="$2" envfile="$3"; shift 3
+  local -a pin_env=() pin_flags=()
+  local a
+  for a in "$@"; do
+    case "$a" in
+      -*) pin_flags+=("$a") ;;
+      *) pin_env+=("$a") ;;
+    esac
+  done
+  env -u CQLITE_GATE_MAX_CONCURRENCY \
+    PATH="$shims" CARGO_HOME="$tmp/pin-cargo" \
+    CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="$envfile" \
+    ${pin_env[@]+"${pin_env[@]}"} \
+    timeout -s KILL 300 bash "$root/scripts/bootstrap-agent-machine.sh" \
+      --skip-smoke ${pin_flags[@]+"${pin_flags[@]}"} 2>&1
+}
+
+pinroot="$tmp/pin-root"
+if ! mknotifyroot "$pinroot" good; then
+  bad "gate-pin: could not stage the bootstrap tree"
+else
+  mkdir -p "$tmp/pin-cargo"
+  pin_home_plain="$tmp/pin-home-plain"; mkdir -p "$pin_home_plain/.cargo"
+
+  # 11a. THE CASE. Nothing is persisted, but bootstrap's OWN environment carries the
+  #      value — which is the normal state of a re-run on a fleet box. An unscrubbed
+  #      probe returns the inherited value and reports the box healthy, i.e. it
+  #      certifies exactly the failure this section exists to catch. Must be FAILED.
+  shims_none="$tmp/pin-shims-none"; mkpinshims "$shims_none" -
+  envf_a="$tmp/pin-env-a"; : >"$envf_a"
+  out_a=$(runpin "$pinroot" "$shims_none" "$envf_a" HOME="$pin_home_plain" \
+    CQLITE_GATE_MAX_CONCURRENCY=7)
+  if printf '%s' "$out_a" | grep -q 'gate-pin: FAILED' \
+     && ! printf '%s' "$out_a" | grep -q 'gate-pin: VERIFIED'; then
+    ok "gate-pin: an INHERITED-but-not-persisted value is FAILED, never VERIFIED (the scrub is honoured)"
+  else
+    bad "gate-pin: an inherited value was accepted as evidence the box is pinned"
+    printf '%s\n' "$out_a" | grep -i 'gate-pin' | head -3
+  fi
+
+  # 11b. POSITIVE twin: the pin IS visible to a fresh session (and this run's own
+  #      environment does NOT carry it), so VERIFIED must be reachable. Without this,
+  #      11a would also pass against a section that can only ever say FAILED.
+  shims_one="$tmp/pin-shims-one"; mkpinshims "$shims_one" 1
+  envf_b="$tmp/pin-env-b"; printf 'CQLITE_GATE_MAX_CONCURRENCY=1\n' >"$envf_b"
+  out_b=$(runpin "$pinroot" "$shims_one" "$envf_b" HOME="$pin_home_plain")
+  if printf '%s' "$out_b" | grep -q 'gate-pin: VERIFIED' \
+     && ! printf '%s' "$out_b" | grep -q 'gate-pin: FAILED'; then
+    ok "gate-pin: a pin a fresh profile-free session CAN see is reported VERIFIED"
+  else
+    bad "gate-pin: a genuinely visible pin was not reported VERIFIED"
+    printf '%s\n' "$out_b" | grep -i 'gate-pin' | head -3
+  fi
+
+  # 11c. NO SUDO BINARY: no session can be created, so nothing was measured. It must
+  #      warn — an unmeasured capability may never inherit the permissive branch.
+  shims_nosudo="$tmp/pin-shims-nosudo"; mkpinshims "$shims_nosudo" -; rm -f "$shims_nosudo/sudo"
+  envf_c="$tmp/pin-env-c"; : >"$envf_c"
+  out_c=$(runpin "$pinroot" "$shims_nosudo" "$envf_c" HOME="$pin_home_plain" \
+    CQLITE_GATE_MAX_CONCURRENCY=7)
+  if printf '%s' "$out_c" | grep -qE '\[warn\].*gate-pin: UNMEASURED' \
+     && printf '%s' "$out_c" | grep -q "no 'sudo' on this box" \
+     && ! printf '%s' "$out_c" | grep -qE '\[ok\].*gate-pin'; then
+    ok "gate-pin: no sudo binary => UNMEASURED as a [warn], never an [ok]"
+  else
+    bad "gate-pin: a box with no sudo did not report UNMEASURED-as-a-warn"
+    printf '%s\n' "$out_c" | grep -i 'gate-pin' | head -3
+  fi
+
+  # 11d. SUDO NEEDS A PASSWORD: `sudo -n` never prompts, so the probe cannot run.
+  #      Same posture, different cause text — a remedy that names the wrong cause
+  #      costs the operator a cycle before they learn it does not apply.
+  shims_pw="$tmp/pin-shims-pw"; mkpinshims "$shims_pw" -; mk_stub "$shims_pw" sudo 'exit 1'
+  envf_d="$tmp/pin-env-d"; : >"$envf_d"
+  out_d=$(runpin "$pinroot" "$shims_pw" "$envf_d" HOME="$pin_home_plain" \
+    CQLITE_GATE_MAX_CONCURRENCY=7)
+  if printf '%s' "$out_d" | grep -qE '\[warn\].*gate-pin: UNMEASURED' \
+     && printf '%s' "$out_d" | grep -q 'sudo needs a password' \
+     && ! printf '%s' "$out_d" | grep -qE '\[ok\].*gate-pin'; then
+    ok "gate-pin: passwordless sudo unavailable => UNMEASURED as a [warn], with its own cause"
+  else
+    bad "gate-pin: a password-requiring sudo did not report UNMEASURED-as-a-warn"
+    printf '%s\n' "$out_d" | grep -i 'gate-pin' | head -3
+  fi
+
+  # 11e. --yes PERSISTS into the system env file, and does so IDEMPOTENTLY. Two runs
+  #      must leave exactly one CQLITE_GATE_MAX_CONCURRENCY line: /etc/environment is
+  #      a hot, hand-edited file and a bootstrap that appends on every re-run would
+  #      grow it without bound.
+  envf_e="$tmp/pin-env-e"; : >"$envf_e"
+  runpin "$pinroot" "$shims_none" "$envf_e" HOME="$pin_home_plain" --yes >/dev/null 2>&1
+  runpin "$pinroot" "$shims_none" "$envf_e" HOME="$pin_home_plain" --yes >/dev/null 2>&1
+  pin_e_n=$(grep -c '^CQLITE_GATE_MAX_CONCURRENCY=1$' "$envf_e" 2>/dev/null || true)
+  if [ "${pin_e_n:-0}" = 1 ]; then
+    ok "gate-pin: --yes persists the pin into the system env file, idempotently across re-runs"
+  else
+    bad "gate-pin: expected exactly one persisted pin line, got ${pin_e_n:-0}"
+    cat "$envf_e"
+  fi
+
+  # 11f. AN EXISTING VALUE IS NEVER REWRITTEN. A box deliberately running >1
+  #      concurrent gate overrides the pin, and clobbering that back to 1 on the next
+  #      bootstrap would be a silent regression of a deliberate operator decision.
+  envf_f="$tmp/pin-env-f"; printf 'CQLITE_GATE_MAX_CONCURRENCY=4\n' >"$envf_f"
+  runpin "$pinroot" "$shims_none" "$envf_f" HOME="$pin_home_plain" --yes >/dev/null 2>&1
+  if [ "$(cat "$envf_f")" = "CQLITE_GATE_MAX_CONCURRENCY=4" ]; then
+    ok "gate-pin: an existing CQLITE_GATE_MAX_CONCURRENCY value is left EXACTLY as it is"
+  else
+    bad "gate-pin: --yes rewrote a deliberate override"
+    cat "$envf_f"
+  fi
+
+  # 11g. A file whose last byte is not a newline must not have the pin welded onto its
+  #      final line — pam_env would read the join as one malformed entry, i.e. the
+  #      write would silently un-persist whatever was already there.
+  envf_g="$tmp/pin-env-g"; printf 'FOO=bar' >"$envf_g"
+  runpin "$pinroot" "$shims_none" "$envf_g" HOME="$pin_home_plain" --yes >/dev/null 2>&1
+  if grep -q '^FOO=bar$' "$envf_g" && grep -q '^CQLITE_GATE_MAX_CONCURRENCY=1$' "$envf_g"; then
+    ok "gate-pin: appending to a file with no trailing newline keeps both lines intact"
+  else
+    bad "gate-pin: the append welded onto the previous line"
+    cat -A "$envf_g" | head -3
+  fi
+
+  # 11h. PRESENCE IN A PROFILE CAN NO LONGER REPORT SUCCESS. The profile carries the
+  #      export AND this run inherits the value — the exact pair of proxies the old
+  #      code passed on — while nothing is persisted where a session reads it.
+  pin_home_prof="$tmp/pin-home-prof"; mkdir -p "$pin_home_prof/.cargo"
+  printf 'export CQLITE_GATE_MAX_CONCURRENCY=1\n' >"$pin_home_prof/.bashrc"
+  envf_h="$tmp/pin-env-h"; : >"$envf_h"
+  out_h=$(runpin "$pinroot" "$shims_none" "$envf_h" HOME="$pin_home_prof" \
+    SHELL=/bin/bash CQLITE_GATE_MAX_CONCURRENCY=7)
+  if printf '%s' "$out_h" | grep -q 'gate-pin: FAILED' \
+     && ! printf '%s' "$out_h" | grep -qE '\[ok\].*(gate-pin|CQLITE_GATE_MAX_CONCURRENCY)'; then
+    ok "gate-pin: a profile that carries the export produces NO success verdict"
+  else
+    bad "gate-pin: a profile grep (or the inherited value) still bought a success verdict"
+    printf '%s\n' "$out_h" | grep -iE 'gate-pin|CQLITE_GATE_MAX_CONCURRENCY' | head -4
+  fi
+
+  # 11i. STRUCTURAL, because the behavioural cases above can only cover the branches
+  #      someone thought of: section 5b must contain EXACTLY ONE `ok` call, and it
+  #      must be the probe's VERIFIED verdict. Any future `ok` added for a file write,
+  #      a profile grep or an inherited value reds this immediately.
+  pin_section=$(awk '/^# ---- 5b\./,/^# ---- 5c\./' "$BOOTSTRAP")
+  pin_ok_total=$(printf '%s\n' "$pin_section" | grep -cE '^[[:space:]]*ok "' || true)
+  pin_ok_verified=$(printf '%s\n' "$pin_section" | grep -cE '^[[:space:]]*ok "gate-pin: VERIFIED' || true)
+  if [ -n "$pin_section" ] && [ "${pin_ok_total:-0}" = 1 ] && [ "${pin_ok_verified:-0}" = 1 ]; then
+    ok "gate-pin: section 5b's ONLY success verdict is the probe's VERIFIED line"
+  else
+    bad "gate-pin: section 5b has ${pin_ok_total:-0} ok() call(s), ${pin_ok_verified:-0} of them the probe verdict"
+  fi
+
+  # 11j. The OPT-OUT is loud and NON-PASSING: a switch that returned `ok` would be a
+  #      way to buy a vacuous green, which is the failure mode this section removes.
+  envf_j="$tmp/pin-env-j"; : >"$envf_j"
+  out_j=$(env PATH="$shims_one" HOME="$pin_home_plain" CARGO_HOME="$tmp/pin-cargo" \
+    CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="$envf_j" \
+    timeout -s KILL 300 bash "$pinroot/scripts/bootstrap-agent-machine.sh" \
+      --skip-smoke --skip-gate-pin 2>&1)
+  if printf '%s' "$out_j" | grep -qE '\[warn\].*gate-pin: OPT-OUT' \
+     && ! printf '%s' "$out_j" | grep -qE '\[ok\].*gate-pin'; then
+    ok "gate-pin: --skip-gate-pin is a [warn] OPT-OUT that can never buy a green"
+  else
+    bad "gate-pin: the opt-out did not report as a non-passing OPT-OUT"
+    printf '%s\n' "$out_j" | grep -i 'gate-pin' | head -3
+  fi
+
+  # 11k. The test seam is FAIL-CLOSED and has NO production fallback: set without its
+  #      marker, or relative, it SKIPS the section rather than silently persisting to
+  #      the real /etc/environment (the #3249 lesson — a seam that degrades to the
+  #      production path certifies the production path by accident).
+  envf_k="$tmp/pin-env-k"; : >"$envf_k"
+  # `-u CQLITE_BOOTSTRAP_TEST_MODE` is the point of this half: the marker is exported
+  # suite-wide for host safety, and the case is about a seam set WITHOUT it.
+  out_k=$(env -u CQLITE_BOOTSTRAP_TEST_MODE \
+    PATH="$shims_one" HOME="$pin_home_plain" CARGO_HOME="$tmp/pin-cargo" \
+    CQLITE_BOOTSTRAP_ENV_FILE="$envf_k" \
+    timeout -s KILL 300 bash "$pinroot/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+  out_k2=$(env PATH="$shims_one" HOME="$pin_home_plain" CARGO_HOME="$tmp/pin-cargo" \
+    CQLITE_BOOTSTRAP_TEST_MODE=1 CQLITE_BOOTSTRAP_ENV_FILE="relative/env" \
+    timeout -s KILL 300 bash "$pinroot/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+  if printf '%s' "$out_k" | grep -q 'gate-pin: SKIPPED' \
+     && printf '%s' "$out_k2" | grep -q 'gate-pin: SKIPPED' \
+     && ! printf '%s' "$out_k" | grep -qE '\[ok\].*gate-pin'; then
+    ok "gate-pin: the test seam is fail-closed (no marker / relative path => SKIPPED, no fallback)"
+  else
+    bad "gate-pin: the test seam was honoured without its marker, or accepted a relative path"
+    printf '%s\n' "$out_k" | grep -i 'gate-pin' | head -2
+    printf '%s\n' "$out_k2" | grep -i 'gate-pin' | head -2
+  fi
 fi
 
 echo

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -2486,13 +2486,18 @@ else
   # 11f. AN EXISTING VALUE IS NEVER REWRITTEN. A box deliberately running >1
   #      concurrent gate overrides the pin, and clobbering that back to 1 on the next
   #      bootstrap would be a silent regression of a deliberate operator decision.
+  #      The run must also SAY it left the value alone: asserting only that the file is
+  #      unchanged is satisfied by a bootstrap that never writes at all, so the case
+  #      would pass against the very code this replaces.
   envf_f="$tmp/pin-env-f"; printf 'CQLITE_GATE_MAX_CONCURRENCY=4\n' >"$envf_f"
-  runpin "$pinroot" "$shims_none" "$envf_f" HOME="$pin_home_plain" --yes >/dev/null 2>&1
-  if [ "$(cat "$envf_f")" = "CQLITE_GATE_MAX_CONCURRENCY=4" ]; then
-    ok "gate-pin: an existing CQLITE_GATE_MAX_CONCURRENCY value is left EXACTLY as it is"
+  out_f=$(runpin "$pinroot" "$shims_none" "$envf_f" HOME="$pin_home_plain" --yes)
+  if [ "$(cat "$envf_f")" = "CQLITE_GATE_MAX_CONCURRENCY=4" ] \
+     && printf '%s' "$out_f" | grep -q 'already carries a CQLITE_GATE_MAX_CONCURRENCY line — left EXACTLY as it is'; then
+    ok "gate-pin: an existing CQLITE_GATE_MAX_CONCURRENCY value is left EXACTLY as it is, and the run says so"
   else
-    bad "gate-pin: --yes rewrote a deliberate override"
+    bad "gate-pin: --yes rewrote a deliberate override (or never looked at the file)"
     cat "$envf_f"
+    printf '%s\n' "$out_f" | grep -i 'gate-pin\|already carries' | head -2
   fi
 
   # 11g. A file whose last byte is not a newline must not have the pin welded onto its

--- a/scripts/tests/test_gate_cpu_budget.sh
+++ b/scripts/tests/test_gate_cpu_budget.sh
@@ -269,6 +269,37 @@ else
   bad "source: a leading-zero value was misread or errored in the cpu-budget line"
 fi
 
+# A DIGIT STRING TOO LARGE TO REPRESENT MUST NOT WRAP INTO A PIN (roborev job 332).
+# `10#$v` on an unrepresentable decimal wraps SILENTLY. Measured before the fix:
+#   ...=99999999999999999999 -> max-concurrency=7766279631452241919(pinned)
+#   ...=9223372036854775808  -> max-concurrency=1(clamped)
+# The first AFFIRMS A PIN AT A VALUE NOBODY SET, which inverts the one property this token
+# exists to carry; the second mislabels an unusable value as a deliberate 0. Both are now
+# `invalid` — refused BY DIGIT COUNT, before the arithmetic, since the bound cannot be
+# decided by the operation that is the defect. The 18/19-digit boundary is asserted in BOTH
+# directions: a bound that refused everything, or nothing, would pass a one-sided check.
+ov_ok=1
+for _ov in "99999999999999999999 3 invalid" "9223372036854775808 3 invalid" \
+           "1000000000000000000 3 invalid" "999999999999999999 999999999999999999 pinned" \
+           "4294967296 4294967296 pinned"; do
+  set -- $_ov
+  _ovline=$(cpu_budget AGENT_GATE_TEST_NCPU=16 CQLITE_GATE_MAX_CONCURRENCY="$1" 2>&1)
+  _ovgot="$(budget_n "$_ovline")($(budget_source "$_ovline"))"
+  [ "$_ovgot" = "$2($3)" ] || { ov_ok=0; echo "  '$1' should give $2($3), got '$_ovgot'"; }
+  # the wrap produced a number the operator never set; assert the value is never invented
+  case "$_ovgot" in
+    *7766279631452241919*) ov_ok=0; echo "  '$1' wrapped into a fabricated cap" ;;
+  esac
+  case "$_ovline" in
+    *"out of range"*|*"value too great"*) ov_ok=0; echo "  '$1' errored in the budget line" ;;
+  esac
+done
+if [ "$ov_ok" = 1 ]; then
+  ok "source: an unrepresentable digit string is invalid, refused by digit count before the arithmetic (18 digits pinned, 19 invalid)"
+else
+  bad "source: an oversized value wrapped, errored, or was misclassified in the cpu-budget line"
+fi
+
 echo
 echo "PASS=$PASS FAIL=$FAIL SKIP=$SKIPS"
 [ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_gate_cpu_budget.sh
+++ b/scripts/tests/test_gate_cpu_budget.sh
@@ -245,6 +245,30 @@ else
   bad "source: N looks resolved in more than one place (a second resolver can drift from the slot cap)"
 fi
 
+# LEADING-ZERO VALUES MUST NOT REACH THE ARITHMETIC AS OCTAL (roborev job 331, Medium).
+# The digit-only guard admits `08`, and bash reads a leading zero as OCTAL — where `08` and
+# `09` are not valid octal — so the value flowed into `cores=$(( _ncpu / n ))` and the GATE
+# ERRORED OUT instead of resolving a cap. Measured before the fix:
+#   CQLITE_GATE_MAX_CONCURRENCY=08 -> "line 1301: 08: value too great for base"
+# Erroring is worse than either honouring or refusing the value, because a gate that dies
+# inside its own budget line produces no verdict at all. `10#` forces base 10 and the value is
+# normalised, so the SUMMARY reports the cap actually honoured.
+zz_ok=1
+for _zz in "08 8 pinned" "09 9 pinned" "01 1 pinned" "0 1 clamped"; do
+  set -- $_zz
+  _zline=$(cpu_budget AGENT_GATE_TEST_NCPU=16 CQLITE_GATE_MAX_CONCURRENCY="$1" 2>&1)
+  _zgot="$(budget_n "$_zline")($(budget_source "$_zline"))"
+  [ "$_zgot" = "$2($3)" ] || { zz_ok=0; echo "  '$1' should give $2($3), got '$_zgot'"; }
+  case "$_zline" in
+    *"value too great for base"*) zz_ok=0; echo "  '$1' produced an octal arithmetic error in the budget line" ;;
+  esac
+done
+if [ "$zz_ok" = 1 ]; then
+  ok "source: leading-zero values are read base-10 (08->8, 09->9, 01->1, 0->1 clamped) and never reach the arithmetic as octal"
+else
+  bad "source: a leading-zero value was misread or errored in the cpu-budget line"
+fi
+
 echo
 echo "PASS=$PASS FAIL=$FAIL SKIP=$SKIPS"
 [ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_gate_cpu_budget.sh
+++ b/scripts/tests/test_gate_cpu_budget.sh
@@ -24,8 +24,14 @@ GATE="$SCRIPT_DIR/../agent-gate.sh"
 
 PASS=0
 FAIL=0
+SKIPS=0
 ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
 bad() { printf 'FAIL - %s\n' "$1"; PASS=$PASS; FAIL=$((FAIL + 1)); }
+# A SKIP IS NOT A PASS (#3414 roborev round 2). The host-conditional case below announced
+# itself through `ok`, which incremented PASS and reported nothing skipped — so a suite
+# total could not distinguish "ran and passed" from "did not run", which is the same
+# proxy-for-a-fact shape this issue exists to remove, one directory over.
+skip() { printf 'skip - %s\n' "$1"; SKIPS=$((SKIPS + 1)); }
 
 # budget_field <line> <field>: extract "<field>=<value>" from a `cpu-budget:` line.
 budget_field() {
@@ -142,7 +148,7 @@ if [ "$(uname -s)" = Darwin ] && command -v taskpolicy >/dev/null 2>&1; then
     bad "wrapper-active line not well-formed (space leaked from '$w'?): $wline"
   fi
 else
-  ok "SKIP wrapper-engage case (not macOS-with-taskpolicy)"
+  skip "wrapper-engage case (not macOS-with-taskpolicy)"
 fi
 
 # --- 8. The cpu-budget line is well-formed (all fields present) ---
@@ -240,5 +246,5 @@ else
 fi
 
 echo
-echo "PASS=$PASS FAIL=$FAIL"
+echo "PASS=$PASS FAIL=$FAIL SKIP=$SKIPS"
 [ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_gate_cpu_budget.sh
+++ b/scripts/tests/test_gate_cpu_budget.sh
@@ -44,8 +44,17 @@ budget_field() {
 # them here to unit-test the derivation against the test's OWN pinned inputs
 # rather than the ambient parent-gate state (else 2/3/6/8 fail nested but pass
 # standalone). `env -u` per-invocation keeps each case's inputs fully controlled.
+#
+# CQLITE_GATE_MAX_CONCURRENCY IS SCRUBBED HERE TOO (issue #3414). Every fleet box
+# exports it (bootstrap pins it in /etc/environment), so without the scrub the
+# `default` source case — the one that reproduces the #3414 fleet condition — could
+# never be exercised on the machines that run this suite: it would inherit `1` and
+# report `pinned`, passing for the wrong reason. `env` applies its `-u` options
+# before the NAME=VALUE assignments, so a case that PASSES the variable still gets
+# the value it asked for, and a case that omits it gets a genuinely unset variable.
 cpu_budget() {
   env -u CARGO_BUILD_JOBS -u AGENT_GATE_WRAPPED -u AGENT_GATE_WRAPPER \
+    -u CQLITE_GATE_MAX_CONCURRENCY \
     CQLITE_GATE_NO_NICE=1 "$@" bash "$GATE" --cpu-budget 2>/dev/null | grep -E '^cpu-budget: ' | head -1
 }
 
@@ -127,7 +136,7 @@ if [ "$(uname -s)" = Darwin ] && command -v taskpolicy >/dev/null 2>&1; then
   # underlying command is `taskpolicy -c utility` (spaces), which must NOT leak
   # `-c`/`utility` into the space-delimited cpu-budget line (roborev #2640).
   if printf '%s\n' "$wline" \
-     | grep -Eq '^cpu-budget: wrapper=[^ ]+ ncpu=[0-9]+ max-concurrency=[0-9]+ cores-per-gate=[0-9]+ build-jobs=[0-9]+\((derived|caller)\) test-threads=[0-9]+$'; then
+     | grep -Eq '^cpu-budget: wrapper=[^ ]+ ncpu=[0-9]+ max-concurrency=[0-9]+\((pinned|default|invalid|clamped)\) cores-per-gate=[0-9]+ build-jobs=[0-9]+\((derived|caller)\) test-threads=[0-9]+$'; then
     ok "wrapper-active cpu-budget line stays single-token/well-formed: $wline"
   else
     bad "wrapper-active line not well-formed (space leaked from '$w'?): $wline"
@@ -139,10 +148,95 @@ fi
 # --- 8. The cpu-budget line is well-formed (all fields present) ---
 line=$(cpu_budget AGENT_GATE_TEST_NCPU=16 CQLITE_GATE_MAX_CONCURRENCY=2)
 if printf '%s\n' "$line" \
-   | grep -Eq '^cpu-budget: wrapper=[^ ]+ ncpu=[0-9]+ max-concurrency=[0-9]+ cores-per-gate=[0-9]+ build-jobs=[0-9]+\((derived|caller)\) test-threads=[0-9]+$'; then
+   | grep -Eq '^cpu-budget: wrapper=[^ ]+ ncpu=[0-9]+ max-concurrency=[0-9]+\((pinned|default|invalid|clamped)\) cores-per-gate=[0-9]+ build-jobs=[0-9]+\((derived|caller)\) test-threads=[0-9]+$'; then
   ok "cpu-budget line well-formed: $line"
 else
   bad "malformed cpu-budget line: $line"
+fi
+
+# --- 9. WHERE N CAME FROM is reported, not just N (issue #3414) ---------------
+# `max-concurrency=3` alone cannot distinguish a box PINNED at 3 from one that
+# DEFAULTED there because nothing set the variable — the exact condition that ran
+# unseen across the whole fleet: the pin was present in ~/.bashrc and invisible to
+# every non-interactive shell, so every gate resolved N from the #1825 formula,
+# admitted co-tenants, and no pasted artifact said so. Four source tokens, each
+# asserted against the VALUE it must accompany, because a token that is right while
+# the number is wrong (or vice versa) is the same unreadable artifact.
+budget_source() {  # budget_source <line>: the "(...)" suffix of max-concurrency=N(...)
+  local f; f=$(budget_field "$1" max-concurrency)
+  case "$f" in *"("*")") f=${f#*(}; printf '%s' "${f%)}" ;; *) printf '' ;; esac
+}
+budget_n() {       # budget_n <line>: the numeric part of max-concurrency=N(...)
+  local f; f=$(budget_field "$1" max-concurrency); printf '%s' "${f%%(*}"
+}
+
+# 9a. UNSET => the #1825 formula max(2,(ncpu-2)/4) = 3 on 16 cores, marked (default).
+line=$(cpu_budget AGENT_GATE_TEST_NCPU=16)
+if [ "$(budget_n "$line")" = 3 ] && [ "$(budget_source "$line")" = default ]; then
+  ok "source: UNSET => max-concurrency=3(default) on 16 cores"
+else
+  bad "source: UNSET should give 3(default), got max-concurrency=$(budget_field "$line" max-concurrency)"
+fi
+
+# 9b. A valid pin is used verbatim and marked (pinned) — the state a correctly
+#     provisioned box must show, so a missing pin is visible on the FIRST summary.
+line=$(cpu_budget AGENT_GATE_TEST_NCPU=16 CQLITE_GATE_MAX_CONCURRENCY=1)
+if [ "$(budget_n "$line")" = 1 ] && [ "$(budget_source "$line")" = pinned ]; then
+  ok "source: CQLITE_GATE_MAX_CONCURRENCY=1 => max-concurrency=1(pinned)"
+else
+  bad "source: an explicit pin should be 1(pinned), got max-concurrency=$(budget_field "$line" max-concurrency)"
+fi
+
+# 9c. A NON-NUMERIC value is silently discarded for the formula. Without the token
+#     that box is textually identical to 9a, which is the #3414 failure shape.
+line=$(cpu_budget AGENT_GATE_TEST_NCPU=16 CQLITE_GATE_MAX_CONCURRENCY=abc)
+if [ "$(budget_n "$line")" = 3 ] && [ "$(budget_source "$line")" = invalid ]; then
+  ok "source: a non-numeric value falls back to the formula and is marked (invalid)"
+else
+  bad "source: 'abc' should give 3(invalid), got max-concurrency=$(budget_field "$line" max-concurrency)"
+fi
+
+# 9d. SET-BUT-EMPTY is a DIFFERENT fact from UNSET and must not read as (default).
+#     `${VAR:-dflt}` cannot tell them apart; `${VAR+set}` can. This case is the one
+#     that pins that distinction — a mis-set tmux/systemd/CI variable lands here.
+line=$(cpu_budget AGENT_GATE_TEST_NCPU=16 CQLITE_GATE_MAX_CONCURRENCY=)
+if [ "$(budget_n "$line")" = 3 ] && [ "$(budget_source "$line")" = invalid ]; then
+  ok "source: an EMPTY value is (invalid), never (default)"
+else
+  bad "source: an empty value should give 3(invalid), got max-concurrency=$(budget_field "$line" max-concurrency)"
+fi
+
+# 9e. A valid integer < 1 is silently raised to 1 — reported as (clamped), never as
+#     (pinned): the operator asked for 0 and got 1, and only the token says so.
+line=$(cpu_budget AGENT_GATE_TEST_NCPU=16 CQLITE_GATE_MAX_CONCURRENCY=0)
+if [ "$(budget_n "$line")" = 1 ] && [ "$(budget_source "$line")" = clamped ]; then
+  ok "source: 0 is clamped to 1 and marked (clamped)"
+else
+  bad "source: 0 should give 1(clamped), got max-concurrency=$(budget_field "$line" max-concurrency)"
+fi
+
+# 9f. The source token must never break the space-delimited token grammar: it lives
+#     INSIDE the max-concurrency token, exactly as build-jobs carries its own source.
+#     (6 key=value tokens after the `cpu-budget:` label = 7 whitespace-separated words.)
+line=$(cpu_budget AGENT_GATE_TEST_NCPU=16 CQLITE_GATE_MAX_CONCURRENCY=2)
+if [ "$(printf '%s\n' "$line" | wc -w | tr -d ' ')" = 7 ]; then
+  ok "source: the token count is unchanged (max-concurrency stays ONE token): $line"
+else
+  bad "source: the source token leaked a space into the cpu-budget line: $line"
+fi
+
+# 9g. ONE resolution, structurally. The slot semaphore (acquire_gate_slot) and the
+#     SUMMARY line must report the SAME N — a second, independently-recomputing
+#     resolver could drift, and then the cap the gate ENFORCES and the cap the
+#     pasted block NAMES would be different numbers with no way to tell. Asserted
+#     against the source because the divergence is unobservable from output alone:
+#     both would look plausible.
+if grep -q '^_gate_max_concurrency() { printf .%s. "\$GATE_MAX_CONCURRENCY"; }$' "$GATE" \
+   && [ "$(grep -c 'GATE_MAX_CONCURRENCY_SOURCE=' "$GATE")" -ge 1 ] \
+   && [ "$(grep -c 'CQLITE_GATE_MAX_CONCURRENCY+set' "$GATE")" = 1 ]; then
+  ok "source: N is resolved ONCE (_gate_max_concurrency reads the single global)"
+else
+  bad "source: N looks resolved in more than one place (a second resolver can drift from the slot cap)"
 fi
 
 echo

--- a/scripts/tests/test_perf_capability_bootstrap.sh
+++ b/scripts/tests/test_perf_capability_bootstrap.sh
@@ -32,6 +32,18 @@ set -uo pipefail
 # shellcheck source=scripts/tests/lib/perf-capability-test-lib.sh
 . "$(cd "$(dirname "$0")" && pwd)/lib/perf-capability-test-lib.sh"
 
+# --- KEEP BOOTSTRAP'S SINGLE-GATE PIN SECTION OUT OF THIS SUITE (issue #3414) ------
+# Section 5b probes PAM visibility with `sudo -n -u <self> …` and, under --yes,
+# persists to /etc/environment. Neither is this suite's subject, and both would land
+# in the perf TRIPWIRES below — whose asserts read EVERY `^sudo ` line and would
+# report the pin probe as a perf-section mutation — and, on a root-run box, in the
+# real /etc/environment. The pin section's own loud, non-passing opt-out keeps it
+# entirely out of the way; exported ONCE here so a case added later inherits it
+# without having to remember (same posture as the GIT_CONFIG_GLOBAL isolation in the
+# sibling bootstrap suite). Section 5b's own coverage lives in
+# scripts/tests/test_bootstrap_agent_machine.sh.
+export CQLITE_BOOTSTRAP_SKIP_GATE_PIN=1
+
 # --- WHOLE-SUITE CAPABILITY GATE (issue #3261, roborev round 6, Medium) ----------------------
 # EVERY case below drives bootstrap's perf section, and that section stages the drop-in through
 # GNU `stat -c` and `mv --no-target-directory`. The sibling suite grew a per-case skip; this one

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -192,7 +192,11 @@ roborev pass actually ran on. Three mechanical rules keep the merge honest:
   gate at a time on a box: `bootstrap-agent-machine.sh` persists `CQLITE_GATE_MAX_CONCURRENCY=1`
   into `/etc/environment` — which PAM reads at session creation, so non-interactive shells see it —
   and then **verifies from a fresh, profile-free session that the value is visible and that the gate
-  honours it** (`gate-pin: VERIFIED`, #3414), rather than trusting that the write happened. With the
+  honours it** (`gate-pin: VERIFIED`, #3414), rather than trusting that the write happened. That
+  verdict is scoped to a PAM-created session, so a gate launched from a systemd unit or container
+  entrypoint is not covered by it; the per-run authority stays the gate's own `cpu-budget:` token.
+  A visible value the gate discards or clamps reports `gate-pin: NOT-HONOURED` — its remedy is to
+  fix the VALUE, since bootstrap never rewrites an existing one. With the
   pin in effect the #1825 machine-wide cap admits exactly one full gate and the #2640 per-gate core
   budget hands that sole gate the full core count; a gate that resolved its cap from the default
   formula instead says so on its own `cpu-budget:` line as `max-concurrency=N(default)`. The gate also derives `CARGO_BUILD_JOBS` + nextest `--test-threads`

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -189,9 +189,13 @@ roborev pass actually ran on. Three mechanical rules keep the merge honest:
   path (e.g. `$(mktemp /tmp/gate-<issue>-XXXXXX.txt)`) — shared `/tmp` names get contended under
   multi-lane load, so one lane's summary can clobber or be misread as another's.
 - **Single full gate per machine — enforced mechanically (#2640).** The default posture is one full
-  gate at a time on a box: `bootstrap-agent-machine.sh` pins `CQLITE_GATE_MAX_CONCURRENCY=1`, so the
-  #1825 machine-wide cap admits exactly one full gate and the #2640 per-gate core budget hands that
-  sole gate the full core count. The gate also derives `CARGO_BUILD_JOBS` + nextest `--test-threads`
+  gate at a time on a box: `bootstrap-agent-machine.sh` persists `CQLITE_GATE_MAX_CONCURRENCY=1`
+  into `/etc/environment` — which PAM reads at session creation, so non-interactive shells see it —
+  and then **verifies from a fresh, profile-free session that the value is visible and that the gate
+  honours it** (`gate-pin: VERIFIED`, #3414), rather than trusting that the write happened. With the
+  pin in effect the #1825 machine-wide cap admits exactly one full gate and the #2640 per-gate core
+  budget hands that sole gate the full core count; a gate that resolved its cap from the default
+  formula instead says so on its own `cpu-budget:` line as `max-concurrency=N(default)`. The gate also derives `CARGO_BUILD_JOBS` + nextest `--test-threads`
   from the slot count and wraps itself in `taskpolicy -c utility` (macOS) / `nice` (Linux), so even
   if two gates do overlap neither oversubscribes the CPU. No manual `pgrep`-serialization is needed.
 

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -194,7 +194,10 @@ roborev pass actually ran on. Three mechanical rules keep the merge honest:
   and then **verifies from a fresh, profile-free session that the value is visible and that the gate
   honours it** (`gate-pin: VERIFIED`, #3414), rather than trusting that the write happened. That
   verdict is scoped to a PAM-created session, so a gate launched from a systemd unit or container
-  entrypoint is not covered by it; the per-run authority stays the gate's own `cpu-budget:` token.
+  entrypoint is not covered by it; it also measures that the file and the session AGREE, not that the
+  file is where the session got the value, so a box setting the same value from a sudoers `env_file`
+  would read VERIFIED with an `/etc/environment` no PAM stack loads. The per-run authority stays the
+  gate's own `cpu-budget:` token.
   A visible value the gate discards or clamps reports `gate-pin: NOT-HONOURED` — its remedy is to
   fix the VALUE, since bootstrap never rewrites an existing one. With the
   pin in effect the #1825 machine-wide cap admits exactly one full gate and the #2640 per-gate core

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -958,8 +958,16 @@ caller blocks cleanly rather than spin-failing.
   above, `invalid` = it was empty or non-numeric and was silently discarded for the
   formula, `clamped` = it was a valid integer < 1 and was silently raised to 1.
   `3` and `3 because nothing set it` are different operational facts — read
-  `N(default)` on a fleet box as *the pin is not provisioned*, and fix it with
-  `bash scripts/bootstrap-agent-machine.sh --yes`.
+  `N(default)` on a fleet box as *the pin is not provisioned*.
+
+  **The remedy DIFFERS BY TOKEN, and getting that wrong sends you in a circle.** A
+  `default` box has no pin line at all, so
+  `bash scripts/bootstrap-agent-machine.sh --fix-gate-pin` (or `--yes`) persists one.
+  An `invalid` or `clamped` box ALREADY HAS the line, holding a bad value — and
+  bootstrap deliberately never rewrites an existing value, because a box running >1
+  gate on purpose must not be clobbered — so re-running it there is a **silent
+  no-op**. Fix the VALUE by hand in `/etc/environment`. Bootstrap says the same thing
+  at the same fork, as `gate-pin: NOT-HONOURED`.
 - **SIGKILL-safe stale-slot reaping:** each slot is an `fcntl.flock` held by a
   small background daemon (`scripts/lib/gate_slot_daemon.py`) that the gate starts
   and monitors. Because the daemon opens the lock fd *after* it is forked, the

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -892,7 +892,11 @@ On **Linux** the line additionally carries a `mold=` token and a `perf=` token
 
 ```
 accelerators: sccache=on nextest=on lanes=on sccache-health=ok mold=linked perf=ok
+cpu-budget: wrapper=nice ncpu=16 max-concurrency=1(pinned) cores-per-gate=16 build-jobs=16(derived) test-threads=16
 ```
+
+(The `cpu-budget:` line is a sibling of `accelerators:` and carries the resolved
+slot cap **and where it came from** — see the concurrency-cap section below.)
 
 - **`sccache`** — cross-worktree compile cache (~25.6% faster fresh builds).
 - **`nextest`** — parallel `core-tests` (the gate's long pole).
@@ -947,6 +951,15 @@ caller blocks cleanly rather than spin-failing.
 - **N** defaults to `max(2, floor((ncpu-2)/4))` — a conservative fraction of cores
   that still lets a couple of gates run on a small box. Override with
   `CQLITE_GATE_MAX_CONCURRENCY`.
+- **Every SUMMARY says where N came from (issue #3414).** The `cpu-budget:` line
+  stamps `max-concurrency=N(pinned|default|invalid|clamped)`, the same idiom as
+  `build-jobs=N(derived|caller)` beside it: `pinned` = the env var held a valid
+  integer ≥ 1 and was used verbatim, `default` = it was unset so N is the formula
+  above, `invalid` = it was empty or non-numeric and was silently discarded for the
+  formula, `clamped` = it was a valid integer < 1 and was silently raised to 1.
+  `3` and `3 because nothing set it` are different operational facts — read
+  `N(default)` on a fleet box as *the pin is not provisioned*, and fix it with
+  `bash scripts/bootstrap-agent-machine.sh --yes`.
 - **SIGKILL-safe stale-slot reaping:** each slot is an `fcntl.flock` held by a
   small background daemon (`scripts/lib/gate_slot_daemon.py`) that the gate starts
   and monitors. Because the daemon opens the lock fd *after* it is forked, the


### PR DESCRIPTION
Closes #3414.

Two acceptance criteria, one theme: **a setting that is present is not a setting that is in effect, and only a probe can tell them apart.**

## AC1 — persist the pin where a non-interactive shell provably reads it, and verify by probing

The pin lived in `~/.bashrc` on all three boxes and was in effect on **none** of them. Stock Ubuntu `.bashrc` opens with

```sh
case $- in *i*) ;; *) return;; esac
```

and a gate is launched non-interactively — so every gate resolved its cap from the #1825 formula (`--slots 3` on 16 cores) while `grep` said the pin was installed. One gate queued **1h31m** and was killed with no verdict; a measurement lane was given an isolation guarantee the semaphore was not providing.

Bootstrap now persists to `/etc/environment`, which PAM reads at session creation with no interactivity guard, and takes its verdict from an **affirmative probe**: it scrubs its own inherited value — and `BASH_ENV`/`ENV` with it, since a non-interactive bash *sources* `$BASH_ENV` and that file can re-export the variable just scrubbed — then reads the value back out of a fresh, profile-free session.

**Five verdicts ship and only the first is an `[ok]`:** `VERIFIED`, `NOT-SYSTEM-WIDE`, `NOT-HONOURED`, `FAILED`, `UNMEASURED` (plus `OPT-OUT`/`SKIPPED`).

An earlier revision emitted `ok "NOT-APPLICABLE"` on non-Linux hosts. That reasoning was right about the *mechanism* — `pam_env` is Linux-specific — and wrong about the *verdict*: an `[ok]` is what `--strict` reads, so it **certified an unpinned host**, which is the exact false-certification shape this change exists to remove. **Scoping a platform out is not the same as passing it.** A non-Linux host whose session shows a value now reports `UNMEASURED`, and `NOT-APPLICABLE` is emitted nowhere.

`VERIFIED` is **scoped and says so**: it measures a PAM-created session, so a gate launched from a systemd unit or a container entrypoint — no PAM in its ancestry — is not covered, and it asserts **agreement, not provenance** (if this box also sets the value from a sudoers `env_file`, an `/etc/environment` that no PAM stack loads would still read `VERIFIED`). Both residuals are printed with the verdict rather than buried.

**The remedy differs by token, and getting that wrong sends an operator in a circle.** A `default` box has no pin line, so `--fix-gate-pin` persists one. An `invalid`/`clamped` box already has the line with a bad value — and bootstrap deliberately never rewrites an existing value, so re-running it is a silent no-op. Bootstrap says so at the same fork, as `gate-pin: NOT-HONOURED`.

## AC2 — the SUMMARY distinguishes a pinned cap from a defaulted one

Every summary now carries `cpu-budget: … max-concurrency=N(pinned|default|invalid|clamped)`.

`3` and `3 because nothing set it` are different operational facts, and the second is what ran unseen for months. `invalid` and `clamped` exist because `${VAR:-dflt}` cannot tell unset from set-empty (`${VAR+set}` can), so a mis-set variable was textually identical to a healthy defaulted box.

**Two defects in this resolver were found by review, not by the gate, and both are worth recording because they are the same subject one layer down:**

1. **`08` made the gate die inside its own budget line.** The digit-only guard admits `08`; bash reads a leading zero as octal, and `08`/`09` are not valid octal → `line 1301: 08: value too great for base`. **A gate that dies inside its own `cpu-budget` line produces no verdict at all** — worse than either honouring or refusing the value.
2. **An unrepresentable value wrapped into a confident false pin.** `=99999999999999999999` reported `max-concurrency=7766279631452241919(pinned)` — the summary **affirming a pin at a value nobody set**, which inverts the one property this token exists to carry. `=9223372036854775808` wrapped negative and reported `(clamped)` when the truth is `invalid`.

The pairing is the useful artefact: **`08` produced *no* verdict; the wrap produced a *confident false* one.** The second is worse.

The bound is a **digit count, not a comparison against `INT64_MAX`**, because it has to be decided *without* the arithmetic that is the defect. Any ≤18-digit decimal is < 9.22e18 and always fits, so 19+ digits is refused as `invalid`. That refuses a handful of representable 19-digit values too, deliberately: a 19-digit slot cap is a mis-set variable by any measure, and `invalid` — silently discarded, use the formula — is the correct answer for one. A lexical compare against `INT64_MAX` would be exact but locale-dependent on digit collation; a length test is not.

## The dominant failure class in this branch, and the rule that came out of it

> **A test whose ok line never appears hasn't passed, it hasn't run, and the suite total is the cheapest discriminator.**

Three tests in this change were **vacuous on first write** and every one was silent about it:

- the octal regression case landed inside the preceding case's `else`, so it ran only on that case's failure — `PASS` stayed at 15 and nothing reported;
- case 11bg passed *against* the defect it was written for (old `tee`(0600) + real `chmod`(0644) also ends at 644) — deleted, with the reasoning left at the deletion site;
- the digest-scope case planted its probe as `…-$$.tmp`, and `.gitignore:79` carries `*.tmp`, so `--exclude-standard` excluded it and the case would have taken its `skip` branch on **every run**.

What caught all three was **an affirmative count plus a RED probe** — never a green suite. `SKIP=0` in the bootstrap total is now load-bearing for the same reason.

A related trap, recorded because it cost a round: a RED arm must differ from the green arm in **exactly** the property under test. One arm used `git archive HEAD` while the fix was uncommitted; another used HEAD's bootstrap, which lacks the helper entirely, so the guard would have red either way. Both proved nothing while looking like proof.

And a construction assert of mine reported the fix *present* in a tree that did not have it, because `grep -c 'roborev job 332'` **substring-matches the older `job 3327`/`3325`**. A job number is a prefix of later job numbers.

## Follow-ups filed, not fixed here

- **#3804** — the gate-pin sudo probe asks a command-specific question (`sudo -n -u … true`), so a policy permitting the real probe but not `true` classifies a permitted operation as DENIED. **Fails closed**: it refuses a legitimate box, it never certifies an unpinned one. Split out under the lead's ruling because the fix restructures the privilege-probing area that produced a finding on six consecutive review rounds — doing that inside a PR about gate-concurrency pinning is how a bounded change becomes an unbounded one. The remedy direction ("run the bounded real probe and classify *its* result") is recorded in the issue.
- **#3685** — the `printf | grep -q` SIGPIPE verdict inversion. Two measured-firing sites are fixed here (37.5% and 30% false-FAIL rates); the remaining sites were measured safe and are left to that issue. The sort key is **bytes discarded** = `len(data) − offset_of_first_match`; `grep -c` sites are safe by construction.
- **#3758** (nits), **#3760** (`.gitignore` for `.gate-*`/`.rescue-*`).

## Not claimed

**Base staleness (#3650).** A squash-merge composes this diff with main's current tip, so a gate PASS at this head does not certify the merged tree. The verdict below is reported as **"gate of record verified at `<sha>`"**, never "certified against main".

## Certification

| | |
|---|---|
| head | `2193211dc991ba015963baef6bc3585ad56396af`, pushed, tree clean |
| **gate of record** | **PASS** — `run-id /tmp/agent-gate.LS7gRc`, `commit: 2193211`, `dirty: no`, `tree-start == tree-end == 2193211dc991`, `tree-integrity: PASS`, `component-set: PASS (37/37)`, no `nested-under`, **zero FAIL, zero SKIP** |
| AC2 wiring evidence | that same block's own line: `cpu-budget: … max-concurrency=1(pinned)` |
| C intent audit | **self-C, disclosed** — `C-VERDICT: PASS`, both ACs `satisfied`. NOT independent: two `spec-auditor` agents were spawned and neither produced a verdict file in 1h30m / 25m. C is design-routed in this repo and this issue is oracle/ops-driven with no OpenSpec change, so C is not a blocking gate here; it was done anyway because the issue carries explicit lead ACs |
| suites | bootstrap `PASS=205 FAIL=0 SKIP=0` (`tree-integrity: STABLE`); cpu-budget `PASS=17 FAIL=0`; `--lite` PASS |
| roborev | **job 333 (round 12), 2 findings — BOTH FIXED, and no review ran after the fixes.** See below. |

### There is no clean roborev at the merged head, and I am not going to write that there is

Round 12 reported two findings, both **regressions of this branch's own round-11 fixes**, and both were fixed (`8446c3ccf`) rather than deferred — deferring would have meant deferring breakage introduced three commits earlier.

That leaves the honest position: **job 333 is a findings-bearing record, so no `roborev-recheck` of it can read clean, and the coordination lead explicitly ruled that round 13 must not run.** The ruling is on this issue's thread, twice — first as *"round 10 is the last round"*, then superseded to *"run round 12 at `c50185522`, one round, then gate → C → `gh pr ready` → arm, regardless"*, with the disposition of each finding class fixed in advance.

So the two fixes in `8446c3ccf`, and the `.gitignore` change in `2193211dc`, **ship unreviewed**. What stands behind them instead: a green gate of record at that exact tree, `PASS=205` with three new cases and one existing structural guard restored, and each fix RED-verified against the unfixed tree with the harness asserting its own construction.

Token accounting for job 333, since `prompt-content: FAIL (8/8 absent)` is the snapshot-delivery artifact rather than a vacuous review: **input 1,509,923 / cached 1,403,648 / output 7,976**, against a genuine band of 398k–649k and a vacuous baseline of ~18.7k input / 0 cached.

### Gates that were run and voided, deliberately or by my own error

Five full gates preceded this one. Recording them because the count is the argument for review-first, not a confession:

- three earlier PASSes (`106fd888a`, `d08468906`, `2ea82896b`) voided by review rounds that each found something a gate structurally cannot — a false certification of an unpinned host, a GNU-only digest silently omitting untracked contents, a repair path that could never repair.
- **gate #5 PASSed at `59f05332a` and was voided by round 11's overflow fix.**
- **gate #6 FAILED `tree-integrity: FAIL (tree-mutated-midrun)` because I edited two files while it was running.** #2926 did exactly its job. The deeper error was sequencing: I had already written down the rule *"roborev BEFORE the gate, because a post-gate fix voids the gate"* and then launched gate #6 in parallel with round 12 anyway, which guaranteed any finding would void it. The mid-run write hazard is now closed by mechanism — `.c-audit-*.md` is gitignored, because a `spec-auditor` writing its verdict mid-gate is structural, and "don't spawn one at the wrong moment" is a convention.

### Base staleness (#3650)

`origin/main` is `1dfae67ab`. A squash-merge composes this diff with main's current tip, so this verdict is **"gate of record verified at `2193211dc`"** — never "certified against main". The diff is shell + docs + yaml; main's commits since the branch point were measured non-overlapping when last checked.
