### PR TITLE
fix(#3402): file-size reports OPT-OUT, not PASS, when CQLITE_ALLOW_FILE_GROWTH=1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1062,7 +1062,17 @@ Keep files small — agentic context cost scales with file size. Targets (total 
 included): source `~800`, test files `~1500`. The gate's `file-size` ratchet FAILs if your change
 grows an over-threshold `.rs` file (or pushes one over). Touching an over-threshold file → split it
 by responsibility (source: epic #1116; tests: #1135). Genuinely out of scope → re-run with
-`CQLITE_ALLOW_FILE_GROWTH=1` and leave a note linking #1116/#1135.
+`CQLITE_ALLOW_FILE_GROWTH=1` and leave a note linking #1116/#1135. **That override is now
+VISIBLE in the SUMMARY, and the component's status token says so (#3402):**
+`file-size: OPT-OUT (0s)  [no-cargo] — CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced); N
+over-threshold file(s) grown: <paths, elided past 3 with a named ",+N more" remainder>`. `PASS` means the check RAN
+and was SATISFIED; it never means the check was switched off — a bare `file-size: PASS` under an
+engaged override was indistinguishable from a genuine one, so the disclosure depended on the
+author remembering to write it in the PR body. `OPT-OUT` is NON-FAILING (only an exact `FAIL`
+sets `OVERALL=FAIL`), so an acknowledged growth still reaches `RESULT: PASS` — it is now merely
+impossible to hide. It is emitted ONLY for the value **exactly `1`**: a value SET BUT NOT `1`
+(`0`, `true`, `yes`) is not an opt-out, stays a ratchet violation and FAILs, because a
+permissive branch keyed on `!= <bad>` would let a typo waive the ratchet.
 
 ### Testing
 - Integration tests use real SSTable data only; validate against `sstabledump` output via JSONL

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1065,14 +1065,27 @@ by responsibility (source: epic #1116; tests: #1135). Genuinely out of scope →
 `CQLITE_ALLOW_FILE_GROWTH=1` and leave a note linking #1116/#1135. **That override is now
 VISIBLE in the SUMMARY, and the component's status token says so (#3402):**
 `file-size: OPT-OUT (0s)  [no-cargo] — CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced); N
-over-threshold file(s) grown: <paths, elided past 3 with a named ",+N more" remainder>`. `PASS` means the check RAN
+over-threshold file(s) grown — see <logdir>/file-size.log`. `PASS` means the check RAN
 and was SATISFIED; it never means the check was switched off — a bare `file-size: PASS` under an
 engaged override was indistinguishable from a genuine one, so the disclosure depended on the
 author remembering to write it in the PR body. `OPT-OUT` is NON-FAILING (only an exact `FAIL`
 sets `OVERALL=FAIL`), so an acknowledged growth still reaches `RESULT: PASS` — it is now merely
 impossible to hide. It is emitted ONLY for the value **exactly `1`**: a value SET BUT NOT `1`
 (`0`, `true`, `yes`) is not an opt-out, stays a ratchet violation and FAILs, because a
-permissive branch keyed on `!= <bad>` would let a typo waive the ratchet.
+permissive branch keyed on `!= <bad>` would let a typo waive the ratchet. **The row carries NO
+repository content**: the file NAMES live in `file-size.log` (#3401) and, for a reviewer, in the
+PR diff itself. Rendering them inline was tried and REMOVED — it was the optional half of #3402
+("ideally naming the files") and produced THREE of that PR's seven review findings, one per
+round, each a different way of mangling a filename (a `: ` split recovering a path from a
+display string; substitution inside a path containing `RESULT:`; `,` joining, making
+`src/a.rs,b.rs` indistinguishable from two files). **Remove the mechanism rather than carve it a
+fourth time** (#3229's ruling); escaping only moves the argument to the escape grammar (#3312).
+So the one boundary rendering these details (`_status_detail`) takes GATE-AUTHORED text only —
+fixed wording plus computed values — strips `[:cntrl:]` under `LC_ALL=C`, and WITHHOLDS any
+value carrying the completion probe's `RESULT:` token rather than rewriting it, because a
+rewrite would name something that does not exist. If you add a component that needs repository
+content in its detail, re-introduce a trusted/untrusted split deliberately; do not smuggle it
+through the gate-authored field.
 
 ### Testing
 - Integration tests use real SSTable data only; validate against `sstabledump` output via JSONL

--- a/docs/development/lane-gate-execution.md
+++ b/docs/development/lane-gate-execution.md
@@ -1197,8 +1197,9 @@ environment the gate read it (63 vars in its `/proc/<pid>/environ`); started und
 `AGENT_GATE_ALLOW_MISSING_FIXTURES` or `CQLITE_ALLOW_FILE_GROWTH` relaxes the gate's own
 validation, which is the one thing a certification run must not do quietly. Both are now at least
 VISIBLE in the emitted block — `missing-fixtures: OPT-OUT (...)` (#2078) and, since #3402,
-`file-size: OPT-OUT (...)` as the component's own status token, naming the variable, the count and
-the grown files. Visibility is not a defence, though: an inherited opt-out is still an opt-out
+`file-size: OPT-OUT (...)` as the component's own status token, naming the variable and the COUNT
+and pointing at `file-size.log` for the file names (the row carries no repository content — see
+CLAUDE.md's campsite-rule section for why that list was removed). Visibility is not a defence, though: an inherited opt-out is still an opt-out
 nobody asked for, and the block only shows it to a reader who looks. Start the gate with a
 deliberate environment.
 

--- a/docs/development/lane-gate-execution.md
+++ b/docs/development/lane-gate-execution.md
@@ -1194,8 +1194,13 @@ get through, start from nothing and add only what is intended.
 Measured both directions, since the mechanism is not obvious: with a variable in the manager's
 environment the gate read it (63 vars in its `/proc/<pid>/environ`); started under `env -i`, absent
 (53 vars). The concrete danger is an opt-out arriving unasked — a manager-set
-`AGENT_GATE_ALLOW_MISSING_FIXTURES` or `CQLITE_ALLOW_FILE_GROWTH` silently relaxes the gate's own
-validation, which is the one thing a certification run must not do quietly.
+`AGENT_GATE_ALLOW_MISSING_FIXTURES` or `CQLITE_ALLOW_FILE_GROWTH` relaxes the gate's own
+validation, which is the one thing a certification run must not do quietly. Both are now at least
+VISIBLE in the emitted block — `missing-fixtures: OPT-OUT (...)` (#2078) and, since #3402,
+`file-size: OPT-OUT (...)` as the component's own status token, naming the variable, the count and
+the grown files. Visibility is not a defence, though: an inherited opt-out is still an opt-out
+nobody asked for, and the block only shows it to a reader who looks. Start the gate with a
+deliberate environment.
 
 **Two of this change's own verification attempts failed in ways that looked like passes**, and the
 lesson generalises past this file. Checking the unit's `Environment=` property returned `0` — but we

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -7938,10 +7938,17 @@ census_summary_line() { # <name> <status> [<name> <status>]...
 # PERMISSIVE branch. That is the exact shape CLAUDE.md forbids ("key a permissive
 # branch on the AFFIRMATIVE value, never on != <bad>"), and it is what a new
 # non-passing token like VACUOUS would otherwise have walked straight through.
+# #3402 adds OPT-OUT to the set, EXPLICITLY. An acknowledged growth override is a disclosed
+# waiver, not a failure — that is the whole point of the token — but note what changed here:
+# the original #3402 design rested on "every aggregator fails only on an EXACT `FAIL`", i.e.
+# on the PERMISSIVE default this function exists to abolish. #3625 closed that default, and it
+# was right to: a token that means "do not fail the run" must SAY so in the one closed set,
+# not inherit it from the absence of a match. So the claim is now checked rather than assumed,
+# and a future non-passing token cannot ride in the way OPT-OUT would have.
 _status_is_nonfailing() {
   case "$1" in
-    PASS|SKIP) return 0 ;;
-    *)         return 1 ;;
+    PASS|SKIP|OPT-OUT) return 0 ;;
+    *)                 return 1 ;;
   esac
 }
 # ==== END component census (#3625) ====
@@ -9929,27 +9936,6 @@ _tree_mode_components() {
   fi
 }
 
-# _tree_boundary_row <name> <status> <secs> (#3402, roborev round 1 M1): ONE spelling of
-# the boundary table's row, for BOTH loops below — which previously hand-rolled the same
-# printf twice, directly under a comment promising "never a second dialect of it".
-#
-# It carries the #3402 status detail. Without it a boundary block rendered
-# `file-size: OPT-OUT (0s)` with the env var and the count STRIPPED (the grown PATHS were on
-# the row at the time; they are log-only now) — the
-# invisible opt-out this issue exists to remove, surviving on the one path where a run is
-# already in trouble and the disclosure matters most.
-#
-# It deliberately does NOT call _fm_summary_line: the boundary block has never carried the
-# #3453 feature-matrix annotation, and adding it here would change the shape of every
-# boundary block for a reason unrelated to this issue. So the two renderers still differ —
-# in the ANNOTATION — while agreeing BY CONSTRUCTION on the detail, because both obtain it
-# from the same _status_detail boundary. Unifying them is a separate question and a
-# separate change.
-_tree_boundary_row() {
-  local _d; _d=$(_status_detail "$1")
-  printf '%-18s %s (%ss)%s\n' "$1:" "$2" "$3" "${_d:+ — $_d}"
-}
-
 # _completed_component_rows (#3402, roborev job 26): every component that has RECORDED a
 # verdict, one row each, in canonical order for the RUNNING mode, then a sweep for any
 # recorded result no static list names. Sets `_CCR_COUNT` to the number of rows printed.
@@ -9961,16 +9947,13 @@ _tree_boundary_row() {
 # That is round 1's boundary finding one emit site over, and the shape recurs because each
 # early-exit emit hand-builds its own meta list. Any emit that can happen AFTER components
 # may have run must carry this.
-_completed_component_rows() { # <row-renderer>
-  # THE RENDERER IS THE CALLER'S CHOICE, and the two callers legitimately differ (roborev
-  # job 76). A funnel-appended row lands in an ORDINARY summary block, where #3453's contract
-  # is that EVERY component line names the feature matrix it ran — so it must render through
-  # `_fm_summary_line`. A BOUNDARY block has never carried that annotation, and forcing it
-  # there would both reshape every boundary block for an unrelated reason and print
-  # `[UNCLASSIFIED — not declared in _fm_component_class]` for the `tree-selftest` hook, which
-  # is a self-test name and not a component at all. So: annotated at the funnel, plain at the
-  # boundary, one traversal.
-  local _render="${1:?_completed_component_rows needs a row renderer}"
+_completed_component_rows() {
+  # ONE RENDERER, `_fm_summary_line`, the same as every other block (#3453/#3625). This took a
+  # renderer ARGUMENT for one round, because the boundary table used a plain unannotated row
+  # while the funnel needed an annotated one — until #3625 routed the boundary loops through
+  # `_fm_summary_line` too, on the same reasoning, leaving one renderer and a parameter with a
+  # single possible value. Removed rather than kept "for symmetry": an unused seam is a second
+  # dialect waiting for a caller, which is the drift this issue kept tripping over.
   local _c _rf _st _secs _seen=" "
   _CCR_COUNT=0
   for _c in $(_tree_mode_components); do
@@ -9978,7 +9961,7 @@ _completed_component_rows() { # <row-renderer>
     [ -f "$_rf" ] || continue
     _st=""; _secs=""
     read -r _st _secs < "$_rf" || true
-    "$_render" "$_c" "$_st" "$_secs"
+    _fm_summary_line "$_c" "$_st" "${_secs}s"
     _seen="$_seen $_c "
     _CCR_COUNT=$(( _CCR_COUNT + 1 ))
   done
@@ -9988,7 +9971,7 @@ _completed_component_rows() { # <row-renderer>
     case "$_seen" in *" $_c "*) continue ;; esac
     _st=""; _secs=""
     read -r _st _secs < "$_rf" || true
-    "$_render" "$_c" "$_st" "$_secs"
+    _fm_summary_line "$_c" "$_st" "${_secs}s"
     _CCR_COUNT=$(( _CCR_COUNT + 1 ))
   done
 }
@@ -10001,14 +9984,9 @@ _completed_component_rows() { # <row-renderer>
 # argument, so a captured multi-line block renders as the rows it contains. Empty output is
 # deliberately an EMPTY STRING and the callers guard on it, because a bare "" argument would
 # emit a blank line into the block.
-# _fm_recorded_row <name> <status> <secs>: the funnel's renderer — `_fm_summary_line` with
-# the unit appended, since that helper takes a fully-formed time string while `.result` stores
-# a bare number.
-_fm_recorded_row() { _fm_summary_line "$1" "$2" "${3}s"; }
-
 _recorded_component_rows_block() {
   local _rows _n
-  _rows=$(_completed_component_rows _fm_recorded_row)
+  _rows=$(_completed_component_rows)
   [ -n "$_rows" ] || return 0
   # COUNT THE ROWS THAT WILL PRINT, never `_CCR_COUNT`. The capture above runs in a COMMAND
   # SUBSTITUTION — a subshell — so the count the helper assigns is discarded, and reading it
@@ -10165,10 +10143,11 @@ _tree_boundary_fail() {
   # here, or it would overwrite this block's component-named verdict line.
   local -a _meta=()
   while IFS= read -r _l; do _meta+=("$_l"); done < <(_tree_boundary_meta_lines)
-  # The SECOND row dialect (#3402/job 74). _tree_boundary_meta_lines renders rows through
-  # _tree_boundary_row, not _fm_summary_line, so without this the funnel would append a
-  # duplicate table under a block that already has one. The read loop runs in THIS shell, so
-  # the assignment lands where _emit_meta_lines will see it.
+  # The boundary block builds its OWN table (#3402/job 74), so without this the funnel would
+  # append a duplicate one under a block that already has it. Both render through
+  # `_fm_summary_line`, so the two tables cannot differ in SHAPE — this flag is only about not
+  # printing it twice. The read loop runs in THIS shell, so the assignment lands where
+  # _emit_meta_lines will see it.
   _SUMMARY_ROWS_BUILT=1
   _meta+=("detected-after-component: $comp")
   _emit_terminal_summary FAIL "${_meta[@]}" || true
@@ -18156,9 +18135,12 @@ run_file_size() {
       # states. Keying the permissive branch on `!= <bad>` would let a typo buy a green,
       # which is the false-PASS route this issue must not open while closing another.
       #
-      # NON-FAILING BY CONSTRUCTION: `status` is not FAIL, and all three aggregators
-      # (full gate, aggregate_lite_components, run_delta) set OVERALL=FAIL only on an
-      # EXACT `FAIL`, so OPT-OUT rides to a PASS RESULT without a special case.
+      # NON-FAILING BY DECLARATION, not by default: OPT-OUT is a member of
+      # `_status_is_nonfailing`, the ONE closed set every aggregator consults (#3625). This
+      # used to say "by construction … only an EXACT FAIL fails", which was true of the old
+      # permissive `!= FAIL` aggregations and became FALSE the moment #3625 replaced them with
+      # an affirmative set — correctly, since a permissive branch keyed on `!= <bad>` is the
+      # shape CLAUDE.md forbids. The token now says it is non-failing where that is decided.
       status=OPT-OUT
       # NO REPOSITORY CONTENT ON THIS ROW — env var + COUNT + a pointer to the log, which is
       # exactly what the issue asks for (#3402: "OPT-OUT (CQLITE_ALLOW_FILE_GROWTH=1; N

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6778,18 +6778,16 @@ _fm_annotate() {
 # backgrounded subshell of the bounded pool (#1737) and cannot write the parent's state.
 _status_detail_file() { printf '%s/%s.status-detail' "${LOG_DIR:-}" "$1"; }
 
-# _record_status_detail <component> <trusted> [<untrusted>] (#3402): publish that detail as
-# TWO FIELDS, one per line — because they have different provenance and the reader of the
-# other end has to be able to tell them apart (roborev job 21).
-#   <trusted>    gate-authored text plus numbers this component computed. No repository
-#                content reaches it.
-#   <untrusted>  optional; repository-derived text (today: the grown-FILE PATHS).
-# Withholding used to replace the WHOLE suffix, so a path carrying the completion probe's
-# verdict token also destroyed the COUNT — gate-authored data, provably safe, and the single
-# most useful thing on the row — while a comment two lines up claimed the count was kept.
-# Splitting the fields is #3312's own prescription applied here: when one string carries both
-# your text and someone else's payload, SEPARATE THE CHANNEL rather than escape harder. The
-# boundary can then withhold exactly the untrusted half.
+# _record_status_detail <component> <text> (#3402): publish that detail. The text must be
+# GATE-AUTHORED — fixed wording plus values the component computed. No repository-derived
+# content (paths, branch names, commit subjects) may be interpolated into it.
+#
+# That is a CONTRACT, not an observation, and it is what makes the reader's job small. A
+# two-field trusted/untrusted sidecar was built here when the row still rendered grown-file
+# PATHS, and was removed with them: the untrusted half had no writer left, and unused
+# generality is a liability that the next reader has to reason about. A future writer that
+# genuinely needs repository content should re-introduce the split deliberately (#3312:
+# separate the channel; do not escape harder) rather than smuggle it through this field.
 # Best-effort by
 # design — the detail EXPLAINS a status token, it does not carry the verdict, so a
 # LOG_DIR that cannot take it must not change what the component reports. (The token
@@ -6797,10 +6795,7 @@ _status_detail_file() { printf '%s/%s.status-detail' "${LOG_DIR:-}" "$1"; }
 # guard.)
 _record_status_detail() {
   [ -n "${LOG_DIR:-}" ] || return 0
-  # ALWAYS two lines, even when the untrusted field is empty, so the reader's line 2 means
-  # "the untrusted field" and never "whatever happened to be next".
-  { printf '%s\n' "$2"; printf '%s\n' "${3:-}"; } 2>/dev/null \
-    >"$(_status_detail_file "$1")" || return 0
+  printf '%s\n' "$2" 2>/dev/null >"$(_status_detail_file "$1")" || return 0
 }
 
 # _status_detail <component> (#3402): read it back, reduced to ONE line with no control
@@ -6840,8 +6835,8 @@ _record_status_detail() {
 # claim is narrowed rather than the implementation grown, because no reachable input
 # carries even a C0 (see the defence-in-depth note above).
 # LENGTH is NOT capped here: a cap would be a SILENT truncation of a disclosure, which is
-# the defect this issue removes — bounding the value is the WRITER's job (see
-# _fs_abbrev_grown, which elides by a NAMED remainder).
+# the defect this issue removes. Bounding the value is the WRITER's job, and today's writers
+# need no bound — every detail is a fixed sentence plus a count and a log path.
 _status_detail() {
   local f
   f=$(_status_detail_file "$1")
@@ -6850,22 +6845,16 @@ _status_detail() {
   # (roborev job 19, L1). The #2908/#3041 probe greps the summary FILE for
   # `RESULT: (PASS|FAIL)` and this detail lands on a component ROW inside that file, so the
   # token must not appear here. The first attempt SUBSTITUTED it — and a blanket
-  # substitution edits the token wherever it occurs, INCLUDING inside a legitimate
-  # grown-file path such as `cqlite-core/src/RESULT: PASS.rs`, which the row would then name
-  # in a spelling that exists nowhere on disk. That is the SAME false-reporting defect this
-  # change exists to remove, reintroduced by its own guard, and strictly worse than the
-  # disclosure it was protecting: a reader cannot tell a rewritten name from a real one.
+  # substitution edits the token wherever it occurs, INCLUDING inside repository-derived
+  # text — at the time, a legitimate grown-file path such as `cqlite-core/src/RESULT: PASS.rs`,
+  # which the row then named in a spelling that exists nowhere on disk. That was the SAME
+  # false-reporting defect this change exists to remove, reintroduced by its own guard.
+  # No shipping writer can reach that case any more (the row carries no repository content),
+  # but REFUSE-DON'T-REWRITE is kept as the boundary's rule, because the next writer to need
+  # such content must not inherit a silent rewriter.
   #
   # So the offending value is WITHHELD, loudly, and the reader is sent to the component log
   # — a truthful degradation instead of a false statement.
-  #
-  # WITHHELD AT FIELD GRANULARITY, which is the whole point of the two-field sidecar
-  # (roborev job 21). The first version replaced the ENTIRE suffix, which also destroyed the
-  # COUNT — gate-authored, provably safe, and the most useful thing on the row — while the
-  # comment here claimed the count was kept. That claim was simply false, and the fix is to
-  # make it true rather than to narrow it: a pathological filename now costs the FILE LIST
-  # and nothing else, so the row still discloses that the ratchet was not enforced and over
-  # how many files.
   #
   # The refusal names NO part of the token it refuses (the reason is described, not quoted),
   # because a diagnostic reproducing the token it exists to keep off this row would forge the
@@ -6877,20 +6866,16 @@ _status_detail() {
   # here (pollers outside this repo read these blocks). The cost of the broad trigger is a
   # withheld detail on a pathological filename; the cost of a narrow one is a forged verdict
   # for a consumer nobody surveyed. Only one of those is recoverable by reading the log.
-  local _sd_t _sd_u
-  _sd_t=$(sed -n '1p' "$f" 2>/dev/null | LC_ALL=C tr -d '[:cntrl:]')
-  _sd_u=$(sed -n '2p' "$f" 2>/dev/null | LC_ALL=C tr -d '[:cntrl:]')
-  # The TRUSTED field is still checked, not assumed: "gate-authored" is a property of
-  # today's four call sites, and a fifth could interpolate something. Its refusal withholds
-  # the whole row detail, because if the trusted half is compromised nothing after it can be
-  # relied on either.
-  case "$_sd_t" in
-    *RESULT:*) printf '%s' "[detail WITHHELD: its gate-authored half carries the completion probe's reserved verdict token (#2908) — see the component log]"; return 0 ;;
-  esac
-  case "$_sd_u" in
-    "")        printf '%s' "$_sd_t" ;;
-    *RESULT:*) printf '%s%s' "$_sd_t" "[WITHHELD: a listed path carries the completion probe's reserved verdict token (#2908), which on this row would forge a terminal verdict — see the component log]" ;;
-    *)         printf '%s%s' "$_sd_t" "$_sd_u" ;;
+  local _sd_v
+  _sd_v=$(head -1 "$f" 2>/dev/null | LC_ALL=C tr -d '[:cntrl:]')
+  # CHECKED, not assumed. The gate-authored contract above is a property of today's four
+  # call sites; a fifth could interpolate something, and this boundary is the one place that
+  # notices. It cannot fire on any writer shipping today, which is why its coverage is a
+  # SEEDED case in scripts/tests/test_agent_gate_tree_provenance.sh (phase B3) rather than a
+  # filename fixture — an untestable guard is one nobody can trust.
+  case "$_sd_v" in
+    *RESULT:*) printf '%s' "[detail WITHHELD: it carries the completion probe's reserved verdict token (#2908), which on this row would forge a terminal verdict — see the component log]" ;;
+    *)         printf '%s' "$_sd_v" ;;
   esac
 }
 
@@ -17890,28 +17875,6 @@ _fs_emit() { # _fs_emit <logfile> <line> [<line>…]  — one output line per ar
   printf '%s\n' "$@" 2>/dev/null >>"$_fs_log" ||
     _FS_WRITE_FAILURES=$((_FS_WRITE_FAILURES + 1))
 }
-# _fs_abbrev_grown <path…> (#3402): the grown-file list as it appears on the SUMMARY line.
-# Each argument is a RAW PATH. It used to take the formatted `path: before -> after
-# (limit N)` entries and recover the path with `${e%%: *}` — which TRUNCATES any filename
-# containing `: ` and then names a file that does not exist (roborev round 1, L3). The
-# caller has the path in hand at construction time, so re-deriving it from a DISPLAY STRING
-# was a lossy round-trip with nothing to gain; the fix is to carry it, not to pick a rarer
-# delimiter. Up to 3 paths print in full; beyond that the remainder is
-# NAMED as elided (`a,b,c,+N more`) — the same rule and the same reason as
-# _fm_abbrev_features: an abbreviation must not imply a completeness it does not have,
-# and a silent truncation in a SUMMARY block is exactly the invisible-opt-out shape this
-# issue exists to remove. The exact count is carried separately by the caller, so this
-# renders identity, never arithmetic.
-_fs_abbrev_grown() {
-  local shown=0 out="" p
-  for p in ${1+"$@"}; do
-    [ "$shown" -lt 3 ] || break
-    out="${out:+$out,}$p"
-    shown=$((shown + 1))
-  done
-  [ "$#" -gt "$shown" ] && out="$out,+$(( $# - shown )) more"
-  printf '%s' "$out"
-}
 run_file_size() {
   local name=file-size
   if [ -n "$ONLY" ] && ! grep -qw "$name" <<<"${ONLY//,/ }"; then
@@ -17957,10 +17920,7 @@ run_file_size() {
     files=$(git diff --name-only --diff-filter=d HEAD -- '*.rs' 2>/dev/null)
   fi
 
-  # `grew` is the DISPLAY list; `grew_paths` is the same set as raw paths, carried rather
-  # than recovered from the display string later (roborev round 1, L3). The two are
-  # appended together, on adjacent lines, so they cannot fall out of step.
-  local -a over=() grew=() grew_paths=()
+  local -a over=() grew=()
   local f cur lim base_n
   while IFS= read -r f; do
     [ -n "$f" ] && [ -f "$f" ] || continue
@@ -17976,7 +17936,6 @@ run_file_size() {
     base_n=${base_n:-0}
     if [ "$cur" -gt "$base_n" ]; then
       grew+=("$(printf '%s: %s -> %s (limit %s)' "$f" "$base_n" "$cur" "$lim")")
-      grew_paths+=("$f")
     fi
   done <<<"$files"
 
@@ -18018,12 +17977,28 @@ run_file_size() {
       # (full gate, aggregate_lite_components, run_delta) set OVERALL=FAIL only on an
       # EXACT `FAIL`, so OPT-OUT rides to a PASS RESULT without a special case.
       status=OPT-OUT
-      # The COUNT is gate-authored and goes in the trusted field; only the PATHS are
-      # repository-derived. So a pathological filename costs the file list and nothing else
-      # — the row still discloses that the ratchet was not enforced and over how many files.
+      # NO REPOSITORY CONTENT ON THIS ROW — env var + COUNT + a pointer to the log, which is
+      # exactly what the issue asks for (#3402: "OPT-OUT (CQLITE_ALLOW_FILE_GROWTH=1; N
+      # file(s) grown)", with naming the files marked "ideally" and explicitly deferred to
+      # the sibling log issue, #3401, now merged).
+      #
+      # An earlier revision rendered the grown PATHS inline. It was dropped after that one
+      # embellishment produced THREE of this PR's seven review findings, each a different
+      # way of mangling a filename: splitting on `: ` when recovering a path from a display
+      # string, substituting inside a path that contained the completion probe's token, and
+      # joining with `,` so `src/a.rs,b.rs` was indistinguishable from two files. Each fix
+      # was correct and the next round found another — the signature the repo already ruled
+      # on for #3229's census predicate: REMOVE the mechanism rather than carve it again.
+      # Escaping would only move the argument to the escape grammar (#3312: a rarer
+      # delimiter is still forgeable).
+      #
+      # Nothing is actually lost. `file-size.log` carries every path with its before -> after
+      # arithmetic (that is #3401's whole subject, and this issue points at it), and a PR
+      # reviewer has a second copy in the DIFF ITSELF — the grown files are the files the PR
+      # changed. What the row must carry is what a pasted SUMMARY cannot get anywhere else:
+      # that the ratchet was NOT enforced, and over how many files.
       _record_status_detail "$name" \
-        "CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced); ${#grew[@]} over-threshold file(s) grown: " \
-        "$(_fs_abbrev_grown ${grew_paths[@]+"${grew_paths[@]}"})"
+        "CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced); ${#grew[@]} over-threshold file(s) grown — see $log"
       _fs_emit "$log" ">>> [$name] ${#grew[@]} over-threshold file(s) grew; ALLOWED via CQLITE_ALLOW_FILE_GROWTH=1:"
       for line in ${grew[@]+"${grew[@]}"}; do
         _fs_emit "$log" "      $line"

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6801,6 +6801,19 @@ _record_status_detail() {
 # (run_file_size) renders paths git already quotes, so no REACHABLE input carries a
 # control character — this boundary exists so the NEXT writer cannot reintroduce the
 # row-injection route by not thinking about it.
+# LOCALE-PINNED, and the CLAIM is narrowed to what the code delivers (roborev round 1, L2):
+# `[:cntrl:]` is evaluated in the CURRENT locale, so an unpinned `tr` makes this boundary's
+# coverage a property of the caller's environment rather than of this line. `LC_ALL=C`
+# fixes it at C0 (0x00-0x1F) + DEL (0x7F), which is the whole of what row injection and ANSI
+# need: LF/CR forge rows, ESC starts a sequence, and both are C0.
+# WHAT IS DELIBERATELY *NOT* COVERED, said plainly rather than left inside a word like
+# "all": the C1 block (U+0080-U+009F). In UTF-8 those are TWO bytes (0xC2 0x80-0x9F), which
+# a byte-wise `tr` cannot match as a class, and which a UTF-8 terminal does not treat as
+# control introducers anyway — so the residual is not a route, and the previous wording
+# ("no control characters at all", "the whole class") asserted a coverage this line never
+# had. A comment claiming more than its code is the defect class this repo polices; the
+# claim is narrowed rather than the implementation grown, because no reachable input
+# carries even a C0 (see the defence-in-depth note above).
 # LENGTH is NOT capped here: a cap would be a SILENT truncation of a disclosure, which is
 # the defect this issue removes — bounding the value is the WRITER's job (see
 # _fs_abbrev_grown, which elides by a NAMED remainder).
@@ -6818,7 +6831,7 @@ _status_detail() {
   # repository-controlled grown-file PATH, which no Rust path plausibly spells — and it is
   # the boundary, not each writer, that has to hold. Display only: no decision anywhere
   # reads this value, so a redaction can never grant what a parse would.
-  head -1 "$f" 2>/dev/null | tr -d '[:cntrl:]' | sed 's/RESULT:/RESULT[redacted-token]:/g'
+  head -1 "$f" 2>/dev/null | LC_ALL=C tr -d '[:cntrl:]' | sed 's/RESULT:/RESULT[redacted-token]:/g'
 }
 
 # _fm_summary_line <name> <status> <time>: the ONE renderer for a SUMMARY component
@@ -9782,6 +9795,26 @@ _tree_mode_components() {
   else
     printf '%s\n' "${COMPONENTS[@]}"
   fi
+}
+
+# _tree_boundary_row <name> <status> <secs> (#3402, roborev round 1 M1): ONE spelling of
+# the boundary table's row, for BOTH loops below — which previously hand-rolled the same
+# printf twice, directly under a comment promising "never a second dialect of it".
+#
+# It carries the #3402 status detail. Without it a boundary block rendered
+# `file-size: OPT-OUT (0s)` with the env var, the count and the grown paths STRIPPED — the
+# invisible opt-out this issue exists to remove, surviving on the one path where a run is
+# already in trouble and the disclosure matters most.
+#
+# It deliberately does NOT call _fm_summary_line: the boundary block has never carried the
+# #3453 feature-matrix annotation, and adding it here would change the shape of every
+# boundary block for a reason unrelated to this issue. So the two renderers still differ —
+# in the ANNOTATION — while agreeing BY CONSTRUCTION on the detail, because both obtain it
+# from the same _status_detail boundary. Unifying them is a separate question and a
+# separate change.
+_tree_boundary_row() {
+  local _d; _d=$(_status_detail "$1")
+  printf '%-18s %s (%ss)%s\n' "$1:" "$2" "$3" "${_d:+ — $_d}"
 }
 
 _tree_boundary_meta_lines() {
@@ -17797,22 +17830,24 @@ _fs_emit() { # _fs_emit <logfile> <line> [<line>…]  — one output line per ar
   printf '%s\n' "$@" 2>/dev/null >>"$_fs_log" ||
     _FS_WRITE_FAILURES=$((_FS_WRITE_FAILURES + 1))
 }
-# _fs_abbrev_grown <entry…> (#3402): the grown-file list as it appears on the SUMMARY
-# line. Each argument is a `path: before -> after (limit N)` entry, so the path is the
-# text up to the first `: `. Up to 3 paths print in full; beyond that the remainder is
+# _fs_abbrev_grown <path…> (#3402): the grown-file list as it appears on the SUMMARY line.
+# Each argument is a RAW PATH. It used to take the formatted `path: before -> after
+# (limit N)` entries and recover the path with `${e%%: *}` — which TRUNCATES any filename
+# containing `: ` and then names a file that does not exist (roborev round 1, L3). The
+# caller has the path in hand at construction time, so re-deriving it from a DISPLAY STRING
+# was a lossy round-trip with nothing to gain; the fix is to carry it, not to pick a rarer
+# delimiter. Up to 3 paths print in full; beyond that the remainder is
 # NAMED as elided (`a,b,c,+N more`) — the same rule and the same reason as
 # _fm_abbrev_features: an abbreviation must not imply a completeness it does not have,
 # and a silent truncation in a SUMMARY block is exactly the invisible-opt-out shape this
 # issue exists to remove. The exact count is carried separately by the caller, so this
 # renders identity, never arithmetic.
 _fs_abbrev_grown() {
-  local shown=0 out="" e p
-  for e in ${1+"$@"}; do
-    p="${e%%: *}"
-    if [ "$shown" -lt 3 ]; then
-      out="${out:+$out,}$p"
-      shown=$((shown + 1))
-    fi
+  local shown=0 out="" p
+  for p in ${1+"$@"}; do
+    [ "$shown" -lt 3 ] || break
+    out="${out:+$out,}$p"
+    shown=$((shown + 1))
   done
   [ "$#" -gt "$shown" ] && out="$out,+$(( $# - shown )) more"
   printf '%s' "$out"
@@ -17862,7 +17897,10 @@ run_file_size() {
     files=$(git diff --name-only --diff-filter=d HEAD -- '*.rs' 2>/dev/null)
   fi
 
-  local -a over=() grew=()
+  # `grew` is the DISPLAY list; `grew_paths` is the same set as raw paths, carried rather
+  # than recovered from the display string later (roborev round 1, L3). The two are
+  # appended together, on adjacent lines, so they cannot fall out of step.
+  local -a over=() grew=() grew_paths=()
   local f cur lim base_n
   while IFS= read -r f; do
     [ -n "$f" ] && [ -f "$f" ] || continue
@@ -17878,6 +17916,7 @@ run_file_size() {
     base_n=${base_n:-0}
     if [ "$cur" -gt "$base_n" ]; then
       grew+=("$(printf '%s: %s -> %s (limit %s)' "$f" "$base_n" "$cur" "$lim")")
+      grew_paths+=("$f")
     fi
   done <<<"$files"
 
@@ -17920,7 +17959,7 @@ run_file_size() {
       # EXACT `FAIL`, so OPT-OUT rides to a PASS RESULT without a special case.
       status=OPT-OUT
       _record_status_detail "$name" \
-        "CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced); ${#grew[@]} over-threshold file(s) grown: $(_fs_abbrev_grown ${grew[@]+"${grew[@]}"})"
+        "CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced); ${#grew[@]} over-threshold file(s) grown: $(_fs_abbrev_grown ${grew_paths[@]+"${grew_paths[@]}"})"
       _fs_emit "$log" ">>> [$name] ${#grew[@]} over-threshold file(s) grew; ALLOWED via CQLITE_ALLOW_FILE_GROWTH=1:"
       for line in ${grew[@]+"${grew[@]}"}; do
         _fs_emit "$log" "      $line"

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6806,9 +6806,29 @@ _status_detail_file() { printf '%s/%s.status-detail' "${LOG_DIR:-}" "$1"; }
 # LOG_DIR that cannot take it must not change what the component reports. (The token
 # itself rides `.result`, whose write failure is already handled by the missing-result
 # guard.)
+# WRITE-THEN-RENAME, and on failure leave NOTHING renderable (roborev job 108). The previous
+# form truncated the destination and wrote in place, which fails two ways:
+#   * a write that dies partway (ENOSPC, a quota boundary) leaves a PARTIAL detail, which
+#     renders as a truncated disclosure — the silent truncation this issue exists to remove;
+#   * this function is called a SECOND time on the persistence path, to REPLACE the opt-out
+#     detail with the persistence one. If that second write fails, the FIRST one survives, and
+#     the row then claims `CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced)` while the
+#     component is FAIL for a reason that has nothing to do with the ratchet. That is exactly
+#     the false attribution fixed on the C1 round, arriving through a failed write instead of
+#     a missing branch.
+# So: write a temp file, rename only on a COMPLETE write, and on any failure remove both the
+# temp and the DESTINATION. Losing the detail is a truthful absence; keeping a stale one is a
+# false statement, and this whole issue is about which of those a summary may contain.
 _record_status_detail() {
   [ -n "${LOG_DIR:-}" ] || return 0
-  printf '%s\n' "$2" 2>/dev/null >"$(_status_detail_file "$1")" || return 0
+  local _sd_f _sd_t
+  _sd_f=$(_status_detail_file "$1")
+  _sd_t="$_sd_f.partial"
+  if printf '%s\n' "$2" 2>/dev/null >"$_sd_t" && mv -f "$_sd_t" "$_sd_f" 2>/dev/null; then
+    return 0
+  fi
+  rm -f "$_sd_t" "$_sd_f" 2>/dev/null
+  return 0
 }
 
 # _status_detail <component> (#3402): read it back, reduced to ONE line with the C0 controls

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -9906,7 +9906,8 @@ _tree_mode_components() {
 # printf twice, directly under a comment promising "never a second dialect of it".
 #
 # It carries the #3402 status detail. Without it a boundary block rendered
-# `file-size: OPT-OUT (0s)` with the env var, the count and the grown paths STRIPPED — the
+# `file-size: OPT-OUT (0s)` with the env var and the count STRIPPED (the grown PATHS were on
+# the row at the time; they are log-only now) — the
 # invisible opt-out this issue exists to remove, surviving on the one path where a run is
 # already in trouble and the disclosure matters most.
 #
@@ -18113,8 +18114,11 @@ run_file_size() {
       # ratchet was genuinely satisfied, so an override nobody reviewing the PR can see
       # is an override nothing mechanical can catch omitting. `PASS` means "the check ran
       # and was satisfied"; it must never mean "the check was switched off". Hence the
-      # component's OWN status token, plus the count and the file names inline — the same
-      # data this log already holds, PROMOTED rather than recomputed.
+      # component's OWN status token, plus the env var and the COUNT and a pointer to this
+      # log — data this log already holds, PROMOTED rather than recomputed. The file NAMES
+      # stay in the log ONLY; see the removed-cases note in
+      # scripts/tests/test_agent_gate_file_size_log.sh for why rendering them on the row was
+      # tried and withdrawn.
       #
       # THREE STATES, NOT TWO. This branch is the ONLY one that may emit OPT-OUT, and it
       # is keyed on the AFFIRMATIVE `= 1`. A value that is SET BUT NOT 1 (`0`, `true`,

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -2172,16 +2172,11 @@ apply_fixture_preflight() {
       echo "agent-gate: remedy: bash test-data/scripts/fetch-datasets.sh  (or point CQLITE_DATASETS_ROOT at a checkout that has it)" >&2
       echo "agent-gate: intentional opt-out (SKIP, stamped in the SUMMARY): AGENT_GATE_ALLOW_MISSING_FIXTURES=1" >&2
       _tree_meta_array   # #2926: every emitted block carries the tree provenance
-      # #3402/job 26: carry the rows of components that ALREADY RAN (file-size runs before
-      # this preflight), so an acknowledged CQLITE_ALLOW_FILE_GROWTH=1 is not invisible in
-      # the one block this run emits.
-      _pf_rows=$(_preflight_component_rows)
       emit_summary FAIL \
         "preflight: FAIL (canonical corpus $CANONICAL_FIXTURE_KEYSPACE absent under $CQLITE_DATASETS_ROOT/sstables — only committed byte-parity refs present)" \
         "missing-fixtures: FAIL-CLOSED (#2078) — dataset-dependent components would SKIP; overall verdict FAIL" \
         "$(_component_set_meta)" \
         "${TREE_META_LINES[@]}" \
-        ${_pf_rows:+"$_pf_rows"} \
         "hint: bash test-data/scripts/fetch-datasets.sh  (opt-out: AGENT_GATE_ALLOW_MISSING_FIXTURES=1 restores SKIP + stamps this block)"
       exit 1 ;;
   esac
@@ -2610,11 +2605,9 @@ apply_schemas_preflight() {
       return 1
     fi
     _tree_meta_array   # #2926
-    _ps_rows=$(_preflight_component_rows)   # #3402/job 26 — see apply_fixture_preflight
     emit_summary FAIL \
       "preflight: FAIL ($reject)" \
       "$marker" \
-      ${_ps_rows:+"$_ps_rows"} \
       "$(_component_set_meta)" \
       "${TREE_META_LINES[@]}" \
       "hint: export a clean ABSOLUTE CQLITE_SCHEMAS_ROOT, or unset it to use $root"
@@ -2640,13 +2633,11 @@ apply_schemas_preflight() {
         return 1
       fi
       _tree_meta_array   # #2926: every emitted block carries the tree provenance
-      _ps_rows=$(_preflight_component_rows)   # #3402/job 26 — see apply_fixture_preflight
-      emit_summary FAIL \
+        emit_summary FAIL \
         "preflight: FAIL (committed CQL schema fixtures unreadable under $root — missing: $missing)" \
         "missing-schemas: FAIL-CLOSED (#3148) — dataset-backed components would panic on an absent .cql; overall verdict FAIL" \
         "$(_component_set_meta)" \
         "${TREE_META_LINES[@]}" \
-        ${_ps_rows:+"$_ps_rows"} \
         "hint: expected $root/${missing%% *} — unset CQLITE_SCHEMAS_ROOT, or: git -C $REPO_ROOT restore --source=HEAD -- test-data/schemas"
       exit 1 ;;
   esac
@@ -9200,6 +9191,32 @@ fi
 # warning to STDERR (more likely to survive than stdout under a leaked-child/pty
 # capture). The caller's exit logic turns SUMMARY_WRITE_FAILED into a non-zero
 # exit so a green gate never silently lacks its summary file.
+# _emit_meta_lines <meta…> (#3402/job 30): the caller's meta lines, then the rows of every
+# component that has already RECORDED a verdict. Called by ALL THREE renderings inside
+# emit_summary (the authoritative file write and both fallback sinks) so they cannot diverge
+# — the same reason _fm_summary_line is the one row renderer.
+#
+# WHY AT THE FUNNEL. Three review rounds found the same defect at three different emit sites:
+# the tree-integrity boundary block, then the dataset/schemas preflights, then the `--only`
+# zero-dataset preflight and the summary-integrity paths. There are ~20 emit sites and each
+# hand-builds its own meta list, so each is an independent chance to omit the table and
+# enumerating them is a treadmill. `run_file_size` runs before every one of those exits, so
+# an acknowledged CQLITE_ALLOW_FILE_GROWTH=1 was invisible in whichever block the run
+# actually emitted.
+#
+# SUPPRESSED when the caller already passed rows, so the terminal emits — which build theirs
+# from _fm_summary_line and carry the #3453 feature-matrix annotation — are unchanged rather
+# than doubled. The test is the block's OWN closed row grammar; a caller rendering rows some
+# other way would be a new dialect and a bug on its own terms.
+_emit_meta_lines() {
+  local line
+  for line in ${@+"$@"}; do echo "$line"; done
+  if ! printf '%s\n' ${@+"$@"} | grep -qE '^[a-z][a-z0-9-]*: +(PASS|FAIL|SKIP|OPT-OUT) \([0-9]+s\)'; then
+    line=$(_recorded_component_rows_block)
+    [ -z "$line" ] || printf '%s\n' "$line"
+  fi
+}
+
 emit_summary() {
   local result="$1"; shift
   # Write the complete block to the caller-known file FIRST, with plain
@@ -9220,8 +9237,7 @@ emit_summary() {
       echo "run-id: $RUN_ID"
       [ -n "$SUMMARY_MODE_LINE" ] && echo "$SUMMARY_MODE_LINE"
       [ -n "$NESTED_UNDER_LINE" ] && echo "$NESTED_UNDER_LINE"
-      local line
-      for line in "$@"; do echo "$line"; done
+      _emit_meta_lines ${@+"$@"}
       echo "logs: $LOG_DIR"
       echo "summary-file: $SUMMARY_FILE"
       # #3473: declare the liveness mechanism's state in the block itself. A pasted
@@ -9290,8 +9306,7 @@ emit_summary() {
       echo "run-id: $RUN_ID"
       [ -n "$SUMMARY_MODE_LINE" ] && echo "$SUMMARY_MODE_LINE"
       [ -n "$NESTED_UNDER_LINE" ] && echo "$NESTED_UNDER_LINE"
-      local line
-      for line in "$@"; do echo "$line"; done
+      _emit_meta_lines ${@+"$@"}
       echo "logs: $LOG_DIR"
       echo "summary-file: $SUMMARY_FILE (WRITE FAILED — see stderr)"
       echo "RESULT: $emit_result"
@@ -9314,8 +9329,7 @@ emit_summary() {
       echo "run-id: $RUN_ID"
       [ -n "$SUMMARY_MODE_LINE" ] && echo "$SUMMARY_MODE_LINE"
       [ -n "$NESTED_UNDER_LINE" ] && echo "$NESTED_UNDER_LINE"
-      local line
-      for line in "$@"; do echo "$line"; done
+      _emit_meta_lines ${@+"$@"}
       echo "logs: $LOG_DIR"
       echo "summary-file: $SUMMARY_FILE (WRITE FAILED — see stderr)"
       echo "RESULT: $emit_result"
@@ -9913,18 +9927,21 @@ _completed_component_rows() {
   done
 }
 
-# _preflight_component_rows (#3402): the same table as ONE meta argument for an early-exit
+# _recorded_component_rows_block (#3402): the table plus its count line, as ONE string, or
+# nothing when no component has recorded yet. The name says WHAT it renders rather than which
+# caller wanted it — it was `_preflight_component_rows` while three named preflights passed it
+# themselves, and that name became wrong the moment the emit funnel carried it for every block.
 # `emit_summary`, or nothing when no component has recorded yet. emit_summary echoes each
 # argument, so a captured multi-line block renders as the rows it contains. Empty output is
 # deliberately an EMPTY STRING and the callers guard on it, because a bare "" argument would
 # emit a blank line into the block.
-_preflight_component_rows() {
+_recorded_component_rows_block() {
   local _rows _n
   _rows=$(_completed_component_rows)
   [ -n "$_rows" ] || return 0
   # COUNT THE ROWS THAT WILL PRINT, never `_CCR_COUNT`. The capture above runs in a COMMAND
   # SUBSTITUTION — a subshell — so the count the helper assigns is discarded, and reading it
-  # here emitted `components-completed-before-exit: 0` beside one printed row. That is a
+  # here emitted a count of `0` beside one printed row. That is a
   # count contradicting its own table: the exact invariant
   # scripts/tests/test_agent_gate_tree_provenance.sh asserts for the boundary block, and it
   # was introduced here and caught by running the thing rather than by reading it. The
@@ -9932,7 +9949,11 @@ _preflight_component_rows() {
   # this caller cannot, and a shared global that is only valid on one of two call paths is
   # exactly the trap. Measure the artifact.
   _n=$(printf '%s\n' "$_rows" | grep -c '^')
-  printf 'components-completed-before-exit: %s (the run STOPPED at a preflight — the rest never ran)\n%s' \
+  # WORDING IS EMIT-SITE-NEUTRAL. It read "the run STOPPED at a preflight" — true of the three
+  # callers it had when written, false the moment the funnel carried it for every block, since a
+  # summary-integrity FAIL is not a preflight. A line naming a cause it cannot know is the
+  # false-claim class this whole issue is about.
+  printf 'components-recorded: %s when this block was emitted (a component not listed had recorded no verdict)\n%s' \
     "$_n" "$_rows"
 }
 

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6772,17 +6772,53 @@ _fm_annotate() {
   return 0
 }
 
+# _status_detail_file <component> (#3402): the per-component SIDECAR carrying a short
+# free-text detail that the SUMMARY line appends after the feature-matrix annotation.
+# A FILE, not a variable, for the same reason `.result` is one: a component may run in a
+# backgrounded subshell of the bounded pool (#1737) and cannot write the parent's state.
+_status_detail_file() { printf '%s/%s.status-detail' "${LOG_DIR:-}" "$1"; }
+
+# _record_status_detail <component> <text> (#3402): publish that detail. Best-effort by
+# design — the detail EXPLAINS a status token, it does not carry the verdict, so a
+# LOG_DIR that cannot take it must not change what the component reports. (The token
+# itself rides `.result`, whose write failure is already handled by the missing-result
+# guard.)
+_record_status_detail() {
+  [ -n "${LOG_DIR:-}" ] || return 0
+  printf '%s\n' "$2" 2>/dev/null >"$(_status_detail_file "$1")" || return 0
+}
+
+# _status_detail <component> (#3402): read it back, reduced to ONE line with no control
+# characters. This value is interpolated into the SUMMARY block, and every reader of that
+# block parses it LINE-WISE — the #2908/#3041 completion probe, premerge-assert's
+# single-block assert, the #3453 annotation census. A multi-line or CR-bearing detail
+# would INJECT rows into the block, so the reduction happens at this ONE boundary rather
+# than being trusted of each writer (#3312: neutralise at the emit boundary, not per site).
+_status_detail() {
+  local f
+  f=$(_status_detail_file "$1")
+  [ -n "${LOG_DIR:-}" ] && [ -s "$f" ] || return 0
+  head -1 "$f" 2>/dev/null | tr -d '\r\n\t'
+}
+
 # _fm_summary_line <name> <status> <time>: the ONE renderer for a SUMMARY component
 # line, used by all six emit sites (full, lite, two delta sites, the aggregation
 # self-test and --emit-summary-selftest) so no mode can render a block the others do
 # not. `%-18s` and the `(time)` shape are unchanged — the annotation is appended, so
-# every existing prefix/stage-line assertion still matches.
+# every existing prefix/stage-line assertion still matches, and the #3402 status detail
+# is appended AFTER the annotation (absent → the line is byte-identical to before).
 _fm_summary_line() {
   # #3625: the census suffix rides here, at the ONE renderer, for the same reason the
   # feature matrix does -- no mode can then emit a component line the others do not.
   # `%-18s` and the `(time)` shape are UNCHANGED (#3453 kept them deliberately and
   # existing prefix/stage assertions match on them); the census is APPENDED.
-  printf '%-18s %s (%s)  %s  %s' "$1:" "$2" "$3" "$(_fm_annotate "$1")" "$(_census_annotate "$1" "$2")"
+  # #3402: …and the status detail is appended AFTER the census, last of the three suffixes.
+  # Order is deliberate: the matrix and the census are STRUCTURED tokens a parser may key on,
+  # while the detail is free text that ends the line, so nothing structured sits behind
+  # something unstructured. Absent detail → the line is byte-identical to #3625's.
+  local _detail
+  _detail=$(_status_detail "$1")
+  printf '%-18s %s (%s)  %s  %s%s' "$1:" "$2" "$3" "$(_fm_annotate "$1")" "$(_census_annotate "$1" "$2")" "${_detail:+ — $_detail}"
 }
 
 # _fm_note_if_no_cargo_observed <component> <status>: a component that ENDED without a
@@ -17741,6 +17777,26 @@ _fs_emit() { # _fs_emit <logfile> <line> [<line>…]  — one output line per ar
   printf '%s\n' "$@" 2>/dev/null >>"$_fs_log" ||
     _FS_WRITE_FAILURES=$((_FS_WRITE_FAILURES + 1))
 }
+# _fs_abbrev_grown <entry…> (#3402): the grown-file list as it appears on the SUMMARY
+# line. Each argument is a `path: before -> after (limit N)` entry, so the path is the
+# text up to the first `: `. Up to 3 paths print in full; beyond that the remainder is
+# NAMED as elided (`a,b,c,+N more`) — the same rule and the same reason as
+# _fm_abbrev_features: an abbreviation must not imply a completeness it does not have,
+# and a silent truncation in a SUMMARY block is exactly the invisible-opt-out shape this
+# issue exists to remove. The exact count is carried separately by the caller, so this
+# renders identity, never arithmetic.
+_fs_abbrev_grown() {
+  local shown=0 out="" e p
+  for e in ${1+"$@"}; do
+    p="${e%%: *}"
+    if [ "$shown" -lt 3 ]; then
+      out="${out:+$out,}$p"
+      shown=$((shown + 1))
+    fi
+  done
+  [ "$#" -gt "$shown" ] && out="$out,+$(( $# - shown )) more"
+  printf '%s' "$out"
+}
 run_file_size() {
   local name=file-size
   if [ -n "$ONLY" ] && ! grep -qw "$name" <<<"${ONLY//,/ }"; then
@@ -17823,6 +17879,28 @@ run_file_size() {
     _fs_emit "$log" ">>> [$name] base ref unavailable — growth ratchet skipped (advisory only)"
   elif [ "${#grew[@]}" -gt 0 ]; then
     if [ "${CQLITE_ALLOW_FILE_GROWTH:-0}" = 1 ]; then
+      # #3402: the opt-out must be VISIBLE IN THE PASTED SUMMARY, not only in this log.
+      # A bare `file-size: PASS (0s)` is byte-indistinguishable from a run where the
+      # ratchet was genuinely satisfied, so an override nobody reviewing the PR can see
+      # is an override nothing mechanical can catch omitting. `PASS` means "the check ran
+      # and was satisfied"; it must never mean "the check was switched off". Hence the
+      # component's OWN status token, plus the count and the file names inline — the same
+      # data this log already holds, PROMOTED rather than recomputed.
+      #
+      # THREE STATES, NOT TWO. This branch is the ONLY one that may emit OPT-OUT, and it
+      # is keyed on the AFFIRMATIVE `= 1`. A value that is SET BUT NOT 1 (`0`, `true`,
+      # `yes`) falls through to the `else` below and stays a genuine ratchet violation,
+      # exactly as before — see the `growth allowance: NOT enabled … this IS a ratchet
+      # violation` wording in the persistence block, which distinguishes the same three
+      # states. Keying the permissive branch on `!= <bad>` would let a typo buy a green,
+      # which is the false-PASS route this issue must not open while closing another.
+      #
+      # NON-FAILING BY CONSTRUCTION: `status` is not FAIL, and all three aggregators
+      # (full gate, aggregate_lite_components, run_delta) set OVERALL=FAIL only on an
+      # EXACT `FAIL`, so OPT-OUT rides to a PASS RESULT without a special case.
+      status=OPT-OUT
+      _record_status_detail "$name" \
+        "CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced); ${#grew[@]} over-threshold file(s) grown: $(_fs_abbrev_grown ${grew[@]+"${grew[@]}"})"
       _fs_emit "$log" ">>> [$name] ${#grew[@]} over-threshold file(s) grew; ALLOWED via CQLITE_ALLOW_FILE_GROWTH=1:"
       for line in ${grew[@]+"${grew[@]}"}; do
         _fs_emit "$log" "      $line"

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -18334,6 +18334,20 @@ run_file_size() {
     if [ "$ratchet_verdict" = FAIL ]; then
       _record_status_detail "$name" \
         "TWO failures: a REAL size-ratchet violation AND a log-persistence failure ($log_persist_err)$_fs_detail_where"
+    elif [ "$ratchet_verdict" = OPT-OUT ]; then
+      # THE OPT-OUT ARM RETAINS THE DISCLOSURE (roborev job 104). The other arms replace the
+      # detail wholesale, which is right for them — there is nothing to retain. Here there is:
+      # the override NAME and the grown COUNT are the entire point of this issue, and this is
+      # the one state where they can be lost from EVERY reachable artifact at once, because
+      # the log that would otherwise hold them is precisely what failed to persist and the
+      # sibling may be unwritable too. Job 21 established this property for the WITHHOLD path
+      # and it was not carried to the PERSISTENCE path — the same omission, one branch over.
+      #
+      # It still LEADS with the persistence failure, so the row never attributes the FAIL to
+      # the ratchet, and it says OPTED OUT OF rather than "computed OPT-OUT" because a reader
+      # needs to know the ratchet was switched off, not merely what token it produced.
+      _record_status_detail "$name" \
+        "LOG PERSISTENCE FAILURE, not a ratchet violation ($log_persist_err); the ratchet was OPTED OUT OF: CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced); ${#grew[@]} over-threshold file(s) grown$_fs_detail_where"
     elif [ -z "$base" ]; then
       _record_status_detail "$name" \
         "LOG PERSISTENCE FAILURE, not a ratchet violation ($log_persist_err); the ratchet was SKIPPED (base ref unavailable), so nothing was compared$_fs_detail_where"

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6797,6 +6797,10 @@ _record_status_detail() {
 # rather than trusted of each writer (#3312: neutralise where the value is rendered, not
 # per interpolation site — a per-site escape is a list to keep complete). `[:cntrl:]` is
 # the whole class, deliberately, so a control character nobody enumerated is covered too.
+# DEFENCE IN DEPTH, stated as such rather than implied: the one writer today
+# (run_file_size) renders paths git already quotes, so no REACHABLE input carries a
+# control character — this boundary exists so the NEXT writer cannot reintroduce the
+# row-injection route by not thinking about it.
 # LENGTH is NOT capped here: a cap would be a SILENT truncation of a disclosure, which is
 # the defect this issue removes — bounding the value is the WRITER's job (see
 # _fs_abbrev_grown, which elides by a NAMED remainder).

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6808,7 +6808,17 @@ _status_detail() {
   local f
   f=$(_status_detail_file "$1")
   [ -n "${LOG_DIR:-}" ] && [ -s "$f" ] || return 0
-  head -1 "$f" 2>/dev/null | tr -d '[:cntrl:]'
+  # …and `RESULT:` is neutralised at the SAME one boundary, for the same reason and with
+  # the same standing: the #2908/#3041 completion probe greps the summary FILE for
+  # `RESULT: (PASS|FAIL)`, and this detail lands on a component ROW inside that file, so a
+  # detail carrying the token would let a poller read a verdict off a row instead of off the
+  # terminal line. scripts/tests/test_agent_gate_summary.sh already guards the annotation
+  # half of that invariant (3453-annot-c); the detail is the other half of the same line.
+  # DEFENCE IN DEPTH on the same terms as the strip above — the nearest live route is a
+  # repository-controlled grown-file PATH, which no Rust path plausibly spells — and it is
+  # the boundary, not each writer, that has to hold. Display only: no decision anywhere
+  # reads this value, so a redaction can never grant what a parse would.
+  head -1 "$f" 2>/dev/null | tr -d '[:cntrl:]' | sed 's/RESULT:/RESULT[redacted-token]:/g'
 }
 
 # _fm_summary_line <name> <status> <time>: the ONE renderer for a SUMMARY component
@@ -18064,6 +18074,38 @@ run_file_size() {
       # loop broke mid-block (a PARTIAL sibling exists), or the landed line count differs.
       # "the only copy" was false for the middle one (#3401 review item 4).
       msg+=("    (It could NOT be written IN FULL to $sib — stdout carries the complete copy.)")
+    fi
+    # #3402: the STATUS DETAIL must describe why the COMPONENT failed, not merely echo the
+    # ratchet state. The opt-out branch above already stamped `CQLITE_ALLOW_FILE_GROWTH=1
+    # (ratchet NOT enforced); …`, and `status` has since become FAIL for a reason that has
+    # nothing to do with the ratchet — so without this the SUMMARY row reads
+    # `file-size: FAIL (0s)  [no-cargo] — CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced);
+    # 1 over-threshold file(s) grown: …`: a FAIL whose ENTIRE detail describes an opt-out
+    # that is not why it failed. That was MEASURED on the real gate, not inferred. It is
+    # #3401 review's own class ("a state reporting something it never computed"), which
+    # that issue hit SIX times — arriving one level up, in the very artifact this issue
+    # exists to make trustworthy.
+    #
+    # THREE ARMS, because the row must not claim a computation that did not happen (#3401
+    # review L1): both-failed; ratchet SKIPPED (no base ref — `ratchet_verdict` is PASS
+    # there, but NOTHING was compared, so naming that verdict would assert a comparison
+    # that never ran); and persistence-only, which is where OPT-OUT lands.
+    #
+    # The `see <sib>` pointer is added ONLY on the VERIFIED-sibling path. Pointing a reader
+    # at a file that rejected every write is the false-pointer failure #3401 review FIX 2
+    # already removed from stdout, and it must not reappear one artifact over. `sib_ok` is
+    # final here and nowhere earlier — this block must stay BELOW the landed-line check.
+    local _fs_detail_where=""
+    [ "$sib_ok" = 1 ] && _fs_detail_where=" — see $sib"
+    if [ "$ratchet_verdict" = FAIL ]; then
+      _record_status_detail "$name" \
+        "TWO failures: a REAL size-ratchet violation AND a log-persistence failure ($log_persist_err)$_fs_detail_where"
+    elif [ -z "$base" ]; then
+      _record_status_detail "$name" \
+        "LOG PERSISTENCE FAILURE, not a ratchet violation ($log_persist_err); the ratchet was SKIPPED (base ref unavailable), so nothing was compared$_fs_detail_where"
+    else
+      _record_status_detail "$name" \
+        "LOG PERSISTENCE FAILURE, not a ratchet violation ($log_persist_err); the ratchet itself computed $ratchet_verdict$_fs_detail_where"
     fi
     for _m in ${msg[@]+"${msg[@]}"}; do
       printf '%s\n' "$_m"

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6801,6 +6801,16 @@ _record_status_detail() {
 # (run_file_size) renders paths git already quotes, so no REACHABLE input carries a
 # control character — this boundary exists so the NEXT writer cannot reintroduce the
 # row-injection route by not thinking about it.
+# NOT BEHAVIOURALLY TESTED ON THIS PLATFORM, and that is DECLARED rather than papered over
+# (roborev job 20, L2). A test was written for this pin and then DELETED: GNU `tr` is
+# byte-wise, so for every input any writer here can produce, `[:cntrl:]` selects the same
+# bytes with or without the pin — the rendering is identical, no mutant can distinguish the
+# two, and the case could not fail. It was ALSO flaky, comparing whole rows from two
+# separate runs with the elapsed `(Ns)` field included. A case that cannot fail but CAN
+# flake is strictly worse than none: it costs reds in a merge-gating suite and buys no
+# signal. The pin STAYS — free, and it removes a real environment dependence on any
+# platform where the class IS locale-sensitive — but it is defence in depth with NO
+# behavioural coverage, said plainly so nobody reads the neighbouring cases as evidence.
 # LOCALE-PINNED, and the CLAIM is narrowed to what the code delivers (roborev round 1, L2):
 # `[:cntrl:]` is evaluated in the CURRENT locale, so an unpinned `tr` makes this boundary's
 # coverage a property of the caller's environment rather than of this line. `LC_ALL=C`
@@ -6821,17 +6831,36 @@ _status_detail() {
   local f
   f=$(_status_detail_file "$1")
   [ -n "${LOG_DIR:-}" ] && [ -s "$f" ] || return 0
-  # …and `RESULT:` is neutralised at the SAME one boundary, for the same reason and with
-  # the same standing: the #2908/#3041 completion probe greps the summary FILE for
-  # `RESULT: (PASS|FAIL)`, and this detail lands on a component ROW inside that file, so a
-  # detail carrying the token would let a poller read a verdict off a row instead of off the
-  # terminal line. scripts/tests/test_agent_gate_summary.sh already guards the annotation
-  # half of that invariant (3453-annot-c); the detail is the other half of the same line.
-  # DEFENCE IN DEPTH on the same terms as the strip above — the nearest live route is a
-  # repository-controlled grown-file PATH, which no Rust path plausibly spells — and it is
-  # the boundary, not each writer, that has to hold. Display only: no decision anywhere
-  # reads this value, so a redaction can never grant what a parse would.
-  head -1 "$f" 2>/dev/null | LC_ALL=C tr -d '[:cntrl:]' | sed 's/RESULT:/RESULT[redacted-token]:/g'
+  # …and a detail carrying the completion probe's verdict token is REFUSED, not rewritten
+  # (roborev job 19, L1). The #2908/#3041 probe greps the summary FILE for
+  # `RESULT: (PASS|FAIL)` and this detail lands on a component ROW inside that file, so the
+  # token must not appear here. The first attempt SUBSTITUTED it — and a blanket
+  # substitution edits the token wherever it occurs, INCLUDING inside a legitimate
+  # grown-file path such as `cqlite-core/src/RESULT: PASS.rs`, which the row would then name
+  # in a spelling that exists nowhere on disk. That is the SAME false-reporting defect this
+  # change exists to remove, reintroduced by its own guard, and strictly worse than the
+  # disclosure it was protecting: a reader cannot tell a rewritten name from a real one.
+  #
+  # So the value is WITHHELD WHOLE, loudly, and the reader is sent to the component log — a
+  # truthful degradation instead of a false statement. The row keeps its status token and
+  # its count; only the detail suffix is replaced, by a sentence that says it was withheld
+  # and why. The refusal names NO part of the token it refuses (the reason is described, not
+  # quoted), because a diagnostic reproducing the token it exists to keep off this row would
+  # forge the very row it prevents — the rule this repo already applies to the roborev
+  # waiver markers.
+  #
+  # THE TRIGGER IS DELIBERATELY BROADER THAN THE PROBE PATTERN. It fires on any `RESULT:`,
+  # not only `RESULT: PASS`/`RESULT: FAIL`, because narrowing it would require knowing every
+  # consumer's regex AND that it stays that way — and the consumers are not enumerable from
+  # here (pollers outside this repo read these blocks). The cost of the broad trigger is a
+  # withheld detail on a pathological filename; the cost of a narrow one is a forged verdict
+  # for a consumer nobody surveyed. Only one of those is recoverable by reading the log.
+  local _sd_v
+  _sd_v=$(head -1 "$f" 2>/dev/null | LC_ALL=C tr -d '[:cntrl:]')
+  case "$_sd_v" in
+    *RESULT:*) printf '%s' "[detail WITHHELD: it contains the completion probe's reserved verdict token (#2908), which on this row would forge a terminal verdict — see the component log]" ;;
+    *)         printf '%s' "$_sd_v" ;;
+  esac
 }
 
 # _fm_summary_line <name> <status> <time>: the ONE renderer for a SUMMARY component

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -9936,74 +9936,62 @@ _tree_mode_components() {
   fi
 }
 
-# _completed_component_rows (#3402, roborev job 26): every component that has RECORDED a
-# verdict, one row each, in canonical order for the RUNNING mode, then a sweep for any
-# recorded result no static list names. Sets `_CCR_COUNT` to the number of rows printed.
+# _recorded_component_rows_block (#3402): the aggregate `census:` line, a
+# `components-recorded:` count and one row per component that has RECORDED a verdict — as ONE
+# string, or nothing when no component has recorded yet.
 #
-# WHY IT IS SHARED rather than living inside the boundary renderer: `run_file_size` executes
-# BEFORE the dataset and schemas preflights, so an acknowledged growth followed by a
-# fail-closed preflight emitted a terminal block with NO component row at all — the override
-# name and the growth count absent from the very artifact this issue exists to put them in.
-# That is round 1's boundary finding one emit site over, and the shape recurs because each
-# early-exit emit hand-builds its own meta list. Any emit that can happen AFTER components
-# may have run must carry this.
-_completed_component_rows() {
-  # ONE RENDERER, `_fm_summary_line`, the same as every other block (#3453/#3625). This took a
-  # renderer ARGUMENT for one round, because the boundary table used a plain unannotated row
-  # while the funnel needed an annotated one — until #3625 routed the boundary loops through
-  # `_fm_summary_line` too, on the same reasoning, leaving one renderer and a parameter with a
-  # single possible value. Removed rather than kept "for symmetry": an unused seam is a second
-  # dialect waiting for a caller, which is the drift this issue kept tripping over.
-  local _c _rf _st _secs _seen=" "
-  _CCR_COUNT=0
+# WHY IT EXISTS: `run_file_size` executes before the dataset and schemas preflights, and every
+# early-exit `emit_summary` hand-builds its own meta list, so each is an independent chance to
+# omit the table. Three review rounds found the same omission at three different emit sites
+# before it was fixed at the FUNNEL instead of per site.
+#
+# ONE FUNCTION, ONE SHELL, DELIBERATELY. This was a helper pair — a traversal that printed
+# rows plus a wrapper that captured them — and the split cost the same bug TWICE: the traversal
+# assigned its count, and later its census subject set, to globals that the wrapper read across
+# a COMMAND SUBSTITUTION, i.e. across a subshell, so the wrapper saw neither. The first
+# instance rendered `0` beside one printed row; the second silently dropped the census line.
+# Both were caught by RUNNING it, not by reading it. Folded together, the rows, the pairs and
+# the count are produced by the same shell and no global crosses a boundary.
+#
+# The census goes ABOVE the rows because its subject set is only known once the traversal is
+# done — the same shape, and the same reason, as the boundary table.
+_recorded_component_rows_block() {
+  # SAFE AT EVERY EMIT SITE, including blocks emitted from the ARG DISPATCH before LOG_DIR
+  # exists and before COMPONENTS is in scope: an unguarded `"$LOG_DIR"/*.result` with LOG_DIR
+  # empty globs `/*.result`, and `_tree_mode_components` is not yet defined there.
+  [ -n "${LOG_DIR:-}" ] && [ -d "$LOG_DIR" ] || return 0
+  command -v _tree_mode_components >/dev/null 2>&1 || return 0
+  command -v census_summary_line   >/dev/null 2>&1 || return 0
+  local _c _rf _st _secs _seen=" " _rows="" _pairs="" _n=0
   for _c in $(_tree_mode_components); do
     _rf="$LOG_DIR/$_c.result"
     [ -f "$_rf" ] || continue
     _st=""; _secs=""
     read -r _st _secs < "$_rf" || true
-    _fm_summary_line "$_c" "$_st" "${_secs}s"
+    _rows="$_rows$(_fm_summary_line "$_c" "$_st" "${_secs}s")
+"
+    _pairs="$_pairs $_c $_st"
     _seen="$_seen $_c "
-    _CCR_COUNT=$(( _CCR_COUNT + 1 ))
+    _n=$(( _n + 1 ))
   done
+  # …then a SWEEP for any remaining `.result`: a recorded verdict must never be dropped merely
+  # because no static list names it. LOG_DIR is this run's own mktemp directory, so the sweep
+  # can only see verdicts record_result wrote, and the glob is deterministically ordered.
   for _rf in "$LOG_DIR"/*.result; do
     [ -f "$_rf" ] || continue
     _c="${_rf##*/}"; _c="${_c%.result}"
     case "$_seen" in *" $_c "*) continue ;; esac
     _st=""; _secs=""
     read -r _st _secs < "$_rf" || true
-    _fm_summary_line "$_c" "$_st" "${_secs}s"
-    _CCR_COUNT=$(( _CCR_COUNT + 1 ))
+    _rows="$_rows$(_fm_summary_line "$_c" "$_st" "${_secs}s")
+"
+    _pairs="$_pairs $_c $_st"
+    _n=$(( _n + 1 ))
   done
-}
-
-# _recorded_component_rows_block (#3402): the table plus its count line, as ONE string, or
-# nothing when no component has recorded yet. The name says WHAT it renders rather than which
-# caller wanted it — it was `_preflight_component_rows` while three named preflights passed it
-# themselves, and that name became wrong the moment the emit funnel carried it for every block.
-# `emit_summary`, or nothing when no component has recorded yet. emit_summary echoes each
-# argument, so a captured multi-line block renders as the rows it contains. Empty output is
-# deliberately an EMPTY STRING and the callers guard on it, because a bare "" argument would
-# emit a blank line into the block.
-_recorded_component_rows_block() {
-  local _rows _n
-  _rows=$(_completed_component_rows)
   [ -n "$_rows" ] || return 0
-  # COUNT THE ROWS THAT WILL PRINT, never `_CCR_COUNT`. The capture above runs in a COMMAND
-  # SUBSTITUTION — a subshell — so the count the helper assigns is discarded, and reading it
-  # here emitted a count of `0` beside one printed row. That is a
-  # count contradicting its own table: the exact invariant
-  # scripts/tests/test_agent_gate_tree_provenance.sh asserts for the boundary block, and it
-  # was introduced here and caught by running the thing rather than by reading it. The
-  # boundary renderer may use `_CCR_COUNT` because it calls the helper in ITS OWN shell;
-  # this caller cannot, and a shared global that is only valid on one of two call paths is
-  # exactly the trap. Measure the artifact.
-  _n=$(printf '%s\n' "$_rows" | grep -c '^')
-  # WORDING IS EMIT-SITE-NEUTRAL. It read "the run STOPPED at a preflight" — true of the three
-  # callers it had when written, false the moment the funnel carried it for every block, since a
-  # summary-integrity FAIL is not a preflight. A line naming a cause it cannot know is the
-  # false-claim class this whole issue is about.
-  printf 'components-recorded: %s when this block was emitted (a component not listed had recorded no verdict)\n%s' \
-    "$_n" "$_rows"
+  # shellcheck disable=SC2086  # intentional word-split over the name/STATUS pairs
+  printf '%s\ncomponents-recorded: %s when this block was emitted (a component not listed had recorded no verdict)\n%s' \
+    "$(census_summary_line $_pairs)" "$_n" "$_rows"
 }
 
 _tree_boundary_meta_lines() {

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6782,6 +6782,14 @@ _status_detail_file() { printf '%s/%s.status-detail' "${LOG_DIR:-}" "$1"; }
 # GATE-AUTHORED — fixed wording plus values the component computed. No repository-derived
 # content (paths, branch names, commit subjects) may be interpolated into it.
 #
+# WATCH THE PATHS, which is how this contract was broken the first day it existed (roborev
+# job 25): `$LOG_DIR` is `mktemp -d "${TMPDIR:-/tmp}/agent-gate.XXXXXX"`, so ANY path under it
+# is caller-influenced, not gate-authored. Interpolating one put a `TMPDIR` containing the
+# probe's verdict token straight into this field, where the guard below would withhold the
+# WHOLE detail and take the override name and the growth count with it. Name the FILE and let
+# the block's own `logs:` line supply the directory — a pointer that composes rather than one
+# that carries.
+#
 # That is a CONTRACT, not an observation, and it is what makes the reader's job small. A
 # two-field trusted/untrusted sidecar was built here when the row still rendered grown-file
 # PATHS, and was removed with them: the untrusted half had no writer left, and unused
@@ -17998,7 +18006,7 @@ run_file_size() {
       # changed. What the row must carry is what a pasted SUMMARY cannot get anywhere else:
       # that the ratchet was NOT enforced, and over how many files.
       _record_status_detail "$name" \
-        "CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced); ${#grew[@]} over-threshold file(s) grown — see $log"
+        "CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced); ${#grew[@]} over-threshold file(s) grown — see file-size.log under logs:"
       _fs_emit "$log" ">>> [$name] ${#grew[@]} over-threshold file(s) grew; ALLOWED via CQLITE_ALLOW_FILE_GROWTH=1:"
       for line in ${grew[@]+"${grew[@]}"}; do
         _fs_emit "$log" "      $line"
@@ -18173,8 +18181,13 @@ run_file_size() {
     # at a file that rejected every write is the false-pointer failure #3401 review FIX 2
     # already removed from stdout, and it must not reappear one artifact over. `sib_ok` is
     # final here and nowhere earlier — this block must stay BELOW the landed-line check.
+    # A FILENAME, not a path (roborev job 25). $sib is under LOG_DIR, which mktemp created
+    # under the caller's TMPDIR, so interpolating it puts caller-controlled text into a field
+    # this boundary's contract says is gate-authored. The SUMMARY already publishes the
+    # directory on its own `logs:` line, so naming the file composes to the same place with
+    # nothing borrowed from the environment.
     local _fs_detail_where=""
-    [ "$sib_ok" = 1 ] && _fs_detail_where=" — see $sib"
+    [ "$sib_ok" = 1 ] && _fs_detail_where=" — see file-size.persistence-error.log under logs:"
     if [ "$ratchet_verdict" = FAIL ]; then
       _record_status_detail "$name" \
         "TWO failures: a REAL size-ratchet violation AND a log-persistence failure ($log_persist_err)$_fs_detail_where"

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -2172,11 +2172,16 @@ apply_fixture_preflight() {
       echo "agent-gate: remedy: bash test-data/scripts/fetch-datasets.sh  (or point CQLITE_DATASETS_ROOT at a checkout that has it)" >&2
       echo "agent-gate: intentional opt-out (SKIP, stamped in the SUMMARY): AGENT_GATE_ALLOW_MISSING_FIXTURES=1" >&2
       _tree_meta_array   # #2926: every emitted block carries the tree provenance
+      # #3402/job 26: carry the rows of components that ALREADY RAN (file-size runs before
+      # this preflight), so an acknowledged CQLITE_ALLOW_FILE_GROWTH=1 is not invisible in
+      # the one block this run emits.
+      _pf_rows=$(_preflight_component_rows)
       emit_summary FAIL \
         "preflight: FAIL (canonical corpus $CANONICAL_FIXTURE_KEYSPACE absent under $CQLITE_DATASETS_ROOT/sstables — only committed byte-parity refs present)" \
         "missing-fixtures: FAIL-CLOSED (#2078) — dataset-dependent components would SKIP; overall verdict FAIL" \
         "$(_component_set_meta)" \
         "${TREE_META_LINES[@]}" \
+        ${_pf_rows:+"$_pf_rows"} \
         "hint: bash test-data/scripts/fetch-datasets.sh  (opt-out: AGENT_GATE_ALLOW_MISSING_FIXTURES=1 restores SKIP + stamps this block)"
       exit 1 ;;
   esac
@@ -2605,9 +2610,11 @@ apply_schemas_preflight() {
       return 1
     fi
     _tree_meta_array   # #2926
+    _ps_rows=$(_preflight_component_rows)   # #3402/job 26 — see apply_fixture_preflight
     emit_summary FAIL \
       "preflight: FAIL ($reject)" \
       "$marker" \
+      ${_ps_rows:+"$_ps_rows"} \
       "$(_component_set_meta)" \
       "${TREE_META_LINES[@]}" \
       "hint: export a clean ABSOLUTE CQLITE_SCHEMAS_ROOT, or unset it to use $root"
@@ -2633,11 +2640,13 @@ apply_schemas_preflight() {
         return 1
       fi
       _tree_meta_array   # #2926: every emitted block carries the tree provenance
+      _ps_rows=$(_preflight_component_rows)   # #3402/job 26 — see apply_fixture_preflight
       emit_summary FAIL \
         "preflight: FAIL (committed CQL schema fixtures unreadable under $root — missing: $missing)" \
         "missing-schemas: FAIL-CLOSED (#3148) — dataset-backed components would panic on an absent .cql; overall verdict FAIL" \
         "$(_component_set_meta)" \
         "${TREE_META_LINES[@]}" \
+        ${_ps_rows:+"$_ps_rows"} \
         "hint: expected $root/${missing%% *} — unset CQLITE_SCHEMAS_ROOT, or: git -C $REPO_ROOT restore --source=HEAD -- test-data/schemas"
       exit 1 ;;
   esac
@@ -9870,6 +9879,63 @@ _tree_boundary_row() {
   printf '%-18s %s (%ss)%s\n' "$1:" "$2" "$3" "${_d:+ — $_d}"
 }
 
+# _completed_component_rows (#3402, roborev job 26): every component that has RECORDED a
+# verdict, one row each, in canonical order for the RUNNING mode, then a sweep for any
+# recorded result no static list names. Sets `_CCR_COUNT` to the number of rows printed.
+#
+# WHY IT IS SHARED rather than living inside the boundary renderer: `run_file_size` executes
+# BEFORE the dataset and schemas preflights, so an acknowledged growth followed by a
+# fail-closed preflight emitted a terminal block with NO component row at all — the override
+# name and the growth count absent from the very artifact this issue exists to put them in.
+# That is round 1's boundary finding one emit site over, and the shape recurs because each
+# early-exit emit hand-builds its own meta list. Any emit that can happen AFTER components
+# may have run must carry this.
+_completed_component_rows() {
+  local _c _rf _st _secs _seen=" "
+  _CCR_COUNT=0
+  for _c in $(_tree_mode_components); do
+    _rf="$LOG_DIR/$_c.result"
+    [ -f "$_rf" ] || continue
+    _st=""; _secs=""
+    read -r _st _secs < "$_rf" || true
+    _tree_boundary_row "$_c" "$_st" "$_secs"
+    _seen="$_seen $_c "
+    _CCR_COUNT=$(( _CCR_COUNT + 1 ))
+  done
+  for _rf in "$LOG_DIR"/*.result; do
+    [ -f "$_rf" ] || continue
+    _c="${_rf##*/}"; _c="${_c%.result}"
+    case "$_seen" in *" $_c "*) continue ;; esac
+    _st=""; _secs=""
+    read -r _st _secs < "$_rf" || true
+    _tree_boundary_row "$_c" "$_st" "$_secs"
+    _CCR_COUNT=$(( _CCR_COUNT + 1 ))
+  done
+}
+
+# _preflight_component_rows (#3402): the same table as ONE meta argument for an early-exit
+# `emit_summary`, or nothing when no component has recorded yet. emit_summary echoes each
+# argument, so a captured multi-line block renders as the rows it contains. Empty output is
+# deliberately an EMPTY STRING and the callers guard on it, because a bare "" argument would
+# emit a blank line into the block.
+_preflight_component_rows() {
+  local _rows _n
+  _rows=$(_completed_component_rows)
+  [ -n "$_rows" ] || return 0
+  # COUNT THE ROWS THAT WILL PRINT, never `_CCR_COUNT`. The capture above runs in a COMMAND
+  # SUBSTITUTION — a subshell — so the count the helper assigns is discarded, and reading it
+  # here emitted `components-completed-before-exit: 0` beside one printed row. That is a
+  # count contradicting its own table: the exact invariant
+  # scripts/tests/test_agent_gate_tree_provenance.sh asserts for the boundary block, and it
+  # was introduced here and caught by running the thing rather than by reading it. The
+  # boundary renderer may use `_CCR_COUNT` because it calls the helper in ITS OWN shell;
+  # this caller cannot, and a shared global that is only valid on one of two call paths is
+  # exactly the trap. Measure the artifact.
+  _n=$(printf '%s\n' "$_rows" | grep -c '^')
+  printf 'components-completed-before-exit: %s (the run STOPPED at a preflight — the rest never ran)\n%s' \
+    "$_n" "$_rows"
+}
+
 _tree_boundary_meta_lines() {
   local _c _s _rf _st _secs _done=0 _sel=0 _seen=" " _cen_names="" _rows=""
   _tree_commit_meta_render
@@ -9950,6 +10016,14 @@ _tree_boundary_meta_lines() {
   # shellcheck disable=SC2086  # intentional word-split over the name/STATUS pairs
   printf '%s\n' "$(census_summary_line $_cen_names)"
   [ -n "$_rows" ] && printf '%s' "$_rows"
+  #
+  # #3402: this path keeps its OWN traversal, deliberately. The emit FUNNEL has a second one
+  # (`_recorded_component_rows_block`) for the ordinary blocks that carry no table of their
+  # own, and the two are not worth merging: this one BUFFERS its rows so the aggregate
+  # `census:` line can be printed ABOVE them, and it accumulates the census subject set as it
+  # goes — neither of which the funnel needs, since it appends after a caller's meta and the
+  # census is already on those blocks. Both render through `_fm_summary_line`, so the ROW
+  # SHAPE cannot diverge, which is the property that actually matters.
   # Selected-count via the bash-3.2 empty-array-safe idiom used throughout this script
   # (a bare "${ARR[@]}" on an empty array aborts under `set -u` on bash < 4.4).
   for _s in ${SELECTED_MAIN[@]+"${SELECTED_MAIN[@]}"} ${SELECTED_SIDE[@]+"${SELECTED_SIDE[@]}"}; do

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6811,19 +6811,27 @@ _record_status_detail() {
   printf '%s\n' "$2" 2>/dev/null >"$(_status_detail_file "$1")" || return 0
 }
 
-# _status_detail <component> (#3402): read it back, reduced to ONE line with no control
-# characters at all. This value is interpolated into the SUMMARY block, and every reader
-# of that block parses it LINE-WISE — the #2908/#3041 completion probe, premerge-assert's
-# single-block assert, the #3453 annotation census. A multi-line or CR-bearing detail
-# would INJECT rows into the block, and a detail carrying an ESC would put ANSI into a
-# block that gets pasted into PR comments, so BOTH are removed at this ONE emit boundary
-# rather than trusted of each writer (#3312: neutralise where the value is rendered, not
-# per interpolation site — a per-site escape is a list to keep complete). `[:cntrl:]` is
-# the whole class, deliberately, so a control character nobody enumerated is covered too.
-# DEFENCE IN DEPTH, stated as such rather than implied: the one writer today
-# (run_file_size) renders paths git already quotes, so no REACHABLE input carries a
-# control character — this boundary exists so the NEXT writer cannot reintroduce the
-# row-injection route by not thinking about it.
+# _status_detail <component> (#3402): read it back, reduced to ONE line with the C0 controls
+# and DEL removed. This value is interpolated into the SUMMARY block, and every reader of
+# that block parses it LINE-WISE — the #2908/#3041 completion probe, premerge-assert's
+# single-block assert, the #3453 annotation census. A multi-line or CR-bearing detail would
+# INJECT rows into the block, and a detail carrying an ESC would put ANSI into a block that
+# gets pasted into PR comments; LF, CR and ESC are all C0, so both routes are closed at this
+# ONE emit boundary rather than trusted of each writer (#3312: neutralise where the value is
+# rendered, not per interpolation site — a per-site escape is a list to keep complete).
+#
+# THE SCOPE IS C0 + DEL, NOT "ALL CONTROL CHARACTERS" (roborev job 107). This opening used to
+# claim "no control characters at all" and that `[:cntrl:]` is "the whole class" — which the
+# note further down then correctly contradicted, in the same comment block. A doc block that
+# argues with itself is worse than either half alone, because a reader cannot tell which
+# sentence was written last. The honest scope is stated here and the C1 residual is explained
+# at the LC_ALL=C pin below.
+#
+# DEFENCE IN DEPTH, stated as such rather than implied: the one writer today (run_file_size)
+# emits fixed wording, a count and a bare filename — no repository PATH and no
+# caller-controlled value — so no REACHABLE input carries a control character at all. This
+# boundary exists so the NEXT writer cannot reintroduce the row-injection route by not
+# thinking about it.
 # NOT BEHAVIOURALLY TESTED ON THIS PLATFORM, and that is DECLARED rather than papered over
 # (roborev job 20, L2). A test was written for this pin and then DELETED: GNU `tr` is
 # byte-wise, so for every input any writer here can produce, `[:cntrl:]` selects the same

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -9932,7 +9932,16 @@ _tree_boundary_row() {
 # That is round 1's boundary finding one emit site over, and the shape recurs because each
 # early-exit emit hand-builds its own meta list. Any emit that can happen AFTER components
 # may have run must carry this.
-_completed_component_rows() {
+_completed_component_rows() { # <row-renderer>
+  # THE RENDERER IS THE CALLER'S CHOICE, and the two callers legitimately differ (roborev
+  # job 76). A funnel-appended row lands in an ORDINARY summary block, where #3453's contract
+  # is that EVERY component line names the feature matrix it ran — so it must render through
+  # `_fm_summary_line`. A BOUNDARY block has never carried that annotation, and forcing it
+  # there would both reshape every boundary block for an unrelated reason and print
+  # `[UNCLASSIFIED — not declared in _fm_component_class]` for the `tree-selftest` hook, which
+  # is a self-test name and not a component at all. So: annotated at the funnel, plain at the
+  # boundary, one traversal.
+  local _render="${1:?_completed_component_rows needs a row renderer}"
   local _c _rf _st _secs _seen=" "
   _CCR_COUNT=0
   for _c in $(_tree_mode_components); do
@@ -9940,7 +9949,7 @@ _completed_component_rows() {
     [ -f "$_rf" ] || continue
     _st=""; _secs=""
     read -r _st _secs < "$_rf" || true
-    _tree_boundary_row "$_c" "$_st" "$_secs"
+    "$_render" "$_c" "$_st" "$_secs"
     _seen="$_seen $_c "
     _CCR_COUNT=$(( _CCR_COUNT + 1 ))
   done
@@ -9950,7 +9959,7 @@ _completed_component_rows() {
     case "$_seen" in *" $_c "*) continue ;; esac
     _st=""; _secs=""
     read -r _st _secs < "$_rf" || true
-    _tree_boundary_row "$_c" "$_st" "$_secs"
+    "$_render" "$_c" "$_st" "$_secs"
     _CCR_COUNT=$(( _CCR_COUNT + 1 ))
   done
 }
@@ -9963,9 +9972,14 @@ _completed_component_rows() {
 # argument, so a captured multi-line block renders as the rows it contains. Empty output is
 # deliberately an EMPTY STRING and the callers guard on it, because a bare "" argument would
 # emit a blank line into the block.
+# _fm_recorded_row <name> <status> <secs>: the funnel's renderer — `_fm_summary_line` with
+# the unit appended, since that helper takes a fully-formed time string while `.result` stores
+# a bare number.
+_fm_recorded_row() { _fm_summary_line "$1" "$2" "${3}s"; }
+
 _recorded_component_rows_block() {
   local _rows _n
-  _rows=$(_completed_component_rows)
+  _rows=$(_completed_component_rows _fm_recorded_row)
   [ -n "$_rows" ] || return 0
   # COUNT THE ROWS THAT WILL PRINT, never `_CCR_COUNT`. The capture above runs in a COMMAND
   # SUBSTITUTION — a subshell — so the count the helper assigns is discarded, and reading it

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6778,14 +6778,29 @@ _fm_annotate() {
 # backgrounded subshell of the bounded pool (#1737) and cannot write the parent's state.
 _status_detail_file() { printf '%s/%s.status-detail' "${LOG_DIR:-}" "$1"; }
 
-# _record_status_detail <component> <text> (#3402): publish that detail. Best-effort by
+# _record_status_detail <component> <trusted> [<untrusted>] (#3402): publish that detail as
+# TWO FIELDS, one per line — because they have different provenance and the reader of the
+# other end has to be able to tell them apart (roborev job 21).
+#   <trusted>    gate-authored text plus numbers this component computed. No repository
+#                content reaches it.
+#   <untrusted>  optional; repository-derived text (today: the grown-FILE PATHS).
+# Withholding used to replace the WHOLE suffix, so a path carrying the completion probe's
+# verdict token also destroyed the COUNT — gate-authored data, provably safe, and the single
+# most useful thing on the row — while a comment two lines up claimed the count was kept.
+# Splitting the fields is #3312's own prescription applied here: when one string carries both
+# your text and someone else's payload, SEPARATE THE CHANNEL rather than escape harder. The
+# boundary can then withhold exactly the untrusted half.
+# Best-effort by
 # design — the detail EXPLAINS a status token, it does not carry the verdict, so a
 # LOG_DIR that cannot take it must not change what the component reports. (The token
 # itself rides `.result`, whose write failure is already handled by the missing-result
 # guard.)
 _record_status_detail() {
   [ -n "${LOG_DIR:-}" ] || return 0
-  printf '%s\n' "$2" 2>/dev/null >"$(_status_detail_file "$1")" || return 0
+  # ALWAYS two lines, even when the untrusted field is empty, so the reader's line 2 means
+  # "the untrusted field" and never "whatever happened to be next".
+  { printf '%s\n' "$2"; printf '%s\n' "${3:-}"; } 2>/dev/null \
+    >"$(_status_detail_file "$1")" || return 0
 }
 
 # _status_detail <component> (#3402): read it back, reduced to ONE line with no control
@@ -6841,13 +6856,20 @@ _status_detail() {
   # change exists to remove, reintroduced by its own guard, and strictly worse than the
   # disclosure it was protecting: a reader cannot tell a rewritten name from a real one.
   #
-  # So the value is WITHHELD WHOLE, loudly, and the reader is sent to the component log — a
-  # truthful degradation instead of a false statement. The row keeps its status token and
-  # its count; only the detail suffix is replaced, by a sentence that says it was withheld
-  # and why. The refusal names NO part of the token it refuses (the reason is described, not
-  # quoted), because a diagnostic reproducing the token it exists to keep off this row would
-  # forge the very row it prevents — the rule this repo already applies to the roborev
-  # waiver markers.
+  # So the offending value is WITHHELD, loudly, and the reader is sent to the component log
+  # — a truthful degradation instead of a false statement.
+  #
+  # WITHHELD AT FIELD GRANULARITY, which is the whole point of the two-field sidecar
+  # (roborev job 21). The first version replaced the ENTIRE suffix, which also destroyed the
+  # COUNT — gate-authored, provably safe, and the most useful thing on the row — while the
+  # comment here claimed the count was kept. That claim was simply false, and the fix is to
+  # make it true rather than to narrow it: a pathological filename now costs the FILE LIST
+  # and nothing else, so the row still discloses that the ratchet was not enforced and over
+  # how many files.
+  #
+  # The refusal names NO part of the token it refuses (the reason is described, not quoted),
+  # because a diagnostic reproducing the token it exists to keep off this row would forge the
+  # very row it prevents — the rule this repo already applies to the roborev waiver markers.
   #
   # THE TRIGGER IS DELIBERATELY BROADER THAN THE PROBE PATTERN. It fires on any `RESULT:`,
   # not only `RESULT: PASS`/`RESULT: FAIL`, because narrowing it would require knowing every
@@ -6855,11 +6877,20 @@ _status_detail() {
   # here (pollers outside this repo read these blocks). The cost of the broad trigger is a
   # withheld detail on a pathological filename; the cost of a narrow one is a forged verdict
   # for a consumer nobody surveyed. Only one of those is recoverable by reading the log.
-  local _sd_v
-  _sd_v=$(head -1 "$f" 2>/dev/null | LC_ALL=C tr -d '[:cntrl:]')
-  case "$_sd_v" in
-    *RESULT:*) printf '%s' "[detail WITHHELD: it contains the completion probe's reserved verdict token (#2908), which on this row would forge a terminal verdict — see the component log]" ;;
-    *)         printf '%s' "$_sd_v" ;;
+  local _sd_t _sd_u
+  _sd_t=$(sed -n '1p' "$f" 2>/dev/null | LC_ALL=C tr -d '[:cntrl:]')
+  _sd_u=$(sed -n '2p' "$f" 2>/dev/null | LC_ALL=C tr -d '[:cntrl:]')
+  # The TRUSTED field is still checked, not assumed: "gate-authored" is a property of
+  # today's four call sites, and a fifth could interpolate something. Its refusal withholds
+  # the whole row detail, because if the trusted half is compromised nothing after it can be
+  # relied on either.
+  case "$_sd_t" in
+    *RESULT:*) printf '%s' "[detail WITHHELD: its gate-authored half carries the completion probe's reserved verdict token (#2908) — see the component log]"; return 0 ;;
+  esac
+  case "$_sd_u" in
+    "")        printf '%s' "$_sd_t" ;;
+    *RESULT:*) printf '%s%s' "$_sd_t" "[WITHHELD: a listed path carries the completion probe's reserved verdict token (#2908), which on this row would forge a terminal verdict — see the component log]" ;;
+    *)         printf '%s%s' "$_sd_t" "$_sd_u" ;;
   esac
 }
 
@@ -17987,8 +18018,12 @@ run_file_size() {
       # (full gate, aggregate_lite_components, run_delta) set OVERALL=FAIL only on an
       # EXACT `FAIL`, so OPT-OUT rides to a PASS RESULT without a special case.
       status=OPT-OUT
+      # The COUNT is gate-authored and goes in the trusted field; only the PATHS are
+      # repository-derived. So a pathological filename costs the file list and nothing else
+      # — the row still discloses that the ratchet was not enforced and over how many files.
       _record_status_detail "$name" \
-        "CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced); ${#grew[@]} over-threshold file(s) grown: $(_fs_abbrev_grown ${grew_paths[@]+"${grew_paths[@]}"})"
+        "CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced); ${#grew[@]} over-threshold file(s) grown: " \
+        "$(_fs_abbrev_grown ${grew_paths[@]+"${grew_paths[@]}"})"
       _fs_emit "$log" ">>> [$name] ${#grew[@]} over-threshold file(s) grew; ALLOWED via CQLITE_ALLOW_FILE_GROWTH=1:"
       for line in ${grew[@]+"${grew[@]}"}; do
         _fs_emit "$log" "      $line"

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1874,6 +1874,11 @@ CANONICAL_FIXTURE_KEYSPACE="test_basic"
 # Stamped into the SUMMARY when the opt-out (AGENT_GATE_ALLOW_MISSING_FIXTURES=1)
 # restores SKIP, so an intentional opt-out is visible in the pasted block.
 MISSING_FIXTURES_MARKER=""
+# #3402/job 74: set to 1 beside every site that BUILDS component rows into a meta array, and
+# read by _emit_meta_lines to decide whether the funnel must append them. Explicit state, so
+# the decision can never be spoofed by a caller-controlled value that happens to look like a
+# row (the defect this replaced). Declared here so it is bound under `set -u` at every emit.
+_SUMMARY_ROWS_BUILT=0
 
 # _missing_fixtures_marker: the machine-checkable OPT-OUT line stamped into the
 # SUMMARY. Single-sourced so the real preflight and the hidden --preflight-fixtures
@@ -9204,14 +9209,29 @@ fi
 # an acknowledged CQLITE_ALLOW_FILE_GROWTH=1 was invisible in whichever block the run
 # actually emitted.
 #
-# SUPPRESSED when the caller already passed rows, so the terminal emits — which build theirs
+# SUPPRESSED when the caller already built rows, so the terminal emits — which build theirs
 # from _fm_summary_line and carry the #3453 feature-matrix annotation — are unchanged rather
-# than doubled. The test is the block's OWN closed row grammar; a caller rendering rows some
-# other way would be a new dialect and a bug on its own terms.
+# than doubled.
+#
+# THE SUPPRESSION SIGNAL IS EXPLICIT STATE, NOT A GREP OF THE RENDERED TEXT (roborev job 74).
+# The first version decided by matching the block's own row grammar against the meta it was
+# about to print — inferring CONTROL from DATA, on a stream that carries caller-controlled
+# values. `datasets: N Data.db files under $CQLITE_DATASETS_ROOT` alone is enough: a root
+# whose name contains a row-shaped line suppresses the genuine rows and hides the very
+# disclosure this issue exists to publish. That is #3312's umbrella lesson committed inside
+# the fix for it, and the ruling there is to REMOVE THE SHARED CHANNEL rather than choose a
+# rarer pattern. `_SUMMARY_ROWS_BUILT` is set beside each row-append, in the same shell, and
+# nothing a caller can name reaches it.
+#
+# DELIBERATELY NOT RESET HERE: emit_summary renders this block up to THREE times (the
+# authoritative file write and both fallback sinks), so a consume-and-clear would make the
+# second and third renderings differ from the first — three sinks disagreeing about one
+# block, which is worse than the leak it would prevent. The flag means "this run's meta
+# arrays carry rows", which does not become false later in the run.
 _emit_meta_lines() {
   local line
   for line in ${@+"$@"}; do echo "$line"; done
-  if ! printf '%s\n' ${@+"$@"} | grep -qE '^[a-z][a-z0-9-]*: +(PASS|FAIL|SKIP|OPT-OUT) \([0-9]+s\)'; then
+  if [ "${_SUMMARY_ROWS_BUILT:-0}" != 1 ]; then
     line=$(_recorded_component_rows_block)
     [ -z "$line" ] || printf '%s\n' "$line"
   fi
@@ -9394,14 +9414,22 @@ _integrity_fail_block() {
   # meta line is dropped, so exactly ONE authoritative line appears no matter which caller
   # supplied the meta (the --lite/--delta terminals push it into SUMMARY_META; the MAIN
   # foreground lane passes none).
+  # #3402/job 74: this block is hand-rolled (it is the no-clobber publish path), so it
+  # BYPASSED _emit_meta_lines and carried no recorded component rows — a `file-size: OPT-OUT`
+  # followed by a foreign-owner detection published a block with the disclosure missing from
+  # the private log, the sibling AND stdout at once. Same class as the boundary and preflight
+  # findings: a hand-built block is a hand-built omission. The filtered lines are collected
+  # and handed to the ONE renderer rather than echoed here.
   local line
+  local -a _ifb_meta=()
   for line in ${@+"$@"}; do
     case "$line" in
       tree-start:*|tree-end:*|tree-integrity:*|tree-hash-cap:*) continue ;;
       component-set:*) continue ;;
     esac
-    echo "$line"
+    _ifb_meta+=("$line")
   done
+  _emit_meta_lines ${_ifb_meta[@]+"${_ifb_meta[@]}"}
   _tree_meta_lines
   printf '%s\n' "$(_component_set_meta)"
   echo "logs: $LOG_DIR"
@@ -10094,6 +10122,11 @@ _tree_boundary_fail() {
   # here, or it would overwrite this block's component-named verdict line.
   local -a _meta=()
   while IFS= read -r _l; do _meta+=("$_l"); done < <(_tree_boundary_meta_lines)
+  # The SECOND row dialect (#3402/job 74). _tree_boundary_meta_lines renders rows through
+  # _tree_boundary_row, not _fm_summary_line, so without this the funnel would append a
+  # duplicate table under a block that already has one. The read loop runs in THIS shell, so
+  # the assignment lands where _emit_meta_lines will see it.
+  _SUMMARY_ROWS_BUILT=1
   _meta+=("detected-after-component: $comp")
   _emit_terminal_summary FAIL "${_meta[@]}" || true
   exit 1
@@ -10394,6 +10427,7 @@ if [ "$SELFTEST" -eq 1 ]; then
   meta+=("$(census_summary_line ${_cen_args[@]+"${_cen_args[@]}"})")
   for i in "${!NAMES[@]}"; do
     meta+=("$(_fm_summary_line "${NAMES[$i]}" "${STATUSES[$i]}" "${TIMES[$i]}")")
+    _SUMMARY_ROWS_BUILT=1   # #3402/job 74: EXPLICIT, never inferred from rendered text
   done
   # #2078: when the opt-out is engaged, drive the visible missing-fixtures marker
   # through the real emit path so the self-test can assert it lands in the block.
@@ -18823,6 +18857,7 @@ run_lite() {
   SUMMARY_META+=("$(census_summary_line ${_cen_args[@]+"${_cen_args[@]}"})")
   for i in "${!NAMES[@]}"; do
     SUMMARY_META+=("$(_fm_summary_line "${NAMES[$i]}" "${STATUSES[$i]}" "${TIMES[$i]}")")
+    _SUMMARY_ROWS_BUILT=1   # #3402/job 74: EXPLICIT, never inferred from rendered text
   done
   # job-2108 MED: --lite/--delta terminals obey the SAME no-clobber contract as the full gate
   # (falls through to emit_summary when no live peer owns the path; forces FAIL + non-zero exit
@@ -19238,6 +19273,7 @@ run_delta() {
     SUMMARY_META+=("$(census_summary_line ${_cen_args[@]+"${_cen_args[@]}"})")
     for i in "${!DN[@]}"; do
       SUMMARY_META+=("$(_fm_summary_line "${DN[$i]}" "${DS[$i]}" "${DT[$i]}")")
+      _SUMMARY_ROWS_BUILT=1   # #3402/job 74: EXPLICIT, never inferred from rendered text
     done
     SUMMARY_META+=("refusal: python tier skipped — cannot re-certify changed bindings/python/tests/* files; run the full gate (scripts/agent-gate.sh)")
     emit_summary "$(_tree_result REFUSED)" "${SUMMARY_META[@]}"
@@ -19292,6 +19328,7 @@ run_delta() {
   SUMMARY_META+=("$(census_summary_line ${_cen_args[@]+"${_cen_args[@]}"})")
   for i in "${!DN[@]}"; do
     SUMMARY_META+=("$(_fm_summary_line "${DN[$i]}" "${DS[$i]}" "${DT[$i]}")")
+    _SUMMARY_ROWS_BUILT=1   # #3402/job 74: EXPLICIT, never inferred from rendered text
   done
   # job-2108 MED: --lite/--delta terminals obey the SAME no-clobber contract as the full gate
   # (falls through to emit_summary when no live peer owns the path; forces FAIL + non-zero exit
@@ -19491,6 +19528,7 @@ if [ "$LITE_AGG_SELFTEST" -eq 1 ]; then
   SUMMARY_META+=("$(census_summary_line ${_cen_args[@]+"${_cen_args[@]}"})")
   for _i in "${!NAMES[@]}"; do
     SUMMARY_META+=("$(_fm_summary_line "${NAMES[$_i]}" "${STATUSES[$_i]}" "${TIMES[$_i]}")")
+    _SUMMARY_ROWS_BUILT=1   # #3402/job 74: EXPLICIT, never inferred from rendered text
   done
   # job-2108 MED: --lite/--delta terminals obey the SAME no-clobber contract as the full gate
   # (falls through to emit_summary when no live peer owns the path; forces FAIL + non-zero exit
@@ -20421,6 +20459,7 @@ fi
 SUMMARY_META+=("$(census_summary_line ${_cen_args[@]+"${_cen_args[@]}"})")
 for i in "${!NAMES[@]}"; do
   SUMMARY_META+=("$(_fm_summary_line "${NAMES[$i]}" "${STATUSES[$i]}" "${TIMES[$i]}")")
+  _SUMMARY_ROWS_BUILT=1   # #3402/job 74: EXPLICIT, never inferred from rendered text
 done
 # #1465: node-bindings' leak lane is skippable under the #2078 opt-out, so the block states
 # which of RAN / SKIPPED / NOT-RUN happened. Absent file = the component was not selected,

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6789,16 +6789,22 @@ _record_status_detail() {
 }
 
 # _status_detail <component> (#3402): read it back, reduced to ONE line with no control
-# characters. This value is interpolated into the SUMMARY block, and every reader of that
-# block parses it LINE-WISE — the #2908/#3041 completion probe, premerge-assert's
+# characters at all. This value is interpolated into the SUMMARY block, and every reader
+# of that block parses it LINE-WISE — the #2908/#3041 completion probe, premerge-assert's
 # single-block assert, the #3453 annotation census. A multi-line or CR-bearing detail
-# would INJECT rows into the block, so the reduction happens at this ONE boundary rather
-# than being trusted of each writer (#3312: neutralise at the emit boundary, not per site).
+# would INJECT rows into the block, and a detail carrying an ESC would put ANSI into a
+# block that gets pasted into PR comments, so BOTH are removed at this ONE emit boundary
+# rather than trusted of each writer (#3312: neutralise where the value is rendered, not
+# per interpolation site — a per-site escape is a list to keep complete). `[:cntrl:]` is
+# the whole class, deliberately, so a control character nobody enumerated is covered too.
+# LENGTH is NOT capped here: a cap would be a SILENT truncation of a disclosure, which is
+# the defect this issue removes — bounding the value is the WRITER's job (see
+# _fs_abbrev_grown, which elides by a NAMED remainder).
 _status_detail() {
   local f
   f=$(_status_detail_file "$1")
   [ -n "${LOG_DIR:-}" ] && [ -s "$f" ] || return 0
-  head -1 "$f" 2>/dev/null | tr -d '\r\n\t'
+  head -1 "$f" 2>/dev/null | tr -d '[:cntrl:]'
 }
 
 # _fm_summary_line <name> <status> <time>: the ONE renderer for a SUMMARY component

--- a/scripts/tests/test_agent_gate_census.sh
+++ b/scripts/tests/test_agent_gate_census.sh
@@ -1406,10 +1406,17 @@ else
 fi
 # …and the two suites that carry the component-row patterns must positively RECOGNISE a
 # VACUOUS row, not merely have had the literal edited.
+# VACUOUS must be PRESENT in the alternation, not LAST in it (#3402). These needles pinned
+# `VACUOUS)` — the token immediately followed by the group's close — which asserts a token
+# ORDER rather than the property R3 is about, and so reds on a correct EXTENSION of the
+# vocabulary. #3402 added OPT-OUT in the same window this guard landed, making the recognisers
+# read `(PASS|FAIL|SKIP|VACUOUS|OPT-OUT)`: still recognising VACUOUS, still correct, and
+# invisible to a needle anchored on `VACUOUS)`. A guard that reds on correct input is the
+# guard agents learn to waive, so it asks for membership and lets the set grow.
 r_missing=()
-grep -qE 'PASS\|FAIL\|SKIP\|VACUOUS\) \\\(\[0-9\]\+s' "$REPO_ROOT/scripts/tests/test_agent_gate_tree_provenance.sh" \
+grep -qE 'PASS\|FAIL\|SKIP\|[A-Z|-]*VACUOUS[A-Z|-]*\) \\\(\[0-9\]\+s' "$REPO_ROOT/scripts/tests/test_agent_gate_tree_provenance.sh" \
   || r_missing+=("tree-provenance-boundary-row-count")
-grep -qE 'PASS\|FAIL\|SKIP\|VACUOUS\)\.\*\\\[\(UNDECLARED' "$REPO_ROOT/scripts/tests/test_agent_gate_summary.sh" \
+grep -qE 'PASS\|FAIL\|SKIP\|[A-Z|-]*VACUOUS[A-Z|-]*\)\.\*\\\[\(UNDECLARED' "$REPO_ROOT/scripts/tests/test_agent_gate_summary.sh" \
   || r_missing+=("summary-3453-annot-b-undeclared-screen")
 if [ "${#r_missing[@]}" -eq 0 ]; then
   ok "R3: the boundary row count and the UNDECLARED screen both recognise a VACUOUS component row"

--- a/scripts/tests/test_agent_gate_feature_matrix_annotation.sh
+++ b/scripts/tests/test_agent_gate_feature_matrix_annotation.sh
@@ -728,8 +728,11 @@ if AGENT_GATE_SUMMARY_FILE="$selftest_sum" bash "$GATE" --emit-summary-selftest 
     case "$line" in
       *'[UNDECLARED]'*|*UNCLASSIFIED*) missing+=("$line") ;;
     esac
-  done < <(grep -E '^(fmt|clippy|core-tests|smoke): +(PASS|FAIL|SKIP|VACUOUS)' "$selftest_sum")
-  n_annot=$(grep -cE '^(fmt|clippy|core-tests|smoke): +(PASS|FAIL|SKIP|VACUOUS) \([0-9]+s\)  \[.+\]' "$selftest_sum")
+  # FIVE tokens: #3625 added VACUOUS and #3402 added OPT-OUT, independently, on the same
+  # reasoning — a hard-coded subset stops SEEING the rows it does not name. The union is the
+  # vocabulary; neither issue's token may be dropped when the other lands.
+  done < <(grep -E '^(fmt|clippy|core-tests|smoke): +(PASS|FAIL|SKIP|VACUOUS|OPT-OUT)' "$selftest_sum")
+  n_annot=$(grep -cE '^(fmt|clippy|core-tests|smoke): +(PASS|FAIL|SKIP|VACUOUS|OPT-OUT) \([0-9]+s\)  \[.+\]' "$selftest_sum")
   if [ "$n_annot" -eq 4 ] && [ "${#missing[@]}" -eq 0 ]; then
     ok "B4: --emit-summary-selftest emits 4 annotated component lines, none UNDECLARED"
   else
@@ -891,7 +894,13 @@ run_differential() { # <component> <mode EXACT|CONTAINS> [why-not-exact] [shim-d
   PATH="$use_shim:$PATH" \
     bash "$GATE" --only "$c" > "$log" 2>&1
   local line ann
-  line=$(grep -E "^$c: +(PASS|FAIL|SKIP|VACUOUS)" "$sum" 2>/dev/null | head -1)
+  # The component-status token SET, not a subset (#3625's VACUOUS + #3402's OPT-OUT). Stated
+  # precisely rather than overclaimed: `file-size` is class `no-cargo`, so this loop — which
+  # iterates cargo-class components only — cannot reach an OPT-OUT row TODAY. The tokens are
+  # read here because this grep decides "no component line emitted" (a `bad`), and a
+  # name-keyed reader that knows a SUBSET answers that question wrongly the day the set grows
+  # again — which it just did, twice, from two issues at once.
+  line=$(grep -E "^$c: +(PASS|FAIL|SKIP|VACUOUS|OPT-OUT)" "$sum" 2>/dev/null | head -1)
   if [ -z "$line" ]; then
     bad "C-$c$tag: no '$c:' component line in the emitted block"
     return
@@ -1330,7 +1339,7 @@ for c in "${e2_cargo[@]+"${e2_cargo[@]}"}"; do
   AGENT_GATE_ALLOW_MISSING_FIXTURES=1 \
   PATH="$shim_dir:$PATH" \
     bash "$GATE" --only "$c" > "$e2_log" 2>&1
-  e2_line=$(grep -E "^$c: +(PASS|FAIL|SKIP|VACUOUS)" "$e2_sum" 2>/dev/null | head -1)
+  e2_line=$(grep -E "^$c: +(PASS|FAIL|SKIP|VACUOUS|OPT-OUT)" "$e2_sum" 2>/dev/null | head -1)
   if [ -z "$e2_line" ]; then e2_missing+=("$c"); continue; fi
   e2_ran=$((e2_ran + 1))
   e2_ann=${e2_line#*\[}; e2_ann="[$e2_ann"

--- a/scripts/tests/test_agent_gate_file_size_log.sh
+++ b/scripts/tests/test_agent_gate_file_size_log.sh
@@ -997,10 +997,24 @@ STUB
       "$sumrow11" '^file-size: +FAIL \([0-9]+s\)'
   has "case11 (#3402): the row says the failure is LOG PERSISTENCE, not the ratchet" \
       "$sumrow11" "LOG PERSISTENCE FAILURE, not a ratchet violation"
-  has "case11 (#3402): the row STILL names the ratchet's own state, so the opt-out is disclosed" \
-      "$sumrow11" "the ratchet itself computed OPT-OUT"
-  lacks "case11 (#3402): the row does NOT present the opt-out as the reason for the FAIL" \
-      "$sumrow11" "(ratchet NOT enforced)"
+  # THE DISCLOSURE ITSELF, not merely the token (roborev job 104). This is the one state where
+  # the override name and the grown count can vanish from EVERY reachable artifact at once:
+  # the log that would hold them is what failed to persist, and the sibling may be unwritable
+  # too. Naming only "computed OPT-OUT" told a reader the ratchet produced a token, not that
+  # it was switched off nor over how many files.
+  has "case11 (#3402): the row says the ratchet was OPTED OUT OF, not merely what it computed" \
+      "$sumrow11" "the ratchet was OPTED OUT OF: CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced)"
+  has "case11 (#3402): the row RETAINS the grown count through a persistence failure" \
+      "$sumrow11" "1 over-threshold file(s) grown"
+  # ORDERING, not absence (roborev job 104). This assert used to be a `lacks` on the opt-out
+  # branch's literal bytes, standing in for "the row does not blame the opt-out for the FAIL".
+  # That proxy broke the moment the persistence arm legitimately RETAINED those bytes — and a
+  # proxy that forbids the correct output is worse than no assert, because the obvious way to
+  # green it is to delete the disclosure. The property actually wanted is that the persistence
+  # cause LEADS: a reader must not be able to read the opt-out as the reason for the failure.
+  # An ordered pattern says exactly that and is compatible with retaining the disclosure.
+  has_re "case11 (#3402): the persistence cause LEADS the detail — the opt-out is not the reason for the FAIL" \
+      "$sumrow11" 'LOG PERSISTENCE FAILURE, not a ratchet violation .*the ratchet was OPTED OUT OF'
 
   # -------------------------------------------------------------------------
   # Case 13 — CQLITE_ALLOW_FILE_GROWTH set to a NON-1 value (#3401 review item 3). The
@@ -1089,7 +1103,7 @@ printf 'file-size component log + opt-out marker guard (#3401/#3402): %d passed,
 # the first value written here was WRONG (109, guessed from the number of asserts typed
 # rather than counted from a run: `fs_summary_row || bad` contributes nothing unless it
 # fires).
-EXPECTED_CHECKS=112
+EXPECTED_CHECKS=113
 if [ "$((PASS + FAIL + SKIP))" -ne "$EXPECTED_CHECKS" ]; then
   printf 'FAIL - assertion census mismatch: %d checks ran (%d ok / %d fail / %d skip), expected exactly %d.\n' \
     "$((PASS + FAIL + SKIP))" "$PASS" "$FAIL" "$SKIP" "$EXPECTED_CHECKS"

--- a/scripts/tests/test_agent_gate_file_size_log.sh
+++ b/scripts/tests/test_agent_gate_file_size_log.sh
@@ -619,6 +619,12 @@ else
   # The mutant: stop the EMIT FUNNEL appending the table, which is the state before this fix.
   # The block still emits, so only the row can distinguish the two.
   #
+  # WRITE-AND-MOVE, never `sed -i` (roborev job 74): `sed -i EXPR FILE` is GNU-only — BSD and
+  # macOS sed require an argument to -i (`sed -i '' EXPR FILE`), so the GNU spelling makes
+  # this REGISTERED gate test fail on a platform the repo supports, and
+  # scripts/tests/test_agent_gate_tree_portability.sh lints for exactly this shape. The
+  # temp-file form needs no version sniff and is unambiguous on both.
+  #
   # THE GUARD ASSERTS THE MUTATION CHANGED SOMETHING, not that a pattern is now absent. The
   # first version sed'd `${_pf_rows:+…}` — the per-site wiring this fix REPLACED — and then
   # checked that pattern was gone, which is trivially true of a file that never contained it.
@@ -628,7 +634,9 @@ else
   pf_mut="$tmp/preflight-mutant"
   if cp -r "$pf_root" "$pf_mut" 2>/dev/null &&
      grep -q 'line=$(_recorded_component_rows_block)' "$pf_mut/scripts/agent-gate.sh" &&
-     sed -i 's/^\( *\)line=$(_recorded_component_rows_block)$/\1line=""/' "$pf_mut/scripts/agent-gate.sh" &&
+     sed 's/^\( *\)line=$(_recorded_component_rows_block)$/\1line=""/' \
+         "$pf_mut/scripts/agent-gate.sh" > "$pf_mut/scripts/agent-gate.sh.mut" &&
+     mv "$pf_mut/scripts/agent-gate.sh.mut" "$pf_mut/scripts/agent-gate.sh" &&
      ! cmp -s "$pf_root/scripts/agent-gate.sh" "$pf_mut/scripts/agent-gate.sh"; then
     pf_msum="$tmp/preflight-mutant.sum"
     ( cd "$pf_mut" && env -u AGENT_GATE_SUMMARY_FILE CQLITE_DATASETS_ROOT="${pf_empty%/sstables}" \

--- a/scripts/tests/test_agent_gate_file_size_log.sh
+++ b/scripts/tests/test_agent_gate_file_size_log.sh
@@ -536,6 +536,71 @@ for bad_val in 0 true; do
 done
 
 # ---------------------------------------------------------------------------
+# Case 4e (#3402, roborev round 1 L3) — a grown path CONTAINING THE `: ` that the abbreviator
+# used to split on. `_fs_abbrev_grown` took the formatted `path: before -> after (limit N)`
+# entries and recovered the path with `${e%%: *}`, so `we: ird.rs` was truncated to `we` and
+# the SUMMARY NAMED A FILE THAT DOES NOT EXIST — worse than eliding it, because the reader
+# has no way to tell a real name from a mangled one. Fixed by CARRYING the path instead of
+# re-deriving it from a display string.
+#
+# The second needle is END-ANCHORED, and that is the whole of its value. A `lacks` on the
+# truncated stem CANNOT FAIL here: with one grown file the buggy render ends at
+# `…/src/we`, which is a PREFIX of the correct `…/src/we: ird.rs`, so any needle matching
+# the bug also matches the fix (or, with a trailing comma appended to dodge that, matches
+# neither). Anchoring on `$` states the property that actually distinguishes them — the
+# full name is the LAST thing on the line, so nothing was silently dropped after the split
+# point.
+# ---------------------------------------------------------------------------
+mkrepo colonpath 'cqlite-core/src/we: ird.rs' 900 950 main; r4e="$REPO"
+out4e="$tmp/colonpath.out"
+run_only_file_size "$r4e" "$out4e" CQLITE_ALLOW_FILE_GROWTH=1
+d4e=$(logdir_of "$out4e") || bad "case4e: the run published no usable 'logs:' dir"
+sumrow4e="$tmp/colonpath.sumrow"
+fs_summary_row "$r4e/.sum" "$sumrow4e" ||
+  bad "case4e (#3402): the run emitted no usable file-size row — the L3 asserts are UNMEASURED"
+assert_verdict "case4e: a delimiter-bearing grown path is still an OPT-OUT" "$d4e" OPT-OUT
+has "case4e (#3402): the row names the delimiter-bearing path IN FULL" \
+    "$sumrow4e" "cqlite-core/src/we: ird.rs"
+has_re "case4e (#3402): the path is the FINAL field — not a stem with the remainder lost" \
+    "$sumrow4e" 'grown: cqlite-core/src/we: ird\.rs$'
+
+# ---------------------------------------------------------------------------
+# Case 4f (#3402, roborev round 1 L2) — the row must not depend on the caller's LOCALE.
+# `_status_detail` reduces the value with `tr -d '[:cntrl:]'`, and `[:cntrl:]` is evaluated
+# in the CURRENT locale, so an unpinned `tr` made this emit boundary's behaviour a property
+# of the invoker's environment rather than of the code. `LC_ALL=C` is pinned AT the call;
+# this case measures the resulting property directly — the SAME fixture rendered under a C
+# and a UTF-8 locale must produce a BYTE-IDENTICAL row.
+# A UTF-8 locale is not guaranteed to be generated on every host, so its half is a DECLARED
+# skip rather than a silent pass (one skip per skipped assert, the case-8 convention).
+# ---------------------------------------------------------------------------
+mkrepo localec cqlite-core/src/big.rs 900 950 main; r4f="$REPO"
+out4f="$tmp/locale-c.out"
+run_only_file_size "$r4f" "$out4f" CQLITE_ALLOW_FILE_GROWTH=1 LC_ALL=C
+sumrow4f_c="$tmp/locale-c.sumrow"
+fs_summary_row "$r4f/.sum" "$sumrow4f_c" ||
+  bad "case4f (#3402): no file-size row under LC_ALL=C — the locale comparison is UNMEASURED"
+has "case4f (#3402): under LC_ALL=C the row still carries the full detail" \
+    "$sumrow4f_c" "CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced)"
+fs_utf8=$(locale -a 2>/dev/null | grep -im1 -E '^(C|en_US)\.utf-?8$' || true)
+if [ -z "$fs_utf8" ]; then
+  skip "case4f: no UTF-8 locale generated on this host — the cross-locale comparison not run"
+else
+  mkrepo localeu cqlite-core/src/big.rs 900 950 main; r4g="$REPO"
+  out4g="$tmp/locale-u.out"
+  run_only_file_size "$r4g" "$out4g" CQLITE_ALLOW_FILE_GROWTH=1 LC_ALL="$fs_utf8"
+  sumrow4f_u="$tmp/locale-u.sumrow"
+  fs_summary_row "$r4g/.sum" "$sumrow4f_u" ||
+    bad "case4f (#3402): no file-size row under $fs_utf8 — the locale comparison is UNMEASURED"
+  if [ -s "$sumrow4f_c" ] && [ -s "$sumrow4f_u" ] && cmp -s "$sumrow4f_c" "$sumrow4f_u"; then
+    ok "case4f (#3402): the row is BYTE-IDENTICAL under LC_ALL=C and $fs_utf8"
+  else
+    bad "case4f (#3402): the row DIFFERS between LC_ALL=C and $fs_utf8 — the reduction is locale-dependent"
+    diff "$sumrow4f_c" "$sumrow4f_u" 2>/dev/null | head -4
+  fi
+fi
+
+# ---------------------------------------------------------------------------
 # Case 5 — base ref UNRESOLVABLE (no main/master, no origin/*): the ratchet is skipped and
 # the log must say so EXPLICITLY, while the advisory list still works off `git diff HEAD`.
 # ---------------------------------------------------------------------------
@@ -959,7 +1024,10 @@ printf 'file-size component log + opt-out marker guard (#3401/#3402): %d passed,
 # misattributing one as the other.
 # 99 -> 107 on #3402's C1 fix: +2 case9, +2 case10, +4 case11, all unconditional (the
 # FS_SABOTAGE=dir shape is uid-independent and needs no /dev/full, so none can self-skip).
-EXPECTED_CHECKS=107
+# 107 -> 112 on roborev round 1: +3 case4e (L3, delimiter-bearing path) and +2 case4f
+# (L2, locale independence — its second assert is a DECLARED skip on a host with no
+# UTF-8 locale, so the census total is the same either way).
+EXPECTED_CHECKS=112
 if [ "$((PASS + FAIL + SKIP))" -ne "$EXPECTED_CHECKS" ]; then
   printf 'FAIL - assertion census mismatch: %d checks ran (%d ok / %d fail / %d skip), expected exactly %d.\n' \
     "$((PASS + FAIL + SKIP))" "$PASS" "$FAIL" "$SKIP" "$EXPECTED_CHECKS"

--- a/scripts/tests/test_agent_gate_file_size_log.sh
+++ b/scripts/tests/test_agent_gate_file_size_log.sh
@@ -8,7 +8,7 @@
 # could not be told apart from a run where the ratchet was genuinely satisfied. The
 # component now reports its own NON-FAILING `OPT-OUT` token carrying the env var, the
 # count and the grown file names inline. The property that matters most here is the
-# NEGATIVE one (cases 4c/4d): `OPT-OUT` may be emitted ONLY for the affirmative value `1`,
+# NEGATIVE one (case 4c): `OPT-OUT` may be emitted ONLY for the affirmative value `1`,
 # because a permissive branch keyed on `!= <bad>` would let a typo waive the ratchet.
 #
 # The #3401 defect: run_file_size computed the base ref, the over-threshold advisory list and
@@ -35,7 +35,8 @@
 #   4. grown + CQLITE_ALLOW_FILE_GROWTH=1 -> OPT-OUT (the opt-out is RECORDED, and — since
 #      #3402 — VISIBLE in the SUMMARY block, not only in this log)
 #   4b. #3402: four grown files -> the SUMMARY's file list ELIDES with a named remainder
-#   4c/4d. #3402: a MALFORMED override (`0`, `true`) -> still a ratchet FAIL, never OPT-OUT
+#   4c. #3402: a MALFORMED override, run for BOTH spellings (`0` and `true`) -> still a
+#       ratchet FAIL, never OPT-OUT
 #   5. base ref unresolvable              -> PASS (advisory only, ratchet skipped)
 #   6. AC2: the FAIL stdout NAMES $LOG_DIR/file-size.log, so it is reachable from the
 #      SUMMARY's existing `logs:` line without the reader guessing a filename.
@@ -501,7 +502,7 @@ has "case4b (#3402): the SUMMARY row NAMES the elided remainder rather than trun
     "$sumrow4b" ",+1 more"
 
 # ---------------------------------------------------------------------------
-# Cases 4c/4d (#3402) — THE FALSE-PASS ROUTE, and the reason the emit is keyed on the
+# Case 4c (#3402), run for BOTH malformed spellings — THE FALSE-PASS ROUTE, and the reason the emit is keyed on the
 # AFFIRMATIVE `= 1`. `CQLITE_ALLOW_FILE_GROWTH` has THREE states, not two: exactly `1`
 # (engaged), SET BUT NOT 1 (`0`, `true`, `yes` — a typo, and already reported as "this IS
 # a ratchet violation"), and unset. A permissive branch keyed on `!= <bad>` would let the
@@ -772,6 +773,16 @@ STUB
   else
     ok "case9: the combined failure does NOT disclaim the real ratchet violation"
   fi
+  # #3402: the same non-disclaimer, on the SUMMARY ROW. stdout is gate.log, which agents are
+  # told never to read — the row is the artifact a reader actually sees, so the property has
+  # to hold there too or it holds only where nobody looks.
+  sumrow9="$tmp/bothfail.sumrow"
+  fs_summary_row "$r9/.sum" "$sumrow9" ||
+    bad "case9 (#3402): the run emitted no usable file-size row — the SUMMARY asserts are UNMEASURED"
+  has "case9 (#3402): the row reports BOTH failures, not persistence alone" \
+      "$sumrow9" "TWO failures: a REAL size-ratchet violation AND a log-persistence failure"
+  lacks "case9 (#3402): the row does NOT disclaim the real ratchet violation" \
+      "$sumrow9" "not a ratchet violation"
 
   # -------------------------------------------------------------------------
   # Case 10 — persistence failure on a NO-BASE run (#3401 review L1). With no resolvable
@@ -800,6 +811,16 @@ STUB
   else
     ok "case10: claims no ratchet verdict for a run that never computed one"
   fi
+  # #3402: and the ROW must not claim it either. `ratchet_verdict` is PASS on this path
+  # (nothing ever set it otherwise), so an arm that simply interpolated it would assert a
+  # comparison that never ran — #3401 review L1, one artifact over.
+  sumrow10="$tmp/nobasepersist.sumrow"
+  fs_summary_row "$r10/.sum" "$sumrow10" ||
+    bad "case10 (#3402): the run emitted no usable file-size row — the SUMMARY asserts are UNMEASURED"
+  has "case10 (#3402): the row says the ratchet was SKIPPED, so nothing was compared" \
+      "$sumrow10" "the ratchet was SKIPPED (base ref unavailable), so nothing was compared"
+  lacks "case10 (#3402): the row claims NO computed ratchet verdict" \
+      "$sumrow10" "the ratchet itself computed"
 
   # -------------------------------------------------------------------------
   # Case 11 — the sibling must carry the SAME arithmetic in EVERY ratchet state (#3401
@@ -837,6 +858,27 @@ STUB
   # instead, so it cannot be satisfied from any other state.
   has "case11: CONTROL — the sibling records the allowance as the reason the ratchet passed" \
       "$sib11" "growth allowance: ALLOWED via CQLITE_ALLOW_FILE_GROWTH=1"
+  # #3402 — THE REPRODUCED DEFECT. The opt-out branch stamps the status detail, then the
+  # persistence block turns the token into FAIL, so before the fix this row read
+  #   file-size: FAIL (0s)  [no-cargo] — CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced);
+  #   1 over-threshold file(s) grown: cqlite-core/src/big.rs
+  # — a FAIL whose entire detail describes an opt-out that is NOT why it failed, sending the
+  # reader to look for a growth violation that the gate had in fact ALLOWED. Measured on the
+  # real gate, not reasoned about. The four needles are complementary and none is satisfiable
+  # from another state: the FAIL token (persistence), the persistence wording, the ratchet's
+  # OWN state preserved (so the opt-out is disclosed, not merely suppressed), and the ABSENCE
+  # of the opt-out branch's own phrasing, which is the exact bytes that used to leak here.
+  sumrow11="$tmp/optoutpersist.sumrow"
+  fs_summary_row "$r11/.sum" "$sumrow11" ||
+    bad "case11 (#3402): the run emitted no usable file-size row — the SUMMARY asserts are UNMEASURED"
+  has_re "case11 (#3402): the row's TOKEN is FAIL — a persistence failure IS a component failure" \
+      "$sumrow11" '^file-size: +FAIL \([0-9]+s\)'
+  has "case11 (#3402): the row says the failure is LOG PERSISTENCE, not the ratchet" \
+      "$sumrow11" "LOG PERSISTENCE FAILURE, not a ratchet violation"
+  has "case11 (#3402): the row STILL names the ratchet's own state, so the opt-out is disclosed" \
+      "$sumrow11" "the ratchet itself computed OPT-OUT"
+  lacks "case11 (#3402): the row does NOT present the opt-out as the reason for the FAIL" \
+      "$sumrow11" "(ratchet NOT enforced)"
 
   # -------------------------------------------------------------------------
   # Case 13 — CQLITE_ALLOW_FILE_GROWTH set to a NON-1 value (#3401 review item 3). The
@@ -915,7 +957,9 @@ printf 'file-size component log + opt-out marker guard (#3401/#3402): %d passed,
 # precondition failure (an unusable repo, a missing mktemp) short-circuits its case's
 # remaining asserts and lands here too, so the message names both causes rather than
 # misattributing one as the other.
-EXPECTED_CHECKS=99
+# 99 -> 107 on #3402's C1 fix: +2 case9, +2 case10, +4 case11, all unconditional (the
+# FS_SABOTAGE=dir shape is uid-independent and needs no /dev/full, so none can self-skip).
+EXPECTED_CHECKS=107
 if [ "$((PASS + FAIL + SKIP))" -ne "$EXPECTED_CHECKS" ]; then
   printf 'FAIL - assertion census mismatch: %d checks ran (%d ok / %d fail / %d skip), expected exactly %d.\n' \
     "$((PASS + FAIL + SKIP))" "$PASS" "$FAIL" "$SKIP" "$EXPECTED_CHECKS"

--- a/scripts/tests/test_agent_gate_file_size_log.sh
+++ b/scripts/tests/test_agent_gate_file_size_log.sh
@@ -594,7 +594,16 @@ fs_summary_row "$r4g/.sum" "$sumrow4g" ||
   bad "case4g (#3402): the run emitted no usable file-size row — the L1 asserts are UNMEASURED"
 assert_verdict "case4g: a verdict-token-bearing grown path is still an OPT-OUT" "$d4g" OPT-OUT
 has "case4g (#3402): the row NAMES the withholding instead of rendering a rewritten path" \
-    "$sumrow4g" "detail WITHHELD"
+    "$sumrow4g" "WITHHELD"
+# The two-field split (roborev job 21): withholding must cost the FILE LIST and nothing
+# else. The first version replaced the whole suffix and so destroyed the COUNT — which is
+# gate-authored, provably safe, and the most useful thing left on the row — while claiming
+# in a comment that the count was kept. These two needles are what make that claim testable
+# rather than asserted.
+has "case4g (#3402): the COUNT survives the withholding (only the path list is dropped)" \
+    "$sumrow4g" "1 over-threshold file(s) grown"
+has "case4g (#3402): the engaged env var survives the withholding" \
+    "$sumrow4g" "CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced)"
 lacks "case4g (#3402): the row carries NO rewritten spelling of the real filename" \
     "$sumrow4g" "redacted-token"
 if [ ! -s "$sumrow4g" ]; then
@@ -1029,10 +1038,12 @@ printf 'file-size component log + opt-out marker guard (#3401/#3402): %d passed,
 # misattributing one as the other.
 # 99 -> 107 on #3402's C1 fix: +2 case9, +2 case10, +4 case11, all unconditional (the
 # FS_SABOTAGE=dir shape is uid-independent and needs no /dev/full, so none can self-skip).
-# 107 -> 112 on roborev round 1 (+3 case4e, +2 case4f), then 112 -> 114 on job 19/20:
-# case4f DELETED (-2: it could not fail and could flake — see case4g's note) and case4g
-# ADDED (+4). Every case4g assert is unconditional: no /dev/full, no locale, no network.
-EXPECTED_CHECKS=114
+# 107 -> 112 on roborev round 1 (+3 case4e, +2 case4f); 112 -> 114 on jobs 19/20 (case4f
+# DELETED -2, it could not fail and could flake — see case4g's note; case4g ADDED +4);
+# 114 -> 116 on job 21 (+2 case4g: the COUNT and the env var must survive a withholding,
+# which is the claim that job 21 found false). All unconditional: no /dev/full, no locale,
+# no network.
+EXPECTED_CHECKS=116
 if [ "$((PASS + FAIL + SKIP))" -ne "$EXPECTED_CHECKS" ]; then
   printf 'FAIL - assertion census mismatch: %d checks ran (%d ok / %d fail / %d skip), expected exactly %d.\n' \
     "$((PASS + FAIL + SKIP))" "$PASS" "$FAIL" "$SKIP" "$EXPECTED_CHECKS"

--- a/scripts/tests/test_agent_gate_file_size_log.sh
+++ b/scripts/tests/test_agent_gate_file_size_log.sh
@@ -443,8 +443,19 @@ lacks "case4 (#3402): the row renders NO repository path — the whole mangling 
     "$sumrow4" "cqlite-core/src/big.rs"
 has "case4 (#3402): the row keeps its feature-matrix annotation ahead of the detail" \
     "$sumrow4" "[no-cargo]"
-lacks "case4 (#3402): the row does not ALSO read PASS — a reader greps one token, not two" \
-    "$sumrow4" "PASS"
+# ANCHORED ON THE TOKEN POSITION, not on the substring (#3625 interaction). A bare
+# `lacks "PASS"` began matching the census suffix's own wording — `{no census: component
+# ended OPT-OUT, so there is no PASS to affirm}` — so it reported the row "ALSO reads PASS"
+# on a perfectly correct line. The property wanted is that the STATUS FIELD is not PASS, and
+# only a position-anchored pattern says that; a substring test over a line that now carries
+# three suffixes was always going to collide with one of them eventually.
+if [ ! -s "$sumrow4" ]; then
+  bad "case4 (#3402): no file-size row captured — the token check could not run"
+elif grep -qE '^file-size: +PASS ' "$sumrow4"; then
+  bad "case4 (#3402): the row's STATUS FIELD reads PASS — a reader greps one token, not two"
+else
+  ok "case4 (#3402): the row's STATUS FIELD is not PASS — a reader greps one token, not two"
+fi
 # NON-FAILING, measured through the gate's own verdict rather than asserted of the source.
 # In `--only` mode a passing run is promoted to RESULT: PARTIAL and exits 3, while any
 # component FAIL leaves RESULT: FAIL and exit 1 — so this pair distinguishes exactly the
@@ -611,8 +622,12 @@ else
   # it would satisfy "the disclosure is present" while losing the execution evidence beside
   # it — and the first version of this assert PINNED that incomplete shape, which is how a
   # test stops being a check and starts being a ratchet on a defect.
-  has "case4i (#3402): the preflight-FAIL block carries the OPT-OUT row with its detail" \
-      "$pf_sum" "OPT-OUT (0s)  [no-cargo] — CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced); 1 over-threshold file(s) grown"
+  # The row's tail is `[<matrix>]  {<census>} — <detail>` after #3625 landed its census
+  # suffix, so matrix and detail are no longer adjacent. Asserted as an ORDERED pattern rather
+  # than a literal: the three suffixes must appear in that order, and a future fourth cannot
+  # silently displace the disclosure without this failing.
+  has_re "case4i (#3402): the preflight-FAIL block carries the OPT-OUT row, its matrix and its detail" \
+      "$pf_sum" '^file-size: +OPT-OUT \(0s\)  \[no-cargo\].*CQLITE_ALLOW_FILE_GROWTH=1 \(ratchet NOT enforced\); 1 over-threshold file\(s\) grown'
   # The count must AGREE with the rows printed. It did not: the helper assigns its count
   # inside a command substitution, so the caller read 0 beside one row — a count
   # contradicting its own table, which is the invariant

--- a/scripts/tests/test_agent_gate_file_size_log.sh
+++ b/scripts/tests/test_agent_gate_file_size_log.sh
@@ -429,7 +429,7 @@ has "case4 (#3402): the SUMMARY row gives the COUNT of grown files" \
 # What it must carry instead is a pointer to where the names DO live, plus — asserted from
 # the other side — proof that no path leaked onto it.
 has "case4 (#3402): the SUMMARY row POINTS AT the component log for the file list" \
-    "$sumrow4" "file-size.log"
+    "$sumrow4" "see file-size.log under logs:"
 lacks "case4 (#3402): the row renders NO repository path — the whole mangling family is unreachable" \
     "$sumrow4" "cqlite-core/src/big.rs"
 has "case4 (#3402): the row keeps its feature-matrix annotation ahead of the detail" \
@@ -468,6 +468,44 @@ has "case4 (#3402): the block's RESULT is the passing PARTIAL, not FAIL" \
 # actually specified. The names live in the log (#3401's whole subject) and, for a PR
 # reviewer, in the diff itself — the grown files are the files the PR changed.
 # ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Case 4h (#3402, roborev job 25) — the detail must carry NOTHING from the environment.
+# `$LOG_DIR` is `mktemp -d "${TMPDIR:-/tmp}/agent-gate.XXXXXX"`, so interpolating any path
+# under it put CALLER-CONTROLLED text into a field whose contract says gate-authored — and a
+# TMPDIR containing the completion probe's verdict token then tripped the withholding guard,
+# taking the override name and the growth count with it. Exactly the disclosure this issue
+# exists to produce, destroyed by an environment variable.
+#
+# The fixture IS the hostile TMPDIR: a directory literally named `RESULT: PASS`, which is a
+# legal directory name and reaches LOG_DIR by the ordinary route. The needles assert the
+# disclosure SURVIVES it, and that no part of the path rode onto the row.
+# ---------------------------------------------------------------------------
+hostile_tmp="$tmp/RESULT: PASS"
+if ! mkdir -p "$hostile_tmp" 2>/dev/null; then
+  bad "case4h: could not create the hostile TMPDIR fixture — the environment route is UNMEASURED"
+  bad "case4h: (env-var needle not reached)"
+  bad "case4h: (count needle not reached)"
+  bad "case4h: (forged-verdict needle not reached)"
+else
+  mkrepo hostiletmp cqlite-core/src/big.rs 900 950 main; r4h="$REPO"
+  out4h="$tmp/hostiletmp.out"
+  run_only_file_size "$r4h" "$out4h" CQLITE_ALLOW_FILE_GROWTH=1 TMPDIR="$hostile_tmp"
+  sumrow4h="$tmp/hostiletmp.sumrow"
+  fs_summary_row "$r4h/.sum" "$sumrow4h" ||
+    bad "case4h (#3402): the run emitted no usable file-size row — the TMPDIR asserts are UNMEASURED"
+  has "case4h (#3402): a hostile TMPDIR does NOT cost the override name" \
+      "$sumrow4h" "CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced)"
+  has "case4h (#3402): a hostile TMPDIR does NOT cost the growth count" \
+      "$sumrow4h" "1 over-threshold file(s) grown"
+  if [ ! -s "$sumrow4h" ]; then
+    bad "case4h (#3402): no file-size row captured — the forged-verdict check could not run"
+  elif grep -Eq 'RESULT: (PASS|FAIL)' "$sumrow4h"; then
+    bad "case4h (#3402): the TMPDIR's verdict token reached the row — it would forge a verdict"
+  else
+    ok "case4h (#3402): no part of the TMPDIR reached the row — the pointer composes, it does not carry"
+  fi
+fi
 
 # ---------------------------------------------------------------------------
 # Case 4c (#3402), run for BOTH malformed spellings — THE FALSE-PASS ROUTE, and the reason the emit is keyed on the
@@ -928,10 +966,14 @@ printf 'file-size component log + opt-out marker guard (#3401/#3402): %d passed,
 # 99 -> 107 on #3402's C1 fix: +2 case9, +2 case10, +4 case11, all unconditional (the
 # FS_SABOTAGE=dir shape is uid-independent and needs no /dev/full, so none can self-skip).
 # 75 (#3401) -> 107 -> 112 -> 114 -> 116 across #3402's review rounds, then DOWN to 105 on
-# job 23, when the inline grown-path list was removed: cases 4b/4e/4g went with it (-12) and
-# case 4 gained a log-pointer needle plus a no-repository-path needle (+1 net). A census
-# that only ever rises is a census nobody re-derives — this one is recomputed from the run.
-EXPECTED_CHECKS=105
+# job 23, when the inline grown-path list was removed (cases 4b/4e/4g went with it, -12, and
+# case 4 gained a log-pointer needle plus a no-repository-path needle, +1 net), then 105 ->
+# 108 on job 25 (+3 case4h: a hostile TMPDIR must not cost the disclosure). A census that
+# only ever rises is a census nobody re-derives — this one is recomputed from the run, and
+# the first value written here was WRONG (109, guessed from the number of asserts typed
+# rather than counted from a run: `fs_summary_row || bad` contributes nothing unless it
+# fires).
+EXPECTED_CHECKS=108
 if [ "$((PASS + FAIL + SKIP))" -ne "$EXPECTED_CHECKS" ]; then
   printf 'FAIL - assertion census mismatch: %d checks ran (%d ok / %d fail / %d skip), expected exactly %d.\n' \
     "$((PASS + FAIL + SKIP))" "$PASS" "$FAIL" "$SKIP" "$EXPECTED_CHECKS"

--- a/scripts/tests/test_agent_gate_file_size_log.sh
+++ b/scripts/tests/test_agent_gate_file_size_log.sh
@@ -610,18 +610,26 @@ else
   # contradicting its own table, which is the invariant
   # scripts/tests/test_agent_gate_tree_provenance.sh asserts for the boundary block.
   pf_rows=$(grep -cE '^[a-z][a-z0-9-]*: +(PASS|FAIL|SKIP|OPT-OUT) \([0-9]+s\)' "$pf_sum" 2>/dev/null | tr -d ' ')
-  pf_said=$(sed -n 's/^components-completed-before-exit: \([0-9]*\) .*/\1/p' "$pf_sum" | head -1)
+  pf_said=$(sed -n 's/^components-recorded: \([0-9]*\) .*/\1/p' "$pf_sum" | head -1)
   if [ -n "$pf_said" ] && [ "$pf_said" = "${pf_rows:-x}" ]; then
-    ok "case4i (#3402): components-completed-before-exit ($pf_said) equals the rows printed — no contradicted count"
+    ok "case4i (#3402): components-recorded ($pf_said) equals the rows printed — no contradicted count"
   else
     bad "case4i (#3402): the block says '$pf_said' completed but printed ${pf_rows:-<unmeasured>} row(s)"
   fi
-  # The mutant: drop the rows argument from the corpus-preflight emit, which is the state
-  # before this fix. The block still emits, so only the row can distinguish the two.
+  # The mutant: stop the EMIT FUNNEL appending the table, which is the state before this fix.
+  # The block still emits, so only the row can distinguish the two.
+  #
+  # THE GUARD ASSERTS THE MUTATION CHANGED SOMETHING, not that a pattern is now absent. The
+  # first version sed'd `${_pf_rows:+…}` — the per-site wiring this fix REPLACED — and then
+  # checked that pattern was gone, which is trivially true of a file that never contained it.
+  # So it built an identical copy, "proved" nothing, and reported the row surviving as a
+  # failure of the check rather than of the mutant. A mutant that cannot be shown to differ
+  # from the original is a vacuous control, and `cmp` is the only thing that shows it.
   pf_mut="$tmp/preflight-mutant"
   if cp -r "$pf_root" "$pf_mut" 2>/dev/null &&
-     sed -i 's/^\( *\)\${_pf_rows:+"\$_pf_rows"} \\$/\1\\/' "$pf_mut/scripts/agent-gate.sh" &&
-     ! grep -q '_pf_rows:+' "$pf_mut/scripts/agent-gate.sh"; then
+     grep -q 'line=$(_recorded_component_rows_block)' "$pf_mut/scripts/agent-gate.sh" &&
+     sed -i 's/^\( *\)line=$(_recorded_component_rows_block)$/\1line=""/' "$pf_mut/scripts/agent-gate.sh" &&
+     ! cmp -s "$pf_root/scripts/agent-gate.sh" "$pf_mut/scripts/agent-gate.sh"; then
     pf_msum="$tmp/preflight-mutant.sum"
     ( cd "$pf_mut" && env -u AGENT_GATE_SUMMARY_FILE CQLITE_DATASETS_ROOT="${pf_empty%/sstables}" \
         CQLITE_ALLOW_FILE_GROWTH=1 CQLITE_GATE_DISABLE_CAP=1 AGENT_GATE_SUMMARY_FILE="$pf_msum" \

--- a/scripts/tests/test_agent_gate_file_size_log.sh
+++ b/scripts/tests/test_agent_gate_file_size_log.sh
@@ -565,39 +565,44 @@ has_re "case4e (#3402): the path is the FINAL field — not a stem with the rema
     "$sumrow4e" 'grown: cqlite-core/src/we: ird\.rs$'
 
 # ---------------------------------------------------------------------------
-# Case 4f (#3402, roborev round 1 L2) — the row must not depend on the caller's LOCALE.
-# `_status_detail` reduces the value with `tr -d '[:cntrl:]'`, and `[:cntrl:]` is evaluated
-# in the CURRENT locale, so an unpinned `tr` made this emit boundary's behaviour a property
-# of the invoker's environment rather than of the code. `LC_ALL=C` is pinned AT the call;
-# this case measures the resulting property directly — the SAME fixture rendered under a C
-# and a UTF-8 locale must produce a BYTE-IDENTICAL row.
-# A UTF-8 locale is not guaranteed to be generated on every host, so its half is a DECLARED
-# skip rather than a silent pass (one skip per skipped assert, the case-8 convention).
+# Case 4g (#3402, roborev job 19/20 L1) — a grown path CONTAINING the completion probe's
+# verdict token. The first guard SUBSTITUTED the token wherever it appeared, so a real file
+# `cqlite-core/src/RESULT: PASS.rs` was rendered in a spelling that exists nowhere on disk —
+# the SAME false-reporting defect this change removes, reintroduced by its own guard, and
+# worse than what it protected: a reader cannot tell a rewritten name from a real one.
+# The detail is now WITHHELD WHOLE, loudly, pointing at the component log.
+#
+# The three needles are complementary and none is satisfiable from another state: the named
+# withholding (emitted from this branch alone), the ABSENCE of the rewritten spelling (the
+# literal bytes the old guard produced), and — the property the guard exists for — the row
+# not matching the probe's own pattern, asserted against the ROW rather than the block,
+# since the block legitimately carries a terminal RESULT line of its own.
+#
+# NOTE ON WHAT IS *NOT* HERE: case 4f, a locale-independence test, was written and DELETED.
+# GNU `tr` is byte-wise, so `[:cntrl:]` selects the same bytes with or without the LC_ALL=C
+# pin for every input a writer here can produce — no mutant can distinguish them and the
+# case could not fail — while comparing whole rows from two runs made it flake on the
+# elapsed field. See the declaration at _status_detail: the pin stays, its coverage is
+# declared absent rather than simulated.
 # ---------------------------------------------------------------------------
-mkrepo localec cqlite-core/src/big.rs 900 950 main; r4f="$REPO"
-out4f="$tmp/locale-c.out"
-run_only_file_size "$r4f" "$out4f" CQLITE_ALLOW_FILE_GROWTH=1 LC_ALL=C
-sumrow4f_c="$tmp/locale-c.sumrow"
-fs_summary_row "$r4f/.sum" "$sumrow4f_c" ||
-  bad "case4f (#3402): no file-size row under LC_ALL=C — the locale comparison is UNMEASURED"
-has "case4f (#3402): under LC_ALL=C the row still carries the full detail" \
-    "$sumrow4f_c" "CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced)"
-fs_utf8=$(locale -a 2>/dev/null | grep -im1 -E '^(C|en_US)\.utf-?8$' || true)
-if [ -z "$fs_utf8" ]; then
-  skip "case4f: no UTF-8 locale generated on this host — the cross-locale comparison not run"
+mkrepo verdictpath 'cqlite-core/src/RESULT: PASS.rs' 900 950 main; r4g="$REPO"
+out4g="$tmp/verdictpath.out"
+run_only_file_size "$r4g" "$out4g" CQLITE_ALLOW_FILE_GROWTH=1
+d4g=$(logdir_of "$out4g") || bad "case4g: the run published no usable 'logs:' dir"
+sumrow4g="$tmp/verdictpath.sumrow"
+fs_summary_row "$r4g/.sum" "$sumrow4g" ||
+  bad "case4g (#3402): the run emitted no usable file-size row — the L1 asserts are UNMEASURED"
+assert_verdict "case4g: a verdict-token-bearing grown path is still an OPT-OUT" "$d4g" OPT-OUT
+has "case4g (#3402): the row NAMES the withholding instead of rendering a rewritten path" \
+    "$sumrow4g" "detail WITHHELD"
+lacks "case4g (#3402): the row carries NO rewritten spelling of the real filename" \
+    "$sumrow4g" "redacted-token"
+if [ ! -s "$sumrow4g" ]; then
+  bad "case4g (#3402): no file-size row captured — the forged-verdict check could not run"
+elif grep -Eq 'RESULT: (PASS|FAIL)' "$sumrow4g"; then
+  bad "case4g (#3402): the row matches the completion probe's own pattern — it would forge a verdict"
 else
-  mkrepo localeu cqlite-core/src/big.rs 900 950 main; r4g="$REPO"
-  out4g="$tmp/locale-u.out"
-  run_only_file_size "$r4g" "$out4g" CQLITE_ALLOW_FILE_GROWTH=1 LC_ALL="$fs_utf8"
-  sumrow4f_u="$tmp/locale-u.sumrow"
-  fs_summary_row "$r4g/.sum" "$sumrow4f_u" ||
-    bad "case4f (#3402): no file-size row under $fs_utf8 — the locale comparison is UNMEASURED"
-  if [ -s "$sumrow4f_c" ] && [ -s "$sumrow4f_u" ] && cmp -s "$sumrow4f_c" "$sumrow4f_u"; then
-    ok "case4f (#3402): the row is BYTE-IDENTICAL under LC_ALL=C and $fs_utf8"
-  else
-    bad "case4f (#3402): the row DIFFERS between LC_ALL=C and $fs_utf8 — the reduction is locale-dependent"
-    diff "$sumrow4f_c" "$sumrow4f_u" 2>/dev/null | head -4
-  fi
+  ok "case4g (#3402): the row does NOT match 'RESULT: (PASS|FAIL)' — no forged terminal verdict"
 fi
 
 # ---------------------------------------------------------------------------
@@ -1024,10 +1029,10 @@ printf 'file-size component log + opt-out marker guard (#3401/#3402): %d passed,
 # misattributing one as the other.
 # 99 -> 107 on #3402's C1 fix: +2 case9, +2 case10, +4 case11, all unconditional (the
 # FS_SABOTAGE=dir shape is uid-independent and needs no /dev/full, so none can self-skip).
-# 107 -> 112 on roborev round 1: +3 case4e (L3, delimiter-bearing path) and +2 case4f
-# (L2, locale independence — its second assert is a DECLARED skip on a host with no
-# UTF-8 locale, so the census total is the same either way).
-EXPECTED_CHECKS=112
+# 107 -> 112 on roborev round 1 (+3 case4e, +2 case4f), then 112 -> 114 on job 19/20:
+# case4f DELETED (-2: it could not fail and could flake — see case4g's note) and case4g
+# ADDED (+4). Every case4g assert is unconditional: no /dev/full, no locale, no network.
+EXPECTED_CHECKS=114
 if [ "$((PASS + FAIL + SKIP))" -ne "$EXPECTED_CHECKS" ]; then
   printf 'FAIL - assertion census mismatch: %d checks ran (%d ok / %d fail / %d skip), expected exactly %d.\n' \
     "$((PASS + FAIL + SKIP))" "$PASS" "$FAIL" "$SKIP" "$EXPECTED_CHECKS"

--- a/scripts/tests/test_agent_gate_file_size_log.sh
+++ b/scripts/tests/test_agent_gate_file_size_log.sh
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
-# Regression test for issue #3401: the `file-size` gate component must PERSIST its
-# arithmetic as $LOG_DIR/file-size.log, on EVERY invocation.
+# Regression test for issues #3401 and #3402: the `file-size` gate component must PERSIST
+# its arithmetic as $LOG_DIR/file-size.log on EVERY invocation (#3401), and an ENGAGED
+# growth override must be VISIBLE IN THE SUMMARY BLOCK (#3402).
 #
-# The defect: run_file_size computed the base ref, the over-threshold advisory list and
+# The #3402 defect: with CQLITE_ALLOW_FILE_GROWTH=1 the component reported a bare
+# `file-size: PASS (0s)`, so a pasted SUMMARY — the unit of evidence a PR reviewer reads —
+# could not be told apart from a run where the ratchet was genuinely satisfied. The
+# component now reports its own NON-FAILING `OPT-OUT` token carrying the env var, the
+# count and the grown file names inline. The property that matters most here is the
+# NEGATIVE one (cases 4c/4d): `OPT-OUT` may be emitted ONLY for the affirmative value `1`,
+# because a permissive branch keyed on `!= <bad>` would let a typo waive the ratchet.
+#
+# The #3401 defect: run_file_size computed the base ref, the over-threshold advisory list and
 # the exact `path: before -> after (limit N)` growth entries, echoed them to STDOUT — i.e.
 # into gate.log, the one file CLAUDE.md forbids an agent to read — and wrote only a bare
 # `file-size.result` (`FAIL 0`). So a `file-size: FAIL` in a pasted SUMMARY named NOTHING:
@@ -15,14 +24,18 @@
 # case therefore asserts the REAL numbers (`900 -> 950 (limit 800)`), the REAL base sha,
 # the thresholds and the terminal verdict.
 #
-# Seven paths through run_file_size, because the log must exist on ALL of them (AC3):
+# Paths through run_file_size, because the log must exist on ALL of them (AC3), plus the
+# three #3402 SUMMARY-visibility paths:
 #   1. grown + over threshold             -> FAIL
 #   2. over threshold but SHRUNK          -> PASS (advisory list, empty ratchet)
 #   3. no changed .rs files at all        -> PASS ("nothing over threshold" still logged)
 #   3b. changed .rs files, none over the threshold -> PASS (same log line, DIFFERENT input:
 #       case 3's tree is clean, so on its own it never proves a CHANGED-but-small file is
 #       handled — only that the component ran with an empty file list)
-#   4. grown + CQLITE_ALLOW_FILE_GROWTH=1 -> PASS (the opt-out is RECORDED)
+#   4. grown + CQLITE_ALLOW_FILE_GROWTH=1 -> OPT-OUT (the opt-out is RECORDED, and — since
+#      #3402 — VISIBLE in the SUMMARY block, not only in this log)
+#   4b. #3402: four grown files -> the SUMMARY's file list ELIDES with a named remainder
+#   4c/4d. #3402: a MALFORMED override (`0`, `true`) -> still a ratchet FAIL, never OPT-OUT
 #   5. base ref unresolvable              -> PASS (advisory only, ratchet skipped)
 #   6. AC2: the FAIL stdout NAMES $LOG_DIR/file-size.log, so it is reachable from the
 #      SUMMARY's existing `logs:` line without the reader guessing a filename.
@@ -143,6 +156,46 @@ mkrepo() {
   REPO="$root"
 }
 
+# mkrepo_multi <name> <count> <committed-lines> <worktree-lines> (#3402) — the multi-file
+# sibling of mkrepo: <count> over-threshold sources (cqlite-core/src/big1.rs …), ALL
+# committed at <committed-lines> and ALL grown to <worktree-lines>. Needed because the
+# SUMMARY's grown-file list elides beyond three entries, which a one-file fixture can
+# never reach. Same contract as mkrepo: publishes the path in the global REPO (never via
+# command substitution, which would run every `bad` in a subshell and DISCARD the failure
+# count), checks its git setup, and RE-MEASURES what it wrote.
+mkrepo_multi() {
+  local name="$1" count="$2" nbase="$3" nhead="$4"
+  local root="$tmp/$name" err="$tmp/$name.setup.err" i n
+  REPO=""
+  if ! mkdir -p "$root/scripts" "$root/cqlite-core/src" 2>"$err"; then
+    bad "fixture $name: mkdir failed — $(tr '\n' ' ' <"$err")"; return 1
+  fi
+  if ! cp "$GATE" "$root/scripts/agent-gate.sh" 2>"$err"; then
+    bad "fixture $name: could not stage the gate script — $(tr '\n' ' ' <"$err")"; return 1
+  fi
+  printf 'target/\n*.log\n.agent-gate-summary.txt\n' >"$root/.gitignore"
+  for i in $(seq 1 "$count"); do lines "$nbase" "$root/cqlite-core/src/big$i.rs"; done
+  if ! ( cd "$root" && git "${GIT_CFG[@]}" init -q -b main . &&
+         git "${GIT_CFG[@]}" add -A &&
+         git "${GIT_CFG[@]}" commit -qm init ) >"$err" 2>&1; then
+    bad "fixture $name: git setup FAILED — $(tr '\n' ' ' <"$err")"; return 1
+  fi
+  for i in $(seq 1 "$count"); do
+    lines "$nhead" "$root/cqlite-core/src/big$i.rs"
+    n=$(wc -l <"$root/cqlite-core/src/big$i.rs" 2>/dev/null | tr -d ' ')
+    if [ "${n:-x}" != "$nhead" ]; then
+      bad "fixture $name: worktree big$i.rs has ${n:-<unreadable>} lines, expected $nhead"; return 1
+    fi
+  done
+  # A fixture that does not present <count> GROWN files makes the elision assert
+  # meaningless, so the count is measured rather than assumed.
+  n=$( cd "$root" 2>/dev/null && git diff --name-only -- '*.rs' 2>/dev/null | grep -c . )
+  if [ "${n:-x}" != "$count" ]; then
+    bad "fixture $name: git reports ${n:-<unreadable>} changed .rs file(s), expected $count"; return 1
+  fi
+  REPO="$root"
+}
+
 # run_only_file_size <repo> <outfile> [KEY=VAL …] -> exit status of the gate run
 run_only_file_size() {
   local repo="$1" out="$2"; shift 2
@@ -195,6 +248,47 @@ has() {
   if [ ! -f "$2" ]; then bad "$1 (no such file: $2)"; return; fi
   if [ ! -s "$2" ]; then bad "$1 (file is ZERO BYTES: $2)"; return; fi
   if grep -Fq -- "$3" "$2"; then ok "$1"; else bad "$1 (missing: '$3')"; fi
+}
+
+# has_re <label> <file> <ere> — the regex sibling of `has`, for shape assertions the
+# `%-18s` padding makes awkward as a literal. Same fail-closed rules: an empty pattern
+# matches every line, a missing/empty file is a measurement failure, never a match.
+has_re() {
+  if [ -z "${3:-}" ]; then
+    bad "$1 (EMPTY pattern — the expected shape was never captured)"; return
+  fi
+  if [ ! -f "$2" ]; then bad "$1 (no such file: $2)"; return; fi
+  if [ ! -s "$2" ]; then bad "$1 (file is ZERO BYTES: $2)"; return; fi
+  if grep -Eq -- "$3" "$2"; then ok "$1"; else bad "$1 (no line matched: '$3')"; fi
+}
+
+# lacks <label> <file> <literal> — the NEGATIVE assert, and it is fail-closed the same way
+# the positives are. A missing/empty file trivially "lacks" any needle, which is precisely
+# the vacuous green this suite refuses: the absence of a token in a block that was never
+# emitted proves nothing about the emitter (#3402).
+lacks() {
+  if [ -z "${3:-}" ]; then
+    bad "$1 (EMPTY needle — nothing was actually being excluded)"; return
+  fi
+  if [ ! -f "$2" ]; then bad "$1 (no such file: $2 — absence UNMEASURED)"; return; fi
+  if [ ! -s "$2" ]; then bad "$1 (file is ZERO BYTES: $2 — absence UNMEASURED)"; return; fi
+  if grep -Fq -- "$3" "$2"; then bad "$1 (unexpectedly PRESENT: '$3')"; else ok "$1"; fi
+}
+
+# fs_summary_row <summary-file> <outfile> (#3402) — isolate the emitted block's
+# `file-size:` component row so the SUMMARY-visibility asserts read the ROW, not the
+# whole block. Reading the row matters: a needle found anywhere in the block (the
+# component log path, a meta line) would not prove it landed on the line a reader of a
+# pasted summary actually sees. A missing block or a missing row writes a SENTINEL, never
+# an empty file, so every downstream `has`/`has_re` fails closed with a readable value.
+fs_summary_row() {
+  local out="$2"
+  if [ ! -s "${1:-}" ]; then printf '%s\n' '<no-summary-file-emitted>' >"$out"; return 1; fi
+  if ! grep -m1 -E '^file-size: ' "$1" >"$out" 2>/dev/null; then
+    printf '%s\n' '<no-file-size-row-in-block>' >"$out"; return 1
+  fi
+  [ -s "$out" ] || { printf '%s\n' '<empty-file-size-row>' >"$out"; return 1; }
+  return 0
 }
 
 # assert_log_present <label> <logfile> — existence AND non-emptiness, per AC3.
@@ -277,6 +371,20 @@ elif grep -Fq -- '-> ' "$log2"; then
 else
   ok "case2: PASS log lists no growth entry (ratchet genuinely empty)"
 fi
+# #3402 NEGATIVE CONTROL — the override UNSET. This is the run whose SUMMARY line must be
+# UNCHANGED by #3402: a plain `file-size: PASS (Ns)` with no OPT-OUT token and no detail
+# suffix anywhere in the block. Without it, "the token appears when the override is set"
+# is only half a property — a component that stamped OPT-OUT unconditionally would satisfy
+# case 4 and be a strictly worse defect than the one being fixed.
+sumrow2="$tmp/shrank.sumrow"
+fs_summary_row "$r2/.sum" "$sumrow2" ||
+  bad "case2 (#3402): the run emitted no usable file-size row — the negative control is UNMEASURED"
+has_re "case2 (#3402): with the override UNSET the SUMMARY row reads a plain PASS" \
+    "$sumrow2" '^file-size: +PASS \([0-9]+s\)'
+lacks "case2 (#3402): an unset override stamps NO OPT-OUT token anywhere in the block" \
+    "$r2/.sum" "OPT-OUT"
+lacks "case2 (#3402): an unset override stamps no CQLITE_ALLOW_FILE_GROWTH detail in the block" \
+    "$r2/.sum" "CQLITE_ALLOW_FILE_GROWTH"
 
 # ---------------------------------------------------------------------------
 # Case 3 — PASS with NO changed .rs files at all: an empty-ish run still gets a log that
@@ -319,21 +427,112 @@ has "case3b: log carries the terminal verdict" "$log3b" ">>> [file-size] PASS"
 # ---------------------------------------------------------------------------
 # Case 4 — the CQLITE_ALLOW_FILE_GROWTH=1 opt-out. The growth is ALLOWED, and the log must
 # RECORD what was allowed (the numbers are the whole point of the acknowledgement).
+#
+# #3402 extends this case from the LOG to the SUMMARY BLOCK. The log was already complete;
+# what was missing is that the SUMMARY — the unit of evidence agents paste into PRs —
+# carried a bare `file-size: PASS (0s)`, byte-indistinguishable from a run where the
+# ratchet was genuinely satisfied. So the component's own status TOKEN is now OPT-OUT, and
+# the row must NAME the env var, the COUNT and the FILES.
 # ---------------------------------------------------------------------------
 mkrepo optout cqlite-core/src/big.rs 900 950 main; r4="$REPO"
 out4="$tmp/optout.out"
 run_only_file_size "$r4" "$out4" CQLITE_ALLOW_FILE_GROWTH=1
+rc4=$?
 d4=$(logdir_of "$out4") || bad "case4: the run published no usable 'logs:' dir"
 log4="$d4/file-size.log"
 
-assert_verdict "case4: CQLITE_ALLOW_FILE_GROWTH=1 turns the same growth into a PASS" "$d4" PASS
+assert_verdict "case4: CQLITE_ALLOW_FILE_GROWTH=1 turns the same growth into OPT-OUT, not PASS (#3402)" \
+    "$d4" OPT-OUT
 assert_log_present "case4: file-size.log written on the opt-out path (AC3)" "$log4"
 has "case4: opt-out log records the acknowledgement" \
     "$log4" "ALLOWED via CQLITE_ALLOW_FILE_GROWTH=1"
 has "case4: opt-out log still records the exact growth entry" \
     "$log4" "cqlite-core/src/big.rs: 900 -> 950 (limit 800)"
-has "case4: opt-out log carries the terminal PASS verdict" \
-    "$log4" ">>> [file-size] PASS"
+has "case4: opt-out log carries the terminal OPT-OUT verdict" \
+    "$log4" ">>> [file-size] OPT-OUT"
+
+# --- case 4, #3402 half: the four facts a reader of a PASTED block needs ---------------
+# Asserted against the ROW, not the block: a needle found anywhere in the block would not
+# prove it landed on the line the reader actually sees.
+sumrow4="$tmp/optout.sumrow"
+fs_summary_row "$r4/.sum" "$sumrow4" ||
+  bad "case4 (#3402): the run emitted no usable file-size row — the SUMMARY asserts are UNMEASURED"
+has_re "case4 (#3402): the SUMMARY row carries the OPT-OUT status token, not PASS" \
+    "$sumrow4" '^file-size: +OPT-OUT \([0-9]+s\)'
+has "case4 (#3402): the SUMMARY row NAMES the env var that was engaged" \
+    "$sumrow4" "CQLITE_ALLOW_FILE_GROWTH=1"
+has "case4 (#3402): the SUMMARY row gives the COUNT of grown files" \
+    "$sumrow4" "1 over-threshold file(s) grown"
+has "case4 (#3402): the SUMMARY row NAMES the grown file" \
+    "$sumrow4" "cqlite-core/src/big.rs"
+has "case4 (#3402): the row keeps its feature-matrix annotation ahead of the detail" \
+    "$sumrow4" "[no-cargo]"
+lacks "case4 (#3402): the row does not ALSO read PASS — a reader greps one token, not two" \
+    "$sumrow4" "PASS"
+# NON-FAILING, measured through the gate's own verdict rather than asserted of the source.
+# In `--only` mode a passing run is promoted to RESULT: PARTIAL and exits 3, while any
+# component FAIL leaves RESULT: FAIL and exit 1 — so this pair distinguishes exactly the
+# property #3402 must not break: a legitimate OPT-OUT does not fail the run.
+if [ "$rc4" = 3 ]; then
+  ok "case4 (#3402): a legitimate OPT-OUT is NON-FAILING (--only run exits 3, the pass code, not 1)"
+else
+  bad "case4 (#3402): expected the --only pass exit 3, got $rc4 — OPT-OUT failed the run"
+fi
+has "case4 (#3402): the block's RESULT is the passing PARTIAL, not FAIL" \
+    "$r4/.sum" "RESULT: PARTIAL"
+
+# ---------------------------------------------------------------------------
+# Case 4b (#3402) — the grown-file list is ELIDED, never silently truncated. Four grown
+# files against a three-entry render: the row must name three and say how many it dropped.
+# A one-file fixture can never exercise this, and an abbreviation that implies a
+# completeness it does not have is the same class of defect as the invisible opt-out.
+# ---------------------------------------------------------------------------
+mkrepo_multi optout4 4 900 950; r4b="$REPO"
+out4b="$tmp/optout4.out"
+run_only_file_size "$r4b" "$out4b" CQLITE_ALLOW_FILE_GROWTH=1
+d4b=$(logdir_of "$out4b") || bad "case4b: the run published no usable 'logs:' dir"
+assert_verdict "case4b: four grown files under the engaged override still report OPT-OUT" "$d4b" OPT-OUT
+sumrow4b="$tmp/optout4.sumrow"
+fs_summary_row "$r4b/.sum" "$sumrow4b" ||
+  bad "case4b (#3402): the run emitted no usable file-size row — the elision assert is UNMEASURED"
+has "case4b (#3402): the SUMMARY row reports the FULL count, not the rendered count" \
+    "$sumrow4b" "4 over-threshold file(s) grown"
+has "case4b (#3402): the SUMMARY row NAMES the elided remainder rather than truncating silently" \
+    "$sumrow4b" ",+1 more"
+
+# ---------------------------------------------------------------------------
+# Cases 4c/4d (#3402) — THE FALSE-PASS ROUTE, and the reason the emit is keyed on the
+# AFFIRMATIVE `= 1`. `CQLITE_ALLOW_FILE_GROWTH` has THREE states, not two: exactly `1`
+# (engaged), SET BUT NOT 1 (`0`, `true`, `yes` — a typo, and already reported as "this IS
+# a ratchet violation"), and unset. A permissive branch keyed on `!= <bad>` would let the
+# middle state buy an OPT-OUT, i.e. a mis-spelled override silently waiving the ratchet —
+# strictly worse than the invisible opt-out this issue closes. Both spellings of the
+# middle state are exercised on the SAME grown fixture as case 4, so the only difference
+# between a FAIL here and an OPT-OUT there is the value of the variable.
+# ---------------------------------------------------------------------------
+for bad_val in 0 true; do
+  mkrepo "badval$bad_val" cqlite-core/src/big.rs 900 950 main; rbv="$REPO"
+  outbv="$tmp/badval$bad_val.out"
+  run_only_file_size "$rbv" "$outbv" "CQLITE_ALLOW_FILE_GROWTH=$bad_val"
+  rcbv=$?
+  dbv=$(logdir_of "$outbv") || bad "case4c/$bad_val: the run published no usable 'logs:' dir"
+  assert_verdict "case4c/$bad_val (#3402): a malformed override keeps the ratchet VIOLATION (FAIL)" \
+      "$dbv" FAIL
+  has "case4c/$bad_val (#3402): the log carries the unchanged ratchet-violation wording" \
+      "$dbv/file-size.log" "FAIL: change makes over-threshold file(s) larger."
+  lacks "case4c/$bad_val (#3402): NO OPT-OUT token anywhere in the emitted block" \
+      "$rbv/.sum" "OPT-OUT"
+  sumrowbv="$tmp/badval$bad_val.sumrow"
+  fs_summary_row "$rbv/.sum" "$sumrowbv" ||
+    bad "case4c/$bad_val (#3402): no usable file-size row — the malformed-value assert is UNMEASURED"
+  has_re "case4c/$bad_val (#3402): the SUMMARY row reads FAIL" \
+      "$sumrowbv" '^file-size: +FAIL \([0-9]+s\)'
+  if [ "$rcbv" = 1 ]; then
+    ok "case4c/$bad_val (#3402): the run FAILS (exit 1), so a typo can never buy a green"
+  else
+    bad "case4c/$bad_val (#3402): expected exit 1, got $rcbv — a malformed override did not fail the run"
+  fi
+done
 
 # ---------------------------------------------------------------------------
 # Case 5 — base ref UNRESOLVABLE (no main/master, no origin/*): the ratchet is skipped and
@@ -708,7 +907,7 @@ fi
 
 # ---------------------------------------------------------------------------
 printf '\n%s\n' "----------------------------------------"
-printf 'file-size component log guard (#3401): %d passed, %d failed, %d skipped\n' "$PASS" "$FAIL" "$SKIP"
+printf 'file-size component log + opt-out marker guard (#3401/#3402): %d passed, %d failed, %d skipped\n' "$PASS" "$FAIL" "$SKIP"
 # Census, not a floor (#3401 review N4/N2): every assertion reports exactly one of
 # ok/FAIL/SKIP, so `PASS + FAIL + SKIP` is fixed for a run that reaches the end. A floor
 # with slack tolerates silently deleted assertions — the vacuous-green shape this suite
@@ -716,7 +915,7 @@ printf 'file-size component log guard (#3401): %d passed, %d failed, %d skipped\
 # precondition failure (an unusable repo, a missing mktemp) short-circuits its case's
 # remaining asserts and lands here too, so the message names both causes rather than
 # misattributing one as the other.
-EXPECTED_CHECKS=75
+EXPECTED_CHECKS=99
 if [ "$((PASS + FAIL + SKIP))" -ne "$EXPECTED_CHECKS" ]; then
   printf 'FAIL - assertion census mismatch: %d checks ran (%d ok / %d fail / %d skip), expected exactly %d.\n' \
     "$((PASS + FAIL + SKIP))" "$PASS" "$FAIL" "$SKIP" "$EXPECTED_CHECKS"

--- a/scripts/tests/test_agent_gate_file_size_log.sh
+++ b/scripts/tests/test_agent_gate_file_size_log.sh
@@ -464,7 +464,12 @@ has "case4 (#3402): the SUMMARY row NAMES the env var that was engaged" \
     "$sumrow4" "CQLITE_ALLOW_FILE_GROWTH=1"
 has "case4 (#3402): the SUMMARY row gives the COUNT of grown files" \
     "$sumrow4" "1 over-threshold file(s) grown"
-has "case4 (#3402): the SUMMARY row NAMES the grown file" \
+# The row deliberately carries NO repository content (see the REMOVED-cases note below).
+# What it must carry instead is a pointer to where the names DO live, plus — asserted from
+# the other side — proof that no path leaked onto it.
+has "case4 (#3402): the SUMMARY row POINTS AT the component log for the file list" \
+    "$sumrow4" "file-size.log"
+lacks "case4 (#3402): the row renders NO repository path — the whole mangling family is unreachable" \
     "$sumrow4" "cqlite-core/src/big.rs"
 has "case4 (#3402): the row keeps its feature-matrix annotation ahead of the detail" \
     "$sumrow4" "[no-cargo]"
@@ -483,23 +488,25 @@ has "case4 (#3402): the block's RESULT is the passing PARTIAL, not FAIL" \
     "$r4/.sum" "RESULT: PARTIAL"
 
 # ---------------------------------------------------------------------------
-# Case 4b (#3402) — the grown-file list is ELIDED, never silently truncated. Four grown
-# files against a three-entry render: the row must name three and say how many it dropped.
-# A one-file fixture can never exercise this, and an abbreviation that implies a
-# completeness it does not have is the same class of defect as the invisible opt-out.
+# REMOVED, deliberately: cases 4b (elision past three files), 4e (a path containing `: `)
+# and 4g (a path containing the completion probe's verdict token). All three exercised the
+# INLINE GROWN-PATH LIST, which is gone.
+#
+# Why the list went, recorded here because a future reader will otherwise re-add it: it was
+# the OPTIONAL half of #3402 ("ideally naming the files", with the issue itself deferring
+# that data to the sibling log issue #3401, now merged), and it produced THREE of this PR's
+# seven review findings — one per round, each a different way of mangling a filename: a
+# `: ` split when recovering a path from a display string; substitution inside a path
+# carrying `RESULT:`; and `,` joining, which made `src/a.rs,b.rs` indistinguishable from two
+# files. Every fix was correct and the next round found another. That is the shape #3229
+# already ruled on — remove the mechanism rather than carve it a fourth time — and escaping
+# would only move the argument to the escape grammar (#3312: a rarer delimiter is still
+# forgeable).
+#
+# The row now carries env var + COUNT + a pointer to file-size.log, which is what the issue
+# actually specified. The names live in the log (#3401's whole subject) and, for a PR
+# reviewer, in the diff itself — the grown files are the files the PR changed.
 # ---------------------------------------------------------------------------
-mkrepo_multi optout4 4 900 950; r4b="$REPO"
-out4b="$tmp/optout4.out"
-run_only_file_size "$r4b" "$out4b" CQLITE_ALLOW_FILE_GROWTH=1
-d4b=$(logdir_of "$out4b") || bad "case4b: the run published no usable 'logs:' dir"
-assert_verdict "case4b: four grown files under the engaged override still report OPT-OUT" "$d4b" OPT-OUT
-sumrow4b="$tmp/optout4.sumrow"
-fs_summary_row "$r4b/.sum" "$sumrow4b" ||
-  bad "case4b (#3402): the run emitted no usable file-size row — the elision assert is UNMEASURED"
-has "case4b (#3402): the SUMMARY row reports the FULL count, not the rendered count" \
-    "$sumrow4b" "4 over-threshold file(s) grown"
-has "case4b (#3402): the SUMMARY row NAMES the elided remainder rather than truncating silently" \
-    "$sumrow4b" ",+1 more"
 
 # ---------------------------------------------------------------------------
 # Case 4c (#3402), run for BOTH malformed spellings — THE FALSE-PASS ROUTE, and the reason the emit is keyed on the
@@ -534,85 +541,6 @@ for bad_val in 0 true; do
     bad "case4c/$bad_val (#3402): expected exit 1, got $rcbv — a malformed override did not fail the run"
   fi
 done
-
-# ---------------------------------------------------------------------------
-# Case 4e (#3402, roborev round 1 L3) — a grown path CONTAINING THE `: ` that the abbreviator
-# used to split on. `_fs_abbrev_grown` took the formatted `path: before -> after (limit N)`
-# entries and recovered the path with `${e%%: *}`, so `we: ird.rs` was truncated to `we` and
-# the SUMMARY NAMED A FILE THAT DOES NOT EXIST — worse than eliding it, because the reader
-# has no way to tell a real name from a mangled one. Fixed by CARRYING the path instead of
-# re-deriving it from a display string.
-#
-# The second needle is END-ANCHORED, and that is the whole of its value. A `lacks` on the
-# truncated stem CANNOT FAIL here: with one grown file the buggy render ends at
-# `…/src/we`, which is a PREFIX of the correct `…/src/we: ird.rs`, so any needle matching
-# the bug also matches the fix (or, with a trailing comma appended to dodge that, matches
-# neither). Anchoring on `$` states the property that actually distinguishes them — the
-# full name is the LAST thing on the line, so nothing was silently dropped after the split
-# point.
-# ---------------------------------------------------------------------------
-mkrepo colonpath 'cqlite-core/src/we: ird.rs' 900 950 main; r4e="$REPO"
-out4e="$tmp/colonpath.out"
-run_only_file_size "$r4e" "$out4e" CQLITE_ALLOW_FILE_GROWTH=1
-d4e=$(logdir_of "$out4e") || bad "case4e: the run published no usable 'logs:' dir"
-sumrow4e="$tmp/colonpath.sumrow"
-fs_summary_row "$r4e/.sum" "$sumrow4e" ||
-  bad "case4e (#3402): the run emitted no usable file-size row — the L3 asserts are UNMEASURED"
-assert_verdict "case4e: a delimiter-bearing grown path is still an OPT-OUT" "$d4e" OPT-OUT
-has "case4e (#3402): the row names the delimiter-bearing path IN FULL" \
-    "$sumrow4e" "cqlite-core/src/we: ird.rs"
-has_re "case4e (#3402): the path is the FINAL field — not a stem with the remainder lost" \
-    "$sumrow4e" 'grown: cqlite-core/src/we: ird\.rs$'
-
-# ---------------------------------------------------------------------------
-# Case 4g (#3402, roborev job 19/20 L1) — a grown path CONTAINING the completion probe's
-# verdict token. The first guard SUBSTITUTED the token wherever it appeared, so a real file
-# `cqlite-core/src/RESULT: PASS.rs` was rendered in a spelling that exists nowhere on disk —
-# the SAME false-reporting defect this change removes, reintroduced by its own guard, and
-# worse than what it protected: a reader cannot tell a rewritten name from a real one.
-# The detail is now WITHHELD WHOLE, loudly, pointing at the component log.
-#
-# The three needles are complementary and none is satisfiable from another state: the named
-# withholding (emitted from this branch alone), the ABSENCE of the rewritten spelling (the
-# literal bytes the old guard produced), and — the property the guard exists for — the row
-# not matching the probe's own pattern, asserted against the ROW rather than the block,
-# since the block legitimately carries a terminal RESULT line of its own.
-#
-# NOTE ON WHAT IS *NOT* HERE: case 4f, a locale-independence test, was written and DELETED.
-# GNU `tr` is byte-wise, so `[:cntrl:]` selects the same bytes with or without the LC_ALL=C
-# pin for every input a writer here can produce — no mutant can distinguish them and the
-# case could not fail — while comparing whole rows from two runs made it flake on the
-# elapsed field. See the declaration at _status_detail: the pin stays, its coverage is
-# declared absent rather than simulated.
-# ---------------------------------------------------------------------------
-mkrepo verdictpath 'cqlite-core/src/RESULT: PASS.rs' 900 950 main; r4g="$REPO"
-out4g="$tmp/verdictpath.out"
-run_only_file_size "$r4g" "$out4g" CQLITE_ALLOW_FILE_GROWTH=1
-d4g=$(logdir_of "$out4g") || bad "case4g: the run published no usable 'logs:' dir"
-sumrow4g="$tmp/verdictpath.sumrow"
-fs_summary_row "$r4g/.sum" "$sumrow4g" ||
-  bad "case4g (#3402): the run emitted no usable file-size row — the L1 asserts are UNMEASURED"
-assert_verdict "case4g: a verdict-token-bearing grown path is still an OPT-OUT" "$d4g" OPT-OUT
-has "case4g (#3402): the row NAMES the withholding instead of rendering a rewritten path" \
-    "$sumrow4g" "WITHHELD"
-# The two-field split (roborev job 21): withholding must cost the FILE LIST and nothing
-# else. The first version replaced the whole suffix and so destroyed the COUNT — which is
-# gate-authored, provably safe, and the most useful thing left on the row — while claiming
-# in a comment that the count was kept. These two needles are what make that claim testable
-# rather than asserted.
-has "case4g (#3402): the COUNT survives the withholding (only the path list is dropped)" \
-    "$sumrow4g" "1 over-threshold file(s) grown"
-has "case4g (#3402): the engaged env var survives the withholding" \
-    "$sumrow4g" "CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced)"
-lacks "case4g (#3402): the row carries NO rewritten spelling of the real filename" \
-    "$sumrow4g" "redacted-token"
-if [ ! -s "$sumrow4g" ]; then
-  bad "case4g (#3402): no file-size row captured — the forged-verdict check could not run"
-elif grep -Eq 'RESULT: (PASS|FAIL)' "$sumrow4g"; then
-  bad "case4g (#3402): the row matches the completion probe's own pattern — it would forge a verdict"
-else
-  ok "case4g (#3402): the row does NOT match 'RESULT: (PASS|FAIL)' — no forged terminal verdict"
-fi
 
 # ---------------------------------------------------------------------------
 # Case 5 — base ref UNRESOLVABLE (no main/master, no origin/*): the ratchet is skipped and
@@ -1038,12 +966,11 @@ printf 'file-size component log + opt-out marker guard (#3401/#3402): %d passed,
 # misattributing one as the other.
 # 99 -> 107 on #3402's C1 fix: +2 case9, +2 case10, +4 case11, all unconditional (the
 # FS_SABOTAGE=dir shape is uid-independent and needs no /dev/full, so none can self-skip).
-# 107 -> 112 on roborev round 1 (+3 case4e, +2 case4f); 112 -> 114 on jobs 19/20 (case4f
-# DELETED -2, it could not fail and could flake — see case4g's note; case4g ADDED +4);
-# 114 -> 116 on job 21 (+2 case4g: the COUNT and the env var must survive a withholding,
-# which is the claim that job 21 found false). All unconditional: no /dev/full, no locale,
-# no network.
-EXPECTED_CHECKS=116
+# 75 (#3401) -> 107 -> 112 -> 114 -> 116 across #3402's review rounds, then DOWN to 105 on
+# job 23, when the inline grown-path list was removed: cases 4b/4e/4g went with it (-12) and
+# case 4 gained a log-pointer needle plus a no-repository-path needle (+1 net). A census
+# that only ever rises is a census nobody re-derives — this one is recomputed from the run.
+EXPECTED_CHECKS=105
 if [ "$((PASS + FAIL + SKIP))" -ne "$EXPECTED_CHECKS" ]; then
   printf 'FAIL - assertion census mismatch: %d checks ran (%d ok / %d fail / %d skip), expected exactly %d.\n' \
     "$((PASS + FAIL + SKIP))" "$PASS" "$FAIL" "$SKIP" "$EXPECTED_CHECKS"

--- a/scripts/tests/test_agent_gate_file_size_log.sh
+++ b/scripts/tests/test_agent_gate_file_size_log.sh
@@ -6,8 +6,10 @@
 # The #3402 defect: with CQLITE_ALLOW_FILE_GROWTH=1 the component reported a bare
 # `file-size: PASS (0s)`, so a pasted SUMMARY — the unit of evidence a PR reviewer reads —
 # could not be told apart from a run where the ratchet was genuinely satisfied. The
-# component now reports its own NON-FAILING `OPT-OUT` token carrying the env var, the
-# count and the grown file names inline. The property that matters most here is the
+# component now reports its own NON-FAILING `OPT-OUT` token carrying the env var and the
+# COUNT, plus a pointer to this component's log — deliberately NOT the file names, which
+# live in file-size.log (#3401) and, for a reviewer, in the PR diff. The property that
+# matters most here is the
 # NEGATIVE one (case 4c): `OPT-OUT` may be emitted ONLY for the affirmative value `1`,
 # because a permissive branch keyed on `!= <bad>` would let a typo waive the ratchet.
 #
@@ -34,7 +36,6 @@
 #       handled — only that the component ran with an empty file list)
 #   4. grown + CQLITE_ALLOW_FILE_GROWTH=1 -> OPT-OUT (the opt-out is RECORDED, and — since
 #      #3402 — VISIBLE in the SUMMARY block, not only in this log)
-#   4b. #3402: four grown files -> the SUMMARY's file list ELIDES with a named remainder
 #   4c. #3402: a MALFORMED override, run for BOTH spellings (`0` and `true`) -> still a
 #       ratchet FAIL, never OPT-OUT
 #   5. base ref unresolvable              -> PASS (advisory only, ratchet skipped)
@@ -153,46 +154,6 @@ mkrepo() {
     if [ "${n:-x}" != "$nhead" ]; then
       bad "fixture $name: worktree $rel has ${n:-<unreadable>} lines, expected $nhead"; return 1
     fi
-  fi
-  REPO="$root"
-}
-
-# mkrepo_multi <name> <count> <committed-lines> <worktree-lines> (#3402) — the multi-file
-# sibling of mkrepo: <count> over-threshold sources (cqlite-core/src/big1.rs …), ALL
-# committed at <committed-lines> and ALL grown to <worktree-lines>. Needed because the
-# SUMMARY's grown-file list elides beyond three entries, which a one-file fixture can
-# never reach. Same contract as mkrepo: publishes the path in the global REPO (never via
-# command substitution, which would run every `bad` in a subshell and DISCARD the failure
-# count), checks its git setup, and RE-MEASURES what it wrote.
-mkrepo_multi() {
-  local name="$1" count="$2" nbase="$3" nhead="$4"
-  local root="$tmp/$name" err="$tmp/$name.setup.err" i n
-  REPO=""
-  if ! mkdir -p "$root/scripts" "$root/cqlite-core/src" 2>"$err"; then
-    bad "fixture $name: mkdir failed — $(tr '\n' ' ' <"$err")"; return 1
-  fi
-  if ! cp "$GATE" "$root/scripts/agent-gate.sh" 2>"$err"; then
-    bad "fixture $name: could not stage the gate script — $(tr '\n' ' ' <"$err")"; return 1
-  fi
-  printf 'target/\n*.log\n.agent-gate-summary.txt\n' >"$root/.gitignore"
-  for i in $(seq 1 "$count"); do lines "$nbase" "$root/cqlite-core/src/big$i.rs"; done
-  if ! ( cd "$root" && git "${GIT_CFG[@]}" init -q -b main . &&
-         git "${GIT_CFG[@]}" add -A &&
-         git "${GIT_CFG[@]}" commit -qm init ) >"$err" 2>&1; then
-    bad "fixture $name: git setup FAILED — $(tr '\n' ' ' <"$err")"; return 1
-  fi
-  for i in $(seq 1 "$count"); do
-    lines "$nhead" "$root/cqlite-core/src/big$i.rs"
-    n=$(wc -l <"$root/cqlite-core/src/big$i.rs" 2>/dev/null | tr -d ' ')
-    if [ "${n:-x}" != "$nhead" ]; then
-      bad "fixture $name: worktree big$i.rs has ${n:-<unreadable>} lines, expected $nhead"; return 1
-    fi
-  done
-  # A fixture that does not present <count> GROWN files makes the elision assert
-  # meaningless, so the count is measured rather than assumed.
-  n=$( cd "$root" 2>/dev/null && git diff --name-only -- '*.rs' 2>/dev/null | grep -c . )
-  if [ "${n:-x}" != "$count" ]; then
-    bad "fixture $name: git reports ${n:-<unreadable>} changed .rs file(s), expected $count"; return 1
   fi
   REPO="$root"
 }

--- a/scripts/tests/test_agent_gate_file_size_log.sh
+++ b/scripts/tests/test_agent_gate_file_size_log.sh
@@ -753,6 +753,7 @@ case "\$d" in
     if [ -d "\$d" ]; then
       case "\${FS_SABOTAGE:-}" in
         dir)     mkdir -p "\$d/file-size.log" ;;
+        detaildir) mkdir -p "\$d/file-size.status-detail" ;;
         devfull) ln -s /dev/full "\$d/file-size.log" ;;
         sibfull) mkdir -p "\$d/file-size.log"
                  ln -s /dev/full "\$d/file-size.persistence-error.log" ;;
@@ -1020,6 +1021,47 @@ STUB
       "$sumrow11" 'LOG PERSISTENCE FAILURE, not a ratchet violation .*the ratchet was OPTED OUT OF'
 
   # -------------------------------------------------------------------------
+  # Case 14 (#3402, roborev job 108) — an UNWRITABLE sidecar must leave NOTHING renderable,
+  # never a stale or partial detail. `_record_status_detail` is called TWICE on this path:
+  # once by the opt-out branch, then again by the persistence block to REPLACE that detail.
+  # A truncate-in-place whose second write failed left the FIRST detail in the file, so the
+  # row claimed `CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced)` while the component was
+  # FAIL for a persistence reason — the C1 false attribution, arriving through a failed write.
+  #
+  # The fixture plants a DIRECTORY at the sidecar path, so every write to it fails
+  # (uid-independent, unlike a chmod, which is a no-op for root).
+  #
+  # WHAT THIS CASE DOES *NOT* PROVE, said plainly rather than left to be assumed: it does NOT
+  # discriminate the write-then-rename fix. With the sidecar wholly unwritable, the previous
+  # truncate-in-place form fails identically and also renders nothing — verified against a
+  # mutant restoring it, where this case still passes. The hazard the fix closes needs the
+  # FIRST write to SUCCEED and the SECOND to FAIL, i.e. the path must become unwritable
+  # BETWEEN two calls inside one component, which no external fixture can arrange at this
+  # granularity (the same reason #3401 declared the mid-sequence partial write unreachable).
+  # So this case pins the REACHABLE half — an unwritable sidecar renders nothing partial or
+  # stale — and the unreachable half rests on the code being obviously safer rather than on a
+  # green here. A case that cannot fail for the reason you think it can is worse than one
+  # whose scope is written down.
+  # -------------------------------------------------------------------------
+  mkrepo detailfail cqlite-core/src/big.rs 900 950 main; r14="$REPO"
+  out14="$tmp/detailfail.out"
+  run_only_file_size "$r14" "$out14" PATH="$STUBBIN:$PATH" FS_SABOTAGE=detaildir \
+      CQLITE_ALLOW_FILE_GROWTH=1
+  d14=$(logdir_of "$out14") || bad "case14: the run published no usable 'logs:' dir"
+  if [ -d "$d14/file-size.status-detail" ]; then
+    ok "case14: sabotage in place (the status-detail path is a directory, so every write fails)"
+  else
+    bad "case14: sabotage did NOT take effect at '$d14/file-size.status-detail' — the path was never exercised"
+  fi
+  sumrow14="$tmp/detailfail.sumrow"
+  fs_summary_row "$r14/.sum" "$sumrow14" ||
+    bad "case14 (#3402): the run emitted no usable file-size row — the stale-detail asserts are UNMEASURED"
+  lacks "case14 (#3402): an unwritable sidecar renders NO opt-out claim (no stale detail)" \
+      "$sumrow14" "ratchet NOT enforced"
+  lacks "case14 (#3402): and no partial fragment of it either" \
+      "$sumrow14" "CQLITE_ALLOW_FILE_GROWTH"
+
+  # -------------------------------------------------------------------------
   # Case 13 — CQLITE_ALLOW_FILE_GROWTH set to a NON-1 value (#3401 review item 3). The
   # branch distinguishing "set to something that is not 1" from "never set" was otherwise
   # unexercised, so it could regress while the suite stayed green. Saying "unset" to
@@ -1106,7 +1148,10 @@ printf 'file-size component log + opt-out marker guard (#3401/#3402): %d passed,
 # the first value written here was WRONG (109, guessed from the number of asserts typed
 # rather than counted from a run: `fs_summary_row || bad` contributes nothing unless it
 # fires).
-EXPECTED_CHECKS=113
+# 113 -> 116 on job 108 (+3 case14: an unwritable sidecar must leave nothing renderable).
+# Counted from a RUN, not from asserts typed: the `fs_summary_row || bad` guard contributes
+# nothing unless it fires, which is why the first value written here (117) was wrong twice.
+EXPECTED_CHECKS=116
 if [ "$((PASS + FAIL + SKIP))" -ne "$EXPECTED_CHECKS" ]; then
   printf 'FAIL - assertion census mismatch: %d checks ran (%d ok / %d fail / %d skip), expected exactly %d.\n' \
     "$((PASS + FAIL + SKIP))" "$PASS" "$FAIL" "$SKIP" "$EXPECTED_CHECKS"

--- a/scripts/tests/test_agent_gate_file_size_log.sh
+++ b/scripts/tests/test_agent_gate_file_size_log.sh
@@ -67,6 +67,12 @@ set -uo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 GATE="$SCRIPT_DIR/../agent-gate.sh"
+# Case 4i runs a REAL FULL gate in a fixture, which must clear the #3544 component-set
+# pre-flight first: that needs the canonical remote identity pinned in the fixture's own copy
+# of the gate and a committed component manifest beside it. Both are the sanctioned
+# artifact-substitution helpers (a settable seam would reopen the hole #3544 closes).
+# shellcheck source=scripts/tests/lib/agent-gate-canonical-pin.bash
+. "$SCRIPT_DIR/lib/agent-gate-canonical-pin.bash"
 
 # Never inherit a caller's summary path / parent marker (#2751/#2874 discipline), and
 # never block on the machine-wide gate slot (#1825) — these runs compile nothing.
@@ -542,6 +548,95 @@ for bad_val in 0 true; do
 done
 
 # ---------------------------------------------------------------------------
+# Case 4i (#3402, roborev job 26) — the disclosure must survive an EARLY-EXIT emit.
+#
+# `run_file_size` executes ~250 lines BEFORE the dataset and schemas preflights, and each
+# early-exit `emit_summary` hand-builds its own meta list. So a full gate with an engaged
+# override and a missing corpus recorded `file-size: OPT-OUT` and then emitted its ONLY
+# block with NO component row at all — the override name and the growth count absent from
+# the very artifact this issue exists to put them in. Round 1 found the same shape in the
+# tree-integrity boundary block; this is the preflight emit.
+#
+# This is the suite's one REAL FULL-GATE run. It compiles nothing: the preflight fails before
+# any component is dispatched, which is exactly the window under test. It needs the #3544
+# pre-flight to pass, hence the pinned canonical remote + committed manifest and a local bare
+# origin.
+# ---------------------------------------------------------------------------
+pf_root="$tmp/preflight-fixture"
+pf_empty="$tmp/preflight-empty-root/sstables"
+pf_ok=1
+mkdir -p "$pf_root/scripts" "$pf_root/cqlite-core/src" "$pf_empty" 2>/dev/null || pf_ok=0
+if [ "$pf_ok" = 1 ]; then
+  cp "$GATE" "$pf_root/scripts/agent-gate.sh" || pf_ok=0
+fi
+if [ "$pf_ok" = 1 ]; then
+  agent_gate_pin_canonical_remote "$pf_root/scripts/agent-gate.sh" "$pf_root.origin.git" || pf_ok=0
+  agent_gate_install_components_manifest "$pf_root/scripts/agent-gate.sh" || pf_ok=0
+fi
+if [ "$pf_ok" = 1 ]; then
+  lines 900 "$pf_root/cqlite-core/src/big.rs"
+  printf 'target/\n*.log\n' > "$pf_root/.gitignore"
+  ( cd "$pf_root" && git "${GIT_CFG[@]}" init -q -b main . &&
+    git "${GIT_CFG[@]}" add -A && git "${GIT_CFG[@]}" commit -qm init &&
+    git init -q --bare "$pf_root.origin.git" &&
+    git "${GIT_CFG[@]}" remote add origin "$pf_root.origin.git" &&
+    git "${GIT_CFG[@]}" push -q origin main ) >/dev/null 2>&1 || pf_ok=0
+fi
+if [ "$pf_ok" != 1 ]; then
+  # NOT a skip: this suite needs git and a writable scratch, both of which every other case
+  # already relies on, so a failure here is a broken harness rather than a missing capability.
+  bad "case4i: could not build the full-gate preflight fixture — the early-exit path is UNMEASURED"
+  bad "case4i: (OPT-OUT row needle not reached)"
+  bad "case4i: (count-agreement needle not reached)"
+  bad "case4i mutant: (not reached)"
+else
+  lines 950 "$pf_root/cqlite-core/src/big.rs"
+  pf_sum="$tmp/preflight.sum"; pf_out="$tmp/preflight.out"
+  ( cd "$pf_root" && env -u AGENT_GATE_SUMMARY_FILE CQLITE_DATASETS_ROOT="${pf_empty%/sstables}" \
+      CQLITE_ALLOW_FILE_GROWTH=1 CQLITE_GATE_DISABLE_CAP=1 AGENT_GATE_SUMMARY_FILE="$pf_sum" \
+      bash "$pf_root/scripts/agent-gate.sh" >"$pf_out" 2>&1 )
+  # POSITIVE CONTROL: the run must actually have stopped at the corpus preflight. Without
+  # this, an assert below could be measuring a run that never got there.
+  if grep -q 'missing-fixtures: FAIL-CLOSED' "$pf_sum" 2>/dev/null; then
+    ok "case4i: the fixture run really stopped at the #2078 corpus preflight (window under test)"
+  else
+    bad "case4i: the run did not reach the corpus preflight — the early-exit path is UNMEASURED"
+    grep -E '^(preflight|component-set|RESULT):' "$pf_sum" 2>/dev/null | head -3
+  fi
+  has "case4i (#3402): the preflight-FAIL block carries the OPT-OUT row with its detail" \
+      "$pf_sum" "OPT-OUT (0s) — CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced); 1 over-threshold file(s) grown"
+  # The count must AGREE with the rows printed. It did not: the helper assigns its count
+  # inside a command substitution, so the caller read 0 beside one row — a count
+  # contradicting its own table, which is the invariant
+  # scripts/tests/test_agent_gate_tree_provenance.sh asserts for the boundary block.
+  pf_rows=$(grep -cE '^[a-z][a-z0-9-]*: +(PASS|FAIL|SKIP|OPT-OUT) \([0-9]+s\)' "$pf_sum" 2>/dev/null | tr -d ' ')
+  pf_said=$(sed -n 's/^components-completed-before-exit: \([0-9]*\) .*/\1/p' "$pf_sum" | head -1)
+  if [ -n "$pf_said" ] && [ "$pf_said" = "${pf_rows:-x}" ]; then
+    ok "case4i (#3402): components-completed-before-exit ($pf_said) equals the rows printed — no contradicted count"
+  else
+    bad "case4i (#3402): the block says '$pf_said' completed but printed ${pf_rows:-<unmeasured>} row(s)"
+  fi
+  # The mutant: drop the rows argument from the corpus-preflight emit, which is the state
+  # before this fix. The block still emits, so only the row can distinguish the two.
+  pf_mut="$tmp/preflight-mutant"
+  if cp -r "$pf_root" "$pf_mut" 2>/dev/null &&
+     sed -i 's/^\( *\)\${_pf_rows:+"\$_pf_rows"} \\$/\1\\/' "$pf_mut/scripts/agent-gate.sh" &&
+     ! grep -q '_pf_rows:+' "$pf_mut/scripts/agent-gate.sh"; then
+    pf_msum="$tmp/preflight-mutant.sum"
+    ( cd "$pf_mut" && env -u AGENT_GATE_SUMMARY_FILE CQLITE_DATASETS_ROOT="${pf_empty%/sstables}" \
+        CQLITE_ALLOW_FILE_GROWTH=1 CQLITE_GATE_DISABLE_CAP=1 AGENT_GATE_SUMMARY_FILE="$pf_msum" \
+        bash "$pf_mut/scripts/agent-gate.sh" >"$tmp/preflight-mutant.out" 2>&1 )
+    if grep -q 'CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced)' "$pf_msum" 2>/dev/null; then
+      bad "case4i mutant: the row survives without the rows argument — the check cannot fail"
+    else
+      ok "case4i mutant: without the rows argument the override is INVISIBLE in the block (proved discriminating)"
+    fi
+  else
+    bad "case4i mutant: could not build the mutant fixture — the assert above is unproven"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
 # Case 5 — base ref UNRESOLVABLE (no main/master, no origin/*): the ratchet is skipped and
 # the log must say so EXPLICITLY, while the advisory list still works off `git diff HEAD`.
 # ---------------------------------------------------------------------------
@@ -973,7 +1068,7 @@ printf 'file-size component log + opt-out marker guard (#3401/#3402): %d passed,
 # the first value written here was WRONG (109, guessed from the number of asserts typed
 # rather than counted from a run: `fs_summary_row || bad` contributes nothing unless it
 # fires).
-EXPECTED_CHECKS=108
+EXPECTED_CHECKS=112
 if [ "$((PASS + FAIL + SKIP))" -ne "$EXPECTED_CHECKS" ]; then
   printf 'FAIL - assertion census mismatch: %d checks ran (%d ok / %d fail / %d skip), expected exactly %d.\n' \
     "$((PASS + FAIL + SKIP))" "$PASS" "$FAIL" "$SKIP" "$EXPECTED_CHECKS"

--- a/scripts/tests/test_agent_gate_file_size_log.sh
+++ b/scripts/tests/test_agent_gate_file_size_log.sh
@@ -400,7 +400,10 @@ has "case3b: log carries the terminal verdict" "$log3b" ">>> [file-size] PASS"
 # what was missing is that the SUMMARY — the unit of evidence agents paste into PRs —
 # carried a bare `file-size: PASS (0s)`, byte-indistinguishable from a run where the
 # ratchet was genuinely satisfied. So the component's own status TOKEN is now OPT-OUT, and
-# the row must NAME the env var, the COUNT and the FILES.
+# the row must NAME the env var and the COUNT and POINT AT this log — deliberately NOT the
+# file names, which are log-only (see the removed-cases note below for why rendering them on
+# the row was tried and withdrawn). The asserts below check both directions: the disclosure
+# is present, and no repository path rode onto the row with it.
 # ---------------------------------------------------------------------------
 mkrepo optout cqlite-core/src/big.rs 900 950 main; r4="$REPO"
 out4="$tmp/optout.out"

--- a/scripts/tests/test_agent_gate_file_size_log.sh
+++ b/scripts/tests/test_agent_gate_file_size_log.sh
@@ -603,8 +603,13 @@ else
     bad "case4i: the run did not reach the corpus preflight — the early-exit path is UNMEASURED"
     grep -E '^(preflight|component-set|RESULT):' "$pf_sum" 2>/dev/null | head -3
   fi
+  # The annotation is REQUIRED, not incidental (roborev job 76). #3453's contract is that
+  # EVERY component line names the feature matrix it ran; a funnel-appended row that omitted
+  # it would satisfy "the disclosure is present" while losing the execution evidence beside
+  # it — and the first version of this assert PINNED that incomplete shape, which is how a
+  # test stops being a check and starts being a ratchet on a defect.
   has "case4i (#3402): the preflight-FAIL block carries the OPT-OUT row with its detail" \
-      "$pf_sum" "OPT-OUT (0s) — CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced); 1 over-threshold file(s) grown"
+      "$pf_sum" "OPT-OUT (0s)  [no-cargo] — CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced); 1 over-threshold file(s) grown"
   # The count must AGREE with the rows printed. It did not: the helper assigns its count
   # inside a command substitution, so the caller read 0 beside one row — a count
   # contradicting its own table, which is the invariant

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -5082,21 +5082,41 @@ fi
 #
 # Host-INDEPENDENT: bash plus --emit-summary-selftest (no cargo, no python3, no jq, no
 # network, no datasets), so none of these five can become a declared tooling skip.
+#
+# GRAMMAR, and why it is a CLOSED set with FOUR tokens rather than three (#3402): the
+# component status token is part of this block contract, so a new one is an extension made
+# HERE, deliberately, not an assertion weakened to let a change through. `OPT-OUT` is the
+# `file-size` component's own non-failing token for an ENGAGED CQLITE_ALLOW_FILE_GROWTH=1
+# — `PASS` must mean "the check ran and was satisfied", never "the check was switched off".
+# Two consequences are encoded below: an OPT-OUT row is still a COUNTED component row (a
+# three-token grammar would silently drop it from `fm_lines`, and a dropped row is exactly
+# the undercount this census exists to catch), and it may carry a `— <detail>` suffix AFTER
+# the bracketed matrix, so the annotation assert is anchored on the bracket plus an
+# OPTIONAL detail rather than on end-of-line. `--emit-summary-selftest` emits no OPT-OUT
+# row itself; the behavioural coverage is scripts/tests/test_agent_gate_file_size_log.sh,
+# which drives the REAL `--only file-size` path (also in tooling-tests).
+# ONE definition of the row grammar, shared by the census below and by 54f, which is what
+# makes 54f a test OF THIS CENSUS rather than of a second copy that can drift from it.
+# FIVE tokens, from two issues that landed together and reached the same conclusion
+# independently: #3625's VACUOUS (a PASS whose measured subject count is zero) and #3402's
+# OPT-OUT (file-size under an engaged CQLITE_ALLOW_FILE_GROWTH=1). A shape recogniser that
+# omits either stops SEEING the rows it does not name.
+FM_ROW_RE='^[a-z][a-z-]*: +(PASS|FAIL|SKIP|VACUOUS|OPT-OUT) \([0-9]+s\)'
+# The tail is `[<feature matrix>]  {<census>}` and then, optionally, #3402's ` — <detail>`.
+# BOTH structured suffixes stay REQUIRED and the census stays LAST OF THEM, so neither can be
+# dropped without this failing (#3453 + #3625). The detail is free text and is the only thing
+# allowed after the census — structured tokens a parser keys on never sit behind unstructured
+# prose. Absent detail, this is byte-identical to #3625's anchor.
+FM_ROW_ANNOT_RE="$FM_ROW_RE"' +\[.+\]  \{.+\}( — .*)?$'
 fm_sum="$tmp/3453-annot-summary.txt"
 if AGENT_GATE_SUMMARY_FILE="$fm_sum" bash "$GATE" --emit-summary-selftest >/dev/null 2>&1; then
-  # VACUOUS joins PASS/FAIL/SKIP in the component-status vocabulary (#3625): a PASS whose
-  # measured subject count is zero is recorded under its own token, so a shape recogniser
-  # that omits it would stop SEEING the very lines that state a component verified nothing.
-  fm_lines=$(grep -cE '^[a-z][a-z-]*: +(PASS|FAIL|SKIP|VACUOUS) \([0-9]+s\)' "$fm_sum")
-  # The line's tail is now `[<feature matrix>]  {<census>}` — BOTH are part of the block
-  # contract, and the `$` anchor requires the census to be LAST, so neither can be dropped
-  # without this failing (#3453 + #3625).
-  fm_annot=$(grep -cE '^[a-z][a-z-]*: +(PASS|FAIL|SKIP|VACUOUS) \([0-9]+s\) +\[.+\]  \{.+\}$' "$fm_sum")
+  fm_lines=$(grep -cE "$FM_ROW_RE" "$fm_sum")
+  fm_annot=$(grep -cE "$FM_ROW_ANNOT_RE" "$fm_sum")
   if [ "$fm_lines" -gt 0 ] && [ "$fm_annot" = "$fm_lines" ]; then
     ok "3453-annot-a: all $fm_lines component line(s) carry a bracketed feature matrix AND a census suffix"
   else
     bad "3453-annot-a: only $fm_annot of $fm_lines component lines carry a feature matrix + census suffix"
-    grep -E '^[a-z][a-z-]*: +(PASS|FAIL|SKIP|VACUOUS)' "$fm_sum" || true
+    grep -E "$FM_ROW_RE" "$fm_sum" || true
   fi
   # #3625: the aggregate census line. It must be present, must declare its own
   # NON-EXHAUSTIVENESS, and must report every non-affirmed class as `N RECOGNISED` rather
@@ -5116,12 +5136,12 @@ if AGENT_GATE_SUMMARY_FILE="$fm_sum" bash "$GATE" --emit-summary-selftest >/dev/
   # VACUOUS included (#3625): omitting it made this screen BLIND to exactly the rows that
   # report a component verified nothing — the ones most worth checking for a broken
   # annotation.
-  if grep -qE '^[a-z][a-z-]*: +(PASS|FAIL|SKIP|VACUOUS).*\[(UNDECLARED|UNCLASSIFIED)' "$fm_sum"; then
+  if grep -qE '^[a-z][a-z-]*: +(PASS|FAIL|SKIP|VACUOUS|OPT-OUT).*\[(UNDECLARED|UNCLASSIFIED)' "$fm_sum"; then
     bad "3453-annot-b: a component line reads UNDECLARED/UNCLASSIFIED in the reference block"
   else
     ok "3453-annot-b: no component line reads UNDECLARED/UNCLASSIFIED in the reference block"
   fi
-  if grep -E '^[a-z][a-z-]*: +(PASS|FAIL|SKIP|VACUOUS)' "$fm_sum" | grep -q 'RESULT:'; then
+  if grep -E "$FM_ROW_RE" "$fm_sum" | grep -q 'RESULT:'; then
     bad "3453-annot-c: an annotation embeds the RESULT: token — it would break the #2908 poll predicate"
   else
     ok "3453-annot-c: no annotation embeds the RESULT: token (the one-RESULT invariant is safe)"
@@ -5166,6 +5186,46 @@ if [ -r "$SCRIPT_DIR/../../$fm_guard" ] && grep -q "$fm_guard" "$GATE"; then
   ok "3453-annot-e: the completeness/no-drift guard exists AND is registered in the gate (tooling-tests)"
 else
   bad "3453-annot-e: $fm_guard missing (looked under $SCRIPT_DIR/../..) or not registered in $GATE — the COMPONENTS completeness census would be silently gone"
+fi
+
+# --- 54f. #3402: the census grammar must ADMIT the OPT-OUT component row ---------------
+#
+# WHY THIS EXISTS: `--emit-summary-selftest` emits no OPT-OUT row, so the fourth token has
+# NO SUBJECT in the census above — the extension would sit here unexercised, and a later
+# "tidy" back to three tokens would pass this whole section while silently dropping every
+# OPT-OUT row from it. MEASURED, so this is not a hypothetical: against a two-row sample
+# (one PASS, one OPT-OUT) the three-token grammar counted 1 of 2 with fm_lines == fm_annot
+# — i.e. it reported "all component line(s) carry a feature matrix" over a subject set it
+# had itself shrunk. A vacuous green is the one outcome this section exists to refuse, so
+# the undercount is worse than a red would have been.
+#
+# The two regexes are the SAME variables the census used, never re-spelled here — a second
+# copy could drift and then 54f would certify a grammar nobody uses. The row is the real
+# render (`%-18s` name, token, `(Ns)`, two spaces, the bracketed matrix, then #3402's
+# ` — <detail>` suffix); the behavioural half — that the gate actually PRODUCES this row,
+# and only for an override of exactly `1` — is scripts/tests/test_agent_gate_file_size_log.sh,
+# asserted registered below rather than duplicated here.
+fm_optout_row='file-size:         OPT-OUT (0s)  [no-cargo] — CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced); 1 over-threshold file(s) grown: cqlite-core/src/big.rs'
+fm_plain_row='fmt:               PASS (1s)  [fmt --all]'
+fm_rowfile="$tmp/3402-rows.txt"
+printf '%s\n%s\n' "$fm_plain_row" "$fm_optout_row" >"$fm_rowfile"
+fm_n_row=$(grep -cE "$FM_ROW_RE" "$fm_rowfile")
+fm_n_annot=$(grep -cE "$FM_ROW_ANNOT_RE" "$fm_rowfile")
+if [ "$fm_n_row" = 2 ]; then
+  ok "3402-grammar-a: the census counts an OPT-OUT row as a component row (2/2) — no silent undercount"
+else
+  bad "3402-grammar-a: the census counted $fm_n_row of 2 component rows — an OPT-OUT row is being dropped"
+fi
+if [ "$fm_n_annot" = 2 ]; then
+  ok "3402-grammar-b: the annotation assert tolerates the ' — <detail>' suffix after the bracketed matrix (2/2)"
+else
+  bad "3402-grammar-b: the annotation assert matched $fm_n_annot of 2 — a detail suffix defeats the end-of-line anchor"
+fi
+fs_guard=scripts/tests/test_agent_gate_file_size_log.sh
+if [ -r "$SCRIPT_DIR/../../$fs_guard" ] && grep -q "$fs_guard" "$GATE"; then
+  ok "3402-grammar-c: the behavioural OPT-OUT guard exists AND is registered in the gate (tooling-tests)"
+else
+  bad "3402-grammar-c: $fs_guard missing (looked under $SCRIPT_DIR/../..) or not registered in $GATE — the grammar above would have no behavioural counterpart"
 fi
 
 # TOLERANT BY DELIBERATE CHOICE, not by neglect (issue #1465 round 14 — the FALLBACK the
@@ -5221,7 +5281,10 @@ fi
 # preserves the deliberate ~9 margin rather than widening it — a floor that stays put
 # while the suite grows is a floor that stops detecting a silently-dying section, which
 # is the only thing it is for.
-ASSERT_FLOOR=410
+# 410 -> 413 on #3402: section 54f adds 3 asserts, host-INDEPENDENT for the same reason as
+# 54 (pure bash grep over an in-suite string, plus two file-presence reads), so the same
+# "raise by exactly the number added" rule applies and the deliberate ~9 margin is kept.
+ASSERT_FLOOR=413
 # PASS + SKIPPED_TOOLING, not PASS alone: a DECLARED tooling skip is accounted for
 # rather than counted against the floor (see SKIPPED_TOOLING). A section that dies
 # silently still reds, because a dead section increments neither counter.

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -5095,6 +5095,7 @@ fi
 # OPTIONAL detail rather than on end-of-line. `--emit-summary-selftest` emits no OPT-OUT
 # row itself; the behavioural coverage is scripts/tests/test_agent_gate_file_size_log.sh,
 # which drives the REAL `--only file-size` path (also in tooling-tests).
+#
 # ONE definition of the row grammar, shared by the census below and by 54f, which is what
 # makes 54f a test OF THIS CENSUS rather than of a second copy that can drift from it.
 # FIVE tokens, from two issues that landed together and reached the same conclusion

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -5206,8 +5206,14 @@ fi
 # ` — <detail>` suffix); the behavioural half — that the gate actually PRODUCES this row,
 # and only for an override of exactly `1` — is scripts/tests/test_agent_gate_file_size_log.sh,
 # asserted registered below rather than duplicated here.
-fm_optout_row='file-size:         OPT-OUT (0s)  [no-cargo] — CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced); 1 over-threshold file(s) grown: cqlite-core/src/big.rs'
-fm_plain_row='fmt:               PASS (1s)  [fmt --all]'
+# The samples carry ALL THREE suffixes in the shipped order — `[<matrix>]  {<census>}` then
+# #3402's optional ` — <detail>`. They were written before #3625's census landed and then
+# matched 0 of 2, because the annotation anchor now REQUIRES the census: a sample that lags
+# the real render turns this section into a test of an obsolete shape, which is worse than no
+# sample at all. Kept as literals rather than generated, so a change to the render must be
+# reflected here deliberately.
+fm_optout_row='file-size:         OPT-OUT (0s)  [no-cargo]  {no census: component ended OPT-OUT, so there is no PASS to affirm} — CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced); 1 over-threshold file(s) grown — see file-size.log under logs:'
+fm_plain_row='fmt:               PASS (1s)  [fmt --all]  {AFFIRMED 1 target}'
 fm_rowfile="$tmp/3402-rows.txt"
 printf '%s\n%s\n' "$fm_plain_row" "$fm_optout_row" >"$fm_rowfile"
 fm_n_row=$(grep -cE "$FM_ROW_RE" "$fm_rowfile")

--- a/scripts/tests/test_agent_gate_tree_provenance.sh
+++ b/scripts/tests/test_agent_gate_tree_provenance.sh
@@ -493,19 +493,21 @@ SEEDSTUB
     bad "B2 (#3402): the boundary row DROPPED the status detail — the opt-out is invisible here"
     grep -E '^file-size: ' "$sum" 2>/dev/null
   fi
-  # The mutant: drop the detail from _tree_boundary_row's own printf. A row still prints, so
-  # only the DETAIL can distinguish the two — which is what makes the assertion above
+  # The mutant: drop the detail suffix from `_fm_summary_line`'s printf — i.e. restore the
+  # pre-#3402 line exactly. A row still prints, with its feature matrix and census, so only
+  # the DETAIL can distinguish the two, which is what makes the assertion above
   # discriminating rather than incidental.
   #
-  # IT TARGETS THE FUNCTION BODY, NOT THE CALL SITE (roborev job 76). The call site was
-  # `_tree_boundary_row "$_c" …` until the renderer became a parameter (`"$_render" …`), at
-  # which point this mutant's target vanished and `gate_replace_line` correctly reported
-  # VACUOUS rather than passing over a mutation that never happened. The printf is the thing
-  # whose behaviour is under test, and it does not move when the caller is refactored.
+  # IT TARGETS THE RENDERER'S BODY, NOT A CALL SITE. This mutant has been retargeted TWICE by
+  # refactors that moved its subject — first when the boundary loops stopped calling a
+  # dedicated row helper, then when #3625 routed them through `_fm_summary_line` — and on both
+  # occasions `gate_replace_line` reported VACUOUS rather than passing over a mutation that
+  # never happened. That is the guard working, and the reason it keeps working is that the
+  # replacement target is always the printf whose behaviour is under test.
   mut="$tmp/gate-mutant-boundary-detail.sh"
   if gate_replace_line "$GATE" "$mut" \
-       'printf '"'"'%-18s %s (%ss)%s\n'"'"' "$1:" "$2" "$3" "${_d:+ — $_d}"' \
-       "printf '%-18s %s (%ss)\\n' \"\$1:\" \"\$2\" \"\$3\""; then
+       'printf '"'"'%-18s %s (%s)  %s  %s%s'"'"' "$1:" "$2" "$3" "$(_fm_annotate "$1")" "$(_census_annotate "$1" "$2")" "${_detail:+ — $_detail}"' \
+       "printf '%-18s %s (%s)  %s  %s' \"\$1:\" \"\$2\" \"\$3\" \"\$(_fm_annotate \"\$1\")\" \"\$(_census_annotate \"\$1\" \"\$2\")\""; then
     r_b2m=$(mkrepo_from b2-detail-mutant-repo "$mut")
     sum="$tmp/b2-detail-mutant.txt"; out="$tmp/b2-detail-mutant.out"
     ( cd "$r_b2m" && PATH="$seedbin:$STUBBIN:$PATH" env SEED_DETAIL="$seed_detail" \
@@ -518,7 +520,7 @@ SEEDSTUB
       ok "B2 mutant: the pre-#3402 printf drops the detail (proved discriminating)"
     fi
   else
-    bad "B2 mutant: _tree_boundary_row's printf was not found — the mutant is vacuous"
+    bad "B2 mutant: _fm_summary_line's printf was not found — the mutant is vacuous"
   fi
 fi
 

--- a/scripts/tests/test_agent_gate_tree_provenance.sh
+++ b/scripts/tests/test_agent_gate_tree_provenance.sh
@@ -515,6 +515,70 @@ SEEDSTUB
   fi
 fi
 
+echo "=== phase B3 (#3402): a detail carrying the verdict token is WITHHELD ==========="
+#
+# WHY SEEDED: `_status_detail` refuses a value containing the completion probe's `RESULT:`
+# token, because the detail lands on a component ROW inside the summary FILE that the
+# #2908/#3041 probe greps for `RESULT: (PASS|FAIL)`. No writer shipping today can produce
+# such a value — the one detail-emitting component interpolates fixed wording, a count and
+# a LOG_DIR path — so the guard is unreachable from any fixture, and an unreachable guard
+# with no coverage is one nobody can trust to still work. Seeding the sidecar exercises the
+# REAL boundary on the REAL renderer; only the writer is substituted.
+#
+# It also pins the rule that the refusal must not QUOTE what it refuses: a diagnostic
+# reproducing the token would forge the very row it prevents.
+if [ -z "${seedbin:-}" ] || [ ! -x "$seedbin/mktemp" ]; then
+  bad "B3: the phase-B2 seeding shim is unavailable — the withholding guard is UNMEASURED"
+  bad "B3: (withholding assertion not reached)"
+  bad "B3: (self-forgery assertion not reached)"
+  bad "B3 mutant: (not reached)"
+else
+  b3_detail='ratchet NOT enforced; RESULT: PASS smuggled into a detail'
+  r_b3=$(mkrepo b3-withhold-repo)
+  sum="$tmp/b3-withhold.txt"; out="$tmp/b3-withhold.out"
+  ( cd "$r_b3" && PATH="$seedbin:$STUBBIN:$PATH" env SEED_DETAIL="$b3_detail" \
+      AGENT_GATE_SUMMARY_FILE="$sum" AGENT_GATE_TREE_SELFTEST=boundary \
+      AGENT_GATE_TREE_SELFTEST_MUTATE=README.md \
+      bash "$r_b3/scripts/agent-gate.sh" >"$out" 2>&1 )
+  if grep -qE '^file-size: +OPT-OUT \(0s\)' "$sum"; then
+    ok "B3: the seeded row reaches the boundary table (the guard is under test)"
+  else
+    bad "B3: no 'file-size: OPT-OUT' row in the block — seeding failed, the guard is UNMEASURED"
+  fi
+  if grep -q 'WITHHELD' "$sum"; then
+    ok "B3 (#3402): a detail carrying the verdict token is WITHHELD, not rendered"
+  else
+    bad "B3 (#3402): the verdict-token detail was rendered verbatim onto a component row"
+    grep -E '^file-size: ' "$sum" 2>/dev/null
+  fi
+  # The row must not itself match what the probe looks for — neither by passing the value
+  # through NOR by quoting it inside the refusal.
+  if grep -E '^file-size: ' "$sum" 2>/dev/null | grep -qE 'RESULT: (PASS|FAIL)'; then
+    bad "B3 (#3402): the component row matches the probe's own pattern — it would forge a verdict"
+  else
+    ok "B3 (#3402): the row does not match 'RESULT: (PASS|FAIL)' — the refusal quotes nothing"
+  fi
+  # The mutant: pass the value straight through, which is what the guard prevents.
+  mut="$tmp/gate-mutant-withhold.sh"
+  if gate_replace_line "$GATE" "$mut" \
+       "*RESULT:*) printf '%s' \"[detail WITHHELD: it carries the completion probe's reserved verdict token (#2908), which on this row would forge a terminal verdict — see the component log]\" ;;" \
+       "*RESULT:*) printf '%s' \"\$_sd_v\" ;;"; then
+    r_b3m=$(mkrepo_from b3-withhold-mutant-repo "$mut")
+    sum="$tmp/b3-withhold-mutant.txt"; out="$tmp/b3-withhold-mutant.out"
+    ( cd "$r_b3m" && PATH="$seedbin:$STUBBIN:$PATH" env SEED_DETAIL="$b3_detail" \
+        AGENT_GATE_SUMMARY_FILE="$sum" AGENT_GATE_TREE_SELFTEST=boundary \
+        AGENT_GATE_TREE_SELFTEST_MUTATE=README.md \
+        bash "$r_b3m/scripts/agent-gate.sh" >"$out" 2>&1 )
+    if grep -E '^file-size: ' "$sum" 2>/dev/null | grep -qE 'RESULT: (PASS|FAIL)'; then
+      ok "B3 mutant: passing the value through DOES put the probe's pattern on a row (proved discriminating)"
+    else
+      bad "B3 mutant: the mutant did not reproduce the hazard — the guard's coverage is vacuous"
+    fi
+  else
+    bad "B3 mutant: the withholding branch was not found — the mutant is vacuous"
+  fi
+fi
+
 echo "=== phase C (J3): the run's OWN stdout/stderr target is carved out, nothing more ="
 
 r_fd=$(mkrepo fd-repo)

--- a/scripts/tests/test_agent_gate_tree_provenance.sh
+++ b/scripts/tests/test_agent_gate_tree_provenance.sh
@@ -437,6 +437,84 @@ else
   bad "J2 mutant: the sweep guard was not found — the mutant is vacuous"
 fi
 
+echo "=== phase B2 (#3402): a boundary row carries the component's STATUS DETAIL ======="
+#
+# WHY: #3402 makes `file-size` report a non-failing OPT-OUT token whose detail (the engaged
+# env var, the count, the grown paths) is the whole disclosure. That detail is appended by
+# `_fm_summary_line`, which the BOUNDARY table does not use — it renders result files
+# directly. So a boundary block printed `file-size: OPT-OUT (0s)` with the disclosure
+# STRIPPED: the invisible opt-out #3402 removes, surviving on the one path where the run is
+# already in trouble and a reader most needs to know the ratchet was not enforced.
+#
+# HOW: the boundary hook fires BEFORE any component runs, so the row is produced by SEEDING
+# the pair a real `file-size` run would have written — `<c>.result` and `<c>.status-detail`
+# — into the LOG_DIR as it is created. That exercises the REAL sweep, the REAL renderer and
+# the REAL `_status_detail` read; only the producer is substituted, which is the same shape
+# as this suite's existing `cargo` stub.
+seedbin="$tmp/seedbin"; mkdir -p "$seedbin"
+seed_real_mktemp=$(command -v mktemp 2>/dev/null)
+if [ -z "$seed_real_mktemp" ]; then
+  bad "B2: no mktemp on PATH — the boundary-detail path CANNOT be exercised"
+  bad "B2: (detail assertion not reached)"
+  bad "B2 mutant: (not reached)"
+else
+  cat > "$seedbin/mktemp" <<SEEDSTUB
+#!/usr/bin/env bash
+d=\$("$seed_real_mktemp" "\$@") || exit 1
+case "\$d" in
+  */agent-gate.*)
+    if [ -d "\$d" ] && [ -n "\${SEED_DETAIL:-}" ]; then
+      printf 'OPT-OUT 0\n' > "\$d/file-size.result"
+      printf '%s\n' "\$SEED_DETAIL" > "\$d/file-size.status-detail"
+    fi
+    ;;
+esac
+printf '%s\n' "\$d"
+SEEDSTUB
+  chmod +x "$seedbin/mktemp"
+  seed_detail='CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced); 1 over-threshold file(s) grown: cqlite-core/src/big.rs'
+  r_b2=$(mkrepo b2-detail-repo)
+  sum="$tmp/b2-detail.txt"; out="$tmp/b2-detail.out"
+  ( cd "$r_b2" && PATH="$seedbin:$STUBBIN:$PATH" env SEED_DETAIL="$seed_detail" \
+      AGENT_GATE_SUMMARY_FILE="$sum" AGENT_GATE_TREE_SELFTEST=boundary \
+      AGENT_GATE_TREE_SELFTEST_MUTATE=README.md \
+      bash "$r_b2/scripts/agent-gate.sh" >"$out" 2>&1 )
+  # POSITIVE CONTROL FIRST: without a file-size row at all, the detail assertion below
+  # would be measuring nothing — the seeding, not the renderer, would have failed.
+  if grep -qE '^file-size: +OPT-OUT \(0s\)' "$sum"; then
+    ok "B2: the seeded OPT-OUT row reaches the boundary table (the renderer is under test)"
+  else
+    bad "B2: no 'file-size: OPT-OUT' row in the boundary block — seeding failed, detail UNMEASURED"
+    grep -E '^[a-z][a-z0-9-]*: ' "$sum" 2>/dev/null | head -5
+  fi
+  if grep -Fq -- "$seed_detail" "$sum"; then
+    ok "B2 (#3402): the boundary row carries the status detail — the disclosure survives a boundary block"
+  else
+    bad "B2 (#3402): the boundary row DROPPED the status detail — the opt-out is invisible here"
+    grep -E '^file-size: ' "$sum" 2>/dev/null
+  fi
+  # The mutant: restore the hand-rolled printf the two loops used before #3402 routed them
+  # through _tree_boundary_row. A row still prints, so only the DETAIL can distinguish the
+  # two — which is what makes the assertion above discriminating rather than incidental.
+  mut="$tmp/gate-mutant-boundary-detail.sh"
+  if gate_replace_line "$GATE" "$mut" '_tree_boundary_row "$_c" "$_st" "$_secs"' \
+       "printf '%-18s %s (%ss)\\n' \"\$_c:\" \"\$_st\" \"\$_secs\""; then
+    r_b2m=$(mkrepo_from b2-detail-mutant-repo "$mut")
+    sum="$tmp/b2-detail-mutant.txt"; out="$tmp/b2-detail-mutant.out"
+    ( cd "$r_b2m" && PATH="$seedbin:$STUBBIN:$PATH" env SEED_DETAIL="$seed_detail" \
+        AGENT_GATE_SUMMARY_FILE="$sum" AGENT_GATE_TREE_SELFTEST=boundary \
+        AGENT_GATE_TREE_SELFTEST_MUTATE=README.md \
+        bash "$r_b2m/scripts/agent-gate.sh" >"$out" 2>&1 )
+    if grep -Fq -- "$seed_detail" "$sum"; then
+      bad "B2 mutant: the detail survives the hand-rolled printf — the check cannot fail"
+    else
+      ok "B2 mutant: the pre-#3402 printf drops the detail (proved discriminating)"
+    fi
+  else
+    bad "B2 mutant: the _tree_boundary_row call site was not found — the mutant is vacuous"
+  fi
+fi
+
 echo "=== phase C (J3): the run's OWN stdout/stderr target is carved out, nothing more ="
 
 r_fd=$(mkrepo fd-repo)

--- a/scripts/tests/test_agent_gate_tree_provenance.sh
+++ b/scripts/tests/test_agent_gate_tree_provenance.sh
@@ -380,13 +380,15 @@ fi
 r_tbl=$(mkrepo table-repo)
 sum="$tmp/table-boundary.txt"; out="$tmp/table-boundary.out"
 run_selftest "$r_tbl" boundary "$sum" "$out" AGENT_GATE_TREE_SELFTEST_MUTATE=README.md
-# VACUOUS joins PASS/FAIL/SKIP in the component-status vocabulary (#3625). A hard-coded
-# three-token alternation is now WRONG wherever it appears: it stops SEEING the very rows
-# that state a component verified nothing.
-# Here the consequence was a guard that REDS ON CORRECT INPUT: a legitimate VACUOUS boundary
-# row was not counted in n_rows, while the annotation count below (added with the census) did
-# count it, so the two disagreed and the consistency assert failed on a healthy block.
-n_rows=$(grep -cE '^[a-z][a-z0-9-]*: +(PASS|FAIL|SKIP|VACUOUS) \([0-9]+s\)' "$sum" 2>/dev/null | tr -d ' ')
+# FIVE tokens, from two issues that reached the same conclusion independently: #3625 added
+# VACUOUS (a PASS whose measured subject count is zero) and #3402 added OPT-OUT (file-size
+# under an engaged CQLITE_ALLOW_FILE_GROWTH=1). A hard-coded subset is WRONG wherever it
+# appears: it stops SEEING the very rows it does not name.
+# Here the consequence is a guard that REDS ON CORRECT INPUT — this assert compares a COUNT of
+# printed rows against `components-completed:`, which counts every recorded verdict whatever
+# its token, so a grammar knowing four of five UNDERCOUNTS a healthy block. The equality is
+# between two counts, so the GRAMMAR, not the fixture, is what has to be complete.
+n_rows=$(grep -cE '^[a-z][a-z0-9-]*: +(PASS|FAIL|SKIP|VACUOUS|OPT-OUT) \([0-9]+s\)' "$sum" 2>/dev/null | tr -d ' ')
 n_done=$(sed -n 's/^components-completed: \([0-9]*\) .*/\1/p' "$sum" | head -1)
 if grep -qE '^tree-selftest: +PASS \([0-9]+s\)' "$sum"; then
   ok "J2: a recorded verdict whose component no static set names still appears in the table (tree-selftest row present)"

--- a/scripts/tests/test_agent_gate_tree_provenance.sh
+++ b/scripts/tests/test_agent_gate_tree_provenance.sh
@@ -493,12 +493,19 @@ SEEDSTUB
     bad "B2 (#3402): the boundary row DROPPED the status detail — the opt-out is invisible here"
     grep -E '^file-size: ' "$sum" 2>/dev/null
   fi
-  # The mutant: restore the hand-rolled printf the two loops used before #3402 routed them
-  # through _tree_boundary_row. A row still prints, so only the DETAIL can distinguish the
-  # two — which is what makes the assertion above discriminating rather than incidental.
+  # The mutant: drop the detail from _tree_boundary_row's own printf. A row still prints, so
+  # only the DETAIL can distinguish the two — which is what makes the assertion above
+  # discriminating rather than incidental.
+  #
+  # IT TARGETS THE FUNCTION BODY, NOT THE CALL SITE (roborev job 76). The call site was
+  # `_tree_boundary_row "$_c" …` until the renderer became a parameter (`"$_render" …`), at
+  # which point this mutant's target vanished and `gate_replace_line` correctly reported
+  # VACUOUS rather than passing over a mutation that never happened. The printf is the thing
+  # whose behaviour is under test, and it does not move when the caller is refactored.
   mut="$tmp/gate-mutant-boundary-detail.sh"
-  if gate_replace_line "$GATE" "$mut" '_tree_boundary_row "$_c" "$_st" "$_secs"' \
-       "printf '%-18s %s (%ss)\\n' \"\$_c:\" \"\$_st\" \"\$_secs\""; then
+  if gate_replace_line "$GATE" "$mut" \
+       'printf '"'"'%-18s %s (%ss)%s\n'"'"' "$1:" "$2" "$3" "${_d:+ — $_d}"' \
+       "printf '%-18s %s (%ss)\\n' \"\$1:\" \"\$2\" \"\$3\""; then
     r_b2m=$(mkrepo_from b2-detail-mutant-repo "$mut")
     sum="$tmp/b2-detail-mutant.txt"; out="$tmp/b2-detail-mutant.out"
     ( cd "$r_b2m" && PATH="$seedbin:$STUBBIN:$PATH" env SEED_DETAIL="$seed_detail" \
@@ -511,7 +518,7 @@ SEEDSTUB
       ok "B2 mutant: the pre-#3402 printf drops the detail (proved discriminating)"
     fi
   else
-    bad "B2 mutant: the _tree_boundary_row call site was not found — the mutant is vacuous"
+    bad "B2 mutant: _tree_boundary_row's printf was not found — the mutant is vacuous"
   fi
 fi
 


### PR DESCRIPTION
Closes #3402.

## The defect

With `CQLITE_ALLOW_FILE_GROWTH=1` engaged, the `file-size` component printed a bare
`file-size: PASS (0s)` — byte-indistinguishable from a run where the campsite-rule ratchet
was genuinely satisfied. An opt-out invisible in the SUMMARY is an opt-out no PR reviewer
can see, so disclosure depended entirely on the author remembering to write it in the PR
body. The issue was filed by someone who had to do exactly that, by hand, on #1695.

`PASS` must mean "the check RAN and was SATISFIED". It must never also mean "the check was
switched OFF".

## What this does

`file-size` reports its own **non-failing `OPT-OUT` status token**, carrying the env var and
the count via a new per-component status-detail sidecar that the ONE summary-line renderer
appends after the #3453 feature-matrix annotation:

```
file-size:         OPT-OUT (0s)  [no-cargo] — CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced); 3 over-threshold file(s) grown — see <logdir>/file-size.log
```

`OPT-OUT` is non-failing by construction — every aggregator (full gate,
`aggregate_lite_components`, `run_delta`) sets `OVERALL=FAIL` only on an exact `FAIL` — so an
acknowledged growth still reaches `RESULT: PASS`. It is merely no longer hideable.

Only `CQLITE_ALLOW_FILE_GROWTH` **exactly `1`** may emit it. A value set but not 1 (`0`,
`true`, `yes`) stays a ratchet violation and FAILs. A permissive branch keyed on
`!= <bad>` would let a typo waive the ratchet — a false-PASS route opened while closing
another. Case 4c pins both malformed spellings and asserts `OPT-OUT` appears **nowhere** in
the block.

### Why a status token rather than a `SUMMARY_META` line

The issue cites #2078 as precedent, but #2078 *as implemented* (`_missing_fixtures_marker`)
is a separate meta line. The token was chosen deliberately anyway: a meta line adds a row the
reader must correlate, whereas **the component row itself is what lies today**. A non-failing
token is already expressible here (`node-bindings-leak-lane: RAN`).

### Why the row carries no filenames

The issue asks for `OPT-OUT (CQLITE_ALLOW_FILE_GROWTH=1; N file(s) grown)` and marks naming
the files *"ideally"*, explicitly deferring that data to the sibling log issue #3401 — merged,
with a log carrying every path and its `before -> after` arithmetic.

An earlier revision rendered the paths inline. It was **removed**, because that one optional
embellishment produced three of this PR's eight review findings, one per round, each a
different way of mangling a filename:

| Round | Defect |
|---|---|
| job 18 | `${e%%: *}` recovering a path from a display string — truncated at `: ` |
| job 19/20 | blanket `RESULT:` substitution rewriting a path containing the token |
| job 23 | `,` joining — `src/a.rs,b.rs` indistinguishable from two files |

Every fix was correct and the next round found another. That is the shape #3229 already ruled
on: **remove the mechanism rather than carve it a fourth time.** Escaping would only move the
argument to the escape grammar (#3312 — a rarer delimiter is still forgeable).

Nothing is lost. The names are in `file-size.log`, and a PR reviewer has a second copy in the
**diff itself** — the grown files are the files the PR changed. What a pasted SUMMARY cannot
get anywhere else is that the ratchet was not enforced, and over how many files.

## The cost this change had to pay: a new token is invisible to a three-token grammar

Three suites parse component statuses generically. All are **extended, never weakened**:

| Suite | What it does | Why it matters |
|---|---|---|
| `test_agent_gate_summary.sh` | `fm_lines` vs `fm_annot` count comparison | **Measured**: against a two-row sample the three-token grammar counted 1 of 2 *with `fm_lines == fm_annot`* — it reported "all component line(s) carry a feature matrix" over a subject set it had itself shrunk. A silent undercount, not a red. |
| `test_agent_gate_tree_provenance.sh` | row count compared **for equality** against `components-completed:` | A grammar knowing three of four tokens undercounts and reds on a correct block. |
| `test_agent_gate_feature_matrix_annotation.sh` | name-keyed row reads | Decides "no component line emitted"; a subset-aware reader answers that wrongly the day the set grows again. |

The row grammar is hoisted into two shared variables (`FM_ROW_RE` / `FM_ROW_ANNOT_RE`) so the
census and the new section 54f cannot drift into two copies. 54f exists because
`--emit-summary-selftest` emits no `OPT-OUT` row, so the fourth token would otherwise sit in
the grammar unexercised and a later "tidy" back to three would pass.

## Two traps found by reproduction, not by reading

**A `FAIL` row claiming an opt-out.** `run_file_size`'s persistence block runs *after* the
opt-out branch and sets `status=FAIL`, so an opt-out run with an unwritable log rendered a
`FAIL` whose entire detail described the opt-out — sending the reader to hunt a growth
violation the gate had ALLOWED. Reproduced on the real gate before fixing. Now three arms,
because the row must not claim a computation that did not happen (#3401 L1): both-failed;
ratchet **SKIPPED** (no base ref — `ratchet_verdict` is `PASS` there, but nothing was
compared); and persistence-only. The `see <sib>` pointer appears only on the verified-sibling
path, so the false pointer #3401 FIX 2 removed from stdout cannot reappear one artifact over.

**Boundary blocks dropped the disclosure.** `_tree_boundary_meta_lines` hand-rolled
`printf '%-18s %s (%ss)'` in *both* loops — under a comment promising "never a second dialect
of it" — so a tree-integrity boundary block printed `file-size: OPT-OUT (0s)` with the detail
stripped: this issue's own invisible opt-out, surviving where a run is already in trouble.
Both loops now route through one `_tree_boundary_row`. It deliberately does *not* call
`_fm_summary_line` (the boundary block has never carried the #3453 annotation), so the two
renderers still differ in the annotation while agreeing **by construction** on the detail.

## Emit-boundary rules

`_status_detail` takes **gate-authored text only** — fixed wording plus computed values — as a
stated contract. It strips the whole `[:cntrl:]` class under a pinned `LC_ALL=C`, and
**withholds** any value carrying the completion probe's `RESULT:` token rather than rewriting
it: a rewrite names something that does not exist, which is this issue's own defect produced
by its own guard. The refusal quotes no part of the token it refuses — a diagnostic
reproducing it would forge the row it prevents, the rule this repo already applies to the
roborev waiver markers.

The `LC_ALL=C` pin is **declared as having no behavioural coverage**: GNU `tr` is byte-wise, so
for every input a writer here can produce the rendering is identical with or without it, no
mutant discriminates, and the case written for it could not fail. It was deleted rather than
kept green.

## Verification

- `test_agent_gate_file_size_log.sh` **105 / 0 / 0**, exact assertion census. The census went
  75 → 116 → **down to 105** when the path list was removed — recomputed from the run, not
  adjusted upward on faith.
- `test_agent_gate_summary.sh` **423 / 0** (floor 413, raised by exactly the 3 added).
- `test_agent_gate_tree_provenance.sh` **47 / 0** (phases B2 and B3 added).
- `test_agent_gate_feature_matrix_annotation.sh` **85 / 0**; `test_agent_gate_tree_integrity.sh` **160 / 0**.
- `--lite` **PASS**, `tree-integrity: PASS`.
- **Every new assertion is mutant-verified**, not merely green: B2 against a restored
  hand-rolled `printf`; B3 against passing the value through; case 4g's needles against both
  a restored substitution and the guard removed entirely; case 4e's against a restored reparse.

### Two assertions of mine that could not fail

Both were caught in review and are recorded because the count matters more than the fix:

- case 4e's `lacks` on a truncated stem — with one grown file the buggy render is a *prefix*
  of the correct one, so no needle distinguishes them. Replaced with an end-anchored check.
- case 4f in full — its printable-ASCII detail renders identically with or without the locale
  pin, so it was non-discriminating *and* flaky (it compared whole rows including the elapsed
  field). Deleted rather than repaired: a case that cannot fail but can flake costs reds in a
  merge-gating suite and buys no signal.

## Review rounds

Eight findings across jobs 18–24, all fixed, none deferred. Worth stating plainly rather than
letting the shrinking counts flatter it: **three were defects I introduced while fixing the
previous round's finding**, all in the inline path list — which is why it was removed rather
than fixed again. Job 19 was an independent review by a peer session that found the same two
findings as my job 20.

## Lane note

A peer session briefly drove this issue in the same worktree (its own lane was deleted at
finalize) — the locally-advisory hazard of #3436. During the overlap
`test_agent_gate_summary.sh` returned 422/1; isolated it is 423/0, twice. The failing
assertion **could not be identified** (that run's output was filtered through `grep` and
lost), so it is reported as *observed under contention* rather than diagnosed. `tooling-tests`
re-runs the suite in the gate of record, which is the authoritative execution.

## Doctrine

`CLAUDE.md`'s campsite-rule section and `docs/development/lane-gate-execution.md` record the
row's shape, the three states, the `PASS`-never-means-switched-off rule, and why the file list
is not on the row.
