### PR TITLE
fix(#3633): empty partition key takes Cassandra's MINIMUM token, in the reader AND the BTI writer

### DIFF
--- a/cqlite-core/src/storage/sstable/bti/parser/partitions.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser/partitions.rs
@@ -569,9 +569,17 @@ pub(crate) fn encode_partition_key_for_bti_trie_uncounted(raw_key_bytes: &[u8]) 
 /// layout (`[0x40] ++ be8(token ^ 0x8000_0000_0000_0000)`).
 ///
 /// This lets a caller that already holds the 128-bit hash words derive the trie
-/// key without re-hashing the raw key (issue #1681): `token` must be
-/// `cassandra_murmur3_normalize_token(h1)`, so the output is byte-identical to
-/// [`encode_partition_key_for_bti_trie`] over the same raw bytes.
+/// key without re-hashing the raw key (issue #1681).
+///
+/// **`token` is the key's TOKEN, which is not always `normalize(h1)`.** For a
+/// NON-EMPTY key, pass `cassandra_murmur3_normalize_token(h1)` and the output is
+/// byte-identical to [`encode_partition_key_for_bti_trie`] over the same raw
+/// bytes. For an EMPTY key, `normalize(h1) == 0` but the token is
+/// `CASSANDRA_MINIMUM_TOKEN`, so a caller passing `normalize(h1)` there encodes
+/// at token 0 and its leaf becomes unreachable by every reader probe, which is
+/// exactly the defect fixed in issue #3633. Callers on this single-pass route
+/// MUST carry their own `is_empty()` guard; the safe route is
+/// `cassandra_murmur3_token`, which already does.
 pub fn encode_bti_trie_key_from_token(token: i64) -> [u8; 9] {
     let bc: u64 = (token as u64) ^ 0x8000_0000_0000_0000u64;
     let bc_bytes = bc.to_be_bytes();

--- a/cqlite-core/src/storage/sstable/writer/partitions_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/partitions_writer.rs
@@ -75,7 +75,7 @@ use crate::error::{Error, Result};
 use crate::storage::sstable::bti::encode_bti_trie_key_from_token;
 use crate::storage::sstable::bti::parser::FLAG_HAS_HASH_BYTE;
 use crate::util::cassandra_murmur3::{
-    cassandra_murmur3_normalize_token, cassandra_murmur3_x64_128,
+    cassandra_murmur3_normalize_token, cassandra_murmur3_x64_128, CASSANDRA_MINIMUM_TOKEN,
 };
 use std::collections::BTreeMap;
 
@@ -183,7 +183,20 @@ impl PartitionsTrieWriter {
         // h1 → normalized token → trie key; h2 as u8 = the leaf filter hash byte
         // (`DecoratedKey.filterHashLowerBits() as u8`).
         let (h1, h2) = cassandra_murmur3_x64_128(raw_key_bytes);
-        let key = encode_bti_trie_key_from_token(cassandra_murmur3_normalize_token(h1));
+        // An EMPTY key takes the ring MINIMUM, not `normalize(h1)` (issue #3633).
+        // `Murmur3Partitioner.getToken(ByteBuffer, long[])` short-circuits a
+        // zero-length key to `MINIMUM` BEFORE consulting the hash, while
+        // `decorateKey` still stores `hash[0]`/`hash[1]` on the `DecoratedKey` --
+        // so the token is MINIMUM and the filter hash byte still comes from the
+        // real `h2`. Reading `cassandra_murmur3_token` here would cost a second
+        // hash pass and lose `h2`, which is why the guard is inlined and the
+        // single pass above is preserved (issue #1681, S4).
+        let token = if raw_key_bytes.is_empty() {
+            CASSANDRA_MINIMUM_TOKEN
+        } else {
+            cassandra_murmur3_normalize_token(h1)
+        };
+        let key = encode_bti_trie_key_from_token(token);
         let hash_byte = h2 as u8;
 
         // Track only the boundary raw keys (min/max trie key). `finish` sorts by

--- a/cqlite-core/src/storage/sstable/writer/partitions_writer_tests.rs
+++ b/cqlite-core/src/storage/sstable/writer/partitions_writer_tests.rs
@@ -955,3 +955,54 @@ fn partition_leaf_rows_offset_roundtrips() {
         }
     }
 }
+
+/// An EMPTY partition key is written at the ring MINIMUM, so the reader — which
+/// derives its probe token from `cassandra_murmur3_token` — finds it (issue #3633).
+///
+/// This is a genuine WRITER/READER DIFFERENTIAL, not a self-consistent
+/// round-trip: the two sides reach the minimum token by different code paths
+/// (the writer's inlined `is_empty()` guard vs. the reader's helper call), and
+/// the VALUE is pinned to the Cassandra oracle in
+/// `cassandra_murmur3::tests::empty_partition_key_token_is_cassandra_minimum`.
+/// Before the writer carried the guard it stored this leaf at
+/// `normalize(h1) == 0` while the reader probed at `i64::MIN`, so the lookup
+/// returned `None` — this test fails without the fix.
+#[test]
+fn empty_partition_key_is_written_at_cassandra_minimum_token() {
+    let mut w = PartitionsTrieWriter::new();
+    w.add_partition_with_payload(b"", PartitionPayload::DataOffset(7));
+    // A non-empty sibling, so this is not a degenerate single-leaf trie.
+    w.add_partition_with_payload(b"a", PartitionPayload::DataOffset(9));
+    let bytes = w.finish().expect("finish");
+
+    let mut cur = Cursor::new(bytes);
+    let loc = lookup_raw_key_in_bti_partitions_db(&mut cur, b"")
+        .expect("lookup must not error")
+        .expect("the empty key must be found at the MINIMUM token");
+    match loc {
+        BtiPartitionLocation::DataOffset(o) => assert_eq!(o, 7),
+        BtiPartitionLocation::RowsOffset(o) => {
+            panic!("expected DataOffset(7), got RowsOffset({o})")
+        }
+    }
+
+    // The non-empty sibling is unaffected by the guard.
+    let mut cur = Cursor::new(w2_bytes());
+    let loc = lookup_raw_key_in_bti_partitions_db(&mut cur, b"a")
+        .expect("lookup must not error")
+        .expect("the non-empty key must still be found");
+    match loc {
+        BtiPartitionLocation::DataOffset(o) => assert_eq!(o, 9),
+        BtiPartitionLocation::RowsOffset(o) => {
+            panic!("expected DataOffset(9), got RowsOffset({o})")
+        }
+    }
+}
+
+/// Rebuild the same two-leaf trie as above (a `finish()` consumes the writer).
+fn w2_bytes() -> Vec<u8> {
+    let mut w = PartitionsTrieWriter::new();
+    w.add_partition_with_payload(b"", PartitionPayload::DataOffset(7));
+    w.add_partition_with_payload(b"a", PartitionPayload::DataOffset(9));
+    w.finish().expect("finish")
+}

--- a/cqlite-core/src/util/cassandra_murmur3.rs
+++ b/cqlite-core/src/util/cassandra_murmur3.rs
@@ -144,13 +144,13 @@ pub fn cassandra_murmur3_x64_128(data: &[u8]) -> (i64, i64) {
 /// The minimum token of Cassandra's Murmur3 ring — `Murmur3Partitioner.MINIMUM`.
 ///
 /// `git show cassandra-5.0.8:src/java/org/apache/cassandra/dht/Murmur3Partitioner.java`
-/// line 50: `public static final LongToken MINIMUM = new LongToken(Long.MIN_VALUE);`
+/// field `MINIMUM`: `public static final LongToken MINIMUM = new LongToken(Long.MIN_VALUE);`
 ///
 /// It is the token of the **empty** partition key and of nothing else: the javadoc on
-/// `getToken` (lines 250-255) states that "all generated token are strictly bigger than
+/// `getToken` states that "all generated token are strictly bigger than
 /// MINIMUM ... we don't want MINIMUM to correspond to any key because the range
 /// (MINIMUM, X] doesn't include MINIMUM but we use such range to select all data whose
-/// token is smaller than X", and `normalize` (lines 291-295) enforces that by remapping
+/// token is smaller than X", and `normalize(long)` enforces that by remapping
 /// a hashed `Long.MIN_VALUE` to `Long.MAX_VALUE`.
 ///
 /// Named rather than spelled `i64::MIN` at each site so the ring minimum is greppable:
@@ -165,7 +165,7 @@ pub const CASSANDRA_MINIMUM_TOKEN: i64 = i64::MIN;
 ///
 /// An **empty** key short-circuits to [`CASSANDRA_MINIMUM_TOKEN`] without hashing,
 /// exactly as Cassandra does (`Murmur3Partitioner.getToken(ByteBuffer, long[])`,
-/// cassandra-5.0.8 lines 261-267: `if (key.remaining() == 0) return MINIMUM;`).
+/// cassandra-5.0.8: `if (key.remaining() == 0) return MINIMUM;`).
 /// The hash of the empty input is `h1 == 0` and `normalize(0) == 0`, so without
 /// this branch an empty key would be placed on the ring at token 0 (issue #3633).
 pub fn cassandra_murmur3_token(data: &[u8]) -> i64 {
@@ -558,7 +558,7 @@ mod tests {
     /// value at seed 0 and must stay asserted as-is. It does NOT contradict
     /// `cassandra_murmur3_token(b"") == CASSANDRA_MINIMUM_TOKEN`: Cassandra's
     /// `Murmur3Partitioner.getToken(ByteBuffer, long[])` (cassandra-5.0.8, lines
-    /// 261-267) returns `MINIMUM` for a zero-length key BEFORE consulting the hash,
+    /// returns `MINIMUM` for a zero-length key BEFORE consulting the hash,
     /// so the raw hash and the token legitimately differ at empty input. Do not
     /// "reconcile" the two — changing this assertion would break the port of
     /// `MurmurHash.hash3_x64_128`.
@@ -632,8 +632,8 @@ mod tests {
     ///
     /// Oracle (pinned Cassandra 5.0.8, the only format authority here):
     /// `git show cassandra-5.0.8:src/java/org/apache/cassandra/dht/Murmur3Partitioner.java`
-    /// - line 50: `public static final LongToken MINIMUM = new LongToken(Long.MIN_VALUE);`
-    /// - lines 261-267: `private LongToken getToken(ByteBuffer key, long[] hash)` is
+    /// - field `MINIMUM`: `public static final LongToken MINIMUM = new LongToken(Long.MIN_VALUE);`
+    /// - `private LongToken getToken(ByteBuffer key, long[] hash)` is
     ///   `{ if (key.remaining() == 0) return MINIMUM; return new LongToken(normalize(hash[0])); }`
     ///
     /// So Cassandra returns `Long.MIN_VALUE` for a zero-length key, short-circuiting
@@ -680,7 +680,7 @@ mod tests {
             );
             // A non-empty key never lands on MINIMUM: `normalize` maps `i64::MIN`
             // to `i64::MAX` precisely so the ring minimum stays unreachable
-            // (Murmur3Partitioner.normalize, cassandra-5.0.8 lines 291-295).
+            // (Murmur3Partitioner.normalize(long), cassandra-5.0.8).
             assert_ne!(cassandra_murmur3_token(key), CASSANDRA_MINIMUM_TOKEN);
         }
     }

--- a/cqlite-core/src/util/cassandra_murmur3.rs
+++ b/cqlite-core/src/util/cassandra_murmur3.rs
@@ -183,8 +183,18 @@ pub fn cassandra_murmur3_token(data: &[u8]) -> i64 {
 ///
 /// Exposed so a caller that already holds `(h1, h2)` from a single
 /// [`cassandra_murmur3_x64_128`] pass can derive the token without re-hashing
-/// the key (issue #1681). `cassandra_murmur3_token(data)` is exactly
-/// `cassandra_murmur3_normalize_token(cassandra_murmur3_x64_128(data).0)`.
+/// the key (issue #1681).
+///
+/// **This is NOT the whole token function.** For a NON-EMPTY key,
+/// `cassandra_murmur3_token(data)` equals
+/// `cassandra_murmur3_normalize_token(cassandra_murmur3_x64_128(data).0)`. For an
+/// EMPTY key it does NOT: the token is [`CASSANDRA_MINIMUM_TOKEN`], because
+/// `Murmur3Partitioner.getToken(ByteBuffer, long[])` short-circuits a zero-length
+/// key to `MINIMUM` before consulting the hash, while `normalize(0) == 0`
+/// (issue #3633). A caller taking this single-pass route MUST carry its own
+/// `is_empty()` guard: reading this equivalence as unconditional is exactly how
+/// the BTI partitions writer came to place an empty key at token 0 while the
+/// reader probed at `i64::MIN`.
 pub fn cassandra_murmur3_normalize_token(h1: i64) -> i64 {
     normalize(h1)
 }

--- a/cqlite-core/src/util/cassandra_murmur3.rs
+++ b/cqlite-core/src/util/cassandra_murmur3.rs
@@ -632,9 +632,9 @@ mod tests {
     ///
     /// Oracle (pinned Cassandra 5.0.8, the only format authority here):
     /// `git show cassandra-5.0.8:src/java/org/apache/cassandra/dht/Murmur3Partitioner.java`
-    ///   - line 50:      `public static final LongToken MINIMUM = new LongToken(Long.MIN_VALUE);`
-    ///   - lines 261-267: `private LongToken getToken(ByteBuffer key, long[] hash)`
-    ///                    `{ if (key.remaining() == 0) return MINIMUM; ... }`
+    /// - line 50: `public static final LongToken MINIMUM = new LongToken(Long.MIN_VALUE);`
+    /// - lines 261-267: `private LongToken getToken(ByteBuffer key, long[] hash)` is
+    ///   `{ if (key.remaining() == 0) return MINIMUM; return new LongToken(normalize(hash[0])); }`
     ///
     /// So Cassandra returns `Long.MIN_VALUE` for a zero-length key, short-circuiting
     /// the hash entirely. The raw hash of `b""` at seed 0 is `h1 == 0` and

--- a/cqlite-core/src/util/cassandra_murmur3.rs
+++ b/cqlite-core/src/util/cassandra_murmur3.rs
@@ -162,7 +162,17 @@ pub const CASSANDRA_MINIMUM_TOKEN: i64 = i64::MIN;
 ///
 /// Takes h1 from the 128-bit hash and applies `normalize`:
 /// maps `i64::MIN` to `i64::MAX` (Cassandra excludes the minimum token value).
+///
+/// An **empty** key short-circuits to [`CASSANDRA_MINIMUM_TOKEN`] without hashing,
+/// exactly as Cassandra does (`Murmur3Partitioner.getToken(ByteBuffer, long[])`,
+/// cassandra-5.0.8 lines 261-267: `if (key.remaining() == 0) return MINIMUM;`).
+/// The hash of the empty input is `h1 == 0` and `normalize(0) == 0`, so without
+/// this branch an empty key would be placed on the ring at token 0 (issue #3633).
 pub fn cassandra_murmur3_token(data: &[u8]) -> i64 {
+    // `key.remaining() == 0` in Cassandra's terms.
+    if data.is_empty() {
+        return CASSANDRA_MINIMUM_TOKEN;
+    }
     let (h1, _) = cassandra_murmur3_x64_128(data);
     cassandra_murmur3_normalize_token(h1)
 }
@@ -543,6 +553,15 @@ mod tests {
     }
 
     /// Verify the raw hash function returns (h1, h2) — not swapped
+    ///
+    /// NOTE (issue #3633): `h1 == 0` for `b""` is the CORRECT raw murmur3_x64_128
+    /// value at seed 0 and must stay asserted as-is. It does NOT contradict
+    /// `cassandra_murmur3_token(b"") == CASSANDRA_MINIMUM_TOKEN`: Cassandra's
+    /// `Murmur3Partitioner.getToken(ByteBuffer, long[])` (cassandra-5.0.8, lines
+    /// 261-267) returns `MINIMUM` for a zero-length key BEFORE consulting the hash,
+    /// so the raw hash and the token legitimately differ at empty input. Do not
+    /// "reconcile" the two — changing this assertion would break the port of
+    /// `MurmurHash.hash3_x64_128`.
     #[test]
     fn test_hash_returns_h1_h2_order() {
         // For the empty input with seed 0, both h1 and h2 should be 0
@@ -647,7 +666,10 @@ mod tests {
             (&[0x80], -5284281814142962636),
             (&[0xFF], -4442228696663692417),
             (&[0, 0, 0, 0, 0, 0, 0, 0], 2945182322382062539),
-            (&[0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], 9204767954415360687u64 as i64),
+            (
+                &[0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+                9204767954415360687u64 as i64,
+            ),
             (&[0x11; 16], 4360155383588533346),
         ];
         for (key, expected) in vectors {

--- a/cqlite-core/src/util/cassandra_murmur3.rs
+++ b/cqlite-core/src/util/cassandra_murmur3.rs
@@ -141,6 +141,23 @@ pub fn cassandra_murmur3_x64_128(data: &[u8]) -> (i64, i64) {
     (h1 as i64, h2 as i64)
 }
 
+/// The minimum token of Cassandra's Murmur3 ring — `Murmur3Partitioner.MINIMUM`.
+///
+/// `git show cassandra-5.0.8:src/java/org/apache/cassandra/dht/Murmur3Partitioner.java`
+/// line 50: `public static final LongToken MINIMUM = new LongToken(Long.MIN_VALUE);`
+///
+/// It is the token of the **empty** partition key and of nothing else: the javadoc on
+/// `getToken` (lines 250-255) states that "all generated token are strictly bigger than
+/// MINIMUM ... we don't want MINIMUM to correspond to any key because the range
+/// (MINIMUM, X] doesn't include MINIMUM but we use such range to select all data whose
+/// token is smaller than X", and `normalize` (lines 291-295) enforces that by remapping
+/// a hashed `Long.MIN_VALUE` to `Long.MAX_VALUE`.
+///
+/// Named rather than spelled `i64::MIN` at each site so the ring minimum is greppable:
+/// this is the single authoritative definition shared by the streaming k-way merge, the
+/// `WHERE pk IN (...)` fan-out and the scan fallbacks (see [`cmp_partition_keys_by_token`]).
+pub const CASSANDRA_MINIMUM_TOKEN: i64 = i64::MIN;
+
 /// Compute a Murmur3 partition token matching Cassandra's Murmur3Partitioner.
 ///
 /// Takes h1 from the 128-bit hash and applies `normalize`:
@@ -589,6 +606,60 @@ mod tests {
                 "bc first byte mismatch for UUID {:02X}*16",
                 c.uuid_byte
             );
+        }
+    }
+
+    /// An EMPTY partition key hashes to the ring MINIMUM, not to `normalize(h1)`.
+    ///
+    /// Oracle (pinned Cassandra 5.0.8, the only format authority here):
+    /// `git show cassandra-5.0.8:src/java/org/apache/cassandra/dht/Murmur3Partitioner.java`
+    ///   - line 50:      `public static final LongToken MINIMUM = new LongToken(Long.MIN_VALUE);`
+    ///   - lines 261-267: `private LongToken getToken(ByteBuffer key, long[] hash)`
+    ///                    `{ if (key.remaining() == 0) return MINIMUM; ... }`
+    ///
+    /// So Cassandra returns `Long.MIN_VALUE` for a zero-length key, short-circuiting
+    /// the hash entirely. The raw hash of `b""` at seed 0 is `h1 == 0` and
+    /// `normalize(0) == 0`, so without the guard CQLite would answer `0` — a token
+    /// that belongs to some other key's slot on the ring.
+    #[test]
+    fn empty_partition_key_token_is_cassandra_minimum() {
+        assert_eq!(
+            cassandra_murmur3_token(b""),
+            CASSANDRA_MINIMUM_TOKEN,
+            "empty key must map to Murmur3Partitioner.MINIMUM"
+        );
+        assert_eq!(CASSANDRA_MINIMUM_TOKEN, i64::MIN);
+        // The guard is on the key length, not on the hash value: the raw hash of the
+        // empty input is still 0 (see `test_hash_returns_h1_h2_order`).
+        assert_eq!(cassandra_murmur3_x64_128(b"").0, 0);
+        assert_eq!(cassandra_murmur3_normalize_token(0), 0);
+    }
+
+    /// The empty-key guard must not perturb any NON-empty key (hot-path regression
+    /// pin). Every expected value here is an already-pinned vector from the test
+    /// vectors above, all of which derive from Cassandra's `Murmur3Partitioner`.
+    #[test]
+    fn non_empty_key_tokens_unchanged_by_empty_key_guard() {
+        let vectors: &[(&[u8], i64)] = &[
+            (b"a", -8839064797231613815),
+            (b"hello", -3758069500696749310),
+            (&[0x00], 5048724184180415669),
+            (&[0x80], -5284281814142962636),
+            (&[0xFF], -4442228696663692417),
+            (&[0, 0, 0, 0, 0, 0, 0, 0], 2945182322382062539),
+            (&[0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], 9204767954415360687u64 as i64),
+            (&[0x11; 16], 4360155383588533346),
+        ];
+        for (key, expected) in vectors {
+            assert_eq!(
+                cassandra_murmur3_token(key),
+                *expected,
+                "token changed for non-empty key {key:02X?}"
+            );
+            // A non-empty key never lands on MINIMUM: `normalize` maps `i64::MIN`
+            // to `i64::MAX` precisely so the ring minimum stays unreachable
+            // (Murmur3Partitioner.normalize, cassandra-5.0.8 lines 291-295).
+            assert_ne!(cassandra_murmur3_token(key), CASSANDRA_MINIMUM_TOKEN);
         }
     }
 }


### PR DESCRIPTION
Closes #3633

## What

`cassandra_murmur3_token` had no empty-key branch, so an empty partition key was placed on the ring at token `0`. Cassandra's `Murmur3Partitioner.getToken` short-circuits a zero-length key to `MINIMUM` (`Long.MIN_VALUE`) *before* consulting the hash. This adds that guard, exports `CASSANDRA_MINIMUM_TOKEN` so the ring minimum is greppable, and fixes the **BTI partitions writer**, which computed its trie token independently and would otherwise have disagreed with the reader.

## Read this before reading the diff: this change alters the KIND of failure, not just the amount

The issue body says `cassandra_murmur3_token` is "the single authoritative token definition". **That premise is false.** Three independent implementations of that one definition exist:

| # | Site | Before | After this PR |
|---|---|---|---|
| 1 | `cassandra_murmur3.rs` `cassandra_murmur3_token` | `0` | **`i64::MIN`** |
| 2 | `partitions_writer.rs` (BTI writer, inlined single-pass for #1681) | `0` | **`i64::MIN`** |
| 3 | `trino-connector/.../Murmur3Token.java:38` | `0` | **still `0`** — deferred to #3785 |

**Before this change all three agreed on `0` — consistently wrong. Fixing only the reader would have made them inconsistent**: the reader probing at `i64::MIN` while the writer stored the leaf at `0`, leaving it unreachable by every reader probe. That is a worse failure *kind* than the original, which is precisely why (2) is fixed here and not deferred — it is the half this PR destabilises. A reviewer who does not know this reads the diff as a pure improvement; it is not, and the remaining Java gap is a real, named window that stays open until #3785 lands.

**What makes that window acceptable:** an empty partition key is unreachable from valid Cassandra output — Cassandra rejects it at write time and CQLite fails closed on it (#2302/#2325, `walk_in_range_partition_slices` returns `FellBack`/corruption rather than emitting one). So every part of this stays **latent**, consistent with the issue's own P3 rationale. A named latent divergence with a filed follow-up is a normal state; an unnamed one is not.

## Oracle — pinned `cassandra-5.0.8`, no CQLite `file:line` used as authority

`git show cassandra-5.0.8:src/java/org/apache/cassandra/dht/Murmur3Partitioner.java`

- field `MINIMUM` — `public static final LongToken MINIMUM = new LongToken(Long.MIN_VALUE);`
- `private LongToken getToken(ByteBuffer key, long[] hash)` — `if (key.remaining() == 0) return MINIMUM; return new LongToken(normalize(hash[0]));`
- `normalize(long)` — `return v == Long.MIN_VALUE ? Long.MAX_VALUE : v;` // *"We exclude the MINIMUM value; see getToken()"*
- `decorateKey(ByteBuffer)` — `long[] hash = getHash(key); return new PreHashedDecoratedKey(getToken(key, hash), key, hash[0], hash[1]);`

Citations in code are anchored on **field/method names plus verbatim quoted code**, deliberately not line numbers: a line number cannot be checked by the next reader without trusting whoever wrote it, and it drifts between versions. (An earlier revision of this branch cited line numbers; two of the three were wrong.)

## Why the fix is COMPLETE, not cosmetic

Cassandra's invariant is that *all generated tokens are strictly bigger than MINIMUM*, because the range `(MINIMUM, X]` excludes MINIMUM and is used to select all data with a token below X. That needs two things, and both now hold:

1. the empty key maps to MINIMUM — this change; and
2. MINIMUM is **unreachable** from the hash path — `normalize(i64::MIN) == i64::MAX`, verified against the pinned source, so no non-empty key can ever land on it.

Had (2) been false, MINIMUM would collide with a real key's token and the fix would have satisfied the acceptance criteria while leaving range scans wrong.

`decorateKey` computes the hash **unconditionally** and keeps `hash[0]`/`hash[1]` on the `DecoratedKey` even when the token is `MINIMUM` — so the BTI writer takes `MINIMUM` as its token while the leaf filter-hash byte still comes from the real `h2`. The guard is inlined rather than calling `cassandra_murmur3_token`, which would cost a second hash pass and discard `h2`: **#1681's single-pass optimisation is preserved, not traded away.**

## Tests

- `empty_partition_key_token_is_cassandra_minimum` — pins `cassandra_murmur3_token(b"") == i64::MIN`, and separately pins that the RAW hash of `b""` is still `0`, so the two layers cannot be conflated.
- `non_empty_key_tokens_unchanged_by_empty_key_guard` — 8 keys, hot-path regression pin. Every expected value is a **reused pre-existing pin** from elsewhere in the file, never a freshly observed CQLite output, so the test cannot be circular. Each also asserts `!= CASSANDRA_MINIMUM_TOKEN`.
- `empty_partition_key_is_written_at_cassandra_minimum_token` — a writer/reader **differential**, not a self-consistent round-trip: the two sides reach the minimum by different code paths (the writer's inlined guard vs. the reader's helper), and the value is pinned to the oracle elsewhere. **Verified RED**: with the writer guard removed, the empty key's lookup returns `None` and this test fails.
- `test_hash_returns_h1_h2_order` is **unchanged** and still asserts `h1 == 0` for `b""` — the correct raw murmur3 value at seed 0 — with a note recording why the raw hash and the token legitimately differ, so the next reader does not "reconcile" them.

A fourth test was written and **removed**: it pinned the reader's probe encoding, and the red check showed it **passed with the writer guard absent**, because it exercised only the already-fixed reader path. It would have overstated its coverage.

## Doc fixes are part of the defect, not tidying

Two public docs told callers that `cassandra_murmur3_token(data)` is *exactly* `normalize(x64_128(data).0)` and to pass `normalize(h1)` on the #1681 single-pass route. **That instruction is what the BTI writer followed into this bug.** Both now scope the equivalence to non-empty keys and name `CASSANDRA_MINIMUM_TOKEN`. The class was swept, not patched site-by-site: those two were the only such docs in `cqlite-core`.

## Deferred, with a filed follow-up

**#3785** owns the Java `Murmur3Token` fix, per lead ruling on `REQ-3633-01`. `trino-connector` is a separate Java artifact this PR's gate does not build or test, so fixing it here would ship a change **certified by nothing**. #3785 additionally requires a **cross-language parity assertion** — the real defect is that three implementations drifted and nothing detects drift.

## File-size ratchet: `CQLITE_ALLOW_FILE_GROWTH=1` is required, and here is why

The campsite ratchet FAILs this diff, and the **gate of record must be run with `CQLITE_ALLOW_FILE_GROWTH=1`**. Disclosed rather than buried, because it is an escape hatch on a merge gate:

```
cqlite-core/src/storage/sstable/bti/parser/partitions.rs:      984 -> 992  (limit 800)
cqlite-core/src/storage/sstable/writer/partitions_writer.rs: 1252 -> 1265 (limit 800)
```

Both files were **already over threshold on `main`** (984 and 1252); this change did not push either over, it grew files that were over. The growth is not reducible to zero:

- `partitions.rs` **+8** is entirely the doc fix roborev job 7 required — the doc that told callers to pass `normalize(h1)` and thereby caused the writer bug.
- `partitions_writer.rs` **+13** is the empty-key guard itself (~5 lines irreducible) plus its oracle rationale.

Clearing the ratchet honestly would mean splitting a 1265-line writer and a 992-line parser — a refactor under epic #1116 / #1135, not something to smuggle into a P3 token fix. Per CLAUDE.md that makes this the documented out-of-scope case; the flag prints an explicit `ALLOWED via CQLITE_ALLOW_FILE_GROWTH=1` line, so its use is visible in the gate log rather than inferred.

## Certification

**Full gate of record: `RESULT: PASS`, 37/37 components.**

```
run-id: /tmp/agent-gate.z8vIJz
commit: 2a7db58 branch: issue-3633-murmur3-empty-partition-key dirty: no
tree-start: 2a7db580ea86 dirty: no digest: 033523ffb415
tree-end:   2a7db580ea86 dirty: no digest: 033523ffb415
tree-integrity: PASS
component-set: PASS (37/37 names vs origin/main 8c503f7cfafa562d436985a104be9e7807fed1a1)
file-size: PASS (0s)          [via CQLITE_ALLOW_FILE_GROWTH=1 — see the section above]
clippy: PASS (972s)  core-tests: PASS (1008s)  tooling-tests: PASS (2153s)
all-features-check: PASS (1271s)  feature-iso-parquet: PASS (820s)
feature-iso-delta-scan: PASS (776s)  binding-rust-tests: PASS (816s)
RESULT: PASS
```

Summary file: `/tmp/gate-full-3633-b.txt`. The `run-id` and `launch-nonce` were verified against the process actually launched from this lane, per #3616 — a summary located by recency can be a peer lane's.

Note the gate's first attempt died at component 6 with a clean exit 0 and no verdict (not OOM — box-wide `oom_kill 0`; not memory — 1.0G peak; not load — 2.0). Reported as `REQ-3633-02` on the issue. **It is not a signal about this diff**: the relaunch passed 37/37 on the identical tree digest.

- C (spec-auditor): <FILL>
- roborev: findings DEFERRED to #3785 per lead ruling on `REQ-3633-01`; to be recorded via `roborev-defer: findings` + `--recheck-job`. **Not yet granted — this PR will not be armed until it reads `DEFERRED`.**
