### PR TITLE
test(#3724): cross-binding parity for the multicell UDT map keys, and pin the fixture-resolution contract

### DIFF
--- a/bindings/node/__test__/issue-3504-udt-field-namespace.test.js
+++ b/bindings/node/__test__/issue-3504-udt-field-namespace.test.js
@@ -482,7 +482,7 @@ describe('UDT field-name / type-identity collision (issue #3504)', () => {
   // CQLITE_DATASETS_ROOT (#3131/#3148; issue #3724 AC5)
   // ==========================================================================
 
-  test('the fixture and the parity reference resolve checkout-relative, not via CQLITE_DATASETS_ROOT', () => {
+  test('the fixture and the parity reference resolve checkout-relative, not via the datasets-root env var', () => {
     // The file docstring and the reference's `note_on_paths` DOCUMENT this
     // contract; nothing ASSERTED it. `assertFixturePresent` cannot: it checks
     // existence at the ALREADY-RESOLVED path, so it would pass unchanged if
@@ -500,8 +500,8 @@ describe('UDT field-name / type-identity collision (issue #3504)', () => {
     // Half 2 can see it. A maintainer reading a failure needs to know which run
     // they are looking at, and neither state is the "right" one to run under.
     const ambientNote =
-      `ambient CQLITE_DATASETS_ROOT: ` +
-      `${process.env.CQLITE_DATASETS_ROOT === undefined ? '(unset)' : process.env.CQLITE_DATASETS_ROOT}`;
+      `ambient CQLITE_DATASETS_ROOT: ` + // CONTROL: names the variable under test, diagnostic label only
+      `${process.env.CQLITE_DATASETS_ROOT === undefined ? '(unset)' : process.env.CQLITE_DATASETS_ROOT}`; // CONTROL: the AMBIENT read, diagnostic only
     // jest matchers take no message argument, so the note is added by RETHROWING:
     // the matcher's own diff is preserved and the ambient value is appended to it.
     const withAmbient = (assertions) => {
@@ -563,7 +563,7 @@ describe('UDT field-name / type-identity collision (issue #3504)', () => {
     try {
       expect(fs.readdirSync(bogus)).toEqual([]);
 
-      const childEnv = { ...process.env, CQLITE_DATASETS_ROOT: bogus };
+      const childEnv = { ...process.env, CQLITE_DATASETS_ROOT: bogus }; // CONTROL: the perturbation itself
       // Cleared for the CHILD only: `setup.js:246-251` makes a corpus-less root
       // a hard throw under either strict-fixture flag (as the gate's
       // node-bindings lane sets them), which would leave the probe unable to run
@@ -653,11 +653,27 @@ describe('UDT field-name / type-identity collision (issue #3504)', () => {
     //     source. Requiring it to SAY so is what stops the exemption silently
     //     growing into a consumer.
     //
-    // DECLARED BOUND, because a guard that overstates its reach is worse than
-    // none: a consumer reading `process.env` DIRECTLY names no constant and is
-    // invisible here. That half is what the child-process probe above measures,
-    // so the two are complementary rather than overlapping.
+    // A SECOND NEEDLE, closing the cheap half of what this guard used to merely
+    // declare (roborev #3724 round 4): the env VARIABLE NAME itself. A future test
+    // that skips the corpus constants and reads `process.env.<var>` DIRECTLY names
+    // none of the constants above, so the first needle cannot see it — but such a
+    // read must contain the variable's name as a literal, and a literal in this
+    // file's source plainly IS checkable. Same two exemptions, same count assert.
+    //
+    // DECLARED RESIDUAL, and it is what keeps this guard honest — the half a
+    // source scan genuinely cannot reach is an INDIRECT read: a helper that
+    // returns the value, a COMPUTED or concatenated variable name
+    // (`process.env[someVar]`), or an alias bound to `process.env` names neither a
+    // corpus constant nor the literal, so neither needle fires. That half stays
+    // the child-process probe's job — it measures the RESOLVED paths under a
+    // perturbed environment, whatever route a consumer took to read it, so the two
+    // are complementary rather than overlapping and neither alone closes the class.
+    // Deliberately NOT met with an AST or dataflow "environment read" detector: a
+    // recogniser over author-controlled code accumulates false PASSes, and a guard
+    // with known false PASSes is worse than no guard at all.
     const forbidden = ['SSTABLES' + '_DIR', 'TEST_DATA' + '_ROOT', 'DATASETS' + '_AVAILABLE'];
+    const envVar = 'CQLITE_' + 'DATASETS_ROOT';
+    const needles = [...forbidden, envVar];
     const source = fs.readFileSync(__filename, 'utf8');
 
     const offenders = [];
@@ -669,7 +685,7 @@ describe('UDT field-name / type-identity collision (issue #3504)', () => {
       if (line.includes('CONTROL')) {
         return;
       }
-      for (const name of forbidden) {
+      for (const name of needles) {
         if (line.includes(name)) {
           offenders.push(`${index + 1}: ${trimmed}`);
           return;
@@ -683,10 +699,16 @@ describe('UDT field-name / type-identity collision (issue #3504)', () => {
     // split would silently make the scan look for a name that occurs nowhere and
     // the test would pass having checked nothing. The two known control lines
     // must therefore be FOUND — by the same `includes` the scan uses.
-    const controlLines = source
-      .split('\n')
-      .filter((line) => line.includes('CONTROL') && forbidden.some((n) => line.includes(n)));
-    expect(controlLines.length).toBe(2);
+    const controlLinesFor = (names) =>
+      source
+        .split('\n')
+        .filter((line) => line.includes('CONTROL') && names.some((n) => line.includes(n)));
+    expect(controlLinesFor(forbidden).length).toBe(2);
+    // The env-var needle's own control set, counted SEPARATELY: folding the two
+    // into one total would let a typo in either split hide behind the other's
+    // matches. MEASURED at 4 -- the ambient diagnostic's label and read, the
+    // perturbation, and the probe's echo of it.
+    expect(controlLinesFor([envVar]).length).toBe(4);
   });
 });
 
@@ -776,7 +798,7 @@ const mod = require(modulePath);
 const payload = {
   // The POSITIVE CONTROL pair: what the child actually saw, and a constant
   // whose documented contract IS to follow it.
-  envSeen: process.env.CQLITE_DATASETS_ROOT,
+  envSeen: process.env.CQLITE_DATASETS_ROOT, // CONTROL: the probe echoes the perturbed value back
   controlEnvRouted: global.testPaths.SSTABLES_DIR, // CONTROL: env-routed BY CONTRACT, never a consumer
   // The INVARIANT: this suite's own resolved constants.
   projectRoot: global.testPaths.PROJECT_ROOT,

--- a/bindings/node/__test__/issue-3504-udt-field-namespace.test.js
+++ b/bindings/node/__test__/issue-3504-udt-field-namespace.test.js
@@ -450,15 +450,16 @@ describe('UDT field-name / type-identity collision (issue #3504)', () => {
   // CQLITE_DATASETS_ROOT (#3131/#3148; issue #3724 AC5)
   // ==========================================================================
 
-  test('the fixture and the parity reference resolve checkout-relative, not via CQLITE_DATASETS_ROOT', async () => {
+  test('the fixture and the parity reference resolve checkout-relative, not via CQLITE_DATASETS_ROOT', () => {
     // The file docstring and the reference's `note_on_paths` DOCUMENT this
     // contract; nothing ASSERTED it. `assertFixturePresent` cannot: it checks
     // existence at the ALREADY-RESOLVED path, so it would pass unchanged if
     // resolution became env-routed and the env root happened to hold the file.
-    // Committed fixtures are committed SOURCE; the corpus resolvers are an
-    // EITHER/OR on the variable (`setup.js:23-25`), so a fixture reached
-    // through one is invisible exactly where the suite runs, because every gate
-    // run sets it.
+    // MEASURED: with `FIXTURE_ROOT` re-anchored on the env-routed
+    // `TEST_DATA_ROOT` and `CQLITE_DATASETS_ROOT` pointed at a symlink to the
+    // checkout's `test-data`, all 13 other tests here — the guard and the
+    // cross-binding parity case included — stay GREEN and only this one reds.
+    const { spawnSync } = require('child_process');
     const os = require('os');
 
     // Half 1 — AFFIRMATIVE EQUALITY against a `__dirname`-derived repo root. A
@@ -467,92 +468,146 @@ describe('UDT field-name / type-identity collision (issue #3504)', () => {
     // from the absence of a bad signal.
     const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
     const expectedRoot = path.join(REPO_ROOT, 'test-data', 'fixtures', 'issue_3504');
+    const expectedFacts = path.join(expectedRoot, 'binding-parity-facts.json');
     expect(FIXTURE_ROOT).toBe(expectedRoot);
-    expect(PARITY_FACTS).toBe(path.join(expectedRoot, 'binding-parity-facts.json'));
+    expect(PARITY_FACTS).toBe(expectedFacts);
     // SCHEMA is pinned to the RESOLVED schemas dir, not to the checkout:
     // `CQLITE_SCHEMAS_ROOT` legitimately relocates that directory
     // (`setup.js:67-102`, the gate-validated #3148 contract), so pinning it to
-    // the checkout would red on a correct out-of-tree run. Only the FIXTURE
-    // corpus and the parity facts are in AC5's scope.
-    expect(SCHEMA).toBe(path.join(global.testPaths.SCHEMAS_DIR, 'issue-3504-udt-collision.cql'));
+    // the checkout would red a correct out-of-tree run. Only the FIXTURE corpus
+    // and the parity facts are in AC5's scope.
+    const expectedSchema = path.join(
+      global.testPaths.SCHEMAS_DIR,
+      'issue-3504-udt-collision.cql'
+    );
+    expect(SCHEMA).toBe(expectedSchema);
 
-    // Half 2 — BEHAVIOURAL INVARIANCE under a datasets root holding no corpus.
+    // Half 2 — BEHAVIOURAL INVARIANCE, MEASURED IN A CHILD PROCESS.
     //
-    // ASYMMETRY WITH THE PYTHON SUITE, STATED BECAUSE IT BOUNDS WHAT THIS HALF
-    // PROVES: the Python case re-evaluates ITS OWN module under the bogus root
-    // (`importlib` gives it a throwaway module object), so it catches even a
-    // resolution that reads the variable directly at load time. Here that is
-    // unavailable — re-requiring this file would re-register its `describe`/
-    // `test` blocks mid-run, which jest forbids — so the probe re-evaluates the
-    // RESOLVER (`setup.js`) instead and pins the ANCHOR. The two mutants that
-    // matters for: one anchored on the env-routed constant reds
-    // UNCONDITIONALLY, because `TEST_DATA_ROOT`/`SSTABLES_DIR` never equals
-    // `PROJECT_ROOT` even with the variable unset; one reading the variable
-    // directly at load time reds in half 1 on every gate run, since every gate
-    // run sets it.
-    const savedTestPaths = global.testPaths;
-    const savedEnv = {
-      CQLITE_DATASETS_ROOT: process.env.CQLITE_DATASETS_ROOT,
-      CQLITE_REQUIRE_FIXTURES: process.env.CQLITE_REQUIRE_FIXTURES,
-      CQLITE_PARITY_REQUIRE_DATASETS: process.env.CQLITE_PARITY_REQUIRE_DATASETS,
-    };
+    // Module-level constants freeze at load, so reloading a NEIGHBOURING module
+    // in-process cannot observe a resolution that reads the variable DIRECTLY
+    // at load time: such a check stays green whenever the variable happened to
+    // be unset when this file was first imported. Jest forbids re-requiring a
+    // test file mid-run (its `describe` would re-register), so the probe is a
+    // fresh `node` that stubs `describe` to a no-op, requires `setup.js` and
+    // then THIS file, and reads the constants back off `module.exports`.
+    //
+    // It asserts a PAIR, because the invariant alone would be satisfiable by an
+    // environment the child never saw:
+    //   * the POSITIVE CONTROL — the child echoes the perturbed value back, and
+    //     `SSTABLES_DIR`, whose documented contract IS to follow the variable
+    //     (`setup.js:23-25`), HAS moved onto the bogus root;
+    //   * the INVARIANT — the fixture root and parity-facts path are unmoved and
+    //     checkout-derived, and the fixture still reads its three rows.
+    //
+    // Nothing in the parent process is mutated: no env var, no global, no module
+    // registry. The pollution risk is removed rather than managed.
     const bogus = fs.mkdtempSync(path.join(os.tmpdir(), 'cqlite-3724-no-corpus-'));
+    const outPath = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'cqlite-3724-probe-')),
+      'probe.json'
+    );
     try {
-      process.env.CQLITE_DATASETS_ROOT = bogus;
-      // The two strict-fixture flags are cleared for the re-evaluation ONLY:
-      // `setup.js:246-251` THROWS under a corpus-less root when either is set
-      // (as the gate's node-bindings lane sets them), which would make this
-      // probe unable to run rather than able to measure.
-      delete process.env.CQLITE_REQUIRE_FIXTURES;
-      delete process.env.CQLITE_PARITY_REQUIRE_DATASETS;
-
-      // Re-evaluate the path resolver in a FRESH module registry, so its
-      // constants are recomputed against the bogus root.
-      jest.isolateModules(() => {
-        require('./setup.js');
-      });
-      const fresh = global.testPaths;
-
-      // Non-vacuity: the env-routed constant really DID move onto the bogus
-      // root — otherwise the invariance below would prove only that the
-      // variable is ignored everywhere.
-      expect(fresh).not.toBe(savedTestPaths);
-      expect(fresh.SSTABLES_DIR).toBe(path.join(bogus, 'sstables'));
       expect(fs.readdirSync(bogus)).toEqual([]);
 
-      // THE INVARIANT: the anchor this file's paths are built from is
-      // env-INDEPENDENT, byte-identical under the bogus root, and equal to the
-      // `__dirname`-derived checkout root.
-      expect(fresh.PROJECT_ROOT).toBe(savedTestPaths.PROJECT_ROOT);
-      expect(fresh.PROJECT_ROOT).toBe(REPO_ROOT);
-      expect(FIXTURE_ROOT).toBe(
-        path.join(fresh.PROJECT_ROOT, 'test-data', 'fixtures', 'issue_3504')
-      );
+      const childEnv = { ...process.env, CQLITE_DATASETS_ROOT: bogus };
+      // Cleared for the CHILD only: `setup.js:246-251` makes a corpus-less root
+      // a hard throw under either strict-fixture flag (as the gate's
+      // node-bindings lane sets them), which would leave the probe unable to run
+      // rather than able to measure.
+      delete childEnv.CQLITE_REQUIRE_FIXTURES;
+      delete childEnv.CQLITE_PARITY_REQUIRE_DATASETS;
 
-      // ...and the committed artifacts still OPEN and READ while the variable
-      // points at an empty directory.
-      const probeDb = await Database.open(FIXTURE_ROOT, { schema: SCHEMA });
-      try {
-        const result = await probeDb.executeNative(QUERY);
-        expect(result.rows.map((row) => row.id).sort()).toEqual([1, 2, 3]);
-      } finally {
-        await probeDb.close();
+      const probe = spawnSync(
+        process.execPath,
+        ['-e', RESOLUTION_PROBE, __dirname, __filename, outPath],
+        { env: childEnv, encoding: 'utf8', timeout: 180000 }
+      );
+      expect(probe.error).toBeUndefined();
+      if (probe.status !== 0) {
+        throw new Error(
+          `resolution probe failed (status=${probe.status})\n` +
+            `--- stdout ---\n${probe.stdout}\n--- stderr ---\n${probe.stderr}`
+        );
       }
-      const reference = JSON.parse(fs.readFileSync(PARITY_FACTS, 'utf8'));
-      expect(reference.udts['row1.c'].typeName).toBe('collide');
+      const payload = JSON.parse(fs.readFileSync(outPath, 'utf8'));
+
+      // POSITIVE CONTROL — the perturbation really was in effect, and a constant
+      // whose contract is to follow the variable really did move onto it.
+      expect(payload.envSeen).toBe(bogus);
+      expect(payload.controlEnvRouted).toBe(path.join(bogus, 'sstables'));
+      expect(payload.controlEnvRouted).not.toBe(global.testPaths.SSTABLES_DIR);
+
+      // THE INVARIANT — unmoved, checkout-derived, and still readable.
+      expect(payload.projectRoot).toBe(REPO_ROOT);
+      expect(payload.fixtureRoot).toBe(expectedRoot);
+      expect(payload.parityFacts).toBe(expectedFacts);
+      // The schemas dir must not move either: it follows CQLITE_SCHEMAS_ROOT,
+      // which the probe leaves exactly as this process has it.
+      expect(payload.schemasDir).toBe(global.testPaths.SCHEMAS_DIR);
+      expect(payload.schema).toBe(expectedSchema);
+      expect(payload.readError).toBeNull();
+      expect(payload.rowIds).toEqual([1, 2, 3]);
     } finally {
-      // Restore BEFORE anything else can observe the probe's state: the
-      // re-required setup.js reassigns `global.testPaths`, and three env vars
-      // were changed. No sibling test may see either.
-      global.testPaths = savedTestPaths;
-      for (const [name, value] of Object.entries(savedEnv)) {
-        if (value === undefined) {
-          delete process.env[name];
-        } else {
-          process.env[name] = value;
-        }
-      }
       fs.rmSync(bogus, { recursive: true, force: true });
+      fs.rmSync(path.dirname(outPath), { recursive: true, force: true });
     }
   });
 });
+
+// The child-process probe for the AC5 behavioural half above. Run as
+// `node -e <this> <testsDir> <thisFile> <outPath>` with a perturbed
+// `CQLITE_DATASETS_ROOT`, it re-resolves `setup.js` AND this module from scratch
+// and records BOTH the paths this suite resolves and a path that legitimately
+// DOES follow that variable, so the parent can prove the perturbation was in
+// effect. `describe` is the only jest global it stubs: this file registers its
+// suite at module scope, and with the callback never invoked no other one is
+// reached.
+const RESOLUTION_PROBE = `
+global.describe = () => {};
+const fsProbe = require('fs');
+const pathProbe = require('path');
+const [testsDir, modulePath, outPath] = process.argv.slice(1);
+require(pathProbe.join(testsDir, 'setup.js'));
+const mod = require(modulePath);
+const payload = {
+  // The POSITIVE CONTROL pair: what the child actually saw, and a constant
+  // whose documented contract IS to follow it.
+  envSeen: process.env.CQLITE_DATASETS_ROOT,
+  controlEnvRouted: global.testPaths.SSTABLES_DIR,
+  // The INVARIANT: this suite's own resolved constants.
+  projectRoot: global.testPaths.PROJECT_ROOT,
+  schemasDir: global.testPaths.SCHEMAS_DIR,
+  fixtureRoot: mod.FIXTURE_ROOT,
+  parityFacts: mod.PARITY_FACTS,
+  schema: mod.SCHEMA,
+  rowIds: null,
+  readError: null,
+};
+// The read is attempted AFTER the paths are recorded, and its failure is
+// REPORTED rather than thrown: an env-routed resolution makes the open fail, and
+// the parent must be able to name the path mismatch that caused it instead of
+// reporting only a dead child.
+(async () => {
+  try {
+    const { Database } = require(pathProbe.join(testsDir, '..', 'lib', 'index.js'));
+    const db = await Database.open(mod.FIXTURE_ROOT, { schema: mod.SCHEMA });
+    try {
+      const result = await db.executeNative(mod.QUERY);
+      payload.rowIds = result.rows.map((row) => row.id).sort();
+    } finally {
+      await db.close();
+    }
+  } catch (err) {
+    payload.readError = String((err && err.stack) || err);
+  }
+  fsProbe.writeFileSync(outPath, JSON.stringify(payload));
+})();
+`;
+
+// Exported for that probe, and ONLY for it. Reading the constants off
+// `module.exports` is what makes the probe measure THIS file's resolution rather
+// than a re-derivation of it — a re-derivation would assert nothing about the
+// constants the suite actually uses, which is precisely the vacuity this
+// replaced. Harmless to jest: a test file may carry exports.
+module.exports = { FIXTURE_ROOT, SCHEMA, PARITY_FACTS, QUERY };

--- a/bindings/node/__test__/issue-3504-udt-field-namespace.test.js
+++ b/bindings/node/__test__/issue-3504-udt-field-namespace.test.js
@@ -415,9 +415,17 @@ describe('UDT field-name / type-identity collision (issue #3504)', () => {
     const reference = JSON.parse(fs.readFileSync(PARITY_FACTS, 'utf8'));
     const expected = reference.udts;
 
+    // Every entry is DERIVED from this binding's own output; nothing here is a
+    // literal. `cm`/`tm` (MULTICELL: the key lives in the CELL PATH) sit beside
+    // `fcm`/`ftm` (FROZEN: a single value cell) because those are two different
+    // decoders in cqlite-core and only the frozen one used to reach a UDT at all
+    // (#3612). Carrying both makes this case a parity control in TWO directions
+    // at once: cross-BINDING, as every entry here is, and cross-DECODE-PATH.
     const observed = {
       'row1.c': facts(rows.get(1).c),
       'row1.p': facts(rows.get(1).p),
+      'row1.cm_key': facts(soleEntry(rows.get(1).cm)[0]),
+      'row1.tm_key': facts(soleEntry(rows.get(1).tm)[0]),
       'row1.fcm_key': facts(soleEntry(rows.get(1).fcm)[0]),
       'row1.ftm_key': facts(soleEntry(rows.get(1).ftm)[0]),
       'row1.fs_0': facts([...rows.get(1).fs][0]),
@@ -431,8 +439,24 @@ describe('UDT field-name / type-identity collision (issue #3504)', () => {
     expect(Object.keys(observed).sort()).toEqual(Object.keys(expected).sort());
     expect(observed).toEqual(expected);
 
-    expect(soleEntry(rows.get(1).fcm)[1]).toBe(reference.map_values['row1.fcm_value']);
-    expect(soleEntry(rows.get(1).ftm)[1]).toBe(reference.map_values['row1.ftm_value']);
+    // The map VALUES, one per map column, also derived from this binding.
+    const mapValues = reference.map_values;
+    expect(soleEntry(rows.get(1).cm)[1]).toBe(mapValues['row1.cm_value']);
+    expect(soleEntry(rows.get(1).tm)[1]).toBe(mapValues['row1.tm_value']);
+    expect(soleEntry(rows.get(1).fcm)[1]).toBe(mapValues['row1.fcm_value']);
+    expect(soleEntry(rows.get(1).ftm)[1]).toBe(mapValues['row1.ftm_value']);
+    // ...and those four values must be PAIRWISE DISTINCT in the reference, which
+    // is what makes the four assertions above discriminating. The four map
+    // columns hold the SAME key by construction, so a case that read the wrong
+    // column's cell -- exactly the confusion a multicell/frozen pair invites --
+    // would pass unnoticed against equal values.
+    const declaredMapValues = [
+      mapValues['row1.cm_value'],
+      mapValues['row1.tm_value'],
+      mapValues['row1.fcm_value'],
+      mapValues['row1.ftm_value'],
+    ];
+    expect(new Set(declaredMapValues).size).toBe(declaredMapValues.length);
 
     // Non-vacuity: the reference must actually carry the colliding subjects, or
     // an emptied/renamed file would let this pass having compared nothing. Both
@@ -443,6 +467,14 @@ describe('UDT field-name / type-identity collision (issue #3504)', () => {
     expect(expected['row1.c'].fields._type).toBe('user-supplied-type');
     expect(ownField(expected['row1.c'].fields, '__proto__')).toBe('user-supplied-proto');
     expect(expected['row1.c'].typeName).toBe('collide');
+    // ...and the reference states the CROSS-DECODE-PATH identity in its own
+    // right: the multicell key facts EQUAL the frozen ones, which is #3612's
+    // property (a caller cannot tell the two spellings of one map apart). Stated
+    // here so the committed FILE remains a valid control on its own -- the
+    // per-binding case that measures this within one binding lives above, and
+    // this file is what compares the two bindings.
+    expect(expected['row1.cm_key']).toEqual(expected['row1.fcm_key']);
+    expect(expected['row1.tm_key']).toEqual(expected['row1.ftm_key']);
   });
 
   // ==========================================================================

--- a/bindings/node/__test__/issue-3504-udt-field-namespace.test.js
+++ b/bindings/node/__test__/issue-3504-udt-field-namespace.test.js
@@ -521,14 +521,18 @@ describe('UDT field-name / type-identity collision (issue #3504)', () => {
       const probe = spawnSync(
         process.execPath,
         ['-e', RESOLUTION_PROBE, __dirname, __filename, outPath],
-        { env: childEnv, encoding: 'utf8', timeout: 180000 }
+        { env: childEnv, encoding: 'utf8', timeout: PROBE_TIMEOUT_MS }
       );
-      expect(probe.error).toBeUndefined();
-      if (probe.status !== 0) {
-        throw new Error(
-          `resolution probe failed (status=${probe.status})\n` +
-            `--- stdout ---\n${probe.stdout}\n--- stderr ---\n${probe.stderr}`
-        );
+
+      // AFFIRMATIVE COMPLETION ASSERT, before a single byte of the payload is
+      // read. A timed-out, unspawnable or dead probe must fail NAMING that, and
+      // must never fall through into comparing absent output against an
+      // expected path: that either misleads (a "path mismatch" for a hang) or,
+      // with no payload written at all, risks a comparison that passes having
+      // measured nothing.
+      const failure = probeCompletionFailure(probe, PROBE_TIMEOUT_MS, outPath);
+      if (failure !== null) {
+        throw new Error(failure);
       }
       const payload = JSON.parse(fs.readFileSync(outPath, 'utf8'));
 
@@ -554,6 +558,74 @@ describe('UDT field-name / type-identity collision (issue #3504)', () => {
     }
   });
 });
+
+// The child bound for the AC5 probe below. MEASURED, not picked: jest's resolved
+// `testTimeout` here is 30000ms — `globalConfig.testTimeout` from
+// `jest.config.js`, with BOTH project entries null, read via
+// `npx jest --showConfig` on jest 29.7.0 — and this file sets no per-test
+// override. `spawnSync` BLOCKS the event loop, so jest physically cannot
+// interrupt it while it runs; the bound must therefore stay strictly BELOW
+// jest's, so the call always returns first and jest's deadline remains the outer
+// enforcing authority instead of being silently unenforceable. This is half of
+// it, and ~300x the probe's measured warm runtime (~50ms), so a loaded box
+// cannot flake on it. Do NOT raise jest's timeout to accommodate this bound —
+// that inverts the fix.
+const PROBE_TIMEOUT_MS = 15000;
+
+/**
+ * Why the probe did not complete, as a message naming the cause — or `null` when
+ * it completed and left a payload.
+ *
+ * The states are the ones `spawnSync` actually reports, measured on this node
+ * rather than assumed: a timeout is `error.code === 'ETIMEDOUT'` with
+ * `status === null` and `signal === 'SIGTERM'`; an ordinary failure is a numeric
+ * non-zero `status` with no `error`; and an exit-0 child that wrote nothing is
+ * `status === 0`, which only the payload check below can catch.
+ *
+ * @param {import('child_process').SpawnSyncReturns<string>} result
+ * @param {number} timeoutMs
+ * @param {string} outPath
+ * @returns {string|null}
+ */
+function probeCompletionFailure(result, timeoutMs, outPath) {
+  const detail =
+    `--- child stdout ---\n${result.stdout === undefined ? '(none)' : result.stdout}\n` +
+    `--- child stderr ---\n${result.stderr === undefined ? '(none)' : result.stderr}`;
+  if (result.error && result.error.code === 'ETIMEDOUT') {
+    return (
+      `resolution probe TIMED OUT after ${timeoutMs}ms (spawnSync ETIMEDOUT, killed with ` +
+      `${String(result.signal)}). It normally completes in well under a second, so this is a ` +
+      `hang, not a slow box — nothing about path resolution was measured.\n${detail}`
+    );
+  }
+  if (result.error) {
+    return (
+      `resolution probe could not be spawned: ` +
+      `${result.error.code || result.error.message} (bound ${timeoutMs}ms)\n${detail}`
+    );
+  }
+  if (result.signal !== null && result.signal !== undefined) {
+    return (
+      `resolution probe was KILLED by ${String(result.signal)} (bound ${timeoutMs}ms)\n${detail}`
+    );
+  }
+  if (typeof result.status !== 'number') {
+    return (
+      `resolution probe did not exit normally (status=${String(result.status)}, ` +
+      `signal=${String(result.signal)}, bound ${timeoutMs}ms)\n${detail}`
+    );
+  }
+  if (result.status !== 0) {
+    return `resolution probe exited ${result.status} (bound ${timeoutMs}ms)\n${detail}`;
+  }
+  if (!fs.existsSync(outPath)) {
+    return (
+      `resolution probe exited 0 but wrote no payload to ${outPath} — nothing was ` +
+      `measured, so no path comparison below would mean anything\n${detail}`
+    );
+  }
+  return null;
+}
 
 // The child-process probe for the AC5 behavioural half above. Run as
 // `node -e <this> <testsDir> <thisFile> <outPath>` with a perturbed

--- a/bindings/node/__test__/issue-3504-udt-field-namespace.test.js
+++ b/bindings/node/__test__/issue-3504-udt-field-namespace.test.js
@@ -660,17 +660,32 @@ describe('UDT field-name / type-identity collision (issue #3504)', () => {
     // read must contain the variable's name as a literal, and a literal in this
     // file's source plainly IS checkable. Same two exemptions, same count assert.
     //
-    // DECLARED RESIDUAL, and it is what keeps this guard honest — the half a
-    // source scan genuinely cannot reach is an INDIRECT read: a helper that
-    // returns the value, a COMPUTED or concatenated variable name
-    // (`process.env[someVar]`), or an alias bound to `process.env` names neither a
-    // corpus constant nor the literal, so neither needle fires. That half stays
-    // the child-process probe's job — it measures the RESOLVED paths under a
-    // perturbed environment, whatever route a consumer took to read it, so the two
-    // are complementary rather than overlapping and neither alone closes the class.
-    // Deliberately NOT met with an AST or dataflow "environment read" detector: a
-    // recogniser over author-controlled code accumulates false PASSes, and a guard
-    // with known false PASSes is worse than no guard at all.
+    // WHAT THE TWO GUARDS COVER, AND WHAT NOTHING HERE COVERS. This paragraph used
+    // to say the residual "stays the child-process probe's job — whatever route a
+    // consumer took to read it". That was FALSE, and correcting it is the point of
+    // this note (roborev N-C1): the probe records and compares only the constants
+    // this module EXPORTS — `FIXTURE_ROOT`, `PARITY_FACTS`, `SCHEMA`, `QUERY`, see
+    // `module.exports` at the foot of this file — so it cannot observe a path that
+    // some other test builds inside its own body. Stated as it actually is:
+    //   * THIS SCAN catches the env variable's name written as a LITERAL, in any
+    //     spelling (it is a substring test, so quoting is irrelevant), plus any of
+    //     the named corpus constants;
+    //   * THE CHILD PROBE above proves those EXPORTED CONSTANTS stay
+    //     checkout-anchored while `CQLITE_DATASETS_ROOT` is perturbed;
+    //   * NEITHER covers an INDIRECT read — a helper that returns the value, a
+    //     COMPUTED or concatenated variable name (`process.env[someVar]`), or an
+    //     alias bound to `process.env` — used by a FUTURE TEST IN THIS FILE to
+    //     build its OWN path. That is an UNCOVERED RESIDUAL, not a covered one:
+    //     the read names neither a constant nor the literal, so this scan is
+    //     blind, and such a path never reaches an exported constant, so the probe
+    //     is blind to it as well.
+    //
+    // Deliberately NOT closed by widening either guard. These two already exceed
+    // what AC5 asks for, and a recogniser over computed names is the unbounded
+    // shape this repository keeps having to delete — it accumulates false PASSes
+    // and an exemption list that grows every round, and a guard with known false
+    // PASSes is worse than no guard. A narrow guard that says what it does NOT
+    // cover is worth more than a broad one implying completeness it cannot deliver.
     const forbidden = ['SSTABLES' + '_DIR', 'TEST_DATA' + '_ROOT', 'DATASETS' + '_AVAILABLE'];
     const envVar = 'CQLITE_' + 'DATASETS_ROOT';
     const needles = [...forbidden, envVar];

--- a/bindings/node/__test__/issue-3504-udt-field-namespace.test.js
+++ b/bindings/node/__test__/issue-3504-udt-field-namespace.test.js
@@ -462,6 +462,25 @@ describe('UDT field-name / type-identity collision (issue #3504)', () => {
     const { spawnSync } = require('child_process');
     const os = require('os');
 
+    // The AMBIENT value, appended to every failure below. Half 1's discriminating
+    // power depends on it: SET (as every gate run has it) and an env-routed
+    // resolution reds on the equality alone; UNSET (the usual local run) and only
+    // Half 2 can see it. A maintainer reading a failure needs to know which run
+    // they are looking at, and neither state is the "right" one to run under.
+    const ambientNote =
+      `ambient CQLITE_DATASETS_ROOT: ` +
+      `${process.env.CQLITE_DATASETS_ROOT === undefined ? '(unset)' : process.env.CQLITE_DATASETS_ROOT}`;
+    // jest matchers take no message argument, so the note is added by RETHROWING:
+    // the matcher's own diff is preserved and the ambient value is appended to it.
+    const withAmbient = (assertions) => {
+      try {
+        assertions();
+      } catch (err) {
+        err.message = `${err.message}\n${ambientNote}`;
+        throw err;
+      }
+    };
+
     // Half 1 — AFFIRMATIVE EQUALITY against a `__dirname`-derived repo root. A
     // "the env value is not a prefix" check would go vacuous whenever the
     // variable is unset or coincidentally equals the checkout: a pass derived
@@ -469,8 +488,10 @@ describe('UDT field-name / type-identity collision (issue #3504)', () => {
     const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
     const expectedRoot = path.join(REPO_ROOT, 'test-data', 'fixtures', 'issue_3504');
     const expectedFacts = path.join(expectedRoot, 'binding-parity-facts.json');
-    expect(FIXTURE_ROOT).toBe(expectedRoot);
-    expect(PARITY_FACTS).toBe(expectedFacts);
+    withAmbient(() => {
+      expect(FIXTURE_ROOT).toBe(expectedRoot);
+      expect(PARITY_FACTS).toBe(expectedFacts);
+    });
     // SCHEMA is pinned to the RESOLVED schemas dir, not to the checkout:
     // `CQLITE_SCHEMAS_ROOT` legitimately relocates that directory
     // (`setup.js:67-102`, the gate-validated #3148 contract), so pinning it to
@@ -480,7 +501,7 @@ describe('UDT field-name / type-identity collision (issue #3504)', () => {
       global.testPaths.SCHEMAS_DIR,
       'issue-3504-udt-collision.cql'
     );
-    expect(SCHEMA).toBe(expectedSchema);
+    withAmbient(() => expect(SCHEMA).toBe(expectedSchema));
 
     // Half 2 — BEHAVIOURAL INVARIANCE, MEASURED IN A CHILD PROCESS.
     //
@@ -536,26 +557,104 @@ describe('UDT field-name / type-identity collision (issue #3504)', () => {
       }
       const payload = JSON.parse(fs.readFileSync(outPath, 'utf8'));
 
-      // POSITIVE CONTROL — the perturbation really was in effect, and a constant
-      // whose contract is to follow the variable really did move onto it.
-      expect(payload.envSeen).toBe(bogus);
-      expect(payload.controlEnvRouted).toBe(path.join(bogus, 'sstables'));
-      expect(payload.controlEnvRouted).not.toBe(global.testPaths.SSTABLES_DIR);
+      withAmbient(() => {
+        // POSITIVE CONTROL — the perturbation really was in effect, and a
+        // constant whose contract is to follow the variable really did move onto
+        // it.
+        expect(payload.envSeen).toBe(bogus);
+        expect(payload.controlEnvRouted).toBe(path.join(bogus, 'sstables'));
+        expect(payload.controlEnvRouted).not.toBe(global.testPaths.SSTABLES_DIR); // CONTROL
 
-      // THE INVARIANT — unmoved, checkout-derived, and still readable.
-      expect(payload.projectRoot).toBe(REPO_ROOT);
-      expect(payload.fixtureRoot).toBe(expectedRoot);
-      expect(payload.parityFacts).toBe(expectedFacts);
-      // The schemas dir must not move either: it follows CQLITE_SCHEMAS_ROOT,
-      // which the probe leaves exactly as this process has it.
-      expect(payload.schemasDir).toBe(global.testPaths.SCHEMAS_DIR);
-      expect(payload.schema).toBe(expectedSchema);
-      expect(payload.readError).toBeNull();
-      expect(payload.rowIds).toEqual([1, 2, 3]);
+        // THE INVARIANT — unmoved, checkout-derived, and BOTH artifacts read.
+        expect(payload.projectRoot).toBe(REPO_ROOT);
+        expect(payload.fixtureRoot).toBe(expectedRoot);
+        expect(payload.parityFacts).toBe(expectedFacts);
+        // The schemas dir must not move either: it follows CQLITE_SCHEMAS_ROOT,
+        // which the probe leaves exactly as this process has it.
+        expect(payload.schemasDir).toBe(global.testPaths.SCHEMAS_DIR);
+        expect(payload.schema).toBe(expectedSchema);
+        // A read failure is REPORTED without a cause being claimed: the
+        // `beforeAll` guard has already ruled out a broken checkout, but a
+        // decoder regression or a lost force-added binary would look identical
+        // here, and naming one would assert what this test has not established.
+        expect(payload.readError).toBeNull();
+        expect(payload.rowIds).toEqual([1, 2, 3]);
+        // AC5 covers the parity-facts FILE as much as the corpus, so the probe
+        // OPENED it rather than only recording its path. Non-vacuity: an emptied
+        // or renamed reference would otherwise let the path equality above stand
+        // in for a file nobody opened. Asserted NON-ZERO rather than at an exact
+        // count, which is #3724's own subject to widen.
+        expect(payload.parityFactsError).toBeNull();
+        expect(payload.parityFactsUdts).toBeGreaterThan(0);
+      });
     } finally {
       fs.rmSync(bogus, { recursive: true, force: true });
       fs.rmSync(path.dirname(outPath), { recursive: true, force: true });
     }
+  });
+
+  test('this file names no env-routed corpus constant outside its positive control', () => {
+    // THE CLASS THIS CLOSES, WHICH THE ENVIRONMENT CASES ONLY SAMPLE. The test
+    // above pins the CONSTANTS this module resolves today. A future test added to
+    // this file that builds its OWN path from `setup.js`'s env-routed corpus
+    // constants is invisible to it: that path would resolve through
+    // `CQLITE_DATASETS_ROOT` while every assertion above stayed green, because
+    // those assertions are about `FIXTURE_ROOT`/`PARITY_FACTS` and not about the
+    // file's other consumers. This repository has ALREADY paid for exactly that
+    // defect, in this very directory — `setup.js`'s round-10 note records
+    // `write.test.js` and `write-smoke.test.js` building the schemas path
+    // themselves and BYPASSING the resolver, so the variable was honoured by part
+    // of the suite and ignored by the rest.
+    //
+    // Answered from THIS FILE'S OWN SOURCE. The needles are SPLIT, and here that
+    // split is the MECHANISM rather than belt-and-braces: unlike the Python
+    // sibling, which tokenizes and so can ignore strings by type, this scan is
+    // textual, so an unsplit literal would match its own source and the test
+    // could never pass.
+    //
+    // Two line classes are exempt, both deliberately:
+    //   * a PURE COMMENT line (trimmed, starts with `//`, `*` or `/*`) — this
+    //     file discusses the env-routed constants at length in prose, and prose
+    //     is not a consumer;
+    //   * a line carrying the `CONTROL` marker — the positive control legitimately
+    //     READS the env-routed constant, in the test above and in the probe
+    //     source. Requiring it to SAY so is what stops the exemption silently
+    //     growing into a consumer.
+    //
+    // DECLARED BOUND, because a guard that overstates its reach is worse than
+    // none: a consumer reading `process.env` DIRECTLY names no constant and is
+    // invisible here. That half is what the child-process probe above measures,
+    // so the two are complementary rather than overlapping.
+    const forbidden = ['SSTABLES' + '_DIR', 'TEST_DATA' + '_ROOT', 'DATASETS' + '_AVAILABLE'];
+    const source = fs.readFileSync(__filename, 'utf8');
+
+    const offenders = [];
+    source.split('\n').forEach((line, index) => {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) {
+        return;
+      }
+      if (line.includes('CONTROL')) {
+        return;
+      }
+      for (const name of forbidden) {
+        if (line.includes(name)) {
+          offenders.push(`${index + 1}: ${trimmed}`);
+          return;
+        }
+      }
+    });
+
+    expect(offenders).toEqual([]);
+
+    // NON-VACUITY, and it is load-bearing: every needle is split, so a typo in a
+    // split would silently make the scan look for a name that occurs nowhere and
+    // the test would pass having checked nothing. The two known control lines
+    // must therefore be FOUND — by the same `includes` the scan uses.
+    const controlLines = source
+      .split('\n')
+      .filter((line) => line.includes('CONTROL') && forbidden.some((n) => line.includes(n)));
+    expect(controlLines.length).toBe(2);
   });
 });
 
@@ -646,7 +745,7 @@ const payload = {
   // The POSITIVE CONTROL pair: what the child actually saw, and a constant
   // whose documented contract IS to follow it.
   envSeen: process.env.CQLITE_DATASETS_ROOT,
-  controlEnvRouted: global.testPaths.SSTABLES_DIR,
+  controlEnvRouted: global.testPaths.SSTABLES_DIR, // CONTROL: env-routed BY CONTRACT, never a consumer
   // The INVARIANT: this suite's own resolved constants.
   projectRoot: global.testPaths.PROJECT_ROOT,
   schemasDir: global.testPaths.SCHEMAS_DIR,
@@ -655,7 +754,21 @@ const payload = {
   schema: mod.SCHEMA,
   rowIds: null,
   readError: null,
+  parityFactsUdts: null,
+  parityFactsError: null,
 };
+
+// AC5 covers the parity-facts FILE as much as the corpus, so the probe OPENS it
+// rather than only recording its path — otherwise that half is path-equality
+// only while the corpus half is path-equality PLUS a read-back. Synchronous, so
+// it is recorded before the payload is written below.
+try {
+  payload.parityFactsUdts = Object.keys(
+    JSON.parse(fsProbe.readFileSync(mod.PARITY_FACTS, 'utf8')).udts
+  ).length;
+} catch (err) {
+  payload.parityFactsError = String((err && err.stack) || err);
+}
 // The read is attempted AFTER the paths are recorded, and its failure is
 // REPORTED rather than thrown: an env-routed resolution makes the open fail, and
 // the parent must be able to name the path mismatch that caused it instead of

--- a/bindings/node/__test__/issue-3504-udt-field-namespace.test.js
+++ b/bindings/node/__test__/issue-3504-udt-field-namespace.test.js
@@ -444,4 +444,115 @@ describe('UDT field-name / type-identity collision (issue #3504)', () => {
     expect(ownField(expected['row1.c'].fields, '__proto__')).toBe('user-supplied-proto');
     expect(expected['row1.c'].typeName).toBe('collide');
   });
+
+  // ==========================================================================
+  // AC5 — the committed fixture resolves CHECKOUT-RELATIVE, never through
+  // CQLITE_DATASETS_ROOT (#3131/#3148; issue #3724 AC5)
+  // ==========================================================================
+
+  test('the fixture and the parity reference resolve checkout-relative, not via CQLITE_DATASETS_ROOT', async () => {
+    // The file docstring and the reference's `note_on_paths` DOCUMENT this
+    // contract; nothing ASSERTED it. `assertFixturePresent` cannot: it checks
+    // existence at the ALREADY-RESOLVED path, so it would pass unchanged if
+    // resolution became env-routed and the env root happened to hold the file.
+    // Committed fixtures are committed SOURCE; the corpus resolvers are an
+    // EITHER/OR on the variable (`setup.js:23-25`), so a fixture reached
+    // through one is invisible exactly where the suite runs, because every gate
+    // run sets it.
+    const os = require('os');
+
+    // Half 1 — AFFIRMATIVE EQUALITY against a `__dirname`-derived repo root. A
+    // "the env value is not a prefix" check would go vacuous whenever the
+    // variable is unset or coincidentally equals the checkout: a pass derived
+    // from the absence of a bad signal.
+    const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+    const expectedRoot = path.join(REPO_ROOT, 'test-data', 'fixtures', 'issue_3504');
+    expect(FIXTURE_ROOT).toBe(expectedRoot);
+    expect(PARITY_FACTS).toBe(path.join(expectedRoot, 'binding-parity-facts.json'));
+    // SCHEMA is pinned to the RESOLVED schemas dir, not to the checkout:
+    // `CQLITE_SCHEMAS_ROOT` legitimately relocates that directory
+    // (`setup.js:67-102`, the gate-validated #3148 contract), so pinning it to
+    // the checkout would red on a correct out-of-tree run. Only the FIXTURE
+    // corpus and the parity facts are in AC5's scope.
+    expect(SCHEMA).toBe(path.join(global.testPaths.SCHEMAS_DIR, 'issue-3504-udt-collision.cql'));
+
+    // Half 2 — BEHAVIOURAL INVARIANCE under a datasets root holding no corpus.
+    //
+    // ASYMMETRY WITH THE PYTHON SUITE, STATED BECAUSE IT BOUNDS WHAT THIS HALF
+    // PROVES: the Python case re-evaluates ITS OWN module under the bogus root
+    // (`importlib` gives it a throwaway module object), so it catches even a
+    // resolution that reads the variable directly at load time. Here that is
+    // unavailable — re-requiring this file would re-register its `describe`/
+    // `test` blocks mid-run, which jest forbids — so the probe re-evaluates the
+    // RESOLVER (`setup.js`) instead and pins the ANCHOR. The two mutants that
+    // matters for: one anchored on the env-routed constant reds
+    // UNCONDITIONALLY, because `TEST_DATA_ROOT`/`SSTABLES_DIR` never equals
+    // `PROJECT_ROOT` even with the variable unset; one reading the variable
+    // directly at load time reds in half 1 on every gate run, since every gate
+    // run sets it.
+    const savedTestPaths = global.testPaths;
+    const savedEnv = {
+      CQLITE_DATASETS_ROOT: process.env.CQLITE_DATASETS_ROOT,
+      CQLITE_REQUIRE_FIXTURES: process.env.CQLITE_REQUIRE_FIXTURES,
+      CQLITE_PARITY_REQUIRE_DATASETS: process.env.CQLITE_PARITY_REQUIRE_DATASETS,
+    };
+    const bogus = fs.mkdtempSync(path.join(os.tmpdir(), 'cqlite-3724-no-corpus-'));
+    try {
+      process.env.CQLITE_DATASETS_ROOT = bogus;
+      // The two strict-fixture flags are cleared for the re-evaluation ONLY:
+      // `setup.js:246-251` THROWS under a corpus-less root when either is set
+      // (as the gate's node-bindings lane sets them), which would make this
+      // probe unable to run rather than able to measure.
+      delete process.env.CQLITE_REQUIRE_FIXTURES;
+      delete process.env.CQLITE_PARITY_REQUIRE_DATASETS;
+
+      // Re-evaluate the path resolver in a FRESH module registry, so its
+      // constants are recomputed against the bogus root.
+      jest.isolateModules(() => {
+        require('./setup.js');
+      });
+      const fresh = global.testPaths;
+
+      // Non-vacuity: the env-routed constant really DID move onto the bogus
+      // root — otherwise the invariance below would prove only that the
+      // variable is ignored everywhere.
+      expect(fresh).not.toBe(savedTestPaths);
+      expect(fresh.SSTABLES_DIR).toBe(path.join(bogus, 'sstables'));
+      expect(fs.readdirSync(bogus)).toEqual([]);
+
+      // THE INVARIANT: the anchor this file's paths are built from is
+      // env-INDEPENDENT, byte-identical under the bogus root, and equal to the
+      // `__dirname`-derived checkout root.
+      expect(fresh.PROJECT_ROOT).toBe(savedTestPaths.PROJECT_ROOT);
+      expect(fresh.PROJECT_ROOT).toBe(REPO_ROOT);
+      expect(FIXTURE_ROOT).toBe(
+        path.join(fresh.PROJECT_ROOT, 'test-data', 'fixtures', 'issue_3504')
+      );
+
+      // ...and the committed artifacts still OPEN and READ while the variable
+      // points at an empty directory.
+      const probeDb = await Database.open(FIXTURE_ROOT, { schema: SCHEMA });
+      try {
+        const result = await probeDb.executeNative(QUERY);
+        expect(result.rows.map((row) => row.id).sort()).toEqual([1, 2, 3]);
+      } finally {
+        await probeDb.close();
+      }
+      const reference = JSON.parse(fs.readFileSync(PARITY_FACTS, 'utf8'));
+      expect(reference.udts['row1.c'].typeName).toBe('collide');
+    } finally {
+      // Restore BEFORE anything else can observe the probe's state: the
+      // re-required setup.js reassigns `global.testPaths`, and three env vars
+      // were changed. No sibling test may see either.
+      global.testPaths = savedTestPaths;
+      for (const [name, value] of Object.entries(savedEnv)) {
+        if (value === undefined) {
+          delete process.env[name];
+        } else {
+          process.env[name] = value;
+        }
+      }
+      fs.rmSync(bogus, { recursive: true, force: true });
+    }
+  });
 });

--- a/bindings/python/tests/test_issue_3504_udt_field_namespace.py
+++ b/bindings/python/tests/test_issue_3504_udt_field_namespace.py
@@ -1140,29 +1140,43 @@ def test_this_module_names_no_env_routed_corpus_constant():
     belt-and-braces rather than the mechanism.
 
     A SECOND NEEDLE, closing the cheap half of what this guard used to merely
-    declare (roborev #3724 round 4): the env VARIABLE NAME itself, as a STRING
-    literal. A future test that skips the corpus constants and reads
-    `os.environ["<var>"]` DIRECTLY names none of the constants above, so the NAME
-    scan cannot see it — but such a read must contain the variable's name as a
-    literal, and a literal in this file's source plainly IS checkable. Compared
-    EXACTLY against the quoted spellings, which is the whole reason this file's
-    heavy PROSE about the variable stays out of scope: a docstring is ONE `STRING`
-    token holding the entire docstring, and a diagnostic message like
-    `"ambient <var>: "` is a different string again — neither is ever equal to the
-    bare quoted name. So the exemptions do not have to grow to accommodate prose.
+    declare (roborev #3724 round 4): the env VARIABLE NAME itself. A future test
+    that skips the corpus constants and reads `os.environ["<var>"]` DIRECTLY names
+    none of the constants above, so the NAME scan cannot see it — but such a read
+    must contain the variable's name as a string literal, and a literal in this
+    file's source plainly IS checkable.
+
+    Compared by EVALUATED VALUE, not by source spelling (roborev #3724 round 5).
+    Matching two quoted spellings was evadable by writing the same literal
+    differently, and MEASURED on this interpreter (3.12) each of these parses to a
+    single `ast.Constant` whose value is exactly the variable name, so all of them
+    are caught by ONE comparison:
+    `"X"`, `'X'`, `r"X"`, `\"\"\"X\"\"\"`, `f"X"` (no interpolation), and the
+    implicit adjacent-literal concatenation `"CQLITE_" "DATASETS_ROOT"`.
+    Reading the VALUE also SHRINKS this check rather than growing it: one
+    comparison replaces a set of accepted spellings, and the exemptions do not
+    have to grow to accommodate prose, because a docstring's `Constant` holds the
+    ENTIRE docstring and a message like `"ambient <var>: "` is a different string
+    again — neither is ever equal to the bare name. Comments are not in the AST at
+    all. This is `ast` used as the language's own literal reader, NOT dataflow or
+    reachability analysis: nothing here asks whether a read is executable.
 
     DECLARED RESIDUAL, and it is what keeps this guard honest — the half a source
     scan genuinely cannot reach is an INDIRECT read: a helper that returns the
-    value, a COMPUTED or concatenated variable name (`os.environ[prefix + suffix]`),
-    or an alias bound to `os.environ` names neither a corpus constant nor the
+    value, a COMPUTED or concatenated name (`os.environ[prefix + suffix]`, or an
+    INTERPOLATING f-string, which parses to `Constant("CQLITE_")` +
+    `Constant("DATASETS_ROOT")` — neither equal to the whole — MEASURED), or an
+    alias bound to `os.environ`. None of those names a corpus constant or the
     literal, so neither needle fires. That half stays the child-process probe's
     job — it measures the RESOLVED paths under a perturbed environment, whatever
     route a consumer took to read it, so the two are complementary rather than
-    overlapping and neither alone closes the class. Deliberately NOT met with an
-    AST or dataflow "environment read" detector: a recogniser over
-    author-controlled code accumulates false PASSes, and a guard with known false
-    PASSes is worse than no guard at all.
+    overlapping and neither alone closes the class. Deliberately NOT met with a
+    dataflow or reachability "is this an executable environment read" detector: a
+    recogniser over author-controlled code accumulates false PASSes and an
+    exemption list that grows every round, and a guard with known false PASSes is
+    worse than no guard at all.
     """
+    import ast
     import io
     import tokenize
 
@@ -1175,12 +1189,15 @@ def test_this_module_names_no_env_routed_corpus_constant():
     }
 
     # Split for the same reason, and here the split is load-bearing in a second
-    # way: an unsplit literal below would be a STRING token equal to the quoted
-    # needle, so the scan would match its own source and could never pass.
+    # way: an unsplit literal below would itself be a `Constant` equal to the
+    # needle, so the scan would match its own source and could never pass. The
+    # EXPLICIT `+` is what makes the split work — MEASURED: `ast` does NOT fold a
+    # `BinOp`, so this stays two Constants, while an IMPLICIT adjacent-literal
+    # concatenation WOULD be folded into one and would self-match.
     env_var = "CQLITE_" + "DATASETS_ROOT"
-    quoted_env_var = {'"' + env_var + '"', "'" + env_var + "'"}
 
-    source_lines = Path(__file__).read_text().splitlines()
+    source_text = Path(__file__).read_text()
+    source_lines = source_text.splitlines()
     tokens = list(tokenize.tokenize(io.BytesIO(Path(__file__).read_bytes()).readline))
 
     names = {token.string for token in tokens if token.type == tokenize.NAME}
@@ -1193,14 +1210,20 @@ def test_this_module_names_no_env_routed_corpus_constant():
         "CQLITE_DATASETS_ROOT. Build the path from `PROJECT_ROOT` instead."
     )
 
-    # Needle 2 — the env variable's own name, as a bare quoted STRING literal, on
-    # any line that does not declare itself the positive CONTROL.
+    # Needle 2 — the env variable's own name as a string literal VALUE, on any
+    # line that does not declare itself the positive CONTROL. Line numbers come
+    # from the AST nodes, so the diagnostic still names the offending line.
+    env_literal_lines = [
+        node.lineno
+        for node in ast.walk(ast.parse(source_text))
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and node.value == env_var
+    ]
     env_offenders = sorted(
-        f"{token.start[0]}: {source_lines[token.start[0] - 1].strip()}"
-        for token in tokens
-        if token.type == tokenize.STRING
-        and token.string in quoted_env_var
-        and "CONTROL" not in source_lines[token.start[0] - 1]
+        f"{lineno}: {source_lines[lineno - 1].strip()}"
+        for lineno in env_literal_lines
+        if "CONTROL" not in source_lines[lineno - 1]
     )
     assert not env_offenders, (
         f"this module reads the {env_var} environment variable directly, outside "
@@ -1214,19 +1237,18 @@ def test_this_module_names_no_env_routed_corpus_constant():
 
     # NON-VACUITY for needle 2, counted SEPARATELY from needle 1's: folding the two
     # totals into one would let a typo in either split hide behind the other's
-    # matches. Counted over the file's TEXT, so MEASURED at 3 -- the ambient
-    # diagnostic read, the perturbation, and the probe's echo, which is physically
-    # in this file even though it lives inside a string literal the token scan
-    # cannot reach. That third one is additionally checked as PROBE SOURCE below;
-    # the two asserts are not redundant, since this one sees only text while that
-    # one sees the probe's own structure.
+    # matches. Counted over the AST nodes the needle actually examines, so MEASURED
+    # at 2 -- the ambient diagnostic read and the perturbation. The probe's own
+    # echo is a THIRD reference, invisible here because it lives inside one big
+    # string literal whose VALUE is the whole probe, and it is checked as PROBE
+    # SOURCE below instead.
     env_control_lines = [
-        line
-        for line in source_lines
-        if any(q in line for q in quoted_env_var) and "CONTROL" in line
+        source_lines[lineno - 1]
+        for lineno in env_literal_lines
+        if "CONTROL" in source_lines[lineno - 1]
     ]
-    assert len(env_control_lines) == 3, (
-        f"expected exactly 3 CONTROL-marked references to {env_var} in this "
+    assert len(env_control_lines) == 2, (
+        f"expected exactly 2 CONTROL-marked references to {env_var} in this "
         f"module's code, got {len(env_control_lines)}: {env_control_lines}. A count "
         "that drifts means either a new consumer wearing the marker, or a split "
         "needle typo that now matches nothing."
@@ -1252,10 +1274,11 @@ def test_this_module_names_no_env_routed_corpus_constant():
     # ...and the same discipline for the probe's reference to the env VARIABLE. The
     # probe legitimately reads it, ONCE, to echo the perturbed value back as the
     # positive control's proof; a second reference would be a consumer.
+    # Substring, not a spelling set: the probe source is a string to this module,
+    # so there is no AST of it to read values from — and a substring test is
+    # spelling-insensitive for the same reason the Node guard's is.
     probe_env_lines = [
-        line
-        for line in _RESOLUTION_PROBE.splitlines()
-        if any(q in line for q in quoted_env_var)
+        line for line in _RESOLUTION_PROBE.splitlines() if env_var in line
     ]
     assert len(probe_env_lines) == 1, (
         f"expected exactly one reference to {env_var} in the probe source, got "

--- a/bindings/python/tests/test_issue_3504_udt_field_namespace.py
+++ b/bindings/python/tests/test_issue_3504_udt_field_namespace.py
@@ -772,50 +772,108 @@ def test_a_udt_with_a_collection_field_projects_because_that_field_is_bytes():
 # CQLITE_DATASETS_ROOT (#3131/#3148; issue #3724 AC5)
 # =============================================================================
 
+# The child-process probe for the behavioural half below. It re-evaluates THIS
+# module — and `conftest` — from scratch in a fresh interpreter whose
+# `CQLITE_DATASETS_ROOT` points at an empty directory, then records BOTH the
+# paths this suite resolves AND a path that legitimately DOES follow that
+# variable, so the parent can prove the perturbation was in effect.
+_RESOLUTION_PROBE = r'''
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
 
-def test_fixture_and_parity_facts_resolve_checkout_relative_not_via_the_env(
-    monkeypatch, tmp_path
-):
+tests_dir, module_path, out_path = sys.argv[1], sys.argv[2], sys.argv[3]
+sys.path.insert(0, tests_dir)
+
+import conftest  # noqa: E402  -- re-resolved under the perturbed environment
+import cqlite  # noqa: E402
+
+spec = importlib.util.spec_from_file_location("issue_3504_resolution_probe", module_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+payload = {
+    # The POSITIVE CONTROL pair: what the child actually saw, and a constant
+    # whose documented contract IS to follow it.
+    "env_seen": os.environ.get("CQLITE_DATASETS_ROOT"),
+    "control_env_routed": str(conftest.DATASETS),
+    # The INVARIANT: this suite's own resolved constants.
+    "fixture_root": str(module.FIXTURE_ROOT),
+    "parity_facts": str(module.PARITY_FACTS),
+    "schemas": str(module.SCHEMAS),
+    "schema": str(module.SCHEMA),
+    "row_ids": None,
+    "read_error": None,
+}
+
+# The read is attempted AFTER the paths are recorded, and its failure is
+# REPORTED rather than raised: an env-routed resolution makes the open fail, and
+# the parent must be able to name the path mismatch that caused it instead of
+# reporting only a dead child.
+try:
+    with cqlite.open(module.FIXTURE_ROOT, schema=module.SCHEMA) as db:
+        payload["row_ids"] = sorted(row.get("id") for row in db.execute(module.QUERY).rows)
+except Exception as exc:  # noqa: BLE001 -- reported to the parent, not handled
+    payload["read_error"] = f"{type(exc).__name__}: {exc}"
+
+Path(out_path).write_text(json.dumps(payload))
+'''
+
+
+def test_fixture_and_parity_facts_resolve_checkout_relative_not_via_the_env(tmp_path):
     """SCENARIO: the committed fixture paths do not hang off `CQLITE_DATASETS_ROOT`.
 
     The module docstring above and the reference file's `note_on_paths` DOCUMENT
     this contract; nothing ASSERTED it. `_assert_fixture_present` cannot: it
     checks the file exists at the ALREADY-RESOLVED path, so it would pass
     unchanged if resolution became env-routed and the env root happened to hold
-    the file. Committed fixtures are committed SOURCE and are resolved
+    the file. Committed fixtures are committed SOURCE and resolve
     checkout-relative — and the corpus resolvers are an EITHER/OR on the
-    variable (`conftest.py:42-48`), so a fixture reached through one is
-    invisible exactly where the suite runs, because every gate run sets it.
+    variable (`conftest.py:42-48`), so a fixture reached through one is invisible
+    exactly where the suite runs, because every gate run sets it.
 
     Two halves, and the second is the one that catches a regression.
 
     AFFIRMATIVE EQUALITY. The resolved paths must EQUAL the checkout-derived
-    expectation, anchored on this file's own location. A "the env value is not a
-    prefix" check would go vacuous whenever the variable is unset or
-    coincidentally equals the checkout — a pass derived from the absence of a
-    bad signal, which CLAUDE.md forbids.
+    expectation. A "the env value is not a prefix" check would go vacuous
+    whenever the variable is unset or coincidentally equals the checkout — a
+    pass derived from the absence of a bad signal, which CLAUDE.md forbids. The
+    expectation is derived UNCANONICALIZED, matching how `conftest` derives
+    `PROJECT_ROOT` (`Path(__file__).parent` chains, no `resolve()`): canonicalizing
+    one side only would red on a correct checkout reached through a symlink, and
+    a guard that reds on correct input is the guard agents learn to waive. The
+    canonicalized forms are compared too — like with like on both sides.
 
-    BEHAVIOURAL INVARIANCE. With `CQLITE_DATASETS_ROOT` *and* the env-routed
-    `conftest.DATASETS` it produces both pointed at an EMPTY directory, a FRESH
-    evaluation of this very module must resolve the SAME three paths, and the
-    committed artifacts must still open and read through them. A resolution
-    routed through either would land in the empty directory and red here — on
-    every run, not merely where the exported root differs from the checkout.
-    Both patches are `monkeypatch`'s, so nothing leaks to sibling tests, and the
-    probe module is never inserted into `sys.modules`.
+    BEHAVIOURAL INVARIANCE, MEASURED IN A CHILD PROCESS. Module-level constants
+    freeze at import, so an in-process reload of a neighbouring module cannot
+    observe a resolution that reads the variable DIRECTLY at load time: that
+    check stays green whenever the variable was unset when this module was first
+    imported. So the probe re-evaluates THIS module in a fresh interpreter whose
+    `CQLITE_DATASETS_ROOT` is an empty directory, and asserts a PAIR:
+
+      * the POSITIVE CONTROL — the child echoes back the perturbed value, and
+        `conftest.DATASETS`, whose documented contract IS to follow that
+        variable, HAS moved onto it. Without this the invariant below would be
+        satisfiable by an environment the child never saw.
+      * the INVARIANT — the three paths are unmoved and checkout-derived, and
+        the fixture still reads its three rows through them.
+
+    The parent mutates no environment variable and no module state, so nothing
+    can leak to a sibling test.
 
     NOT ASSERTED: `CQLITE_SCHEMAS_ROOT`. Python's `SCHEMAS` is purely
     checkout-derived and is pinned below, but the Node side legitimately honours
-    that variable (`setup.js:67-72` — the gate-validated #3148 contract), so
+    that variable (`setup.js:67-102` — the gate-validated #3148 contract), so
     honouring it is not an AC5 violation in either binding.
     """
-    import importlib.util
     import os
+    import subprocess
     import sys
 
-    import conftest
-
-    repo_root = Path(__file__).resolve().parents[3]
+    # UNCANONICALIZED, to match `conftest.PROJECT_ROOT`'s own derivation.
+    repo_root = Path(__file__).parents[3]
     expected_root = repo_root / "test-data" / "fixtures" / "issue_3504"
     expected_facts = expected_root / "binding-parity-facts.json"
     expected_schemas = repo_root / "test-data" / "schemas"
@@ -826,34 +884,66 @@ def test_fixture_and_parity_facts_resolve_checkout_relative_not_via_the_env(
     assert PARITY_FACTS == expected_facts
     assert SCHEMAS == expected_schemas
     assert SCHEMA == expected_schema
+    # ...and equal canonicalized too, both sides canonicalized.
+    assert FIXTURE_ROOT.resolve() == expected_root.resolve()
+    assert PARITY_FACTS.resolve() == expected_facts.resolve()
 
-    # Half 2 — invariance under a datasets root that holds no corpus at all.
+    # Half 2 — a fresh interpreter under a datasets root holding no corpus.
     bogus = tmp_path / "no-corpus-here"
     bogus.mkdir()
-    monkeypatch.setenv("CQLITE_DATASETS_ROOT", str(bogus))
-    monkeypatch.setattr(conftest, "DATASETS", bogus)
+    assert not sorted(bogus.iterdir())
+    out_path = tmp_path / "probe.json"
 
-    # Non-vacuity: both env-routed values really did move, and the root really is
-    # corpus-free — otherwise the invariance below would prove nothing.
-    assert os.environ["CQLITE_DATASETS_ROOT"] == str(bogus)
-    assert conftest.DATASETS == bogus
-    assert bogus != expected_root
-    assert not sorted(bogus.glob("**/*-Data.db"))
+    child_env = dict(os.environ)
+    child_env["CQLITE_DATASETS_ROOT"] = str(bogus)
+    # The strict-fixture flags are cleared for the CHILD only: a corpus-less
+    # root makes them a hard failure by design, which would leave the probe
+    # unable to run rather than able to measure.
+    child_env.pop("CQLITE_REQUIRE_FIXTURES", None)
+    child_env.pop("CQLITE_PARITY_REQUIRE_DATASETS", None)
 
-    spec = importlib.util.spec_from_file_location(
-        "issue_3504_udt_field_namespace__resolution_probe", Path(__file__).resolve()
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _RESOLUTION_PROBE,
+            str(Path(__file__).parent),
+            str(Path(__file__)),
+            str(out_path),
+        ],
+        env=child_env,
+        capture_output=True,
+        text=True,
+        timeout=180,
     )
-    assert spec is not None and spec.loader is not None
-    probe = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(probe)
-    assert probe.FIXTURE_ROOT == expected_root
-    assert probe.PARITY_FACTS == expected_facts
-    assert probe.SCHEMA == expected_schema
-    assert "issue_3504_udt_field_namespace__resolution_probe" not in sys.modules
+    assert proc.returncode == 0, (
+        f"resolution probe failed (rc={proc.returncode})\n"
+        f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+    )
+    payload = json.loads(out_path.read_text())
 
-    # ...and the committed artifacts still READ through the re-resolved paths.
-    with cqlite.open(probe.FIXTURE_ROOT, schema=probe.SCHEMA) as db:
-        ids = sorted(row.get("id") for row in db.execute(probe.QUERY).rows)
-    assert ids == [1, 2, 3], f"fixture unreadable under a bogus datasets root: {ids}"
-    reference = json.loads(probe.PARITY_FACTS.read_text())
-    assert reference["udts"]["row1.c"]["typeName"] == "collide"
+    # POSITIVE CONTROL — the perturbation really was in effect, and a constant
+    # whose contract is to follow the variable really did move onto it.
+    assert payload["env_seen"] == str(bogus), (
+        "the probe did not see the perturbed CQLITE_DATASETS_ROOT — the "
+        "invariance below would prove nothing"
+    )
+    assert payload["control_env_routed"] == str(bogus), (
+        "conftest.DATASETS did not follow the perturbed CQLITE_DATASETS_ROOT — "
+        f"got {payload['control_env_routed']}; the control is broken, so the "
+        "invariance below is unmeasured"
+    )
+    assert payload["control_env_routed"] != str(expected_root)
+
+    # THE INVARIANT — unmoved, checkout-derived, and still readable.
+    assert payload["fixture_root"] == str(expected_root)
+    assert payload["parity_facts"] == str(expected_facts)
+    assert payload["schemas"] == str(expected_schemas)
+    assert payload["schema"] == str(expected_schema)
+    assert payload["read_error"] is None, (
+        "the fixture would not open under a corpus-less datasets root: "
+        f"{payload['read_error']}"
+    )
+    assert payload["row_ids"] == [1, 2, 3], (
+        f"fixture unreadable under a corpus-less datasets root: {payload['row_ids']}"
+    )

--- a/bindings/python/tests/test_issue_3504_udt_field_namespace.py
+++ b/bindings/python/tests/test_issue_3504_udt_field_namespace.py
@@ -772,6 +772,28 @@ def test_a_udt_with_a_collection_field_projects_because_that_field_is_bytes():
 # CQLITE_DATASETS_ROOT (#3131/#3148; issue #3724 AC5)
 # =============================================================================
 
+# The child bound for the resolution probe below. MEASURED: unlike the Node side
+# there is NO competing enforcer to stay under — `bindings/python/pyproject.toml`'s
+# `[tool.pytest.ini_options]` sets no timeout and `pytest-timeout` is not
+# installed (pytest 9.1.1) — so this bound is the ONLY bound, and it is kept
+# generous (~150x the probe's measured warm runtime) rather than mirroring Node's
+# tighter value, which exists there solely to stay below jest's 30s `testTimeout`.
+_PROBE_TIMEOUT_SECS = 60
+
+
+def _probe_stream(value: Any) -> str:
+    """A probe capture stream as text, whatever shape the failure left it in.
+
+    `TimeoutExpired` may carry `None`, and carries `bytes` when the run was not
+    in text mode, so neither is assumed.
+    """
+    if value is None:
+        return "(none)"
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "replace")
+    return str(value)
+
+
 # The child-process probe for the behavioural half below. It re-evaluates THIS
 # module — and `conftest` — from scratch in a fresh interpreter whose
 # `CQLITE_DATASETS_ROOT` points at an empty directory, then records BOTH the
@@ -902,22 +924,42 @@ def test_fixture_and_parity_facts_resolve_checkout_relative_not_via_the_env(tmp_
     child_env.pop("CQLITE_REQUIRE_FIXTURES", None)
     child_env.pop("CQLITE_PARITY_REQUIRE_DATASETS", None)
 
-    proc = subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            _RESOLUTION_PROBE,
-            str(Path(__file__).parent),
-            str(Path(__file__)),
-            str(out_path),
-        ],
-        env=child_env,
-        capture_output=True,
-        text=True,
-        timeout=180,
-    )
+    # AFFIRMATIVE COMPLETION ASSERTS, before a single byte of the payload is
+    # read. A timed-out or dead probe must fail NAMING that, and must never fall
+    # through into comparing absent output against an expected path: that either
+    # misleads (a "path mismatch" for a hang) or, with no payload written at all,
+    # risks a comparison that passes having measured nothing.
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                _RESOLUTION_PROBE,
+                str(Path(__file__).parent),
+                str(Path(__file__)),
+                str(out_path),
+            ],
+            env=child_env,
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_SECS,
+        )
+    except subprocess.TimeoutExpired as expired:
+        pytest.fail(
+            f"resolution probe TIMED OUT after {_PROBE_TIMEOUT_SECS}s. It normally "
+            "completes in well under a second, so this is a hang, not a slow box — "
+            "nothing about path resolution was measured.\n"
+            f"--- stdout ---\n{_probe_stream(expired.stdout)}\n"
+            f"--- stderr ---\n{_probe_stream(expired.stderr)}",
+            pytrace=False,
+        )
     assert proc.returncode == 0, (
-        f"resolution probe failed (rc={proc.returncode})\n"
+        f"resolution probe exited {proc.returncode} (bound {_PROBE_TIMEOUT_SECS}s)\n"
+        f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+    )
+    assert out_path.is_file(), (
+        f"resolution probe exited 0 but wrote no payload to {out_path} — nothing was "
+        "measured, so no path comparison below would mean anything\n"
         f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
     )
     payload = json.loads(out_path.read_text())

--- a/bindings/python/tests/test_issue_3504_udt_field_namespace.py
+++ b/bindings/python/tests/test_issue_3504_udt_field_namespace.py
@@ -894,7 +894,7 @@ spec.loader.exec_module(module)
 payload = {
     # The POSITIVE CONTROL pair: what the child actually saw, and a constant
     # whose documented contract IS to follow it.
-    "env_seen": os.environ.get("CQLITE_DATASETS_ROOT"),
+    "env_seen": os.environ.get("CQLITE_DATASETS_ROOT"),  # CONTROL: the probe echoes the perturbed value back
     # CONTROL: env-routed BY CONTRACT — the positive control, never a consumer.
     "control_env_routed": str(conftest.DATASETS),  # CONTROL
     # The INVARIANT: this suite's own resolved constants. `SCHEMAS`/`SCHEMA` are
@@ -1001,7 +1001,7 @@ def test_fixture_and_parity_facts_resolve_checkout_relative_not_via_the_env(tmp_
     # resolution reds on the equality alone; UNSET (the usual local run) and only
     # Half 2 can see it. A maintainer reading a failure needs to know which run
     # they are looking at, and neither state is the "right" one to run under.
-    ambient = os.environ.get("CQLITE_DATASETS_ROOT")
+    ambient = os.environ.get("CQLITE_DATASETS_ROOT")  # CONTROL: the AMBIENT read, diagnostic only
     ambient_note = (
         "ambient CQLITE_DATASETS_ROOT: "
         f"{ambient if ambient is not None else '(unset)'}"
@@ -1022,7 +1022,7 @@ def test_fixture_and_parity_facts_resolve_checkout_relative_not_via_the_env(tmp_
     out_path = tmp_path / "probe.json"
 
     child_env = dict(os.environ)
-    child_env["CQLITE_DATASETS_ROOT"] = str(bogus)
+    child_env["CQLITE_DATASETS_ROOT"] = str(bogus)  # CONTROL: the perturbation itself
     # The strict-fixture flags are cleared for the CHILD only: a corpus-less
     # root makes them a hard failure by design, which would leave the probe
     # unable to run rather than able to measure.
@@ -1139,10 +1139,29 @@ def test_this_module_names_no_env_routed_corpus_constant():
     literal in this function is a `STRING` token, never a `NAME`), so the split is
     belt-and-braces rather than the mechanism.
 
-    DECLARED BOUND, because a guard that overstates its reach is worse than none:
-    a consumer reading `os.environ` DIRECTLY names no constant and is invisible
-    here. That half is what the child-process probe above measures, so the two
-    are complementary rather than overlapping, and neither alone closes the class.
+    A SECOND NEEDLE, closing the cheap half of what this guard used to merely
+    declare (roborev #3724 round 4): the env VARIABLE NAME itself, as a STRING
+    literal. A future test that skips the corpus constants and reads
+    `os.environ["<var>"]` DIRECTLY names none of the constants above, so the NAME
+    scan cannot see it — but such a read must contain the variable's name as a
+    literal, and a literal in this file's source plainly IS checkable. Compared
+    EXACTLY against the quoted spellings, which is the whole reason this file's
+    heavy PROSE about the variable stays out of scope: a docstring is ONE `STRING`
+    token holding the entire docstring, and a diagnostic message like
+    `"ambient <var>: "` is a different string again — neither is ever equal to the
+    bare quoted name. So the exemptions do not have to grow to accommodate prose.
+
+    DECLARED RESIDUAL, and it is what keeps this guard honest — the half a source
+    scan genuinely cannot reach is an INDIRECT read: a helper that returns the
+    value, a COMPUTED or concatenated variable name (`os.environ[prefix + suffix]`),
+    or an alias bound to `os.environ` names neither a corpus constant nor the
+    literal, so neither needle fires. That half stays the child-process probe's
+    job — it measures the RESOLVED paths under a perturbed environment, whatever
+    route a consumer took to read it, so the two are complementary rather than
+    overlapping and neither alone closes the class. Deliberately NOT met with an
+    AST or dataflow "environment read" detector: a recogniser over
+    author-controlled code accumulates false PASSes, and a guard with known false
+    PASSes is worse than no guard at all.
     """
     import io
     import tokenize
@@ -1155,11 +1174,16 @@ def test_this_module_names_no_env_routed_corpus_constant():
         "DATASETS" + "_AVAILABLE",
     }
 
-    names = {
-        token.string
-        for token in tokenize.tokenize(io.BytesIO(Path(__file__).read_bytes()).readline)
-        if token.type == tokenize.NAME
-    }
+    # Split for the same reason, and here the split is load-bearing in a second
+    # way: an unsplit literal below would be a STRING token equal to the quoted
+    # needle, so the scan would match its own source and could never pass.
+    env_var = "CQLITE_" + "DATASETS_ROOT"
+    quoted_env_var = {'"' + env_var + '"', "'" + env_var + "'"}
+
+    source_lines = Path(__file__).read_text().splitlines()
+    tokens = list(tokenize.tokenize(io.BytesIO(Path(__file__).read_bytes()).readline))
+
+    names = {token.string for token in tokens if token.type == tokenize.NAME}
     offenders = sorted(forbidden & names)
     assert not offenders, (
         f"this module names the env-routed corpus constant(s) {offenders} in CODE. "
@@ -1167,6 +1191,45 @@ def test_this_module_names_no_env_routed_corpus_constant():
         "from `PROJECT_ROOT` (#3131/#3148); a path built from an env-routed root "
         "is invisible exactly where this suite runs, because every gate run sets "
         "CQLITE_DATASETS_ROOT. Build the path from `PROJECT_ROOT` instead."
+    )
+
+    # Needle 2 — the env variable's own name, as a bare quoted STRING literal, on
+    # any line that does not declare itself the positive CONTROL.
+    env_offenders = sorted(
+        f"{token.start[0]}: {source_lines[token.start[0] - 1].strip()}"
+        for token in tokens
+        if token.type == tokenize.STRING
+        and token.string in quoted_env_var
+        and "CONTROL" not in source_lines[token.start[0] - 1]
+    )
+    assert not env_offenders, (
+        f"this module reads the {env_var} environment variable directly, outside "
+        f"its positive control: {env_offenders}. The committed fixture is committed "
+        "SOURCE and resolves checkout-relative from `PROJECT_ROOT` (#3131/#3148); a "
+        "path built from an env-routed root is invisible exactly where this suite "
+        "runs, because every gate run sets that variable. Build the path from "
+        "`PROJECT_ROOT` instead — or, if the reference really is a positive "
+        "control, mark the line CONTROL and say why."
+    )
+
+    # NON-VACUITY for needle 2, counted SEPARATELY from needle 1's: folding the two
+    # totals into one would let a typo in either split hide behind the other's
+    # matches. Counted over the file's TEXT, so MEASURED at 3 -- the ambient
+    # diagnostic read, the perturbation, and the probe's echo, which is physically
+    # in this file even though it lives inside a string literal the token scan
+    # cannot reach. That third one is additionally checked as PROBE SOURCE below;
+    # the two asserts are not redundant, since this one sees only text while that
+    # one sees the probe's own structure.
+    env_control_lines = [
+        line
+        for line in source_lines
+        if any(q in line for q in quoted_env_var) and "CONTROL" in line
+    ]
+    assert len(env_control_lines) == 3, (
+        f"expected exactly 3 CONTROL-marked references to {env_var} in this "
+        f"module's code, got {len(env_control_lines)}: {env_control_lines}. A count "
+        "that drifts means either a new consumer wearing the marker, or a split "
+        "needle typo that now matches nothing."
     )
 
     # The probe's SOURCE is a string literal, so the token scan above cannot see
@@ -1184,4 +1247,21 @@ def test_this_module_names_no_env_routed_corpus_constant():
     assert "CONTROL" in control_lines[0], (
         "the probe's reference to the env-routed constant must declare itself the "
         f"positive CONTROL, or it is indistinguishable from a consumer: {control_lines[0]!r}"
+    )
+
+    # ...and the same discipline for the probe's reference to the env VARIABLE. The
+    # probe legitimately reads it, ONCE, to echo the perturbed value back as the
+    # positive control's proof; a second reference would be a consumer.
+    probe_env_lines = [
+        line
+        for line in _RESOLUTION_PROBE.splitlines()
+        if any(q in line for q in quoted_env_var)
+    ]
+    assert len(probe_env_lines) == 1, (
+        f"expected exactly one reference to {env_var} in the probe source, got "
+        f"{len(probe_env_lines)}: {probe_env_lines}"
+    )
+    assert "CONTROL" in probe_env_lines[0], (
+        "the probe's read of the env variable must declare itself the positive "
+        f"CONTROL, or it is indistinguishable from a consumer: {probe_env_lines[0]!r}"
     )

--- a/bindings/python/tests/test_issue_3504_udt_field_namespace.py
+++ b/bindings/python/tests/test_issue_3504_udt_field_namespace.py
@@ -43,6 +43,7 @@ fixtures are `must_run`).
 from __future__ import annotations
 
 import json
+import signal
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any
@@ -794,6 +795,44 @@ def _probe_stream(value: Any) -> str:
     return str(value)
 
 
+def _probe_completion_failure(proc: Any, out_path: Path) -> str | None:
+    """Why the probe did not complete, as a message naming the cause — or `None`.
+
+    Mirrors the Node side's state set exactly (`probeCompletionFailure`), so the
+    two bindings cannot report a different set of causes for the same probe. The
+    two states that arrive as EXCEPTIONS rather than a result — a timeout and an
+    unspawnable child — are named at the call site; the three visible in a
+    completed `CompletedProcess` are named here.
+    """
+    detail = (
+        f"--- child stdout ---\n{_probe_stream(proc.stdout)}\n"
+        f"--- child stderr ---\n{_probe_stream(proc.stderr)}"
+    )
+    if proc.returncode < 0:
+        # A negative returncode IS the signal number negated; `Signals` names it
+        # when the platform knows it, and an unknown number is reported as-is
+        # rather than guessed at.
+        try:
+            killed_by = signal.Signals(-proc.returncode).name
+        except ValueError:
+            killed_by = f"signal {-proc.returncode}"
+        return (
+            f"resolution probe was KILLED by {killed_by} "
+            f"(bound {_PROBE_TIMEOUT_SECS}s)\n{detail}"
+        )
+    if proc.returncode != 0:
+        return (
+            f"resolution probe exited {proc.returncode} "
+            f"(bound {_PROBE_TIMEOUT_SECS}s)\n{detail}"
+        )
+    if not out_path.is_file():
+        return (
+            f"resolution probe exited 0 but wrote no payload to {out_path} — nothing "
+            f"was measured, so no path comparison below would mean anything\n{detail}"
+        )
+    return None
+
+
 # The child-process probe for the behavioural half below. It re-evaluates THIS
 # module — and `conftest` — from scratch in a fresh interpreter whose
 # `CQLITE_DATASETS_ROOT` points at an empty directory, then records BOTH the
@@ -820,15 +859,30 @@ payload = {
     # The POSITIVE CONTROL pair: what the child actually saw, and a constant
     # whose documented contract IS to follow it.
     "env_seen": os.environ.get("CQLITE_DATASETS_ROOT"),
-    "control_env_routed": str(conftest.DATASETS),
-    # The INVARIANT: this suite's own resolved constants.
+    # CONTROL: env-routed BY CONTRACT — the positive control, never a consumer.
+    "control_env_routed": str(conftest.DATASETS),  # CONTROL
+    # The INVARIANT: this suite's own resolved constants. `SCHEMAS`/`SCHEMA` are
+    # deliberately NOT recorded: AC5 is about the DATASETS root, and the schemas
+    # root is a separate contract that the Node side legitimately lets
+    # `CQLITE_SCHEMAS_ROOT` relocate — pinning it here would certify Python's
+    # non-honouring as correct and would red, with a fixture-resolution message,
+    # the day `conftest` gains the #3148 override.
     "fixture_root": str(module.FIXTURE_ROOT),
     "parity_facts": str(module.PARITY_FACTS),
-    "schemas": str(module.SCHEMAS),
-    "schema": str(module.SCHEMA),
     "row_ids": None,
     "read_error": None,
+    "parity_facts_udts": None,
+    "parity_facts_error": None,
 }
+
+# AC5 covers the parity-facts FILE as much as the corpus, so the probe OPENS it
+# rather than only recording its path — otherwise that half is path-equality
+# only while the corpus half is path-equality PLUS a read-back.
+try:
+    with open(module.PARITY_FACTS, encoding="utf-8") as handle:
+        payload["parity_facts_udts"] = len(json.load(handle)["udts"])
+except Exception as exc:  # noqa: BLE001 -- reported to the parent, not handled
+    payload["parity_facts_error"] = f"{type(exc).__name__}: {exc}"
 
 # The read is attempted AFTER the paths are recorded, and its failure is
 # REPORTED rather than raised: an env-routed resolution makes the open fail, and
@@ -894,21 +948,36 @@ def test_fixture_and_parity_facts_resolve_checkout_relative_not_via_the_env(tmp_
     import subprocess
     import sys
 
+    # FIRST, and before anything can be misattributed: a checkout missing the
+    # committed fixture must fail as a BROKEN CHECKOUT, naming the absent
+    # artifact. Without this the probe's read failure below would be reported
+    # under a corpus-less-root heading it has not established — the Node case
+    # gets this from the `beforeAll` that its `describe` runs.
+    _assert_fixture_present()
+
     # UNCANONICALIZED, to match `conftest.PROJECT_ROOT`'s own derivation.
     repo_root = Path(__file__).parents[3]
     expected_root = repo_root / "test-data" / "fixtures" / "issue_3504"
     expected_facts = expected_root / "binding-parity-facts.json"
-    expected_schemas = repo_root / "test-data" / "schemas"
-    expected_schema = expected_schemas / "issue-3504-udt-collision.cql"
 
-    # Half 1 — the resolved constants ARE the checkout-derived paths.
-    assert FIXTURE_ROOT == expected_root
-    assert PARITY_FACTS == expected_facts
-    assert SCHEMAS == expected_schemas
-    assert SCHEMA == expected_schema
+    # The AMBIENT value, recorded in every failure below. Half 1's discriminating
+    # power depends on it: SET (as every gate run has it) and an env-routed
+    # resolution reds on the equality alone; UNSET (the usual local run) and only
+    # Half 2 can see it. A maintainer reading a failure needs to know which run
+    # they are looking at, and neither state is the "right" one to run under.
+    ambient = os.environ.get("CQLITE_DATASETS_ROOT")
+    ambient_note = (
+        "ambient CQLITE_DATASETS_ROOT: "
+        f"{ambient if ambient is not None else '(unset)'}"
+    )
+
+    # Half 1 — the resolved constants ARE the checkout-derived paths. SCHEMAS and
+    # SCHEMA are deliberately NOT pinned here (see the probe payload comment).
+    assert FIXTURE_ROOT == expected_root, ambient_note
+    assert PARITY_FACTS == expected_facts, ambient_note
     # ...and equal canonicalized too, both sides canonicalized.
-    assert FIXTURE_ROOT.resolve() == expected_root.resolve()
-    assert PARITY_FACTS.resolve() == expected_facts.resolve()
+    assert FIXTURE_ROOT.resolve() == expected_root.resolve(), ambient_note
+    assert PARITY_FACTS.resolve() == expected_facts.resolve(), ambient_note
 
     # Half 2 — a fresh interpreter under a datasets root holding no corpus.
     bogus = tmp_path / "no-corpus-here"
@@ -949,43 +1018,134 @@ def test_fixture_and_parity_facts_resolve_checkout_relative_not_via_the_env(tmp_
             f"resolution probe TIMED OUT after {_PROBE_TIMEOUT_SECS}s. It normally "
             "completes in well under a second, so this is a hang, not a slow box — "
             "nothing about path resolution was measured.\n"
-            f"--- stdout ---\n{_probe_stream(expired.stdout)}\n"
-            f"--- stderr ---\n{_probe_stream(expired.stderr)}",
+            f"{ambient_note}\n"
+            f"--- child stdout ---\n{_probe_stream(expired.stdout)}\n"
+            f"--- child stderr ---\n{_probe_stream(expired.stderr)}",
             pytrace=False,
         )
-    assert proc.returncode == 0, (
-        f"resolution probe exited {proc.returncode} (bound {_PROBE_TIMEOUT_SECS}s)\n"
-        f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
-    )
-    assert out_path.is_file(), (
-        f"resolution probe exited 0 but wrote no payload to {out_path} — nothing was "
-        "measured, so no path comparison below would mean anything\n"
-        f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
-    )
+    except OSError as spawn_error:
+        # The unspawnable state, which used to surface as a raw traceback.
+        pytest.fail(
+            "resolution probe could not be spawned: "
+            f"{spawn_error.__class__.__name__}: {spawn_error} "
+            f"(bound {_PROBE_TIMEOUT_SECS}s)\n{ambient_note}",
+            pytrace=False,
+        )
+    failure = _probe_completion_failure(proc, out_path)
+    assert failure is None, f"{failure}\n{ambient_note}"
     payload = json.loads(out_path.read_text())
 
     # POSITIVE CONTROL — the perturbation really was in effect, and a constant
     # whose contract is to follow the variable really did move onto it.
     assert payload["env_seen"] == str(bogus), (
         "the probe did not see the perturbed CQLITE_DATASETS_ROOT — the "
-        "invariance below would prove nothing"
+        f"invariance below would prove nothing\n{ambient_note}"
     )
     assert payload["control_env_routed"] == str(bogus), (
         "conftest.DATASETS did not follow the perturbed CQLITE_DATASETS_ROOT — "
         f"got {payload['control_env_routed']}; the control is broken, so the "
-        "invariance below is unmeasured"
+        f"invariance below is unmeasured\n{ambient_note}"
     )
     assert payload["control_env_routed"] != str(expected_root)
 
-    # THE INVARIANT — unmoved, checkout-derived, and still readable.
-    assert payload["fixture_root"] == str(expected_root)
-    assert payload["parity_facts"] == str(expected_facts)
-    assert payload["schemas"] == str(expected_schemas)
-    assert payload["schema"] == str(expected_schema)
+    # THE INVARIANT — unmoved, checkout-derived, and both artifacts still read.
+    assert payload["fixture_root"] == str(expected_root), ambient_note
+    assert payload["parity_facts"] == str(expected_facts), ambient_note
+
+    # A read failure is REPORTED without a cause being claimed. `_assert_fixture_present`
+    # above has already ruled out the broken-checkout case, but a decoder
+    # regression, a schema-parse change or a force-added binary lost to a
+    # gitignore would all look identical here, and a message naming one of them
+    # would be asserting what this test has not established.
     assert payload["read_error"] is None, (
-        "the fixture would not open under a corpus-less datasets root: "
-        f"{payload['read_error']}"
+        "the probe could not read the fixture through the re-resolved paths "
+        f"(cause NOT established by this test)\n{ambient_note}\n"
+        f"child error: {payload['read_error']}"
     )
     assert payload["row_ids"] == [1, 2, 3], (
-        f"fixture unreadable under a corpus-less datasets root: {payload['row_ids']}"
+        f"unexpected fixture row ids through the re-resolved paths: "
+        f"{payload['row_ids']}\n{ambient_note}"
+    )
+    assert payload["parity_facts_error"] is None, (
+        "the probe could not read the parity reference through the re-resolved "
+        f"path (cause NOT established by this test)\n{ambient_note}\n"
+        f"child error: {payload['parity_facts_error']}"
+    )
+    # Non-vacuity: an emptied or renamed reference would otherwise let the
+    # path-equality half stand in for a file nobody opened. Asserted NON-ZERO
+    # rather than at an exact count, which is #3724's own subject to widen.
+    assert payload["parity_facts_udts"] > 0, (
+        "the parity reference parsed but carries no `udts` entries — the path "
+        f"equality above would then be comparing a path to an empty file\n{ambient_note}"
+    )
+
+
+def test_this_module_names_no_env_routed_corpus_constant():
+    """SCENARIO: nothing in this file builds a path from an env-routed corpus root.
+
+    THE CLASS THIS CLOSES, WHICH THE ENVIRONMENT CASES ONLY SAMPLE. The test
+    above pins the CONSTANTS this module resolves today. A future test added to
+    this file that builds its OWN path from `conftest`'s env-routed corpus
+    constant is invisible to it: that path would resolve through
+    `CQLITE_DATASETS_ROOT` while every assertion above stayed green, because
+    those assertions are about `FIXTURE_ROOT`/`PARITY_FACTS` and not about the
+    file's other consumers. This repository has ALREADY paid for exactly that
+    defect one binding over — `bindings/node/__test__/setup.js`'s round-10 note
+    records `write.test.js` and `write-smoke.test.js` building the schemas path
+    themselves and BYPASSING the resolver, so the variable was honoured by part
+    of the suite and ignored by the rest.
+
+    Answered from THIS FILE'S OWN SOURCE, TOKENIZED. Only `NAME` tokens count, so
+    a mention in a docstring or a comment is not a consumer — which matters here,
+    because this file discusses the env-routed constant at length in prose. The
+    needles are SPLIT so the scan cannot match its own source; with an
+    exact-token comparison a self-match is already structurally impossible (a
+    literal in this function is a `STRING` token, never a `NAME`), so the split is
+    belt-and-braces rather than the mechanism.
+
+    DECLARED BOUND, because a guard that overstates its reach is worse than none:
+    a consumer reading `os.environ` DIRECTLY names no constant and is invisible
+    here. That half is what the child-process probe above measures, so the two
+    are complementary rather than overlapping, and neither alone closes the class.
+    """
+    import io
+    import tokenize
+
+    # Split, per the note above.
+    forbidden = {
+        "DATA" + "SETS",
+        "SSTABLES" + "_DIR",
+        "TEST_DATA" + "_ROOT",
+        "DATASETS" + "_AVAILABLE",
+    }
+
+    names = {
+        token.string
+        for token in tokenize.tokenize(io.BytesIO(Path(__file__).read_bytes()).readline)
+        if token.type == tokenize.NAME
+    }
+    offenders = sorted(forbidden & names)
+    assert not offenders, (
+        f"this module names the env-routed corpus constant(s) {offenders} in CODE. "
+        "The committed fixture is committed SOURCE and resolves checkout-relative "
+        "from `PROJECT_ROOT` (#3131/#3148); a path built from an env-routed root "
+        "is invisible exactly where this suite runs, because every gate run sets "
+        "CQLITE_DATASETS_ROOT. Build the path from `PROJECT_ROOT` instead."
+    )
+
+    # The probe's SOURCE is a string literal, so the token scan above cannot see
+    # it — and it legitimately names the env-routed constant, ONCE, as the
+    # positive control. That one line is therefore required to SAY it is the
+    # control, so the exemption cannot silently grow into a consumer.
+    control_needle = "conftest." + "DATA" + "SETS"
+    control_lines = [
+        line for line in _RESOLUTION_PROBE.splitlines() if control_needle in line
+    ]
+    assert len(control_lines) == 1, (
+        f"expected exactly one control reference to {control_needle} in the probe "
+        f"source, got {len(control_lines)}: {control_lines}"
+    )
+    assert "CONTROL" in control_lines[0], (
+        "the probe's reference to the env-routed constant must declare itself the "
+        f"positive CONTROL, or it is indistinguishable from a consumer: {control_lines[0]!r}"
     )

--- a/bindings/python/tests/test_issue_3504_udt_field_namespace.py
+++ b/bindings/python/tests/test_issue_3504_udt_field_namespace.py
@@ -1161,20 +1161,35 @@ def test_this_module_names_no_env_routed_corpus_constant():
     all. This is `ast` used as the language's own literal reader, NOT dataflow or
     reachability analysis: nothing here asks whether a read is executable.
 
-    DECLARED RESIDUAL, and it is what keeps this guard honest — the half a source
-    scan genuinely cannot reach is an INDIRECT read: a helper that returns the
-    value, a COMPUTED or concatenated name (`os.environ[prefix + suffix]`, or an
-    INTERPOLATING f-string, which parses to `Constant("CQLITE_")` +
-    `Constant("DATASETS_ROOT")` — neither equal to the whole — MEASURED), or an
-    alias bound to `os.environ`. None of those names a corpus constant or the
-    literal, so neither needle fires. That half stays the child-process probe's
-    job — it measures the RESOLVED paths under a perturbed environment, whatever
-    route a consumer took to read it, so the two are complementary rather than
-    overlapping and neither alone closes the class. Deliberately NOT met with a
-    dataflow or reachability "is this an executable environment read" detector: a
-    recogniser over author-controlled code accumulates false PASSes and an
-    exemption list that grows every round, and a guard with known false PASSes is
-    worse than no guard at all.
+    WHAT THE TWO GUARDS COVER, AND WHAT NOTHING HERE COVERS. This paragraph used to
+    say the residual "stays the child-process probe's job — whatever route a
+    consumer took to read it". That was FALSE, and correcting it is the point of
+    this note (roborev N-C1): the probe records and compares only the constants
+    this module EXPORTS — it reads `module.FIXTURE_ROOT`, `module.PARITY_FACTS`,
+    `module.SCHEMA` and `module.QUERY` back out of a freshly imported copy of this
+    file — so it cannot observe a path that some other test builds inside its own
+    body. Stated as it actually is:
+
+    * THIS SCAN catches the env variable's name written as a LITERAL, in any
+      spelling (compared by evaluated VALUE, so quoting is irrelevant), plus any of
+      the named corpus constants.
+    * THE CHILD PROBE above proves those EXPORTED CONSTANTS stay checkout-anchored
+      while `CQLITE_DATASETS_ROOT` is perturbed.
+    * NEITHER covers an INDIRECT read — a helper that returns the value, a COMPUTED
+      or concatenated name (`os.environ[prefix + suffix]`, or an INTERPOLATING
+      f-string, which parses to `Constant("CQLITE_")` + `Constant("DATASETS_ROOT")`,
+      neither equal to the whole — MEASURED), or an alias bound to `os.environ` —
+      used by a FUTURE TEST IN THIS FILE to build its OWN path. That is an
+      UNCOVERED RESIDUAL, not a covered one: the read names neither a corpus
+      constant nor the literal, so this scan is blind, and such a path never
+      reaches an exported constant, so the probe is blind to it as well.
+
+    Deliberately NOT closed by widening either guard. These two already exceed what
+    AC5 asks for, and a recogniser over computed names is the unbounded shape this
+    repository keeps having to delete — it accumulates false PASSes and an exemption
+    list that grows every round, and a guard with known false PASSes is worse than
+    no guard. A narrow guard that says what it does NOT cover is worth more than a
+    broad one implying completeness it cannot deliver.
     """
     import ast
     import io

--- a/bindings/python/tests/test_issue_3504_udt_field_namespace.py
+++ b/bindings/python/tests/test_issue_3504_udt_field_namespace.py
@@ -507,9 +507,17 @@ def test_binding_facts_match_the_committed_cross_binding_reference(rows):
     reference = json.loads(Path(PARITY_FACTS).read_text())
     expected = reference["udts"]
 
+    # Every entry is DERIVED from this binding's own output; nothing here is a
+    # literal. `cm`/`tm` (MULTICELL: the key lives in the CELL PATH) sit beside
+    # `fcm`/`ftm` (FROZEN: a single value cell) because those are two different
+    # decoders in cqlite-core and only the frozen one used to reach a UDT at all
+    # (#3612). Carrying both makes this case a parity control in TWO directions
+    # at once: cross-BINDING, as every entry here is, and cross-DECODE-PATH.
     observed = {
         "row1.c": _facts(rows[1]["c"]),
         "row1.p": _facts(rows[1]["p"]),
+        "row1.cm_key": _facts(next(iter(rows[1]["cm"]))),
+        "row1.tm_key": _facts(next(iter(rows[1]["tm"]))),
         "row1.fcm_key": _facts(next(iter(rows[1]["fcm"]))),
         "row1.ftm_key": _facts(next(iter(rows[1]["ftm"]))),
         "row1.fs_0": _facts(rows[1]["fs"][0]),
@@ -523,13 +531,41 @@ def test_binding_facts_match_the_committed_cross_binding_reference(rows):
     assert sorted(observed) == sorted(expected)
     assert observed == expected
 
-    assert next(iter(rows[1]["fcm"].values())) == reference["map_values"]["row1.fcm_value"]
-    assert next(iter(rows[1]["ftm"].values())) == reference["map_values"]["row1.ftm_value"]
+    # The map VALUES, one per map column, also derived from this binding.
+    map_values = reference["map_values"]
+    for column, fact_key in (
+        ("cm", "row1.cm_value"),
+        ("tm", "row1.tm_value"),
+        ("fcm", "row1.fcm_value"),
+        ("ftm", "row1.ftm_value"),
+    ):
+        assert next(iter(rows[1][column].values())) == map_values[fact_key], column
+    # ...and those four values must be PAIRWISE DISTINCT in the reference, which
+    # is what makes the four assertions above discriminating. The four map columns
+    # hold the SAME key by construction, so a case that read the wrong column's
+    # cell -- exactly the confusion a multicell/frozen pair invites -- would pass
+    # unnoticed against equal values.
+    declared = [
+        map_values["row1.cm_value"],
+        map_values["row1.tm_value"],
+        map_values["row1.fcm_value"],
+        map_values["row1.ftm_value"],
+    ]
+    assert len(set(declared)) == len(declared), declared
 
     # Non-vacuity: the reference must actually carry the colliding subject, or an
     # emptied/renamed file would let this pass having compared nothing.
     assert expected["row1.c"]["fields"]["_type"] == "user-supplied-type"
     assert expected["row1.c"]["typeName"] == "collide"
+    # ...and the reference states the CROSS-DECODE-PATH identity in its own right:
+    # the multicell key facts EQUAL the frozen ones, which is #3612's property (a
+    # caller cannot tell the two spellings of one map apart). Stated here so the
+    # committed FILE remains a valid control on its own -- the per-binding case
+    # that measures this within one binding is
+    # `test_non_frozen_map_udt_key_projects_like_the_frozen_control`, and this
+    # case is what compares the two BINDINGS.
+    assert expected["row1.cm_key"] == expected["row1.fcm_key"]
+    assert expected["row1.tm_key"] == expected["row1.ftm_key"]
 
 
 # =============================================================================

--- a/bindings/python/tests/test_issue_3504_udt_field_namespace.py
+++ b/bindings/python/tests/test_issue_3504_udt_field_namespace.py
@@ -765,3 +765,95 @@ def test_a_udt_with_a_collection_field_projects_because_that_field_is_bytes():
     # The residual, at the only layer that can reach it today.
     with pytest.raises(TypeError, match=r"unhashable type: 'dict'"):
         hash(cqlite.Udt("t", "k", {"m": {"a": 1}}))
+
+
+# =============================================================================
+# AC5 — the committed fixture resolves CHECKOUT-RELATIVE, never through
+# CQLITE_DATASETS_ROOT (#3131/#3148; issue #3724 AC5)
+# =============================================================================
+
+
+def test_fixture_and_parity_facts_resolve_checkout_relative_not_via_the_env(
+    monkeypatch, tmp_path
+):
+    """SCENARIO: the committed fixture paths do not hang off `CQLITE_DATASETS_ROOT`.
+
+    The module docstring above and the reference file's `note_on_paths` DOCUMENT
+    this contract; nothing ASSERTED it. `_assert_fixture_present` cannot: it
+    checks the file exists at the ALREADY-RESOLVED path, so it would pass
+    unchanged if resolution became env-routed and the env root happened to hold
+    the file. Committed fixtures are committed SOURCE and are resolved
+    checkout-relative — and the corpus resolvers are an EITHER/OR on the
+    variable (`conftest.py:42-48`), so a fixture reached through one is
+    invisible exactly where the suite runs, because every gate run sets it.
+
+    Two halves, and the second is the one that catches a regression.
+
+    AFFIRMATIVE EQUALITY. The resolved paths must EQUAL the checkout-derived
+    expectation, anchored on this file's own location. A "the env value is not a
+    prefix" check would go vacuous whenever the variable is unset or
+    coincidentally equals the checkout — a pass derived from the absence of a
+    bad signal, which CLAUDE.md forbids.
+
+    BEHAVIOURAL INVARIANCE. With `CQLITE_DATASETS_ROOT` *and* the env-routed
+    `conftest.DATASETS` it produces both pointed at an EMPTY directory, a FRESH
+    evaluation of this very module must resolve the SAME three paths, and the
+    committed artifacts must still open and read through them. A resolution
+    routed through either would land in the empty directory and red here — on
+    every run, not merely where the exported root differs from the checkout.
+    Both patches are `monkeypatch`'s, so nothing leaks to sibling tests, and the
+    probe module is never inserted into `sys.modules`.
+
+    NOT ASSERTED: `CQLITE_SCHEMAS_ROOT`. Python's `SCHEMAS` is purely
+    checkout-derived and is pinned below, but the Node side legitimately honours
+    that variable (`setup.js:67-72` — the gate-validated #3148 contract), so
+    honouring it is not an AC5 violation in either binding.
+    """
+    import importlib.util
+    import os
+    import sys
+
+    import conftest
+
+    repo_root = Path(__file__).resolve().parents[3]
+    expected_root = repo_root / "test-data" / "fixtures" / "issue_3504"
+    expected_facts = expected_root / "binding-parity-facts.json"
+    expected_schemas = repo_root / "test-data" / "schemas"
+    expected_schema = expected_schemas / "issue-3504-udt-collision.cql"
+
+    # Half 1 — the resolved constants ARE the checkout-derived paths.
+    assert FIXTURE_ROOT == expected_root
+    assert PARITY_FACTS == expected_facts
+    assert SCHEMAS == expected_schemas
+    assert SCHEMA == expected_schema
+
+    # Half 2 — invariance under a datasets root that holds no corpus at all.
+    bogus = tmp_path / "no-corpus-here"
+    bogus.mkdir()
+    monkeypatch.setenv("CQLITE_DATASETS_ROOT", str(bogus))
+    monkeypatch.setattr(conftest, "DATASETS", bogus)
+
+    # Non-vacuity: both env-routed values really did move, and the root really is
+    # corpus-free — otherwise the invariance below would prove nothing.
+    assert os.environ["CQLITE_DATASETS_ROOT"] == str(bogus)
+    assert conftest.DATASETS == bogus
+    assert bogus != expected_root
+    assert not sorted(bogus.glob("**/*-Data.db"))
+
+    spec = importlib.util.spec_from_file_location(
+        "issue_3504_udt_field_namespace__resolution_probe", Path(__file__).resolve()
+    )
+    assert spec is not None and spec.loader is not None
+    probe = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(probe)
+    assert probe.FIXTURE_ROOT == expected_root
+    assert probe.PARITY_FACTS == expected_facts
+    assert probe.SCHEMA == expected_schema
+    assert "issue_3504_udt_field_namespace__resolution_probe" not in sys.modules
+
+    # ...and the committed artifacts still READ through the re-resolved paths.
+    with cqlite.open(probe.FIXTURE_ROOT, schema=probe.SCHEMA) as db:
+        ids = sorted(row.get("id") for row in db.execute(probe.QUERY).rows)
+    assert ids == [1, 2, 3], f"fixture unreadable under a bogus datasets root: {ids}"
+    reference = json.loads(probe.PARITY_FACTS.read_text())
+    assert reference["udts"]["row1.c"]["typeName"] == "collide"

--- a/test-data/fixtures/issue_3504/README.md
+++ b/test-data/fixtures/issue_3504/README.md
@@ -80,14 +80,24 @@ and getting it wrong produces a test that passes on unfixed code:
   `udt_hashable_shapes.stn`'s `unhashable_fields`, nested in a tuple in a set
   (golden `[[{"label": "unhashable", "m": {"a": 1}}, 30]]`).
 * **BLIND** — every `collide`/`collide_twin` column (`c`, `fs`, `fcm`, `ftm`,
-  `stu`, `ssu`, `mtu`): the user's `_type` field TOTALLY overwrites the injected
+  `stu`, `ssu`, `mtu`, and since #3612 `cm`/`tm` too — third bullet): the user's
+  `_type` field TOTALLY overwrites the injected
   one, and because `serde_json` is built with `preserve_order` and `Map::insert`
   keeps an existing key's position while `collide` declares `"_type"` first, even
   the key ORDER matched. Assert these as preservation guards only, labelled as
   such. `id 3`'s `"_type": null` is the USER's null field and is CORRECT.
-* **NOT A SUBJECT AT ALL** — `cm`/`tm`: a non-frozen map's key lives in the cell
-  path and `parse_cell_path_key` falls back to `Value::Blob`, so the key never
-  becomes a `Value::Udt` and cannot exercise a UDT renderer.
+* **RECLASSIFIED BY #3612** — `cm`/`tm`. This bullet read **NOT A SUBJECT AT
+  ALL**, and the reasoning was sound for the code of the time: a non-frozen map's
+  key lives in the cell path, `parse_cell_path_key` fell back to `Value::Blob`,
+  so the key never became a `Value::Udt` and could not exercise a UDT renderer.
+  That is now HISTORY. The site delegates to the structural decoder (see the
+  #3612 note above), so these keys DO reach both bindings and the CLI's
+  `--format json`. They join the **BLIND** class rather than the RED-capable one,
+  for the second bullet's reason and not a new one: their key type is
+  `collide`/`collide_twin`, which DECLARES `_type`, so the user's field totally
+  overwrites any injected marker. `cqlite-core`'s `ToJson` stays a non-subject
+  for them, because its `Map` arm `Display`-stringifies every key regardless of
+  type.
 
 ## Layout
 
@@ -153,7 +163,7 @@ FIELD is `None`.
 A **non-frozen** `map<frozen<udt>,int>` is multicell, so its key lives in the
 CELL PATH; a **frozen** map is a single value cell whose key type resolves
 through the on-disk marshal element type / the `UdtRegistry`. The two spellings
-took different decode paths, and only one of them worked.
+took different decode paths, and until #3612 only one of them worked.
 
 **Historically** (and this is why both shapes are committed):
 `parse_cell_path_key` matched a closed set of **primitive** cell-path types and
@@ -174,35 +184,58 @@ in either decode path makes the two disagree.
 
 ## Table 2: `udt_hashable_shapes` — the projection totality boundary (R1-2)
 
-Python's `value_to_hashable_key` has arms for `List`, `Map`, `Frozen` and `Udt`.
-`Tuple` and `Set` have **none** and fall through to `value_to_py` (issue #3500,
-deliberately not fixed by #3504). Making a UDT a hashable `cqlite.Udt`
-nevertheless **moved** the boundary, because what made those fallthrough shapes
-unprojectable was the UDT being an unhashable `dict`. This table carries one
-column per side, each in its **own row** — the `TypeError` is raised while
-converting a row, so a row holding both would hide the projectable cell.
+**THIS SECTION HAS BEEN RE-MEASURED TWICE, AND THE HISTORY IS THE POINT.** The
+boundary moved under #3504 and again under #3500, in different ways, so anything
+here stated as a mechanism decays fast. The column below labelled `now` was
+measured against THIS tree; the two earlier columns are kept as record.
 
-Measured per row (point read; `origin/main`'s binding built into the same venv
-for the "before" column):
+When #3504 landed, `value_to_hashable_key` had arms for `List`, `Map`, `Frozen`
+and `Udt` only, while `Tuple` and `Set` had **none** and fell through to
+`value_to_py`. Making a UDT a hashable `cqlite.Udt` **moved** the boundary without
+adding an arm, because what made those fall-through shapes unprojectable was the
+UDT being an unhashable `dict`. **#3500 then made both `value_to_hashable_key` and
+`contains_udt` TOTAL** — every `Value` variant named, no wildcard arm, pinned by
+`#[deny(clippy::wildcard_enum_match_arm)]` — which moved it again. VERIFIED in
+`bindings/python/src/value_hashable.rs` on this tree: `Tuple` and `Set` now HAVE
+arms (`Value::List(items) | Value::Tuple(items)`, then `Value::Set(items)`), and
+`contains_udt` traverses `Value::List | Value::Set | Value::Tuple`. So the
+"`Tuple` and `Set` have none" premise is **no longer true** and is recorded above
+only as the state #3504 was written against.
 
-| row | column | type | before #3504 | after |
-|---|---|---|---|---|
-| 1 | `stu` | `frozen<set<frozen<tuple<frozen<collide>,int>>>>` | `TypeError: unhashable type: 'dict'` | `frozenset({(Udt, 10)})` |
-| 1 | `mtu` | `frozen<map<frozen<tuple<frozen<collide>,int>>,int>>` | `TypeError: unhashable type: 'dict'` | `{(Udt, 20): 5}` |
-| 2 | `ssu` | `frozen<set<frozen<set<frozen<collide>>>>>` | `TypeError: unhashable type: 'list'` | **identical** — still raises |
-| 3 | `stn` | `frozen<set<frozen<tuple<frozen<unhashable_fields>,int>>>>` | `TypeError: unhashable type: 'dict'` | `frozenset({(Udt, 30)})` |
+This table carries one column per side, each in its **own row** — a `TypeError` is
+raised while converting a row, so a row holding both would hide the projectable
+cell. That is also why the Python suite reads this table by primary key rather
+than scanning it.
 
-Two things to read off it:
+| row | column | type | before #3504 | after #3504 | now (`+#3500`, measured on this tree) |
+|---|---|---|---|---|---|
+| 1 | `stu` | `frozen<set<frozen<tuple<frozen<collide>,int>>>>` | `TypeError: unhashable type: 'dict'` | `frozenset({(Udt, 10)})` | `list[tuple[Udt(collide), 10]]` |
+| 1 | `mtu` | `frozen<map<frozen<tuple<frozen<collide>,int>>,int>>` | `TypeError: unhashable type: 'dict'` | `{(Udt, 20): 5}` | `dict{tuple[Udt(collide), 20]: 5}` |
+| 2 | `ssu` | `frozen<set<frozen<set<frozen<collide>>>>>` | `TypeError: unhashable type: 'list'` | still raises | `list[list[Udt(collide)]]` — **no longer raises** |
+| 3 | `stn` | `frozen<set<frozen<tuple<frozen<unhashable_fields>,int>>>>` | `TypeError: unhashable type: 'dict'` | `frozenset({(Udt, 30)})` | `list[tuple[Udt(unhashable_fields), 30]]` |
 
-- `ssu` still fails for a reason #3504 never touched: the **inner** set has a UDT
-  element, so `set_to_py` renders it as a Python `list` for CLI parity (#804),
-  and a list is unhashable in the outer set. The error text (`'list'`, not
-  `'dict'`) is what identifies the cause.
-- `stn` **succeeds**, contradicting the obvious prediction that a UDT with a
-  `map`-typed field stays unhashable. It does so only because CQLite decodes a
-  collection field inside a frozen UDT as `Value::Blob`, so the field arrives as
-  hashable `bytes` rather than a `dict`. That is a **decode gap** orthogonal to
-  #3504 (the correct value is `{"a": 1}`), pinned as characterization by
+Three things to read off it, none of which is what the pre-#3500 text said:
+
+- **NOTHING in this table raises today.** What distinguishes the columns now is the
+  CONTAINER, not projectability: `contains_udt` traverses the whole subtree, so
+  `set_to_py` sees the UDT under the tuple / under the inner set and takes its
+  #804 `list` branch for the whole column. That is why the three `set` columns are
+  `list` and only `mtu` — a map KEY, which has no #804 branch to take and must
+  project — still goes through `value_to_hashable_key`, now via its real `Tuple`
+  ARM rather than a fall-through.
+- `ssu`'s change is the one to watch, because the older text asserted the
+  opposite. It used to fail for a cause #3504 never touched (the inner set has a
+  UDT element, `set_to_py` renders it as a `list` for CLI parity (#804), and a
+  `list` is unhashable in the outer set — the error text said `'list'`, not
+  `'dict'`). #3500 made the OUTER set take the `list` branch too, so there is no
+  longer a set to hash it into.
+- `stn`'s **decode gap survives and is still the interesting fact**, though it is
+  no longer what makes the column succeed: CQLite decodes a collection field
+  inside a frozen UDT as `Value::Blob`, so `m` arrives as `bytes` rather than a
+  `dict`. MEASURED on this tree: `m` is
+  `b'\x00\x00\x00\x01\x00\x00\x00\x01a\x00\x00\x00\x04\x00\x00\x00\x01'`,
+  i.e. the serialized form of the golden's `{"a": 1}`, which is the correct value.
+  Orthogonal to both #3504 and #3500, and pinned as characterization by
   `bindings/python/tests/test_issue_3504_udt_field_namespace.py`. `Udt.__hash__`
   does still propagate `TypeError` for a genuinely unhashable field value; no
   decoder path reaches that today, so it is asserted on a hand-built value.

--- a/test-data/fixtures/issue_3504/README.md
+++ b/test-data/fixtures/issue_3504/README.md
@@ -97,6 +97,7 @@ dataset tests open that root and query `test_udt_collision.udt_collide`.
 
 ```
 test-data/fixtures/issue_3504/
+├── binding-parity-facts.json           the CROSS-BINDING reference (see below)
 └── test_udt_collision/
     ├── udt_collide-<uuid>/
     │   ├── nb-1-big-Data.db            (+ Index/Summary/Filter/Statistics/CRC/Digest/TOC)
@@ -106,6 +107,14 @@ test-data/fixtures/issue_3504/
 ```
 
 Uncompressed (no `CompressionInfo.db`), BIG `nb`, ~500-byte `Data.db`.
+
+`binding-parity-facts.json` is committed TEXT, not a binary: it records the UDT
+facts (`typeName`/`keyspace`/`fields`) and map values that BOTH bindings must
+produce from row `id 1`. The Python and Node suites each derive that fact set
+from their OWN binding output and assert equality against this one file, so the
+two surfaces are compared as DATA and cannot drift apart independently. It is
+resolved CHECKOUT-RELATIVE for the same reason the binaries are — see its
+`note_on_paths`.
 
 ## Schema and regeneration
 
@@ -126,8 +135,8 @@ Uncompressed (no `CompressionInfo.db`), BIG `nb`, ~500-byte `Data.db`.
 |---|---|---|---|
 | `c` | `frozen<collide>` | `_type='user-supplied-type'`, `_keyspace='user-supplied-keyspace'`, `__proto__='user-supplied-proto'`, `real_field=42` | **site 3**: the rendered UDT. Distinct, recognizable values, so an overwrite is *visible* rather than merely absent. |
 | `p` | `frozen<plain>` | `label='no-colliding-field'`, `real_field=7` | the non-colliding contrast — a UDT with no `_type` field at all, where reading `_type` out of the field namespace must fail. |
-| `cm` | `map<frozen<collide>,int>` | key `_type='key-type-marker'`, `_keyspace='key-keyspace-marker'`, `__proto__='key-proto-marker'`, `real_field=100` → 1 | the shape a user would naturally write. **MEASURED: does NOT reach the Python hashable projection** — see below. |
-| `tm` | `map<frozen<collide_twin>,int>` | same field values → 2 | the same, one type over. |
+| `cm` | `map<frozen<collide>,int>` | key `_type='key-type-marker'`, `_keyspace='key-keyspace-marker'`, `__proto__='key-proto-marker'`, `real_field=100` → 1 | the shape a user would naturally write, and the MULTICELL half of the standing parity control: the key lives in the CELL PATH, so it decodes through different code from the frozen `fcm` below. **MEASURED (post-#3612): reaches both bindings' UDT rendering, with key facts identical to `fcm`'s** — see below. |
+| `tm` | `map<frozen<collide_twin>,int>` | same field values → 2 | the same, one type over. The four map columns' VALUES (1/2/3/4) are pairwise distinct on purpose: the keys are identical, so only the value tells a reader which column's cell they actually got. |
 | `fcm` | `frozen<map<frozen<collide>,int>>` | same field values → 3 | **site 4's actual subject**: decodes to `Frozen(Map([(Udt{…}, 3)]))`, so the key really is a UDT. |
 | `ftm` | `frozen<map<frozen<collide_twin>,int>>` | same field values → 4 | same field NAMES and VALUES as `fcm`'s key under a **different type name**: two projected keys that must stay DISTINCT once type identity leaves the field namespace. |
 | `fs` | `frozen<set<frozen<collide>>>` | `_type='set-member-type'`, `_keyspace='set-member-keyspace'`, `__proto__='set-member-proto'`, `real_field=200` | the set path into the same projection (`set_to_py` shares `value_to_hashable_key` with map keys). |

--- a/test-data/fixtures/issue_3504/binding-parity-facts.json
+++ b/test-data/fixtures/issue_3504/binding-parity-facts.json
@@ -6,6 +6,7 @@
   "query": "SELECT * FROM test_udt_collision.udt_collide",
   "note_on_proto_field": "The `__proto__` entries are ORDINARY DECLARED UDT FIELDS of the `collide`/`collide_twin` types, not JSON prototype trickery: `JSON.parse` and Python's `json` both create them as ordinary own keys (neither invokes a setter), so this file compares them like any other field. They exist because an ordinary JavaScript property assignment on a plain object reaches `Object.prototype`'s inherited `__proto__` accessor, which silently discarded such a field (string value) or replaced the object's prototype (null value) -- roborev R1-1 on #3504. The Node binding therefore builds its `fields` bag with a NULL PROTOTYPE. The Python side has no analogous hazard (a `dict` `__setitem__` consults no prototype chain), so the same field set is expected verbatim in both bindings.",
   "note_on_paths": "Both paths are CHECKOUT-RELATIVE and resolved from the repo root with NO environment variable. Neither suite may route them through CQLITE_DATASETS_ROOT: the suites' corpus resolution is an either/or on that variable, and when it is set -- which every gate run does -- the checkout copy is never consulted, so a corpus-rooted fixture is invisible exactly where they run.",
+  "note_on_multicell_map_keys": "The `row1.cm_key`/`row1.tm_key` entries are the MULTICELL spelling of the frozen `row1.fcm_key`/`row1.ftm_key` pair: `cm`/`tm` are `map<frozen<udt>,int>` (multicell, so the key lives in the CELL PATH) while `fcm`/`ftm` are `frozen<map<frozen<udt>,int>>` (a single value cell). The two decode paths are DIFFERENT CODE and only the frozen one used to work -- `parse_cell_path_key` matched a closed set of PRIMITIVE cell-path types and fell back to `Value::Blob` for a frozen UDT, so `cm`/`tm` keys arrived as opaque bytes and never reached either binding's UDT rendering at all (issue #3612, fixed by the site now at cqlite-core/src/storage/sstable/reader/parsing/row_decoder/complex_column/cell_path_key.rs, which delegates to the structural decoder). MEASURED from both bindings built from this tree: the two spellings' key facts are IDENTICAL IN CONTENT to their frozen siblings above, which is the whole point -- a caller cannot tell the spellings apart. That makes the pair a standing PARITY CONTROL in two directions at once: cross-BINDING (Python vs Node, as every entry here is) and cross-DECODE-PATH (multicell vs frozen), so a regression in either cell-path or value-cell decoding reddens both suites. The map VALUES differ on purpose (`cm`->1, `tm`->2 against `fcm`->3, `ftm`->4), so a test cannot accidentally read one column's cell while believing it read the other's.",
   "udts": {
     "row1.c": {
       "typeName": "collide",
@@ -23,6 +24,26 @@
       "fields": {
         "label": "no-colliding-field",
         "real_field": 7
+      }
+    },
+    "row1.cm_key": {
+      "typeName": "collide",
+      "keyspace": "test_udt_collision",
+      "fields": {
+        "_type": "key-type-marker",
+        "_keyspace": "key-keyspace-marker",
+        "__proto__": "key-proto-marker",
+        "real_field": 100
+      }
+    },
+    "row1.tm_key": {
+      "typeName": "collide_twin",
+      "keyspace": "test_udt_collision",
+      "fields": {
+        "_type": "key-type-marker",
+        "_keyspace": "key-keyspace-marker",
+        "__proto__": "key-proto-marker",
+        "real_field": 100
       }
     },
     "row1.fcm_key": {
@@ -75,6 +96,8 @@
     }
   },
   "map_values": {
+    "row1.cm_value": 1,
+    "row1.tm_value": 2,
     "row1.fcm_value": 3,
     "row1.ftm_value": 4
   }


### PR DESCRIPTION
Closes #3724.

Adds the **multicell** map keys (`cm`/`tm`) to the single cross-binding UDT parity reference
`test-data/fixtures/issue_3504/binding-parity-facts.json`, alongside the frozen spelling it already
recorded, and pins the fixture-resolution contract that file depends on.

Builds on #3612 (PR #3736), which is what makes these keys structurally comparable at all.

## Why these entries are not a copy of the frozen ones

Measured on `main` **before** #3612 landed: the `cm` and `tm` cell-path keys were the **same 70-byte
opaque payload** — byte-identical to each other — even though they declare *different* key UDTs:

```
0000000f "key-type-marker"  00000013 "key-keyspace-marker"  00000010 "key-proto-marker"  00000004 100
```

That is the standard frozen-UDT serialization (4-byte length + value per field, 8+62 = 70 bytes):
**positional, carrying no field names and no type identity.** Their frozen siblings `fcm`/`ftm` *were*
distinguishable.

So `row1.cm_key.typeName == "collide"` and `row1.tm_key.typeName == "collide_twin"` can only come from
the **schema's declared key type** — the bytes cannot supply it. The two new entries therefore carry
**identical `fields` and different `typeName`**, a distinction that is entirely schema-attributed.

That is what makes the cross-binding entry non-vacuous in a statable way: a binding that dropped schema
type attribution on the multicell path would emit the *same* `typeName` for both keys from identical
bytes, and the shared facts file catches it. #3612's per-binding assertions cannot — each compares a
column to its **own** frozen sibling, so both bindings could agree internally while disagreeing with
each other. Closing that gap is what this issue is for (AC2), and it is why those #3612 assertions are
**kept** rather than replaced (AC4): within-binding spelling equivalence and cross-binding agreement are
different properties.

## Acceptance criteria

**AC1 — fixture widened.** `binding-parity-facts.json` gains `udts["row1.cm_key"]`, `udts["row1.tm_key"]`
(Node spelling: `typeName`/`keyspace`/`fields`) and `map_values["row1.cm_value"]`/`["row1.tm_value"]`,
plus a `note_on_multicell_map_keys` recording the schema-attribution reasoning above. Values were
**measured from both rebuilt bindings**, never derived from the frozen entries — they happen to match
them field-for-field, but because that is what the bindings emit.

**AC2 — both suites derive the facts from their own binding output.** The `observed` maps in
`bindings/node/__test__/issue-3504-udt-field-namespace.test.js` and
`bindings/python/tests/test_issue_3504_udt_field_namespace.py` are widened; both already assert key-set
equality in **both directions** plus whole-map equality, so neither side can quietly shrink. Nothing is
hard-coded.

**AC3 — mutant check, recorded in both directions.**

*Mutant A* — a `_MUTANT` suffix planted in the registry-qualified UDT arm of `cell_path_key.rs`, scoped
so `cm` mutated while `fcm` did not, and rebuilt for **Python only**:

```
E  AssertionError: assert 'collide_MUTANT' == 'collide'
E  {'row1.cm_key': {'typeName': 'collide_MUTANT', ...}} != {'row1.cm_key': {'typeName': 'collide', ...}}
python: 2 failed, 18 passed          node: 15 passed (artifact unmutated)
```

Exactly the mutated binding's suite reddens — which is what AC3 asks.

*Mutant B* — deleting `row1.cm_key` from the JSON with no rebuild reddens **both** suites (python 1
failed, node 1 failed), proving the new entries are genuinely **consumed**. "An entry that nothing
reads" is the failure mode AC3 exists to exclude, so it is tested rather than asserted.

**AC4 — #3612's per-binding assertions kept, byte-unmodified.** The only diff touching them is a comment
naming `test_non_frozen_map_udt_key_projects_like_the_frozen_control`. Nothing was restructured to read
from the facts file.

**AC5 — the resolution contract is now asserted, not merely documented.** Both suites resolve the fixture
corpus and the facts file **checkout-relative, and DELIBERATELY NOT through `CQLITE_DATASETS_ROOT`** —
Python via `conftest.PROJECT_ROOT` (from `__file__`), Node via `global.testPaths.PROJECT_ROOT` (from
`__dirname`), each deliberately declining to import the env-routed `conftest.DATASETS` / `SSTABLES_DIR`.
That is the #3131/#3148 rule in miniature: committed fixtures are committed source and must never hang
off that variable, because the suites' corpus resolution is an either/or on it, and when it is set —
which every gate run does — an env-rooted fixture is invisible exactly where these suites run.

**Nothing asserted that before this PR.** The docstrings and the file's own `note_on_paths` documented
it; the nearest guard (`_assert_fixture_present`/`assertFixturePresent`) checks the file exists *at the
already-resolved path*, which would keep passing under env-routed resolution as long as the env root
happened to contain it. Two new tests per binding close it:

* a **child-process probe** under a bogus `CQLITE_DATASETS_ROOT`, asserting the **invariant** (fixture
  root and facts path unmoved, checkout-derived) **and a positive control** (a path that legitimately
  *does* follow that variable has moved to the bogus root). The control is load-bearing: without it the
  invariant passes vacuously whenever the variable was unset at module load — a vacuity caught in review,
  since the first version reloaded only `setup.js` and not the module computing the paths:

  ```
  same mutant (paths made env-derived), variable unset:
    Node OLD (in-process reload):  14 passed, 14 total   <-- vacuous
    Node NEW (child process):       1 failed, 13 passed
  ```

  Probe-completion states are classified **before any payload byte is read** (timeout / unspawnable /
  killed / non-zero exit / **exit 0 with no payload**), each failing with a named cause, and the child
  bound sits under jest's measured `testTimeout: 30000` so jest stays the enforcing authority.

* a **structural guard** that the module names no env-routed corpus constant and does not read
  `CQLITE_DATASETS_ROOT` directly. Python compares the literal's **evaluated value** via `ast`, so
  `r"..."`, `"""..."""`, a plain f-string and implicit concatenation are all caught by one comparison;
  Node's substring scan is spelling-insensitive by construction (verified by test). The single legitimate
  reference is `CONTROL`-marked and counted, so a typo'd needle cannot green silently.

  **Declared residual:** an *indirect* read — a helper returning the value, a computed name, an alias
  bound to `os.environ`/`process.env` — is invisible to any source scan; that half remains the child
  probe's job. Stated rather than papered over, on the standing ruling that a guard with known
  false-PASSes is worse than none.

**AC6 — both gate lanes execute these suites, verified by observation.** `python-bindings` runs
`pytest bindings/python/tests -q` with no `-k`/`-m`/`--ignore`/`--deselect`, the only pytest config being
`markers = ["slow"]` with no `addopts`; measured **793 collected**, the parity test among them, zero
collection errors, zero deselections. `node-bindings` runs the whole jest suite with
`CQLITE_REQUIRE_FIXTURES=1`; measured **31 test files** listed, this suite among them. A missing fixture
is **loud** in both (throw / fixture ERROR), never a silent skip.

## README audit

`test-data/fixtures/issue_3504/README.md` described pre-#3612 behaviour in several places. Spot-fixing
did not converge — three separate rounds each found another stale spot — so the file was audited end to
end. Corrected: the `cm`/`tm` bullet, the BLIND enumeration that omitted them entirely, the column table,
and an "only one of them worked" claim now bounded by "until #3612". `binding-parity-facts.json` was
missing from the file listing and is now listed.

The audit also found staleness from a **different** issue, where nobody was looking: Table 2's premise
that `Tuple` and `Set` have no hashable arms is false (`bindings/python/src/value_hashable.rs` has arms
for both; `contains_udt` traverses `List|Set|Tuple`), and the `udt_hashable_shapes` binaries *are*
present although the schema file says they are not — so the table was **re-measured** rather than
declared unverifiable. One row asserted the opposite of the truth (`ssu` "still raises"; it no longer
does). Nothing in that table raises today, and the discriminator is the container, not projectability.

One claim could **not** be verified and was deliberately left unchanged: the Cassandra citation at
`:58-62` (`UserType.java:261`/`:280`) — no clone on this box and `CQLITE_CASSANDRA_REPO` unset.

## Test plan

* Python `test_issue_3504_udt_field_namespace.py`: **20 passed, 0 skipped**
* Node `issue-3504-udt-field-namespace.test.js`: **15 passed, 0 skipped**
* Full `pytest bindings/python/tests -q`: **733 passed, 61 skipped, 1 xfailed** — skip count unmoved,
  so the child probes leak no environment (the parent mutates no env, global or module state)
* Every committed fact re-verified **mechanically** against both rebuilt bindings after the final rebase
  (each measured triple diffed against the JSON, not eyeballed): all MATCH
* `--lite` PASS at `5540ff18f`; `tree-integrity: PASS`

## Notes

* Rebased onto `30adb0ad5`, which carries #3634's token-bound refactor. That change is under the scan
  path these bindings read through, so it was **verified inert by re-measuring** rather than assumed —
  the base-staleness advisory reports `NO-STALENESS-RECOGNISED`, but #3634 is precisely its declared
  gap 1 (a commit changing something the diff *calls* without touching its paths).
* roborev: 6 rounds, ending `RESULT: PASS` / `findings: NONE` (affirmative, no deferral marker).
* **Offered as a follow-up, not decided here:** #3612 also asserts the `cm`/`tm` structural shape inline
  against literals, so that fact is now stated in two places. AC4 says keep those assertions, and the
  drift is fail-loud (both sides read real binding output, so a change reds both suites together) —
  maintenance noise rather than a correctness hole. Reconciling them would edit #3612's deliverable, so
  it is left for the owner to rule on.
