### PR TITLE
docs(#3553): re-baseline the 0.17 served-path target to the measured deliverable (~1.35-1.4M rows/s)

### DIFF
--- a/docs/architecture/0.17-throughput-mission.md
+++ b/docs/architecture/0.17-throughput-mission.md
@@ -1,12 +1,26 @@
 # 0.17 Throughput Mission — tracking & mission document
 
-**Status as of 2026-08-04.** Living document. The board (GitHub Project #1) is the dispatch
+**Status as of 2026-08-30.** Living document. The board (GitHub Project #1) is the dispatch
 authority; this file is the *narrative* — mission, what's measured, what's in flight, and the gaps
 that keep biting. When board and this doc disagree on status, the board wins; open a PR to fix this
 file.
 
 Parent epic: **#2817** (0.17 scan-path throughput program). Exploration umbrella: **#3023**.
 
+> **2026-08-30 headline — PHASE 2. THE TARGET IS RE-BASELINED TO THE MEASURED DELIVERABLE.**
+> Phase 1 is complete (#3299, #3248, #2605 all merged) and the owner has adjudicated it in [the adjudication one-pager of record](https://github.com/pmcfadin/cqlite/issues/2817#issuecomment-5467056309)
+> on epic #2817. **0.17's served-path target is now `~1.35–1.4M rows/s` box-level**, against a served
+> position of ~1.2M (#3248 — basis and its caveats in §0). The **1.3× served/bare ratio
+> (2,102,167 rows/s box-level) is measured-unreachable with fundable 0.17 work** — #3248 priced the
+> Flight-marginal levers and **deleting 89% of all of that code reaches only ~1.53×** — so it is
+> **RETAINED as the ceiling-derived bound and tagged to the 0.18 representation program**, not a 0.17
+> pass/fail bar. The funded set is #2820, #2824, #3552, #3551 (+ this re-baseline); #3303/#3304 are
+> **KILLED** and #3305/#3306/#3288 **DEFERRED** on #3224's unmeasurable LLC counters. **Two premises
+> died with Phase 1**: scan-core cache contention (~4 pp non-clock loss — near-perfect scaling) and
+> vectorized-execution upside on row-shaped input (#2605: DataFusion within ±3% of the row engine,
+> I/O controlled). §0 and §6 carry the numbers; §7's plan-of-record lever table predates this
+> adjudication.
+>
 > **2026-08-04 headline — the mechanism is NAMED, and it tells us which levers can possibly work.**
 > #3224 measured both of #3217's endpoints on an `i4i.metal` where the LLC counters actually program.
 > **The full-box IPC decay is LLC capacity contention:** `LLC-load-misses/row` **triples** (11.94 →
@@ -68,17 +82,52 @@ On the 1-hardware-thread basis (the valid basis for cycles/row and IPC): merge 7
 number, and it is why this program felt stalled — it was stalled on *attribution*, not on
 engineering throughput.
 
-**Remaining to target (per-core basis):** 1.3× of bare scan = **315,730 rows/s**. We are at
-252,999. **We need +24.8%.** This is gap A — both endpoints sit at S=1, so LEVEL levers (cycles/row
-on the Flight path) close it directly; #3224's slope criterion is about gap B and does not demote
-them here (§6).
+**Remaining to the CEILING-DERIVED per-core bound — RETAINED, and NOT the 0.17 bar:** 1.3× of bare
+scan = **315,730 rows/s** against 252,999, i.e. **+24.8%**. This is gap A. **The 1.3× ratio itself is
+measured-unreachable with fundable 0.17 work** — #3248 priced every Flight-marginal lever it found and
+**deleting 89% of all Flight-marginal code reaches only ~1.53×** — so since the 2026-08-30 Phase-2
+adjudication this figure is a **bound requiring the 0.18 representation program**, not a 0.17
+pass/fail bar. 0.17's bar is the served-path target below. Gap A's *lever class* is unchanged: both
+endpoints sit at S=1, so LEVEL levers (cycles/row on the Flight path) close it directly; #3224's slope
+criterion is about gap B and does not demote them here (§6).
 
-**Remaining to target (BOX-LEVEL basis): the target is known, the current position is NOT.** The
-target is **2,102,167 rows/s** (below). Where we are today at box level is `do_get`, and the only
-box-level `do_get` figure in existence is #3217's **1,076,917 rows/s measured on the LZ4 corpus** —
-which may not be divided into a target measured on the uncompressed corpus, for the reason this
-section opens with. So **"we need +N%" is not statable at box level yet, and is deliberately left
-unstated rather than filled with a cross-corpus subtraction.**
+**THE 0.17 SERVED-PATH TARGET (re-baselined 2026-08-30, Phase-2 adjudication): `~1.35–1.4M rows/s`
+box-level.** The source is [the adjudication one-pager of record](https://github.com/pmcfadin/cqlite/issues/2817#issuecomment-5467056309) on epic #2817, which sets 0.17's honest served deliverable and
+retires the 1.3×-ratio target as a 0.17 bar. **The served position it is stated against is
+`~1.2M rows/s` box-level**, cited there to **#3248** — whose measured figure is **206,480 rows/s per
+physical core** (warm, uncompressed 693.69 B/row corpus, S=1, median of 3, spread 2.4%;
+`docs/reports/ws0-3248-artifacts/ac0/summary.txt`), composed to six cores: 206,480 × 6 = 1,238,880.
+
+**Read that composition as exactly what it is.** It is a per-core measurement multiplied by S, **not a
+measured box-level `do_get`** — that measurement still does not exist (next paragraph) — and it
+applies **no scaling discount**, where #3299 measured served marginal efficiency at S=6 = **0.8203**
+(§6). So ~1.2M is the *optimistic* end of the composition; it is the baseline the adjudication's
+uplift is stated against, and it is not a substitute for the missing measurement.
+
+**What the band implies, arithmetic shown:** `1.35M / 1.2M` = **+12.5%** and `1.4M / 1.2M` = **+16.7%**
+over that served baseline — the adjudication's and #3553's *"roughly +10–15%"* is the owner's rounding
+of the same band. **Only one funded lever is individually priced:** #3552's estimate-fold at
+**860 cyc/row ⇒ ~+3.3% served** (#3248). #3551 (SMT-unpin + allocator trial) carries a **kill criterion
+of <3%**. #2820 (batch fan-in) and #2824 (`madvise` under Auto-mmap) attack the two dominant terms —
+`stream_merge` at **14.72 µs/row** of CPU and cold page-in at **60.17 µs/row** of wall, both **#2605** —
+and are **not individually priced**. The band is therefore an **owner-set target over a partly-priced
+lever set, not a sum of measurements**, and it is labelled that way wherever it is quoted.
+
+**THE 2,102,167 rows/s FIGURE IS RETAINED — as the ceiling-derived bound, and it now belongs to 0.18.**
+`bare_scan_aggregate(S=6) / 1.3` = `2,732,817 / 1.3` = **2,102,167 rows/s** (#3299) is still the number
+the 1.3× deployment ratio implies, and it is **measured-unreachable with fundable 0.17 work**: #3248
+priced every Flight-marginal lever it found, and **deleting 89% of all Flight-marginal code reaches only
+~1.53×** (its own bias-corrected re-check moves that by **0.0009×** against ~0.2× of slack — #3248
+[comment 5460457579](https://github.com/pmcfadin/cqlite/issues/3248#issuecomment-5460457579)). Closing it needs the storage-representation changes the owner deferred to **0.18**
+(#2817 ruling 2026-08-29). Quote it with that tag; it is not a 0.17 pass/fail bar.
+
+**Unchanged by the re-baseline: box-level `do_get` on this corpus is still UNMEASURED.** The only
+*directly measured* box-level `do_get` figure in existence is #3217's **1,076,917 rows/s on the LZ4
+corpus**, which may not be divided into anything measured on the uncompressed corpus, for the reason
+this section opens with. Nor may the ~1.2M composition above be divided into #3299's 2,732,817: a
+different session and a different binary, and this section's own rule forbids deriving a cross-session
+absolute. So the served/bare **ratio** at box level is still not statable as a number, and stays
+deliberately unstated rather than filled with a cross-session or cross-corpus division.
 
 **Why #3299 could not close it, precisely — it is a client-provisioning limit, not a corpus or
 instrument limit.** Measuring `do_get` on the same corpus needs client and server on one box, and
@@ -90,27 +139,30 @@ class this measurement chain exists to prevent. A valid box-level `do_get` on th
 host with roughly **30+ physical cores** to provision a 6-core server at the rig's own client ratio.
 → tracked as a #3299 follow-up.
 
-**The bar (owner ruling 2026-08-04): BOX-LEVEL AGGREGATE rows/s.** The box-level denominator is
-now **MEASURED** — #3299 (PR pending) swept bare scan over S=1..6 physical cores × an N ladder of
-concurrent streams, 25 points × 3 reps, every counter at 100.00% `pct_running`:
+**The bar's UNIT (owner ruling 2026-08-04, unchanged by the 2026-08-30 re-baseline — only the number
+moved): BOX-LEVEL AGGREGATE rows/s.** The box-level bare-scan ceiling is **MEASURED** — #3299
+(PR #3408, merged) swept bare scan over S=1..6 physical cores × an N ladder of concurrent streams,
+25 points × 3 reps, every counter at 100.00% `pct_running`:
 
 **Box-level bare scan at 6 physical cores = 2,732,817 rows/s** (median of 3, within-session spread
 0.74%, best-N = 24 streams), against 487,213 rows/s from the best a single physical core achieves
 (N=2). That is **93.5% marginal efficiency at six cores**.
 
- **THE TARGET IS A FLOOR ON `do_get`, AND IT SITS BELOW BARE SCAN.** In one sentence: the bar is
-`do_get_aggregate(S=6) >= bare_scan_aggregate(S=6) / 1.3`, so the target is
-**2,732,817 / 1.3 = 2,102,167 rows/s** — a number **77% of** box-level bare scan that `do_get` must
-climb **up to**, with bare scan as the unreachable ceiling above it. It is **NOT** `1.3 x bare scan`
-(= 3,552,662), which would put the target **30% ABOVE our own measured ceiling** and be unreachable
-by construction. The direction matters because the two readings differ by **1.69x** in the number
-the 0.17 mission is defined against, and this issue's own body used the wrong one.
+ **HOW TO READ THE RETAINED 1.3× BOUND: IT IS A FLOOR ON `do_get`, AND IT SITS BELOW BARE SCAN.** In
+one sentence: the ratio reads `do_get_aggregate(S=6) >= bare_scan_aggregate(S=6) / 1.3`, so the bound
+is **2,732,817 / 1.3 = 2,102,167 rows/s** — a number **77% of** box-level bare scan that `do_get` would
+have to climb **up to**, with bare scan as the unreachable ceiling above it. It is **NOT**
+`1.3 x bare scan` (= 3,552,662), which would put it **30% ABOVE our own measured ceiling** and be
+unreachable by construction. The direction matters because the two readings differ by **1.69x** in the
+number the 0.17 mission was defined against, and this issue's own body used the wrong one.
 
-**Box-level target = `bare_scan_aggregate(S=6) / 1.3` = 2,102,167 rows/s.** Note the operation is
+**Retained bound = `bare_scan_aggregate(S=6) / 1.3` = 2,102,167 rows/s.** Note the operation is
 **DIVISION**: this document's idiom "within ~1.3× of X" means `X / 1.3`, as §0's own per-core
 arithmetic does (`410,449 / 1.3 = 315,730`, exact). An earlier revision of this line wrote
-`1.3 × bare_scan_aggregate(S=6)`, which would put the target *above* our own measured ceiling and
-is unreachable by construction.
+`1.3 × bare_scan_aggregate(S=6)`, which would put it *above* our own measured ceiling and is
+unreachable by construction. **Both corrections stand as written** — they are about how to read the
+ratio, which the 2026-08-30 re-baseline does not touch. What the re-baseline changed is the ratio's
+STATUS: a 0.18 bound, no longer 0.17's pass/fail bar (above).
 
 **Byte basis (mission §1):** the #3096 measurement corpus — 4,000,000 rows, **693.69 B/row,
 UNCOMPRESSED**, no `CompressionInfo.db`. This figure therefore **CANNOT be divided against**
@@ -282,13 +334,22 @@ result.
 
 ## 6. THE TARGET — two gaps, not one
 
-**The deployment bar (owner ruling 2026-08-04): box-level aggregate `do_get` rows/s within ~1.3× of
-box-level bare scan.** The box denominator is **MEASURED (#3299)**: bare scan sustains
-**2,732,817 rows/s on 6 physical cores** (median of 3, spread 0.74%, best-N = 24 streams;
-uncompressed 693.69 B/row corpus), so the **box-level target is `2,732,817 / 1.3` =
-2,102,167 rows/s**. The numerator — box-level `do_get` on the *same* corpus — is still unmeasured
-and needs a 30+ physical-core host to provision the client at the rig's calibrated 1:4 ratio (§0),
-so **the box-level gap cannot yet be quoted as a percentage**. The program therefore still
+**0.17's TARGET (re-baselined 2026-08-30, Phase-2 adjudication): served-path `~1.35–1.4M rows/s`
+box-level**, against a served position of **`~1.2M`** — #3248's 206,480 rows/s/physical core composed
+to six cores, with the basis and its caveats spelled out in §0. Source: [the adjudication one-pager of record](https://github.com/pmcfadin/cqlite/issues/2817#issuecomment-5467056309) on epic #2817.
+Funded against it: #2820 (merge, the dominant CPU term at 14.72 µs/row — #2605), #2824 (`madvise`, the
+dominant wall term at 60.17 µs/row — #2605), #3552 (estimate-fold, 860 cyc/row ⇒ ~+3.3% served —
+#3248) and #3551 (SMT-unpin + allocator trial, kill criterion <3%).
+
+**The RETAINED bound (owner ruling 2026-08-04, now tagged to 0.18): box-level aggregate `do_get`
+rows/s within ~1.3× of box-level bare scan.** The box denominator is **MEASURED (#3299)**: bare scan
+sustains **2,732,817 rows/s on 6 physical cores** (median of 3, spread 0.74%, best-N = 24 streams;
+uncompressed 693.69 B/row corpus), so that ratio implies **`2,732,817 / 1.3` = 2,102,167 rows/s**.
+**It is measured-unreachable with fundable 0.17 work** — #3248: deleting **89% of all Flight-marginal
+code** reaches only **~1.53×** — and closing it needs the storage-representation changes deferred to
+**0.18** (#2817, 2026-08-29). The numerator — box-level `do_get` on the *same* corpus — is **still
+unmeasured** and needs a 30+ physical-core host to provision the client at the rig's calibrated 1:4
+ratio (§0), so **the box-level ratio still cannot be quoted as a number**. The program therefore still
 tracks two component gaps — which are DIFFERENT problems with DIFFERENT lever classes, and
 an earlier revision of this section conflated them:
 
@@ -464,6 +525,15 @@ measured on its own host and must not be mixed with these.
 
 ### THE PLAN OF RECORD (2026-08-04 afternoon session — the complete path)
 
+> **SUPERSEDED IN PART (2026-08-30 Phase-2 adjudication, [the adjudication one-pager of record](https://github.com/pmcfadin/cqlite/issues/2817#issuecomment-5467056309)).** Phase 0 and Phase 1 below
+> DELIVERED (#3272; #3299/#3248/#2605 merged). **Phase 2's lever list did not survive its own gates**:
+> #3303 and #3304 are **KILLED** on probes D3/D5, and #3305/#3306/#3288 are **DEFERRED** because every
+> L3/LLC event on the fleet returns a hard 0 at 100.00% enabled, leaving their gating criteria
+> unmeasurable. The funded 0.17 set is **#2820, #2824, #3552, #3551**, and the target Phase 3 verifies
+> against is the re-baselined served-path `~1.35–1.4M rows/s` (§0, §6) — **not** the 2,102,167 figure
+> quoted in the rows below, which is now the 0.18-tagged ceiling-derived bound. Rows are left as
+> written for the record; read them with this note.
+
 Every lever is **filed but Backlog**, gated on a named diagnostic with a pre-registered kill
 criterion — nothing is funded before its gate passes (the #3096 lesson, applied in advance). "Do we
 need to measure more?" **Yes — but front-loaded and finite**: Phase 1 is three issues measured in
@@ -474,7 +544,7 @@ days, and it is the LAST general measurement phase; everything after it is lever
 | **0 — Harden** (gating) | **#3272** | The rig every number rests on, guard layer reviewed (now incl. #3224's round-8 seven + #3096's seven) | Trustworthy diagnostics |
 | **1 — Measure** (parallel, ~days) | **#3299** (metal box: bare-scan C(S) → **the box target number**, E1 occupancy, E2 footprint sweep, E3 optional) ∥ **#3248** (gap-A profile: encode complement, bytes-touched differential, probes D3/D4/D5, predictions P1–P3 pre-registered) ∥ **#3287** (opportunistic: 32.24% residual split + `4.6×` re-derivation — needs the preserved `/data` volume) | The box-level target as a NUMBER; each lever's gate verdict; the footprint baseline #3288 needs | Attribution complete |
 | **2 — Levers** (each opens only on its gate) | D3 → **#3303** (fuse `estimate_value_size`, 42% of touched bytes) · D5/D4+P1 → **#3304** (column-first build + borrowed bytes) · E2 knee → **#3305** (byte-budgeted batches) · E1 → **#3306** (footprint-aware admission) · footprint baseline → **#3288** (further bytes-touched cuts) | Gap A: **#3303+#3304 → ~318–340k rows/s/core** (+26–34% from 252,999, at/above the old per-core bar). Gap B: **#3305 (+#3306 stability)** recover a material fraction of the 29% scaling discount | Throughput moves for the first time since #3058 |
-| **3 — Verify + anchor** | Re-run the #3100-style A/B + box aggregate on the lever build (external numbers, noise floor stated); **ONE through-Trino re-probe vs #2866** (the field checkpoint) | The box target hit or the honest gap; the program's first field anchor | "Worth deploying" demonstrated |
+| **3 — Verify + anchor** | Re-run the #3100-style A/B + box aggregate on the lever build (external numbers, noise floor stated); **ONE through-Trino re-probe vs #2866** (the field checkpoint) | **PASS/FAIL against the re-baselined served-path target `~1.35–1.4M rows/s` box-level (§0, §6) — NOT the 2,102,167 bound**; else the honest gap, plus the program's first field anchor | "Worth deploying" demonstrated |
 | **∥ Correctness** (independent) | **#3129** (multi-gen phantom row) | Deployability — rule 8: correctness gates speed | — |
 
 **Contingencies, deliberately unfiled:** L4 (arena + `Value`-enum shrink, oxc-analogue ~20%+10%) if
@@ -492,13 +562,25 @@ program.
 | Issue | P | Finding |
 |---|---|---|
 | **#3272** | P1 | **Harden the WS0 measurement rig before anything is funded on it — 7 open findings.** Every remaining number is a cycles/row attribution on this rig, and #3224's 29 fixed findings were all in its guard layer. **Gating.** |
-| **#3299** | P1 | **Bare-scan C(S) S=1..6 — the missing box-level ceiling. DELIVERED (measurement).** Box-level bare scan = **2,732,817 rows/s at 6 physical cores** ⇒ target = `bare_scan(S=6) / 1.3` = **2,102,167 rows/s** (§0, §6; note the operation is DIVISION). Verdict on the #3288 calibration: **bare scan does NOT decay** (93.5% marginal efficiency; cycles/row ×1.041) so the scaling discount is not intrinsic to the corpus and **#3288's ceiling is preserved**. **AC3 (LLC verdict) DEFERRED** per its own pre-registered AC5 — no LLC instrument counts on `c7i`. **Residual: box-level `do_get` on the same corpus is unmeasured** (client provisioning needs 30+ physical cores) so the box-level gap is not yet a percentage. Ran on a fresh `c7i.4xlarge`, not metal — deliberate: the target is a ratio against c7i-measured figures, so same-class hardware was the requirement. |
+| **#3299** | P1 | **Bare-scan C(S) S=1..6 — the missing box-level ceiling. DELIVERED (measurement).** Box-level bare scan = **2,732,817 rows/s at 6 physical cores** ⇒ `bare_scan(S=6) / 1.3` = **2,102,167 rows/s** (§0, §6; note the operation is DIVISION) — which since the 2026-08-30 adjudication is the **0.18-tagged ceiling-derived bound, not 0.17's target** (§0). Verdict on the #3288 calibration: **bare scan does NOT decay** (93.5% marginal efficiency; cycles/row ×1.041) so the scaling discount is not intrinsic to the corpus and **#3288's ceiling is preserved**. **AC3 (LLC verdict) DEFERRED** per its own pre-registered AC5 — no LLC instrument counts on `c7i`. **Residual: box-level `do_get` on the same corpus is unmeasured** (client provisioning needs 30+ physical cores) so the box-level gap is not yet a percentage. Ran on a fresh `c7i.4xlarge`, not metal — deliberate: the target is a ratio against c7i-measured figures, so same-class hardware was the requirement. |
 | **#3248** | P1 | **Gap A's critical path.** Profile inside the ~79% unlocated per-core delta (~1.2 µs/row of 1.52), **plus the bytes-touched-per-row differential (`do_get` vs bare scan, S=1) that baselines #3288 and every level lever's footprint check.** Buys a profile, not a patch. Also owns the ~1.4% noise-floor remedy (§0). |
 | **#3288** | P1 | **Gap B's lever: cut bytes touched per row on the Flight read path.** The only named slope candidate. **Blocked on #3248's footprint baseline** — "fit ~1/6 of a 54 MiB LLC" is a constraint on a quantity not yet measured — and calibrated by #3299's LLC verdict on bare scan. |
 
 **Standing checkpoint (owner session 2026-08-04):** after the next lever lands, run ONE
 through-Trino re-probe against #2866's setup, so the program's numbers are anchored to "worth
 deploying" at least once. #2866 stays open until that reframe.
+
+**THE VERIFICATION BAR #2866 IS READ AGAINST (2026-08-30 re-baseline).** #2866 verifies the *delivered*
+number against the **re-baselined served-path target: `~1.35–1.4M rows/s` box-level** (§0, §6;
+[the adjudication one-pager of record](https://github.com/pmcfadin/cqlite/issues/2817#issuecomment-5467056309)). Explicitly: **the 2,102,167 rows/s figure is NOT #2866's pass/fail bar** — it is the
+0.18-tagged ceiling-derived bound, and reading the verification round against it would fail a delivery
+that met everything 0.17 funded. Two properties of the bar carry from §0 and must be restated in the
+verification report rather than assumed: the served baseline it improves on (**~1.2M**) is a per-core
+measurement composed to six cores and **not** a measured box-level `do_get`, and #3299's served
+marginal efficiency at S=6 (**0.8203**) is not applied to it — so a verification round that measures
+box-level `do_get` **directly** should report the delivered number against the target **and** state
+whether the baseline it is compared to was re-measured on the same basis. No further perf adjudication
+is scheduled inside 0.17.
 
 ### Remaining attribution (opportunistic, no longer gating)
 | Issue | P | Finding |
@@ -554,7 +636,7 @@ deploying" at least once. #2866 stays open until that reframe.
 | **#3101** | P1 | `cqlite info`/`read-sstable` allocate ~1.0× Data.db (8.5 GiB RSS on 8.2 GiB file); OOMs before emitting a row. **Query path is CLEAN** (23 MiB). Violates the <128 MB target on a shipped command. |
 | **#3060** | P2 | `cqlite-flight` may never exit when signalled mid-stream — ~176% CPU spin. |
 | **#3061** | P3 | Streaming scan 1,017 MiB peak RSS, Data.db mapped twice. Likely an RSS-measurement question. |
-| **#2866** | — | **Origin issue** — the ~20 MB/s single-`DoGet` benchmark that started the program. Reframe/close against §0. |
+| **#2866** | — | **Origin issue** — the ~20 MB/s single-`DoGet` benchmark that started the program, now **0.17's Phase-3 verification round**: one field round reporting the delivered number against the **re-baselined served-path target `~1.35–1.4M rows/s`** (§0, §6), not against the 2,102,167 bound. #2818's i4i cold/warm profile is **folded into it** (2026-08-30 adjudication). Reframe/close against §0. |
 | **#3145 / #3151 / #3158 / #3102 / #3105 / #3040** | P1–P3 | uuid/timeuuid rendering, unasserted row-tombstone decision, batched nits, and the mmap-plane comment cleanup. |
 
 ---
@@ -662,14 +744,16 @@ trustworthy.
 
 ## 11. The one-line status
 
-**#3058 shipped a real 3.06×; throughput has not moved since — but as of 2026-08-04 the program has
-a COMPLETE NUMBERED PATH (§7 plan of record): #3272 hardens the rig → #3299/#3248 finish the
-measurement (the box target as a number; each lever's gate verdict) → four filed levers open only
-on their gates (#3303 fuse-size 42%-of-bytes, #3304 column-first on the arrow-avro anchor, #3305
-byte-budgeted batches, #3306 footprint admission) with expected gap-A outcome ~318–340k rows/s/core
-(+26–34%) and a material bite of the 29% scaling discount → verify with a #3100-style re-measure
-and ONE through-Trino re-probe (#2866). Every lever carries a pre-registered kill criterion;
-#3129's correctness fix rides in parallel.**
+**PHASE 2 (as of 2026-08-30). #3058 shipped a real 3.06× and throughput has not moved since;
+Phase-1 measurement is COMPLETE (#3299, #3248, #2605 merged) and adjudicated ([the adjudication one-pager of record](https://github.com/pmcfadin/cqlite/issues/2817#issuecomment-5467056309)):
+two of the four gated levers are KILLED and three DEFERRED on unmeasurable LLC counters, so 0.17's
+target is re-baselined to the measured deliverable — served-path `~1.35–1.4M rows/s` box-level, from
+~1.2M today (§0, §6) — funded by #2820 (merge, 14.72 µs/row of CPU), #2824 (`madvise`, 60.17 µs/row of
+wall), #3552 (estimate-fold, ~+3.3% served) and #3551 (SMT/allocator trial, kill criterion <3%), with
+the 1.3×-ratio figure (2,102,167 rows/s) RETAINED as the ceiling-derived bound and tagged to the 0.18
+representation program. #2866 is the one field round that verifies the delivered number against the
+re-baselined target; every lever keeps a pre-registered kill criterion, and the read-completeness +
+correctness batch rides in parallel.**
 
 ---
 

--- a/docs/architecture/0.17-throughput-mission.md
+++ b/docs/architecture/0.17-throughput-mission.md
@@ -115,11 +115,12 @@ round to the same ~1.2M, so no published figure moves — but quote #3299 for it
 figure multiplied by S.
 
 **What the band implies, arithmetic shown:** `1,350,000 / 1,198,673` = **+12.6%** and
-`1,400,000 / 1,198,673` = **+16.8%** — the adjudication's and #3553's *"roughly +10–15%"* is the
-owner's rounding of the same band. Against the measured ceiling the band reads as a served/bare ratio
-of **2,732,817 / 1.4M = 1.95× to 2,732,817 / 1.35M = 2.02×**, from **2.28× today** — i.e. 0.17 is
-funded to close roughly a quarter to a third of the distance from 2.28× to the 1.3× deployment ratio,
-and no more. **Only one funded lever is individually priced:** #3552's estimate-fold at
+`1,400,000 / 1,198,673` = **+16.8%**. **#3553's** *"roughly +10–15%"* is a rounding of that same band
+— note it is **#3553's own phrasing and NOT the one-pager's**, which states the band only as
+`~1.35–1.4M rows/s` and never as a percentage. Against the measured ceiling the band reads as a
+served/bare ratio of **2,732,817 / 1.4M = 1.95× to 2,732,817 / 1.35M = 2.02×**, from **2.28× today** —
+i.e. 0.17 is funded to close **26–34%** of the distance from 2.28× to the 1.3× deployment ratio
+(`(2.28 − 2.02) / (2.28 − 1.30) = 26.5%` to `(2.28 − 1.95) / (2.28 − 1.30) = 33.7%`), and no more. **Only one funded lever is individually priced:** #3552's estimate-fold at
 **860 cyc/row ⇒ ~+3.3% served** (#3248). #3551 (SMT-unpin + allocator trial) carries a **kill criterion
 of <3%**. #2820 (batch fan-in) and #2824 (`madvise` under Auto-mmap) attack the two dominant terms —
 `stream_merge` at **14.72 µs/row** of CPU and cold page-in at **60.17 µs/row** of wall, both **#2605** —
@@ -131,8 +132,25 @@ lever set, not a sum of measurements**, and it is labelled that way wherever it 
 the 1.3× deployment ratio implies, and it is **measured-unreachable with fundable 0.17 work**: #3248
 priced every Flight-marginal lever it found, and **deleting 89% of all Flight-marginal code reaches only
 ~1.53×** (its own bias-corrected re-check moves that by **0.0009×** against ~0.2× of slack — #3248
-[comment 5460457579](https://github.com/pmcfadin/cqlite/issues/3248#issuecomment-5460457579)). Closing it needs the storage-representation changes the owner deferred to **0.18**
-(#2817 ruling 2026-08-29). Quote it with that tag; it is not a 0.17 pass/fail bar.
+[comment 5460457579](https://github.com/pmcfadin/cqlite/issues/3248#issuecomment-5460457579)).
+
+**State the basis change in that argument, because this document forbids hiding one.** #3248's
+~1.53× is a **per-core** ratio from a **different session** (its own per-core ratio is 1.685×,
+`docs/reports/ws0-3248-artifacts/ac0/summary.txt`), set beside a **box-level** bound. **No division is
+performed across the two** — and the inference is **conservative in the direction that matters**:
+`do_get` scales *worse* than bare scan (marginal efficiency 0.820 vs 0.935, #3299 §9), so the box
+ratio is **2.28× against 2.00× per core** on #3299's own same-session pair. A per-core lever ceiling
+of ~1.53× therefore bounds the box case *a fortiori*, and the owner's adjudication is what draws that
+conclusion — #3248's own report deliberately declined to re-assert the target (its AC6).
+
+Closing the bound needs the **storage-representation work** the owner moved out of 0.17
+(#2817 ruling 2026-08-29). **On its name:** the adjudication called it "one 0.18 program", and a
+[later ruling 39 minutes on](https://github.com/pmcfadin/cqlite/issues/2817#issuecomment-5467210858)
+superseded that — Mustang / columnar merge / #941 **may proceed upstream in the Cassandra project
+instead of as a CQLite program**, and 0.18's CQLite headline is the memtable freshness path (#1807).
+So read "the 0.18 representation program" throughout this document as **"the storage-representation
+work, deferred out of 0.17, whose home is still being decided"**; what is settled is that it is not
+0.17's. Quote the bound with that tag; it is not a 0.17 pass/fail bar.
 
 **RETIRED (2026-08-30): "box-level `do_get` on this corpus is unmeasured, so the gap is not a
 percentage."** An earlier revision of this section said exactly that, and reasoned that the rig's

--- a/docs/architecture/0.17-throughput-mission.md
+++ b/docs/architecture/0.17-throughput-mission.md
@@ -9,12 +9,13 @@ Parent epic: **#2817** (0.17 scan-path throughput program). Exploration umbrella
 
 > **2026-08-30 headline — PHASE 2. THE TARGET IS RE-BASELINED TO THE MEASURED DELIVERABLE.**
 > Phase 1 is complete (#3299, #3248, #2605 all merged) and the owner has adjudicated it in [the adjudication one-pager of record](https://github.com/pmcfadin/cqlite/issues/2817#issuecomment-5467056309)
-> on epic #2817. **0.17's served-path target is now `~1.35–1.4M rows/s` box-level**, against a served
-> position of ~1.2M (#3248 — basis and its caveats in §0). The **1.3× served/bare ratio
+> on epic #2817. **0.17's served-path target is now `~1.35–1.4M rows/s` box-level**, against a
+> **measured** served position of **1,198,673 rows/s** (#3299 §9 — the first same-corpus, same-session
+> figure for both arms; §0 carries the table and #3299's two disclosures). The **1.3× served/bare ratio
 > (2,102,167 rows/s box-level) is measured-unreachable with fundable 0.17 work** — #3248 priced the
 > Flight-marginal levers and **deleting 89% of all of that code reaches only ~1.53×** — so it is
 > **RETAINED as the ceiling-derived bound and tagged to the 0.18 representation program**, not a 0.17
-> pass/fail bar. The funded set is #2820, #2824, #3552, #3551 (+ this re-baseline); #3303/#3304 are
+> pass/fail bar. The set funded against it is #2820, #2824, #3552, #3551 (+ this re-baseline); #3303/#3304 are
 > **KILLED** and #3305/#3306/#3288 **DEFERRED** on #3224's unmeasurable LLC counters. **Two premises
 > died with Phase 1**: scan-core cache contention (~4 pp non-clock loss — near-perfect scaling) and
 > vectorized-execution upside on row-shaped input (#2605: DataFusion within ±3% of the row engine,
@@ -93,20 +94,32 @@ criterion is about gap B and does not demote them here (§6).
 
 **THE 0.17 SERVED-PATH TARGET (re-baselined 2026-08-30, Phase-2 adjudication): `~1.35–1.4M rows/s`
 box-level.** The source is [the adjudication one-pager of record](https://github.com/pmcfadin/cqlite/issues/2817#issuecomment-5467056309) on epic #2817, which sets 0.17's honest served deliverable and
-retires the 1.3×-ratio target as a 0.17 bar. **The served position it is stated against is
-`~1.2M rows/s` box-level**, cited there to **#3248** — whose measured figure is **206,480 rows/s per
-physical core** (warm, uncompressed 693.69 B/row corpus, S=1, median of 3, spread 2.4%;
-`docs/reports/ws0-3248-artifacts/ac0/summary.txt`), composed to six cores: 206,480 × 6 = 1,238,880.
+retires the 1.3×-ratio target as a 0.17 bar.
 
-**Read that composition as exactly what it is.** It is a per-core measurement multiplied by S, **not a
-measured box-level `do_get`** — that measurement still does not exist (next paragraph) — and it
-applies **no scaling discount**, where #3299 measured served marginal efficiency at S=6 = **0.8203**
-(§6). So ~1.2M is the *optimistic* end of the composition; it is the baseline the adjudication's
-uplift is stated against, and it is not a substitute for the missing measurement.
+**Both endpoints are MEASURED, same corpus, same host, same session — #3299 §9 (PR #3408), the first
+such pair in this program.** Corpus B throughout (uncompressed, 693.69 B/row); no cross-corpus and no
+cross-session division appears in this table:
 
-**What the band implies, arithmetic shown:** `1.35M / 1.2M` = **+12.5%** and `1.4M / 1.2M` = **+16.7%**
-over that served baseline — the adjudication's and #3553's *"roughly +10–15%"* is the owner's rounding
-of the same band. **Only one funded lever is individually priced:** #3552's estimate-fold at
+| | S=1 (per physical core) | S=6 (box) |
+|---|--:|--:|
+| bare scan | 487,213 | **2,732,817** |
+| `do_get` | 243,536 | **1,198,673** |
+| `do_get` / bare scan | 0.500 | **0.439** |
+| gap (bare ÷ `do_get`) | 2.00× | **2.28×** |
+
+**So the served position is `1,198,673 rows/s` box-level — the ~1.2M in the one-pager.** Note a
+citation correction: the one-pager attributes that figure to **#3248**, whose own measurements are
+**per-core** (206,480 rows/s/physical core warm, `docs/reports/ws0-3248-artifacts/ac0/summary.txt`);
+the box-level number of record is **#3299's 1,198,673** (S=6, best-N = 16, spread 1.53%). The two
+round to the same ~1.2M, so no published figure moves — but quote #3299 for it, and never a per-core
+figure multiplied by S.
+
+**What the band implies, arithmetic shown:** `1,350,000 / 1,198,673` = **+12.6%** and
+`1,400,000 / 1,198,673` = **+16.8%** — the adjudication's and #3553's *"roughly +10–15%"* is the
+owner's rounding of the same band. Against the measured ceiling the band reads as a served/bare ratio
+of **2,732,817 / 1.4M = 1.95× to 2,732,817 / 1.35M = 2.02×**, from **2.28× today** — i.e. 0.17 is
+funded to close roughly a quarter to a third of the distance from 2.28× to the 1.3× deployment ratio,
+and no more. **Only one funded lever is individually priced:** #3552's estimate-fold at
 **860 cyc/row ⇒ ~+3.3% served** (#3248). #3551 (SMT-unpin + allocator trial) carries a **kill criterion
 of <3%**. #2820 (batch fan-in) and #2824 (`madvise` under Auto-mmap) attack the two dominant terms —
 `stream_merge` at **14.72 µs/row** of CPU and cold page-in at **60.17 µs/row** of wall, both **#2605** —
@@ -121,23 +134,36 @@ priced every Flight-marginal lever it found, and **deleting 89% of all Flight-ma
 [comment 5460457579](https://github.com/pmcfadin/cqlite/issues/3248#issuecomment-5460457579)). Closing it needs the storage-representation changes the owner deferred to **0.18**
 (#2817 ruling 2026-08-29). Quote it with that tag; it is not a 0.17 pass/fail bar.
 
-**Unchanged by the re-baseline: box-level `do_get` on this corpus is still UNMEASURED.** The only
-*directly measured* box-level `do_get` figure in existence is #3217's **1,076,917 rows/s on the LZ4
-corpus**, which may not be divided into anything measured on the uncompressed corpus, for the reason
-this section opens with. Nor may the ~1.2M composition above be divided into #3299's 2,732,817: a
-different session and a different binary, and this section's own rule forbids deriving a cross-session
-absolute. So the served/bare **ratio** at box level is still not statable as a number, and stays
-deliberately unstated rather than filled with a cross-session or cross-corpus division.
+**RETIRED (2026-08-30): "box-level `do_get` on this corpus is unmeasured, so the gap is not a
+percentage."** An earlier revision of this section said exactly that, and reasoned that the rig's
+calibrated **1:4** server:client split cannot be honoured on an 8-physical-core `c7i` (a 6-core server
+leaves the client 2 cores — 6:2, a 12× swing), so a box-level `do_get` point would be **client-bound**:
+a measurement of the loadgen, understating `do_get`, overstating the gap and flattering #3288. **#3299
+posed that as a test rather than a conclusion, and the test REFUTED it** (§11.1 of
+`docs/reports/ws0-3299-report.md`): with the server fixed at 6 physical cores and an identical ramp,
+only the client varied —
 
-**Why #3299 could not close it, precisely — it is a client-provisioning limit, not a corpus or
-instrument limit.** Measuring `do_get` on the same corpus needs client and server on one box, and
-the rig's own calibrated split provisions the loadgen **4 physical cores per 1 server core**. On the
-8-physical-core `c7i` a 6-core server leaves the client 2 cores — a 6:2 ratio against the
-calibrated 1:4, a 12× swing — which would very likely be **client-bound**, i.e. a measurement of
-the loadgen. That error understates `do_get`, overstates the gap, and flatters #3288: the one error
-class this measurement chain exists to prevent. A valid box-level `do_get` on this corpus needs a
-host with roughly **30+ physical cores** to provision a 6-core server at the rig's own client ratio.
-→ tracked as a #3299 follow-up.
+| client cores | rows/s |
+|---|--:|
+| 2 physical (`6,14,7,15`) | 1,027,268 |
+| 1 physical (`6,14`) | 1,027,467 |
+
+**+0.02%, far inside spread — not client-bound.** Halving the client changed nothing, which it could
+not do if the client were the limit. So the box-level figure above stands as `do_get`, the 30+-core
+host is **not** a precondition, and the box-level remaining IS a percentage: **+75.4%** to the retained
+2,102,167 bound (#3299 §9: `2,102,167 / 1,198,673 = 1.754`), **+12.6–16.8%** to the re-baselined target.
+#3217's **1,076,917 rows/s** stays out of every ratio here for the reason this section opens with — it
+is the **LZ4 corpus** and may not be divided against a figure measured on the uncompressed one.
+
+**#3299's TWO DISCLOSURES ride with its cross-arm numbers and are not papered over** (§11 of its
+report): **(a)** bare-scan S=6 ran 6 cores pinned with 2 **idle** and no client while `do_get` S=6 ran
+6 serving with those 2 **busy** driving load — not identical machine states, so the cross-arm
+comparison is **not a controlled A/B** (it is still the right comparison, because the deployment bar is
+itself asymmetric: real `do_get` has clients and bare scan does not); and **(b)** the two arms are
+**not windowed identically** — bare scan uses #3299's control-FIFO aligned window, `do_get` uses
+`flight-loadgen`'s own per-step accounting (the #3100/#3217 arm-B convention, chosen for comparability
+with those figures), so every cross-arm ratio inherits whatever systematic difference the two
+instruments carry. Quote the ratios with that attached.
 
 **The bar's UNIT (owner ruling 2026-08-04, unchanged by the 2026-08-30 re-baseline — only the number
 moved): BOX-LEVEL AGGREGATE rows/s.** The box-level bare-scan ceiling is **MEASURED** — #3299
@@ -335,11 +361,15 @@ result.
 ## 6. THE TARGET — two gaps, not one
 
 **0.17's TARGET (re-baselined 2026-08-30, Phase-2 adjudication): served-path `~1.35–1.4M rows/s`
-box-level**, against a served position of **`~1.2M`** — #3248's 206,480 rows/s/physical core composed
-to six cores, with the basis and its caveats spelled out in §0. Source: [the adjudication one-pager of record](https://github.com/pmcfadin/cqlite/issues/2817#issuecomment-5467056309) on epic #2817.
-Funded against it: #2820 (merge, the dominant CPU term at 14.72 µs/row — #2605), #2824 (`madvise`, the
-dominant wall term at 60.17 µs/row — #2605), #3552 (estimate-fold, 860 cyc/row ⇒ ~+3.3% served —
-#3248) and #3551 (SMT-unpin + allocator trial, kill criterion <3%).
+box-level**, against a **measured** served position of **1,198,673 rows/s** at S=6 (#3299 §9, same
+corpus and session as the ceiling; §0 carries the table and the two disclosures). Source: [the adjudication one-pager of record](https://github.com/pmcfadin/cqlite/issues/2817#issuecomment-5467056309) on epic #2817.
+**Funded against it** (as adjudicated 2026-08-30): #2820 (batch fan-in — attacks the dominant CPU term,
+`stream_merge` at 14.72 µs/row, #2605), #2824 (`madvise` under Auto-mmap — the dominant wall term, cold
+page-in at 60.17 µs/row, #2605), #3552 (estimate-fold, 860 cyc/row ⇒ ~+3.3% served, #3248) and #3551
+(SMT-unpin + allocator trial, kill criterion <3%). **#2820 and #3552 have since closed COMPLETED**
+(#2820 via PR #3659, 2026-08-31; #3552 2026-09-01), so treat this list as the funded *set*, not as
+work outstanding — **and note that no delivered served number is published here**: reporting it against
+the target is #2866's round (§7), not something to infer from a lever having merged.
 
 **The RETAINED bound (owner ruling 2026-08-04, now tagged to 0.18): box-level aggregate `do_get`
 rows/s within ~1.3× of box-level bare scan.** The box denominator is **MEASURED (#3299)**: bare scan
@@ -347,10 +377,11 @@ sustains **2,732,817 rows/s on 6 physical cores** (median of 3, spread 0.74%, be
 uncompressed 693.69 B/row corpus), so that ratio implies **`2,732,817 / 1.3` = 2,102,167 rows/s**.
 **It is measured-unreachable with fundable 0.17 work** — #3248: deleting **89% of all Flight-marginal
 code** reaches only **~1.53×** — and closing it needs the storage-representation changes deferred to
-**0.18** (#2817, 2026-08-29). The numerator — box-level `do_get` on the *same* corpus — is **still
-unmeasured** and needs a 30+ physical-core host to provision the client at the rig's calibrated 1:4
-ratio (§0), so **the box-level ratio still cannot be quoted as a number**. The program therefore still
-tracks two component gaps — which are DIFFERENT problems with DIFFERENT lever classes, and
+**0.18** (#2817, 2026-08-29). The numerator — box-level `do_get` on the *same* corpus — is **MEASURED
+at 1,198,673 rows/s** (#3299 §9), so the box-level position **is** a number: **2.28× of bare scan, and
++75.4% short of the 2,102,167 bound**. The earlier "client-bound, needs a 30+ core host" objection was
+posed as a test and **refuted** (halving the client cores moved rows/s by +0.02% — §0). The program
+still tracks two component gaps — which are DIFFERENT problems with DIFFERENT lever classes, and
 an earlier revision of this section conflated them:
 
 | Gap | Measurement | Size | Mechanism | Lever class |
@@ -433,8 +464,10 @@ the Flight path.
 
 1. **Cross-host, cross-corpus, cross-arm.** #3224/#3217 are `i4i.metal` / LZ4 196.09 B/row /
    `do_get`; #3299 is `c7i.4xlarge` / uncompressed 693.69 B/row / bare scan. **No ratio between the
-   two sets is computed.** What is compared is the *shape* (flat vs rising), not magnitudes. The
-   same-corpus `do_get` comparison that would remove this caveat is the unmeasured numerator in §0.
+   two sets is computed.** What is compared is the *shape* (flat vs rising), not magnitudes. **The
+   same-corpus `do_get` comparison that removes this caveat now EXISTS** — #3299 §9 measured both arms
+   on corpus B in one session (§0's table) — but it is a `c7i` pair, so it removes the cross-corpus and
+   cross-arm halves and **not** the cross-host one against #3224/#3217's `i4i.metal` figures.
 2. **AC3 is DEFERRED, so the residual is unattributed.** No LLC instrument produces a count on
    `c7i` — `LLC-load*` are `<not supported>` and every other L3 spelling returns a hard **0 at
    100.00% `pct_running`** on a workload that cannot have zero L3 misses. That is an unavailable
@@ -562,7 +595,7 @@ program.
 | Issue | P | Finding |
 |---|---|---|
 | **#3272** | P1 | **Harden the WS0 measurement rig before anything is funded on it — 7 open findings.** Every remaining number is a cycles/row attribution on this rig, and #3224's 29 fixed findings were all in its guard layer. **Gating.** |
-| **#3299** | P1 | **Bare-scan C(S) S=1..6 — the missing box-level ceiling. DELIVERED (measurement).** Box-level bare scan = **2,732,817 rows/s at 6 physical cores** ⇒ `bare_scan(S=6) / 1.3` = **2,102,167 rows/s** (§0, §6; note the operation is DIVISION) — which since the 2026-08-30 adjudication is the **0.18-tagged ceiling-derived bound, not 0.17's target** (§0). Verdict on the #3288 calibration: **bare scan does NOT decay** (93.5% marginal efficiency; cycles/row ×1.041) so the scaling discount is not intrinsic to the corpus and **#3288's ceiling is preserved**. **AC3 (LLC verdict) DEFERRED** per its own pre-registered AC5 — no LLC instrument counts on `c7i`. **Residual: box-level `do_get` on the same corpus is unmeasured** (client provisioning needs 30+ physical cores) so the box-level gap is not yet a percentage. Ran on a fresh `c7i.4xlarge`, not metal — deliberate: the target is a ratio against c7i-measured figures, so same-class hardware was the requirement. |
+| **#3299** | P1 | **Bare-scan C(S) S=1..6 — the missing box-level ceiling. DELIVERED (measurement).** Box-level bare scan = **2,732,817 rows/s at 6 physical cores** ⇒ `bare_scan(S=6) / 1.3` = **2,102,167 rows/s** (§0, §6; note the operation is DIVISION) — which since the 2026-08-30 adjudication is the **0.18-tagged ceiling-derived bound, not 0.17's target** (§0). Verdict on the #3288 calibration: **bare scan does NOT decay** (93.5% marginal efficiency; cycles/row ×1.041) so the scaling discount is not intrinsic to the corpus and **#3288's ceiling is preserved**. **AC3 (LLC verdict) DEFERRED** per its own pre-registered AC5 — no LLC instrument counts on `c7i`. **Also delivered, and superseding an earlier "residual" line here: box-level `do_get` on the same corpus IS measured — 1,198,673 rows/s** (§9 of its report; the client-bound objection was tested and refuted at +0.02%), so the box-level gap **is** a percentage: +75.4% to the retained bound, +12.6–16.8% to the re-baselined target (§0). Ran on a fresh `c7i.4xlarge`, not metal — deliberate: the target is a ratio against c7i-measured figures, so same-class hardware was the requirement. |
 | **#3248** | P1 | **Gap A's critical path.** Profile inside the ~79% unlocated per-core delta (~1.2 µs/row of 1.52), **plus the bytes-touched-per-row differential (`do_get` vs bare scan, S=1) that baselines #3288 and every level lever's footprint check.** Buys a profile, not a patch. Also owns the ~1.4% noise-floor remedy (§0). |
 | **#3288** | P1 | **Gap B's lever: cut bytes touched per row on the Flight read path.** The only named slope candidate. **Blocked on #3248's footprint baseline** — "fit ~1/6 of a 54 MiB LLC" is a constraint on a quantity not yet measured — and calibrated by #3299's LLC verdict on bare scan. |
 
@@ -574,13 +607,18 @@ deploying" at least once. #2866 stays open until that reframe.
 number against the **re-baselined served-path target: `~1.35–1.4M rows/s` box-level** (§0, §6;
 [the adjudication one-pager of record](https://github.com/pmcfadin/cqlite/issues/2817#issuecomment-5467056309)). Explicitly: **the 2,102,167 rows/s figure is NOT #2866's pass/fail bar** — it is the
 0.18-tagged ceiling-derived bound, and reading the verification round against it would fail a delivery
-that met everything 0.17 funded. Two properties of the bar carry from §0 and must be restated in the
-verification report rather than assumed: the served baseline it improves on (**~1.2M**) is a per-core
-measurement composed to six cores and **not** a measured box-level `do_get`, and #3299's served
-marginal efficiency at S=6 (**0.8203**) is not applied to it — so a verification round that measures
-box-level `do_get` **directly** should report the delivered number against the target **and** state
-whether the baseline it is compared to was re-measured on the same basis. No further perf adjudication
-is scheduled inside 0.17.
+that met everything 0.17 funded.
+
+**The baseline the delivered number is improved on is `1,198,673 rows/s`** (#3299 §9, S=6, best-N = 16,
+spread 1.53%), so the bar in numbers is **+12.6% to reach 1.35M, +16.8% to reach 1.4M**. Three
+properties of that baseline carry from §0 into the verification report and must be **restated there
+rather than assumed**: it is a `c7i.4xlarge` figure on the uncompressed 693.69 B/row corpus (nothing
+measured on the LZ4 corpus may be divided against it); the cross-arm comparison it sits in is **not a
+controlled A/B** (bare scan ran with 2 idle cores and no client, `do_get` with those 2 busy driving
+load); and the two arms are **windowed by different instruments** (#3299's aligned window vs
+`flight-loadgen`'s per-step accounting). #2866 is a **through-Trino** probe, so it introduces a fourth
+basis change of its own — report it as its own measurement against the target, not as a continuation of
+#3299's series. No further perf adjudication is scheduled inside 0.17.
 
 ### Remaining attribution (opportunistic, no longer gating)
 | Issue | P | Finding |
@@ -747,8 +785,8 @@ trustworthy.
 **PHASE 2 (as of 2026-08-30). #3058 shipped a real 3.06× and throughput has not moved since;
 Phase-1 measurement is COMPLETE (#3299, #3248, #2605 merged) and adjudicated ([the adjudication one-pager of record](https://github.com/pmcfadin/cqlite/issues/2817#issuecomment-5467056309)):
 two of the four gated levers are KILLED and three DEFERRED on unmeasurable LLC counters, so 0.17's
-target is re-baselined to the measured deliverable — served-path `~1.35–1.4M rows/s` box-level, from
-~1.2M today (§0, §6) — funded by #2820 (merge, 14.72 µs/row of CPU), #2824 (`madvise`, 60.17 µs/row of
+target is re-baselined to the measured deliverable — served-path `~1.35–1.4M rows/s` box-level, from a
+measured 1,198,673 rows/s today (#3299; §0, §6) — the set funded against it being #2820 (merge, 14.72 µs/row of CPU), #2824 (`madvise`, 60.17 µs/row of
 wall), #3552 (estimate-fold, ~+3.3% served) and #3551 (SMT/allocator trial, kill criterion <3%), with
 the 1.3×-ratio figure (2,102,167 rows/s) RETAINED as the ceiling-derived bound and tagged to the 0.18
 representation program. #2866 is the one field round that verifies the delivered number against the


### PR DESCRIPTION
Closes #3553.

Re-baselines the 0.17 served-path target in `docs/architecture/0.17-throughput-mission.md` from the
ceiling-derived 2,102,167 rows/s to the measured deliverable, per the Phase-2 adjudication one-pager
of record ([#2817 comment 5467056309](https://github.com/pmcfadin/cqlite/issues/2817#issuecomment-5467056309)).

## What changed

| § | change |
|---|---|
| header | new dated 2026-08-30 headline: Phase 2, the re-baselined target, the killed/deferred lever dispositions, the two premises Phase 1 killed. The 2026-08-04 headline is left below it for the record. Status line → 2026-08-30. |
| **§0** | **0.17's target is now served-path `~1.35–1.4M rows/s` box-level.** Added #3299 §9's same-corpus/same-session table for BOTH arms; the served position stated as its **measured** 1,198,673 rows/s; the implied uplift shown as arithmetic; the 2,102,167 figure **retained** and tagged to the 0.18 representation program; the per-core 315,730 bar retagged the same way. |
| **§0** | **Retired a stale claim** — see the correction below. |
| **§6** | target block re-baselined; the retained 1.3× bound relabelled as a 0.18 bound with its unreachability evidence; funded levers cited to the measurements they attack; caveat 1 corrected. |
| §7 | plan-of-record note recording that Phase 2's lever list did not survive its own gates (#3303/#3304 KILLED, #3305/#3306/#3288 DEFERRED); #3299 and #2866 rows corrected. |
| **§7** | **AC3: #2866's verification bar now reads against the NEW target**, in numbers (+12.6% / +16.8%), with the three basis properties it must restate rather than assume, and an explicit "2,102,167 is NOT #2866's pass/fail bar". |
| §11 | one-line status is now Phase-2. |

## The correction this PR found

While verifying sources I found the mission doc was **stale in three places**, and that the
one-pager's `~1.2M` served figure has a different provenance than it cites:

- **#3299 DID measure box-level `do_get` on the uncompressed corpus: 1,198,673 rows/s at S=6**
  (`docs/reports/ws0-3299-report.md` §9). The doc said it was unmeasured, that a 30+ physical-core
  host was needed to provision the client at the rig's 1:4 ratio, and that the box-level gap "cannot
  yet be quoted as a percentage" (§0 twice, §6, §7's #3299 row).
- **#3299 posed the client-bound objection as a test and the test refuted it** (§11.1): server fixed
  at 6 physical cores, only the client varied — 2 physical cores 1,027,268 rows/s vs 1 physical core
  1,027,467 rows/s, **+0.02%**. Halving the client changed nothing, which it could not do if the
  client were the limit.
- So the box-level remaining **is** a percentage: **+75.4%** to the retained bound (#3299 §9),
  **+12.6–16.8%** to the re-baselined target.
- **Citation correction, no number moves:** the one-pager attributes `~1.2M` to **#3248**, whose own
  measurements are per-core (206,480 rows/s/physical core, `docs/reports/ws0-3248-artifacts/ac0/summary.txt`).
  Both round to ~1.2M; the box-level number of record is #3299's. The doc now says to quote #3299 for
  it and never a per-core figure multiplied by S.
- #3299's **two disclosures** ride with its cross-arm numbers in the doc rather than being dropped:
  the machine states differ (bare scan 2 idle cores and no client vs `do_get` 2 busy driving load), so
  it is **not a controlled A/B**; and the arms are **windowed by different instruments** (#3299's
  aligned window vs `flight-loadgen`'s per-step accounting).

## Acceptance criteria

**AC1 — no published number invented; every figure cites its measurement issue.** Verified against
primary sources, not this document's own prior text:

| figure | source (read, not recalled) |
|---|---|
| target `~1.35–1.4M rows/s` box-level | #2817 comment 5467056309 (owner adjudication) |
| served today **1,198,673** (S=6, best-N=16, spread 1.53%); **243,536** (S=1) | `docs/reports/ws0-3299-report.md` §9 (:542) / §9.x (:558-560) |
| bare scan **2,732,817** (S=6) / **487,213** (S=1); ratios 0.439 / 0.500; gaps 2.28× / 2.00× | same table, :541-544 |
| **+75.4%** remaining to 2,102,167; `2,732,817 / 1.3 = 2,102,167` | :548, :552 |
| client-bound refutation 1,027,268 / 1,027,467 = +0.02% | :642 and §11.1 |
| 206,480 rows/s/physical core (warm, spread 2.4%, n=3) | `docs/reports/ws0-3248-artifacts/ac0/summary.txt:24` |
| deleting **89%** of Flight-marginal code reaches **~1.53×** | #3248 comment 5455472811 |
| that ceiling survives bias correction (shifts 0.0009× vs ~0.2× slack) | #3248 comment 5460457579 |
| #3552 estimate-fold **860 cyc/row ⇒ ~+3.3% served** | #3248 comment 5455472811; #3552 title |
| #3551 kill criterion **<3%** | #2817 comment 5467056309 |
| `stream_merge` **14.72 µs/row**; cold page-in **60.17 µs/row** | `docs/architecture/2605-datafusion-spike-report.md:376,378` |
| DataFusion within ±3%, I/O controlled; ~4 pp non-clock scan loss | #2817 comment 5467056309 (#2605; #3299 4.01 pp at :456) |
| 0.18 deferral of storage-representation work | #2817 owner ruling 2026-08-29 |
| #2820 closed COMPLETED via PR #3659 (2026-08-31); #3552 closed 2026-09-01 | `gh issue view` |

Derived figures publish their arithmetic in the document: `1,350,000 / 1,198,673 = 1.1262` (+12.6%),
`1,400,000 / 1,198,673 = 1.1680` (+16.8%), `2,732,817 / 1.4M = 1.95×`, `2,732,817 / 1.35M = 2.02×`.
**No cross-corpus or cross-session division was introduced** — the §0 table is one #3299 session on
one corpus, and #3217's LZ4 1,076,917 stays out of every ratio. A composition of #3248's per-core
figure to six cores was drafted and then **removed** in favour of #3299's direct measurement.

**AC2 — `classify-docs-only` confirms prose; no roborev claim.**

```
$ git diff --name-only origin/main...HEAD | bash scripts/ci/classify-docs-only.sh
docs-only
classify-docs-only: all changed files are docs -> short-circuit to green
exit 0
```

Per CLAUDE.md a code-free diff **cannot be roborev-certified**, so **no roborev claim is made for this
PR**. The sanctioned substitute is the primary-source verification table above.

**AC3 — the #2866 verification round's pass/fail bar reads against the NEW target.** §7 gains a
dedicated block stating the bar (`~1.35–1.4M rows/s` box-level), the baseline it improves on
(1,198,673) and the numbers (+12.6% / +16.8%), plus an explicit statement that 2,102,167 is **not**
#2866's bar — reading the verification round against it would fail a delivery that met everything 0.17
funded. The Phase-3 row and the #2866 ranked-list row carry the same bar.

## Scope

Deliberately **not** re-dispositioning §7's lever tables or §5/§13's historical session records — those
are records of what was measured at the time. §7 gains one pointer note so the plan of record cannot be
read as still targeting 2,102,167.
