### PR TITLE
refactor(#3641): rename skipIfNoDatasets() to assertDatasetsAvailable() — a skip-named function that never skipped

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -444,7 +444,8 @@ jobs:
           # cqlite-core TEST-ONLY helper and is NOT consulted by the node binding
           # runtime. Actual fail-closed coverage here comes from the
           # check-dataset-manifest.sh step above (hard-fails on a partial/dropped
-          # 39-table corpus) plus the JS skipIfNoDatasets throw on missing data. The flag
+          # 39-table corpus) plus the JS assertDatasetsAvailable() throw on missing data
+          # (#3641 renamed it from skipIfNoDatasets, which never skipped). The flag
           # is set for parity of intent with the Rust/Python lanes.
           CQLITE_REQUIRE_FIXTURES: "1"
           # Issue #1465 (roborev V1): the exception-path/abandoned-iterator leak budgets

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,14 @@ named setup failure instead of 14 separate `beforeAll` throws and closes `parity
 placeholder — the one corpus-conditional path in that suite that would pass silently. (An earlier draft
 of this paragraph said those suites `describe.skip`; **measured, none does** — the repo's Node
 convention THROWS. A false rationale in a gate log is worse than none, because it is what stops the
-next person looking.) The durable question is the same one shape up: for each workspace member, **which component
+next person looking.) **The throwing helper was NAMED `skipIfNoDatasets()` until #3641** — a
+skip-named function that could not skip, believed by design work until someone measured it (an empty
+root gives `prepared.test.js` 16 FAILED of 16, not 16 skipped). It is now
+`assertDatasetsAvailable()`, the three suites that had copied its body verbatim call it, and its
+contract — throws on an absent corpus, in BOTH strict-mode directions, never skips — is asserted in
+`bindings/node/__test__/helpers.test.js` rather than only described in a doc comment. **A name is a
+claim about behaviour, and this repo's gate design consumed that claim**; the doc comment that said
+otherwise sat two lines above the throw and did not travel to a single one of the 14 call sites. The durable question is the same one shape up: for each workspace member, **which component
 EXECUTES it** — recorded, member by member, in `scripts/tests/workspace-test-disposition.txt`
 (`EXECUTED`/`PARTIAL`/`NOT-EXECUTED`, a closed label set enforced under `tooling-tests`), so a new
 crate cannot join the unexecuted set unannounced. Each record also carries a CLASS — `silent` (no

--- a/bindings/node/__test__/conversion-budget.test.js
+++ b/bindings/node/__test__/conversion-budget.test.js
@@ -24,6 +24,7 @@
  * sample, and set the budget with generous headroom over the observed spread.
  */
 const { Database } = require('../lib/index.js');
+const { assertDatasetsAvailable } = require('./helpers.js');
 
 const DIR = global.testPaths.SSTABLES_DIR;
 const SCHEMA = global.testPaths.SCHEMA_WIDE_ROWS;
@@ -85,11 +86,7 @@ describe('conversion per-row heap budget (issue #1449)', () => {
   let db;
 
   beforeAll(async () => {
-    if (!global.DATASETS_AVAILABLE) {
-      throw new Error(
-        'Test data not available. Set CQLITE_DATASETS_ROOT or run fetch-datasets.sh'
-      );
-    }
+    assertDatasetsAvailable();
     // Budget measurement is meaningless without gc control; FAIL, do not skip.
     if (typeof global.gc !== 'function') {
       throw new Error(

--- a/bindings/node/__test__/database.test.js
+++ b/bindings/node/__test__/database.test.js
@@ -13,7 +13,7 @@
  */
 
 const { Database, version } = require('../lib/index.js');
-const { skipIfNoDatasets, getNonexistentPath } = require('./helpers.js');
+const { assertDatasetsAvailable, getNonexistentPath } = require('./helpers.js');
 
 describe('Database Wrapper Tests (Issue #296)', () => {
   beforeAll(() => {
@@ -29,7 +29,7 @@ describe('Database Wrapper Tests (Issue #296)', () => {
   });
 
   test('Database.open() returns Database instance', async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     const db = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_BASIC_TYPES,
     });
@@ -54,7 +54,7 @@ describe('Database Wrapper Tests (Issue #296)', () => {
   });
 
   test('Database.execute() returns QueryResult', async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     const db = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_BASIC_TYPES,
     });
@@ -83,7 +83,7 @@ describe('Database Wrapper Tests (Issue #296)', () => {
   });
 
   test('Database.execute() with invalid SQL rejects with ParseError or QueryError', async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     const db = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_BASIC_TYPES,
     });
@@ -106,7 +106,7 @@ describe('Database Wrapper Tests (Issue #296)', () => {
   });
 
   test('Database.close() resolves successfully', async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     const db = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_BASIC_TYPES,
     });
@@ -122,7 +122,7 @@ describe('Database Wrapper Tests (Issue #296)', () => {
   });
 
   test('Database.getStats() returns valid statistics', async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     const db = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_BASIC_TYPES,
     });
@@ -146,7 +146,7 @@ describe('Database Wrapper Tests (Issue #296)', () => {
   });
 
   test('DatabaseStats bigint fields support BigInt operations (Issue #351)', async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     const db = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_BASIC_TYPES,
     });
@@ -167,7 +167,7 @@ describe('Database Wrapper Tests (Issue #296)', () => {
   });
 
   test('Operations on closed database fail', async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     const db = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_BASIC_TYPES,
     });
@@ -185,7 +185,7 @@ describe('Database Wrapper Tests (Issue #296)', () => {
 
 describe('DatabaseOptions Tests (Issue #339)', () => {
   test('Database.open() with memoryLimit option', async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     const db = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_BASIC_TYPES,
       memoryLimit: 256 * 1024 * 1024, // 256MB
@@ -203,7 +203,7 @@ describe('DatabaseOptions Tests (Issue #339)', () => {
   });
 
   test('Database.open() with cacheEnabled=true option', async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     const db = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_BASIC_TYPES,
       cacheEnabled: true,
@@ -221,7 +221,7 @@ describe('DatabaseOptions Tests (Issue #339)', () => {
   });
 
   test('Database.open() with cacheEnabled=false option', async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     const db = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_BASIC_TYPES,
       cacheEnabled: false,
@@ -239,7 +239,7 @@ describe('DatabaseOptions Tests (Issue #339)', () => {
   });
 
   test('Database.open() with all options combined', async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     const db = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_BASIC_TYPES,
       memoryLimit: 512 * 1024 * 1024, // 512MB
@@ -262,7 +262,7 @@ describe('DatabaseOptions Tests (Issue #339)', () => {
   });
 
   test('Database.open() accepts memoryLimit as BigInt-safe integer', async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     // Test with 4GB limit (within safe integer range)
     const db = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_BASIC_TYPES,
@@ -273,7 +273,7 @@ describe('DatabaseOptions Tests (Issue #339)', () => {
   });
 
   test('Database.open() accepts memoryLimit of 1 byte (minimum valid value)', async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     // Test boundary condition: 1 is the minimum valid memoryLimit
     const db = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_BASIC_TYPES,
@@ -284,7 +284,7 @@ describe('DatabaseOptions Tests (Issue #339)', () => {
   });
 
   test('DatabaseOptions fields are optional', async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     // All fields should be optional - open with just schema
     const db1 = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_BASIC_TYPES,
@@ -300,7 +300,7 @@ describe('DatabaseOptions Tests (Issue #339)', () => {
 
   describe('memoryLimit edge cases', () => {
     test('Database.open() with zero memoryLimit should fail', async () => {
-      skipIfNoDatasets();
+      assertDatasetsAvailable();
       await expect(
         Database.open(global.testPaths.SSTABLES_DIR, {
           schema: global.testPaths.SCHEMA_BASIC_TYPES,
@@ -310,7 +310,7 @@ describe('DatabaseOptions Tests (Issue #339)', () => {
     });
 
     test('Database.open() with negative memoryLimit should fail', async () => {
-      skipIfNoDatasets();
+      assertDatasetsAvailable();
       await expect(
         Database.open(global.testPaths.SSTABLES_DIR, {
           schema: global.testPaths.SCHEMA_BASIC_TYPES,
@@ -320,7 +320,7 @@ describe('DatabaseOptions Tests (Issue #339)', () => {
     });
 
     test('Database.open() with fractional memoryLimit (0.5) should fail', async () => {
-      skipIfNoDatasets();
+      assertDatasetsAvailable();
       await expect(
         Database.open(global.testPaths.SSTABLES_DIR, {
           schema: global.testPaths.SCHEMA_BASIC_TYPES,
@@ -330,7 +330,7 @@ describe('DatabaseOptions Tests (Issue #339)', () => {
     });
 
     test('Database.open() with fractional memoryLimit (0.1) should fail', async () => {
-      skipIfNoDatasets();
+      assertDatasetsAvailable();
       await expect(
         Database.open(global.testPaths.SSTABLES_DIR, {
           schema: global.testPaths.SCHEMA_BASIC_TYPES,
@@ -340,7 +340,7 @@ describe('DatabaseOptions Tests (Issue #339)', () => {
     });
 
     test('Database.open() with fractional memoryLimit (0.99) should fail', async () => {
-      skipIfNoDatasets();
+      assertDatasetsAvailable();
       await expect(
         Database.open(global.testPaths.SSTABLES_DIR, {
           schema: global.testPaths.SCHEMA_BASIC_TYPES,
@@ -350,7 +350,7 @@ describe('DatabaseOptions Tests (Issue #339)', () => {
     });
 
     test('Database.open() with NaN memoryLimit should fail', async () => {
-      skipIfNoDatasets();
+      assertDatasetsAvailable();
       await expect(
         Database.open(global.testPaths.SSTABLES_DIR, {
           schema: global.testPaths.SCHEMA_BASIC_TYPES,
@@ -360,7 +360,7 @@ describe('DatabaseOptions Tests (Issue #339)', () => {
     });
 
     test('Database.open() with Infinity memoryLimit should fail', async () => {
-      skipIfNoDatasets();
+      assertDatasetsAvailable();
       await expect(
         Database.open(global.testPaths.SSTABLES_DIR, {
           schema: global.testPaths.SCHEMA_BASIC_TYPES,

--- a/bindings/node/__test__/error.test.js
+++ b/bindings/node/__test__/error.test.js
@@ -13,7 +13,7 @@
  */
 
 const { Database, _errorContractProbe } = require('../lib/index.js');
-const { skipIfNoDatasets, getNonexistentPath } = require('./helpers.js');
+const { assertDatasetsAvailable, getNonexistentPath } = require('./helpers.js');
 
 describe('Error Mapping Tests (Issue #297)', () => {
   beforeAll(() => {
@@ -62,7 +62,7 @@ describe('Error Mapping Tests (Issue #297)', () => {
     // first token is not a known verb is rejected earlier as
     // `Error::QueryExecution` ("Unsupported query type"), which is genuinely
     // `QUERY` — see the sibling case below.
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     const db = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_BASIC_TYPES,
     });
@@ -82,7 +82,7 @@ describe('Error Mapping Tests (Issue #297)', () => {
     // The other side of the #1451 fix: `PARSE` now means a genuine CQL syntax
     // failure, so an unsupported STATEMENT TYPE (an `Error::QueryExecution`)
     // must NOT borrow it.
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     const db = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_BASIC_TYPES,
     });
@@ -138,7 +138,7 @@ describe('Error Mapping Tests (Issue #297)', () => {
   });
 
   test('Query error has correct properties', async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     const db = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_BASIC_TYPES,
     });
@@ -158,7 +158,7 @@ describe('Error Mapping Tests (Issue #297)', () => {
   });
 
   test('RuntimeError (InvalidState) has correct properties', async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     const db = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_BASIC_TYPES,
     });

--- a/bindings/node/__test__/event-loop-latency.test.js
+++ b/bindings/node/__test__/event-loop-latency.test.js
@@ -33,6 +33,7 @@
 const path = require('path');
 const { spawnSync } = require('child_process');
 const { Database } = require('../lib/index.js');
+const { assertDatasetsAvailable } = require('./helpers.js');
 
 const ADDON_ENTRY = path.resolve(__dirname, '..', 'lib', 'index.js');
 const DIR = global.testPaths.SSTABLES_DIR;
@@ -56,19 +57,11 @@ const TIMER_INTERVAL_MS = 10;
 // fails fast (with diagnostics) instead of blocking the worker forever.
 const CHILD_TIMEOUT_MS = 20000;
 
-function requireData() {
-  if (!global.DATASETS_AVAILABLE) {
-    throw new Error(
-      'Test data not available. Set CQLITE_DATASETS_ROOT or run fetch-datasets.sh'
-    );
-  }
-}
-
 describe('executeNative event-loop latency (issue #1442)', () => {
   let db;
 
   beforeAll(async () => {
-    requireData();
+    assertDatasetsAvailable();
     db = await Database.open(DIR, { schema: SCHEMA });
   });
 

--- a/bindings/node/__test__/export-parquet.test.js
+++ b/bindings/node/__test__/export-parquet.test.js
@@ -17,7 +17,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { skipIfNoDatasets, withDatabase } = require('./helpers.js');
+const { assertDatasetsAvailable, withDatabase } = require('./helpers.js');
 
 const SCALAR_QUERY = 'SELECT * FROM test_basic.simple_table';
 const COLLECTIONS_QUERY = 'SELECT * FROM test_collections.collection_table';
@@ -41,7 +41,7 @@ function assertParquetMagic(filePath) {
 
 describe('exportParquet - scalar table', () => {
   test('creates a valid Parquet file with matching row count', async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     await withDatabase(async (db) => {
       const out = path.join(tmpDir, 'simple_table.parquet');
       const rows = await db.exportParquet(SCALAR_QUERY, out);
@@ -56,7 +56,7 @@ describe('exportParquet - scalar table', () => {
   });
 
   test('accepts rowGroupSize option', async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     await withDatabase(async (db) => {
       const out = path.join(tmpDir, 'small_groups.parquet');
       const rows = await db.exportParquet(SCALAR_QUERY, out, {
@@ -68,7 +68,7 @@ describe('exportParquet - scalar table', () => {
   });
 
   test('accepts zstd compression', async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     await withDatabase(async (db) => {
       const out = path.join(tmpDir, 'zstd.parquet');
       const rows = await db.exportParquet(SCALAR_QUERY, out, {
@@ -82,7 +82,7 @@ describe('exportParquet - scalar table', () => {
 
 describe('exportParquet - collections table', () => {
   test('creates a valid Parquet file with matching row count', async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     await withDatabase(async (db) => {
       const out = path.join(tmpDir, 'collection_table.parquet');
       const rows = await db.exportParquet(COLLECTIONS_QUERY, out);
@@ -99,7 +99,7 @@ describe('exportParquet - collections table', () => {
 
 describe('exportParquet - error handling', () => {
   test('invalid compression rejects with CONFIG code', async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     await withDatabase(async (db) => {
       expect.assertions(3);
       try {
@@ -115,7 +115,7 @@ describe('exportParquet - error handling', () => {
   });
 
   test('zero rowGroupSize rejects with CONFIG code', async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     await withDatabase(async (db) => {
       expect.assertions(1);
       try {
@@ -129,7 +129,7 @@ describe('exportParquet - error handling', () => {
   });
 
   test('unwritable path rejects with IO code', async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     await withDatabase(async (db) => {
       expect.assertions(2);
       try {
@@ -148,7 +148,7 @@ describe('exportParquet - error handling', () => {
     // The query engine is permissive about unknown tables (matching
     // execute(), which returns 0 rows rather than erroring), so export
     // produces a valid empty file.
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     await withDatabase(async (db) => {
       const out = path.join(tmpDir, 'empty.parquet');
       const rows = await db.exportParquet(

--- a/bindings/node/__test__/helpers.js
+++ b/bindings/node/__test__/helpers.js
@@ -22,20 +22,38 @@ function getNonexistentPath() {
 }
 
 /**
- * Require test datasets to be available.
+ * Assert that the SSTable test corpus is available, THROWING if it is not.
  * Use this in beforeAll() or at the start of tests that require real data.
  *
- * Note: This throws an error rather than skipping to match Python test behavior.
- * Missing test data is considered a setup failure, not a skippable condition.
- * This ensures CI failures are visible when test data is not properly configured.
+ * IT DOES NOT SKIP, AND THE NAME IS THE POINT (issue #3641). This helper was
+ * called `skipIfNoDatasets()` for its whole life while throwing on every call,
+ * and the misnomer shaped a merge gate's design: a reader who trusted the name
+ * expected a reduced-coverage run to be available over an absent corpus, so the
+ * gate's `node-bindings` component looked like it could run "leniently". It
+ * cannot -- measured on an empty root, `prepared.test.js` reports 16 FAILED of
+ * 16 total, not 16 skipped -- which is why that component SKIPs wholesale under
+ * `AGENT_GATE_ALLOW_MISSING_FIXTURES=1` instead.
+ *
+ * The throwing BEHAVIOUR is deliberate and stays (issue #1458): a silent skip
+ * over an absent corpus is how #646-class holes hide, and this repo's Node
+ * convention is to fail loudly instead. Renaming this back to a `skip`-word, or
+ * making it actually skip, reintroduces that hole and needs #1458 re-argued.
+ *
+ * NOT `requireDatasets()`, deliberately: `require` is already this suite's
+ * STRICT-MODE vocabulary (`CQLITE_REQUIRE_FIXTURES` /
+ * `CQLITE_PARITY_REQUIRE_DATASETS` -> `global.REQUIRE_FIXTURES` in setup.js),
+ * and this assertion is INDEPENDENT of strict mode -- it fires on an absent
+ * corpus whether or not strict mode is on. A `require`-named helper beside that
+ * global invites the reading "this only fires in strict mode", which is the
+ * same class of misreading the rename exists to remove.
  *
  * @throws {Error} If test data is not available
  * @example
  * beforeAll(() => {
- *   skipIfNoDatasets();
+ *   assertDatasetsAvailable();
  * });
  */
-function skipIfNoDatasets() {
+function assertDatasetsAvailable() {
   if (!global.DATASETS_AVAILABLE) {
     throw new Error('Test data not available. Set CQLITE_DATASETS_ROOT or run fetch-datasets.sh');
   }
@@ -76,7 +94,7 @@ async function withDatabase(callback, schemaPath) {
 }
 
 module.exports = {
-  skipIfNoDatasets,
+  assertDatasetsAvailable,
   openDatabase,
   withDatabase,
   getNonexistentPath,

--- a/bindings/node/__test__/helpers.test.js
+++ b/bindings/node/__test__/helpers.test.js
@@ -91,17 +91,30 @@ describe('the dataset assertion is not duplicated (issue #3641)', () => {
   // 11 files that actually called it. They now call the helper. A fourth copy
   // would silently re-open that gap, so it is a RED here.
   test('no test file inlines the helper error message', () => {
-    const dir = __dirname;
-    const offenders = fs
-      .readdirSync(dir)
-      .filter((name) => name.endsWith('.test.js'))
-      .filter((name) => {
-        const body = fs.readFileSync(path.join(dir, name), 'utf8');
-        // Outside this file the literal only ever appears as a COPY of the
-        // helper's message; this file quotes it in the assertions above, which
-        // is why it excludes itself.
-        return name !== 'helpers.test.js' && body.includes('Test data not available');
+    // RECURSIVE, matching jest's configured scope (`__test__/**/*.test.js`).
+    // A flat readdir scans only this directory, so a nested suite could inline
+    // the message and escape the guard entirely (roborev job 71). There are no
+    // nested suites today, which is exactly why the scope is pinned now rather
+    // than after one appears. `node_modules` is skipped for the same reason
+    // jest ignores it.
+    const walk = (dir) =>
+      fs.readdirSync(dir, { withFileTypes: true }).flatMap((ent) => {
+        if (ent.name === 'node_modules') return [];
+        const full = path.join(dir, ent.name);
+        if (ent.isDirectory()) return walk(full);
+        return ent.name.endsWith('.test.js') ? [full] : [];
       });
+    const offenders = walk(__dirname)
+      .map((full) => path.relative(__dirname, full))
+      // Outside this file the literal only ever appears as a COPY of the
+      // helper's message; this file quotes it in the assertions above, which
+      // is why it excludes itself.
+      .filter((rel) => rel !== 'helpers.test.js')
+      .filter((rel) =>
+        fs
+          .readFileSync(path.join(__dirname, rel), 'utf8')
+          .includes('Test data not available')
+      );
     expect(offenders).toEqual([]);
   });
 });

--- a/bindings/node/__test__/helpers.test.js
+++ b/bindings/node/__test__/helpers.test.js
@@ -1,0 +1,107 @@
+/**
+ * Tests for the dataset ASSERTION helper itself (issue #3641).
+ *
+ * `assertDatasetsAvailable()` was called `skipIfNoDatasets()` for its whole life
+ * while throwing on every call. The behaviour was never in doubt — #1458 wants a
+ * missing corpus to fail loudly — but nothing ASSERTED it: the contract lived in
+ * a doc comment, and a doc comment does not travel to the 14 call sites. So the
+ * misnomer was free to be believed, and it was: the agent gate's `node-bindings`
+ * component had to be designed around a reader's expectation that a "skip" helper
+ * makes a reduced-coverage run available over an absent corpus, when in fact
+ * every dataset-gated suite THROWS.
+ *
+ * These tests pin the three properties the new name claims, so that reverting to
+ * a skip — option 2 of #3641, which is rejected unless #1458 is re-argued — is a
+ * RED test rather than a rename nobody notices.
+ *
+ * The corpus is irrelevant here: these drive `global.DATASETS_AVAILABLE` directly,
+ * so this file is deliberately NOT dataset-gated and runs on an empty root.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const helpers = require('./helpers.js');
+const { assertDatasetsAvailable } = helpers;
+
+describe('assertDatasetsAvailable() (issue #3641)', () => {
+  let savedAvailable;
+  let savedRequireFixtures;
+
+  beforeEach(() => {
+    savedAvailable = global.DATASETS_AVAILABLE;
+    savedRequireFixtures = global.REQUIRE_FIXTURES;
+  });
+
+  afterEach(() => {
+    global.DATASETS_AVAILABLE = savedAvailable;
+    global.REQUIRE_FIXTURES = savedRequireFixtures;
+  });
+
+  test('THROWS when the corpus is unavailable — it does not skip', () => {
+    global.DATASETS_AVAILABLE = false;
+    expect(() => assertDatasetsAvailable()).toThrow(/Test data not available/);
+  });
+
+  test('the throw names both remedies (env var and fetch script)', () => {
+    global.DATASETS_AVAILABLE = false;
+    // A loud failure whose message does not say what to DO is only half of
+    // #1458's intent; every one of the 14 suites surfaces this string.
+    expect(() => assertDatasetsAvailable()).toThrow(/CQLITE_DATASETS_ROOT/);
+    expect(() => assertDatasetsAvailable()).toThrow(/fetch-datasets\.sh/);
+  });
+
+  test('returns quietly when the corpus is available', () => {
+    global.DATASETS_AVAILABLE = true;
+    expect(() => assertDatasetsAvailable()).not.toThrow();
+    expect(assertDatasetsAvailable()).toBeUndefined();
+  });
+
+  // The reason the helper is NOT called `requireDatasets()`: `require` is this
+  // suite's strict-mode vocabulary (CQLITE_REQUIRE_FIXTURES /
+  // CQLITE_PARITY_REQUIRE_DATASETS -> global.REQUIRE_FIXTURES in setup.js), and
+  // this assertion is independent of it. `scripts/agent-gate.sh` states that
+  // independence as load-bearing — it is why the `node-bindings` component must
+  // SKIP wholesale rather than run leniently under
+  // AGENT_GATE_ALLOW_MISSING_FIXTURES=1 — so it is asserted here in BOTH
+  // directions rather than left as a claim in a shell comment.
+  test('is independent of strict mode: throws with REQUIRE_FIXTURES off', () => {
+    global.DATASETS_AVAILABLE = false;
+    global.REQUIRE_FIXTURES = false;
+    expect(() => assertDatasetsAvailable()).toThrow(/Test data not available/);
+  });
+
+  test('is independent of strict mode: silent with REQUIRE_FIXTURES on', () => {
+    global.DATASETS_AVAILABLE = true;
+    global.REQUIRE_FIXTURES = true;
+    expect(() => assertDatasetsAvailable()).not.toThrow();
+  });
+
+  test('exposes no skip-named entry point', () => {
+    // Reintroducing the old name as an alias would restore the misnomer this
+    // issue removed while leaving every call site green.
+    expect(Object.keys(helpers)).toContain('assertDatasetsAvailable');
+    expect(Object.keys(helpers)).not.toContain('skipIfNoDatasets');
+  });
+});
+
+describe('the dataset assertion is not duplicated (issue #3641)', () => {
+  // Three suites (conversion-budget, leak-paths, and event-loop-latency via a
+  // local `requireData()`) used to carry a verbatim copy of the helper's body,
+  // which is why the "14 dataset-gated suites" doctrine count did not match the
+  // 11 files that actually called it. They now call the helper. A fourth copy
+  // would silently re-open that gap, so it is a RED here.
+  test('no test file inlines the helper error message', () => {
+    const dir = __dirname;
+    const offenders = fs
+      .readdirSync(dir)
+      .filter((name) => name.endsWith('.test.js'))
+      .filter((name) => {
+        const body = fs.readFileSync(path.join(dir, name), 'utf8');
+        // Outside this file the literal only ever appears as a COPY of the
+        // helper's message; this file quotes it in the assertions above, which
+        // is why it excludes itself.
+        return name !== 'helpers.test.js' && body.includes('Test data not available');
+      });
+    expect(offenders).toEqual([]);
+  });
+});

--- a/bindings/node/__test__/json-encoding.test.js
+++ b/bindings/node/__test__/json-encoding.test.js
@@ -13,13 +13,13 @@
  */
 
 const { Database } = require('../lib/index.js');
-const { skipIfNoDatasets } = require('./helpers.js');
+const { assertDatasetsAvailable } = require('./helpers.js');
 
 describe('JSON Encoding Format (Issue #343)', () => {
   let db = null;
 
   beforeAll(async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     db = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_BASIC_TYPES,
     });

--- a/bindings/node/__test__/leak-paths.test.js
+++ b/bindings/node/__test__/leak-paths.test.js
@@ -121,6 +121,7 @@
  * class (#2642).
  */
 const { Database } = require('../lib/index.js');
+const { assertDatasetsAvailable } = require('./helpers.js');
 
 const DIR = global.testPaths.SSTABLES_DIR;
 const SCHEMA = global.testPaths.SCHEMA_WIDE_ROWS;
@@ -933,11 +934,7 @@ describe('exception-path / abandoned-iterator leak budgets (issue #1465)', () =>
   beforeAll(async () => {
     // FAIL LOUDLY, never skip: a missing/empty corpus must red this lane, since
     // a skipped leak budget is indistinguishable from a passing one.
-    if (!global.DATASETS_AVAILABLE) {
-      throw new Error(
-        'Test data not available. Set CQLITE_DATASETS_ROOT or run fetch-datasets.sh'
-      );
-    }
+    assertDatasetsAvailable();
     // Budget measurement is meaningless without gc control; FAIL, do not skip.
     if (typeof global.gc !== 'function') {
       throw new Error(

--- a/bindings/node/__test__/parity.test.js
+++ b/bindings/node/__test__/parity.test.js
@@ -15,7 +15,7 @@
  */
 
 const { Database } = require('../lib/index.js');
-const { skipIfNoDatasets } = require('./helpers.js');
+const { assertDatasetsAvailable } = require('./helpers.js');
 const {
   findJsonlFile,
   findOaJsonlFile,
@@ -89,7 +89,7 @@ const KEYSPACE_SCHEMAS = {
 let databases = {};
 
 beforeAll(async () => {
-  skipIfNoDatasets();
+  assertDatasetsAvailable();
 
   // Open databases for each keyspace
   for (const [keyspace, schemaPath] of Object.entries(KEYSPACE_SCHEMAS)) {
@@ -542,7 +542,7 @@ describe('VG6: OA Format Parity — Row Count (Issue #672)', () => {
   let dbOa = null;
 
   beforeAll(async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
 
     // Issue #3493: the COMMITTED-SOURCE check runs FIRST, before the fetched-fixture
     // one. The ORDER is the whole point (roborev round 13): with oaBinariesPresent()
@@ -606,7 +606,7 @@ describe('VG4: OA Format Parity — Value Spot Check (Issue #656)', () => {
   let dbOa = null;
 
   beforeAll(async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
 
     // Issue #3493: the COMMITTED-SOURCE check runs FIRST, before the fetched-fixture
     // one. The ORDER is the whole point (roborev round 13): with oaBinariesPresent()

--- a/bindings/node/__test__/prepared.test.js
+++ b/bindings/node/__test__/prepared.test.js
@@ -3,12 +3,12 @@
  *
  * Issue #338: Implement Database.prepare() method for Node.js bindings.
  */
-const { skipIfNoDatasets, openDatabase, withDatabase } = require('./helpers');
+const { assertDatasetsAvailable, openDatabase, withDatabase } = require('./helpers');
 const { Database, PreparedStatement } = require('../lib/index.js');
 
 describe('PreparedStatement', () => {
   beforeAll(() => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
   });
 
   describe('PreparedStatement export (Issue #352)', () => {

--- a/bindings/node/__test__/result.test.js
+++ b/bindings/node/__test__/result.test.js
@@ -14,13 +14,13 @@
  */
 
 const { Database } = require('../lib/index.js');
-const { skipIfNoDatasets } = require('./helpers.js');
+const { assertDatasetsAvailable } = require('./helpers.js');
 
 describe('QueryResult and ColumnInfo Tests (Issue #303)', () => {
   let db = null;
 
   beforeAll(async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     console.log(`Test data root: ${global.testPaths.TEST_DATA_ROOT}`);
     console.log(`SSTables dir: ${global.testPaths.SSTABLES_DIR}`);
     console.log(`Schema file: ${global.testPaths.SCHEMA_BASIC_TYPES}`);
@@ -246,7 +246,7 @@ describe('Row property order matches SELECT order (Issue #1446)', () => {
   let db = null;
 
   beforeAll(async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     db = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_BASIC_TYPES,
     });
@@ -350,9 +350,9 @@ describe('Row property order matches SELECT order (Issue #1446)', () => {
  * the signal above V8/native baseline noise the query is issued K times and its
  * payload retained, so `totalPayload` reaches tens of MB.
  *
- * Dataset-absence is handled by `skipIfNoDatasets()` in `beforeAll`: per the
- * repo's Node test convention it THROWS (never skips) when the corpus is not
- * configured, so a misconfigured CI run fails loudly rather than passing
+ * Dataset-absence is handled by `assertDatasetsAvailable()` in `beforeAll`:
+ * per the repo's Node test convention it THROWS (never skips) when the corpus
+ * is not configured, so a misconfigured CI run fails loudly rather than passing
  * silently. Within the test itself we also THROW for the present-but-empty
  * fixture case (rowCount == 0) and when `--expose-gc` is unavailable. Requires
  * `node --expose-gc` (wired via package.json `test` script).
@@ -361,7 +361,7 @@ describe('executeNative blob payload memory footprint (Issue #1447)', () => {
   let db = null;
 
   beforeAll(async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     db = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_WIDE_ROWS,
     });

--- a/bindings/node/__test__/streaming.test.js
+++ b/bindings/node/__test__/streaming.test.js
@@ -13,7 +13,7 @@
 const fs = require('fs');
 const path = require('path');
 const { Database } = require('../lib/index.js');
-const { skipIfNoDatasets, openDatabase, withDatabase } = require('./helpers.js');
+const { assertDatasetsAvailable, openDatabase, withDatabase } = require('./helpers.js');
 
 // Query over the largest basic-types table available (simple_table, ~1000 rows).
 // Large enough that per-row AsyncTask dispatch overhead is measurable.
@@ -58,7 +58,7 @@ async function fsReadLatency(file) {
 
 describe('Streaming Iterator Tests (Issue #305)', () => {
   beforeAll(() => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
   });
 
   describe('Basic Streaming', () => {

--- a/bindings/node/__test__/types.test.js
+++ b/bindings/node/__test__/types.test.js
@@ -17,7 +17,7 @@
  */
 
 const { Database } = require('../lib/index.js');
-const { skipIfNoDatasets } = require('./helpers.js');
+const { assertDatasetsAvailable } = require('./helpers.js');
 
 // Helper to check if value is a Date (works across realms)
 const isDate = (value) =>
@@ -55,7 +55,7 @@ describe('Type Conversion Tests (Issue #308)', () => {
   let dbCollections = null;
 
   beforeAll(async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
 
     // Open databases for different keyspaces
     dbBasic = await Database.open(global.testPaths.SSTABLES_DIR, {

--- a/bindings/node/__test__/value.test.js
+++ b/bindings/node/__test__/value.test.js
@@ -21,13 +21,13 @@
  */
 
 const { Database } = require('../lib/index.js');
-const { skipIfNoDatasets } = require('./helpers.js');
+const { assertDatasetsAvailable } = require('./helpers.js');
 
 describe('Value Type Conversion Tests (Issue #302)', () => {
   let db = null;
 
   beforeAll(async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     console.log(`Test data root: ${global.testPaths.TEST_DATA_ROOT}`);
     console.log(`SSTables dir: ${global.testPaths.SSTABLES_DIR}`);
     console.log(`Schema file: ${global.testPaths.SCHEMA_BASIC_TYPES}`);
@@ -405,7 +405,7 @@ describe('Set/Map constructor caching (#1448)', () => {
   let db = null;
 
   beforeAll(async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     db = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_COLLECTIONS,
     });

--- a/bindings/node/__test__/writetime-ttl.test.js
+++ b/bindings/node/__test__/writetime-ttl.test.js
@@ -15,7 +15,7 @@
 'use strict';
 
 const { Database } = require('../lib/index.js');
-const { skipIfNoDatasets } = require('./helpers.js');
+const { assertDatasetsAvailable } = require('./helpers.js');
 
 const QUERY =
   'SELECT id, WRITETIME(name), TTL(name) FROM test_basic.simple_table LIMIT 5';
@@ -24,7 +24,7 @@ describe('WRITETIME/TTL output (Issue #693)', () => {
   let db = null;
 
   beforeAll(async () => {
-    skipIfNoDatasets();
+    assertDatasetsAvailable();
     db = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_BASIC_TYPES,
     });

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -11800,10 +11800,13 @@ EOF
 # COMMENT FIRST GAVE (roborev/rust-reviewer round 1, B4). 14 of the suite's files gate on
 # dataset availability, so node-bindings IS now in DATASET_COMPONENTS (it was NOT before,
 # and that comment was correct then and would be a stale rationale now). Since #3641 the
-# 14 is checkable rather than remembered: `grep -l 'assertDatasetsAvailable(' __test__/
-# *.test.js` lists exactly those files plus helpers.test.js, the helper's own test. Before
-# #3641 it was 11 callers of `skipIfNoDatasets()` PLUS 3 files carrying a verbatim COPY of
-# its body, so the number in this comment and any grep for it disagreed by three.
+# 14 is checkable rather than remembered: `grep -l 'assertDatasetsAvailable('
+# __test__/*.test.js` lists exactly those plus helpers.test.js, the helper's own test.
+# The OPERAND is kept contiguous on one line deliberately (roborev job 71): split as
+# `__test__/` + `*.test.js` it is two operands, and it does not fail loudly -- measured,
+# it silently lists 2 files and exits 0, so a reader would under-count the gated suites.
+# Before #3641 it was 11 callers of `skipIfNoDatasets()` PLUS 3 files carrying a verbatim
+# COPY of its body, so the number in this comment and any grep for it disagreed by three.
 #
 # The FULL gate additionally exports CQLITE_REQUIRE_FIXTURES=1. What that buys, MEASURED:
 #   * ONE clean, named setup failure (setup.js's `No SSTable fixtures found: …` throw)

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -150,7 +150,9 @@
 #                      closes parity.test.js's `test.skip` placeholder, the one
 #                      corpus-conditional path that WOULD pass silently. It is NOT
 #                      protection against `describe.skip`: no *.test.js uses it (the
-#                      repo's Node convention is skipIfNoDatasets(), which THROWS).
+#                      repo's Node convention is assertDatasetsAvailable(), which
+#                      THROWS — #3641 renamed it from skipIfNoDatasets(), a skip-named
+#                      function that never skipped).
 #                      --only/--lite stay lenient and the #2078 opt-out is honoured,
 #                      with the mode PRINTED. check_jest_suites_ran is
 #                      the affirmative guard: the reported suite total must equal the
@@ -11797,11 +11799,15 @@ EOF
 # THE CORPUS HALF IS NOW HONOURED, NOT AVOIDED — AND THE REASON IS NOT THE ONE THIS
 # COMMENT FIRST GAVE (roborev/rust-reviewer round 1, B4). 14 of the suite's files gate on
 # dataset availability, so node-bindings IS now in DATASET_COMPONENTS (it was NOT before,
-# and that comment was correct then and would be a stale rationale now).
+# and that comment was correct then and would be a stale rationale now). Since #3641 the
+# 14 is checkable rather than remembered: `grep -l 'assertDatasetsAvailable(' __test__/
+# *.test.js` lists exactly those files plus helpers.test.js, the helper's own test. Before
+# #3641 it was 11 callers of `skipIfNoDatasets()` PLUS 3 files carrying a verbatim COPY of
+# its body, so the number in this comment and any grep for it disagreed by three.
 #
 # The FULL gate additionally exports CQLITE_REQUIRE_FIXTURES=1. What that buys, MEASURED:
 #   * ONE clean, named setup failure (setup.js's `No SSTable fixtures found: …` throw)
-#     instead of 14 separate `beforeAll` THROWS from `skipIfNoDatasets()`; and
+#     instead of 14 separate `beforeAll` THROWS from `assertDatasetsAvailable()`; and
 #   * it closes `parity.test.js:70`'s `test.skip` placeholder — the ONE
 #     corpus-conditional path in the whole suite that would otherwise pass SILENTLY.
 #
@@ -11809,7 +11815,7 @@ EOF
 # claim was false in three ways. There is no `describe.skip` anywhere in
 # `bindings/node/__test__/*.test.js` — the only occurrence of that string is inside a
 # COMMENT in dataset-guard.test.js. The repo's Node convention is the OPPOSITE of
-# skipping: `helpers.js`'s `skipIfNoDatasets()` THROWS, and `result.test.js` says so
+# skipping: `helpers.js`'s `assertDatasetsAvailable()` THROWS, and `result.test.js` says so
 # outright ("per the repo's Node test convention it THROWS (never skips) … so a
 # misconfigured CI run fails loudly rather than passing silently"). The earlier text also
 # said "7 suites"; the measured number is 14.
@@ -11866,7 +11872,7 @@ run_node_bindings() {
   # FAIL where it used to PASS: the old scope was `write-readback-content` alone, which
   # self-generates its SSTables. `env -u`'ing the strict variables (correct for B2, and kept)
   # does NOT help here, because the suites do not gate on them — `helpers.js`'s
-  # `skipIfNoDatasets()` throws on `!global.DATASETS_AVAILABLE` and never consults
+  # `assertDatasetsAvailable()` throws on `!global.DATASETS_AVAILABLE` and never consults
   # `REQUIRE_FIXTURES` at all. So 14 suites throw whenever the corpus is absent, opt-out or
   # not.
   #
@@ -11887,7 +11893,7 @@ run_node_bindings() {
     status=SKIP
     echo ">>> [$name] SKIP (AGENT_GATE_ALLOW_MISSING_FIXTURES=1 and no usable corpus at CQLITE_DATASETS_ROOT='${CQLITE_DATASETS_ROOT:-<unset>}')"
     echo ">>> [$name]   NOT VALIDATED by this run: the 14 dataset-gated jest suites. helpers.js's"
-    echo ">>> [$name]   skipIfNoDatasets() THROWS on an absent corpus and never consults the strict-mode"
+    echo ">>> [$name]   assertDatasetsAvailable() THROWS on an absent corpus and never consults strict-mode"
     echo ">>> [$name]   env vars, so they cannot be run leniently — the honest options are SKIP or FAIL,"
     echo ">>> [$name]   and FAIL would make the documented #2078 opt-out ineffective (roborev C2)."
     echo ">>> [$name]   The corpus-free half (incl. the #1231 write-readback content proof) is ALSO"


### PR DESCRIPTION
Closes #3641.

## What was wrong

`bindings/node/__test__/helpers.js` exported `skipIfNoDatasets()` — a `skipIf*` function
that **throws**. The throwing behaviour is correct and deliberate (#1458: a silent skip over
an absent corpus is how #646-class holes hide); the **name** was the defect.

It was not a cosmetic one. The name is a claim about behaviour, and this repo's merge-gate
design consumed that claim: a reader who trusts it expects a reduced-coverage run to be
available over an absent corpus, so the gate's `node-bindings` component looks like it could
run "leniently" under `AGENT_GATE_ALLOW_MISSING_FIXTURES=1`. It cannot — measured on an empty
root, `prepared.test.js` gives **16 failed / 16 total**, not 16 skipped — which is why that
component has to SKIP wholesale. The doc comment saying so sat two lines above the throw and
travelled to none of the call sites.

## What this does — option 1 of the issue, with the second spelling

`skipIfNoDatasets()` → **`assertDatasetsAvailable()`** across every call site.

**Why `assertDatasetsAvailable()` and not `requireDatasets()`** (the issue offers both):
`require` is already this suite's *strict-mode* vocabulary — `CQLITE_REQUIRE_FIXTURES` /
`CQLITE_PARITY_REQUIRE_DATASETS` → `global.REQUIRE_FIXTURES` in `setup.js`. This assertion is
**independent** of strict mode: it fires on an absent corpus whether or not strict mode is on,
and `agent-gate.sh` relies on that independence in the comment explaining why the component
SKIPs rather than running leniently. A `require`-named helper sitting beside that global
invites the reading "this only fires in strict mode" — the same class of misreading the rename
exists to remove. `assert*` says *throws* and borrows no strict-mode meaning.

## Three verbatim copies of the helper, now callers

The issue says *"14 dataset-gated suites depend on it"*. Measured on `main`, that was **11
files calling `skipIfNoDatasets()` (46 call sites) plus 3 files carrying a verbatim COPY of its
body** — `conversion-budget.test.js`, `leak-paths.test.js`, and `event-loop-latency.test.js`
behind a third name for the same thing, a local `requireData()`. Same condition, same error
message, three spellings.

All three now call the helper, so the doctrine count is true of the FUNCTION and not just of
the behaviour: `grep -l 'assertDatasetsAvailable(' bindings/node/__test__/*.test.js` lists
exactly those 14 files plus `helpers.test.js` (the helper's own test). No behaviour change —
the inlined bodies were character-identical to the helper's.

## The test that makes this worth gating

New `bindings/node/__test__/helpers.test.js` asserts what the old name denied, so option 2
("keep the name, make it actually skip" — rejected unless #1458 is re-argued) is a RED test
rather than a rename nobody notices:

- THROWS when the corpus is unavailable; returns quietly when it is available.
- The throw names both remedies (`CQLITE_DATASETS_ROOT`, `fetch-datasets.sh`).
- Independent of strict mode **in both directions** — throws with `REQUIRE_FIXTURES` off,
  silent with it on. This is the property `agent-gate.sh` states as load-bearing and that
  nothing asserted.
- No skip-named entry point is exported (an alias would restore the misnomer while leaving
  every call site green).
- No test file re-inlines the helper's error message — a guard against a fourth copy
  re-opening the 11-vs-14 gap.

It is deliberately **not** dataset-gated: it drives `global.DATASETS_AVAILABLE` directly and
runs on an empty root.

## Prose corrected in the same diff

`scripts/agent-gate.sh` (5 references, incl. the runtime SKIP message the component prints),
`.github/workflows/node-ci.yml`, and `CLAUDE.md`. The gate comment's "14" is now stated as
checkable-by-grep rather than remembered, with the 11-plus-3 history recorded so the next
person does not re-measure it.

## Verification

**Whole Node suite, real corpus** (`CQLITE_DATASETS_ROOT=/data/datasets`, debug build):
`Test Suites: 32 passed, 32 total / Tests: 2 skipped, 597 passed, 599 total`.

**RED-verified**, because a structural guard that has never failed is not evidence. With a
`skipIfNoDatasets: assertDatasetsAvailable` alias re-added AND the error message re-inlined into
`smoke.test.js`, `helpers.test.js` reports `2 failed, 5 passed` — the two structural cases,
by name. Both planted breaks reverted; tree clean.

**`--lite` PASS** at `e618f28` (`file-size fmt clippy roborev-lints scoped-tests`;
`scoped-tests` = `test cqlite-node default-features`).

**roborev PASS** (job 1, `gpt-5.6-sol`, `findings: NONE`, `prompt-content: PASS (18/18 code
census paths present)`, 227k input / 183k cached tokens).

**C intent audit: PASS** (spec-auditor, anchored to issue #3641's own acceptance criteria — this
is oracle-routed, so there is no OpenSpec change). All six criteria satisfied. Two nits it raised
are batched into #3772 and deliberately NOT fixed here: a stale hard-coded jest census count in
`scripts/agent-gate.sh` (pre-existing, verdict-neutral, and a `scripts/` edit is not
`--delta`-eligible so folding it in would cost a second full gate), and a describe title that
overstates its exact-literal guard.

## ⚠️ NO GATE OF RECORD YET — REBASED to `a9bfd46`, queued for the gate slot

Three full gates were launched and all three were **stopped by the owner by hand**, to protect a
peer lane's P1 build from `/data` exhaustion on a 295 GB filesystem shared by four lanes each
holding a 50–140 GB `target/`. None of the three was a gate failure.

| run | wall | reached | died in |
|---|---|---|---|
| r1 `GqTAAj` | 51 min | **20 PASS / 0 FAIL** | `work-counters-guard` |
| r2 `23qhnl` | 7 min | early | `clippy` |
| r3 `kHRTJV` | 29 min | **18 PASS / 0 FAIL** | `tombstones-scan` |

Per owner ruling on #3641 (option 3) the PR was held at `e618f28` until the predecessors
cleared, rather than burning a fourth gate on a tree that a rebase would void.

**Predecessors cleared 15:25Z.** Rebased onto `9da235a6c` → head **`a9bfd46`**, clean, no
conflicts. `git range-diff` reports both commits `=`, i.e. the diff is byte-identical and only the
base moved, so the round-1 roborev verdict applies to identical content. Re-verified post-rebase:
0 executable `skipIfNoDatasets`, 15 files matching `assertDatasetsAvailable(` (the 14 gated suites
plus `helpers.test.js`), every `*.test.js` passing `node --check`. A test file main added in the
interim (`issue-3612-multicell-tuple-map-key.test.js`) was checked against the new duplication
guard: it neither inlines the message nor consults `DATASETS_AVAILABLE`, so the guard does not fire
and the 14-suite census is unchanged. **`--lite` PASS at `a9bfd46`.**

Now queued for the box5 gate slot (third in the owner's order). The single gate of record runs when
the slot is free.

### What the non-certifying runs DID establish — information, NOT certification

Recorded here at the owner's request, and it must not be read as a gate of record:

- **No component has ever reddened, in any of the three runs.** Aggregate across r1 and r3, every
  component that touches this diff has cleared: `file-size`, `fmt`, `clippy`, `roborev-lints`,
  `core-tests`, `node-bindings`, `python-bindings`, `binding-rust-tests`,
  `binding-unwind-profile`, `all-features-check`, `flight-tests`, `legacy-heuristics`, both
  `feature-iso-*` lanes, `memory-budget`, `parity-report`, `delivery-telemetry`, `smoke`.
- **`node-bindings` PASSed twice**, in 293 s on r3, reporting *"suite set RECONCILED: 32
  `*.test.js` — two INDEPENDENT oracles agree (recursive find over `__test__/` vs
  `jest --listTests`)"* and *"corpus complete"*. So the new `helpers.test.js` is picked up by both
  oracles, and the 17-file rename clears the component that owns it.

That retires the substantive risk of a large rename. It is not a substitute for the single gate of
record this PR still owes, and the merge waits for it.

Full `AGENT-GATE SUMMARY` to be added by the closer after the post-rebase gate.




---

# ✅ CERTIFIED — gate of record, roborev, and C all green at `42774074b`

Rebased current with `main` (dropping the two commits #3872 landed independently), re-reviewed, then gated last with the tree frozen.

## AGENT-GATE SUMMARY (the gate of record — 37/37, 0 FAIL, 0 SKIP)

```

==== AGENT-GATE SUMMARY ====
run-id: /tmp/agent-gate.vHsnkV
commit: 4277407 branch: issue-3641-node-helpers-skip-throws dirty: no
datasets: 144 Data.db files under /data/datasets
schemas: 8/8 canonical .cql readable under /data/lanes/lane-3641/test-data/schemas (checkout-relative)
component-set: PASS (37/37 names vs origin/main 9bb2cc571f48830d205ca5aa11cbccd6d20165a6; NAMES ONLY — not implementations, and no component is run here) — baseline read via the committed manifest; objects: baseline REUSED from this lane's SHARED store — store TRUSTED, not verified (#3746)
ci-pins: DATASET_TAG: datasets-v3 DATASET_ASSET: cassandra5-small-full-v3.5.tar.gz DATASET_SHA256: 414195074f6df446a7381aad051af84158e9a021a6e2cd21cbc6c3ad0be1ba16 
accelerators: sccache=on nextest=on lanes=on sccache-health=ok mold=linked perf=ok
cpu-budget: wrapper=nice ncpu=16 max-concurrency=1(pinned) cores-per-gate=16 build-jobs=16(derived) test-threads=16
tree-start: 42774074b361 dirty: no digest: 89a1d20c8195
tree-end: 42774074b361 dirty: no digest: 89a1d20c8195
tree-integrity: PASS
census: 24/37 components AFFIRMED a count; 13 DECLARED-GAP (RECOGNISED); 0 NOT-MEASURED (RECOGNISED); 0 measured-ZERO (RECOGNISED); 0 not-applicable (component did not PASS); 0 no-subject (PASSed; the run had nothing to measure); 0 UNDECLARED; 0 unrecognised; 0 row(s) carry a VACUOUS status. NON-EXHAUSTIVE: the gap set is CURATED, so an unaffirmed component is UNMEASURED, never verified (#3625; the remaining gaps are tracked in #3162).
file-size:         PASS (0s)  [no-cargo]  {no census — shell/python guard prints no AGENT-GATE-CENSUS contract line yet (#3162)}
fmt:               PASS (8s)  [fmt workspace features=n/a]  {no census — cargo fmt --all --check emits no per-file tally to count}
clippy:            PASS (241s)  [clippy workspace(excl 5) --all-features | clippy cqlite-core --features 33:all-compression,arrow,bench-internals,+30 more | clippy cqlite-cli --features 10:benchmarks,ci_zero_tolerance,cli-helpers,+7 more | clippy cqlite-flight+cqlite-py+cqlite-node --features cqlite-node/write-support]  {no census — cargo clippy emits a per-crate tally only COLD; a warm run prints Finished alone}
roborev-lints:     PASS (70s)  [no-cargo]  {no census — shell/python guard prints no AGENT-GATE-CENSUS contract line yet (#3162)}
core-tests:        PASS (887s)  [nextest run cqlite-core --features cli-helpers | test cqlite-core --features cli-helpers]  {verified: 5518 tests passed (across 2 result line(s))}
tombstones-scan:   PASS (41s)  [test cqlite-core --features write-support,cli-helpers,tombstones]  {verified: 2 tests passed (across 1 result line(s))}
scan-offload-guard: PASS (149s)  [test cqlite-core --features cli-helpers,scan-offload-probe x2]  {verified: 15 tests passed (across 8 result line(s))}
work-counters-guard: PASS (81s)  [test cqlite-core --features write-support,cli-helpers,state_machine,work-counters]  {verified: 60 tests passed (across 15 result line(s))}
byte-budget-guard: PASS (13s)  [test cqlite-core --features write-support,cli-helpers,state_machine]  {verified: 21 tests passed (across 5 result line(s))}
arrow-parity-guard: PASS (37s)  [test cqlite-core --features arrow]  {verified: 4 tests passed (across 1 result line(s))}
memory-budget:     PASS (226s)  [test cqlite-core --features cli-helpers,dhat-heap,arrow x3 | test cqlite-flight --features dhat-heap]  {verified: 6 tests passed (across 4 result line(s))}
integration-tests: PASS (64s)  [test cqlite-integration-tests default-features x2]  {verified: 42 tests passed and 25 test binaries built/verified}
format-compat:     PASS (36s)  [test format-compatibility-tests default-features]  {verified: 10 tests passed (across 1 result line(s))}
write-tests:       PASS (140s)  [test cqlite-core --features write-support x3]  {verified: 3835 tests passed (across 3 result line(s))}
cli-tests:         PASS (149s)  [test cqlite-cli default-features | test cqlite-cli --features write-support]  {verified: 742 tests passed (across 47 result line(s))}
compaction-byte-parity: PASS (7s)  [test cqlite-core --features write-support x2]  {verified: 12 tests passed (across 4 result line(s))}
bti-multiclustering: PASS (4s)  [test cqlite-core --features state_machine,cli-helpers x2]  {verified: 12 tests passed (across 3 result line(s))}
query-semantics-oracle: PASS (1s)  [test cqlite-core --features state_machine,cli-helpers]  {verified: 6 tests passed (across 1 result line(s))}
flight-query-semantics-oracle: PASS (47s)  [test cqlite-flight default-features]  {verified: 4 tests passed (across 2 result line(s))}
flight-tests:      PASS (116s)  [test cqlite-flight default-features]  {verified: 392 tests passed (across 2 result line(s))}
legacy-heuristics: PASS (232s)  [build cqlite-core --features legacy-heuristics]  {verified: 3729 tests passed (across 6 result line(s))}
feature-iso-parquet: PASS (142s)  [test cqlite-core --no-default-features --features all-compression,parquet]  {verified: 1 test binaries built/verified}
feature-iso-delta-scan: PASS (65s)  [test cqlite-core --no-default-features --features all-compression,delta-scan]  {verified: 1 test binaries built/verified}
python-bindings:   PASS (639s)  [via maturin: feature set NOT observed]  {verified: 786 pytest tests passed}
node-bindings:     PASS (538s)  [via npm run build (napi): feature set NOT observed]  {verified: 601 jest tests passed}
binding-rust-tests: PASS (102s)  [test cqlite-ffi-common default-features | test cqlite-node --features write-support]  {verified: 123 tests passed (across 5 result line(s))}
delivery-telemetry: PASS (4s)  [no-cargo]  {no census — shell/python guard prints no AGENT-GATE-CENSUS contract line yet (#3162)}
oom-audit:         PASS (1s)  [build xtask default-features | run xtask default-features]  {no census — xtask/report driver prints no machine-readable subject count (#3162)}
parity-report:     PASS (25s)  [run cassandra-parity default-features]  {no census — xtask/report driver prints no machine-readable subject count (#3162)}
operator-metrics-doc: PASS (26s)  [run cqlite-core default-features]  {no census — xtask/report driver prints no machine-readable subject count (#3162)}
kit-dashboard-drift: PASS (1s)  [test cqlite-core default-features]  {verified: 6 tests passed (across 1 result line(s))}
binding-unwind-profile: PASS (1s)  [no-cargo]  {no census — shell/python guard prints no AGENT-GATE-CENSUS contract line yet (#3162)}
pub-surface:       PASS (0s)  [no-cargo]  {no census — shell/python guard prints no AGENT-GATE-CENSUS contract line yet (#3162)}
tooling-tests:     PASS (2355s)  [test ws0-corpus-gen default-features | + cargo not observable: cargo may run inside ~60 nested test scripts (child processes)]  {no census — shell/python guard prints no AGENT-GATE-CENSUS contract line yet (#3162)}
minimal-build:     PASS (57s)  [build cqlite-core --no-default-features --features all-compression | test cqlite-core --no-default-features --features all-compression]  {verified: 1 test binaries built/verified}
all-features-check: PASS (371s)  [check cqlite-core --all-features | clippy cqlite-core --all-features]  {no census — cargo check/clippy passes execute no tests; the subject is a feature set, not a count}
smoke:             PASS (359s)  [build cqlite-cli default-features]  {no census — smoke-test-all-tables.sh prints no machine-readable table count (#3162)}
node-bindings-leak-lane: RAN (#1465 exception-path/abandoned-iterator leak budgets executed inside #3522's whole-suite npm test; AFFIRMED from that run's own jest JSON report — every named budget test present and passed)
logs: /tmp/agent-gate.vHsnkV
summary-file: /tmp/gate-3641-arm.txt
heartbeat: on file: /tmp/gate-3641-arm.txt.heartbeat interval: 20s
launch-nonce: 20260902T190830Z-2529676-618031839
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```

## ROBOREV REVIEW SUMMARY (re-run after the rebase, per #3752)

```
```

## C intent audit — PASS

spec-auditor, anchored to issue #3641's own acceptance criteria (oracle-routed, no OpenSpec change). All six satisfied. Its one qualified criterion was #6, prose truthfulness, where it flagged the stale jest census — that gap is now closed (upstream by #3872, and the redundant local commits were dropped in this rebase). Nothing outside criterion 6's surface moved, so the verdict carries.

## Scope notes

- **Issue #3641 was closed into umbrella #3195**, so this lands under that umbrella.
- **#3772 is partially resolved**: item 1 (the hard-coded jest count) is fixed on `main` by #3872 slice 1/2. **Item 2 remains open** — `helpers.test.js`'s duplication guard matches the exact error-message literal, so a reworded copy evades it and a file merely quoting the string would false-RED it. Deferred deliberately: no failing scenario exists in the tree, and the remedy is a design call between two competing mechanisms.
- **Base staleness is reported as information, never a refusal.** The verdict is **"gate of record verified at `42774074b`"**, not "certified against main" — a squash composes this diff with main's current tip, and #3650 slice 2 (gating the merge result) is not implemented.
