### PR TITLE
docs(#3460): request a waiver only when the head is FINAL — pushed, conflict-free, post-gate, reviewed at that sha

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1264,9 +1264,12 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   FAIL → waiver naming that base/head/job → recheck ⇒ `WAIVED` + `RESULT: PASS`, with zero reviewer
   invocations; and a recheck of a *different* job stays `STALE`.
   **REQUEST A WAIVER ONLY WHEN THE HEAD IS FINAL — pushed, conflict-free, post-gate, and REVIEWED AT
-  THAT SHA (#3460).** The binding above is `base` AND `head` AND `job` compared for EXACT EQUALITY
-  against the run's own `HEAD_SHA` (`git rev-parse HEAD`, recomputed in EVERY mode INCLUDING
-  `--recheck-job`), so **any commit landing after the request makes the grant unapplicable** —
+  THAT SHA (#3460).** The binding above is `base` AND `head` AND `job`, each compared for EXACT
+  EQUALITY and each against a DIFFERENT value: `head` against the run's own `HEAD_SHA`
+  (`git rev-parse HEAD`, assigned ONCE before mode dispatch — NO path derives head from the job record,
+  `--recheck-job` included), `base` against `RANGE_BASE_SHA`, which is the **MERGE-BASE and NOT the base
+  ref's tip** (#3392 — copy it from the block's `assert-base:` line, NEVER from `base:`), and `job`
+  against this run's job id. So **any commit landing after the request makes the grant unapplicable** —
   `waiver: STALE`, and the FAIL stands. The order is therefore: push every local commit → rebase or
   resolve until the PR is not `CONFLICTING` → gate of record → **a roborev confirmation pass ON THAT
   FINAL SHA** → only then request the waiver, naming THAT round's triple. **`--recheck-job` is not an
@@ -1276,22 +1279,31 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   reviewed `6f5fc2b7c` and two commits landed after it), and #2605 was the same — so the final sha needs
   its OWN round, and THAT round's job id is the one the waiver must name. **THE TRAP CATCHES A LANE
   DOING THE CAREFUL THING, which is why it is written down rather than left to judgement**: the absence
-  diagnostic prints `base … head … job …` and those values are CORRECT at the moment it prints them,
-  while nothing in the output says they will be invalid after the next push — so copying the verified
-  triple straight into a request is simultaneously the obvious action and the wrong one whenever
-  anything is still going to move the head. Measured cost: THREE independent lanes on ONE day
-  (2026-08-28) — #1705/PR #3382 (grant received, then a conflict with just-merged #1701 had to be
-  resolved), #1699/PR #3403 (the triple was exact and the PR was `CONFLICTING` at the same moment),
-  #3248/PR #3455 (fixes committed but unpushed, AND `CONFLICTING`) — each spending an authorization on
-  code that would not merge, and asking the authorizer to judge a review that no longer described the
-  diff. **DO NOT LOOSEN THE BINDING TO MAKE THIS EASIER**: all three instances are the binding WORKING,
-  and a waiver riding to a later review is the hole #3312 exists to close. **NOT MECHANIZED, and only
-  ONE of the three halves is**: `push-assert` catches the unpushed half (`FAIL (unpushed commits)`,
-  aborting the round before any review), while `mergeable`/`CONFLICTING` appears NOWHERE in the wrapper,
-  the waiver scanner or `premerge-assert.sh` — so a pushed-but-`CONFLICTING` head passes every check and
-  still yields a triple that dies on the rebase. Converting this rule into a refusal, and naming WHY a
-  triple is stale (`head moved` / `base moved` / `job mismatch`) instead of a generic staleness verdict,
-  is **#3827** — a change to the wrapper, which per its own doctrine cannot certify itself.
+  diagnostic prints `base … head … job …`, those values are CORRECT at the moment it prints them, and
+  **the failing block itself says nothing about a push invalidating them** — only `--help` does ("a
+  push, a different base or a re-run each need a fresh one"), which is not where a lane reading a FAIL
+  is looking. So copying the verified triple straight into a request is simultaneously the obvious
+  action and the wrong one whenever anything is still going to move the head. Measured cost: THREE
+  independent lanes on ONE day (2026-08-28) — #1705/PR #3382 (grant received, then a conflict with
+  just-merged #1701 had to be resolved), #1699/PR #3403 (the triple was exact and the PR was
+  `CONFLICTING` at the same moment), #3248/PR #3455 (fixes committed but unpushed, AND `CONFLICTING`) —
+  each spending an authorization on code that would not merge, and asking the authorizer to judge a
+  review that no longer described the diff. **DO NOT LOOSEN THE BINDING TO MAKE THIS EASIER**: all three
+  instances are the binding WORKING, and a waiver riding to a later review is the hole #3312 exists to
+  close. **TWO OF THE FOUR CONDITIONS ARE MECHANIZED AND TWO ARE NOT — KNOW WHICH.** *Pushed* is:
+  `push-assert` FAILs the round before any review is enqueued (`FAIL (unpushed commits)` when the remote
+  branch exists and local is ahead; `FAIL (branch absent on remote <remote>)` when it was never pushed —
+  four spellings, one verdict). *Reviewed-at-that-sha* is: `sha-assert` FAILs when the record's range
+  head ≠ local `HEAD`, and the head binding catches it again at waiver time. But **`mergeable` /
+  `CONFLICTING` appears NOWHERE** in the wrapper, the waiver scanner or `premerge-assert.sh`, and
+  **NOTHING correlates the reviewed sha with a gate of record** — so a pushed, reviewed,
+  still-`CONFLICTING` head passes every check and yields a triple that dies on the rebase. Mechanizing
+  those two, and splitting the staleness VERDICT TOKEN (`STALE` for all three causes today, though its
+  DETAIL already names the diverged field and both values) into `head moved` / `base moved` /
+  `job mismatch`, is **#3827** — whose demonstration is **circular rather than impossible**: every
+  sanctioned invocation is the branch's own `scripts/flow/roborev-review.sh`, so the round reviewing a
+  wrapper change RUNS the changed wrapper (the same property #3544 records for `agent-gate.sh`, and
+  NOT the read-from-root self-certification bar of #3229).
   **The marker is decided by ONE anchored pattern, and the reason is trimmed BEFORE it is judged**, so
   field order and value boundaries are enforced and `reason=TODO ` / whitespace-only reasons are refused
   like their untrimmed forms — per-field extraction had enforced neither.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1263,6 +1263,35 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   legitimate but can never be pasted as evidence of a *fresh* review. Demonstrated end to end: absence
   FAIL → waiver naming that base/head/job → recheck ⇒ `WAIVED` + `RESULT: PASS`, with zero reviewer
   invocations; and a recheck of a *different* job stays `STALE`.
+  **REQUEST A WAIVER ONLY WHEN THE HEAD IS FINAL — pushed, conflict-free, post-gate, and REVIEWED AT
+  THAT SHA (#3460).** The binding above is `base` AND `head` AND `job` compared for EXACT EQUALITY
+  against the run's own `HEAD_SHA` (`git rev-parse HEAD`, recomputed in EVERY mode INCLUDING
+  `--recheck-job`), so **any commit landing after the request makes the grant unapplicable** —
+  `waiver: STALE`, and the FAIL stands. The order is therefore: push every local commit → rebase or
+  resolve until the PR is not `CONFLICTING` → gate of record → **a roborev confirmation pass ON THAT
+  FINAL SHA** → only then request the waiver, naming THAT round's triple. **`--recheck-job` is not an
+  escape**: #3392 stabilised the BASE comparison against a moving `main`, and nothing can make a HEAD
+  binding survive a genuine content change. **The confirmation pass is the step that gets skipped, and
+  skipping it has its own failure shape**: #3367's gated sha had never been reviewed at all (round 25
+  reviewed `6f5fc2b7c` and two commits landed after it), and #2605 was the same — so the final sha needs
+  its OWN round, and THAT round's job id is the one the waiver must name. **THE TRAP CATCHES A LANE
+  DOING THE CAREFUL THING, which is why it is written down rather than left to judgement**: the absence
+  diagnostic prints `base … head … job …` and those values are CORRECT at the moment it prints them,
+  while nothing in the output says they will be invalid after the next push — so copying the verified
+  triple straight into a request is simultaneously the obvious action and the wrong one whenever
+  anything is still going to move the head. Measured cost: THREE independent lanes on ONE day
+  (2026-08-28) — #1705/PR #3382 (grant received, then a conflict with just-merged #1701 had to be
+  resolved), #1699/PR #3403 (the triple was exact and the PR was `CONFLICTING` at the same moment),
+  #3248/PR #3455 (fixes committed but unpushed, AND `CONFLICTING`) — each spending an authorization on
+  code that would not merge, and asking the authorizer to judge a review that no longer described the
+  diff. **DO NOT LOOSEN THE BINDING TO MAKE THIS EASIER**: all three instances are the binding WORKING,
+  and a waiver riding to a later review is the hole #3312 exists to close. **NOT MECHANIZED, and only
+  ONE of the three halves is**: `push-assert` catches the unpushed half (`FAIL (unpushed commits)`,
+  aborting the round before any review), while `mergeable`/`CONFLICTING` appears NOWHERE in the wrapper,
+  the waiver scanner or `premerge-assert.sh` — so a pushed-but-`CONFLICTING` head passes every check and
+  still yields a triple that dies on the rebase. Converting this rule into a refusal, and naming WHY a
+  triple is stale (`head moved` / `base moved` / `job mismatch`) instead of a generic staleness verdict,
+  is **#3827** — a change to the wrapper, which per its own doctrine cannot certify itself.
   **The marker is decided by ONE anchored pattern, and the reason is trimmed BEFORE it is judged**, so
   field order and value boundaries are enforced and `reason=TODO ` / whitespace-only reasons are refused
   like their untrimmed forms — per-field extraction had enforced neither.

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -334,6 +334,50 @@ mechanism below, under *"the unwaivable rule made one merge unobtainable"*.
    legitimate but can never be pasted as evidence of a *fresh* review. Demonstrated end to end: absence
    FAIL → waiver naming that base/head/job → recheck ⇒ `WAIVED` + `RESULT: PASS`, with zero reviewer
    invocations; and a recheck of a *different* job stays `STALE`.
+   **REQUEST A WAIVER ONLY WHEN THE HEAD IS FINAL — pushed, conflict-free, post-gate, and reviewed AT
+   THAT SHA (issue #3460).** The binding above is `base` AND `head` AND `job`, compared for **exact
+   equality** against the run's own `HEAD_SHA` (`git rev-parse HEAD`, recomputed in every mode
+   **including `--recheck-job`**), so **any commit landing after the request makes the grant
+   unapplicable** — the run reports `waiver: STALE` and the FAIL stands. The order is therefore:
+
+   1. **push** every local commit (an unpushed head cannot produce a valid triple at all — `push-assert`
+      fails the round with `FAIL (unpushed commits)` before any review is enqueued);
+   2. **rebase or resolve** until the PR is no longer `CONFLICTING`;
+   3. **gate of record**;
+   4. a **roborev confirmation pass on that final sha**;
+   5. *then* request the waiver, naming **that** round's `base`/`head`/`job`.
+
+   **`--recheck-job` is not an escape.** #3392 stabilised the *base* comparison against a moving `main`,
+   and nothing can make a *head* binding survive a genuine content change — that is what the binding is
+   for.
+
+   **The confirmation pass is the step that gets skipped, and skipping it has its own failure shape.**
+   #3367 found its gated sha had never been reviewed at all: round 25 reviewed `6f5fc2b7c` and two
+   commits landed after it; #2605 hit the same shape. The final sha needs its **own** review round, and
+   *that* round's job id is the one the waiver must name.
+
+   **The trap catches a lane doing the careful thing, which is why it is written down rather than left
+   to judgement.** The absence diagnostic prints `base … head … job …`, and those values are *correct at
+   the moment it prints them*. Nothing in the output says they will be invalid after the next push — so
+   copying the verified triple straight into a request is simultaneously the obvious action and the
+   wrong one whenever anything is still going to move the head. Measured cost: **three independent lanes
+   on one day** (2026-08-28) — #1705/PR #3382 (grant received, then a conflict with just-merged #1701
+   had to be resolved), #1699/PR #3403 (the triple was exact and the PR was `CONFLICTING` at the same
+   moment), #3248/PR #3455 (fixes committed but unpushed, **and** `CONFLICTING`) — each spending an
+   authorization on code that would not merge, and asking the authorizer to judge a review that no
+   longer described the diff.
+
+   **Do not loosen the binding to make this easier.** All three instances are the binding *working*, and
+   a waiver riding to a later review is the hole #3312 exists to close.
+
+   **Not mechanized, and only one of the three halves is.** `push-assert` covers *pushed*;
+   `mergeable`/`CONFLICTING` appears **nowhere** in the wrapper, the waiver scanner or
+   `premerge-assert.sh`, and nothing correlates the reviewed sha with a gate of record — so a
+   pushed-but-`CONFLICTING` head passes every check and still yields a triple that dies on the rebase.
+   Converting this rule into a refusal, and naming *why* a triple is stale (`head moved` / `base moved` /
+   `job mismatch`) instead of a generic staleness verdict, is **issue #3827** — a change to the wrapper,
+   which per its own doctrine cannot certify itself.
+
    **The marker is decided by ONE anchored pattern, and the reason is trimmed BEFORE it is judged**, so
    field order and value boundaries are enforced and `reason=TODO ` / whitespace-only reasons are refused
    like their untrimmed forms — per-field extraction had enforced neither.

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -335,13 +335,19 @@ mechanism below, under *"the unwaivable rule made one merge unobtainable"*.
    FAIL → waiver naming that base/head/job → recheck ⇒ `WAIVED` + `RESULT: PASS`, with zero reviewer
    invocations; and a recheck of a *different* job stays `STALE`.
    **REQUEST A WAIVER ONLY WHEN THE HEAD IS FINAL — pushed, conflict-free, post-gate, and reviewed AT
-   THAT SHA (issue #3460).** The binding above is `base` AND `head` AND `job`, compared for **exact
-   equality** against the run's own `HEAD_SHA` (`git rev-parse HEAD`, recomputed in every mode
-   **including `--recheck-job`**), so **any commit landing after the request makes the grant
-   unapplicable** — the run reports `waiver: STALE` and the FAIL stands. The order is therefore:
+   THAT SHA (issue #3460).** The binding above is `base` AND `head` AND `job`, each compared for **exact
+   equality** and each against a **different** value:
 
-   1. **push** every local commit (an unpushed head cannot produce a valid triple at all — `push-assert`
-      fails the round with `FAIL (unpushed commits)` before any review is enqueued);
+   - `head` against the run's own `HEAD_SHA` (`git rev-parse HEAD`, assigned **once** before mode
+     dispatch — no path derives head from the job record, `--recheck-job` included);
+   - `base` against `RANGE_BASE_SHA`, which is the **merge-base and *not* the base ref's tip** (#3392) —
+     copy it from the block's `assert-base:` line, **never** from `base:`;
+   - `job` against this run's job id.
+
+   So **any commit landing after the request makes the grant unapplicable** — the run reports
+   `waiver: STALE` and the FAIL stands. The order is therefore:
+
+   1. **push** every local commit;
    2. **rebase or resolve** until the PR is no longer `CONFLICTING`;
    3. **gate of record**;
    4. a **roborev confirmation pass on that final sha**;
@@ -358,25 +364,36 @@ mechanism below, under *"the unwaivable rule made one merge unobtainable"*.
 
    **The trap catches a lane doing the careful thing, which is why it is written down rather than left
    to judgement.** The absence diagnostic prints `base … head … job …`, and those values are *correct at
-   the moment it prints them*. Nothing in the output says they will be invalid after the next push — so
-   copying the verified triple straight into a request is simultaneously the obvious action and the
-   wrong one whenever anything is still going to move the head. Measured cost: **three independent lanes
-   on one day** (2026-08-28) — #1705/PR #3382 (grant received, then a conflict with just-merged #1701
-   had to be resolved), #1699/PR #3403 (the triple was exact and the PR was `CONFLICTING` at the same
-   moment), #3248/PR #3455 (fixes committed but unpushed, **and** `CONFLICTING`) — each spending an
-   authorization on code that would not merge, and asking the authorizer to judge a review that no
-   longer described the diff.
+   the moment it prints them*. **The failing block itself says nothing about a push invalidating them** —
+   only `--help` does ("a push, a different base or a re-run each need a fresh one"), which is not where
+   a lane reading a FAIL is looking. So copying the verified triple straight into a request is
+   simultaneously the obvious action and the wrong one whenever anything is still going to move the
+   head. Measured cost: **three independent lanes on one day** (2026-08-28) — #1705/PR #3382 (grant
+   received, then a conflict with just-merged #1701 had to be resolved), #1699/PR #3403 (the triple was
+   exact and the PR was `CONFLICTING` at the same moment), #3248/PR #3455 (fixes committed but unpushed,
+   **and** `CONFLICTING`) — each spending an authorization on code that would not merge, and asking the
+   authorizer to judge a review that no longer described the diff.
 
    **Do not loosen the binding to make this easier.** All three instances are the binding *working*, and
    a waiver riding to a later review is the hole #3312 exists to close.
 
-   **Not mechanized, and only one of the three halves is.** `push-assert` covers *pushed*;
-   `mergeable`/`CONFLICTING` appears **nowhere** in the wrapper, the waiver scanner or
-   `premerge-assert.sh`, and nothing correlates the reviewed sha with a gate of record — so a
-   pushed-but-`CONFLICTING` head passes every check and still yields a triple that dies on the rebase.
-   Converting this rule into a refusal, and naming *why* a triple is stale (`head moved` / `base moved` /
-   `job mismatch`) instead of a generic staleness verdict, is **issue #3827** — a change to the wrapper,
-   which per its own doctrine cannot certify itself.
+   **Two of the four conditions are mechanized and two are not — know which.**
+
+   | condition | mechanized? | what enforces it |
+   |---|---|---|
+   | pushed | **yes** | `push-assert` fails the round *before any review is enqueued* — `FAIL (unpushed commits)` when the remote branch exists and local is ahead, `FAIL (branch absent on remote <remote>)` when it was never pushed |
+   | reviewed at that sha | **yes** | `sha-assert` fails when the record's range head ≠ local `HEAD`; the head binding catches it again at waiver time |
+   | conflict-free | **no** | `mergeable` / `CONFLICTING` appears **nowhere** in the wrapper, the waiver scanner or `premerge-assert.sh` |
+   | post-gate | **no** | nothing correlates the reviewed sha with a gate of record |
+
+   So a pushed, reviewed, still-`CONFLICTING` head passes every check and yields a triple that dies on
+   the rebase. Mechanizing those two, and splitting the staleness **verdict token** (`STALE` for all
+   three causes today, though its *detail* already names the diverged field and both values) into
+   `head moved` / `base moved` / `job mismatch`, is **issue #3827** — whose demonstration is *circular
+   rather than impossible*: every sanctioned invocation is the branch's own
+   `scripts/flow/roborev-review.sh`, so the round that reviews a wrapper change runs the **changed**
+   wrapper (the property #3544 records for `agent-gate.sh` — not the read-from-root self-certification
+   bar of #3229).
 
    **The marker is decided by ONE anchored pattern, and the reason is trimmed BEFORE it is judged**, so
    field order and value boundaries are enforced and `reason=TODO ` / whitespace-only reasons are refused


### PR DESCRIPTION
Closes #3460

Three independent lanes hit the same ordering trap on 2026-08-28 — #1705/PR #3382, #1699/PR #3403, #3248/PR #3455. None was a judgement error: a lane posts an absence-waiver request with a `base`/`head`/`job` triple that is **correct at the instant it posts**, then the head moves for an ordinary reason (a push, a rebase, a conflict resolution) and the grant is unapplicable. The sequencing simply was not written down.

## What this changes

Documents the rule — item **1** of the issue, and its whole scope — in two places:

- `CLAUDE.md`, in the roborev absence-waiver block, immediately after the `--recheck-job` paragraph;
- `website/src/content/docs/agents-developing/roborev-findings.md`, at the matching point in the same discussion.

> **Request an absence waiver only when the head is FINAL — pushed, conflict-free, post-gate, and reviewed at that sha.**
>
> push every local commit → rebase/resolve until the PR is not `CONFLICTING` → gate of record → **a roborev confirmation pass on that final sha** → *then* request the waiver, naming **that** round's triple.

It also records why a careful lane walks into this (the absence diagnostic prints a triple that is correct *now* and says nothing about the next push), that `--recheck-job` is **not** an escape (#3392 stabilised the *base* comparison; nothing can make a *head* binding survive a content change), and that the confirmation pass is the step that gets skipped (#3367's gated sha had never been reviewed at all; #2605 the same shape).

**The binding is not loosened.** All three instances are #3312's `base`+`head`+`job` binding working exactly as designed, and the issue puts loosening it explicitly out of scope.

## Certification posture — read this before looking for a roborev block

The diff is two markdown files and nothing else:

```
$ git diff --name-only origin/main...HEAD | bash scripts/ci/classify-docs-only.sh
docs-only
classify-docs-only: all changed files are docs -> short-circuit to green   # exit 0
```

Per CLAUDE.md a **code-free diff cannot be roborev-certified at all**, and no docs-only change may ever record "roborev clean". The wrapper's pre-enqueue `code-free:` check would fail it before a review was enqueued, so **no roborev pass is claimed here**. The sanctioned substitute is primary-source verification, recorded below. The full gate of record still runs normally.

## Primary-source verification

Every mechanical claim in the new prose was checked against the wrapper source rather than against existing prose — this PR's own subject is that a doctrine claim about a mechanism decays like a comment.

| claim in the new text | evidence |
|---|---|
| the scope compare is **exact equality** of `base`+`head`+`job` | `scripts/flow/roborev-review.sh:1702` — the `WAIVED` arm admits only if `ROBOREV_WAIVER_SCOPE` equals `base=… head=… job=…` **and** the state is `granted` |
| `HEAD_SHA` is the **local** HEAD, in every mode | `scripts/flow/roborev-review.sh:691` — `HEAD_SHA=$(git -C "$REPO" rev-parse --verify --quiet HEAD ...)`, computed once during argument setup, so `--recheck-job` recomputes it the same way ⇒ a moved head can never match a granted scope |
| the **pushed** half *is* mechanized | `scripts/flow/roborev-review-oracles.sh:479` — `PUSH_ASSERT="FAIL (unpushed commits)"`, which aborts the round before any review is enqueued |
| **conflict-free** is *not* mechanized | `mergeable` / `CONFLICTING` appear **nowhere** in `scripts/flow/roborev-review*.sh`, `scripts/flow/roborev-waiver-scan.py`, or `scripts/flow/premerge-assert.sh` — so a pushed-but-`CONFLICTING` head passes every check and still yields a triple that dies on the rebase |
| the absence diagnostic hands over a triple with no staleness warning | `scripts/flow/roborev-review-checks.sh:228` — the `prompt-content:` absence `ERROR` prints `base … head … job …` and deliberately does not print the marker form; nothing in it indicates the values are about to go stale |
| #3367's gated sha had never been reviewed | #3367 comment, verbatim: *"Round 25 reviewed `6f5fc2b7c`; two commits landed after it (`f8f38ad4f`, `b8015e865`), so the sha you are gating had never been reviewed"* |
| the three incident lanes | PRs #3382, #3403, #3455 all exist and are MERGED, matching the lanes named in the issue |

### The fact-check pass changed the diff — seven corrections

An independent adversarial pass was run over the first draft with one instruction: try to **falsify** every mechanical claim, and catch drift between the two renderings. It found seven, and **two would have shipped as false doctrine** — the failure mode CLAUDE.md calls worse than no doctrine, because a false rationale is what stops the next person looking. Commit `26f0d664f`:

| # | correction | why it mattered |
|---|---|---|
| 1 | **"reviewed at that sha" IS mechanized** — the draft implied it was not | `sha-assert` FAILs when the record's range head ≠ local `HEAD` (`roborev-review.sh:1361`). The text now names **four** conditions and states which **two** are mechanized (pushed, reviewed-at-that-sha) and which two are not (conflict-free, gate correlation) |
| 2 | **"cannot certify itself" was wrong about #3827** | #3229's bar is config read from the repo **root**/base ref. The wrapper is invoked as the branch's own relative path and sources via `BASH_SOURCE`, so the reviewing round **runs the changed wrapper** (#3544's property). Restated as *circular, not impossible* — the opposite of an excuse, since a new refusal **will** fire in its own round. #3827's body carried the same error and is corrected |
| 3 | only `head` compares to `HEAD_SHA` | `base` compares to `RANGE_BASE_SHA`, the **merge-base** (`roborev-review-oracles.sh:550`). The text now says so and tells the reader to copy `assert-base:`, not `base:` — the #3392 trap |
| 4 | `FAIL (unpushed commits)` is one of **four** push-assert spellings | a never-pushed branch gives `FAIL (branch absent on remote …)`; both are now named |
| 5 | `--help` **does** warn a push needs a fresh waiver (`roborev-review.sh:441`) | narrowed to: the failing **block** is silent, only `--help` says it — which is not where a lane reading a FAIL is looking |
| 6 | the staleness **token** is generic; its **detail** already names the diverged field and both values (`roborev-waiver-scan.py:313`) | #3827's ask is scoped to the token |
| 7 | **drift between the two renderings** | CLAUDE.md counted "three halves" while naming two; both files now carry the same four-condition split |

Corrections 1, 3 and 4 were then re-verified directly against source rather than taken on the pass's word.

## Scope split

Items **2** (have the wrapper refuse to print a request-ready triple when the head is not final) and **3** (have the recheck name *why* a triple is stale) are the mechanism half. The issue itself calls (2) "the durable one" but a separate PR, and per its own doctrine a change to the wrapper cannot certify itself in the round that changes it. Both are split out to **#3827**, and the new doctrine text **cites that gap rather than implying coverage** — it states plainly that only one of the three halves of "final" is mechanized today.

## Gate

Docs-only diff; no compiled input touched. The full `scripts/agent-gate.sh` gate of record runs on the final sha and its `AGENT-GATE SUMMARY` block is recorded below by the closer.

### Gate of record: run 2 (`26f0d664f`) — RESULT: PASS, 37/37

This is the gate the merge rests on. Nothing else certifies it.

| field | value |
|---|---|
| summary-file | `/tmp/gate-3460-full2-summary.txt` |
| run-id | `/tmp/agent-gate.uUoZPH` |
| commit / tree-start / tree-end | `26f0d66` / `26f0d664f939` / `26f0d664f939` |
| tree digest | `b50906f10853` |
| dirty | `no` |
| tree-integrity | `PASS` |
| component-set | `PASS (37/37 vs origin/main e6389ab31)` |
| verdict | **`RESULT: PASS`** — 37/37, no FAIL, no SKIP (`tooling-tests: PASS (2397s)`) |

### Run 1 disposition — SUPERSEDED, and NOT a basis for this merge

An earlier full gate at this same sha returned `RESULT: FAIL` with `tooling-tests` as the sole red
(36/37). It was investigated, identified, and then **superseded by the run-2 PASS above** — it is
recorded here for traceability only. No waiver is claimed and none is required: `premerge-assert`
demands `RESULT: PASS` token-exactly with no opt-out, so a prose-diff waiver could never have
unblocked this merge, and the run-1 block was never offered to the merge gate.

Cause identified as **#3685** (`printf "$big_var" | grep -q` under `set -o pipefail` returns 141 on a
SUCCESSFUL match — SIGPIPE inverts the verdict; ~200 sites in `scripts/tests`), matched at the assert
rather than by component name:

- the four failures were all in `scripts/tests/test_bootstrap_agent_machine.sh` (201 PASS / 4 FAIL),
  `push:` capability group; the suite sets `set -uo pipefail` and
  `push_plain() { printf '%s' "$1" | sed …; }`, making `push_plain "$out" | grep -q …` a 3-stage pipe;
- the log carried `sed: couldn't flush stdout: Broken pipe` immediately before three of the four;
- the diagnostic printed *after* `…lost its stray-ref guidance in transit` contained the exact string
  its `grep` searched for — the match succeeded and the assert still took the `else` branch.

Control, run by the lead: the same suite on a clean `origin/main` worktree (`e6389ab31`) =
**205 PASS / 0 FAIL, 0 broken-pipe events**, versus 201/4 with exactly 4 broken-pipe events under
load. Not a main-red. Run 2 then passed on the **identical tree** (digest `b50906f10853`, unchanged) —
identical code, opposite verdict, which is the signature of the race, not of a masked defect.

No source was patched to green the gate and no summary was hand-edited at any point.
