### PR TITLE
fix(#3648): enforce dirty: no on the gate of record at the merge site

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1610,8 +1610,12 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   launch the gate — #2874's reader contract needs the launcher) and it cannot prove the summary came
   from a real run rather than a hand-written file: a **hostile invoker is out of the threat model**;
   what this closes is **accident and drift** — a diligent worker with no step in its path telling it
-  the gate of record was never run. `dirty:` is REPORTED in the success line, not enforced (failing on it
-  is proposed separately in #3648). **The FOURTH argument is optional and is the ONLY way a `--delta`
+  the gate of record was never run. `dirty:` is REPORTED in the success line **and ENFORCED** (#3648): the gate of record's
+  block — and, in Case B, the delta block's too — must read `dirty: no`, matched AFFIRMATIVELY, so an
+  absent or unrecognised value REFUSES rather than being read as clean. A `dirty: yes` run certified the
+  sha PLUS uncommitted tracked edits (the capture is `--exclude-standard`, so never a gitignored log) and
+  `commit:`/`tree-start:` cannot see the difference. There is deliberately NO opt-out — a dirty tree is
+  always re-gateable, so an override could only buy a vacuous green. **The FOURTH argument is optional and is the ONLY way a `--delta`
   re-cert can certify a merge** — because #1892 *mandates* `--delta`, "never a repeat full gate", for a
   test/docs-only diff on top of a full PASS at anchor `X`, and mandates that the PR record BOTH blocks.
   A 3-arg-only guard therefore red on correct, doctrine-mandated input, which is the guard agents learn

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -670,7 +670,28 @@ assert_covers() {
 # re-gateable — commit or discard, then re-run — so an escape hatch could only
 # buy a vacuous green, which is the shape this whole script exists to refuse.
 assert_clean_tree() {
-  local what="$1" val="$2"
+  local what="$1" val="$2" kind="$3"
+  # The REMEDY is per-artifact, because the two artifacts are re-produced by
+  # DIFFERENT runs (#3648 roborev round 1, finding 1). Telling the operator to
+  # "re-run the FULL gate" over a dirty DELTA block contradicts #1892, which
+  # mandates `--delta` — never a repeat full gate — for a test/docs-only diff on
+  # top of a full PASS. A refusal naming the wrong remedy sends a correct operator
+  # down a route doctrine forbids, which is worse than naming none.
+  #
+  # `kind` is REQUIRED and an unrecognised value REFUSES. It deliberately takes no
+  # `${3:-full}` default: a permissive default is how a new call site silently
+  # inherits the wrong remedy, and this file's whole discipline is that an
+  # unestablished value is never given the benign branch.
+  local rerun
+  case "$kind" in
+    full)  rerun="re-run the FULL gate on the clean tree and pass that summary" ;;
+    delta) rerun="re-run the --delta re-certification on the clean tree and pass that summary (the anchor's own full-gate PASS is unaffected)" ;;
+    *)
+      refuse_no_gate \
+        "INTERNAL: assert_clean_tree was called with remedy kind '$kind', which is not" \
+        "'full' or 'delta'. Refusing rather than guessing a remedy (#3648)."
+      ;;
+  esac
   if [ "$val" = no ]; then
     return 0
   fi
@@ -678,17 +699,20 @@ assert_clean_tree() {
     refuse_no_gate \
       "The $what records NO 'dirty:' value on its 'commit:' line — nothing was measured" \
       "about whether that run executed against a committed tree, so it cannot certify one." \
-      "REMEDY: re-run the FULL gate on a clean tree and pass THAT summary."
+      "REMEDY: $rerun."
   fi
   refuse_no_gate \
     "The $what records 'dirty: $val' — the gate of record must be 'dirty: no' (#3648)." \
-    "'yes' means that run certified the sha PLUS uncommitted TRACKED edits (the gate's" \
-    "capture is --exclude-standard, so this is never a gitignored log). Anything that is" \
+    "'yes' means that run certified the sha PLUS uncommitted NON-IGNORED content — both" \
+    "modified TRACKED files and UNTRACKED files the repo's ignore rules do not exclude," \
+    "since the gate's capture pairs a tracked-side diff with" \
+    "\`git ls-files --others --exclude-standard\` (so this is never a gitignored log, and it" \
+    "is not tracked-only either). Anything that is" \
     "neither 'yes' nor 'no' means the state was never established — and an unestablished" \
     "state is not a clean one. Either way the tree that was gated is not provably the tree" \
     "that will merge: commit:/tree-start: name the same sha in both cases and cannot see it." \
-    "REMEDY: commit the edits (or discard them), then re-run the FULL gate on the clean" \
-    "tree and pass that summary. There is deliberately NO opt-out: a dirty tree is always" \
+    "REMEDY: commit the edits (or discard them), then $rerun." \
+    "There is deliberately NO opt-out: a dirty tree is always" \
     "re-gateable, so an override could only buy a vacuous green."
 }
 
@@ -855,7 +879,7 @@ else
   # The delta run's OWN tree must be clean too: it is the run that covers the
   # tree being merged, so a dirty delta re-cert certifies edits that are not in
   # the PR exactly as a dirty full gate does.
-  assert_clean_tree "delta block" "$delta_dirty"
+  assert_clean_tree "delta block" "$delta_dirty" delta
 fi
 
 # `dirty:` is REPORTED **AND ENFORCED** (#3648, replacing the deferral note this
@@ -864,7 +888,7 @@ fi
 # both blocks are held to the same requirement. The evidence line below still
 # prints the value — after this call it can only ever read `dirty: no`, which is
 # the affirmative record that the check RAN.
-assert_clean_tree "full-gate block" "$full_dirty"
+assert_clean_tree "full-gate block" "$full_dirty" full
 
 # ---------------------------------------------------------------------------
 # THE ADVISORY IS MEASURED **BEFORE** THE HEAD CHECK (#3650, roborev job 250)

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -444,7 +444,7 @@ _gate_awk() {
     if (WANT == "delta") { S = DELTA_S; E = DELTA_E } else { S = FULL_S; E = FULL_E }
     blocks = 0; full = 0; lite = 0; delta = 0; open = 0; unterminated = 0
     n_result = 0; n_ti = 0; n_commit = 0; n_ts = 0; n_mode = 0
-    n_anchor = 0; n_nested = 0; anchor_unresolved = 0
+    n_anchor = 0; n_nested = 0; anchor_unresolved = 0; n_dirty = 0
     v_result = ""; v_ti = ""; v_commit = ""; v_ts = ""; v_dirty = ""
     v_mode = ""; v_anchor = ""
   }
@@ -468,7 +468,16 @@ _gate_awk() {
     }
     else if ($1 == "commit:") {
       n_commit++; v_commit = $2
-      for (i = 2; i < NF; i++) if ($i == "dirty:") v_dirty = $(i + 1)
+      # COUNT every `dirty:` token and keep the FIRST value, never the last.
+      # The old loop assigned on every match, so `dirty: yes dirty: no` reduced
+      # to `no` and certified a dirty run (#3648 roborev round 2). That is the
+      # "last one wins" rule assert_single_key exists to refuse, one field down.
+      # Scanned to NF (not NF-1) so a BARE trailing `dirty:` still COUNTS as an
+      # occurrence; its value stays empty and refuses on the empty-value path.
+      for (i = 2; i <= NF; i++) if ($i == "dirty:") {
+        n_dirty++
+        if (n_dirty == 1 && i < NF) v_dirty = $(i + 1)
+      }
     }
     next
   }
@@ -486,6 +495,7 @@ _gate_awk() {
     print "n_ts=" n_ts
     print "n_anchor=" n_anchor
     print "n_nested=" n_nested
+    print "n_dirty=" n_dirty
     print "anchor_unresolved=" anchor_unresolved
     print "v_result=" v_result
     print "v_ti=" v_ti
@@ -507,7 +517,7 @@ gate_parse_file() {
   gp_out=$(_gate_awk "$1" "$2") || refuse_tool_failure awk "$3"
   GP_blocks=""; GP_full=""; GP_lite=""; GP_delta=""; GP_unterminated=""
   GP_n_mode=""; GP_n_result=""; GP_n_ti=""; GP_n_commit=""; GP_n_ts=""
-  GP_n_anchor=""; GP_n_nested=""; GP_anchor_unresolved=""
+  GP_n_anchor=""; GP_n_nested=""; GP_anchor_unresolved=""; GP_n_dirty=""
   GP_v_result=""; GP_v_ti=""; GP_v_commit=""; GP_v_ts=""; GP_v_dirty=""
   GP_v_mode=""; GP_v_anchor=""
   while IFS='=' read -r gp_k gp_v; do
@@ -524,6 +534,7 @@ gate_parse_file() {
       n_ts)         GP_n_ts="$gp_v" ;;
       n_anchor)     GP_n_anchor="$gp_v" ;;
       n_nested)     GP_n_nested="$gp_v" ;;
+      n_dirty)      GP_n_dirty="$gp_v" ;;
       anchor_unresolved) GP_anchor_unresolved="$gp_v" ;;
       v_result)     GP_v_result="$gp_v" ;;
       v_ti)         GP_v_ti="$gp_v" ;;
@@ -537,7 +548,7 @@ gate_parse_file() {
 $gp_out
 GATE_PARSE
   for gp_k in blocks full lite delta unterminated n_mode n_result n_ti n_commit \
-              n_ts n_anchor n_nested anchor_unresolved; do
+              n_ts n_anchor n_nested anchor_unresolved n_dirty; do
     eval "gp_v=\${GP_$gp_k}"
     case "$gp_v" in
       ''|*[!0-9]*)
@@ -622,9 +633,10 @@ assert_covers() {
 # against a COMMITTED tree (#3648).
 #
 # WHY THIS IS ENFORCED AND NOT MERELY REPORTED. A gate that ran with `dirty: yes`
-# certified sha PLUS uncommitted tracked edits — not the sha. The gate's tree
-# capture uses `--exclude-standard`, so `dirty: yes` is real uncommitted TRACKED
-# content, never a gitignored log. The escape is then ordinary: a full gate PASSes
+# certified sha PLUS uncommitted non-ignored content — not the sha. The gate's tree
+# capture pairs a tracked-side diff with `git ls-files --others --exclude-standard`,
+# so `dirty: yes` is real uncommitted NON-IGNORED content — tracked edits AND/OR
+# untracked files the ignore rules do not exclude — never a gitignored log. The escape is then ordinary: a full gate PASSes
 # at HEAD X with edits in the worktree, the edits are discarded or simply never
 # committed, X is pushed and merged — and the gate of record covered a tree that
 # is NOT the one that lands. `commit:`/`tree-start:` cannot see it: both name X in
@@ -692,6 +704,16 @@ assert_clean_tree() {
         "'full' or 'delta'. Refusing rather than guessing a remedy (#3648)."
       ;;
   esac
+  # AMBIGUITY BEFORE VALUE: more than one `dirty:` on the commit: line means the
+  # block states the tree's cleanliness twice, and no reading of it is
+  # authoritative. Refused BEFORE the `= no` compare, or `dirty: yes dirty: no`
+  # would return 0 here on the second token's value (#3648 roborev round 2).
+  if [ "${4:-1}" -gt 1 ] 2>/dev/null; then
+    refuse_no_gate \
+      "The $what has ${4} 'dirty:' fields on its 'commit:' line — AMBIGUOUS, refusing." \
+      "A block that states its tree state twice authorises nothing: a 'last one wins'" \
+      "reading would let a trailing 'dirty: no' override the real value."
+  fi
   if [ "$val" = no ]; then
     return 0
   fi
@@ -801,6 +823,7 @@ assert_single_key "$GP_n_ts" tree-start "full-gate block"
 full_commit="$GP_v_commit"
 full_ts="$GP_v_ts"
 full_dirty="$GP_v_dirty"
+full_ndirty="$GP_n_dirty"
 
 if [ -z "$delta_file" ]; then
   # CASE A — DIRECT: the gate of record ran on the merged tree itself.
@@ -876,10 +899,11 @@ else
   delta_commit="$GP_v_commit"
   delta_ts="$GP_v_ts"
   delta_dirty="$GP_v_dirty"
+  delta_ndirty="$GP_n_dirty"
   # The delta run's OWN tree must be clean too: it is the run that covers the
   # tree being merged, so a dirty delta re-cert certifies edits that are not in
   # the PR exactly as a dirty full gate does.
-  assert_clean_tree "delta block" "$delta_dirty" delta
+  assert_clean_tree "delta block" "$delta_dirty" delta "$delta_ndirty"
 fi
 
 # `dirty:` is REPORTED **AND ENFORCED** (#3648, replacing the deferral note this
@@ -888,7 +912,7 @@ fi
 # both blocks are held to the same requirement. The evidence line below still
 # prints the value — after this call it can only ever read `dirty: no`, which is
 # the affirmative record that the check RAN.
-assert_clean_tree "full-gate block" "$full_dirty" full
+assert_clean_tree "full-gate block" "$full_dirty" full "$full_ndirty"
 
 # ---------------------------------------------------------------------------
 # THE ADVISORY IS MEASURED **BEFORE** THE HEAD CHECK (#3650, roborev job 250)

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -20,8 +20,9 @@
 # certified sha never verified that a certified sha EXISTS. The gate-of-record
 # convention was honour-system doctrine; this script is the one point every merge
 # passes through, so the convention becomes a mechanism here: a summary file
-# carrying a FULL-gate block with `RESULT: PASS`, `tree-integrity: PASS`, and
-# provenance (`commit:` + `tree-start:`) covering the certified sha is REQUIRED.
+# carrying a FULL-gate block with `RESULT: PASS`, `tree-integrity: PASS`,
+# `dirty: no` (#3648), and provenance (`commit:` + `tree-start:`) covering the
+# certified sha is REQUIRED.
 #
 # TWO DISTINCT ESCAPES, ONE MECHANISM
 #   * #3408 — NO GATE AT ALL. That PR merged on 22 `--lite` PASSes and not one
@@ -617,6 +618,54 @@ assert_covers() {
   fi
 }
 
+# assert_clean_tree <what> <value>: the run that block records must have executed
+# against a COMMITTED tree (#3648).
+#
+# WHY THIS IS ENFORCED AND NOT MERELY REPORTED. A gate that ran with `dirty: yes`
+# certified sha PLUS uncommitted tracked edits — not the sha. The gate's tree
+# capture uses `--exclude-standard`, so `dirty: yes` is real uncommitted TRACKED
+# content, never a gitignored log. The escape is then ordinary: a full gate PASSes
+# at HEAD X with edits in the worktree, the edits are discarded or simply never
+# committed, X is pushed and merged — and the gate of record covered a tree that
+# is NOT the one that lands. `commit:`/`tree-start:` cannot see it: both name X in
+# exactly that run. Measured on this box over 3232 full-gate summaries: 306 (9.5%)
+# ran dirty, but only 19 (0.59%) were dirty AND `RESULT: PASS`, so enforcement at
+# the merge point fires on precisely the hazard and almost nothing else.
+#
+# The compare is AFFIRMATIVE — `= no`, never `!= yes` — for the same reason the
+# RESULT/tree-integrity token compares are: a `!= yes` test is a two-valued
+# predicate over a multi-state signal and would hand every unmeasured state
+# (`unverified`, an absent field, a future value) the PERMISSIVE branch. An absent
+# or unrecognised value therefore REFUSES; it is never skipped and never read as
+# clean, exactly as a non-hex `commit:`/`tree-start:` placeholder refuses rather
+# than being skipped.
+#
+# THERE IS NO ENV OPT-OUT AND NONE MAY BE ADDED. A dirty tree is always
+# re-gateable — commit or discard, then re-run — so an escape hatch could only
+# buy a vacuous green, which is the shape this whole script exists to refuse.
+assert_clean_tree() {
+  local what="$1" val="$2"
+  if [ "$val" = no ]; then
+    return 0
+  fi
+  if [ -z "$val" ]; then
+    refuse_no_gate \
+      "The $what records NO 'dirty:' value on its 'commit:' line — nothing was measured" \
+      "about whether that run executed against a committed tree, so it cannot certify one." \
+      "REMEDY: re-run the FULL gate on a clean tree and pass THAT summary."
+  fi
+  refuse_no_gate \
+    "The $what records 'dirty: $val' — the gate of record must be 'dirty: no' (#3648)." \
+    "'yes' means that run certified the sha PLUS uncommitted TRACKED edits (the gate's" \
+    "capture is --exclude-standard, so this is never a gitignored log). Anything that is" \
+    "neither 'yes' nor 'no' means the state was never established — and an unestablished" \
+    "state is not a clean one. Either way the tree that was gated is not provably the tree" \
+    "that will merge: commit:/tree-start: name the same sha in both cases and cannot see it." \
+    "REMEDY: commit the edits (or discard them), then re-run the FULL gate on the clean" \
+    "tree and pass that summary. There is deliberately NO opt-out: a dirty tree is always" \
+    "re-gateable, so an override could only buy a vacuous green."
+}
+
 # assert_pass_block <what>: the verdict half every accepted block must satisfy —
 # terminated, RESULT: PASS, tree-integrity: PASS, and not a nested sub-gate.
 assert_pass_block() {
@@ -777,14 +826,19 @@ else
   delta_commit="$GP_v_commit"
   delta_ts="$GP_v_ts"
   delta_dirty="$GP_v_dirty"
-  [ -n "$delta_dirty" ] || delta_dirty=unknown
+  # The delta run's OWN tree must be clean too: it is the run that covers the
+  # tree being merged, so a dirty delta re-cert certifies edits that are not in
+  # the PR exactly as a dirty full gate does.
+  assert_clean_tree "delta block" "$delta_dirty"
 fi
 
-# `dirty:` is REPORTED, not enforced — DELIBERATELY. Failing on `dirty: yes` is
-# not in the owner's ruling on #3465 and is not absorbed into this change; it is
-# proposed separately in #3648. This is a decision, not an oversight: print it so
-# a dirty gate of record is VISIBLE at the merge point.
-[ -n "$full_dirty" ] || full_dirty=unknown
+# `dirty:` is REPORTED **AND ENFORCED** (#3648, replacing the deferral note this
+# line used to carry). In CASE B this is the ANCHOR's own tree: a full PASS taken
+# on a dirty tree anchors the whole chain on a tree nobody can reconstruct, so
+# both blocks are held to the same requirement. The evidence line below still
+# prints the value — after this call it can only ever read `dirty: no`, which is
+# the affirmative record that the check RAN.
+assert_clean_tree "full-gate block" "$full_dirty"
 
 # ---------------------------------------------------------------------------
 # THE ADVISORY IS MEASURED **BEFORE** THE HEAD CHECK (#3650, roborev job 250)

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -628,9 +628,23 @@ assert_covers() {
 # at HEAD X with edits in the worktree, the edits are discarded or simply never
 # committed, X is pushed and merged — and the gate of record covered a tree that
 # is NOT the one that lands. `commit:`/`tree-start:` cannot see it: both name X in
-# exactly that run. Measured on this box over 3232 full-gate summaries: 306 (9.5%)
-# ran dirty, but only 19 (0.59%) were dirty AND `RESULT: PASS`, so enforcement at
-# the merge point fires on precisely the hazard and almost nothing else.
+# exactly that run.
+#
+# HOW OFTEN THIS FIRES — MEASURED, WITH ITS POPULATION AND ITS LIMITS (2026-09-01,
+# #3648). Census of one box's `/tmp/agent-gate.*` summaries, restricted to blocks
+# that could ever BE a gate of record: FULL-gate blocks, deduplicated by `run-id`,
+# NOT `nested-under:`, and carrying a canonical `RESULT` token — n=2395, of which
+# 1608 are `RESULT: PASS`. Of those 1608 PASSes an affirmative `dirty: no` match
+# refuses 26 (~1.6%), broken down by cause so the figure can be re-derived rather
+# than inherited: 19 `dirty: yes`, 7 carrying NO `dirty:` field at all, and 0
+# `unverified` (all 40 `unverified` blocks in the population are already FAIL).
+# So the absent-field arm below is not hypothetical — it is 7 of the 26.
+# LIMITS, stated because a number in a comment decays like any other claim: this
+# is a SINGLE-BOX `/tmp` census over run dirs of unknown age, blind to runs that
+# were pruned, and the fixture exclusion (canonical `RESULT` + no `nested-under:`)
+# is a heuristic that removes this repo's own planted near-miss summaries, not a
+# guarantee that none survive. Percentages taken over the UNfiltered population
+# are unstable for exactly that reason; the absolute counts are not.
 #
 # The compare is AFFIRMATIVE — `= no`, never `!= yes` — for the same reason the
 # RESULT/tree-integrity token compares are: a `!= yes` test is a two-valued
@@ -639,6 +653,18 @@ assert_covers() {
 # or unrecognised value therefore REFUSES; it is never skipped and never read as
 # clean, exactly as a non-hex `commit:`/`tree-start:` placeholder refuses rather
 # than being skipped.
+#
+# `dirty: unverified` IS A REAL EMITTED VALUE, AND THIS ARM IS DEFENCE IN DEPTH —
+# NOT A HOLE THIS CHANGE CLOSES. scripts/agent-gate.sh:8814 emits
+# `commit: unverified branch: <b> dirty: unverified` deliberately, when no
+# validated tree capture exists (the start capture failed, or there is no worktree
+# at the terminal emit) — the run is ALREADY fail-closed there and must not name a
+# sha nothing verified. Such a block is therefore refused THREE times over: by
+# `RESULT: FAIL`, by the non-hex `commit:` placeholder, and now here. The
+# redundancy is deliberate: each of those three is a separate key, and a value
+# that means "the state was never measured" must not survive on the strength of
+# one neighbouring check (the standing rule that no key may delegate its failure
+# to its neighbour).
 #
 # THERE IS NO ENV OPT-OUT AND NONE MAY BE ADDED. A dirty tree is always
 # re-gateable — commit or discard, then re-run — so an escape hatch could only

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -444,7 +444,7 @@ _gate_awk() {
     if (WANT == "delta") { S = DELTA_S; E = DELTA_E } else { S = FULL_S; E = FULL_E }
     blocks = 0; full = 0; lite = 0; delta = 0; open = 0; unterminated = 0
     n_result = 0; n_ti = 0; n_commit = 0; n_ts = 0; n_mode = 0
-    n_anchor = 0; n_nested = 0; anchor_unresolved = 0; n_dirty = 0
+    n_anchor = 0; n_nested = 0; anchor_unresolved = 0; n_dirty = 0; n_tsdirty = 0
     v_result = ""; v_ti = ""; v_commit = ""; v_ts = ""; v_dirty = ""
     v_mode = ""; v_anchor = ""
   }
@@ -460,7 +460,19 @@ _gate_awk() {
     if ($1 == "MODE:")                { n_mode++;   v_mode = $2 }
     else if ($1 == "RESULT:")         { n_result++; v_result = $2 }
     else if ($1 == "tree-integrity:") { n_ti++;     v_ti = $2 }
-    else if ($1 == "tree-start:")     { n_ts++;     v_ts = $2 }
+    else if ($1 == "tree-start:") {
+      n_ts++; v_ts = $2
+      # tree-start: carries its OWN `dirty:`, and it is NOT redundant with the
+      # commit: one: commit: renders TREE_END_DIRTY on the normal path
+      # (agent-gate.sh:8810), so a run that STARTED dirty and finished clean --
+      # legal under the non-fatal `tree-integrity: PASS (lockfile-settled: ...)`
+      # class (agent-gate.sh:8754) -- shows `commit: ... dirty: no` while having
+      # executed against uncommitted content (#3648 roborev round 4).
+      for (i = 2; i <= NF; i++) if ($i == "dirty:") {
+        n_tsdirty++
+        if (n_tsdirty == 1 && i < NF) v_tsdirty = $(i + 1)
+      }
+    }
     else if ($1 == "nested-under:")   { n_nested++ }
     else if ($1 == "delta-anchor:") {
       n_anchor++; v_anchor = $2
@@ -496,12 +508,14 @@ _gate_awk() {
     print "n_anchor=" n_anchor
     print "n_nested=" n_nested
     print "n_dirty=" n_dirty
+    print "n_tsdirty=" n_tsdirty
     print "anchor_unresolved=" anchor_unresolved
     print "v_result=" v_result
     print "v_ti=" v_ti
     print "v_commit=" v_commit
     print "v_ts=" v_ts
     print "v_dirty=" v_dirty
+    print "v_tsdirty=" v_tsdirty
     print "v_mode=" v_mode
     print "v_anchor=" v_anchor
   }
@@ -517,9 +531,9 @@ gate_parse_file() {
   gp_out=$(_gate_awk "$1" "$2") || refuse_tool_failure awk "$3"
   GP_blocks=""; GP_full=""; GP_lite=""; GP_delta=""; GP_unterminated=""
   GP_n_mode=""; GP_n_result=""; GP_n_ti=""; GP_n_commit=""; GP_n_ts=""
-  GP_n_anchor=""; GP_n_nested=""; GP_anchor_unresolved=""; GP_n_dirty=""
+  GP_n_anchor=""; GP_n_nested=""; GP_anchor_unresolved=""; GP_n_dirty=""; GP_n_tsdirty=""
   GP_v_result=""; GP_v_ti=""; GP_v_commit=""; GP_v_ts=""; GP_v_dirty=""
-  GP_v_mode=""; GP_v_anchor=""
+  GP_v_mode=""; GP_v_anchor=""; GP_v_tsdirty=""
   while IFS='=' read -r gp_k gp_v; do
     case "$gp_k" in
       blocks)       GP_blocks="$gp_v" ;;
@@ -535,12 +549,14 @@ gate_parse_file() {
       n_anchor)     GP_n_anchor="$gp_v" ;;
       n_nested)     GP_n_nested="$gp_v" ;;
       n_dirty)      GP_n_dirty="$gp_v" ;;
+      n_tsdirty)    GP_n_tsdirty="$gp_v" ;;
       anchor_unresolved) GP_anchor_unresolved="$gp_v" ;;
       v_result)     GP_v_result="$gp_v" ;;
       v_ti)         GP_v_ti="$gp_v" ;;
       v_commit)     GP_v_commit="$gp_v" ;;
       v_ts)         GP_v_ts="$gp_v" ;;
       v_dirty)      GP_v_dirty="$gp_v" ;;
+      v_tsdirty)    GP_v_tsdirty="$gp_v" ;;
       v_mode)       GP_v_mode="$gp_v" ;;
       v_anchor)     GP_v_anchor="$gp_v" ;;
     esac
@@ -548,7 +564,7 @@ gate_parse_file() {
 $gp_out
 GATE_PARSE
   for gp_k in blocks full lite delta unterminated n_mode n_result n_ti n_commit \
-              n_ts n_anchor n_nested anchor_unresolved n_dirty; do
+              n_ts n_anchor n_nested anchor_unresolved n_dirty n_tsdirty; do
     eval "gp_v=\${GP_$gp_k}"
     case "$gp_v" in
       ''|*[!0-9]*)
@@ -682,7 +698,7 @@ assert_covers() {
 # re-gateable — commit or discard, then re-run — so an escape hatch could only
 # buy a vacuous green, which is the shape this whole script exists to refuse.
 assert_clean_tree() {
-  local what="$1" val="$2" kind="$3"
+  local what="$1" val="$2" kind="$3" line="${5:?assert_clean_tree: line label required}"
   # The REMEDY is per-artifact, because the two artifacts are re-produced by
   # DIFFERENT runs (#3648 roborev round 1, finding 1). Telling the operator to
   # "re-run the FULL gate" over a dirty DELTA block contradicts #1892, which
@@ -710,7 +726,7 @@ assert_clean_tree() {
   # would return 0 here on the second token's value (#3648 roborev round 2).
   if [ "${4:-1}" -gt 1 ] 2>/dev/null; then
     refuse_no_gate \
-      "The $what has ${4} 'dirty:' fields on its 'commit:' line — AMBIGUOUS, refusing." \
+      "The $what has ${4} 'dirty:' fields on its '$line' line — AMBIGUOUS, refusing." \
       "A block that states its tree state twice authorises nothing: a 'last one wins'" \
       "reading would let a trailing 'dirty: no' override the real value."
   fi
@@ -719,7 +735,7 @@ assert_clean_tree() {
   fi
   if [ -z "$val" ]; then
     refuse_no_gate \
-      "The $what records NO 'dirty:' value on its 'commit:' line — nothing was measured" \
+      "The $what records NO 'dirty:' value on its '$line' line — nothing was measured" \
       "about whether that run executed against a committed tree, so it cannot certify one." \
       "REMEDY: $rerun."
   fi
@@ -824,6 +840,8 @@ full_commit="$GP_v_commit"
 full_ts="$GP_v_ts"
 full_dirty="$GP_v_dirty"
 full_ndirty="$GP_n_dirty"
+full_tsdirty="$GP_v_tsdirty"
+full_ntsdirty="$GP_n_tsdirty"
 
 if [ -z "$delta_file" ]; then
   # CASE A — DIRECT: the gate of record ran on the merged tree itself.
@@ -900,10 +918,13 @@ else
   delta_ts="$GP_v_ts"
   delta_dirty="$GP_v_dirty"
   delta_ndirty="$GP_n_dirty"
+  delta_tsdirty="$GP_v_tsdirty"
+  delta_ntsdirty="$GP_n_tsdirty"
   # The delta run's OWN tree must be clean too: it is the run that covers the
   # tree being merged, so a dirty delta re-cert certifies edits that are not in
   # the PR exactly as a dirty full gate does.
-  assert_clean_tree "delta block" "$delta_dirty" delta "$delta_ndirty"
+  assert_clean_tree "delta block" "$delta_dirty" delta "$delta_ndirty" commit:
+  assert_clean_tree "delta block" "$delta_tsdirty" delta "$delta_ntsdirty" tree-start:
 fi
 
 # `dirty:` is REPORTED **AND ENFORCED** (#3648, replacing the deferral note this
@@ -912,7 +933,8 @@ fi
 # both blocks are held to the same requirement. The evidence line below still
 # prints the value — after this call it can only ever read `dirty: no`, which is
 # the affirmative record that the check RAN.
-assert_clean_tree "full-gate block" "$full_dirty" full "$full_ndirty"
+assert_clean_tree "full-gate block" "$full_dirty" full "$full_ndirty" commit:
+assert_clean_tree "full-gate block" "$full_tsdirty" full "$full_ntsdirty" tree-start:
 
 # ---------------------------------------------------------------------------
 # THE ADVISORY IS MEASURED **BEFORE** THE HEAD CHECK (#3650, roborev job 250)

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -679,6 +679,20 @@ case "$OUT" in
     ok "dirty: the refusal states there is no opt-out (a dirty tree is re-gateable)" ;;
   *) bad "dirty: the refusal must state that there is no opt-out (got: $OUT)" ;;
 esac
+# 25(b2) THE DIAGNOSTIC MUST DESCRIBE THE GATE'S ACTUAL DIRTY IDENTITY (#3648
+# roborev round 1, finding 2). It previously said "uncommitted TRACKED edits",
+# which is FALSE: agent-gate.sh pairs the tracked-side diff with
+# `git ls-files --others --exclude-standard`, so a non-ignored UNTRACKED file makes
+# the tree dirty too. An operator told "tracked" looks for a modified file, finds
+# none, and concludes the gate is broken.
+case "$OUT" in
+  *"NON-IGNORED content"*) ok "dirty: the refusal describes NON-IGNORED content, not tracked-only" ;;
+  *) bad "dirty: the refusal must not narrow the dirty identity to tracked files (got: $OUT)" ;;
+esac
+case "$OUT" in
+  *"UNTRACKED files"*) ok "dirty: the refusal names UNTRACKED files as a dirty cause" ;;
+  *) bad "dirty: the refusal must name untracked files as a dirty cause (got: $OUT)" ;;
+esac
 
 # 25(c) ABSENT `dirty:` field -> REFUSE. Never skipped, never read as clean:
 # the same discipline as a non-hex commit:/tree-start: placeholder.
@@ -1046,6 +1060,26 @@ delta_summary "$T/delta-dirty-yes.txt" "$ANCHOR" "$C7" "$C12" PASS PASS \
   "$DELTA_MODE" "(full-gate PASS commit)" yes
 refused_pair "delta block dirty: yes -> refuse (it covers the MERGED tree)" \
   "$ANCHORFULL" "$T/delta-dirty-yes.txt" "The delta block records 'dirty: yes'"
+# 33(x)(b2) THE REMEDY IS PER-ARTIFACT (#3648 roborev round 1, finding 1). A dirty
+# DELTA block must send the operator back to the `--delta` re-certification, NOT to
+# a repeat full gate: #1892 mandates `--delta` for a test/docs-only diff on top of a
+# full PASS and forbids re-running the full gate. A refusal naming the wrong remedy
+# routes a correct operator down a path doctrine forbids.
+case "$OUT" in
+  *"re-run the --delta re-certification on the clean tree"*)
+    ok "dirty (delta): the refusal names the DELTA remedy, not a repeat full gate" ;;
+  *) bad "dirty (delta): the refusal must name the --delta remedy (got: $OUT)" ;;
+esac
+case "$OUT" in
+  *"re-run the FULL gate"*)
+    bad "dirty (delta): the delta refusal must NOT tell the operator to re-run the FULL gate (got: $OUT)" ;;
+  *) ok "dirty (delta): the delta refusal does NOT misdirect to a repeat full gate" ;;
+esac
+case "$OUT" in
+  *"anchor's own full-gate PASS is unaffected"*)
+    ok "dirty (delta): the refusal states the anchor's full PASS still stands" ;;
+  *) bad "dirty (delta): the refusal should say the anchor PASS is unaffected (got: $OUT)" ;;
+esac
 
 # 33(x)(c) the ANCHOR (full) block dirty -> refuse, naming the full-gate block.
 # The delta here is the GOOD one, so the refusal cannot be the delta's.

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -219,16 +219,50 @@ C12="da9a7cb2abc0"
 # A "-" omits that line entirely. Line SHAPES are copied from a real full-gate
 # summary (/tmp/cqlite-gates/**/full-gate.txt), trailing fields included, so the
 # parser is exercised against the grammar the gate emits and not a simplification.
+#
+# The 8th parameter is the `dirty:` VALUE on the `commit:` line (#3648), which is
+# the field the assert now enforces. Defaults to `no` (via `${8-no}`, so an
+# EMPTY string is a value and not "unset"). Rendering is delegated to
+# `dirty_field`/`dirty_tree_start`, so a case can build the three shapes the
+# enforcement must refuse — absent field, present-but-empty value, unrecognised
+# value — as well as the two it must decide on.
+#
+# `tree-start:` MIRRORS the value only when it is `yes`/`no`; for the sentinel
+# shapes it stays a clean `dirty: no`. That disagreement is deliberate: it pins
+# that the check reads the value from the `commit:` line (which is where the
+# parser takes it from) and does NOT fall back to the clean-looking one below it.
+
+# dirty_field <value> — the ` dirty: <value>` suffix the gate writes on `commit:`.
+# "-" omits the field entirely; an EMPTY value renders the bare key.
+dirty_field() {
+  case "$1" in
+    -)  : ;;
+    '') printf ' dirty:' ;;
+    *)  printf ' dirty: %s' "$1" ;;
+  esac
+}
+
+# dirty_tree_start <value> — see the note above: mirror yes/no, else `no`.
+dirty_tree_start() {
+  case "$1" in
+    yes|no) printf '%s' "$1" ;;
+    *)      printf 'no' ;;
+  esac
+}
+
 emit_summary_block() {
-  local start="$1" end="$2" mode="$3" commit="$4" tstart="$5" ti="$6" result="$7"
+  local start="$1" end="$2" mode="$3" commit="$4" tstart="$5" ti="$6" result="$7" \
+        dirty="${8-no}"
   printf '%s\n' "$start"
   printf 'run-id: /tmp/agent-gate.9cIQgX\n'
   [ "$mode" = "-" ] || printf '%s\n' "$mode"
-  [ "$commit" = "-" ] || printf 'commit: %s branch: issue-3465-require-gate-of-record dirty: no\n' "$commit"
+  [ "$commit" = "-" ] || printf 'commit: %s branch: issue-3465-require-gate-of-record%s\n' \
+    "$commit" "$(dirty_field "$dirty")"
   printf 'datasets: 144 Data.db files under /data/datasets\n'
   printf 'accelerators: sccache=on nextest=on lanes=on mold=absent perf=paranoid-4\n'
-  [ "$tstart" = "-" ] || printf 'tree-start: %s dirty: no digest: 671a6275687c\n' "$tstart"
-  printf 'tree-end: %s dirty: no digest: 671a6275687c\n' "$tstart"
+  [ "$tstart" = "-" ] || printf 'tree-start: %s dirty: %s digest: 671a6275687c\n' \
+    "$tstart" "$(dirty_tree_start "$dirty")"
+  printf 'tree-end: %s dirty: %s digest: 671a6275687c\n' "$tstart" "$(dirty_tree_start "$dirty")"
   [ "$ti" = "-" ] || printf 'tree-integrity: %s\n' "$ti"
   printf 'file-size:         PASS (0s)\n'
   printf 'smoke:             PASS (193s)\n'
@@ -244,17 +278,17 @@ LITE_E="==== END AGENT-GATE LITE SUMMARY ===="
 DELTA_S="==== AGENT-GATE DELTA SUMMARY ===="
 DELTA_E="==== END AGENT-GATE DELTA SUMMARY ===="
 
-# full_block [commit] [tree-start] [tree-integrity] [result] -> STDOUT.
+# full_block [commit] [tree-start] [tree-integrity] [result] [dirty] -> STDOUT.
 # Separate from full_summary because composing two blocks into one file cannot go
 # through a `>"$f"` helper: `full_summary /dev/stdout` inside a `{ } > file` group
 # TRUNCATES the file, which silently produced a ONE-block fixture for a
 # two-block case (found while writing these tests — the case passed vacuously).
 full_block() {
   emit_summary_block "$FULL_S" "$FULL_E" "-" \
-    "${1:-$C7}" "${2:-$C12}" "${3:-PASS}" "${4:-PASS}"
+    "${1:-$C7}" "${2:-$C12}" "${3:-PASS}" "${4:-PASS}" "${5-no}"
 }
 
-# full_summary <file> [commit] [tree-start] [tree-integrity] [result]
+# full_summary <file> [commit] [tree-start] [tree-integrity] [result] [dirty]
 full_summary() {
   local f="$1"
   shift
@@ -602,22 +636,95 @@ if run 0 "ANSI-coloured full summary -> still parsed -> exit 0" \
   ok "ansi: escapes are stripped before marker/verdict matching (#3400)"
 fi
 
-# --- Case 25: dirty: is REPORTED, not enforced -------------------------------
-# Deliberate: failing on `dirty: yes` is not in the #3465 ruling. It must be
-# VISIBLE at the merge point, but it does not block.
-{
-  printf '%s\n' "$FULL_S"
-  printf 'commit: %s branch: main dirty: yes\n' "$C7"
-  printf 'tree-start: %s dirty: yes digest: 671a6275687c\n' "$C12"
-  printf 'tree-integrity: PASS\n'
-  printf 'RESULT: PASS\n'
-  printf '%s\n' "$FULL_E"
-} >"$T/dirty.txt"
-if run 0 "dirty: yes -> still exit 0 (reported, not enforced)" 2421 "$CERTIFIED" "$T/dirty.txt"; then
+# --- Case 25: dirty: is REPORTED **AND ENFORCED** (#3648) --------------------
+# A gate that ran with `dirty: yes` certified sha PLUS uncommitted TRACKED edits
+# (the gate's capture is --exclude-standard, so never a gitignored log), and
+# `commit:`/`tree-start:` name the same sha either way — so this is the one
+# property of that hazard the sha binding provably cannot see. It was REPORTED
+# and not enforced until #3648; these cases pin the enforcement.
+#
+# The POSITIVE CONTROL comes first on purpose: without it a suite that refused
+# everything would look green while proving nothing about the accepted shape.
+
+# 25(a) POSITIVE CONTROL — `dirty: no` still passes, and is still reported.
+full_summary "$T/dirty-no.txt" "$C7" "$C12" PASS PASS no
+if run 0 "dirty: no -> exit 0 (the clean tree is still accepted)" \
+  2421 "$CERTIFIED" "$T/dirty-no.txt"; then
   case "$OUT" in
-    *"dirty: yes"*) ok "dirty: a dirty gate of record is REPORTED in the evidence line" ;;
-    *) bad "dirty: the evidence line must report dirty: yes (got: $OUT)" ;;
+    *"tree-integrity: PASS dirty: no"*)
+      ok "dirty: a clean gate of record is still REPORTED in the evidence line" ;;
+    *) bad "dirty: the evidence line must still report dirty: no (got: $OUT)" ;;
   esac
+fi
+
+# 25(b) THE AC'S NAMED TEST — a full PASS identical BUT FOR `dirty: yes`.
+# Built from the same builder as 25(a) with only that one field changed, so the
+# case cannot pass by differing somewhere else.
+full_summary "$T/dirty-yes.txt" "$C7" "$C12" PASS PASS yes
+if diff <(full_block "$C7" "$C12" PASS PASS no | grep -v 'dirty:') \
+        <(full_block "$C7" "$C12" PASS PASS yes | grep -v 'dirty:') >/dev/null; then
+  ok "dirty fixture: the yes/no fixtures differ ONLY in their dirty: fields"
+else
+  bad "dirty fixture: the yes/no fixtures differ somewhere other than dirty:"
+fi
+refused "dirty: yes -> REFUSE (the run certified sha + uncommitted edits, #3648)" \
+  "$T/dirty-yes.txt" "records 'dirty: yes'"
+case "$OUT" in
+  *"commit the edits (or discard them), then re-run the FULL gate"*)
+    ok "dirty: the refusal names the REMEDY (commit or discard, then re-gate)" ;;
+  *) bad "dirty: the refusal must name the remedy (got: $OUT)" ;;
+esac
+case "$OUT" in
+  *"NO opt-out"*)
+    ok "dirty: the refusal states there is no opt-out (a dirty tree is re-gateable)" ;;
+  *) bad "dirty: the refusal must state that there is no opt-out (got: $OUT)" ;;
+esac
+
+# 25(c) ABSENT `dirty:` field -> REFUSE. Never skipped, never read as clean:
+# the same discipline as a non-hex commit:/tree-start: placeholder.
+full_summary "$T/dirty-absent.txt" "$C7" "$C12" PASS PASS -
+if grep -q '^commit: .* dirty:' "$T/dirty-absent.txt"; then
+  bad "dirty fixture: the absent-field fixture still carries a dirty: on commit:"
+else
+  ok "dirty fixture: the absent-field fixture really omits dirty: from commit:"
+fi
+refused "commit: line with NO dirty: field -> refuse (nothing was measured)" \
+  "$T/dirty-absent.txt" "records NO 'dirty:' value"
+
+# 25(d) PRESENT KEY, EMPTY VALUE -> REFUSE. Distinct from an absent field: the
+# gate said something and it reduced to nothing.
+full_summary "$T/dirty-empty.txt" "$C7" "$C12" PASS PASS ""
+if grep -q '^commit: .* dirty:$' "$T/dirty-empty.txt"; then
+  ok "dirty fixture: the empty-value fixture ends its commit: line at the bare key"
+else
+  bad "dirty fixture: expected a bare trailing 'dirty:' on the commit: line"
+fi
+refused "commit: dirty: with an EMPTY value -> refuse" \
+  "$T/dirty-empty.txt" "records NO 'dirty:' value"
+
+# 25(e) UNRECOGNISED values -> REFUSE. `unknown` is pinned by name because it is
+# the literal this script used to substitute for a missing value while `dirty:`
+# was merely reported; `unverified` is what the gate itself writes when its tree
+# capture failed. An unestablished state is not a clean one.
+for _d in maybe unknown unverified YES No; do
+  full_summary "$T/dirty-$_d.txt" "$C7" "$C12" PASS PASS "$_d"
+  refused "dirty: $_d (unrecognised) -> refuse, never read as clean" \
+    "$T/dirty-$_d.txt" "records 'dirty: $_d'"
+done
+unset _d
+
+# 25(f) The check reads the `commit:` line, NOT the clean-looking `tree-start:`
+# one below it. The 25(b) fixture disagrees between the two on purpose.
+if grep -q '^tree-start: .* dirty: yes' "$T/dirty-yes.txt"; then
+  ok "dirty: the refused fixture's tree-start: mirrors yes (the gate's real shape)"
+else
+  bad "dirty: expected the yes fixture's tree-start: to mirror the value"
+fi
+if grep -q '^tree-start: .* dirty: no' "$T/dirty-maybe.txt" &&
+   grep -q "^commit: .* dirty: maybe" "$T/dirty-maybe.txt"; then
+  ok "dirty: an unrecognised commit: value refuses despite a clean tree-start: line"
+else
+  bad "dirty: the sentinel fixture should disagree between commit: and tree-start:"
 fi
 
 # --- Case 26: the mutated-path commit: parenthetical parses ------------------
@@ -676,23 +783,27 @@ fi
 DELTA_MODE="MODE: delta (TEST/DOCS-ONLY RE-CERTIFICATION — NOT the gate of record; gate of record = the full agent-gate.sh PASS at anchor $ANCHOR)"
 
 # delta_block [anchor] [commit] [tree-start] [tree-integrity] [result] [mode] \
-#             [anchor-parenthetical] -> STDOUT.  "-" omits a line entirely.
+#             [anchor-parenthetical] [dirty] -> STDOUT.  "-" omits a line entirely.
+# The 9th parameter is the delta run's OWN `dirty:` value (#3648), rendered by the
+# same helpers as the full block's.
 # Line SHAPES are copied from scripts/agent-gate.sh's delta emit site
 # (anchor_meta + SUMMARY_MODE_LINE), trailing fields included.
 delta_block() {
   local anchor="${1:-$ANCHOR}" commit="${2:-$C7}" tstart="${3:-$C12}" \
         ti="${4:-PASS}" result="${5:-PASS}" mode="${6:-$DELTA_MODE}" \
-        paren="${7:-(full-gate PASS commit)}"
+        paren="${7:-(full-gate PASS commit)}" dirty="${8-no}"
   printf '%s\n' "$DELTA_S"
   printf 'run-id: /tmp/agent-gate.dLt4Qx\n'
   [ "$mode" = "-" ] || printf '%s\n' "$mode"
-  [ "$commit" = "-" ] || printf 'commit: %s branch: issue-3465-require-gate-of-record dirty: no\n' "$commit"
+  [ "$commit" = "-" ] || printf 'commit: %s branch: issue-3465-require-gate-of-record%s\n' \
+    "$commit" "$(dirty_field "$dirty")"
   [ "$anchor" = "-" ] || printf 'delta-anchor: %s %s\n' "$anchor" "$paren"
   printf 'delta-anchor-run-id: /tmp/agent-gate.9cIQgX\n'
   printf 'gate-of-record: full agent-gate.sh run at %s (this DELTA re-certifies a test/docs-only diff; it is NOT a substitute for the full gate)\n' "$anchor"
   printf 'delta-executors: cargo test -p cqlite-core --test issue_3465 (3), docs (2)\n'
-  [ "$tstart" = "-" ] || printf 'tree-start: %s dirty: no digest: 671a6275687c\n' "$tstart"
-  printf 'tree-end: %s dirty: no digest: 671a6275687c\n' "$tstart"
+  [ "$tstart" = "-" ] || printf 'tree-start: %s dirty: %s digest: 671a6275687c\n' \
+    "$tstart" "$(dirty_tree_start "$dirty")"
+  printf 'tree-end: %s dirty: %s digest: 671a6275687c\n' "$tstart" "$(dirty_tree_start "$dirty")"
   [ "$ti" = "-" ] || printf 'tree-integrity: %s\n' "$ti"
   printf 'logs: /tmp/agent-gate.dLt4Qx\n'
   [ "$result" = "-" ] || printf 'RESULT: %s\n' "$result"
@@ -860,6 +971,42 @@ refused_pair "a LITE-only file as the ANCHOR -> refuse (the #3408 case, 4-arg fo
 full_summary "$T/anchor-nonhex.txt" "unverified" "$A12" PASS PASS
 refused_pair "anchor commit: non-hex -> refuse (a real sha is still required)" \
   "$T/anchor-nonhex.txt" "$GOODDELTA" "is not lowercase hex"
+
+# --- Case 33(x): `dirty: no` is required of BOTH blocks in Case B (#3648) ----
+# The delta run is the one that covers the tree being MERGED, and the anchor is
+# the full PASS the whole chain hangs from. A dirty tree in either place breaks
+# the same property, so both are held to the requirement.
+
+# 33(x)(a) POSITIVE CONTROL — both clean -> exit 0, both evidence lines report it.
+if run 0 "delta pair with BOTH blocks dirty: no -> exit 0" \
+  2421 "$CERTIFIED" "$ANCHORFULL" "$GOODDELTA"; then
+  case "$OUT" in
+    *"GATE-OF-RECORD commit: $A7"*"dirty: no"*"DELTA-RECERT anchor:"*"dirty: no"*)
+      ok "dirty (case B): BOTH evidence lines report the clean tree" ;;
+    *) bad "dirty (case B): both evidence lines must report dirty: no (got: $OUT)" ;;
+  esac
+fi
+
+# 33(x)(b) the DELTA block dirty -> refuse, naming the delta block.
+delta_summary "$T/delta-dirty-yes.txt" "$ANCHOR" "$C7" "$C12" PASS PASS \
+  "$DELTA_MODE" "(full-gate PASS commit)" yes
+refused_pair "delta block dirty: yes -> refuse (it covers the MERGED tree)" \
+  "$ANCHORFULL" "$T/delta-dirty-yes.txt" "The delta block records 'dirty: yes'"
+
+# 33(x)(c) the ANCHOR (full) block dirty -> refuse, naming the full-gate block.
+# The delta here is the GOOD one, so the refusal cannot be the delta's.
+full_summary "$T/anchor-dirty-yes.txt" "$A7" "$A12" PASS PASS yes
+refused_pair "anchor block dirty: yes -> refuse even with a clean delta re-cert" \
+  "$T/anchor-dirty-yes.txt" "$GOODDELTA" "The full-gate block records 'dirty: yes'"
+
+# 33(x)(d) an ABSENT dirty: field in either block -> refuse (never read as clean).
+delta_summary "$T/delta-dirty-absent.txt" "$ANCHOR" "$C7" "$C12" PASS PASS \
+  "$DELTA_MODE" "(full-gate PASS commit)" -
+refused_pair "delta block with NO dirty: field -> refuse" \
+  "$ANCHORFULL" "$T/delta-dirty-absent.txt" "The delta block records NO 'dirty:' value"
+full_summary "$T/anchor-dirty-absent.txt" "$A7" "$A12" PASS PASS -
+refused_pair "anchor block with NO dirty: field -> refuse" \
+  "$T/anchor-dirty-absent.txt" "$GOODDELTA" "The full-gate block records NO 'dirty:' value"
 
 # =============================================================================
 # #3465 review — the remaining refusal branches

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -917,7 +917,13 @@ DELTA_MODE="MODE: delta (TEST/DOCS-ONLY RE-CERTIFICATION — NOT the gate of rec
 delta_block() {
   local anchor="${1:-$ANCHOR}" commit="${2:-$C7}" tstart="${3:-$C12}" \
         ti="${4:-PASS}" result="${5:-PASS}" mode="${6:-$DELTA_MODE}" \
-        paren="${7:-(full-gate PASS commit)}" dirty="${8-no}"
+        paren="${7:-(full-gate PASS commit)}" dirty="${8-no}" \
+        tsdirty="${9-__mirror__}"
+  # 9th param, mirroring by default: the delta block's tree-start: dirty value,
+  # allowed to DIVERGE from its commit: one for the lockfile-settled case
+  # (#3648 roborev round 5 -- without it the delta tree-start: assertion was
+  # uncovered, since every delta fixture mirrored a single value into both).
+  [ "$tsdirty" = "__mirror__" ] && tsdirty="$dirty"
   printf '%s\n' "$DELTA_S"
   printf 'run-id: /tmp/agent-gate.dLt4Qx\n'
   [ "$mode" = "-" ] || printf '%s\n' "$mode"
@@ -928,7 +934,7 @@ delta_block() {
   printf 'gate-of-record: full agent-gate.sh run at %s (this DELTA re-certifies a test/docs-only diff; it is NOT a substitute for the full gate)\n' "$anchor"
   printf 'delta-executors: cargo test -p cqlite-core --test issue_3465 (3), docs (2)\n'
   [ "$tstart" = "-" ] || printf 'tree-start: %s dirty: %s digest: 671a6275687c\n' \
-    "$tstart" "$(dirty_tree_start "$dirty")"
+    "$tstart" "$(dirty_tree_start "$tsdirty")"
   printf 'tree-end: %s dirty: %s digest: 671a6275687c\n' "$tstart" "$(dirty_tree_start "$dirty")"
   [ "$ti" = "-" ] || printf 'tree-integrity: %s\n' "$ti"
   printf 'logs: /tmp/agent-gate.dLt4Qx\n'
@@ -1144,6 +1150,29 @@ esac
 full_summary "$T/anchor-dirty-yes.txt" "$A7" "$A12" PASS PASS yes
 refused_pair "anchor block dirty: yes -> refuse even with a clean delta re-cert" \
   "$T/anchor-dirty-yes.txt" "$GOODDELTA" "The full-gate block records 'dirty: yes'"
+
+# 33(x)(c2) THE DELTA HALF OF THE LOCKFILE-SETTLED CASE (#3648 roborev round 5).
+# 33(x)(b)/(c) mirror ONE dirty value into both commit: and tree-start:, so they
+# would still pass with the delta-specific tree-start: assertion deleted -- i.e.
+# that assertion was uncovered. (My own round-4 RED-verify showed it: removing
+# BOTH tree-start assertions red only ONE case.) These two pin each block's
+# tree-start: independently, with commit: clean so the refusal cannot be its.
+delta_summary "$T/delta-start-only.txt" "$ANCHOR" "$C7" "$C12" \
+  "PASS (lockfile-settled: Cargo.lock)" PASS "$DELTA_MODE" "(full-gate PASS commit)" no yes
+if grep -qE '^tree-start: .* dirty: yes ' "$T/delta-start-only.txt" \
+   && grep -qE '^commit: .* dirty: no$' "$T/delta-start-only.txt"; then
+  ok "dirty fixture (delta): dirty at START, clean at commit: -- values are INDEPENDENT"
+else
+  bad "dirty fixture (delta): expected tree-start dirty: yes with commit: dirty: no"
+fi
+refused_pair "delta tree-start: dirty: yes with a clean commit: -> refuse" \
+  "$ANCHORFULL" "$T/delta-start-only.txt" "tree-start:"
+
+# And the ANCHOR's own tree-start:, with a wholly clean delta beside it.
+full_summary "$T/anchor-start-only.txt" "$A7" "$A12" \
+  "PASS (lockfile-settled: Cargo.lock)" PASS no yes
+refused_pair "anchor tree-start: dirty: yes with a clean commit: and a clean delta -> refuse" \
+  "$T/anchor-start-only.txt" "$GOODDELTA" "tree-start:"
 
 # 33(x)(d) an ABSENT dirty: field in either block -> refuse (never read as clean).
 delta_summary "$T/delta-dirty-absent.txt" "$ANCHOR" "$C7" "$C12" PASS PASS \

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -637,7 +637,8 @@ if run 0 "ANSI-coloured full summary -> still parsed -> exit 0" \
 fi
 
 # --- Case 25: dirty: is REPORTED **AND ENFORCED** (#3648) --------------------
-# A gate that ran with `dirty: yes` certified sha PLUS uncommitted TRACKED edits
+# A gate that ran with `dirty: yes` certified sha PLUS uncommitted NON-IGNORED
+# content (tracked edits and/or non-ignored untracked files)
 # (the gate's capture is --exclude-standard, so never a gitignored log), and
 # `commit:`/`tree-start:` name the same sha either way — so this is the one
 # property of that hazard the sha binding provably cannot see. It was REPORTED
@@ -704,6 +705,33 @@ else
 fi
 refused "commit: line with NO dirty: field -> refuse (nothing was measured)" \
   "$T/dirty-absent.txt" "records NO 'dirty:' value"
+
+# 25(c2) DUPLICATED `dirty:` FIELD -> REFUSE, and refuse on the AMBIGUITY rather
+# than on either value (#3648 roborev round 2, finding 1 -- Medium). The parser
+# used to assign on EVERY `dirty:` token, so the LAST one won: a commit: line
+# reading `dirty: yes dirty: no` reduced to `no` and CERTIFIED a dirty run. That
+# is precisely the "last one wins" reading assert_single_key refuses for whole
+# keys, one field down, and it is a false PASS in a merge gate. The refusal must
+# fire BEFORE the `= no` compare, so a trailing clean value cannot short-circuit.
+full_summary "$T/dirty-dup.txt"
+sed -i 's/^\(commit: .* dirty: no\)$/\1 dirty: yes/' "$T/dirty-dup.txt"
+if grep -qE '^commit: .* dirty: no dirty: yes$' "$T/dirty-dup.txt"; then
+  ok "dirty fixture: the duplicate-field fixture really carries TWO dirty: tokens"
+else
+  bad "dirty fixture: expected two dirty: tokens on the commit: line"
+fi
+refused "commit: line with TWO dirty: fields -> refuse (AMBIGUOUS, not last-wins)" \
+  "$T/dirty-dup.txt" "AMBIGUOUS"
+# And the mirror image: a clean value LAST must not rescue a dirty value first.
+full_summary "$T/dirty-dup-clean-last.txt" "$C7" "$C12" PASS PASS yes
+sed -i 's/^\(commit: .* dirty: yes\)$/\1 dirty: no/' "$T/dirty-dup-clean-last.txt"
+if grep -qE '^commit: .* dirty: yes dirty: no$' "$T/dirty-dup-clean-last.txt"; then
+  ok "dirty fixture: the clean-last fixture is dirty FIRST, clean LAST"
+else
+  bad "dirty fixture: expected 'dirty: yes dirty: no' on the commit: line"
+fi
+refused "commit: dirty: yes then dirty: no -> refuse (a trailing clean value cannot rescue it)" \
+  "$T/dirty-dup-clean-last.txt" "AMBIGUOUS"
 
 # 25(d) PRESENT KEY, EMPTY VALUE -> REFUSE. Distinct from an absent field: the
 # gate said something and it reduced to nothing.

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -252,7 +252,13 @@ dirty_tree_start() {
 
 emit_summary_block() {
   local start="$1" end="$2" mode="$3" commit="$4" tstart="$5" ti="$6" result="$7" \
-        dirty="${8-no}"
+        dirty="${8-no}" tsdirty="${9-__mirror__}"
+  # 9th param: tree-start:/tree-end:'s OWN dirty value, allowed to DIVERGE from
+  # commit:'s. Defaults to mirroring so every pre-existing caller is unchanged.
+  # The divergence is REAL, not synthetic: commit: renders the END capture, so a
+  # lockfile-settled run legally reads tree-start dirty:yes + commit dirty:no
+  # (#3648 roborev round 4).
+  [ "$tsdirty" = "__mirror__" ] && tsdirty="$dirty"
   printf '%s\n' "$start"
   printf 'run-id: /tmp/agent-gate.9cIQgX\n'
   [ "$mode" = "-" ] || printf '%s\n' "$mode"
@@ -261,7 +267,7 @@ emit_summary_block() {
   printf 'datasets: 144 Data.db files under /data/datasets\n'
   printf 'accelerators: sccache=on nextest=on lanes=on mold=absent perf=paranoid-4\n'
   [ "$tstart" = "-" ] || printf 'tree-start: %s dirty: %s digest: 671a6275687c\n' \
-    "$tstart" "$(dirty_tree_start "$dirty")"
+    "$tstart" "$(dirty_tree_start "$tsdirty")"
   printf 'tree-end: %s dirty: %s digest: 671a6275687c\n' "$tstart" "$(dirty_tree_start "$dirty")"
   [ "$ti" = "-" ] || printf 'tree-integrity: %s\n' "$ti"
   printf 'file-size:         PASS (0s)\n'
@@ -285,7 +291,7 @@ DELTA_E="==== END AGENT-GATE DELTA SUMMARY ===="
 # two-block case (found while writing these tests — the case passed vacuously).
 full_block() {
   emit_summary_block "$FULL_S" "$FULL_E" "-" \
-    "${1:-$C7}" "${2:-$C12}" "${3:-PASS}" "${4:-PASS}" "${5-no}"
+    "${1:-$C7}" "${2:-$C12}" "${3:-PASS}" "${4:-PASS}" "${5-no}" "${6-__mirror__}"
 }
 
 # full_summary <file> [commit] [tree-start] [tree-integrity] [result] [dirty]
@@ -732,6 +738,30 @@ else
 fi
 refused "commit: dirty: yes then dirty: no -> refuse (a trailing clean value cannot rescue it)" \
   "$T/dirty-dup-clean-last.txt" "AMBIGUOUS"
+
+# 25(c3) THE LOCKFILE-SETTLED HOLE (#3648 roborev round 4, Medium). `commit:`
+# renders the END capture (agent-gate.sh:8810), so reading cleanliness from it
+# ALONE is not enough: a gate that STARTED against a dirty Cargo.lock and
+# finished clean emits `tree-start: ... dirty: yes` + `commit: ... dirty: no`,
+# and `tree-integrity:` is a NON-FATAL `PASS (lockfile-settled: ...)`
+# (agent-gate.sh:8754) -- a legal, real PASS. Checking commit: only would certify
+# a run that executed against uncommitted content, which is this issue's own
+# defect one capture down. BOTH captures must read clean.
+full_summary "$T/dirty-start-only.txt" "$C7" "$C12" \
+  "PASS (lockfile-settled: Cargo.lock)" PASS no yes
+if grep -qE '^tree-start: .* dirty: yes ' "$T/dirty-start-only.txt" \
+   && grep -qE '^commit: .* dirty: no$' "$T/dirty-start-only.txt"; then
+  ok "dirty fixture: the lockfile-settled fixture is dirty at START, clean at commit:"
+else
+  bad "dirty fixture: expected tree-start dirty: yes with commit: dirty: no"
+fi
+if grep -q 'tree-integrity: PASS (lockfile-settled' "$T/dirty-start-only.txt"; then
+  ok "dirty fixture: the lockfile-settled fixture carries the NON-FATAL integrity PASS"
+else
+  bad "dirty fixture: expected a lockfile-settled tree-integrity PASS"
+fi
+refused "tree-start: dirty: yes with a clean commit: -> refuse (lockfile-settled run)" \
+  "$T/dirty-start-only.txt" "tree-start:"
 
 # 25(d) PRESENT KEY, EMPTY VALUE -> REFUSE. Distinct from an absent field: the
 # gate said something and it reduced to nothing.

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -704,14 +704,68 @@ refused "commit: dirty: with an EMPTY value -> refuse" \
 
 # 25(e) UNRECOGNISED values -> REFUSE. `unknown` is pinned by name because it is
 # the literal this script used to substitute for a missing value while `dirty:`
-# was merely reported; `unverified` is what the gate itself writes when its tree
-# capture failed. An unestablished state is not a clean one.
-for _d in maybe unknown unverified YES No; do
+# was merely reported. `YES`/`No` are pinned because the compare is TOKEN-EXACT
+# and case-sensitive: a near-miss spelling is an unestablished state, not a clean
+# one. (`unverified` is a REAL emitted value and gets its own case below.)
+for _d in maybe unknown YES No; do
   full_summary "$T/dirty-$_d.txt" "$C7" "$C12" PASS PASS "$_d"
   refused "dirty: $_d (unrecognised) -> refuse, never read as clean" \
     "$T/dirty-$_d.txt" "records 'dirty: $_d'"
 done
 unset _d
+
+# 25(g) `dirty: unverified` — A REAL EMITTED VALUE, refused as DEFENCE IN DEPTH.
+# scripts/agent-gate.sh:8814 writes `commit: unverified branch: <b> dirty:
+# unverified` deliberately, when no validated tree capture exists (the start
+# capture failed, or there is no worktree at the terminal emit): the run is
+# already fail-closed there and must not name a sha nothing verified. So this arm
+# closes NO live hole — a real such block is refused by `RESULT: FAIL` and by the
+# non-hex `commit:` placeholder as well. It is tested BY NAME anyway, and the
+# fixture deliberately keeps RESULT: PASS and a VALID hex commit: so that the
+# refusal can only be the `dirty:` one: a value meaning "never measured" must not
+# survive on the strength of a neighbouring key, and an untested correct
+# behaviour is one refactor away from an untested wrong one.
+full_summary "$T/dirty-unverified.txt" "$C7" "$C12" PASS PASS unverified
+refused "dirty: unverified (the gate's own not-measured value) -> refuse on its OWN merit" \
+  "$T/dirty-unverified.txt" "records 'dirty: unverified'"
+
+# 25(h) A FOLLOWING KEY IS NOT A VALUE. scripts/agent-gate.sh renders these lines
+# by unquoted interpolation of variables initialised to the empty string
+# (TREE_START_DIRTY/TREE_END_DIRTY), so a block really can carry a `dirty:` key
+# with nothing of its own after it — and on a space-joined line the NEXT KEY then
+# sits where the value would be. Reading `digest:` as the dirty state would be a
+# two-valued read of a multi-state signal one layer down: it is neither `no` nor
+# absent, so it must REFUSE, naming what it actually found.
+full_summary "$T/dirty-next-key.txt" "$C7" "$C12" PASS PASS "digest: a7743efe8d80"
+if grep -q "^commit: .* dirty: digest: a7743efe8d80" "$T/dirty-next-key.txt"; then
+  ok "dirty fixture: the following-key fixture puts another key where the value goes"
+else
+  bad "dirty fixture: expected 'dirty: digest: ...' on the commit: line"
+fi
+refused "dirty: followed by another KEY -> refuse (a key is not a value)" \
+  "$T/dirty-next-key.txt" "records 'dirty: digest:'"
+
+# 25(i) A SELFTEST-SHAPED block cannot certify a merge. The gate's selftest emits
+# `commit: selftest branch: selftest dirty: no`, `tree-start: selftest ... digest:
+# selftest` and `tree-integrity: PASS (selftest)` (scripts/agent-gate.sh:7826,
+# :8921). Token-exactly that block reads `tree-integrity: PASS`, `RESULT: PASS`
+# and `dirty: no` — so the ONE key refusing it is the hex check on
+# `commit:`/`tree-start:`. That is correct and sufficient, and it is ONE key
+# holding the door; pointing this script at a selftest summary is a plausible
+# accident, so pin the property rather than leave it incidental. UNLIKE every
+# other case in this group it is green BEFORE and AFTER #3648 — it characterises
+# behaviour that already existed, and is recorded as such rather than counted as
+# evidence for the new enforcement.
+full_summary "$T/selftest-block.txt" selftest selftest "PASS (selftest)" PASS no
+if grep -q '^commit: selftest ' "$T/selftest-block.txt" &&
+   grep -q '^tree-integrity: PASS (selftest)' "$T/selftest-block.txt" &&
+   grep -q '^RESULT: PASS' "$T/selftest-block.txt"; then
+  ok "selftest fixture: the block really is a PASS with the selftest placeholders"
+else
+  bad "selftest fixture: expected a selftest-shaped PASS block"
+fi
+refused "a SELFTEST-shaped full block -> refuse (it certifies the gate, not this PR)" \
+  "$T/selftest-block.txt" "is not lowercase hex"
 
 # 25(f) The check reads the `commit:` line, NOT the clean-looking `tree-start:`
 # one below it. The 25(b) fixture disagrees between the two on purpose.

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -880,7 +880,7 @@ DELTA_MODE="MODE: delta (TEST/DOCS-ONLY RE-CERTIFICATION — NOT the gate of rec
 
 # delta_block [anchor] [commit] [tree-start] [tree-integrity] [result] [mode] \
 #             [anchor-parenthetical] [dirty] -> STDOUT.  "-" omits a line entirely.
-# The 9th parameter is the delta run's OWN `dirty:` value (#3648), rendered by the
+# The 8th parameter is the delta run's OWN `dirty:` value (#3648), rendered by the
 # same helpers as the full block's.
 # Line SHAPES are copied from scripts/agent-gate.sh's delta emit site
 # (anchor_meta + SUMMARY_MODE_LINE), trailing fields included.

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -153,8 +153,12 @@ roborev pass actually ran on. Three mechanical rules keep the merge honest:
   contract requires the party that LAUNCHED the run, which this script is not), and it cannot prove
   the summary came from a genuine gate rather than a hand-written file — a hostile invoker is out of
   the threat model, since whoever runs the script controls the process. What it closes is **accident
-  and drift**, which is the observed failure mode. `dirty:` is reported in the success line, not
-  enforced (failing on it is proposed separately in #3648).
+  and drift**, which is the observed failure mode. `dirty:` is reported in the success line **and
+  enforced** (#3648): the gate-of-record block — and, in Case B, the delta block too — must read
+  `dirty: no`, matched affirmatively, so an absent or unrecognised value REFUSES rather than being read
+  as clean. A `dirty: yes` run certified the sha PLUS uncommitted tracked edits, which `commit:`/
+  `tree-start:` cannot distinguish from the clean tree. No env opt-out exists and none may be added — a
+  dirty tree is always re-gateable.
   **The OPTIONAL fourth argument is the only way a `--delta` re-cert can certify a merge.** #1892
   *mandates* `--delta` — "never a repeat full gate" — for a test/docs-only diff on top of a full PASS
   at anchor `X`, and mandates that the PR record BOTH blocks, so a 3-arg-only guard red on correct,

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -87,7 +87,12 @@ carry).
   convention: the third argument is REQUIRED, and the script refuses the merge unless that file holds
   one full `==== AGENT-GATE SUMMARY ====` block with `RESULT: PASS`, `tree-integrity: PASS`, no
   `nested-under:` line (#2874: a nested sub-gate runs at the SAME tree, so the sha binding provably
-  cannot see it) and `commit:`/`tree-start:` covering the certified sha. A `--lite` summary is refused
+  cannot see it), `dirty: no` (#3648) and `commit:`/`tree-start:` covering the certified sha. The
+  `dirty:` requirement is the third property the sha binding cannot see: a `dirty: yes` run certified
+  the sha PLUS uncommitted TRACKED edits (the gate's capture is `--exclude-standard`, so never a
+  gitignored log) and stamps the very same `commit:`/`tree-start:` it would have stamped clean. It is
+  matched AFFIRMATIVELY — an absent, empty or unrecognised value REFUSES rather than being read as
+  clean — and there is deliberately no env opt-out, because a dirty tree is always re-gateable. A `--lite` summary is refused
   by name anywhere, and a `--delta` summary as the THIRD argument (their headers are distinct by
   construction) — which is exactly the PR #3408 escape: 22 lite PASSes and no full gate.
   **The OPTIONAL fourth argument is how a `--delta` re-cert certifies a merge.** #1892 *mandates*
@@ -95,7 +100,9 @@ carry).
   `X`, and mandates the PR record BOTH blocks — so a 3-arg-only guard red on correct, mandated input.
   In that shape the third argument is the ANCHOR's full PASS (its sha need not be the certified sha)
   and the fourth is one `==== AGENT-GATE DELTA SUMMARY ====` block carrying `MODE: delta` (asserted
-  affirmatively, the inverse of the full block's belt), `RESULT: PASS`, `tree-integrity: PASS`, a
+  affirmatively, the inverse of the full block's belt), `RESULT: PASS`, `tree-integrity: PASS`,
+  `dirty: no` (#3648 — required of the anchor block too, since a dirty anchor hangs the whole chain
+  off a tree nobody can reconstruct), a
   `delta-anchor:` naming exactly that anchor — an `(UNRESOLVED)` anchor refuses — and its own
   `commit:`/`tree-start:` at the certified sha. The chain is closed end to end; a delta block ALONE
   is still the #3408 escape and still refused.


### PR DESCRIPTION
Closes #3648.

`scripts/flow/premerge-assert.sh` **reported** the gate-of-record block's `dirty:` value without enforcing it. A gate that ran with `dirty: yes` certified *sha + uncommitted content*, not the sha — so discarding the edits and merging left the gate of record covering a tree that is not the one that lands. `commit:`/`tree-start:` cannot see it: both name the same sha either way.

Per the owner's ruling of 2026-08-31, enforcement is at the **merge site**, not the measurement site.

## What changed

`dirty: no` is now required, affirmatively matched (`= no`, never `!= yes`), fail-closed, **no env opt-out** — a dirty tree is always re-gateable, so an escape hatch could only buy a vacuous green. Required of **both captures** (`commit:` *and* `tree-start:`) on the full gate-of-record block, and in the 4-arg `--delta` form on the delta block *and* its anchor. Absent, empty, unrecognised (`unverified`, `maybe`, case-variants) and **duplicated** fields all refuse rather than being skipped. Refusals name which line was dirty and give a per-artifact remedy.

## The measurement AC1 asked for

Owner's open question was *"how often do fleet full gates legitimately run dirty — if rarely, also refuse at certification time."*

Census of this box's `/tmp` gate summaries; strict population = full blocks, run-id-deduped, no `nested-under:`, canonical `RESULT`. **n=2395, of which 1608 PASS.** An affirmative `dirty: no` match refuses **26 of 1608 (~1.6%)** — 19 `dirty: yes`, 7 with no `dirty:` field at all, 0 `unverified` (all 40 `unverified` blocks already FAIL).

**Answer: 9.5% of full gates run dirty — NOT rare.** So by the ruling's own conditional I did **not** file a follow-up to refuse at certification time. Merge-site enforcement fires on 1.6% of *usable* PASSes because 287 of the 306 dirty runs already FAILed for other reasons — it targets the hazard and almost nothing else, which is what makes it obeyable rather than waivable. Measurement-site enforcement would refuse 306 runs (16x) and forbid a legitimate workflow: running a full gate mid-edit to see where you stand. That run is not a certification; only its *use* as one is the defect.

Limits, stated in-code so the next reader re-derives rather than inherits: one box's `/tmp`, run dirs of unknown age, blind to pruned runs, and the fixture exclusion is a heuristic — this repo's own planted near-miss `RESULT` tokens live in genuine `/tmp/agent-gate.*/summary.txt` paths, which is why the raw percentages are unstable while the absolute counts are not. Two earlier attempts at this census were wrong (overlapping globs double-counting; `head -1` classification undercounting 100x) and two more traps were found on re-derivation (`-maxdepth 2` missing ~16% of files; the contaminated denominator).

## Review rounds — 5 rounds, every finding fixed, nothing deferred

| round | job | findings |
|---|---|---|
| 1 | 28 | 2 Low: delta refusal misdirected to a repeat full gate (contradicts #1892); `"uncommitted TRACKED edits"` false |
| 2 | 31 | **1 Medium — false PASS**: awk assigned on every `dirty:` token, so `dirty: yes dirty: no` read as clean. + comments contradicting the fixed diagnostic |
| 3 | 33 | 1 Low: `delta_block`'s `dirty:` is the 8th parameter, not the 9th |
| 4 | 34 | **1 Medium — false PASS**: `commit:` renders the END capture, so a lockfile-settled run reads `tree-start: dirty: yes` + `commit: dirty: no` under a legal non-fatal integrity PASS |
| 5 | 36 | 1 Low: delta fixtures mirrored one value into both lines, so the delta `tree-start:` assertion was uncovered |
| 6 | 37 | **`findings: NONE`, `RESULT: PASS`** |

Round 4 is this issue's own defect one capture down, and was verified against the emitter (`agent-gate.sh:8810` renders `TREE_END_DIRTY`; `:8754` is the non-fatal `lockfile-settled` PASS) before being fixed. Round 5 was a gap my own round-4 RED-verify had exposed and I read past — removing two assertions red only one case.

## Tests

`scripts/tests/test_premerge_assert.sh`: **189 → 204 cases, 0 failed**, executed by the full gate's `tooling-tests` (`agent-gate.sh:16379`). Note `--lite` does **not** run this suite, so it was run directly every round.

**Mutation-checked as the AC requires, observed not claimed**: neutering `assert_clean_tree` reds **15** cases (189 → 174 passed); restored, 189/0. Every added case is RED-verified individually, and each `tree-start:` assertion is pinned independently (removing only the delta one reds 1; only the full/anchor one reds 2).

## Follow-up filed

**#3807** — `agent-gate.sh`'s *unguarded* branch derives `dirty:` from whether `git status`'s stdout is empty, never its exit status, so a **failed** measurement renders `dirty: no`. A tristate collapsed onto the permissive answer. Not fixed here: `agent-gate.sh` is off-limits while PR #3806 is in flight, and the ruling scoped this issue to the merge site. Latent today only because that branch also emits `tree-integrity: SKIP`, which this script refuses — a hole held closed by a neighbouring key.

Also resolved on the thread: `dirty: unverified` is **deliberate** (paired with `commit: unverified` when no validated capture exists), and those blocks are already refused three times over, so that arm is defence in depth and is documented as such rather than as closing a live hole.
