### PR TITLE
docs(#3654): roborev job ids are per-daemon — document the scope and the verification that settles it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1384,6 +1384,43 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   What distinguishes them is a **human plus the review's token accounting** (genuine: 398k–649k input /
   314k–554k cached; vacuous baseline ~18.7k / 0). That trade was chosen over a machine guessing from
   injectable text.
+  **THAT COST IS TRUE AT REVIEW TIME AND FALSE AFTER THE FACT, WHICH IS WHERE THE BEST ABSENCE
+  EVIDENCE LIVES (#3654).** The prompt roborev SENT is RETAINED in the job record and retrievable
+  later — `roborev show <id> --prompt` — even though the snapshot file it names is transient and
+  already deleted, and a delivery-by-path prompt says so in its own words under `### Combined
+  Diff`. That is DIRECT evidence a diff was delivered, where token accounting is INFERENCE (a large
+  number is merely CONSISTENT with a real review), so **the stored prompt is the PREFERRED evidence
+  in an absence-waiver request and a request LEADS with it**; token accounting is the FALLBACK, for
+  when the prompt cannot be retrieved. **It resurrects nothing of the deleted delivery classifier,
+  and that distinction is load-bearing rather than a caveat:** the classifier read injectable prompt
+  text AT DECISION TIME to produce an AUTOMATED verdict, while this is a HUMAN reading a STORED
+  record as evidence for a HAND-GRANTED waiver — there is no automated verdict to spoof. Nothing in
+  the wrapper parses the prompt for delivery mode, and nothing may be added that does.
+  **AND `job=` IS DAEMON-SCOPED, WHICH NOBODY HAD WRITTEN DOWN (#3654).** Each box runs its own
+  roborev daemon with its own database and its own sequential ids, so **two boxes can legitimately
+  present the SAME id for DIFFERENT reviews** — measured: `job=265` on two lanes 50 minutes apart,
+  different ranges, branches and token counts, both correct — and the coordination lead read the
+  repetition as a collision and WITHHELD a valid waiver. The failure is symmetric and the other
+  direction is worse: a lead who therefore treats `job=` as uninformative discards the one field
+  binding an authorization to a REVIEW rather than to a RANGE. So **verify the record's `git_ref`,
+  never the id alone** — `roborev show <id> --json | jq '.job | {id, git_ref, branch, status,
+  token_usage}'`, because `show` NESTS those fields under `.job` and carries `source_machine_id`
+  NOWHERE, while `roborev list --json --repo <abs> --branch <branch>` rows carry the daemon id and
+  `list` filters by the CURRENT BRANCH by default. **A LOCAL ROW COUNT IS NOT EVIDENCE OF
+  UNIQUENESS**: `roborev list … | jq '[.[] | select(.id==N)] | length'` returns `1` whether or not
+  another box holds that id, because `list` only ever sees the LOCAL daemon — another probe whose
+  output is IDENTICAL under the two states it claims to separate (the `RESULT: INCOMPLETE` launch
+  sentinel read as a verdict; a gate run dir found by `ls -t`; `mergeable: MERGEABLE` on a
+  marker-bearing merge commit) — and it gave both lanes the right answer for a reason that did not
+  hold. The block therefore NAMES the daemon: **`job-machine:` beside `job:`**, INFORMATIONAL (in
+  neither the verdict scan nor the affirmation backstop, so no state of it can red a correct run),
+  with three affirmative renderings — the uuid when a record carried `source_machine_id`, `NOT
+  RECORDED` when a record WAS read and carries none (a real state: `show --json` never carries the
+  field, so the wrapper takes one supplementary `list` read rather than reporting nothing on every
+  real run), and `UNAVAILABLE` when no record could be read, naming the `job-record:` state it
+  inherits. **The marker grammar is UNCHANGED**: no machine field was added to either kind — the
+  authorizer would have to know it, it is derivable from the record, and every field in a hand-typed
+  control line is one more way for a legitimate authorization to read `MALFORMED`.
   **THE ABSENCE WAIVER — the break-glass, its four constraints, and why the documentation is not the
   credential (#3312 job 23).** The **OWNER or the coordination LEAD** may excuse an absence FAIL with a
   **dedicated, column-zero line** of a PR comment:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1406,7 +1406,12 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   never the id alone** — `roborev show <id> --json | jq '.job | {id, git_ref, branch, status,
   token_usage}'`, because `show` NESTS those fields under `.job` and carries `source_machine_id`
   NOWHERE, while `roborev list --json --repo <abs> --branch <branch>` rows carry the daemon id and
-  `list` filters by the CURRENT BRANCH by default. **A LOCAL ROW COUNT IS NOT EVIDENCE OF
+  `list` filters by the CURRENT BRANCH by default. **Read `.job`, never a `show` payload's TOP-LEVEL
+  `id`**: that is the REVIEW row's own sequence and need not be the job you asked for (measured over
+  ten records — asking for 9 returns `id=8`, `job_id=9`, `job.id=9`), so a top-level jq manufactures
+  the very "is this the right review?" doubt the check exists to remove. The wrapper is unaffected —
+  `find_job` matches `id`/`job_id`/`job` and then prefers the object carrying `git_ref` — so this is
+  a trap for the human running the check by hand, not a live false `STALE`. **A LOCAL ROW COUNT IS NOT EVIDENCE OF
   UNIQUENESS**: `roborev list … | jq '[.[] | select(.id==N)] | length'` returns `1` whether or not
   another box holds that id, because `list` only ever sees the LOCAL daemon — another probe whose
   output is IDENTICAL under the two states it claims to separate (the `RESULT: INCOMPLETE` launch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1441,9 +1441,15 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   output is IDENTICAL under the two states it claims to separate (the `RESULT: INCOMPLETE` launch
   sentinel read as a verdict; a gate run dir found by `ls -t`; `mergeable: MERGEABLE` on a
   marker-bearing merge commit) — and it gave both lanes the right answer for a reason that did not
-  hold. Use `git_ref`. **Whether the block should NAME the issuing daemon — and the cross-box
-  question that comes with it, since the marker travels through GITHUB while `--recheck-job` reads
-  the LOCAL daemon — is tracked as #3825, together with the marker-grammar question it raises.**
+  hold. Use `git_ref`. **AND WHAT THE `git_ref` CHECK SETTLES IS SCOPED TO ONE DAEMON — the rest is
+  NOT CLAIMED.** It settles that the id names the review you think it does *on this daemon*. It does
+  NOT settle the cross-box case: two daemons can hold the same id for the SAME `git_ref` range, so a
+  waiver authorized against machine A's review can be accepted by `--recheck-job` against machine B's
+  DIFFERENT review of that range, and **no local lookup can detect it** — `roborev list` only ever
+  sees the local daemon, while the marker travels through GITHUB. So same-range cross-daemon
+  collisions remain UNPROTECTED; that is declared, not closed. **Whether the block should NAME the
+  issuing daemon — and the cross-box question that comes with it — is tracked as #3825, together with
+  the marker-grammar question it raises.**
   **THE ABSENCE WAIVER — the break-glass, its four constraints, and why the documentation is not the
   credential (#3312 job 23).** The **OWNER or the coordination LEAD** may excuse an absence FAIL with a
   **dedicated, column-zero line** of a PR comment:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1389,7 +1389,7 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   later — `roborev show <id> --prompt` — even though the snapshot file it names is transient and
   already deleted, and a delivery-by-path prompt says so in its own words under `### Combined
   Diff`. That is the **DIRECT ARTIFACT** — roborev's ACTUAL prompt rather than a statistic about it —
-  and an absence-waiver request should **LEAD with it**. **IT IS NOT SELF-AUTHENTICATING, AND THE
+  **IT IS NOT SELF-AUTHENTICATING, AND THE
   TRUST PROPERTIES RUN THE OPPOSITE WAY FROM THE OBVIOUS READING:** roborev's prompt EMBEDS
   repository-controlled content at positions indistinguishable from roborev's own text, so a
   reviewed branch can carry text MIMICKING that delivery wording — a human in the loop is not a
@@ -1401,10 +1401,10 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   That bites where the counts are used: the vacuous baseline is ~18.7k input / 0 cached, so padding
   non-diff prompt content can make a review that received NO diff look token-rich. **NEITHER SIGNAL
   ESTABLISHES PROVENANCE, and they are NOT INDEPENDENT** — both are functions of the same
-  repository-influenced prompt. The prompt still LEADS; the counts are read ALONGSIDE it as a
-  consistency check, never as unforgeable corroboration. What evidence SHOULD be required before
-  granting is an OPEN QUESTION, PENDING on #3654 (an earlier revision of this paragraph asserted the
-  counts were unwritable-and-therefore-corroborating; that was false in the half that mattered). **It resurrects nothing of the deleted delivery classifier,
+  repository-influenced prompt. **Which evidence a waiver should rest on is an OPEN QUESTION,
+  tracked as #3826** — nothing here recommends one signal over the other, or any ordering between
+  them (an earlier revision of this paragraph asserted the counts were
+  unwritable-and-therefore-corroborating; that was false in the half that mattered). **It resurrects nothing of the deleted delivery classifier,
   and that distinction is load-bearing rather than a caveat:** the classifier read injectable prompt
   text AT DECISION TIME to produce an AUTOMATED verdict, while this is a HUMAN reading a STORED
   record as evidence for a HAND-GRANTED waiver — there is no automated verdict to spoof. Nothing in
@@ -1417,8 +1417,8 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   direction is worse: a lead who therefore treats `job=` as uninformative discards the one field
   binding an authorization to a REVIEW rather than to a RANGE. So **verify the record's `git_ref`,
   never the id alone** — `roborev show <id> --json | jq '.job | {id, git_ref, branch, status,
-  token_usage}'`, because `show` NESTS those fields under `.job` and carries `source_machine_id`
-  NOWHERE, while `roborev list --json --repo <abs> --branch <branch>` rows carry the daemon id and
+  token_usage}'`, because `show` NESTS those fields under `.job`, while for
+  `roborev list --json --repo <abs> --branch <branch>`
   `list`'s default branch filter follows the **`--repo` PATH's CURRENT HEAD**, not the branch your
   shell is standing in — so name `--branch` whenever that checkout is not on the job's branch, which
   is exactly the `--recheck-job` case. An earlier revision of this line named the cwd's branch and
@@ -1435,31 +1435,9 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   output is IDENTICAL under the two states it claims to separate (the `RESULT: INCOMPLETE` launch
   sentinel read as a verdict; a gate run dir found by `ls -t`; `mergeable: MERGEABLE` on a
   marker-bearing merge commit) — and it gave both lanes the right answer for a reason that did not
-  hold. The block therefore NAMES the daemon: **`job-machine:` beside `job:`**, INFORMATIONAL (in
-  neither the verdict scan nor the affirmation backstop, so no state of it can red a correct run),
-  with three affirmative renderings — the uuid when a record carried `source_machine_id`, `NOT
-  RECORDED` when a record WAS read and carries none (a real state: `show --json` never carries the
-  field, so the wrapper takes one supplementary `list` read rather than reporting nothing on every
-  real run), and `UNAVAILABLE` when no record could be read, naming the `job-record:` state it
-  inherits. **The marker grammar is UNCHANGED**: no machine field was added to either kind — the
-  authorizer would have to know it, it is derivable from the record, and every field in a hand-typed
-  control line is one more way for a legitimate authorization to read `MALFORMED`.
-  **DECLARED BOUNDARY — WHAT THE `job=` BINDING DOES NOT CLOSE (#3654).** CLAIMED: within ONE daemon,
-  base+head+job names one review and `--recheck-job` re-decides THAT record. **NOT CLAIMED: that a
-  marker cannot cross boxes.** The marker travels through GITHUB, not through the daemon, while
-  `--recheck-job <id>` reads the LOCAL daemon's record — so if two boxes hold the SAME id for the
-  SAME `git_ref` range, a waiver granted after an authorizer inspected box A's review is ACCEPTED on
-  box B against box B's DIFFERENT review: `sha-assert` passes, the id matches, the authorization
-  crosses reviews. "A repeated id cannot reach another box's recheck" is true of the RECORD and
-  IRRELEVANT to the MARKER, which is what actually travels; on this fleet ids have already collided
-  at 265 and two lanes have reviewed one branch (2026-09-01, a peer session and this lane both landing
-  on #3654 within seconds; cause tracked as **#3810** — `CLAIM_ACTOR` defaults to the literal `flow`, so
-  `claim.sh` answers `VERIFY-OK` to both lanes on one box). **It is NOT closed here** because closing it means
-  adding a field to a hand-typed control line, which this issue's disposition forbids — a DESIGN
-  CALL, escalated to the owner and PENDING on #3654. The mitigation that exists today is
-  OPERATIONAL, not mechanical: the block NAMES the daemon, so an authorizer comparing `job-machine:`
-  between the request and the recheck SEES a cross-box mismatch. That is why the key exists — and it
-  is informational, so a reader who does not compare it is stopped by nothing.
+  hold. Use `git_ref`. **Whether the block should NAME the issuing daemon — and the cross-box
+  question that comes with it, since the marker travels through GITHUB while `--recheck-job` reads
+  the LOCAL daemon — is tracked as #3825, together with the marker-grammar question it raises.**
   **THE ABSENCE WAIVER — the break-glass, its four constraints, and why the documentation is not the
   credential (#3312 job 23).** The **OWNER or the coordination LEAD** may excuse an absence FAIL with a
   **dedicated, column-zero line** of a PR comment:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1412,7 +1412,11 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   never the id alone** — `roborev show <id> --json | jq '.job | {id, git_ref, branch, status,
   token_usage}'`, because `show` NESTS those fields under `.job` and carries `source_machine_id`
   NOWHERE, while `roborev list --json --repo <abs> --branch <branch>` rows carry the daemon id and
-  `list` filters by the CURRENT BRANCH by default. **Read `.job`, never a `show` payload's TOP-LEVEL
+  `list`'s default branch filter follows the **`--repo` PATH's CURRENT HEAD**, not the branch your
+  shell is standing in — so name `--branch` whenever that checkout is not on the job's branch, which
+  is exactly the `--recheck-job` case. (The earlier claim here, "filters by the CURRENT BRANCH",
+  meant the cwd's and was FALSE: its evidence was a `null` from a `--repo` sitting on `main`, which
+  both readings explain identically — a probe whose output cannot distinguish what it asserts.) **Read `.job`, never a `show` payload's TOP-LEVEL
   `id`**: that is the REVIEW row's own sequence and need not be the job you asked for (measured over
   ten records — asking for 9 returns `id=8`, `job_id=9`, `job.id=9`), so a top-level jq manufactures
   the very "is this the right review?" doubt the check exists to remove. The wrapper is unaffected —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1418,7 +1418,12 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   binding an authorization to a REVIEW rather than to a RANGE. So **verify the record's `git_ref`,
   never the id alone** — `roborev show <id> --json | jq '.job | {id, git_ref, branch, status,
   token_usage}'`, because `show` NESTS those fields under `.job`, while for
-  `roborev list --json --repo <abs> --branch <branch>`
+  `roborev list --json --limit <n> --repo <abs> --branch <branch>`
+  **`--limit` is REQUIRED READING and must be RAISED until the job appears or the returned row
+  count STOPS GROWING** — it defaults to 50 (measured, v0.61.2), so an older job is outside the
+  window and the query yields nothing though the record exists, an absence indistinguishable from
+  "no such job" and exactly the reach a waiver argument needs; an empty result at a limit that is
+  still growing the row count is UNMEASURED, not an answer. And
   `list`'s default branch filter follows the **`--repo` PATH's CURRENT HEAD**, not the branch your
   shell is standing in — so name `--branch` whenever that checkout is not on the job's branch, which
   is exactly the `--recheck-job` case. An earlier revision of this line named the cwd's branch and
@@ -1431,7 +1436,8 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   `find_job` matches `id`/`job_id`/`job` and then prefers the object carrying `git_ref` — so this is
   a trap for the human running the check by hand, not a live false `STALE`. **A LOCAL ROW COUNT IS NOT EVIDENCE OF
   UNIQUENESS**: `roborev list … | jq '[.[] | select(.id==N)] | length'` returns `1` whether or not
-  another box holds that id, because `list` only ever sees the LOCAL daemon — another probe whose
+  another box holds that id, because `list` only ever sees the LOCAL daemon — and `0` when the row
+  fell outside the `--limit` window, so the count says nothing about the window it was taken over — another probe whose
   output is IDENTICAL under the two states it claims to separate (the `RESULT: INCOMPLETE` launch
   sentinel read as a verdict; a gate run dir found by `ls -t`; `mergeable: MERGEABLE` on a
   marker-bearing merge commit) — and it gave both lanes the right answer for a reason that did not

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1394,10 +1394,17 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   repository-controlled content at positions indistinguishable from roborev's own text, so a
   reviewed branch can carry text MIMICKING that delivery wording — a human in the loop is not a
   channel separation, it is the same shared channel with a slower parser — so the prompt is read for
-  the STRUCTURAL fact it reports, never as proof of its own provenance. The **token accounting has
-  the opposite property**: recorded BY THE DAEMON, unwritable by the reviewed branch, so it
-  CORROBORATES where the prompt cannot and is **not a mere fallback**. The two are COMPLEMENTARY,
-  not ranked — where both exist an authorizer should want both. **It resurrects nothing of the deleted delivery classifier,
+  the STRUCTURAL fact it reports, never as proof of its own provenance. The **token accounting is
+  DAEMON-RECORDED BUT NOT INDEPENDENT, and it does not establish delivery either**: the RECORD is
+  authentic (the branch cannot rewrite it), but the counts measure THE PROMPT, and the prompt embeds
+  repository-controlled content — so a branch influences their MAGNITUDE without forging anything.
+  That bites where the counts are used: the vacuous baseline is ~18.7k input / 0 cached, so padding
+  non-diff prompt content can make a review that received NO diff look token-rich. **NEITHER SIGNAL
+  ESTABLISHES PROVENANCE, and they are NOT INDEPENDENT** — both are functions of the same
+  repository-influenced prompt. The prompt still LEADS; the counts are read ALONGSIDE it as a
+  consistency check, never as unforgeable corroboration. What evidence SHOULD be required before
+  granting is an OPEN QUESTION, PENDING on #3654 (an earlier revision of this paragraph asserted the
+  counts were unwritable-and-therefore-corroborating; that was false in the half that mattered). **It resurrects nothing of the deleted delivery classifier,
   and that distinction is load-bearing rather than a caveat:** the classifier read injectable prompt
   text AT DECISION TIME to produce an AUTOMATED verdict, while this is a HUMAN reading a STORED
   record as evidence for a HAND-GRANTED waiver — there is no automated verdict to spoof. Nothing in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1407,8 +1407,11 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   unwritable-and-therefore-corroborating; that was false in the half that mattered). **It resurrects nothing of the deleted delivery classifier,
   and that distinction is load-bearing rather than a caveat:** the classifier read injectable prompt
   text AT DECISION TIME to produce an AUTOMATED verdict, while this is a HUMAN reading a STORED
-  record as evidence for a HAND-GRANTED waiver — there is no automated verdict to spoof. Nothing in
-  the wrapper parses the prompt for delivery mode, and nothing may be added that does.
+  record as evidence for a HAND-GRANTED waiver, so the direct PARSER exploit is gone: nothing in
+  the wrapper parses the prompt for delivery mode, and nothing may be added that does. **THAT IS
+  ALL IT BUYS** — the human is IN the path, not outside it, so spoofed repository-controlled prompt
+  text can still mislead an authorizer into issuing the marker, and the marker is what makes
+  `--recheck-job` pass. That exposure is **#3826**'s subject and is NOT settled here.
   **AND `job=` IS DAEMON-SCOPED, WHICH NOBODY HAD WRITTEN DOWN (#3654).** Each box runs its own
   roborev daemon with its own database and its own sequential ids, so **two boxes can legitimately
   present the SAME id for DIFFERENT reviews** — measured: `job=265` on two lanes 50 minutes apart,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1388,10 +1388,16 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   EVIDENCE LIVES (#3654).** The prompt roborev SENT is RETAINED in the job record and retrievable
   later — `roborev show <id> --prompt` — even though the snapshot file it names is transient and
   already deleted, and a delivery-by-path prompt says so in its own words under `### Combined
-  Diff`. That is DIRECT evidence a diff was delivered, where token accounting is INFERENCE (a large
-  number is merely CONSISTENT with a real review), so **the stored prompt is the PREFERRED evidence
-  in an absence-waiver request and a request LEADS with it**; token accounting is the FALLBACK, for
-  when the prompt cannot be retrieved. **It resurrects nothing of the deleted delivery classifier,
+  Diff`. That is the **DIRECT ARTIFACT** — roborev's ACTUAL prompt rather than a statistic about it —
+  and an absence-waiver request should **LEAD with it**. **IT IS NOT SELF-AUTHENTICATING, AND THE
+  TRUST PROPERTIES RUN THE OPPOSITE WAY FROM THE OBVIOUS READING:** roborev's prompt EMBEDS
+  repository-controlled content at positions indistinguishable from roborev's own text, so a
+  reviewed branch can carry text MIMICKING that delivery wording — a human in the loop is not a
+  channel separation, it is the same shared channel with a slower parser — so the prompt is read for
+  the STRUCTURAL fact it reports, never as proof of its own provenance. The **token accounting has
+  the opposite property**: recorded BY THE DAEMON, unwritable by the reviewed branch, so it
+  CORROBORATES where the prompt cannot and is **not a mere fallback**. The two are COMPLEMENTARY,
+  not ranked — where both exist an authorizer should want both. **It resurrects nothing of the deleted delivery classifier,
   and that distinction is load-bearing rather than a caveat:** the classifier read injectable prompt
   text AT DECISION TIME to produce an AUTOMATED verdict, while this is a HUMAN reading a STORED
   record as evidence for a HAND-GRANTED waiver — there is no automated verdict to spoof. Nothing in
@@ -1426,6 +1432,20 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   inherits. **The marker grammar is UNCHANGED**: no machine field was added to either kind — the
   authorizer would have to know it, it is derivable from the record, and every field in a hand-typed
   control line is one more way for a legitimate authorization to read `MALFORMED`.
+  **DECLARED BOUNDARY — WHAT THE `job=` BINDING DOES NOT CLOSE (#3654).** CLAIMED: within ONE daemon,
+  base+head+job names one review and `--recheck-job` re-decides THAT record. **NOT CLAIMED: that a
+  marker cannot cross boxes.** The marker travels through GITHUB, not through the daemon, while
+  `--recheck-job <id>` reads the LOCAL daemon's record — so if two boxes hold the SAME id for the
+  SAME `git_ref` range, a waiver granted after an authorizer inspected box A's review is ACCEPTED on
+  box B against box B's DIFFERENT review: `sha-assert` passes, the id matches, the authorization
+  crosses reviews. "A repeated id cannot reach another box's recheck" is true of the RECORD and
+  IRRELEVANT to the MARKER, which is what actually travels; on this fleet ids have already collided
+  at 265 and two lanes have reviewed one branch. **It is NOT closed here** because closing it means
+  adding a field to a hand-typed control line, which this issue's disposition forbids — a DESIGN
+  CALL, escalated to the owner and PENDING on #3654. The mitigation that exists today is
+  OPERATIONAL, not mechanical: the block NAMES the daemon, so an authorizer comparing `job-machine:`
+  between the request and the recheck SEES a cross-box mismatch. That is why the key exists — and it
+  is informational, so a reader who does not compare it is stopped by nothing.
   **THE ABSENCE WAIVER — the break-glass, its four constraints, and why the documentation is not the
   credential (#3312 job 23).** The **OWNER or the coordination LEAD** may excuse an absence FAIL with a
   **dedicated, column-zero line** of a PR comment:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1384,8 +1384,8 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   What distinguishes them is a **human plus the review's token accounting** (genuine: 398k–649k input /
   314k–554k cached; vacuous baseline ~18.7k / 0). That trade was chosen over a machine guessing from
   injectable text.
-  **THAT COST IS TRUE AT REVIEW TIME AND FALSE AFTER THE FACT, WHICH IS WHERE THE BEST ABSENCE
-  EVIDENCE LIVES (#3654).** The prompt roborev SENT is RETAINED in the job record and retrievable
+  **THAT COST IS TRUE AT REVIEW TIME, AND FALSE AFTER THE FACT ONLY FOR A HUMAN READING THE STORED
+  RECORD — IT STAYS TRUE OF THE MACHINE, AND MUST (#3654).** The prompt roborev SENT is RETAINED in the job record and retrievable
   later — `roborev show <id> --prompt` — even though the snapshot file it names is transient and
   already deleted, and a delivery-by-path prompt says so in its own words under `### Combined
   Diff`. That is the **DIRECT ARTIFACT** — roborev's ACTUAL prompt rather than a statistic about it —
@@ -1414,9 +1414,10 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   NOWHERE, while `roborev list --json --repo <abs> --branch <branch>` rows carry the daemon id and
   `list`'s default branch filter follows the **`--repo` PATH's CURRENT HEAD**, not the branch your
   shell is standing in — so name `--branch` whenever that checkout is not on the job's branch, which
-  is exactly the `--recheck-job` case. (The earlier claim here, "filters by the CURRENT BRANCH",
-  meant the cwd's and was FALSE: its evidence was a `null` from a `--repo` sitting on `main`, which
-  both readings explain identically — a probe whose output cannot distinguish what it asserts.) **Read `.job`, never a `show` payload's TOP-LEVEL
+  is exactly the `--recheck-job` case. An earlier revision of this line named the cwd's branch and
+  was FALSE; the evidence offered for it — a `null` from a `--repo` sitting on `main` — is explained
+  identically by both readings, so it could never have separated them. The measurement that does:
+  from cwd `/tmp`, which is not a git repository at all, `--repo <lane>` returns that lane's rows. **Read `.job`, never a `show` payload's TOP-LEVEL
   `id`**: that is the REVIEW row's own sequence and need not be the job you asked for (measured over
   ten records — asking for 9 returns `id=8`, `job_id=9`, `job.id=9`), so a top-level jq manufactures
   the very "is this the right review?" doubt the check exists to remove. The wrapper is unaffected —
@@ -1444,7 +1445,9 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   box B against box B's DIFFERENT review: `sha-assert` passes, the id matches, the authorization
   crosses reviews. "A repeated id cannot reach another box's recheck" is true of the RECORD and
   IRRELEVANT to the MARKER, which is what actually travels; on this fleet ids have already collided
-  at 265 and two lanes have reviewed one branch. **It is NOT closed here** because closing it means
+  at 265 and two lanes have reviewed one branch (2026-09-01, a peer session and this lane both landing
+  on #3654 within seconds; cause tracked as **#3810** — `CLAIM_ACTOR` defaults to the literal `flow`, so
+  `claim.sh` answers `VERIFY-OK` to both lanes on one box). **It is NOT closed here** because closing it means
   adding a field to a hand-typed control line, which this issue's disposition forbids — a DESIGN
   CALL, escalated to the owner and PENDING on #3654. The mitigation that exists today is
   OPERATIONAL, not mechanical: the block NAMES the daemon, so an authorizer comparing `job-machine:`

--- a/openspec/specs/roborev-review-guard/spec.md
+++ b/openspec/specs/roborev-review-guard/spec.md
@@ -998,7 +998,11 @@ path (exit `0`) is likewise not a verdict and SHALL emit no block.
 
 #### Scenario: The block carries every per-check key in the contracted order
 - **WHEN** a review was enqueued and completed
-- **THEN** the block carries `repo:`, `branch:`, `base:`, `head-sha:`, `reviewed-sha:`, `assert-base:`, `job:`, `model:`, `census:`, `tokens:`, `push-assert:`, `census-check:`, `code-free:`, `job-record:`, `sha-assert:`, `review-completed:`, `prompt-content:`, `vacuity-tier1:`, `vacuity-tier2:`, `findings:`, `roborev-exit:` and `log:` in that order, ahead of the terminal `RESULT:` — twenty-three keys in all, each exactly once
+- **THEN** the block carries `repo:`, `branch:`, `base:`, `head-sha:`, `reviewed-sha:`, `assert-base:`, `job:`, `job-machine:`, `model:`, `census:`, `tokens:`, `push-assert:`, `census-check:`, `code-free:`, `job-record:`, `sha-assert:`, `review-completed:`, `prompt-content:`, `vacuity-tier1:`, `vacuity-tier2:`, `findings:`, `roborev-exit:` and `log:` in that order, ahead of the terminal `RESULT:` — twenty-four keys in all, each exactly once
+
+#### Scenario: The block names the daemon that issued the job id
+- **WHEN** a normal run's or a `--recheck-job` run's block is read
+- **THEN** `job-machine:` sits beside `job:` and carries exactly one of three affirmative renderings — the daemon uuid when a record carried `source_machine_id`, `NOT RECORDED (...)` when a job record was read and carries none, or `UNAVAILABLE (...)` naming the `job-record:` state it inherits — never a blank, and it is informational: it appears in neither the verdict-grammar scan nor the affirmation backstop, so none of its states can make a run pass or fail on its own (roborev job ids are per-daemon, so the value disambiguates a pasted block; the record's `git_ref`, not the id, remains what identifies a review — #3654)
 
 #### Scenario: The block states which base the range assert compared against
 - **WHEN** a normal run's block is read

--- a/openspec/specs/roborev-review-guard/spec.md
+++ b/openspec/specs/roborev-review-guard/spec.md
@@ -998,11 +998,7 @@ path (exit `0`) is likewise not a verdict and SHALL emit no block.
 
 #### Scenario: The block carries every per-check key in the contracted order
 - **WHEN** a review was enqueued and completed
-- **THEN** the block carries `repo:`, `branch:`, `base:`, `head-sha:`, `reviewed-sha:`, `assert-base:`, `job:`, `job-machine:`, `model:`, `census:`, `tokens:`, `push-assert:`, `census-check:`, `code-free:`, `job-record:`, `sha-assert:`, `review-completed:`, `prompt-content:`, `vacuity-tier1:`, `vacuity-tier2:`, `findings:`, `roborev-exit:` and `log:` in that order, ahead of the terminal `RESULT:` — twenty-four keys in all, each exactly once
-
-#### Scenario: The block names the daemon that issued the job id
-- **WHEN** a normal run's or a `--recheck-job` run's block is read
-- **THEN** `job-machine:` sits beside `job:` and carries exactly one of three affirmative renderings — the daemon uuid when a record carried `source_machine_id`, `NOT RECORDED (...)` when a job record was read and carries none, or `UNAVAILABLE (...)` naming the `job-record:` state it inherits — never a blank, and it is informational: it appears in neither the verdict-grammar scan nor the affirmation backstop, so none of its states can make a run pass or fail on its own (roborev job ids are per-daemon, so the value disambiguates a pasted block; the record's `git_ref`, not the id, remains what identifies a review — #3654)
+- **THEN** the block carries `repo:`, `branch:`, `base:`, `head-sha:`, `reviewed-sha:`, `assert-base:`, `job:`, `model:`, `census:`, `tokens:`, `push-assert:`, `census-check:`, `code-free:`, `job-record:`, `sha-assert:`, `review-completed:`, `prompt-content:`, `vacuity-tier1:`, `vacuity-tier2:`, `findings:`, `roborev-exit:` and `log:` in that order, ahead of the terminal `RESULT:` — twenty-three keys in all, each exactly once
 
 #### Scenario: The block states which base the range assert compared against
 - **WHEN** a normal run's block is read

--- a/scripts/flow/roborev-job-facts.py
+++ b/scripts/flow/roborev-job-facts.py
@@ -80,10 +80,13 @@ def find_job(data, want):
     # `roborev show <id> --json` returns a REVIEW row whose top level carries
     # [agent, closed, created_at, id, job, job_id, output, prompt, uuid, verdict_bool]
     # and nests the JOB row — git_ref, status, model, requested_model, token_usage,
-    # verdict — under a "job" key. Both objects answer to the same id, so returning the
-    # FIRST id match handed back the review row, which has none of the fields the
-    # asserts need. Prefer an id match that actually carries git_ref (measured, issue
-    # #2964 round 6); fall back to the first match only if none does.
+    # verdict — under a "job" key. Both objects ANSWER TO the requested id, though by
+    # DIFFERENT keys: the nested job row through its own `id`, the review row through
+    # `job_id` (its top-level `id` is the review row's own sequence and need NOT equal
+    # the job — measured over ten records on v0.61.2, #3654). So returning the FIRST
+    # match handed back the review row, which has none of the fields the asserts need.
+    # Prefer an id match that actually carries git_ref (measured, issue #2964 round 6);
+    # fall back to the first match only if none does.
     matches = []
     for obj in objects(data):
         for key in ("id", "job_id", "job"):

--- a/scripts/flow/roborev-job-facts.py
+++ b/scripts/flow/roborev-job-facts.py
@@ -74,7 +74,20 @@ TOKEN_CONTAINER_KEYS = ("token_usage", "tokenUsage", "usage", "token_counts")
 # ADDING IT CANNOT CHANGE WHICH ROW `find_job` SELECTS: that function looks only at the
 # id-bearing keys and then prefers a match carrying `git_ref`; STRING_FACTS is read solely
 # by the output loop below, after the row has been chosen.
-STRING_FACTS = ("git_ref", "status", "model", "requested_model", "verdict", "source_machine_id")
+# `branch` is exported for ONE reason (#3654 round 2): the daemon's job list is
+# BRANCH-FILTERED, so a supplementary lookup must be scoped to the branch the JOB was
+# enqueued for — asking about the ambient current branch answers about a DIFFERENT branch,
+# which is how a `--recheck-job` of an older job silently reported no daemon at all.
+# Measured: `roborev show <id> --json` carries it at `.job.branch`, `list` rows at top level.
+STRING_FACTS = (
+    "git_ref",
+    "status",
+    "model",
+    "requested_model",
+    "verdict",
+    "source_machine_id",
+    "branch",
+)
 
 
 def objects(node):

--- a/scripts/flow/roborev-job-facts.py
+++ b/scripts/flow/roborev-job-facts.py
@@ -60,7 +60,21 @@ OUTPUT_TOKEN_KEYS = (
     "completionTokens",
 )
 TOKEN_CONTAINER_KEYS = ("token_usage", "tokenUsage", "usage", "token_counts")
-STRING_FACTS = ("git_ref", "status", "model", "requested_model", "verdict")
+# `source_machine_id` NAMES THE DAEMON THAT ISSUED THE JOB ID (#3654). Job ids are
+# PER-DAEMON: two fleet boxes legitimately presented the same `job=265` for different
+# reviews, and a coordination lead read the repetition as a collision and withheld a
+# valid absence waiver. It is a STRING FACT like the others and nothing more — it is
+# reported so the wrapper's block can NAME the daemon, never asserted on.
+#
+# MEASURED (roborev v0.61.2, this fleet): `roborev list --json` ROWS carry it at top
+# level beside id/git_ref/branch/repo_path; `roborev show <id> --json` does NOT carry it
+# ANYWHERE, not even in its nested `job` object. So its absence from a given payload is a
+# REAL, expected state and must render as such rather than as an empty value.
+#
+# ADDING IT CANNOT CHANGE WHICH ROW `find_job` SELECTS: that function looks only at the
+# id-bearing keys and then prefers a match carrying `git_ref`; STRING_FACTS is read solely
+# by the output loop below, after the row has been chosen.
+STRING_FACTS = ("git_ref", "status", "model", "requested_model", "verdict", "source_machine_id")
 
 
 def objects(node):

--- a/scripts/flow/roborev-job-facts.py
+++ b/scripts/flow/roborev-job-facts.py
@@ -60,34 +60,7 @@ OUTPUT_TOKEN_KEYS = (
     "completionTokens",
 )
 TOKEN_CONTAINER_KEYS = ("token_usage", "tokenUsage", "usage", "token_counts")
-# `source_machine_id` NAMES THE DAEMON THAT ISSUED THE JOB ID (#3654). Job ids are
-# PER-DAEMON: two fleet boxes legitimately presented the same `job=265` for different
-# reviews, and a coordination lead read the repetition as a collision and withheld a
-# valid absence waiver. It is a STRING FACT like the others and nothing more — it is
-# reported so the wrapper's block can NAME the daemon, never asserted on.
-#
-# MEASURED (roborev v0.61.2, this fleet): `roborev list --json` ROWS carry it at top
-# level beside id/git_ref/branch/repo_path; `roborev show <id> --json` does NOT carry it
-# ANYWHERE, not even in its nested `job` object. So its absence from a given payload is a
-# REAL, expected state and must render as such rather than as an empty value.
-#
-# ADDING IT CANNOT CHANGE WHICH ROW `find_job` SELECTS: that function looks only at the
-# id-bearing keys and then prefers a match carrying `git_ref`; STRING_FACTS is read solely
-# by the output loop below, after the row has been chosen.
-# `branch` is exported for ONE reason (#3654 round 2): the daemon's job list is
-# BRANCH-FILTERED, so a supplementary lookup must be scoped to the branch the JOB was
-# enqueued for — asking about the ambient current branch answers about a DIFFERENT branch,
-# which is how a `--recheck-job` of an older job silently reported no daemon at all.
-# Measured: `roborev show <id> --json` carries it at `.job.branch`, `list` rows at top level.
-STRING_FACTS = (
-    "git_ref",
-    "status",
-    "model",
-    "requested_model",
-    "verdict",
-    "source_machine_id",
-    "branch",
-)
+STRING_FACTS = ("git_ref", "status", "model", "requested_model", "verdict")
 
 
 def objects(node):

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -83,7 +83,7 @@
 #
 #   ==== ROBOREV REVIEW SUMMARY ====
 #   repo: / branch: / base: / head-sha: / reviewed-sha: / assert-base: / job: /
-#   job-machine: / model: / census: /
+#   model: / census: /
 #   tokens: / push-assert: / census-check: / code-free: / job-record: /
 #   sha-assert: / review-completed: / prompt-content: /
 #   vacuity-tier1: / vacuity-tier2: / findings: / [deferral:] / roborev-exit: / log:
@@ -184,29 +184,6 @@
 #   roborev-exit      PASS | FINDINGS (exit N) | ERROR (exit N) | SKIP
 #   model             <model> | <model> (SUBSTITUTED — requested '<r>') |
 #                     <model> (UNCONFIRMED — no model field in the job record) | -
-#   job-machine       <uuid> (source_machine_id; job ids are per-daemon) |
-#                     NOT RECORDED (...) | UNAVAILABLE (...)
-#                     WHICH DAEMON ISSUED THE `job:` ID ABOVE (#3654). INFORMATIONAL, exactly
-#                     like `census:`/`tokens:`/`waiver:` — it is in neither the verdict-grammar
-#                     scan nor the affirmation loop (both enumerate the verdict-carrying keys by
-#                     name), so it can never make a run pass or fail; a `NOT RECORDED` or
-#                     `UNAVAILABLE` here beside affirmative keys still reaches RESULT: PASS.
-#                     WHY IT EXISTS: **roborev job ids are PER-DAEMON, not global.** Each fleet
-#                     box runs its own daemon with its own database and its own sequential ids,
-#                     so two boxes can legitimately present the SAME id for DIFFERENT reviews —
-#                     measured, `job=265` on two lanes 50 minutes apart — and a coordination lead
-#                     read the repetition as a collision and WITHHELD a valid absence waiver. A
-#                     pasted block is read by people who are not on the box, so it names the
-#                     daemon. It is NOT an authorization field and NOT a uniqueness proof: the
-#                     binding that identifies a review is the record's `git_ref` (see
-#                     `reviewed-sha:`), and the marker grammar is deliberately UNCHANGED — no
-#                     machine field was added to it, because every field in a hand-typed control
-#                     line is another way for a legitimate authorization to read MALFORMED.
-#                     THE THREE STATES ARE AFFIRMATIVE AND CLOSED, never blank: the uuid when a
-#                     record carried `source_machine_id`; `NOT RECORDED` when a job record WAS
-#                     read and carries none (a REAL state — `roborev show <id> --json` does not
-#                     carry the field at all; `roborev list --json` rows do); `UNAVAILABLE` when
-#                     no job record could be read, naming the `job-record:` state it inherits.
 #   census            `<N> file(s), +<A>/-<D>` | -
 #   tokens            `input=<n> cached=<n> output=<n>` | UNAVAILABLE
 # FINDINGS means the reviewer RAN and reported findings (a GENUINE review to triage and
@@ -248,7 +225,7 @@
 # range), `review-completed` (job status + an allow-list of terminal verdict markers),
 # `prompt-content` (the CODE subset of our census inside the prompt actually sent). Prose matching (`vacuity-tier1`) and token accounting (`vacuity-tier2`)
 # CORROBORATE; tier 1 can only ever raise a NOTICE. `base:`, `head-sha:`, `reviewed-sha:`,
-# `assert-base:`, `job-machine:`, `census:`, `tokens:`, `waiver:` and `deferral:` are INFORMATIONAL — they are in neither
+# `assert-base:`, `census:`, `tokens:`, `waiver:` and `deferral:` are INFORMATIONAL — they are in neither
 # the verdict-grammar scan nor the affirmation loop (both enumerate the verdict-carrying keys
 # by name), so none of them can make a run pass or fail on its own.
 #
@@ -423,36 +400,33 @@ review's token accounting (genuine reviews measured 398k-649k input / 314k-554k 
 the vacuous baseline is ~18.7k input / 0 cached).
 
 THAT SENTENCE IS TRUE AT REVIEW TIME, AND FALSE AFTER THE FACT ONLY FOR A HUMAN READING
-THE STORED RECORD — IT STAYS TRUE OF THE MACHINE, AND MUST. THAT IS WHERE THE BEST
-EVIDENCE IS (#3654). The prompt roborev SENT is retained in the job record and can be
-retrieved later, even though the snapshot file it names is transient and long deleted:
+THE STORED RECORD — IT STAYS TRUE OF THE MACHINE, AND MUST (#3654). The prompt roborev
+SENT is retained in the job record and can be retrieved later, even though the snapshot
+file it names is transient and long deleted:
 
     roborev show <id> --prompt
 
 Under '### Combined Diff' a delivery-by-path prompt carries roborev's own wording — 'Diff
 too large to include inline ... Read the diff from: <path>'. That is the DIRECT ARTIFACT:
-roborev's ACTUAL prompt rather than a statistic about it, and it is what an absence-waiver
-request should LEAD with.
+roborev's ACTUAL prompt rather than a statistic about it.
 
-IT IS NOT SELF-AUTHENTICATING, AND THE TRUST PROPERTIES RUN THE OPPOSITE WAY FROM THE
-OBVIOUS READING. roborev's prompt EMBEDS repository-controlled content — project
-guidelines, AGENTS.md, additional context, previous-review bodies — at positions
-indistinguishable from roborev's own text, so a reviewed branch can carry text MIMICKING
-that delivery wording and an authorizer would read it as roborev's. A human in the loop is
-not a channel separation; it is the same shared channel with a slower parser. So the
-prompt is read for the STRUCTURAL fact it reports, never as proof of its own provenance.
-THE TOKEN ACCOUNTING IS DAEMON-RECORDED BUT NOT INDEPENDENT, AND IT DOES NOT ESTABLISH
-DELIVERY EITHER. The RECORD is authentic — the daemon writes the counts and the reviewed
-branch cannot rewrite them. Their VALUE is a different claim: the counts measure THE
-PROMPT, and the prompt embeds repository-controlled content, so a branch influences their
-MAGNITUDE without forging anything. That bites exactly where the counts are used — the
-vacuous baseline is about 18.7k input / 0 cached, so padding non-diff prompt content can
-make a review that never received the diff look token-rich. So NEITHER SIGNAL ESTABLISHES
-PROVENANCE, and the two are NOT INDEPENDENT: both are functions of the same
-repository-influenced prompt. The prompt still LEADS and a request should still lead with
-it, with the counts read ALONGSIDE it as a consistency check — never as unforgeable
-corroboration. What evidence SHOULD be required before granting is an OPEN QUESTION,
-PENDING on #3654, and is deliberately not settled here.
+WHAT THE TWO SIGNALS CAN AND CANNOT ESTABLISH. THE PROMPT IS NOT SELF-AUTHENTICATING:
+roborev's prompt EMBEDS repository-controlled content — project guidelines, AGENTS.md,
+additional context, previous-review bodies — at positions indistinguishable from roborev's
+own text, so a reviewed branch can carry text MIMICKING that delivery wording and an
+authorizer would read it as roborev's. A human in the loop is not a channel separation; it
+is the same shared channel with a slower parser. So the prompt reports a STRUCTURAL fact
+and is never proof of its own provenance. THE TOKEN ACCOUNTING IS DAEMON-RECORDED BUT NOT
+INDEPENDENT: the RECORD is authentic — the daemon writes the counts and the reviewed branch
+cannot rewrite them — but their VALUE measures THE PROMPT, and the prompt embeds
+repository-controlled content, so a branch influences their MAGNITUDE without forging
+anything. That bites exactly where the counts are used — the vacuous baseline is about
+18.7k input / 0 cached, so padding non-diff prompt content can make a review that never
+received the diff look token-rich. So NEITHER SIGNAL ESTABLISHES PROVENANCE, and the two
+are NOT INDEPENDENT: both are functions of the same repository-influenced prompt.
+
+WHICH EVIDENCE A WAIVER SHOULD REST ON IS AN OPEN QUESTION, TRACKED AS #3826. Nothing
+here recommends one signal over the other, or any ordering between them.
 
 THIS RESURRECTS NOTHING OF THE DELETED DELIVERY CLASSIFIER, and the distinction is
 load-bearing rather than a caveat. The classifier failed because it inferred delivery
@@ -513,19 +487,12 @@ branches, different token counts, both correct. A repeated id is therefore NOT e
 of a collision; reading it as one cost a valid waiver a round. The check that settles it:
 
     roborev show <id> --json | jq '.job | {id, git_ref, branch, status, token_usage}'
-    roborev list --json --limit <N> --repo <abs-repo> --branch <branch> | jq '.[] | select(.id==<id>) | {id, source_machine_id, git_ref, branch}'
+    roborev list --json --repo <abs-repo> --branch <branch> | jq '.[] | select(.id==<id>) | {id, git_ref, branch}'
 
 git_ref MUST equal the marker's <base40>..<head40>. THREE TRAPS IN THOSE COMMANDS, all
 measured on roborev v0.61.2: (1) 'show <id> --json' NESTS git_ref/status/token_usage
-under '.job' and does not carry source_machine_id ANYWHERE, so a top-level jq over that
-payload prints nulls for all four — a check whose output cannot show what it claims;
-(0) 'roborev list' returns only the newest --limit rows (DEFAULT 50) and offers NO offset
-or cursor, so an OLDER job sits BEYOND the first page and the command returns NOTHING
-though the record exists. That is not a corner case: a --recheck-job names an old job by
-construction, and a heavily-reviewed branch accumulates rows, so "the job is deep" and
-"someone is applying a waiver" are the SAME population. RAISE <N> — 50, 200, 800 — until
-the row appears or the list stops growing. THE WRAPPER'S OWN LOOKUP DOES THIS
-AUTOMATICALLY; only this manual form needs the limit raised by hand;
+under '.job', so a top-level jq over that payload prints nulls for all of them — a check
+whose output cannot show what it claims;
 (2) 'roborev list' defaults its branch filter to the CURRENT HEAD OF THE --repo PATH —
 NOT to the branch your shell is standing in (measured: from a cwd that is not a git
 repository at all, '--repo <lane>' returns that lane's branch's rows) — so pass --branch
@@ -549,34 +516,6 @@ it appears to rule out — a probe whose output is IDENTICAL under the two state
 to separate, the same class as reading the gate's 'RESULT: INCOMPLETE' launch sentinel as
 a verdict, or locating a gate run directory with 'ls -t'. Run on both of the 'job=265'
 lanes, it gave the right answer for a reason that did not hold. Use git_ref.
-
-THE BLOCK NAMES THE DAEMON, so a pasted artifact is self-describing for a reader who is
-not on the box: 'job-machine:' sits beside 'job:' and reports source_machine_id when a
-record carried it, 'NOT RECORDED' when a record was read and carries none, and
-'UNAVAILABLE' when no record could be read. It is INFORMATIONAL and can never pass or
-fail a run. THE MARKER GRAMMAR IS DELIBERATELY UNCHANGED: no machine field was added to
-it, in either marker kind. The authorizer would have to know the value, it is derivable
-from the record, and every field in a hand-typed control line is one more way for a
-legitimate authorization to read MALFORMED.
-
-DECLARED BOUNDARY — WHAT THE 'job=' BINDING DOES NOT CLOSE, AND WHY IT IS NOT CLOSED HERE
-(#3654). CLAIMED: within ONE daemon, base+head+job names one review, and '--recheck-job'
-re-decides THAT record. NOT CLAIMED: that a marker cannot cross boxes. The marker travels
-through GITHUB, not through the daemon, while '--recheck-job <id>' reads the LOCAL
-daemon's record for that id — so if two boxes hold the SAME id for the SAME git_ref range,
-a waiver granted after an authorizer inspected box A's review is ACCEPTED on box B against
-box B's DIFFERENT review: sha-assert passes, the id matches, and the authorization crosses
-reviews. 'A repeated id cannot reach another box's recheck' is true of the RECORD and
-IRRELEVANT to the MARKER, which is the thing that actually travels. Not exotic on this
-fleet: ids have already collided at 265, and two lanes reviewing one branch has happened.
-
-IT IS NOT CLOSED HERE because closing it means adding a field to a HAND-TYPED CONTROL
-LINE, which this issue's own disposition forbids — so it is a DESIGN CALL, escalated to
-the owner and PENDING on #3654, not something this change may decide. THE MITIGATION THAT
-EXISTS TODAY IS OPERATIONAL, NOT MECHANICAL: the block NAMES the issuing daemon, so an
-authorizer comparing 'job-machine:' between the request and the recheck SEES a cross-box
-mismatch — which is why the key exists at all. It is informational and CANNOT enforce: a
-reader who does not compare it is stopped by nothing.
 
 THREE THINGS STOP THE DOCUMENTATION BECOMING THE CREDENTIAL. (1) The marker must BE the
 line: an indented, '>'-quoted, bulleted or mid-sentence copy does not match, so pasting
@@ -842,9 +781,6 @@ JOB="-"
 MODEL_LINE="-"
 CENSUS="-"
 TOKENS="UNAVAILABLE"
-# Was a job record READ at all (any payload, complete or not)? Distinct from `record_required_present`,
-# which answers about COMPLETENESS — see the `job-machine:` state selection below (#3654 round 2).
-JOB_RECORD_READ=0
 # Populated by roborev_census (in the sourced oracles file); declared here so the
 # array always exists even if that oracle ever returns before filling it.
 # shellcheck disable=SC2034 # read in roborev-review-oracles.sh, not here
@@ -862,39 +798,6 @@ PUSH_ASSERT="SKIP"
 CENSUS_CHECK="SKIP"
 CODE_FREE="SKIP"
 JOB_RECORD="SKIP"
-# WHICH DAEMON ISSUED THE JOB ID (#3654). Initialised to the state a run that never reached a job
-# record is actually in — never blank, and never a bare `-`, which would read as "no daemon" rather
-# than "nothing was read". Recomputed once, below, from the facts the record read produced.
-#
-# IT INTERPOLATES `$JOB_RECORD` RATHER THAN HARD-CODING `SKIP`, and it is declared HERE, directly
-# after that variable, for two reasons that are one reason: a hard-coded `SKIP` made an abort
-# between the record poll and the recompute emit `job-record: PASS` beside
-# `job-machine: UNAVAILABLE (... job-record: SKIP)` — two keys contradicting each other about the
-# same fact.
-#
-# ROUND 3 FINDING: INTERPOLATING HERE MOVED THAT BUG INSTEAD OF REMOVING IT. `$JOB_RECORD` is
-# `SKIP` AT THIS POINT, so the expansion captures `SKIP` permanently and an abort after the record
-# poll still emits the contradictory pair. The general rule, which is the part worth keeping: for a
-# value whose whole purpose is to reflect LATER state, no expansion at an EARLY site can ever be
-# right — it has to be BUILT WHEN IT IS READ. So this stays deliberately EMPTY and the fallback is
-# constructed at emit time by `job_machine_value` below. (The `on_exit` EXIT trap emits the block
-# on ANY abort, which is exactly the path that made this reachable.)
-JOB_MACHINE=""
-job_machine_value() { # the job-machine: value, resolved against the CURRENT job-record state
-  # A computed state wins; otherwise the run never reached the recompute, and the honest thing to
-  # report is the state AS IT STANDS NOW, not as it stood at initialization.
-  if [ -n "$JOB_MACHINE" ]; then printf '%s' "$JOB_MACHINE"; return 0; fi
-  # ROUND 4: THE FALLBACK MUST ALSO CONSULT WHETHER A RECORD WAS READ. Reporting a flat
-  # `UNAVAILABLE (no job record was read)` on every abort is FALSE whenever the run died AFTER the
-  # record poll — a record WAS read, and the only thing missing is the daemon lookup. That is the
-  # same mis-attribution as round 2's (collapsing read-failure onto field-absence): two different
-  # facts flattened into one affirmative sentence.
-  if [ "${JOB_RECORD_READ:-0}" -eq 1 ]; then
-    printf 'NOT RECORDED (a job record WAS read, but the run ended before the daemon lookup completed, so the issuing daemon was never determined — job-record: %s)' "$JOB_RECORD"
-    return 0
-  fi
-  printf 'UNAVAILABLE (no job record was read — job-record: %s)' "$JOB_RECORD"
-}
 SHA_ASSERT="SKIP"
 # The POSITIVE "a review actually happened" assert. Absence of a vacuous phrase is
 # NOT evidence a review occurred: a transcript that only says "Waiting for job N to
@@ -1076,15 +979,6 @@ emit_summary() {
   # visible rather than inferred. Placed beside `head-sha:`/`reviewed-sha:`, the other endpoints.
   emit_kv 'assert-base' "${RANGE_BASE_SHA:--} (merge-base of $BASE and HEAD; $BASE tip ${BASE_TIP_SHA:--})"
   emit_kv 'job' "$JOB"
-  # ===== WHICH DAEMON'S JOB ID THAT IS (#3654) =====
-  # INFORMATIONAL, exactly like `assert-base:`/`census:`/`tokens:` — NOT in the verdict-grammar scan
-  # and NOT in the affirmation loop (both enumerate the verdict-carrying keys by name), so it can
-  # never make a run pass or fail on its own. Emitted UNCONDITIONALLY and beside `job:`, because the
-  # thing it disambiguates is the value on the line above it: roborev job ids are PER-DAEMON, and a
-  # block is pasted into PR threads read by people who are not on the box. A conditional emit would
-  # reproduce the defect — a reader with no `job-machine:` line cannot tell "this daemon was not
-  # recorded" from "this wrapper does not report it".
-  emit_kv 'job-machine' "$(job_machine_value)"
   emit_kv 'model' "$MODEL_LINE"
   emit_kv 'census' "$CENSUS"
   emit_kv 'tokens' "$TOKENS"
@@ -1439,18 +1333,10 @@ read_job_record() { # read_job_record <job> -> populates FACTS_FILE / PROMPT_FIL
       # `--repo` run from another lane returns those same rows). It is correct here BY CONSTRUCTION
       # for the ordinary case — the wrapper enqueued the review for the `--repo` checkout's own
       # branch — and it must NOT grow a `--branch` here: `sha-assert` depends on this read, and
-      # changing what it selects is a separate question from #3654. The supplementary machine read
-      # below is a NEW read and scopes to the RECORD's own branch; that difference is deliberate and
-      # documented there, and it is what makes the key work on the recheck path.
+      # changing what it selects is a separate question from #3654.
       list) json=$(roborev list --json --limit 50 --repo "$REPO" 2>/dev/null || printf '') ;;
     esac
     extract_job_facts "$1" "$json" "$FACTS_FILE" "$PROMPT_FILE" "$RECORD_OUTPUT_FILE" || continue
-    # A RECORD WAS READ. Tracked SEPARATELY from `record_required_present`, which answers a
-    # DIFFERENT question — completeness — and answering "was anything read?" with it made
-    # `job-machine:` state that no record could be read when one had been (#3654 round 2). Two
-    # questions, two signals; a state that is not an affirmative true statement about what
-    # happened is the diagnostic that stops the next person looking.
-    JOB_RECORD_READ=1
     if record_required_present; then
       rm -f "$best_facts"
       return 0
@@ -1464,111 +1350,6 @@ read_job_record() { # read_job_record <job> -> populates FACTS_FILE / PROMPT_FIL
   fi
   rm -f "$best_facts"
   return 1
-}
-
-# ===== WHICH DAEMON ISSUED THIS JOB ID — A SUPPLEMENTARY, ISOLATED READ (#3654) =====
-# `source_machine_id` is carried by `roborev list --json` ROWS ONLY: measured on roborev v0.61.2,
-# `roborev show <id> --json` does not carry it anywhere, not even in its nested `job` object. And
-# `read_job_record` above STOPS at the first payload that answers, which on a healthy daemon is
-# `show` — so a machine id read only through that loop would be `NOT RECORDED` on EVERY real run,
-# i.e. a key that reports nothing while looking like it reports something. Hence one extra `list`
-# read, and ONLY when the record already read did not carry the field.
-#
-# ISOLATED ON PURPOSE: it writes to its OWN scratch facts file and never to `$FACTS_FILE`, so it
-# cannot change any fact an assert reads, cannot change which row the record loop chose, and cannot
-# move a verdict. It runs AFTER the record poll loop has settled, so it also cannot perturb the
-# transient-read modelling above it. A failure here is not an error — it yields no id, and the key
-# says so affirmatively.
-#
-# IT IS SCOPED TO THE RECORD'S OWN BRANCH, NOT TO THE CHECKOUT'S (#3654 round 2). `roborev list`
-# is BRANCH-FILTERED and its default follows the CURRENT HEAD OF THE `--repo` PATH; `$BRANCH` is
-# read from that same HEAD, so both name the branch the CHECKOUT is on and neither names the JOB's
-# — so scoping by it answers about a DIFFERENT branch whenever the job was enqueued elsewhere, and
-# `--recheck-job` is exactly where that happens (an older job, a renamed or rebased lane). That
-# would have rendered `NOT RECORDED` for a record that HAS a `source_machine_id`, silently defeating
-# the operator mitigation this key exists for — the documented "compare `job-machine:` between the
-# request and the recheck" — in the one mode it is documented for. So the branch comes from the
-# JOB RECORD (`.job.branch` on `show`, top level on `list`), which is the job's own fact.
-#
-# AND THERE IS NO AMBIENT FALLBACK. When the record does not name its branch the lookup is NOT
-# retried against `$BRANCH`: that would answer about a different branch while looking like an
-# answer about this job — the same defect one layer down. The state says so instead.
-#
-# `--limit 50` IS SOUND ONCE THE BRANCH IS RIGHT, and the bound is per-branch rather than
-# per-daemon: measured on this fleet, the whole daemon database held 31 records across all
-# branches, so 50 jobs on ONE branch is far past anything observed. If it were ever exceeded the
-# result is the affirmative `NOT RECORDED` state with a named cause — never a wrong id, because the
-# extractor matches the job id and returns nothing when it is absent.
-#
-# BOUNDED CASES WHERE IT LEGITIMATELY DOES NOT RESOLVE, so the state is read as information and not
-# as a defect: a roborev build whose `list` rows do not carry `source_machine_id`; a record that
-# does not name its own branch; and a branch holding more than `--limit 50` jobs. Each lands on
-# `NOT RECORDED` with its own cause named, which is why that value explains itself rather than
-# merely reporting an absence.
-# TWO GLOBALS, NOT STDOUT, AND THAT IS LOAD-BEARING. This first PRINTED the uuid and was called in
-# a command substitution — so the SUBSHELL's assignment to `JOB_MACHINE_MISS` never reached the
-# parent and every miss rendered the generic cause instead of the one it had just measured (caught
-# by case jm15). A result that is two values does not fit one channel.
-JOB_MACHINE_ID=""
-JOB_MACHINE_MISS=""
-read_machine_fact() { # read_machine_fact <job> -> sets JOB_MACHINE_ID | JOB_MACHINE_MISS
-  local mfacts="$FACTS_FILE.machine" mprompt="$FACTS_FILE.machine.prompt" json="" id="" job_branch=""
-  JOB_MACHINE_ID=""
-  JOB_MACHINE_MISS=""
-  id=$(fact source_machine_id)
-  if [ -n "$id" ]; then JOB_MACHINE_ID="$id"; return 0; fi
-  job_branch=$(fact branch)
-  if [ -z "$job_branch" ]; then
-    JOB_MACHINE_MISS="the job record does not name its own branch, and the daemon's job list is branch-filtered, so the lookup could not be scoped to this job; it was deliberately NOT retried against the branch this invocation is on, which would answer about a different branch than the job's"
-    return 1
-  fi
-  # ===== DEPTH: RETRIEVE UNTIL FOUND OR EXHAUSTED, NEVER A BIGGER CONSTANT (#3654 round 3) =====
-  # Round 2 fixed the wrong-branch half of this lookup and left the DEPTH half: a fixed
-  # `--limit 50` silently drops the target once the branch holds more than 50 jobs, so the
-  # cross-box mitigation failed for precisely the long-lived jobs most likely to be RECHECKED —
-  # and a recheck is the one mode the mitigation is documented for. Raising the constant would
-  # relocate that defect rather than remove it, so the loop instead stops on an AFFIRMATIVE
-  # end-of-list signal.
-  #
-  # WHY DOUBLING AND NOT AN OFFSET: `roborev list` has no offset or cursor — measured on
-  # v0.61.2, `--limit` is its ONLY depth control — so depth is reached by asking for more rows.
-  # The daemon returning the SAME payload for a strictly larger limit is the only evidence
-  # available that it has no more rows to give; that, not a constant, is the terminating
-  # condition. The round guard below is a runaway stop, not a depth policy, and when it fires it
-  # is NAMED in the miss cause rather than reported as a plain absence.
-  local lim=50 prev="" found=0 rounds=0
-  while : ; do
-    json=$(roborev list --json --limit "$lim" --repo "$REPO" --branch "$job_branch" 2>/dev/null || printf '')
-    if [ -z "$json" ]; then
-      JOB_MACHINE_MISS="the daemon returned no job list for this job's own branch '$job_branch'"
-      return 1
-    fi
-    : >"$mfacts"
-    : >"$mprompt"
-    if extract_job_facts "$1" "$json" "$mfacts" "$mprompt"; then found=1; break; fi
-    # Identical payload for a strictly larger limit: the daemon has nothing deeper to return.
-    if [ "$json" = "$prev" ]; then break; fi
-    prev="$json"
-    rounds=$((rounds + 1))
-    if [ "$rounds" -ge 12 ]; then break; fi
-    lim=$((lim * 2))
-  done
-  if [ "$found" -ne 1 ]; then
-    rm -f "$mfacts" "$mprompt"
-    if [ "$rounds" -ge 12 ]; then
-      JOB_MACHINE_MISS="job '$1' was not found on its own branch '$job_branch' after searching to a depth of $lim rows, where the search hit its runaway guard rather than the end of the daemon's list"
-    else
-      JOB_MACHINE_MISS="job '$1' is not in the daemon's job list for its own branch '$job_branch', searched to a depth of $lim rows and to the end of what the daemon returns"
-    fi
-    return 1
-  fi
-  id=$(sed -n 's/^source_machine_id=//p' "$mfacts" | head -1)
-  rm -f "$mfacts" "$mprompt"
-  if [ -z "$id" ]; then
-    JOB_MACHINE_MISS="neither the job record nor the daemon's job list for branch '$job_branch' carries source_machine_id"
-    return 1
-  fi
-  JOB_MACHINE_ID="$id"
 }
 
 # REQUIRED to stop polling: the fields without which an assert cannot run at all.
@@ -1633,31 +1414,6 @@ TOKEN_STATE=$(fact token_state)
 TOK_IN=$(fact input_tokens)
 TOK_CACHED=$(fact cached_input_tokens)
 TOK_OUT=$(fact output_tokens)
-
-# ===== `job-machine:` — THREE AFFIRMATIVE STATES, NEVER BLANK, NEVER FAILING (#3654) =====
-# The states are decided here, once, so the emit site has nothing to infer. Ordered
-# id-then-record-then-nothing, and the last two are told apart by whether a job record was READ at
-# all: "the record does not carry the field" and "there is no record" are different operator
-# actions, and collapsing them onto one value is the shape this repository keeps paying for. The
-# key is INFORMATIONAL — it is in neither the verdict-grammar scan nor the affirmation loop — so
-# none of these three can red an otherwise-clean run.
-# CALLED IN THIS SHELL, NEVER IN A COMMAND SUBSTITUTION: it reports a uuid AND, when there is none,
-# the cause it measured — and a subshell would discard the second (see read_machine_fact).
-if [ "$announce_ok" -eq 1 ]; then
-  read_machine_fact "$JOB" || true
-fi
-# THE SPLIT IS "WAS A RECORD READ", NOT "IS IT COMPLETE" (#3654 round 2). This used to branch on
-# `record_required_present`, which asks about COMPLETENESS — so a record that WAS read but is
-# nonterminal or incomplete rendered `UNAVAILABLE (no job record could be read)`, a state that is
-# simply FALSE about what happened. Each of the three states has to be an affirmative TRUE statement
-# or the key is worse than absent, so the read is tracked on its own signal.
-if [ -n "$JOB_MACHINE_ID" ]; then
-  JOB_MACHINE="$JOB_MACHINE_ID (source_machine_id; job ids are per-daemon)"
-elif [ "${JOB_RECORD_READ:-0}" -eq 1 ]; then
-  JOB_MACHINE="NOT RECORDED (${JOB_MACHINE_MISS:-a job record was read, but the lookup recorded no cause for the missing daemon id — this is a defect in the lookup, not a measurement}; 'roborev list --json' rows carry that field, 'roborev show <id> --json' does not. Identify the review by the record's git_ref, never by the id alone)"
-else
-  JOB_MACHINE="UNAVAILABLE (no job record could be read at all, so the issuing daemon is unknown — job-record: $JOB_RECORD)"
-fi
 
 # The sanctioned form reviews a RANGE, so the job record's `git_ref` is
 # `<base40>..<head40>` and BOTH endpoints are asserted — strictly stronger than the

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -1487,16 +1487,44 @@ read_machine_fact() { # read_machine_fact <job> -> sets JOB_MACHINE_ID | JOB_MAC
     JOB_MACHINE_MISS="the job record does not name its own branch, and the daemon's job list is branch-filtered, so the lookup could not be scoped to this job; it was deliberately NOT retried against the branch this invocation is on, which would answer about a different branch than the job's"
     return 1
   fi
-  json=$(roborev list --json --limit 50 --repo "$REPO" --branch "$job_branch" 2>/dev/null || printf '')
-  if [ -z "$json" ]; then
-    JOB_MACHINE_MISS="the daemon returned no job list for this job's own branch '$job_branch'"
-    return 1
-  fi
-  : >"$mfacts"
-  : >"$mprompt"
-  if ! extract_job_facts "$1" "$json" "$mfacts" "$mprompt"; then
+  # ===== DEPTH: RETRIEVE UNTIL FOUND OR EXHAUSTED, NEVER A BIGGER CONSTANT (#3654 round 3) =====
+  # Round 2 fixed the wrong-branch half of this lookup and left the DEPTH half: a fixed
+  # `--limit 50` silently drops the target once the branch holds more than 50 jobs, so the
+  # cross-box mitigation failed for precisely the long-lived jobs most likely to be RECHECKED —
+  # and a recheck is the one mode the mitigation is documented for. Raising the constant would
+  # relocate that defect rather than remove it, so the loop instead stops on an AFFIRMATIVE
+  # end-of-list signal.
+  #
+  # WHY DOUBLING AND NOT AN OFFSET: `roborev list` has no offset or cursor — measured on
+  # v0.61.2, `--limit` is its ONLY depth control — so depth is reached by asking for more rows.
+  # The daemon returning the SAME payload for a strictly larger limit is the only evidence
+  # available that it has no more rows to give; that, not a constant, is the terminating
+  # condition. The round guard below is a runaway stop, not a depth policy, and when it fires it
+  # is NAMED in the miss cause rather than reported as a plain absence.
+  local lim=50 prev="" found=0 rounds=0
+  while : ; do
+    json=$(roborev list --json --limit "$lim" --repo "$REPO" --branch "$job_branch" 2>/dev/null || printf '')
+    if [ -z "$json" ]; then
+      JOB_MACHINE_MISS="the daemon returned no job list for this job's own branch '$job_branch'"
+      return 1
+    fi
+    : >"$mfacts"
+    : >"$mprompt"
+    if extract_job_facts "$1" "$json" "$mfacts" "$mprompt"; then found=1; break; fi
+    # Identical payload for a strictly larger limit: the daemon has nothing deeper to return.
+    if [ "$json" = "$prev" ]; then break; fi
+    prev="$json"
+    rounds=$((rounds + 1))
+    if [ "$rounds" -ge 12 ]; then break; fi
+    lim=$((lim * 2))
+  done
+  if [ "$found" -ne 1 ]; then
     rm -f "$mfacts" "$mprompt"
-    JOB_MACHINE_MISS="job '$1' is not in the daemon's latest 50 jobs for its own branch '$job_branch'"
+    if [ "$rounds" -ge 12 ]; then
+      JOB_MACHINE_MISS="job '$1' was not found on its own branch '$job_branch' after searching to a depth of $lim rows, where the search hit its runaway guard rather than the end of the daemon's list"
+    else
+      JOB_MACHINE_MISS="job '$1' is not in the daemon's job list for its own branch '$job_branch', searched to a depth of $lim rows and to the end of what the daemon returns"
+    fi
     return 1
   fi
   id=$(sed -n 's/^source_machine_id=//p' "$mfacts" | head -1)

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -441,11 +441,18 @@ indistinguishable from roborev's own text, so a reviewed branch can carry text M
 that delivery wording and an authorizer would read it as roborev's. A human in the loop is
 not a channel separation; it is the same shared channel with a slower parser. So the
 prompt is read for the STRUCTURAL fact it reports, never as proof of its own provenance.
-The TOKEN ACCOUNTING has the opposite property: it is recorded BY THE DAEMON and nothing
-the reviewed branch can write changes it, so it CORROBORATES where the prompt cannot — it
-is NOT a mere fallback for a missing prompt. The two are COMPLEMENTARY rather than ranked:
-where both exist an authorizer should want both, and a request offering only one should
-say which is missing and why.
+THE TOKEN ACCOUNTING IS DAEMON-RECORDED BUT NOT INDEPENDENT, AND IT DOES NOT ESTABLISH
+DELIVERY EITHER. The RECORD is authentic — the daemon writes the counts and the reviewed
+branch cannot rewrite them. Their VALUE is a different claim: the counts measure THE
+PROMPT, and the prompt embeds repository-controlled content, so a branch influences their
+MAGNITUDE without forging anything. That bites exactly where the counts are used — the
+vacuous baseline is about 18.7k input / 0 cached, so padding non-diff prompt content can
+make a review that never received the diff look token-rich. So NEITHER SIGNAL ESTABLISHES
+PROVENANCE, and the two are NOT INDEPENDENT: both are functions of the same
+repository-influenced prompt. The prompt still LEADS and a request should still lead with
+it, with the counts read ALONGSIDE it as a consistency check — never as unforgeable
+corroboration. What evidence SHOULD be required before granting is an OPEN QUESTION,
+PENDING on #3654, and is deliberately not settled here.
 
 THIS RESURRECTS NOTHING OF THE DELETED DELIVERY CLASSIFIER, and the distinction is
 load-bearing rather than a caveat. The classifier failed because it inferred delivery

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -428,12 +428,23 @@ retrieved later, even though the snapshot file it names is transient and long de
 
     roborev show <id> --prompt
 
-A delivery-by-path prompt says so in its own words, under '### Combined Diff' — 'Diff
-too large to include inline ... Read the diff from: <path>' — which is DIRECT evidence
-that a diff was delivered. Token accounting is INFERENCE: a large number is CONSISTENT
-with a real review, nothing more. So the record's stored prompt is the PREFERRED
-evidence in an absence-waiver request and a request should LEAD with it; the token
-accounting is the FALLBACK, for when the prompt cannot be retrieved.
+Under '### Combined Diff' a delivery-by-path prompt carries roborev's own wording — 'Diff
+too large to include inline ... Read the diff from: <path>'. That is the DIRECT ARTIFACT:
+roborev's ACTUAL prompt rather than a statistic about it, and it is what an absence-waiver
+request should LEAD with.
+
+IT IS NOT SELF-AUTHENTICATING, AND THE TRUST PROPERTIES RUN THE OPPOSITE WAY FROM THE
+OBVIOUS READING. roborev's prompt EMBEDS repository-controlled content — project
+guidelines, AGENTS.md, additional context, previous-review bodies — at positions
+indistinguishable from roborev's own text, so a reviewed branch can carry text MIMICKING
+that delivery wording and an authorizer would read it as roborev's. A human in the loop is
+not a channel separation; it is the same shared channel with a slower parser. So the
+prompt is read for the STRUCTURAL fact it reports, never as proof of its own provenance.
+The TOKEN ACCOUNTING has the opposite property: it is recorded BY THE DAEMON and nothing
+the reviewed branch can write changes it, so it CORROBORATES where the prompt cannot — it
+is NOT a mere fallback for a missing prompt. The two are COMPLEMENTARY rather than ranked:
+where both exist an authorizer should want both, and a request offering only one should
+say which is missing and why.
 
 THIS RESURRECTS NOTHING OF THE DELETED DELIVERY CLASSIFIER, and the distinction is
 load-bearing rather than a caveat. The classifier failed because it inferred delivery
@@ -529,6 +540,25 @@ fail a run. THE MARKER GRAMMAR IS DELIBERATELY UNCHANGED: no machine field was a
 it, in either marker kind. The authorizer would have to know the value, it is derivable
 from the record, and every field in a hand-typed control line is one more way for a
 legitimate authorization to read MALFORMED.
+
+DECLARED BOUNDARY — WHAT THE 'job=' BINDING DOES NOT CLOSE, AND WHY IT IS NOT CLOSED HERE
+(#3654). CLAIMED: within ONE daemon, base+head+job names one review, and '--recheck-job'
+re-decides THAT record. NOT CLAIMED: that a marker cannot cross boxes. The marker travels
+through GITHUB, not through the daemon, while '--recheck-job <id>' reads the LOCAL
+daemon's record for that id — so if two boxes hold the SAME id for the SAME git_ref range,
+a waiver granted after an authorizer inspected box A's review is ACCEPTED on box B against
+box B's DIFFERENT review: sha-assert passes, the id matches, and the authorization crosses
+reviews. 'A repeated id cannot reach another box's recheck' is true of the RECORD and
+IRRELEVANT to the MARKER, which is the thing that actually travels. Not exotic on this
+fleet: ids have already collided at 265, and two lanes reviewing one branch has happened.
+
+IT IS NOT CLOSED HERE because closing it means adding a field to a HAND-TYPED CONTROL
+LINE, which this issue's own disposition forbids — so it is a DESIGN CALL, escalated to
+the owner and PENDING on #3654, not something this change may decide. THE MITIGATION THAT
+EXISTS TODAY IS OPERATIONAL, NOT MECHANICAL: the block NAMES the issuing daemon, so an
+authorizer comparing 'job-machine:' between the request and the recheck SEES a cross-box
+mismatch — which is why the key exists at all. It is informational and CANNOT enforce: a
+reader who does not compare it is stopped by nothing.
 
 THREE THINGS STOP THE DOCUMENTATION BECOMING THE CREDENTIAL. (1) The marker must BE the
 line: an indented, '>'-quoted, bulleted or mid-sentence copy does not match, so pasting

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -1456,12 +1456,18 @@ read_job_record() { # read_job_record <job> -> populates FACTS_FILE / PROMPT_FIL
 # does not name its own branch; and a branch holding more than `--limit 50` jobs. Each lands on
 # `NOT RECORDED` with its own cause named, which is why that value explains itself rather than
 # merely reporting an absence.
+# TWO GLOBALS, NOT STDOUT, AND THAT IS LOAD-BEARING. This first PRINTED the uuid and was called in
+# a command substitution — so the SUBSHELL's assignment to `JOB_MACHINE_MISS` never reached the
+# parent and every miss rendered the generic cause instead of the one it had just measured (caught
+# by case jm15). A result that is two values does not fit one channel.
+JOB_MACHINE_ID=""
 JOB_MACHINE_MISS=""
-read_machine_fact() { # read_machine_fact <job> -> prints the daemon uuid, or nothing (+ JOB_MACHINE_MISS)
+read_machine_fact() { # read_machine_fact <job> -> sets JOB_MACHINE_ID | JOB_MACHINE_MISS
   local mfacts="$FACTS_FILE.machine" mprompt="$FACTS_FILE.machine.prompt" json="" id="" job_branch=""
+  JOB_MACHINE_ID=""
   JOB_MACHINE_MISS=""
   id=$(fact source_machine_id)
-  if [ -n "$id" ]; then printf '%s' "$id"; return 0; fi
+  if [ -n "$id" ]; then JOB_MACHINE_ID="$id"; return 0; fi
   job_branch=$(fact branch)
   if [ -z "$job_branch" ]; then
     JOB_MACHINE_MISS="the job record does not name its own branch, and the daemon's job list is branch-filtered, so the lookup could not be scoped to this job; it was deliberately NOT retried against the branch this invocation is on, which would answer about a different branch"
@@ -1485,7 +1491,7 @@ read_machine_fact() { # read_machine_fact <job> -> prints the daemon uuid, or no
     JOB_MACHINE_MISS="neither the job record nor the daemon's job list for branch '$job_branch' carries source_machine_id"
     return 1
   fi
-  printf '%s' "$id"
+  JOB_MACHINE_ID="$id"
 }
 
 # REQUIRED to stop polling: the fields without which an assert cannot run at all.
@@ -1558,9 +1564,10 @@ TOK_OUT=$(fact output_tokens)
 # actions, and collapsing them onto one value is the shape this repository keeps paying for. The
 # key is INFORMATIONAL — it is in neither the verdict-grammar scan nor the affirmation loop — so
 # none of these three can red an otherwise-clean run.
-JOB_MACHINE_ID=""
+# CALLED IN THIS SHELL, NEVER IN A COMMAND SUBSTITUTION: it reports a uuid AND, when there is none,
+# the cause it measured — and a subshell would discard the second (see read_machine_fact).
 if [ "$announce_ok" -eq 1 ]; then
-  JOB_MACHINE_ID=$(read_machine_fact "$JOB" || printf '')
+  read_machine_fact "$JOB" || true
 fi
 # THE SPLIT IS "WAS A RECORD READ", NOT "IS IT COMPLETE" (#3654 round 2). This used to branch on
 # `record_required_present`, which asks about COMPLETENESS — so a record that WAS read but is

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -83,7 +83,7 @@
 #
 #   ==== ROBOREV REVIEW SUMMARY ====
 #   repo: / branch: / base: / head-sha: / reviewed-sha: / assert-base: / job: /
-#   model: / census: /
+#   job-machine: / model: / census: /
 #   tokens: / push-assert: / census-check: / code-free: / job-record: /
 #   sha-assert: / review-completed: / prompt-content: /
 #   vacuity-tier1: / vacuity-tier2: / findings: / [deferral:] / roborev-exit: / log:
@@ -184,6 +184,29 @@
 #   roborev-exit      PASS | FINDINGS (exit N) | ERROR (exit N) | SKIP
 #   model             <model> | <model> (SUBSTITUTED — requested '<r>') |
 #                     <model> (UNCONFIRMED — no model field in the job record) | -
+#   job-machine       <uuid> (source_machine_id; job ids are per-daemon) |
+#                     NOT RECORDED (...) | UNAVAILABLE (...)
+#                     WHICH DAEMON ISSUED THE `job:` ID ABOVE (#3654). INFORMATIONAL, exactly
+#                     like `census:`/`tokens:`/`waiver:` — it is in neither the verdict-grammar
+#                     scan nor the affirmation loop (both enumerate the verdict-carrying keys by
+#                     name), so it can never make a run pass or fail; a `NOT RECORDED` or
+#                     `UNAVAILABLE` here beside affirmative keys still reaches RESULT: PASS.
+#                     WHY IT EXISTS: **roborev job ids are PER-DAEMON, not global.** Each fleet
+#                     box runs its own daemon with its own database and its own sequential ids,
+#                     so two boxes can legitimately present the SAME id for DIFFERENT reviews —
+#                     measured, `job=265` on two lanes 50 minutes apart — and a coordination lead
+#                     read the repetition as a collision and WITHHELD a valid absence waiver. A
+#                     pasted block is read by people who are not on the box, so it names the
+#                     daemon. It is NOT an authorization field and NOT a uniqueness proof: the
+#                     binding that identifies a review is the record's `git_ref` (see
+#                     `reviewed-sha:`), and the marker grammar is deliberately UNCHANGED — no
+#                     machine field was added to it, because every field in a hand-typed control
+#                     line is another way for a legitimate authorization to read MALFORMED.
+#                     THE THREE STATES ARE AFFIRMATIVE AND CLOSED, never blank: the uuid when a
+#                     record carried `source_machine_id`; `NOT RECORDED` when a job record WAS
+#                     read and carries none (a REAL state — `roborev show <id> --json` does not
+#                     carry the field at all; `roborev list --json` rows do); `UNAVAILABLE` when
+#                     no job record could be read, naming the `job-record:` state it inherits.
 #   census            `<N> file(s), +<A>/-<D>` | -
 #   tokens            `input=<n> cached=<n> output=<n>` | UNAVAILABLE
 # FINDINGS means the reviewer RAN and reported findings (a GENUINE review to triage and
@@ -225,7 +248,7 @@
 # range), `review-completed` (job status + an allow-list of terminal verdict markers),
 # `prompt-content` (the CODE subset of our census inside the prompt actually sent). Prose matching (`vacuity-tier1`) and token accounting (`vacuity-tier2`)
 # CORROBORATE; tier 1 can only ever raise a NOTICE. `base:`, `head-sha:`, `reviewed-sha:`,
-# `assert-base:`, `census:`, `tokens:`, `waiver:` and `deferral:` are INFORMATIONAL — they are in neither
+# `assert-base:`, `job-machine:`, `census:`, `tokens:`, `waiver:` and `deferral:` are INFORMATIONAL — they are in neither
 # the verdict-grammar scan nor the affirmation loop (both enumerate the verdict-carrying keys
 # by name), so none of them can make a run pass or fail on its own.
 #
@@ -399,6 +422,28 @@ census paths in the prompt, so both FAIL. What distinguishes them is a HUMAN plu
 review's token accounting (genuine reviews measured 398k-649k input / 314k-554k cached;
 the vacuous baseline is ~18.7k input / 0 cached).
 
+THAT SENTENCE IS TRUE AT REVIEW TIME AND FALSE AFTER THE FACT, WHICH IS WHERE THE BEST
+EVIDENCE IS (#3654). The prompt roborev SENT is retained in the job record and can be
+retrieved later, even though the snapshot file it names is transient and long deleted:
+
+    roborev show <id> --prompt
+
+A delivery-by-path prompt says so in its own words, under '### Combined Diff' — 'Diff
+too large to include inline ... Read the diff from: <path>' — which is DIRECT evidence
+that a diff was delivered. Token accounting is INFERENCE: a large number is CONSISTENT
+with a real review, nothing more. So the record's stored prompt is the PREFERRED
+evidence in an absence-waiver request and a request should LEAD with it; the token
+accounting is the FALLBACK, for when the prompt cannot be retrieved.
+
+THIS RESURRECTS NOTHING OF THE DELETED DELIVERY CLASSIFIER, and the distinction is
+load-bearing rather than a caveat. The classifier failed because it inferred delivery
+MODE from injectable prompt text AT DECISION TIME, to produce an AUTOMATED verdict —
+roborev's prompt embeds repository-controlled content, so that inference was spoofable
+in both directions. What is described here is a HUMAN reading a STORED record as
+evidence for a HAND-GRANTED waiver: no automated verdict is derived from it, so there
+is nothing to spoof into a PASS. Nothing in this wrapper parses the prompt for delivery
+mode, and nothing may be added that does.
+
 THE WAIVER, therefore: the OWNER or the coordination LEAD may excuse an absence FAIL
 with a PR comment that carries this as a DEDICATED LINE, at column zero, all four
 fields present:
@@ -440,6 +485,44 @@ its base, and binding to the tip made a waiver go STALE the instant the base ref
 which is what made this mechanism a dead letter under fleet load. The authorizer's judgment under (d) was about ONE review and
 its token accounting, so the waiver may not outlive it — a push, a different base or a
 re-run each need a fresh one. A marker missing any field is MALFORMED, never granted.
+
+JOB IDS ARE PER-DAEMON, NOT GLOBAL, SO VERIFY THE RECORD'S git_ref AND NEVER THE ID
+ALONE (#3654). Every fleet box runs its own roborev daemon with its own database and its
+own sequential ids, so two boxes can legitimately present the SAME id for DIFFERENT
+reviews — measured: 'job=265' on two lanes 50 minutes apart, different ranges, different
+branches, different token counts, both correct. A repeated id is therefore NOT evidence
+of a collision; reading it as one cost a valid waiver a round. The check that settles it:
+
+    roborev show <id> --json | jq '.job | {id, git_ref, branch, status, token_usage}'
+    roborev list --json --repo <abs-repo> --branch <branch> | jq '.[] | select(.id==<id>) | {id, source_machine_id, git_ref, branch}'
+
+git_ref MUST equal the marker's <base40>..<head40>. TWO TRAPS IN THOSE COMMANDS, both
+measured on roborev v0.61.2: (1) 'show <id> --json' NESTS git_ref/status/token_usage
+under '.job' and does not carry source_machine_id ANYWHERE, so a top-level jq over that
+payload prints nulls for all four — a check whose output cannot show what it claims;
+(2) 'roborev list' filters by the CURRENT BRANCH by default, so pass --branch explicitly
+or a correct query returns null.
+
+AND A LOCAL ROW COUNT IS NOT EVIDENCE OF UNIQUENESS. This, which reads like a collision
+check, is not one:
+
+    roborev list --json ... | jq '[.[] | select(.id==<id>)] | length'    # always 1
+
+'roborev list' only ever sees the LOCAL daemon, so it returns 1 whether or not another
+box holds the same id. It is structurally incapable of detecting the cross-box collision
+it appears to rule out — a probe whose output is IDENTICAL under the two states it claims
+to separate, the same class as reading the gate's 'RESULT: INCOMPLETE' launch sentinel as
+a verdict, or locating a gate run directory with 'ls -t'. Run on both of the 'job=265'
+lanes, it gave the right answer for a reason that did not hold. Use git_ref.
+
+THE BLOCK NAMES THE DAEMON, so a pasted artifact is self-describing for a reader who is
+not on the box: 'job-machine:' sits beside 'job:' and reports source_machine_id when a
+record carried it, 'NOT RECORDED' when a record was read and carries none, and
+'UNAVAILABLE' when no record could be read. It is INFORMATIONAL and can never pass or
+fail a run. THE MARKER GRAMMAR IS DELIBERATELY UNCHANGED: no machine field was added to
+it, in either marker kind. The authorizer would have to know the value, it is derivable
+from the record, and every field in a hand-typed control line is one more way for a
+legitimate authorization to read MALFORMED.
 
 THREE THINGS STOP THE DOCUMENTATION BECOMING THE CREDENTIAL. (1) The marker must BE the
 line: an indented, '>'-quoted, bulleted or mid-sentence copy does not match, so pasting
@@ -705,6 +788,10 @@ JOB="-"
 MODEL_LINE="-"
 CENSUS="-"
 TOKENS="UNAVAILABLE"
+# WHICH DAEMON ISSUED THE JOB ID (#3654). Initialised to the state a run that never reached a job
+# record is actually in — never blank, and never a bare `-`, which would read as "no daemon" rather
+# than "nothing was read". Recomputed once, below, from the facts the record read produced.
+JOB_MACHINE="UNAVAILABLE (no job record was read — job-record: SKIP)"
 # Populated by roborev_census (in the sourced oracles file); declared here so the
 # array always exists even if that oracle ever returns before filling it.
 # shellcheck disable=SC2034 # read in roborev-review-oracles.sh, not here
@@ -903,6 +990,15 @@ emit_summary() {
   # visible rather than inferred. Placed beside `head-sha:`/`reviewed-sha:`, the other endpoints.
   emit_kv 'assert-base' "${RANGE_BASE_SHA:--} (merge-base of $BASE and HEAD; $BASE tip ${BASE_TIP_SHA:--})"
   emit_kv 'job' "$JOB"
+  # ===== WHICH DAEMON'S JOB ID THAT IS (#3654) =====
+  # INFORMATIONAL, exactly like `assert-base:`/`census:`/`tokens:` — NOT in the verdict-grammar scan
+  # and NOT in the affirmation loop (both enumerate the verdict-carrying keys by name), so it can
+  # never make a run pass or fail on its own. Emitted UNCONDITIONALLY and beside `job:`, because the
+  # thing it disambiguates is the value on the line above it: roborev job ids are PER-DAEMON, and a
+  # block is pasted into PR threads read by people who are not on the box. A conditional emit would
+  # reproduce the defect — a reader with no `job-machine:` line cannot tell "this daemon was not
+  # recorded" from "this wrapper does not report it".
+  emit_kv 'job-machine' "$JOB_MACHINE"
   emit_kv 'model' "$MODEL_LINE"
   emit_kv 'census' "$CENSUS"
   emit_kv 'tokens' "$TOKENS"
@@ -1268,6 +1364,37 @@ read_job_record() { # read_job_record <job> -> populates FACTS_FILE / PROMPT_FIL
   return 1
 }
 
+# ===== WHICH DAEMON ISSUED THIS JOB ID — A SUPPLEMENTARY, ISOLATED READ (#3654) =====
+# `source_machine_id` is carried by `roborev list --json` ROWS ONLY: measured on roborev v0.61.2,
+# `roborev show <id> --json` does not carry it anywhere, not even in its nested `job` object. And
+# `read_job_record` above STOPS at the first payload that answers, which on a healthy daemon is
+# `show` — so a machine id read only through that loop would be `NOT RECORDED` on EVERY real run,
+# i.e. a key that reports nothing while looking like it reports something. Hence one extra `list`
+# read, and ONLY when the record already read did not carry the field.
+#
+# ISOLATED ON PURPOSE: it writes to its OWN scratch facts file and never to `$FACTS_FILE`, so it
+# cannot change any fact an assert reads, cannot change which row the record loop chose, and cannot
+# move a verdict. It runs AFTER the record poll loop has settled, so it also cannot perturb the
+# transient-read modelling above it. A failure here is not an error — it yields no id, and the key
+# says so affirmatively.
+read_machine_fact() { # read_machine_fact <job> -> prints the daemon uuid, or nothing
+  local mfacts="$FACTS_FILE.machine" mprompt="$FACTS_FILE.machine.prompt" json="" id=""
+  id=$(fact source_machine_id)
+  if [ -n "$id" ]; then printf '%s' "$id"; return 0; fi
+  json=$(roborev list --json --limit 50 --repo "$REPO" 2>/dev/null || printf '')
+  [ -n "$json" ] || return 1
+  : >"$mfacts"
+  : >"$mprompt"
+  if ! extract_job_facts "$1" "$json" "$mfacts" "$mprompt"; then
+    rm -f "$mfacts" "$mprompt"
+    return 1
+  fi
+  id=$(sed -n 's/^source_machine_id=//p' "$mfacts" | head -1)
+  rm -f "$mfacts" "$mprompt"
+  [ -n "$id" ] || return 1
+  printf '%s' "$id"
+}
+
 # REQUIRED to stop polling: the fields without which an assert cannot run at all.
 if [ "$announce_ok" -eq 1 ]; then
   record_polls=0
@@ -1330,6 +1457,25 @@ TOKEN_STATE=$(fact token_state)
 TOK_IN=$(fact input_tokens)
 TOK_CACHED=$(fact cached_input_tokens)
 TOK_OUT=$(fact output_tokens)
+
+# ===== `job-machine:` — THREE AFFIRMATIVE STATES, NEVER BLANK, NEVER FAILING (#3654) =====
+# The states are decided here, once, so the emit site has nothing to infer. Ordered
+# id-then-record-then-nothing, and the last two are told apart by whether a job record was READ at
+# all: "the record does not carry the field" and "there is no record" are different operator
+# actions, and collapsing them onto one value is the shape this repository keeps paying for. The
+# key is INFORMATIONAL — it is in neither the verdict-grammar scan nor the affirmation loop — so
+# none of these three can red an otherwise-clean run.
+JOB_MACHINE_ID=""
+if [ "$announce_ok" -eq 1 ]; then
+  JOB_MACHINE_ID=$(read_machine_fact "$JOB" || printf '')
+fi
+if [ -n "$JOB_MACHINE_ID" ]; then
+  JOB_MACHINE="$JOB_MACHINE_ID (source_machine_id; job ids are per-daemon)"
+elif record_required_present; then
+  JOB_MACHINE="NOT RECORDED (a job record was read but carries no source_machine_id; 'roborev list --json' rows carry that field, 'roborev show <id> --json' does not. Identify the review by the record's git_ref, never by the id alone)"
+else
+  JOB_MACHINE="UNAVAILABLE (no job record could be read, so the issuing daemon is unknown — job-record: $JOB_RECORD)"
+fi
 
 # The sanctioned form reviews a RANGE, so the job record's `git_ref` is
 # `<base40>..<head40>` and BOTH endpoints are asserted — strictly stronger than the

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -828,10 +828,6 @@ JOB="-"
 MODEL_LINE="-"
 CENSUS="-"
 TOKENS="UNAVAILABLE"
-# WHICH DAEMON ISSUED THE JOB ID (#3654). Initialised to the state a run that never reached a job
-# record is actually in — never blank, and never a bare `-`, which would read as "no daemon" rather
-# than "nothing was read". Recomputed once, below, from the facts the record read produced.
-JOB_MACHINE="UNAVAILABLE (no job record was read — job-record: SKIP)"
 # Was a job record READ at all (any payload, complete or not)? Distinct from `record_required_present`,
 # which answers about COMPLETENESS — see the `job-machine:` state selection below (#3654 round 2).
 JOB_RECORD_READ=0
@@ -852,6 +848,18 @@ PUSH_ASSERT="SKIP"
 CENSUS_CHECK="SKIP"
 CODE_FREE="SKIP"
 JOB_RECORD="SKIP"
+# WHICH DAEMON ISSUED THE JOB ID (#3654). Initialised to the state a run that never reached a job
+# record is actually in — never blank, and never a bare `-`, which would read as "no daemon" rather
+# than "nothing was read". Recomputed once, below, from the facts the record read produced.
+#
+# IT INTERPOLATES `$JOB_RECORD` RATHER THAN HARD-CODING `SKIP`, and it is declared HERE, directly
+# after that variable, for two reasons that are one reason: a hard-coded `SKIP` made an abort
+# between the record poll and the recompute emit `job-record: PASS` beside
+# `job-machine: UNAVAILABLE (... job-record: SKIP)` — two keys contradicting each other about the
+# same fact — while interpolating it at the ORIGINAL site read `$JOB_RECORD` twenty lines before it
+# exists, which under `set -u` aborts the wrapper outright. Keeping the two adjacent is what stops
+# either failure returning.
+JOB_MACHINE="UNAVAILABLE (no job record was read — job-record: $JOB_RECORD)"
 SHA_ASSERT="SKIP"
 # The POSITIVE "a review actually happened" assert. Absence of a vacuous phrase is
 # NOT evidence a review occurred: a transcript that only says "Waiting for job N to
@@ -1437,7 +1445,7 @@ read_job_record() { # read_job_record <job> -> populates FACTS_FILE / PROMPT_FIL
 # transient-read modelling above it. A failure here is not an error — it yields no id, and the key
 # says so affirmatively.
 #
-# IT IS SCOPED TO THE RECORD'S OWN BRANCH, NOT TO THE AMBIENT ONE (#3654 round 2). `roborev list`
+# IT IS SCOPED TO THE RECORD'S OWN BRANCH, NOT TO THE CHECKOUT'S (#3654 round 2). `roborev list`
 # is BRANCH-FILTERED and its default follows the CURRENT HEAD OF THE `--repo` PATH; `$BRANCH` is
 # read from that same HEAD, so both name the branch the CHECKOUT is on and neither names the JOB's
 # — so scoping by it answers about a DIFFERENT branch whenever the job was enqueued elsewhere, and

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -875,8 +875,17 @@ JOB_RECORD="SKIP"
 JOB_MACHINE=""
 job_machine_value() { # the job-machine: value, resolved against the CURRENT job-record state
   # A computed state wins; otherwise the run never reached the recompute, and the honest thing to
-  # report is the job-record state AS IT STANDS NOW, not as it stood at initialization.
+  # report is the state AS IT STANDS NOW, not as it stood at initialization.
   if [ -n "$JOB_MACHINE" ]; then printf '%s' "$JOB_MACHINE"; return 0; fi
+  # ROUND 4: THE FALLBACK MUST ALSO CONSULT WHETHER A RECORD WAS READ. Reporting a flat
+  # `UNAVAILABLE (no job record was read)` on every abort is FALSE whenever the run died AFTER the
+  # record poll — a record WAS read, and the only thing missing is the daemon lookup. That is the
+  # same mis-attribution as round 2's (collapsing read-failure onto field-absence): two different
+  # facts flattened into one affirmative sentence.
+  if [ "${JOB_RECORD_READ:-0}" -eq 1 ]; then
+    printf 'NOT RECORDED (a job record WAS read, but the run ended before the daemon lookup completed, so the issuing daemon was never determined — job-record: %s)' "$JOB_RECORD"
+    return 0
+  fi
   printf 'UNAVAILABLE (no job record was read — job-record: %s)' "$JOB_RECORD"
 }
 SHA_ASSERT="SKIP"

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -528,6 +528,16 @@ to separate, the same class as reading the gate's 'RESULT: INCOMPLETE' launch se
 a verdict, or locating a gate run directory with 'ls -t'. Run on both of the 'job=265'
 lanes, it gave the right answer for a reason that did not hold. Use git_ref.
 
+WHAT THE git_ref CHECK SETTLES, AND WHAT IS NOT CLAIMED (#3654). It settles that the id
+names the review you think it does ON THIS DAEMON. It does NOT settle the cross-box
+question: two daemons can hold the SAME id for the SAME git_ref range, so a waiver
+authorized against machine A's review can be accepted by '--recheck-job' against machine
+B's DIFFERENT review of that range — and no local lookup can detect it, because
+'roborev list' only ever sees the LOCAL daemon. The marker travels through GITHUB while
+'--recheck-job' reads the local daemon, so nothing here binds an authorization to one
+BOX. That residual is NOT CLAIMED and NOT closed here: closing it is #3825, which carries
+the 'job-machine:' key and the marker-grammar question that comes with it.
+
 THREE THINGS STOP THE DOCUMENTATION BECOMING THE CREDENTIAL. (1) The marker must BE the
 line: an indented, '>'-quoted, bulleted or mid-sentence copy does not match, so pasting
 a block or quoting an example grants nothing. (2) A placeholder reason is refused — an

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -433,9 +433,12 @@ load-bearing rather than a caveat. The classifier failed because it inferred del
 MODE from injectable prompt text AT DECISION TIME, to produce an AUTOMATED verdict —
 roborev's prompt embeds repository-controlled content, so that inference was spoofable
 in both directions. What is described here is a HUMAN reading a STORED record as
-evidence for a HAND-GRANTED waiver: no automated verdict is derived from it, so there
-is nothing to spoof into a PASS. Nothing in this wrapper parses the prompt for delivery
-mode, and nothing may be added that does.
+evidence for a HAND-GRANTED waiver, so the direct PARSER exploit is gone: nothing in
+this wrapper parses the prompt for delivery mode, and nothing may be added that does.
+THAT IS ALL IT BUYS. The human is IN the path, not outside it — spoofed
+repository-controlled prompt text can mislead an authorizer into issuing the marker, and
+the marker is what makes '--recheck-job' pass. That exposure is #3826's subject and is
+NOT settled here.
 
 THE WAIVER, therefore: the OWNER or the coordination LEAD may excuse an absence FAIL
 with a PR comment that carries this as a DEDICATED LINE, at column zero, all four

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -1298,11 +1298,17 @@ fact() { sed -n "s/^$1=//p" "$FACTS_FILE" | head -1; }
 #     requested_model / token_usage / verdict at TOP level.
 #   * `roborev show <id> --json` returns a REVIEW row — agent, closed, created_at, id,
 #     job, job_id, output, prompt, uuid, verdict_bool — that NESTS the job row under a
-#     `job` key. Its own `id` equals the job id, so a first-id-match lookup returned
-#     the OUTER row, which carries none of those fields; that looked like an empty
-#     record and silently weakened FOUR asserts at once on a NORMAL run (sha-assert
-#     fell back to prose, review-completed to the transcript alone, tier 2 to
-#     UNAVAILABLE, model to UNCONFIRMED).
+#     `job` key. Its `job_id` (and the nested `job.id`) equal the job asked for, so a
+#     first-match lookup returned the OUTER row, which carries none of those fields;
+#     that looked like an empty record and silently weakened FOUR asserts at once on a
+#     NORMAL run (sha-assert fell back to prose, review-completed to the transcript
+#     alone, tier 2 to UNAVAILABLE, model to UNCONFIRMED).
+#     ITS TOP-LEVEL `id` IS THE REVIEW ROW'S OWN SEQUENCE AND NEED NOT EQUAL THE JOB
+#     (#3654). Measured over records 1-10 on v0.61.2: six agree, and two PAIRS swap —
+#     asking for 8 returns `id=9`, asking for 9 returns `id=8`, likewise 6/7 — while
+#     `job_id` and `job.id` name the requested job in every one of the ten. This
+#     comment used to assert the top-level `id` equalled the job, which
+#     contradicted the help text one file over; doctrine decays exactly like a comment.
 # roborev-job-facts.py now prefers an id match that carries `git_ref`, so the record is
 # complete in ONE read. The loop below is therefore a short SANITY RETRY (it covers a
 # transient read failure and a not-yet-terminal status), never a wait on a write race.

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -422,7 +422,8 @@ census paths in the prompt, so both FAIL. What distinguishes them is a HUMAN plu
 review's token accounting (genuine reviews measured 398k-649k input / 314k-554k cached;
 the vacuous baseline is ~18.7k input / 0 cached).
 
-THAT SENTENCE IS TRUE AT REVIEW TIME AND FALSE AFTER THE FACT, WHICH IS WHERE THE BEST
+THAT SENTENCE IS TRUE AT REVIEW TIME, AND FALSE AFTER THE FACT ONLY FOR A HUMAN READING
+THE STORED RECORD — IT STAYS TRUE OF THE MACHINE, AND MUST. THAT IS WHERE THE BEST
 EVIDENCE IS (#3654). The prompt roborev SENT is retained in the job record and can be
 retrieved later, even though the snapshot file it names is transient and long deleted:
 

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -828,6 +828,9 @@ TOKENS="UNAVAILABLE"
 # record is actually in — never blank, and never a bare `-`, which would read as "no daemon" rather
 # than "nothing was read". Recomputed once, below, from the facts the record read produced.
 JOB_MACHINE="UNAVAILABLE (no job record was read — job-record: SKIP)"
+# Was a job record READ at all (any payload, complete or not)? Distinct from `record_required_present`,
+# which answers about COMPLETENESS — see the `job-machine:` state selection below (#3654 round 2).
+JOB_RECORD_READ=0
 # Populated by roborev_census (in the sourced oracles file); declared here so the
 # array always exists even if that oracle ever returns before filling it.
 # shellcheck disable=SC2034 # read in roborev-review-oracles.sh, not here
@@ -1394,6 +1397,12 @@ read_job_record() { # read_job_record <job> -> populates FACTS_FILE / PROMPT_FIL
       list) json=$(roborev list --json --limit 50 --repo "$REPO" 2>/dev/null || printf '') ;;
     esac
     extract_job_facts "$1" "$json" "$FACTS_FILE" "$PROMPT_FILE" "$RECORD_OUTPUT_FILE" || continue
+    # A RECORD WAS READ. Tracked SEPARATELY from `record_required_present`, which answers a
+    # DIFFERENT question — completeness — and answering "was anything read?" with it made
+    # `job-machine:` state that no record could be read when one had been (#3654 round 2). Two
+    # questions, two signals; a state that is not an affirmative true statement about what
+    # happened is the diagnostic that stops the next person looking.
+    JOB_RECORD_READ=1
     if record_required_present; then
       rm -f "$best_facts"
       return 0
@@ -1423,34 +1432,59 @@ read_job_record() { # read_job_record <job> -> populates FACTS_FILE / PROMPT_FIL
 # transient-read modelling above it. A failure here is not an error — it yields no id, and the key
 # says so affirmatively.
 #
-# IT NAMES THE BRANCH, AND THE RECORD READ ABOVE DOES NOT. `roborev list` filters by the CURRENT
-# BRANCH by default, and this wrapper is invoked from arbitrary directories with an explicit
-# `--repo` — so a default-scoped read here would resolve nothing whenever the invoking cwd's branch
-# is not the branch under review, and `job-machine:` would read `NOT RECORDED` for a reason that has
-# nothing to do with the record. Naming `$BRANCH` removes that dependence. It is safe HERE and not
-# above precisely because this read is new and informational: nothing asserts on its result, and its
-# worst case is the affirmative `NOT RECORDED` state.
+# IT IS SCOPED TO THE RECORD'S OWN BRANCH, NOT TO THE AMBIENT ONE (#3654 round 2). `roborev list`
+# is BRANCH-FILTERED, and `$BRANCH` is merely the branch this invocation is running on — so scoping
+# by it answers about a DIFFERENT branch whenever the job was enqueued under another name, and
+# `--recheck-job` is exactly where that happens (an older job, a renamed or rebased lane). That
+# would have rendered `NOT RECORDED` for a record that HAS a `source_machine_id`, silently defeating
+# the operator mitigation this key exists for — the documented "compare `job-machine:` between the
+# request and the recheck" — in the one mode it is documented for. So the branch comes from the
+# JOB RECORD (`.job.branch` on `show`, top level on `list`), which is the job's own fact.
+#
+# AND THERE IS NO AMBIENT FALLBACK. When the record does not name its branch the lookup is NOT
+# retried against `$BRANCH`: that would answer about a different branch while looking like an
+# answer about this job — the same defect one layer down. The state says so instead.
+#
+# `--limit 50` IS SOUND ONCE THE BRANCH IS RIGHT, and the bound is per-branch rather than
+# per-daemon: measured on this fleet, the whole daemon database held 31 records across all
+# branches, so 50 jobs on ONE branch is far past anything observed. If it were ever exceeded the
+# result is the affirmative `NOT RECORDED` state with a named cause — never a wrong id, because the
+# extractor matches the job id and returns nothing when it is absent.
 #
 # BOUNDED CASES WHERE IT LEGITIMATELY DOES NOT RESOLVE, so the state is read as information and not
-# as a defect: a roborev build whose `list` rows do not carry `source_machine_id`; a branch with more
-# than `--limit 50` jobs, which pushes this record off the read; and a `--recheck-job` of a job that
-# was enqueued for a DIFFERENT branch. Each lands on `NOT RECORDED`, which is why that value names
-# the payload that carries the field rather than merely reporting an absence.
-read_machine_fact() { # read_machine_fact <job> -> prints the daemon uuid, or nothing
-  local mfacts="$FACTS_FILE.machine" mprompt="$FACTS_FILE.machine.prompt" json="" id=""
+# as a defect: a roborev build whose `list` rows do not carry `source_machine_id`; a record that
+# does not name its own branch; and a branch holding more than `--limit 50` jobs. Each lands on
+# `NOT RECORDED` with its own cause named, which is why that value explains itself rather than
+# merely reporting an absence.
+JOB_MACHINE_MISS=""
+read_machine_fact() { # read_machine_fact <job> -> prints the daemon uuid, or nothing (+ JOB_MACHINE_MISS)
+  local mfacts="$FACTS_FILE.machine" mprompt="$FACTS_FILE.machine.prompt" json="" id="" job_branch=""
+  JOB_MACHINE_MISS=""
   id=$(fact source_machine_id)
   if [ -n "$id" ]; then printf '%s' "$id"; return 0; fi
-  json=$(roborev list --json --limit 50 --repo "$REPO" --branch "$BRANCH" 2>/dev/null || printf '')
-  [ -n "$json" ] || return 1
+  job_branch=$(fact branch)
+  if [ -z "$job_branch" ]; then
+    JOB_MACHINE_MISS="the job record does not name its own branch, and the daemon's job list is branch-filtered, so the lookup could not be scoped to this job; it was deliberately NOT retried against the branch this invocation is on, which would answer about a different branch"
+    return 1
+  fi
+  json=$(roborev list --json --limit 50 --repo "$REPO" --branch "$job_branch" 2>/dev/null || printf '')
+  if [ -z "$json" ]; then
+    JOB_MACHINE_MISS="the daemon returned no job list for this job's own branch '$job_branch'"
+    return 1
+  fi
   : >"$mfacts"
   : >"$mprompt"
   if ! extract_job_facts "$1" "$json" "$mfacts" "$mprompt"; then
     rm -f "$mfacts" "$mprompt"
+    JOB_MACHINE_MISS="job '$1' is not in the daemon's latest 50 jobs for its own branch '$job_branch'"
     return 1
   fi
   id=$(sed -n 's/^source_machine_id=//p' "$mfacts" | head -1)
   rm -f "$mfacts" "$mprompt"
-  [ -n "$id" ] || return 1
+  if [ -z "$id" ]; then
+    JOB_MACHINE_MISS="neither the job record nor the daemon's job list for branch '$job_branch' carries source_machine_id"
+    return 1
+  fi
   printf '%s' "$id"
 }
 
@@ -1528,12 +1562,17 @@ JOB_MACHINE_ID=""
 if [ "$announce_ok" -eq 1 ]; then
   JOB_MACHINE_ID=$(read_machine_fact "$JOB" || printf '')
 fi
+# THE SPLIT IS "WAS A RECORD READ", NOT "IS IT COMPLETE" (#3654 round 2). This used to branch on
+# `record_required_present`, which asks about COMPLETENESS — so a record that WAS read but is
+# nonterminal or incomplete rendered `UNAVAILABLE (no job record could be read)`, a state that is
+# simply FALSE about what happened. Each of the three states has to be an affirmative TRUE statement
+# or the key is worse than absent, so the read is tracked on its own signal.
 if [ -n "$JOB_MACHINE_ID" ]; then
   JOB_MACHINE="$JOB_MACHINE_ID (source_machine_id; job ids are per-daemon)"
-elif record_required_present; then
-  JOB_MACHINE="NOT RECORDED (a job record was read but carries no source_machine_id; 'roborev list --json' rows carry that field, 'roborev show <id> --json' does not. Identify the review by the record's git_ref, never by the id alone)"
+elif [ "${JOB_RECORD_READ:-0}" -eq 1 ]; then
+  JOB_MACHINE="NOT RECORDED (${JOB_MACHINE_MISS:-a job record was read but carries no source_machine_id}; 'roborev list --json' rows carry that field, 'roborev show <id> --json' does not. Identify the review by the record's git_ref, never by the id alone)"
 else
-  JOB_MACHINE="UNAVAILABLE (no job record could be read, so the issuing daemon is unknown — job-record: $JOB_RECORD)"
+  JOB_MACHINE="UNAVAILABLE (no job record could be read at all, so the issuing daemon is unknown — job-record: $JOB_RECORD)"
 fi
 
 # The sanctioned form reviews a RANGE, so the job record's `git_ref` is

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -856,10 +856,22 @@ JOB_RECORD="SKIP"
 # after that variable, for two reasons that are one reason: a hard-coded `SKIP` made an abort
 # between the record poll and the recompute emit `job-record: PASS` beside
 # `job-machine: UNAVAILABLE (... job-record: SKIP)` — two keys contradicting each other about the
-# same fact — while interpolating it at the ORIGINAL site read `$JOB_RECORD` twenty lines before it
-# exists, which under `set -u` aborts the wrapper outright. Keeping the two adjacent is what stops
-# either failure returning.
-JOB_MACHINE="UNAVAILABLE (no job record was read — job-record: $JOB_RECORD)"
+# same fact.
+#
+# ROUND 3 FINDING: INTERPOLATING HERE MOVED THAT BUG INSTEAD OF REMOVING IT. `$JOB_RECORD` is
+# `SKIP` AT THIS POINT, so the expansion captures `SKIP` permanently and an abort after the record
+# poll still emits the contradictory pair. The general rule, which is the part worth keeping: for a
+# value whose whole purpose is to reflect LATER state, no expansion at an EARLY site can ever be
+# right — it has to be BUILT WHEN IT IS READ. So this stays deliberately EMPTY and the fallback is
+# constructed at emit time by `job_machine_value` below. (The `on_exit` EXIT trap emits the block
+# on ANY abort, which is exactly the path that made this reachable.)
+JOB_MACHINE=""
+job_machine_value() { # the job-machine: value, resolved against the CURRENT job-record state
+  # A computed state wins; otherwise the run never reached the recompute, and the honest thing to
+  # report is the job-record state AS IT STANDS NOW, not as it stood at initialization.
+  if [ -n "$JOB_MACHINE" ]; then printf '%s' "$JOB_MACHINE"; return 0; fi
+  printf 'UNAVAILABLE (no job record was read — job-record: %s)' "$JOB_RECORD"
+}
 SHA_ASSERT="SKIP"
 # The POSITIVE "a review actually happened" assert. Absence of a vacuous phrase is
 # NOT evidence a review occurred: a transcript that only says "Waiting for job N to
@@ -1049,7 +1061,7 @@ emit_summary() {
   # block is pasted into PR threads read by people who are not on the box. A conditional emit would
   # reproduce the defect — a reader with no `job-machine:` line cannot tell "this daemon was not
   # recorded" from "this wrapper does not report it".
-  emit_kv 'job-machine' "$JOB_MACHINE"
+  emit_kv 'job-machine' "$(job_machine_value)"
   emit_kv 'model' "$MODEL_LINE"
   emit_kv 'census' "$CENSUS"
   emit_kv 'tokens' "$TOKENS"

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -1631,7 +1631,7 @@ fi
 if [ -n "$JOB_MACHINE_ID" ]; then
   JOB_MACHINE="$JOB_MACHINE_ID (source_machine_id; job ids are per-daemon)"
 elif [ "${JOB_RECORD_READ:-0}" -eq 1 ]; then
-  JOB_MACHINE="NOT RECORDED (${JOB_MACHINE_MISS:-a job record was read but carries no source_machine_id}; 'roborev list --json' rows carry that field, 'roborev show <id> --json' does not. Identify the review by the record's git_ref, never by the id alone)"
+  JOB_MACHINE="NOT RECORDED (${JOB_MACHINE_MISS:-a job record was read, but the lookup recorded no cause for the missing daemon id — this is a defect in the lookup, not a measurement}; 'roborev list --json' rows carry that field, 'roborev show <id> --json' does not. Identify the review by the record's git_ref, never by the id alone)"
 else
   JOB_MACHINE="UNAVAILABLE (no job record could be read at all, so the issuing daemon is unknown — job-record: $JOB_RECORD)"
 fi

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -513,12 +513,19 @@ branches, different token counts, both correct. A repeated id is therefore NOT e
 of a collision; reading it as one cost a valid waiver a round. The check that settles it:
 
     roborev show <id> --json | jq '.job | {id, git_ref, branch, status, token_usage}'
-    roborev list --json --repo <abs-repo> --branch <branch> | jq '.[] | select(.id==<id>) | {id, source_machine_id, git_ref, branch}'
+    roborev list --json --limit <N> --repo <abs-repo> --branch <branch> | jq '.[] | select(.id==<id>) | {id, source_machine_id, git_ref, branch}'
 
 git_ref MUST equal the marker's <base40>..<head40>. THREE TRAPS IN THOSE COMMANDS, all
 measured on roborev v0.61.2: (1) 'show <id> --json' NESTS git_ref/status/token_usage
 under '.job' and does not carry source_machine_id ANYWHERE, so a top-level jq over that
 payload prints nulls for all four — a check whose output cannot show what it claims;
+(0) 'roborev list' returns only the newest --limit rows (DEFAULT 50) and offers NO offset
+or cursor, so an OLDER job sits BEYOND the first page and the command returns NOTHING
+though the record exists. That is not a corner case: a --recheck-job names an old job by
+construction, and a heavily-reviewed branch accumulates rows, so "the job is deep" and
+"someone is applying a waiver" are the SAME population. RAISE <N> — 50, 200, 800 — until
+the row appears or the list stops growing. THE WRAPPER'S OWN LOOKUP DOES THIS
+AUTOMATICALLY; only this manual form needs the limit raised by hand;
 (2) 'roborev list' defaults its branch filter to the CURRENT HEAD OF THE --repo PATH —
 NOT to the branch your shell is standing in (measured: from a cwd that is not a git
 repository at all, '--repo <lane>' returns that lane's branch's rows) — so pass --branch

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -496,12 +496,18 @@ of a collision; reading it as one cost a valid waiver a round. The check that se
     roborev show <id> --json | jq '.job | {id, git_ref, branch, status, token_usage}'
     roborev list --json --repo <abs-repo> --branch <branch> | jq '.[] | select(.id==<id>) | {id, source_machine_id, git_ref, branch}'
 
-git_ref MUST equal the marker's <base40>..<head40>. TWO TRAPS IN THOSE COMMANDS, both
+git_ref MUST equal the marker's <base40>..<head40>. THREE TRAPS IN THOSE COMMANDS, all
 measured on roborev v0.61.2: (1) 'show <id> --json' NESTS git_ref/status/token_usage
 under '.job' and does not carry source_machine_id ANYWHERE, so a top-level jq over that
 payload prints nulls for all four — a check whose output cannot show what it claims;
 (2) 'roborev list' filters by the CURRENT BRANCH by default, so pass --branch explicitly
-or a correct query returns null.
+or a correct query returns null; (3) the TOP-LEVEL 'id' of a 'show' payload is the REVIEW
+row's own sequence and is NOT necessarily the job you asked for — measured over ten
+records, asking for 9 returns id=8 with job_id=9 and job.id=9. So read '.job' (or
+'job_id'), never the top-level 'id', or the answer manufactures exactly the "is this the
+right review?" doubt this section exists to remove. The wrapper is unaffected: its
+extractor matches id/job_id/job and then PREFERS the object carrying git_ref, so it lands
+on the job row either way — this is a trap for the HUMAN running the check by hand.
 
 AND A LOCAL ROW COUNT IS NOT EVIDENCE OF UNIQUENESS. This, which reads like a collision
 check, is not one:
@@ -1346,6 +1352,15 @@ read_job_record() { # read_job_record <job> -> populates FACTS_FILE / PROMPT_FIL
     local json=""
     case "$payload" in
       show) json=$(roborev show "$1" --json 2>/dev/null || printf '') ;;
+      # ===== THIS READ IS CURRENT-BRANCH-SCOPED, AND DELIBERATELY UNCHANGED (#3654) =====
+      # `roborev list` defaults to "the current repo AND branch" (measured: a bare
+      # `roborev list --json`, and the form below, both return `null` from a branch with no jobs,
+      # while adding `--branch <other>` returns that branch's rows). It is correct here BY
+      # CONSTRUCTION — the wrapper enqueued the review FOR this branch, so the record it is looking
+      # for is on it — and it must NOT grow a `--branch` here: `sha-assert` depends on this read,
+      # and naming the branch is behaviour-neutral only while the invoking cwd's branch equals
+      # `$BRANCH`. Changing it is a separate question from #3654. The supplementary machine read
+      # below is a NEW read and does name the branch; the difference is deliberate and documented there.
       list) json=$(roborev list --json --limit 50 --repo "$REPO" 2>/dev/null || printf '') ;;
     esac
     extract_job_facts "$1" "$json" "$FACTS_FILE" "$PROMPT_FILE" "$RECORD_OUTPUT_FILE" || continue
@@ -1377,11 +1392,25 @@ read_job_record() { # read_job_record <job> -> populates FACTS_FILE / PROMPT_FIL
 # move a verdict. It runs AFTER the record poll loop has settled, so it also cannot perturb the
 # transient-read modelling above it. A failure here is not an error — it yields no id, and the key
 # says so affirmatively.
+#
+# IT NAMES THE BRANCH, AND THE RECORD READ ABOVE DOES NOT. `roborev list` filters by the CURRENT
+# BRANCH by default, and this wrapper is invoked from arbitrary directories with an explicit
+# `--repo` — so a default-scoped read here would resolve nothing whenever the invoking cwd's branch
+# is not the branch under review, and `job-machine:` would read `NOT RECORDED` for a reason that has
+# nothing to do with the record. Naming `$BRANCH` removes that dependence. It is safe HERE and not
+# above precisely because this read is new and informational: nothing asserts on its result, and its
+# worst case is the affirmative `NOT RECORDED` state.
+#
+# BOUNDED CASES WHERE IT LEGITIMATELY DOES NOT RESOLVE, so the state is read as information and not
+# as a defect: a roborev build whose `list` rows do not carry `source_machine_id`; a branch with more
+# than `--limit 50` jobs, which pushes this record off the read; and a `--recheck-job` of a job that
+# was enqueued for a DIFFERENT branch. Each lands on `NOT RECORDED`, which is why that value names
+# the payload that carries the field rather than merely reporting an absence.
 read_machine_fact() { # read_machine_fact <job> -> prints the daemon uuid, or nothing
   local mfacts="$FACTS_FILE.machine" mprompt="$FACTS_FILE.machine.prompt" json="" id=""
   id=$(fact source_machine_id)
   if [ -n "$id" ]; then printf '%s' "$id"; return 0; fi
-  json=$(roborev list --json --limit 50 --repo "$REPO" 2>/dev/null || printf '')
+  json=$(roborev list --json --limit 50 --repo "$REPO" --branch "$BRANCH" 2>/dev/null || printf '')
   [ -n "$json" ] || return 1
   : >"$mfacts"
   : >"$mprompt"

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -487,9 +487,9 @@ branches, different token counts, both correct. A repeated id is therefore NOT e
 of a collision; reading it as one cost a valid waiver a round. The check that settles it:
 
     roborev show <id> --json | jq '.job | {id, git_ref, branch, status, token_usage}'
-    roborev list --json --repo <abs-repo> --branch <branch> | jq '.[] | select(.id==<id>) | {id, git_ref, branch}'
+    roborev list --json --limit 200 --repo <abs-repo> --branch <branch> | jq '.[] | select(.id==<id>) | {id, git_ref, branch}'
 
-git_ref MUST equal the marker's <base40>..<head40>. THREE TRAPS IN THOSE COMMANDS, all
+git_ref MUST equal the marker's <base40>..<head40>. FOUR TRAPS IN THOSE COMMANDS, all
 measured on roborev v0.61.2: (1) 'show <id> --json' NESTS git_ref/status/token_usage
 under '.job', so a top-level jq over that payload prints nulls for all of them — a check
 whose output cannot show what it claims;
@@ -504,14 +504,25 @@ records, asking for 9 returns id=8 with job_id=9 and job.id=9. So read '.job' (o
 right review?" doubt this section exists to remove. The wrapper is unaffected: its
 extractor matches id/job_id/job and then PREFERS the object carrying git_ref, so it lands
 on the job row either way — this is a trap for the HUMAN running the check by hand.
+(4) 'roborev list' returns a BOUNDED WINDOW of the most recent rows — '--limit' defaults
+to 50 (measured: 'roborev list --help', v0.61.2) — so an older job is simply not in a
+default read and the query yields NOTHING though the record exists —
+an absence indistinguishable from 'no such job', which breaks this whole procedure for
+exactly the reviews a waiver argument reaches back to. So pass '--limit' EXPLICITLY and
+RAISE it until the job appears, or until the returned row count STOPS GROWING (at which
+point the window covers the whole local table and the record really is absent). An empty
+result at a limit that is still growing the row count is UNMEASURED, not an answer. This
+is also what the row count below cannot survive: a count of 1 says nothing about the
+window it was taken over.
 
 AND A LOCAL ROW COUNT IS NOT EVIDENCE OF UNIQUENESS. This, which reads like a collision
 check, is not one:
 
-    roborev list --json ... | jq '[.[] | select(.id==<id>)] | length'    # always 1
+    roborev list --json ... | jq '[.[] | select(.id==<id>)] | length'    # never more than 1
 
 'roborev list' only ever sees the LOCAL daemon, so it returns 1 whether or not another
-box holds the same id. It is structurally incapable of detecting the cross-box collision
+box holds the same id — and 0 when the row fell outside the '--limit' window, which is
+not a collision answer either. It is structurally incapable of detecting the cross-box collision
 it appears to rule out — a probe whose output is IDENTICAL under the two states it claims
 to separate, the same class as reading the gate's 'RESULT: INCOMPLETE' launch sentinel as
 a verdict, or locating a gate run directory with 'ls -t'. Run on both of the 'job=265'

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -511,8 +511,11 @@ git_ref MUST equal the marker's <base40>..<head40>. THREE TRAPS IN THOSE COMMAND
 measured on roborev v0.61.2: (1) 'show <id> --json' NESTS git_ref/status/token_usage
 under '.job' and does not carry source_machine_id ANYWHERE, so a top-level jq over that
 payload prints nulls for all four — a check whose output cannot show what it claims;
-(2) 'roborev list' filters by the CURRENT BRANCH by default, so pass --branch explicitly
-or a correct query returns null; (3) the TOP-LEVEL 'id' of a 'show' payload is the REVIEW
+(2) 'roborev list' defaults its branch filter to the CURRENT HEAD OF THE --repo PATH —
+NOT to the branch your shell is standing in (measured: from a cwd that is not a git
+repository at all, '--repo <lane>' returns that lane's branch's rows) — so pass --branch
+explicitly whenever that checkout is not on the job's branch, which is exactly the
+'--recheck-job' case, or a correct query returns null; (3) the TOP-LEVEL 'id' of a 'show' payload is the REVIEW
 row's own sequence and is NOT necessarily the job you asked for — measured over ten
 records, asking for 9 returns id=8 with job_id=9 and job.id=9. So read '.job' (or
 'job_id'), never the top-level 'id', or the answer manufactures exactly the "is this the
@@ -1385,15 +1388,16 @@ read_job_record() { # read_job_record <job> -> populates FACTS_FILE / PROMPT_FIL
     local json=""
     case "$payload" in
       show) json=$(roborev show "$1" --json 2>/dev/null || printf '') ;;
-      # ===== THIS READ IS CURRENT-BRANCH-SCOPED, AND DELIBERATELY UNCHANGED (#3654) =====
-      # `roborev list` defaults to "the current repo AND branch" (measured: a bare
-      # `roborev list --json`, and the form below, both return `null` from a branch with no jobs,
-      # while adding `--branch <other>` returns that branch's rows). It is correct here BY
-      # CONSTRUCTION — the wrapper enqueued the review FOR this branch, so the record it is looking
-      # for is on it — and it must NOT grow a `--branch` here: `sha-assert` depends on this read,
-      # and naming the branch is behaviour-neutral only while the invoking cwd's branch equals
-      # `$BRANCH`. Changing it is a separate question from #3654. The supplementary machine read
-      # below is a NEW read and does name the branch; the difference is deliberate and documented there.
+      # ===== THIS READ IS BRANCH-SCOPED BY DEFAULT, AND DELIBERATELY UNCHANGED (#3654) =====
+      # `roborev list` filters by branch, and its DEFAULT follows the CURRENT HEAD OF THE `--repo`
+      # PATH — not the branch the invoking shell is standing in (measured: from a cwd that is not a
+      # git repository at all, `--repo <lane>` returns that lane's branch's rows, and the same
+      # `--repo` run from another lane returns those same rows). It is correct here BY CONSTRUCTION
+      # for the ordinary case — the wrapper enqueued the review for the `--repo` checkout's own
+      # branch — and it must NOT grow a `--branch` here: `sha-assert` depends on this read, and
+      # changing what it selects is a separate question from #3654. The supplementary machine read
+      # below is a NEW read and scopes to the RECORD's own branch; that difference is deliberate and
+      # documented there, and it is what makes the key work on the recheck path.
       list) json=$(roborev list --json --limit 50 --repo "$REPO" 2>/dev/null || printf '') ;;
     esac
     extract_job_facts "$1" "$json" "$FACTS_FILE" "$PROMPT_FILE" "$RECORD_OUTPUT_FILE" || continue
@@ -1433,8 +1437,9 @@ read_job_record() { # read_job_record <job> -> populates FACTS_FILE / PROMPT_FIL
 # says so affirmatively.
 #
 # IT IS SCOPED TO THE RECORD'S OWN BRANCH, NOT TO THE AMBIENT ONE (#3654 round 2). `roborev list`
-# is BRANCH-FILTERED, and `$BRANCH` is merely the branch this invocation is running on — so scoping
-# by it answers about a DIFFERENT branch whenever the job was enqueued under another name, and
+# is BRANCH-FILTERED and its default follows the CURRENT HEAD OF THE `--repo` PATH; `$BRANCH` is
+# read from that same HEAD, so both name the branch the CHECKOUT is on and neither names the JOB's
+# — so scoping by it answers about a DIFFERENT branch whenever the job was enqueued elsewhere, and
 # `--recheck-job` is exactly where that happens (an older job, a renamed or rebased lane). That
 # would have rendered `NOT RECORDED` for a record that HAS a `source_machine_id`, silently defeating
 # the operator mitigation this key exists for — the documented "compare `job-machine:` between the
@@ -1470,7 +1475,7 @@ read_machine_fact() { # read_machine_fact <job> -> sets JOB_MACHINE_ID | JOB_MAC
   if [ -n "$id" ]; then JOB_MACHINE_ID="$id"; return 0; fi
   job_branch=$(fact branch)
   if [ -z "$job_branch" ]; then
-    JOB_MACHINE_MISS="the job record does not name its own branch, and the daemon's job list is branch-filtered, so the lookup could not be scoped to this job; it was deliberately NOT retried against the branch this invocation is on, which would answer about a different branch"
+    JOB_MACHINE_MISS="the job record does not name its own branch, and the daemon's job list is branch-filtered, so the lookup could not be scoped to this job; it was deliberately NOT retried against the branch this invocation is on, which would answer about a different branch than the job's"
     return 1
   fi
   json=$(roborev list --json --limit 50 --repo "$REPO" --branch "$job_branch" 2>/dev/null || printf '')

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -6197,7 +6197,7 @@ assert_says 'case (jm10) --help says to verify git_ref, never the id alone' "VER
 assert_says 'case (jm10) --help reads git_ref from the payload that HAS it (.job on show)' \
   "roborev show <id> --json \| jq '\.job \| \{id, git_ref"
 assert_says 'case (jm10) --help reads the daemon id from the LIST payload' \
-  "roborev list --json --repo <abs-repo> --branch <branch>"
+  "roborev list --json --limit <N> --repo <abs-repo> --branch <branch>"
 assert_lacks 'case (jm10) --help does NOT prescribe the top-level jq that measures nulls' \
   "show <id> --json \| jq '\{id, git_ref"
 assert_says 'case (jm10) --help warns that the list default follows the --repo HEAD, not the shell' \
@@ -6446,6 +6446,75 @@ assert_says 'case (jm16) an incomplete-but-READ record is NOT RECORDED' '^job-ma
 assert_lacks 'case (jm16) it never claims no record could be read' '^job-machine: UNAVAILABLE'
 assert_says 'case (jm16) the job-record key independently reports the incompleteness' '^job-record: DEGRADED'
 reset_stub
+
+printf '== (jm20) #3654 r5: the DOCUMENTED manual lookup finds a job beyond the first page ==\n'
+# THE CODE MOVED AND THE DOCUMENTATION DID NOT. The depth fix made the WRAPPER expand its own
+# lookup until found-or-exhausted, while the procedure --help tells a HUMAN to run still took the
+# default page — so a lead following our own written instructions on a deep job got an empty result
+# and no indication why, in exactly the case the code had just learned to handle.
+#
+# IT EXECUTES THE DOCUMENTED COMMAND RATHER THAN GREPPING THE HELP FOR A STRING. A string assert
+# would pass on any text mentioning --limit, including a command that still cannot find the row —
+# the same test-narrowness this issue has now paid for four times. So the command is EXTRACTED from
+# --help, its placeholders substituted as a human would substitute them, and RUN against the stub
+# daemon with the target sixty rows deep.
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'SKIP - jq unavailable; the documented lookup could not be executed\n'
+else
+  CASE_N=$((CASE_N + 1))
+  OUT="$tmp/out-$CASE_N.txt"
+  bash "$WRAPPER_REAL" --help >"$OUT" 2>/dev/null
+  _jm20_cmd=$(grep -E '^ *roborev list --json .*select\(\.id==' "$OUT" | head -1 | sed 's/^ *//')
+  if [ -z "$_jm20_cmd" ]; then
+    bad 'case (jm20) --help prints no roborev list lookup command to execute — the documented procedure is gone'
+  else
+    reset_stub
+    STUB_LIST_DEPTH=60
+    STUB_LIST_BRANCH='issue-earlier-lane'
+    STUB_SOURCE_MACHINE_ID="$JM_UUID"
+    # The stub runs `set -uo pipefail` and dereferences STUB_INVOKED unguarded, so it EXITS if the
+    # variable is unset. run_wrapper supplies it per invocation; a direct call must too, or the
+    # daemon double dies and every probe below returns nothing — which the absence-shaped control
+    # would have read as SUCCESS. That happened while writing this case.
+    STUB_INVOKED="$tmp/jm20-invoked.txt"; : >"$STUB_INVOKED"; export STUB_INVOKED
+    _jm20_base=$(printf '%s' "$_jm20_cmd" \
+      | sed -e "s|<abs-repo>|$jm_work|" -e 's|<branch>|issue-earlier-lane|' -e 's|<id>|4656|')
+    # CONTROL 1 — THE DAEMON ANSWERS AT ALL. An absence-shaped control cannot tell "the row is
+    # deeper than this page" from "the double never ran", and those are exactly the two states this
+    # case must distinguish. So the first page is required to come back FULL of the filler rows.
+    if PATH="$stubbin:$PATH" roborev list --json --limit 50 --repo "$jm_work" \
+         --branch issue-earlier-lane 2>/dev/null | grep -q 'filler-not-the-target'; then
+      ok 'case (jm20) control: the stub daemon answers, and the first page is full of other jobs'
+    else
+      bad 'case (jm20) CONTROL: the stub daemon returned no rows at all, so every probe below would report absence for a reason unrelated to depth'
+    fi
+    # CONTROL 2 — AND THE TARGET IS NOT ON THAT PAGE, or the escalation would succeed trivially.
+    _jm20_ctl=$(printf '%s' "$_jm20_base" | sed 's|<N>|50|')
+    if PATH="$stubbin:$PATH" sh -c "$_jm20_ctl" 2>/dev/null | grep -q "$JM_UUID"; then
+      bad 'case (jm20) CONTROL: the row is already on the first page, so the fixture is not deep enough to test depth'
+    else
+      ok 'case (jm20) control: the first page does NOT hold the row, so only an expanding lookup can find it'
+    fi
+    # THE PROCEDURE ITSELF, followed literally: raise the limit until the row appears.
+    _jm20_found=''
+    if printf '%s' "$_jm20_base" | grep -q '<N>'; then
+      for _jm20_n in 50 200 800; do
+        _jm20_run=$(printf '%s' "$_jm20_base" | sed "s|<N>|$_jm20_n|")
+        if PATH="$stubbin:$PATH" sh -c "$_jm20_run" 2>/dev/null | grep -q "$JM_UUID"; then
+          _jm20_found="$_jm20_n"; break
+        fi
+      done
+    elif PATH="$stubbin:$PATH" sh -c "$_jm20_base" 2>/dev/null | grep -q "$JM_UUID"; then
+      _jm20_found=default
+    fi
+    if [ -n "$_jm20_found" ]; then
+      ok "case (jm20) the documented lookup returns the deep job's daemon id (found at limit $_jm20_found)"
+    else
+      bad 'case (jm20) the documented lookup returns NOTHING for a job past the first page — a lead following our own procedure sees an empty result and no reason why, while the wrapper finds it'
+    fi
+    reset_stub
+  fi
+fi
 
 printf '== (jm11) #3654: a `show` payload whose TOP-LEVEL id is NOT the asked job ==\n'
 # MEASURED SHAPE (ten records): top-level `id` is the REVIEW row's own sequence and can differ from

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -6131,8 +6131,8 @@ assert_says 'case (jm10) --help reads the daemon id from the LIST payload' \
   "roborev list --json --repo <abs-repo> --branch <branch>"
 assert_lacks 'case (jm10) --help does NOT prescribe the top-level jq that measures nulls' \
   "show <id> --json \| jq '\{id, git_ref"
-assert_says 'case (jm10) --help warns that list defaults to the current branch' \
-  'filters by the CURRENT BRANCH by default'
+assert_says 'case (jm10) --help warns that the list default follows the --repo HEAD, not the shell' \
+  'defaults its branch filter to the CURRENT HEAD OF THE --repo PATH'
 assert_says 'case (jm10) --help states that a local row count proves nothing' \
   'A LOCAL ROW COUNT IS NOT EVIDENCE OF UNIQUENESS'
 assert_says 'case (jm10) --help names the failure class the row count belongs to' \
@@ -6278,11 +6278,14 @@ else
 fi
 
 printf '== (jm12) #3654 structural: the supplementary machine read NAMES THE BRANCH ==\n'
-# `roborev list` filters by the CURRENT BRANCH by default (measured: a bare list from a branch with
-# no jobs returns null, while --branch <other> returns that branch's rows), and this wrapper is
-# invoked from arbitrary directories with an explicit --repo. A default-scoped machine read would
-# therefore resolve NOTHING whenever the invoking cwd's branch is not the branch under review, and
-# `job-machine:` would read NOT RECORDED for a reason having nothing to do with the record — a key
+# `roborev list` is BRANCH-FILTERED, and its default follows the CURRENT HEAD OF THE `--repo` PATH
+# — measured: from a cwd that is not a git repository at all, `--repo <lane>` returns that lane's
+# branch's rows, and the same `--repo` run from a different lane's branch returns the same rows. So
+# the default is `$BRANCH` (read from that same HEAD), which is the branch the CHECKOUT is on and
+# NOT the job's. The two diverge on exactly the path this key is documented for: a `--recheck-job`
+# of an older job, a renamed or rebased lane, or a checkout since moved on. A default-scoped or
+# `$BRANCH`-scoped machine read then resolves NOTHING for a record that HAS a source_machine_id,
+# and `job-machine:` reads NOT RECORDED for a reason having nothing to do with the record — a key
 # that can only ever report absence. Only a structural assert pins this: every hermetic case runs
 # with the fixture branch checked out, so the stub answers either way.
 _jm_supp=$(sed -n '/^read_machine_fact() {/,/^}/p' "$WRAPPER_REAL")

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -5897,6 +5897,19 @@ assert_lacks 'case (jd1) --help no longer claims the list filters by the shell b
 assert_says 'case (jd1) --help refuses the row-count probe as a collision check' \
   'A LOCAL ROW COUNT IS NOT EVIDENCE OF UNIQUENESS'
 assert_says 'case (jd1) --help says why the probe cannot work' 'only ever sees the LOCAL daemon'
+# THE PRESCRIBED LOOKUP MUST REACH AN OLDER RECORD. `roborev list` returns a BOUNDED WINDOW —
+# `--limit` defaults to 50 (measured: `roborev list --help`, v0.61.2) — so a limitless documented
+# command answers NOTHING for a job outside it, an absence indistinguishable from "no such job",
+# and it is precisely the older reviews a waiver argument reaches back to. It also undercuts the
+# row-count probe next to it: a count of 1 says nothing about the window it was taken over.
+assert_says 'case (jd1) --help gives the documented list lookup an explicit --limit' \
+  'roborev list --json --limit 200 --repo <abs-repo> --branch'
+assert_says 'case (jd1) --help names the bounded window' 'BOUNDED WINDOW of the most recent rows'
+assert_says 'case (jd1) --help says to raise the limit until the job appears' \
+  'RAISE it until the job appears'
+assert_says 'case (jd1) --help gives the stopping rule for raising it' 'row count STOPS GROWING'
+assert_says 'case (jd1) --help calls a truncated empty result UNMEASURED' 'UNMEASURED, not an answer'
+assert_lacks 'case (jd1) --help no longer claims the row count is unconditionally 1' '# always 1'
 # ASK 5, FACTUAL HALF ONLY (policy is #3826): what each signal can and cannot establish.
 assert_says 'case (jd1) --help scopes the after-the-fact cost to a HUMAN reading the record' \
   'ONLY FOR A HUMAN READING'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -6080,19 +6080,39 @@ printf '== (jm9) #3654: the facts tool extracts source_machine_id from `list`, a
 # the unmeasured-value-as-a-value defect this repository fails runs for.
 _jm_tool="$SCRIPT_DIR/../flow/roborev-job-facts.py"
 _jm_facts="$tmp/jm-facts.txt"
+# ===== SUB-CASES SHARE ONE FACTS FILE, SO EACH RUN MUST START FROM AN EMPTY ONE (#3654 r3) =====
+# Every sub-case below ran the tool `|| true` against the SAME `$_jm_facts`. A tool failure
+# therefore left the PREVIOUS sub-case's output in place and the next assert read it — jm11's
+# `git_ref == aaa..bbb` could pass on jm9's stale file, a green that measured nothing. The tally
+# cannot see that, which is the point. Truncating is necessary and NOT sufficient: the sub-cases
+# asserting an ABSENCE (no `source_machine_id`) are satisfied trivially by an empty file, so the
+# tool is also required to have SUCCEEDED and to have produced output.
+_jm_run() { # _jm_run <job> — payload on stdin; truncates first, then requires the tool to work
+  : >"$_jm_facts"
+  : >"$_jm_prompt"
+  if ! python3 "$_jm_tool" "$1" "$_jm_facts" "$_jm_prompt" >/dev/null 2>&1; then
+    bad "case (jm9/jm11) the facts tool exited non-zero for job $1 — the assert that follows would read an empty or stale facts file"
+    return 1
+  fi
+  if [ ! -s "$_jm_facts" ]; then
+    bad "case (jm9/jm11) the facts tool produced NO facts for job $1 — an absence assert would pass vacuously"
+    return 1
+  fi
+  return 0
+}
 _jm_prompt="$tmp/jm-facts-prompt.txt"
 if [ ! -f "$_jm_tool" ] || ! command -v python3 >/dev/null 2>&1; then
   printf 'SKIP - roborev-job-facts.py or python3 unavailable; the fact-extraction cases did not run\n'
 else
   printf '[{"id":4656,"git_ref":"aaa..bbb","status":"done","source_machine_id":"%s"}]' "$JM_UUID" \
-    | python3 "$_jm_tool" 4656 "$_jm_facts" "$_jm_prompt" >/dev/null 2>&1 || true
+    | _jm_run 4656 || true
   if [ "$(sed -n 's/^source_machine_id=//p' "$_jm_facts" | head -1)" = "$JM_UUID" ]; then
     ok 'case (jm9) a list-shaped row yields source_machine_id as a string fact'
   else
     bad "case (jm9) the list-shaped row did not yield source_machine_id (facts: $(tr '\n' ' ' <"$_jm_facts"))"
   fi
   printf '{"id":4656,"job_id":4656,"agent":"codex","prompt":"p","job":{"id":4656,"git_ref":"aaa..bbb","status":"done"}}' \
-    | python3 "$_jm_tool" 4656 "$_jm_facts" "$_jm_prompt" >/dev/null 2>&1 || true
+    | _jm_run 4656 || true
   if grep -q '^source_machine_id=' "$_jm_facts"; then
     bad "case (jm9) a show-shaped payload emitted a source_machine_id fact — an empty one renders as a blank uuid (facts: $(tr '\n' ' ' <"$_jm_facts"))"
   else
@@ -6102,7 +6122,7 @@ else
   # onto a different row. The review row here answers to the same id and carries no git_ref, so a
   # regression that let the new fact influence selection would surface as the wrong git_ref.
   printf '{"id":4656,"job_id":4656,"source_machine_id":"decoy","job":{"id":4656,"git_ref":"aaa..bbb","status":"done","model":"m"}}' \
-    | python3 "$_jm_tool" 4656 "$_jm_facts" "$_jm_prompt" >/dev/null 2>&1 || true
+    | _jm_run 4656 || true
   if [ "$(sed -n 's/^git_ref=//p' "$_jm_facts" | head -1)" = 'aaa..bbb' ]; then
     ok 'case (jm9) the git_ref-bearing row is still the one selected (the new fact cannot move find_job)'
   else
@@ -6264,7 +6284,7 @@ if [ ! -f "$_jm_tool" ] || ! command -v python3 >/dev/null 2>&1; then
   printf 'SKIP - roborev-job-facts.py or python3 unavailable; the id-divergence case did not run\n'
 else
   printf '{"id":8,"job_id":9,"uuid":"outer-uuid","source_machine_id":"DECOY","prompt":"p","job":{"id":9,"git_ref":"aaa..bbb","status":"done","model":"m"}}' \
-    | python3 "$_jm_tool" 9 "$_jm_facts" "$_jm_prompt" >/dev/null 2>&1 || true
+    | _jm_run 9 || true
   if [ "$(sed -n 's/^git_ref=//p' "$_jm_facts" | head -1)" = 'aaa..bbb' ]; then
     ok 'case (jm11) the nested job row is still selected when the top-level id names another review'
   else

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -6125,10 +6125,18 @@ _jm_facts="$tmp/jm-facts.txt"
 # cannot see that, which is the point. Truncating is necessary and NOT sufficient: the sub-cases
 # asserting an ABSENCE (no `source_machine_id`) are satisfied trivially by an empty file, so the
 # tool is also required to have SUCCEEDED and to have produced output.
-_jm_run() { # _jm_run <job> — payload on stdin; truncates first, then requires the tool to work
+# ===== AND IT MUST RUN IN THIS SHELL, NOT AS A PIPELINE COMPONENT (#3654 round 3) =====
+# `printf ... | _jm_run 4656` puts the function in a SUBSHELL, so its `bad` calls incremented a
+# COPY of FAIL and the verdict was discarded on exit — the tally stayed green while the guard
+# reported a failure into the void. That is CLAUDE.md's rule stated for cargo parsers and general
+# in fact: READ BY REDIRECTION, NEVER A PIPE, because a piped reader runs in a subshell and its
+# verdict is thrown away. The payload is therefore an ARGUMENT written to a file and fed by `<`.
+_jm_payload_file="$tmp/jm-payload.json"
+_jm_run() { # _jm_run <job> <payload> — runs in THIS shell; payload by redirection, never a pipe
+  printf '%s' "$2" >"$_jm_payload_file"
   : >"$_jm_facts"
   : >"$_jm_prompt"
-  if ! python3 "$_jm_tool" "$1" "$_jm_facts" "$_jm_prompt" >/dev/null 2>&1; then
+  if ! python3 "$_jm_tool" "$1" "$_jm_facts" "$_jm_prompt" <"$_jm_payload_file" >/dev/null 2>&1; then
     bad "case (jm9/jm11) the facts tool exited non-zero for job $1 — the assert that follows would read an empty or stale facts file"
     return 1
   fi
@@ -6142,15 +6150,13 @@ _jm_prompt="$tmp/jm-facts-prompt.txt"
 if [ ! -f "$_jm_tool" ] || ! command -v python3 >/dev/null 2>&1; then
   printf 'SKIP - roborev-job-facts.py or python3 unavailable; the fact-extraction cases did not run\n'
 else
-  printf '[{"id":4656,"git_ref":"aaa..bbb","status":"done","source_machine_id":"%s"}]' "$JM_UUID" \
-    | _jm_run 4656 || true
+  _jm_run 4656 "$(printf '[{"id":4656,"git_ref":"aaa..bbb","status":"done","source_machine_id":"%s"}]' "$JM_UUID")" || true
   if [ "$(sed -n 's/^source_machine_id=//p' "$_jm_facts" | head -1)" = "$JM_UUID" ]; then
     ok 'case (jm9) a list-shaped row yields source_machine_id as a string fact'
   else
     bad "case (jm9) the list-shaped row did not yield source_machine_id (facts: $(tr '\n' ' ' <"$_jm_facts"))"
   fi
-  printf '{"id":4656,"job_id":4656,"agent":"codex","prompt":"p","job":{"id":4656,"git_ref":"aaa..bbb","status":"done"}}' \
-    | _jm_run 4656 || true
+  _jm_run 4656 "$(printf '{"id":4656,"job_id":4656,"agent":"codex","prompt":"p","job":{"id":4656,"git_ref":"aaa..bbb","status":"done"}}')" || true
   if grep -q '^source_machine_id=' "$_jm_facts"; then
     bad "case (jm9) a show-shaped payload emitted a source_machine_id fact — an empty one renders as a blank uuid (facts: $(tr '\n' ' ' <"$_jm_facts"))"
   else
@@ -6159,8 +6165,7 @@ else
   # AND THE ROW SELECTION IS UNCHANGED: adding a string fact must not be able to move `find_job`
   # onto a different row. The review row here answers to the same id and carries no git_ref, so a
   # regression that let the new fact influence selection would surface as the wrong git_ref.
-  printf '{"id":4656,"job_id":4656,"source_machine_id":"decoy","job":{"id":4656,"git_ref":"aaa..bbb","status":"done","model":"m"}}' \
-    | _jm_run 4656 || true
+  _jm_run 4656 "$(printf '{"id":4656,"job_id":4656,"source_machine_id":"decoy","job":{"id":4656,"git_ref":"aaa..bbb","status":"done","model":"m"}}')" || true
   if [ "$(sed -n 's/^git_ref=//p' "$_jm_facts" | head -1)" = 'aaa..bbb' ]; then
     ok 'case (jm9) the git_ref-bearing row is still the one selected (the new fact cannot move find_job)'
   else
@@ -6403,8 +6408,7 @@ printf '== (jm11) #3654: a `show` payload whose TOP-LEVEL id is NOT the asked jo
 if [ ! -f "$_jm_tool" ] || ! command -v python3 >/dev/null 2>&1; then
   printf 'SKIP - roborev-job-facts.py or python3 unavailable; the id-divergence case did not run\n'
 else
-  printf '{"id":8,"job_id":9,"uuid":"outer-uuid","source_machine_id":"DECOY","prompt":"p","job":{"id":9,"git_ref":"aaa..bbb","status":"done","model":"m"}}' \
-    | _jm_run 9 || true
+  _jm_run 9 "$(printf '{"id":8,"job_id":9,"uuid":"outer-uuid","source_machine_id":"DECOY","prompt":"p","job":{"id":9,"git_ref":"aaa..bbb","status":"done","model":"m"}}')" || true
   if [ "$(sed -n 's/^git_ref=//p' "$_jm_facts" | head -1)" = 'aaa..bbb' ]; then
     ok 'case (jm11) the nested job row is still selected when the top-level id names another review'
   else

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -387,6 +387,36 @@ case "$cmd" in
       esac
     fi
     _EMIT_MACHINE=1
+    # ===== DEPTH MODEL: THE TARGET ROW SITS BELOW `--limit` NEWER ROWS (#3654 round 3) =====
+    # `roborev list` has no offset — `--limit` is its only depth control — so a job on a busy
+    # branch is reachable ONLY by asking for more rows. With STUB_LIST_DEPTH=N the daemon holds N
+    # newer filler jobs ahead of the target, and returns the newest min(limit, N) of them, adding
+    # the target only when the caller asked deeper than N. A stub that returned the target at any
+    # limit would make a depth case pass before AND after the fix, i.e. measure nothing.
+    if [ -n "${STUB_LIST_DEPTH:-}" ]; then
+      _limit=50 _prev=""
+      for _a in $*; do
+        [ "$_prev" = "--limit" ] && _limit=$_a
+        _prev=$_a
+      done
+      printf '['
+      _i=0
+      while [ "$_i" -lt "$STUB_LIST_DEPTH" ] && [ "$_i" -lt "$_limit" ]; do
+        [ "$_i" -eq 0 ] || printf ','
+        printf '{"id":%s,"git_ref":"dead..beef","status":"done","source_machine_id":"filler-not-the-target"}' \
+          "$((900000 + _i))"
+        _i=$((_i + 1))
+      done
+      # STUB_LIST_OMIT_TARGET models a job that is simply NOT on this branch's list at any depth,
+      # which is what makes the exhaustion path testable: without it the target reappears as soon
+      # as the limit exceeds the filler count, and the "searched to the end" case measures nothing.
+      if [ "$_limit" -gt "$STUB_LIST_DEPTH" ] && [ -z "${STUB_LIST_OMIT_TARGET:-}" ]; then
+        [ "$_i" -eq 0 ] || printf ','
+        emit_job_object
+      fi
+      printf ']\n'
+      exit 0
+    fi
     printf '['; emit_job_object; printf ']\n'
     exit 0
     ;;
@@ -1203,6 +1233,8 @@ export STUB_VERDICT_FIELD=''
 export STUB_RECORD_BLANK_FOR=0
 export STUB_PAYLOAD_JOB=''
 export STUB_LIST_JSON=array
+export STUB_LIST_DEPTH=''
+export STUB_LIST_OMIT_TARGET=''
 export STUB_REVIEW_RC=0
 export STUB_ANNOUNCE_SHA=''
 # #3312 (owner ruling (4)): the WAIVER knobs. There are no snapshot knobs any more — nothing reads a
@@ -1250,6 +1282,8 @@ reset_stub() {
   STUB_RECORD_BLANK_FOR=0
   STUB_PAYLOAD_JOB=''
   STUB_LIST_JSON=array
+  STUB_LIST_DEPTH=''
+  STUB_LIST_OMIT_TARGET=''
   STUB_RECORD_OUTPUT=''
   STUB_RECORD_OUTPUT_FIELD=''
   STUB_GH_COMMENTS=''
@@ -6237,6 +6271,43 @@ assert_verdict 'case (jm14)' PASS 0
 assert_says 'case (jm14) a recheck of an older, differently-branched job names its daemon' \
   "^job-machine: $JM_UUID \(source_machine_id; job ids are per-daemon\)$"
 assert_says 'case (jm14) and it is still a recheck' '^MODE: recheck '
+reset_stub
+
+printf '== (jm17) #3654 r3: a target BEYOND the first 50 rows is still found (depth, not width) ==\n'
+# ROUND 2 FIXED THE BRANCH AND LEFT THE DEPTH. With the branch right, a fixed `--limit 50` still
+# drops the target the moment the branch holds more than 50 jobs — and the jobs that sit deep are
+# the OLD ones, which are exactly the ones a `--recheck-job` names. So the documented cross-box
+# mitigation failed for its own primary case. This case puts the target under 60 newer rows: it
+# FAILS against a fixed `--limit 50` (the key reads NOT RECORDED) and passes once the lookup
+# retrieves until found. Deliberately 60, not 5000 — the property is "deeper than the first page",
+# and a case that needs a huge fixture invites being trimmed later.
+reset_stub
+STUB_ANNOUNCE_SHA="$jm_head"
+STUB_SOURCE_MACHINE_ID="$JM_UUID"
+STUB_JOB_BRANCH='issue-earlier-lane'
+STUB_LIST_BRANCH='issue-earlier-lane'
+STUB_LIST_DEPTH=60
+run_wrapper "$jm_work"
+assert_verdict 'case (jm17)' PASS 0
+assert_says 'case (jm17) the daemon is named for a job below the first page of rows' \
+  "^job-machine: $JM_UUID \(source_machine_id; job ids are per-daemon\)$"
+assert_lacks 'case (jm17) depth never yields a filler row'"'"'s machine id' 'filler-not-the-target'
+reset_stub
+
+printf '== (jm18) #3654 r3: a genuinely absent job says so, naming the depth searched ==\n'
+# THE COMPLEMENT, and the reason the loop needs an affirmative end-of-list signal: retrieving
+# "until found" must still TERMINATE when the job is not there at all, and must say that it
+# reached the end of the daemon's list rather than merely giving up at some number.
+reset_stub
+STUB_ANNOUNCE_SHA="$jm_head"
+STUB_JOB_BRANCH='issue-earlier-lane'
+STUB_LIST_BRANCH='issue-earlier-lane'
+STUB_LIST_DEPTH=10
+STUB_LIST_OMIT_TARGET=1
+run_wrapper "$jm_work"
+assert_says 'case (jm18) the miss names the depth reached and that the list ended' \
+  'searched to a depth of [0-9]+ rows and to the end of what the daemon returns'
+assert_lacks 'case (jm18) it never claims a fixed 50-job window' "latest 50 jobs"
 reset_stub
 
 printf '== (jm15) #3654 r2: NO ambient-branch fallback when the record does not name its branch ==\n'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -267,27 +267,10 @@ emit_job_object() {
   if [ "${STUB_TOKEN_USAGE:-NONE}" != "NONE" ]; then
     usage=",\"token_usage\":\"${STUB_TOKEN_USAGE}\""
   fi
-  # THE JOB'S OWN BRANCH (#3654 round 2). Real payloads carry it — `.job.branch` on `show`, top
-  # level on `list` — and the supplementary machine lookup is scoped BY IT rather than by the
-  # branch the invocation happens to be on. `none` suppresses it, which is how the
-  # "record does not name its branch" state is fixtured.
-  if [ -n "${STUB_JOB_BRANCH:-}" ] && [ "${STUB_JOB_BRANCH:-}" != none ]; then
-    extra="$extra,\"branch\":\"${STUB_JOB_BRANCH}\""
-  fi
   local git_ref="${STUB_GIT_REF:-${STUB_ANNOUNCE_SHA:-}}"
   if [ "${STUB_GIT_REF:-}" = none ]; then git_ref=""; fi
   if [ -n "${STUB_VERDICT_FIELD:-}" ]; then
     extra="$extra,\"verdict\":\"${STUB_VERDICT_FIELD}\""
-  fi
-  # ===== `source_machine_id` IS CARRIED BY `list` ROWS ONLY (#3654) =====
-  # MEASURED on roborev v0.61.2: `roborev list --json` rows carry it at top level, and
-  # `roborev show <id> --json` does not carry it ANYWHERE — not at top level, not in its nested
-  # `job` object. The stub reproduces that asymmetry rather than emitting the field everywhere,
-  # because it is exactly what makes `NOT RECORDED` a REAL state and what forces the wrapper's
-  # supplementary `list` read: a stub that answered on `show` too would make the `list` path
-  # untested and the key look correct while reporting nothing on a real run.
-  if [ -n "${STUB_SOURCE_MACHINE_ID:-}" ] && [ "${_EMIT_MACHINE:-0}" = 1 ]; then
-    extra="$extra,\"source_machine_id\":\"${STUB_SOURCE_MACHINE_ID}\""
   fi
   # The review TEXT the record carries (#3312 job 24). On the JOB row as well as the review row, so every
   # payload shape a recheck may read from carries it, exactly as roborev's own payloads do.
@@ -375,48 +358,6 @@ case "$cmd" in
   list)
     record_read_blank && { printf 'null\n'; exit 0; }
     [ "${STUB_LIST_JSON:-array}" != none ] || { printf 'null\n'; exit 0; }
-    # ===== `roborev list` IS BRANCH-FILTERED, AND THE STUB HONOURS THAT (#3654 round 2) =====
-    # Measured: a bare list from a branch with no jobs returns `null` while `--branch <other>`
-    # returns that branch's rows. Modelling it is what makes the branch-scoping cases REAL — a stub
-    # that answered whatever branch it was asked would pass both before and after the fix, i.e. the
-    # cases would test nothing. STUB_LIST_BRANCH is the branch this daemon has jobs for.
-    if [ -n "${STUB_LIST_BRANCH:-}" ]; then
-      case " $* " in
-        *" --branch ${STUB_LIST_BRANCH} "*|*" --branch ${STUB_LIST_BRANCH}") ;;
-        *" --branch "*) printf 'null\n'; exit 0 ;;
-      esac
-    fi
-    _EMIT_MACHINE=1
-    # ===== DEPTH MODEL: THE TARGET ROW SITS BELOW `--limit` NEWER ROWS (#3654 round 3) =====
-    # `roborev list` has no offset — `--limit` is its only depth control — so a job on a busy
-    # branch is reachable ONLY by asking for more rows. With STUB_LIST_DEPTH=N the daemon holds N
-    # newer filler jobs ahead of the target, and returns the newest min(limit, N) of them, adding
-    # the target only when the caller asked deeper than N. A stub that returned the target at any
-    # limit would make a depth case pass before AND after the fix, i.e. measure nothing.
-    if [ -n "${STUB_LIST_DEPTH:-}" ]; then
-      _limit=50 _prev=""
-      for _a in $*; do
-        [ "$_prev" = "--limit" ] && _limit=$_a
-        _prev=$_a
-      done
-      printf '['
-      _i=0
-      while [ "$_i" -lt "$STUB_LIST_DEPTH" ] && [ "$_i" -lt "$_limit" ]; do
-        [ "$_i" -eq 0 ] || printf ','
-        printf '{"id":%s,"git_ref":"dead..beef","status":"done","source_machine_id":"filler-not-the-target"}' \
-          "$((900000 + _i))"
-        _i=$((_i + 1))
-      done
-      # STUB_LIST_OMIT_TARGET models a job that is simply NOT on this branch's list at any depth,
-      # which is what makes the exhaustion path testable: without it the target reappears as soon
-      # as the limit exceeds the filler count, and the "searched to the end" case measures nothing.
-      if [ "$_limit" -gt "$STUB_LIST_DEPTH" ] && [ -z "${STUB_LIST_OMIT_TARGET:-}" ]; then
-        [ "$_i" -eq 0 ] || printf ','
-        emit_job_object
-      fi
-      printf ']\n'
-      exit 0
-    fi
     printf '['; emit_job_object; printf ']\n'
     exit 0
     ;;
@@ -1104,11 +1045,6 @@ run_wrapper() { # run_wrapper [--wrapper <path>] <work-dir> [extra wrapper args.
   # git_ref is "<base40>..<head40>". Default the stub to the correct range unless the
   # case pinned git_ref itself (or asked for it to be absent with `none`).
   if [ -z "${STUB_GIT_REF:-}" ]; then STUB_GIT_REF=$(range_ref "$work"); fi
-  # The job row reports the branch it was enqueued for, and the daemon lists that branch's jobs —
-  # which, for an ordinary run, is the fixture's own branch (#3654 round 2). Defaulted here, beside
-  # STUB_GIT_REF, for the same reason: a case pins it only when the DIVERGENCE is the subject.
-  if [ -z "${STUB_JOB_BRANCH:-}" ]; then STUB_JOB_BRANCH=$(git -C "$work" rev-parse --abbrev-ref HEAD); fi
-  if [ -z "${STUB_LIST_BRANCH:-}" ]; then STUB_LIST_BRANCH="$STUB_JOB_BRANCH"; fi
   # HOME is redirected to a throwaway directory: nothing in the wrapper reads a roborev
   # config any more (#3283), but HERMETICITY is asserted structurally at the bottom of this
   # file and a host `$HOME/.roborev/` must never be able to influence a fixture run.
@@ -1233,8 +1169,6 @@ export STUB_VERDICT_FIELD=''
 export STUB_RECORD_BLANK_FOR=0
 export STUB_PAYLOAD_JOB=''
 export STUB_LIST_JSON=array
-export STUB_LIST_DEPTH=''
-export STUB_LIST_OMIT_TARGET=''
 export STUB_REVIEW_RC=0
 export STUB_ANNOUNCE_SHA=''
 # #3312 (owner ruling (4)): the WAIVER knobs. There are no snapshot knobs any more — nothing reads a
@@ -1256,15 +1190,6 @@ export STUB_GH_ISSUES=''
 export STUB_GH_ISSUES_CLOSED=''
 export STUB_GH_ISSUE_ERR=''
 export STUB_ON_REVIEW=''
-# #3654: the DAEMON-ID knob. Empty by default, and the stub emits it on the `list` payload ONLY,
-# which is where roborev v0.61.2 actually carries `source_machine_id`.
-export STUB_SOURCE_MACHINE_ID=''
-# #3654 round 2: the BRANCH knobs. STUB_JOB_BRANCH is the branch the job row reports as its own
-# (`none` suppresses the field); STUB_LIST_BRANCH is the branch the daemon's list will answer for.
-# Both default, in run_wrapper, to the fixture's own current branch — the ordinary case — so a case
-# that wants them to DIVERGE has to say so.
-export STUB_JOB_BRANCH=''
-export STUB_LIST_BRANCH=''
 reset_stub() {
   STUB_JOB=4656
   STUB_VERDICT=$'No issues found.\nSummary: reviewed the diff; no issues found.'
@@ -1282,8 +1207,6 @@ reset_stub() {
   STUB_RECORD_BLANK_FOR=0
   STUB_PAYLOAD_JOB=''
   STUB_LIST_JSON=array
-  STUB_LIST_DEPTH=''
-  STUB_LIST_OMIT_TARGET=''
   STUB_RECORD_OUTPUT=''
   STUB_RECORD_OUTPUT_FIELD=''
   STUB_GH_COMMENTS=''
@@ -1294,11 +1217,6 @@ reset_stub() {
   STUB_GH_ISSUES_CLOSED=''
   STUB_GH_ISSUE_ERR=''
   STUB_ON_REVIEW=''
-  # No daemon id by default: the FAIL-CLOSED direction for the `job-machine:` key (#3654) — a case
-  # that wants the uuid arm has to SAY so, so no case passes because the double happened to answer.
-  STUB_SOURCE_MACHINE_ID=''
-  STUB_JOB_BRANCH=''
-  STUB_LIST_BRANCH=''
 }
 
 printf '== case (a): enqueued sha == base ref ==\n'
@@ -3188,12 +3106,6 @@ STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" HOME="$FIXTURE_HOME" \
 RC=$?
 assert_verdict 'case (t9)' FAIL 1
 assert_says 'case (t9) the abort is reported, not silent' 'terminated unexpectedly'
-# THE COMPLEMENT OF (jm19), added with the JOB_RECORD_READ branch (#3654 round 4). This abort lands
-# BEFORE any record read, so UNAVAILABLE is the TRUE state here. Pinning it stops the new branch
-# over-reporting NOT RECORDED on a run that genuinely read nothing: a conditional with only one side
-# pinned is a conditional half-tested, and jm19 pins the other side.
-assert_says 'case (t9) an abort before any record read is UNAVAILABLE, which is true there' \
-  '^job-machine: UNAVAILABLE \(no job record was read'
 assert_one_block 'case (t9)'
 
 printf '== case (u1): token accounting present but UNPARSEABLE is drift, and FAILs ==\n'
@@ -5929,653 +5841,6 @@ assert_says 'case (mb8b) the absence FAIL stands' \
   '^prompt-content: FAIL \(1/1 code census paths absent from the prompt\)$'
 reset_stub
 
-# ============================================================================
-# (jm*) #3654: ROBOREV JOB IDS ARE PER-DAEMON, AND THE BLOCK SAYS WHICH DAEMON
-# ----------------------------------------------------------------------------
-# THE INCIDENT: two lanes on two boxes requested absence waivers 50 minutes apart, both
-# naming `job=265` for DIFFERENT reviews (different ranges, branches and token counts).
-# Both were correct — ids are sequential PER DAEMON — but the coordination lead read the
-# repetition as a collision and WITHHELD a valid waiver. So the block now NAMES the
-# issuing daemon beside the id it disambiguates.
-#
-# THE KEY IS INFORMATIONAL AND THAT IS THE PROPERTY MOST WORTH PINNING: it is in neither
-# the verdict-grammar scan nor the affirmation backstop, so none of its three states can
-# red an otherwise-clean run. A decorative key that can fail a correct review is the guard
-# agents learn to waive.
-JM_UUID='db07281a-b8e0-4c8f-99dc-37ca88a0a54c'
-jm_work=$(make_fixture case_jm pushed)
-jm_head=$(git -C "$jm_work" rev-parse HEAD)
-# The three renderings OBSERVED by the cases below, collected for the closed-set assert
-# (jm6). Collected rather than predicted: a closed set asserted against literals someone
-# typed proves only that the literals were typed.
-jm_seen_uuid=''
-jm_seen_not_recorded=''
-jm_seen_unavailable=''
-jm_render() { grep -E '^job-machine: ' "$OUT" | head -1 || printf ''; }
-
-printf '== (jm1) #3654: the daemon id is surfaced even when `show` alone answered the record ==\n'
-# THE CASE THAT MAKES THE KEY MORE THAN DECORATION. `read_job_record` STOPS at the first payload
-# that carries the required fields, and on a healthy daemon that is `show` — which does not carry
-# `source_machine_id` at all. Read only through that loop the key would be `NOT RECORDED` on EVERY
-# real run: a key reporting nothing while looking like it reports something. So the wrapper takes
-# one supplementary `list` read, and this case is the only thing that proves it happens.
-reset_stub
-STUB_ANNOUNCE_SHA="$jm_head"
-STUB_SOURCE_MACHINE_ID="$JM_UUID"
-run_wrapper "$jm_work"
-assert_verdict 'case (jm1)' PASS 0
-assert_says 'case (jm1) the block names the issuing daemon' "^job-machine: $JM_UUID \(source_machine_id; job ids are per-daemon\)$"
-assert_says 'case (jm1) it sits beside the id it disambiguates' '^job: 4656$'
-jm_seen_uuid=$(jm_render)
-reset_stub
-
-printf '== (jm2) #3654: the same id when the RECORD ITSELF came from the `list` payload ==\n'
-# The other route to the fact: a `show` that returns the REVIEW row (no git_ref) makes the record
-# loop fall through to `list`, so `source_machine_id` is already in the facts file and no
-# supplementary read is needed. Both routes must render identically — otherwise the value a reader
-# sees would depend on which payload happened to answer.
-reset_stub
-STUB_ANNOUNCE_SHA="$jm_head"
-STUB_SOURCE_MACHINE_ID="$JM_UUID"
-STUB_SHOW_JSON=review-row
-run_wrapper "$jm_work"
-assert_verdict 'case (jm2)' PASS 0
-assert_says 'case (jm2) the daemon id is the same on the record-from-list route' "^job-machine: $JM_UUID \(source_machine_id; job ids are per-daemon\)$"
-reset_stub
-
-printf '== (jm3) #3654: NO daemon id anywhere is NOT RECORDED — and still PASSes ==\n'
-# A REAL state, not a defensive one: a roborev build whose payloads carry no `source_machine_id`
-# reaches it on every run. It must therefore be AFFIRMATIVE (never blank, never a bare `-`) and it
-# must never cost a correct review its PASS — this case asserts both at once.
-reset_stub
-STUB_ANNOUNCE_SHA="$jm_head"
-run_wrapper "$jm_work"
-assert_verdict 'case (jm3) an unrecorded daemon never fails a clean run' PASS 0
-# THE CAUSE IS THE ONE THIS RUN MEASURED, not a generic sentence: the record was read, the daemon's
-# list for the job's OWN branch was consulted, and neither carried the field. Asserted with the tail
-# that names WHICH payload carries it, because a cause without a remedy is half a diagnostic.
-assert_says 'case (jm3) the state names the cause it actually measured' \
-  "^job-machine: NOT RECORDED \(neither the job record nor the daemon's job list for branch 'feature' carries source_machine_id;"
-assert_says 'case (jm3) and still names the payload that DOES carry the field' \
-  "'roborev list --json' rows carry that field, 'roborev show <id> --json' does not\. Identify the review by the record's git_ref, never by the id alone\)$"
-assert_lacks 'case (jm3) the key is never blank' '^job-machine: *$'
-jm_seen_not_recorded=$(jm_render)
-reset_stub
-
-printf '== (jm4) #3654: the key is emitted in --recheck-job mode too ==\n'
-# THE MODE THAT MATTERS MOST: `--recheck-job` is the only path an absence waiver travels, and the
-# waiver names a job id — so this is precisely where a reader has to know WHICH daemon issued it.
-reset_stub
-STUB_ANNOUNCE_SHA="$jm_head"
-STUB_SOURCE_MACHINE_ID="$JM_UUID"
-STUB_VERDICT_FIELD='P'
-STUB_RECORD_OUTPUT="$CLEAN_TEXT"
-run_wrapper "$jm_work" --recheck-job 4656
-assert_verdict 'case (jm4)' PASS 0
-assert_says 'case (jm4) a recheck names the issuing daemon' "^job-machine: $JM_UUID \(source_machine_id; job ids are per-daemon\)$"
-assert_says 'case (jm4) and the recheck mode is still declared' '^MODE: recheck '
-reset_stub
-
-printf '== (jm5) #3654: NO readable record at all is UNAVAILABLE, naming what it inherits ==\n'
-# Distinct from (jm3) BECAUSE THEY ARE DIFFERENT OPERATOR ACTIONS: "this roborev build does not
-# record the field" and "no record could be read" send a reader to different places. The run FAILs
-# here — sha-assert cannot verify a range with no record — and the assert below pins that the FAIL
-# is NOT attributed to this key.
-reset_stub
-STUB_ANNOUNCE_SHA="$jm_head"
-STUB_SHOW_JSON=none
-STUB_LIST_JSON=none
-run_wrapper "$jm_work"
-assert_verdict 'case (jm5)' FAIL 1
-assert_says 'case (jm5) the key names the job-record state it inherits' \
-  '^job-machine: UNAVAILABLE \(no job record could be read at all, so the issuing daemon is unknown — job-record: DEGRADED'
-assert_says 'case (jm5) the FAIL belongs to sha-assert, not to job-machine' \
-  '^sha-assert: FAIL \(job record unavailable'
-assert_lacks 'case (jm5) no diagnostic blames the informational key' 'ERROR: job-machine'
-jm_seen_unavailable=$(jm_render)
-reset_stub
-
-printf '== (jm6) #3654: the renderings are a CLOSED SET OF THREE, matched on the state token ==\n'
-# PINNED AS A SET, NOT AS ONE LITERAL, which is the idiom this repo already uses for the gate's
-# component-set `src_note`: pinning ONE literal reds on correct input (which arm fires depends on
-# which payload answered), and pinning NOTHING lets a wording pass delete the key. So all three
-# observed values are reduced to their STATE TOKEN and the set is compared by string equality.
-jm_token() { # jm_token <rendered "job-machine: <value>" line> -> the state token
-  local v="${1#job-machine: }"
-  case "$v" in
-    "$JM_UUID "*) printf '<uuid>' ;;
-    'NOT RECORDED ('*) printf 'NOT RECORDED' ;;
-    'UNAVAILABLE ('*) printf 'UNAVAILABLE' ;;
-    '') printf '<absent>' ;;
-    *) printf '<unrecognised:%s>' "${v%% *}" ;;
-  esac
-}
-jm_set="$(jm_token "$jm_seen_uuid")|$(jm_token "$jm_seen_not_recorded")|$(jm_token "$jm_seen_unavailable")"
-if [ "$jm_set" = '<uuid>|NOT RECORDED|UNAVAILABLE' ]; then
-  ok 'case (jm6) the observed renderings are exactly the closed set {<uuid>, NOT RECORDED, UNAVAILABLE}'
-else
-  bad "case (jm6) the job-machine: renderings are not the closed set of three: observed '$jm_set' (expected '<uuid>|NOT RECORDED|UNAVAILABLE')"
-fi
-# AND EVERY ONE OF THEM CARRIES A REASON, never a bare token: an operator reading a pasted block
-# has to be able to act on it without opening this file.
-for _jm_r in "$jm_seen_uuid" "$jm_seen_not_recorded" "$jm_seen_unavailable"; do
-  case "$_jm_r" in
-    'job-machine: '*' ('*')'*) ok "case (jm6) the rendering carries its own explanation: ${_jm_r%% (*} (...)" ;;
-    *) bad "case (jm6) a job-machine: rendering carries no parenthesised explanation: '$_jm_r'" ;;
-  esac
-done
-
-printf '== (jm7) #3654 structural: job-machine is in NEITHER failing-capable key set ==\n'
-# A BEHAVIOURAL CASE ONLY COVERS THE VALUES SOMEONE THOUGHT OF. (jm3)/(jm5) show that the two
-# non-uuid states do not red a run TODAY; only a structural assert stops a future edit registering
-# the key in the verdict scan or the affirmation backstop, where a `NOT RECORDED` — a routine state
-# on a roborev build that does not carry the field — would fail every review on the fleet.
-# Read from the two STATEMENTS, never from a file-wide grep: the key's own `emit_kv` line would
-# satisfy a file-wide search even with the key registered in both scans.
-_jm_scan_keys=$(sed -n '/^[[:space:]]*for scan_keyed in /,/; do$/p' "$WRAPPER_REAL")
-_jm_aff_keys=$(sed -n '/^[[:space:]]*for keyed in "push-assert=/,/; do$/p' "$WRAPPER_REAL")
-if [ -z "$_jm_scan_keys" ] || [ -z "$_jm_aff_keys" ]; then
-  bad 'case (jm7) could not extract the verdict-scan and affirmation key lists to inspect'
-else
-  if printf '%s\n' "$_jm_scan_keys" | grep -q 'job-machine'; then
-    bad 'case (jm7) job-machine is registered in the failing-capable verdict scan — an informational key would then red a correct run whenever the daemon id is NOT RECORDED (a routine state)'
-  else
-    ok 'case (jm7) job-machine is absent from the failing-capable verdict scan'
-  fi
-  if printf '%s\n' "$_jm_aff_keys" | grep -q 'job-machine'; then
-    bad 'case (jm7) job-machine is registered in the affirmation backstop — a PASS would then require it to read PASS, which it never does'
-  else
-    ok 'case (jm7) job-machine is absent from the affirmation backstop'
-  fi
-fi
-# AND IT IS ACTUALLY EMITTED, unconditionally. Without this the two asserts above are satisfied by
-# DELETING the key, which is the decorative-assert trap this suite has ruled on before.
-# The VALUE EXPRESSION is deliberately not pinned: since #3654 round 3 the fallback is built at
-# emit time (`$(job_machine_value)`) rather than captured at initialization, so pinning the old
-# `"$JOB_MACHINE"` spelling would red on correct code. What must hold is unchanged and is what is
-# asserted — the key goes through `emit_kv`, the ONE neutralisation boundary, unconditionally.
-if grep -qE "^[[:space:]]*emit_kv 'job-machine' \"[^\"]+\"$" "$WRAPPER_REAL"; then
-  ok 'case (jm7) the key is emitted through the ONE value boundary (emit_kv), unconditionally'
-else
-  bad 'case (jm7) job-machine is not emitted via emit_kv — either it is gone, or its value bypasses the neutralisation boundary'
-fi
-
-printf '== (jm8) #3654 structural: NO machine field was added to either marker grammar ==\n'
-# ASK 4 OF THE ISSUE, PINNED. The authorizer would have to know the value, it is derivable from the
-# record, and every field in a hand-typed control line is one more way for a legitimate
-# authorization to read MALFORMED. The two marker patterns are the grammar, so they are the subject.
-_jm_scan_py="$SCRIPT_DIR/../flow/roborev-waiver-scan.py"
-if [ ! -f "$_jm_scan_py" ]; then
-  bad 'case (jm8) the waiver scanner is missing, so the marker grammar could not be inspected'
-else
-  _jm_patterns=$(grep -nE '^[[:space:]]*r"' "$_jm_scan_py" || printf '')
-  if [ -z "$_jm_patterns" ]; then
-    bad 'case (jm8) no marker pattern fragments found in the scanner — the extraction is stale'
-  elif printf '%s\n' "$_jm_patterns" | grep -qiE 'machine'; then
-    bad 'case (jm8) a machine field appears in a marker pattern — the marker grammar must stay unchanged (#3654 ask 4)'
-  else
-    ok 'case (jm8) neither marker pattern names a machine field — the grammar is unchanged'
-  fi
-fi
-
-printf '== (jm9) #3654: the facts tool extracts source_machine_id from `list`, and NOTHING from `show` ==\n'
-# THE PAYLOAD ASYMMETRY AT ITS SOURCE. A `show`-shaped payload must yield NO fact rather than an
-# empty-string one: `source_machine_id=` in the facts file would render as a BLANK uuid, which is
-# the unmeasured-value-as-a-value defect this repository fails runs for.
-_jm_tool="$SCRIPT_DIR/../flow/roborev-job-facts.py"
-_jm_facts="$tmp/jm-facts.txt"
-# ===== SUB-CASES SHARE ONE FACTS FILE, SO EACH RUN MUST START FROM AN EMPTY ONE (#3654 r3) =====
-# Every sub-case below ran the tool `|| true` against the SAME `$_jm_facts`. A tool failure
-# therefore left the PREVIOUS sub-case's output in place and the next assert read it — jm11's
-# `git_ref == aaa..bbb` could pass on jm9's stale file, a green that measured nothing. The tally
-# cannot see that, which is the point. Truncating is necessary and NOT sufficient: the sub-cases
-# asserting an ABSENCE (no `source_machine_id`) are satisfied trivially by an empty file, so the
-# tool is also required to have SUCCEEDED and to have produced output.
-# ===== AND IT MUST RUN IN THIS SHELL, NOT AS A PIPELINE COMPONENT (#3654 round 3) =====
-# `printf ... | _jm_run 4656` puts the function in a SUBSHELL, so its `bad` calls incremented a
-# COPY of FAIL and the verdict was discarded on exit — the tally stayed green while the guard
-# reported a failure into the void. That is CLAUDE.md's rule stated for cargo parsers and general
-# in fact: READ BY REDIRECTION, NEVER A PIPE, because a piped reader runs in a subshell and its
-# verdict is thrown away. The payload is therefore an ARGUMENT written to a file and fed by `<`.
-_jm_payload_file="$tmp/jm-payload.json"
-_jm_run() { # _jm_run <job> <payload> — runs in THIS shell; payload by redirection, never a pipe
-  printf '%s' "$2" >"$_jm_payload_file"
-  : >"$_jm_facts"
-  : >"$_jm_prompt"
-  if ! python3 "$_jm_tool" "$1" "$_jm_facts" "$_jm_prompt" <"$_jm_payload_file" >/dev/null 2>&1; then
-    bad "case (jm9/jm11) the facts tool exited non-zero for job $1 — the assert that follows would read an empty or stale facts file"
-    return 1
-  fi
-  if [ ! -s "$_jm_facts" ]; then
-    bad "case (jm9/jm11) the facts tool produced NO facts for job $1 — an absence assert would pass vacuously"
-    return 1
-  fi
-  return 0
-}
-_jm_prompt="$tmp/jm-facts-prompt.txt"
-if [ ! -f "$_jm_tool" ] || ! command -v python3 >/dev/null 2>&1; then
-  printf 'SKIP - roborev-job-facts.py or python3 unavailable; the fact-extraction cases did not run\n'
-else
-  _jm_run 4656 "$(printf '[{"id":4656,"git_ref":"aaa..bbb","status":"done","source_machine_id":"%s"}]' "$JM_UUID")" || true
-  if [ "$(sed -n 's/^source_machine_id=//p' "$_jm_facts" | head -1)" = "$JM_UUID" ]; then
-    ok 'case (jm9) a list-shaped row yields source_machine_id as a string fact'
-  else
-    bad "case (jm9) the list-shaped row did not yield source_machine_id (facts: $(tr '\n' ' ' <"$_jm_facts"))"
-  fi
-  _jm_run 4656 "$(printf '{"id":4656,"job_id":4656,"agent":"codex","prompt":"p","job":{"id":4656,"git_ref":"aaa..bbb","status":"done"}}')" || true
-  if grep -q '^source_machine_id=' "$_jm_facts"; then
-    bad "case (jm9) a show-shaped payload emitted a source_machine_id fact — an empty one renders as a blank uuid (facts: $(tr '\n' ' ' <"$_jm_facts"))"
-  else
-    ok 'case (jm9) a show-shaped payload yields NO source_machine_id fact at all, not an empty one'
-  fi
-  # AND THE ROW SELECTION IS UNCHANGED: adding a string fact must not be able to move `find_job`
-  # onto a different row. The review row here answers to the same id and carries no git_ref, so a
-  # regression that let the new fact influence selection would surface as the wrong git_ref.
-  _jm_run 4656 "$(printf '{"id":4656,"job_id":4656,"source_machine_id":"decoy","job":{"id":4656,"git_ref":"aaa..bbb","status":"done","model":"m"}}')" || true
-  if [ "$(sed -n 's/^git_ref=//p' "$_jm_facts" | head -1)" = 'aaa..bbb' ]; then
-    ok 'case (jm9) the git_ref-bearing row is still the one selected (the new fact cannot move find_job)'
-  else
-    bad 'case (jm9) adding source_machine_id changed which row find_job selects — the required facts now come from the wrong object'
-  fi
-fi
-
-printf '== (jm10) #3654: --help documents the per-daemon scope, a WORKING check, and the prompt evidence ==\n'
-CASE_N=$((CASE_N + 1))
-OUT="$tmp/out-$CASE_N.txt"
-bash "$WRAPPER_REAL" --help >"$OUT" 2>"$tmp/jm-help-err.txt"
-if [ -s "$tmp/jm-help-err.txt" ]; then
-  bad "case (jm10) --help wrote to stderr: $(head -2 "$tmp/jm-help-err.txt")"
-else
-  ok 'case (jm10) --help is clean on stderr'
-fi
-assert_says 'case (jm10) --help states that job ids are per-daemon' 'JOB IDS ARE PER-DAEMON, NOT GLOBAL'
-assert_says 'case (jm10) --help says to verify git_ref, never the id alone' "VERIFY THE RECORD'S git_ref AND NEVER THE ID"
-# THE PRESCRIBED COMMAND MUST BE ONE THAT WORKS. The issue and its addendum both prescribed
-# `roborev show <id> --json | jq '{id, git_ref, branch, source_machine_id, token_usage}'`, which
-# MEASURES four nulls: show nests those fields under `.job` and carries no source_machine_id at all.
-# Documenting it unchanged would reproduce the very defect the addendum diagnoses.
-assert_says 'case (jm10) --help reads git_ref from the payload that HAS it (.job on show)' \
-  "roborev show <id> --json \| jq '\.job \| \{id, git_ref"
-assert_says 'case (jm10) --help reads the daemon id from the LIST payload' \
-  "roborev list --json --limit <N> --repo <abs-repo> --branch <branch>"
-assert_lacks 'case (jm10) --help does NOT prescribe the top-level jq that measures nulls' \
-  "show <id> --json \| jq '\{id, git_ref"
-assert_says 'case (jm10) --help warns that the list default follows the --repo HEAD, not the shell' \
-  'defaults its branch filter to the CURRENT HEAD OF THE --repo PATH'
-assert_says 'case (jm10) --help states that a local row count proves nothing' \
-  'A LOCAL ROW COUNT IS NOT EVIDENCE OF UNIQUENESS'
-assert_says 'case (jm10) --help names the failure class the row count belongs to' \
-  'IDENTICAL under the two states it claims'
-assert_says 'case (jm10) --help names the prompt as the DIRECT ARTIFACT to lead with' \
-  'That is the DIRECT ARTIFACT'
-assert_says 'case (jm10) --help names the retrieval command' 'roborev show <id> --prompt'
-# THE EVIDENCE AXIS, CORRECTED TWICE (roborev job 39 finding 2, then job 43 finding 1). Version 1
-# called the prompt DIRECT EVIDENCE and the token counts a mere FALLBACK. Version 2 fixed that and
-# overshot, asserting the counts were "recorded BY THE DAEMON and nothing the reviewed branch can
-# write changes it", i.e. unforgeable corroboration. THAT WAS FALSE IN THE HALF THAT MATTERED: the
-# counts measure THE PROMPT, and the prompt embeds repository-controlled content, so a branch cannot
-# forge the RECORD but can move the MAGNITUDE — and the counts exist to separate a real review from
-# one that received nothing (vacuous baseline ~18.7k input / 0 cached), so padding non-diff prompt
-# content defeats exactly that use. What is asserted now is capability AND limit for each signal,
-# plus the two claims that stop the overshoot returning: neither establishes provenance, and the two
-# are not independent.
-assert_says 'case (jm10) --help says the prompt is NOT self-authenticating' \
-  'IT IS NOT SELF-AUTHENTICATING'
-assert_says 'case (jm10) --help names the repository-controlled content that makes it so' \
-  'EMBEDS repository-controlled content'
-assert_says 'case (jm10) --help refuses "a human reads it" as a channel separation' \
-  'not a channel separation'
-assert_says 'case (jm10) --help says the counts are daemon-recorded but NOT independent' \
-  'DAEMON-RECORDED BUT NOT INDEPENDENT'
-assert_says 'case (jm10) --help says the branch moves their MAGNITUDE without forging the record' \
-  'MAGNITUDE without forging anything'
-assert_says 'case (jm10) --help says NEITHER signal establishes provenance' \
-  'NEITHER SIGNAL ESTABLISHES'
-assert_says 'case (jm10) --help records the evidence policy as an open question, not settled here' \
-  'is an OPEN QUESTION'
-# THE OVERSHOOT MUST NOT COME BACK. An authorizer acting on "unforgeable" would grant on a number a
-# branch can inflate, so the retired claim is pinned ABSENT as well as the replacement pinned present.
-# ONE assert, on the retired sentence itself. A second one on "unforgeable corroboration" was written
-# and REMOVED: the replacement text contains those two words wrapped across a line break, so the
-# assert would have passed on a LINE-WRAPPING ACCIDENT and reddened on a reflow — a test passing for
-# a reason unrelated to its claim, which is the defect class this file exists to catch.
-assert_lacks 'case (jm10) --help never calls the counts unwritable by the branch' \
-  'recorded BY THE DAEMON and nothing'
-assert_lacks 'case (jm10) --help no longer demotes token accounting to a fallback' \
-  'the FALLBACK, for when the prompt cannot be retrieved'
-# THE DECLARED CROSS-BOX BOUNDARY (roborev job 39, finding 1). The marker travels through GitHub
-# while --recheck-job reads the LOCAL daemon, so a same-id/same-range collision across two boxes
-# lets an authorization cross reviews. It is NOT closed here (that needs a marker field, which ask 4
-# forbids) — so what must never regress is that the text DECLARES it rather than implying safety.
-assert_says 'case (jm10) --help declares the cross-box boundary' 'DECLARED BOUNDARY'
-assert_says 'case (jm10) --help says what is NOT claimed' 'NOT CLAIMED: that a marker cannot cross boxes'
-assert_says 'case (jm10) --help names the channel the marker actually travels' \
-  'through GITHUB, not through the daemon'
-assert_says 'case (jm10) --help refuses the issue-body argument as irrelevant to the marker' \
-  'true of the RECORD and'
-assert_says 'case (jm10) --help records the escalation rather than deciding it' \
-  'PENDING on #3654'
-assert_says 'case (jm10) --help states the mitigation is operational, not mechanical' \
-  'OPERATIONAL, NOT MECHANICAL|is informational and CANNOT enforce'
-assert_says 'case (jm10) --help says why this is not the deleted classifier' \
-  'RESURRECTS NOTHING OF THE DELETED DELIVERY CLASSIFIER'
-assert_says 'case (jm10) --help records that the marker grammar is unchanged' \
-  'THE MARKER GRAMMAR IS DELIBERATELY UNCHANGED'
-# NOTE: `assert_no_marker_form` is deliberately NOT applied here. `--help` is the ONE sanctioned
-# place the marker form is written out — the diagnostics refuse to print it and point here instead
-# — so a run of it necessarily carries the stem.
-reset_stub
-
-printf '== (jm13) #3654 r2: the lookup is scoped to the JOB record'"'"'s branch, not the ambient one ==\n'
-# THE DAEMON'S JOB LIST IS BRANCH-FILTERED, so the branch used to scope the supplementary read
-# decides whether the key resolves at all. Scoping by the branch the INVOCATION is on answers about
-# a DIFFERENT branch whenever the job was enqueued under another name — and then `job-machine:`
-# reads NOT RECORDED for a record that HAS a source_machine_id. Fixtured by making the two diverge:
-# the daemon holds jobs for the RECORD's branch only, and the fixture is checked out on another.
-reset_stub
-STUB_ANNOUNCE_SHA="$jm_head"
-STUB_SOURCE_MACHINE_ID="$JM_UUID"
-STUB_JOB_BRANCH='issue-earlier-lane'
-STUB_LIST_BRANCH='issue-earlier-lane'
-run_wrapper "$jm_work"
-assert_verdict 'case (jm13)' PASS 0
-assert_says 'case (jm13) the daemon is still named when the job'"'"'s branch is not the current one' \
-  "^job-machine: $JM_UUID \(source_machine_id; job ids are per-daemon\)$"
-reset_stub
-
-printf '== (jm14) #3654 r2: --recheck-job of an OLDER job on another branch still names the daemon ==\n'
-# THE MODE THE MITIGATION IS DOCUMENTED FOR, and the one most likely to miss: a waiver is applied
-# by rechecking a job that may have been enqueued before a rename or a rebase. Before the fix this
-# rendered NOT RECORDED and the documented "compare job-machine: between the request and the
-# recheck" would silently not work in the only mode it exists for — a claim the implementation did
-# not deliver, which is worse than claiming nothing.
-reset_stub
-STUB_ANNOUNCE_SHA="$jm_head"
-STUB_SOURCE_MACHINE_ID="$JM_UUID"
-STUB_JOB_BRANCH='issue-earlier-lane'
-STUB_LIST_BRANCH='issue-earlier-lane'
-STUB_VERDICT_FIELD='P'
-STUB_RECORD_OUTPUT="$CLEAN_TEXT"
-run_wrapper "$jm_work" --recheck-job 4656
-assert_verdict 'case (jm14)' PASS 0
-assert_says 'case (jm14) a recheck of an older, differently-branched job names its daemon' \
-  "^job-machine: $JM_UUID \(source_machine_id; job ids are per-daemon\)$"
-assert_says 'case (jm14) and it is still a recheck' '^MODE: recheck '
-reset_stub
-
-printf '== (jm17) #3654 r3: a target BEYOND the first 50 rows is still found (depth, not width) ==\n'
-# ROUND 2 FIXED THE BRANCH AND LEFT THE DEPTH. With the branch right, a fixed `--limit 50` still
-# drops the target the moment the branch holds more than 50 jobs — and the jobs that sit deep are
-# the OLD ones, which are exactly the ones a `--recheck-job` names. So the documented cross-box
-# mitigation failed for its own primary case. This case puts the target under 60 newer rows: it
-# FAILS against a fixed `--limit 50` (the key reads NOT RECORDED) and passes once the lookup
-# retrieves until found. Deliberately 60, not 5000 — the property is "deeper than the first page",
-# and a case that needs a huge fixture invites being trimmed later.
-reset_stub
-STUB_ANNOUNCE_SHA="$jm_head"
-STUB_SOURCE_MACHINE_ID="$JM_UUID"
-STUB_JOB_BRANCH='issue-earlier-lane'
-STUB_LIST_BRANCH='issue-earlier-lane'
-STUB_LIST_DEPTH=60
-run_wrapper "$jm_work"
-assert_verdict 'case (jm17)' PASS 0
-assert_says 'case (jm17) the daemon is named for a job below the first page of rows' \
-  "^job-machine: $JM_UUID \(source_machine_id; job ids are per-daemon\)$"
-assert_lacks 'case (jm17) depth never yields a filler row'"'"'s machine id' 'filler-not-the-target'
-reset_stub
-
-printf '== (jm18) #3654 r3: a genuinely absent job says so, naming the depth searched ==\n'
-# THE COMPLEMENT, and the reason the loop needs an affirmative end-of-list signal: retrieving
-# "until found" must still TERMINATE when the job is not there at all, and must say that it
-# reached the end of the daemon's list rather than merely giving up at some number.
-reset_stub
-STUB_ANNOUNCE_SHA="$jm_head"
-STUB_JOB_BRANCH='issue-earlier-lane'
-STUB_LIST_BRANCH='issue-earlier-lane'
-STUB_LIST_DEPTH=10
-STUB_LIST_OMIT_TARGET=1
-run_wrapper "$jm_work"
-assert_says 'case (jm18) the miss names the depth reached and that the list ended' \
-  'searched to a depth of [0-9]+ rows and to the end of what the daemon returns'
-assert_lacks 'case (jm18) it never claims a fixed 50-job window' "latest 50 jobs"
-# AND IT MUST NOT MIS-ATTRIBUTE. "We did not read far enough" and "the row carries no
-# source_machine_id" are different facts about different rows, and collapsing them into one
-# affirmative sentence is the round-2 finding repeating one layer down: the row may well exist and
-# carry the field. Separated causes are the whole value of the depth fix — closing the
-# reachability while leaving the sentence would fix the bound and keep the lie.
-assert_lacks 'case (jm18) a depth miss is never reported as field-absence' \
-  'carries no source_machine_id'
-reset_stub
-
-printf '== (jm19) #3654 r3: an abort AFTER the record poll never emits a stale job-record state ==\n'
-# THE PAIR OF KEYS MUST NOT CONTRADICT EACH OTHER. `job-machine:`'s UNAVAILABLE fallback names the
-# `job-record:` state it inherits, and it used to be a fully-formed string built at INITIALIZATION,
-# where `$JOB_RECORD` is `SKIP`. The `on_exit` EXIT trap emits the block on ANY abort, so a run that
-# died after the record poll printed `job-record: PASS` beside
-# `job-machine: UNAVAILABLE (... job-record: SKIP)` — an artifact stating two different things about
-# one fact. Interpolating at that same early site does NOT fix it (the expansion still captures
-# SKIP), which is why the value is built at EMIT time instead.
-#
-# Fixtured by injecting an abort between the poll and the recompute, into a SCRATCH COPY of the
-# wrapper — the one place that window is reachable on demand.
-_jmb_dir="$tmp/jm-abort"
-mkdir -p "$_jmb_dir"
-cp "$WRAPPER_REAL" "$SCRIPT_DIR/../flow/roborev-review-oracles.sh" \
-  "$SCRIPT_DIR/../flow/roborev-review-checks.sh" "$SCAN_TOOL" "$_jmb_dir/"
-if [ -f "$SCRIPT_DIR/../flow/roborev-job-facts.py" ]; then
-  cp "$SCRIPT_DIR/../flow/roborev-job-facts.py" "$_jmb_dir/"
-fi
-if sed_inplace_verified "$_jmb_dir/roborev-review.sh" \
-     's/^JOB_VERDICT=\$(fact verdict)$/exit 9\nJOB_VERDICT=$(fact verdict)/' \
-     'exit 9' ; then
-  reset_stub
-  STUB_ANNOUNCE_SHA="$jm_head"
-  run_wrapper --wrapper "$_jmb_dir/roborev-review.sh" "$jm_work"
-  # The run aborted, so job-record: reached PASS while job-machine: never recomputed. The ONE
-  # property: whatever job-record: says, job-machine: must say the SAME thing.
-  _jmb_rec=$(sed -n 's/^job-record: //p' "$OUT" | head -1)
-  _jmb_mach=$(sed -n 's/^job-machine: //p' "$OUT" | head -1)
-  if [ -z "$_jmb_mach" ]; then
-    bad "case (jm19) no job-machine: line was emitted on the abort path (job-record: '${_jmb_rec:-<none>}')"
-  elif [ -z "$_jmb_rec" ]; then
-    bad 'case (jm19) no job-record: line was emitted, so the two keys could not be compared'
-  else
-    # (1) THE INTERPOLATED NEIGHBOUR IS CURRENT. This was ONCE THE WHOLE CASE, and that was too
-    # narrow: the value can name the right job-record state inside a sentence whose STATE and
-    # EXPLANATION are both false, so the case passed while the artifact still lied.
-    case "$_jmb_mach" in
-      *"job-record: $_jmb_rec"*)
-        ok "case (jm19) job-machine: names the CURRENT job-record state ($_jmb_rec) on an abort" ;;
-      *)
-        bad "case (jm19) the two keys contradict each other: job-record: '$_jmb_rec' but job-machine: '$_jmb_mach'" ;;
-    esac
-    # (2) THE STATE TOKEN ITSELF. A record WAS read here, so UNAVAILABLE — whose whole meaning is
-    # "no record could be read" — is the wrong state, whatever it interpolates.
-    case "$_jmb_mach" in
-      'NOT RECORDED ('*)
-        ok 'case (jm19) the state is NOT RECORDED, which is true: a record WAS read and only the lookup is missing' ;;
-      *)
-        bad "case (jm19) the abort path reports state '${_jmb_mach%% (*}' after a record WAS read — only NOT RECORDED is true here" ;;
-    esac
-    # (3) THE EXPLANATION. The sentence a reader actually acts on must not assert the opposite of
-    # what happened; pinned separately because (2) can hold while the prose still says "no record".
-    case "$_jmb_mach" in
-      *'no job record was read'*)
-        bad "case (jm19) the explanation claims no job record was read, but one was: '$_jmb_mach'" ;;
-      *'job record WAS read'*)
-        ok 'case (jm19) the explanation says a record was read and names the lookup as the missing step' ;;
-      *)
-        bad "case (jm19) the explanation neither affirms nor denies the record read, so a reader cannot tell what happened: '$_jmb_mach'" ;;
-    esac
-  fi
-  reset_stub
-else
-  bad 'case (jm19) could not inject the abort into the scratch wrapper, so the stale-state path was never exercised (a green here would be a probe failing in the direction that looks like success)'
-fi
-
-printf '== (jm15) #3654 r2: NO ambient-branch fallback when the record does not name its branch ==\n'
-# THE FALLBACK THAT MUST NOT EXIST. Here the daemon WOULD answer for the fixture's own branch, so a
-# retry against it would produce a uuid — one belonging to whatever that branch's job is, presented
-# as this job's daemon. Silently answering about a different branch is the same defect one layer
-# down, so the state must say what it could not do instead.
-reset_stub
-STUB_ANNOUNCE_SHA="$jm_head"
-STUB_SOURCE_MACHINE_ID="$JM_UUID"
-STUB_JOB_BRANCH='none'
-STUB_LIST_BRANCH=$(git -C "$jm_work" rev-parse --abbrev-ref HEAD)
-run_wrapper "$jm_work"
-assert_verdict 'case (jm15) an unscopeable lookup never fails a clean run' PASS 0
-assert_says 'case (jm15) the state names what could not be scoped' \
-  '^job-machine: NOT RECORDED \(the job record does not name its own branch'
-assert_says 'case (jm15) and says the ambient fallback was refused, with the reason' \
-  'deliberately NOT retried against the branch this invocation is on, which would answer about a different branch'
-assert_lacks 'case (jm15) no uuid is invented from the ambient branch' "^job-machine: $JM_UUID"
-reset_stub
-
-printf '== (jm16) #3654 r2: a record that WAS read but is incomplete is NOT RECORDED, not UNAVAILABLE ==\n'
-# THE STATE THAT COULD LIE. The rendering used to branch on `record_required_present`, which asks
-# about COMPLETENESS — so a record that was read and is merely nonterminal rendered
-# 'UNAVAILABLE (no job record could be read)', which is FALSE: one was read. The three states are
-# only worth having if each is an affirmative TRUE statement about what happened.
-reset_stub
-STUB_ANNOUNCE_SHA="$jm_head"
-STUB_STATUS='running'
-run_wrapper "$jm_work"
-assert_verdict 'case (jm16)' FAIL 1
-assert_says 'case (jm16) an incomplete-but-READ record is NOT RECORDED' '^job-machine: NOT RECORDED \('
-assert_lacks 'case (jm16) it never claims no record could be read' '^job-machine: UNAVAILABLE'
-assert_says 'case (jm16) the job-record key independently reports the incompleteness' '^job-record: DEGRADED'
-reset_stub
-
-printf '== (jm20) #3654 r5: the DOCUMENTED manual lookup finds a job beyond the first page ==\n'
-# THE CODE MOVED AND THE DOCUMENTATION DID NOT. The depth fix made the WRAPPER expand its own
-# lookup until found-or-exhausted, while the procedure --help tells a HUMAN to run still took the
-# default page — so a lead following our own written instructions on a deep job got an empty result
-# and no indication why, in exactly the case the code had just learned to handle.
-#
-# IT EXECUTES THE DOCUMENTED COMMAND RATHER THAN GREPPING THE HELP FOR A STRING. A string assert
-# would pass on any text mentioning --limit, including a command that still cannot find the row —
-# the same test-narrowness this issue has now paid for four times. So the command is EXTRACTED from
-# --help, its placeholders substituted as a human would substitute them, and RUN against the stub
-# daemon with the target sixty rows deep.
-if ! command -v jq >/dev/null 2>&1; then
-  printf 'SKIP - jq unavailable; the documented lookup could not be executed\n'
-else
-  CASE_N=$((CASE_N + 1))
-  OUT="$tmp/out-$CASE_N.txt"
-  bash "$WRAPPER_REAL" --help >"$OUT" 2>/dev/null
-  _jm20_cmd=$(grep -E '^ *roborev list --json .*select\(\.id==' "$OUT" | head -1 | sed 's/^ *//')
-  if [ -z "$_jm20_cmd" ]; then
-    bad 'case (jm20) --help prints no roborev list lookup command to execute — the documented procedure is gone'
-  else
-    reset_stub
-    STUB_LIST_DEPTH=60
-    STUB_LIST_BRANCH='issue-earlier-lane'
-    STUB_SOURCE_MACHINE_ID="$JM_UUID"
-    # The stub runs `set -uo pipefail` and dereferences STUB_INVOKED unguarded, so it EXITS if the
-    # variable is unset. run_wrapper supplies it per invocation; a direct call must too, or the
-    # daemon double dies and every probe below returns nothing — which the absence-shaped control
-    # would have read as SUCCESS. That happened while writing this case.
-    STUB_INVOKED="$tmp/jm20-invoked.txt"; : >"$STUB_INVOKED"; export STUB_INVOKED
-    _jm20_base=$(printf '%s' "$_jm20_cmd" \
-      | sed -e "s|<abs-repo>|$jm_work|" -e 's|<branch>|issue-earlier-lane|' -e 's|<id>|4656|')
-    # CONTROL 1 — THE DAEMON ANSWERS AT ALL. An absence-shaped control cannot tell "the row is
-    # deeper than this page" from "the double never ran", and those are exactly the two states this
-    # case must distinguish. So the first page is required to come back FULL of the filler rows.
-    if PATH="$stubbin:$PATH" roborev list --json --limit 50 --repo "$jm_work" \
-         --branch issue-earlier-lane 2>/dev/null | grep -q 'filler-not-the-target'; then
-      ok 'case (jm20) control: the stub daemon answers, and the first page is full of other jobs'
-    else
-      bad 'case (jm20) CONTROL: the stub daemon returned no rows at all, so every probe below would report absence for a reason unrelated to depth'
-    fi
-    # CONTROL 2 — AND THE TARGET IS NOT ON THAT PAGE, or the escalation would succeed trivially.
-    _jm20_ctl=$(printf '%s' "$_jm20_base" | sed 's|<N>|50|')
-    if PATH="$stubbin:$PATH" sh -c "$_jm20_ctl" 2>/dev/null | grep -q "$JM_UUID"; then
-      bad 'case (jm20) CONTROL: the row is already on the first page, so the fixture is not deep enough to test depth'
-    else
-      ok 'case (jm20) control: the first page does NOT hold the row, so only an expanding lookup can find it'
-    fi
-    # THE PROCEDURE ITSELF, followed literally: raise the limit until the row appears.
-    _jm20_found=''
-    if printf '%s' "$_jm20_base" | grep -q '<N>'; then
-      for _jm20_n in 50 200 800; do
-        _jm20_run=$(printf '%s' "$_jm20_base" | sed "s|<N>|$_jm20_n|")
-        if PATH="$stubbin:$PATH" sh -c "$_jm20_run" 2>/dev/null | grep -q "$JM_UUID"; then
-          _jm20_found="$_jm20_n"; break
-        fi
-      done
-    elif PATH="$stubbin:$PATH" sh -c "$_jm20_base" 2>/dev/null | grep -q "$JM_UUID"; then
-      _jm20_found=default
-    fi
-    if [ -n "$_jm20_found" ]; then
-      ok "case (jm20) the documented lookup returns the deep job's daemon id (found at limit $_jm20_found)"
-    else
-      bad 'case (jm20) the documented lookup returns NOTHING for a job past the first page — a lead following our own procedure sees an empty result and no reason why, while the wrapper finds it'
-    fi
-    reset_stub
-  fi
-fi
-
-printf '== (jm11) #3654: a `show` payload whose TOP-LEVEL id is NOT the asked job ==\n'
-# MEASURED SHAPE (ten records): top-level `id` is the REVIEW row's own sequence and can differ from
-# the job asked for — asking for 9 returns id=8, job_id=9, job.id=9. Two things must hold, and the
-# second is what this change could have broken: the facts must still come from the JOB row (find_job
-# matches id/job_id/job and then PREFERS the object carrying git_ref), and the OUTER row's own
-# `source_machine_id` must NOT leak into the facts — a decoy machine id attributed to the wrong row
-# is worse than none, because it reads as a measurement.
-if [ ! -f "$_jm_tool" ] || ! command -v python3 >/dev/null 2>&1; then
-  printf 'SKIP - roborev-job-facts.py or python3 unavailable; the id-divergence case did not run\n'
-else
-  _jm_run 9 "$(printf '{"id":8,"job_id":9,"uuid":"outer-uuid","source_machine_id":"DECOY","prompt":"p","job":{"id":9,"git_ref":"aaa..bbb","status":"done","model":"m"}}')" || true
-  if [ "$(sed -n 's/^git_ref=//p' "$_jm_facts" | head -1)" = 'aaa..bbb' ]; then
-    ok 'case (jm11) the nested job row is still selected when the top-level id names another review'
-  else
-    bad 'case (jm11) the id-divergent payload selected the wrong row — the required facts would come from the review row'
-  fi
-  if grep -q '^source_machine_id=DECOY$' "$_jm_facts"; then
-    bad 'case (jm11) the OUTER review row supplied source_machine_id — the daemon id would be attributed to a row that is not the job'
-  else
-    ok 'case (jm11) no source_machine_id leaks from the outer review row (the fact follows the selected row)'
-  fi
-fi
-
-printf '== (jm12) #3654 structural: the supplementary machine read NAMES THE BRANCH ==\n'
-# `roborev list` is BRANCH-FILTERED, and its default follows the CURRENT HEAD OF THE `--repo` PATH
-# — measured: from a cwd that is not a git repository at all, `--repo <lane>` returns that lane's
-# branch's rows, and the same `--repo` run from a different lane's branch returns the same rows. So
-# the default is `$BRANCH` (read from that same HEAD), which is the branch the CHECKOUT is on and
-# NOT the job's. The two diverge on exactly the path this key is documented for: a `--recheck-job`
-# of an older job, a renamed or rebased lane, or a checkout since moved on. A default-scoped or
-# `$BRANCH`-scoped machine read then resolves NOTHING for a record that HAS a source_machine_id,
-# and `job-machine:` reads NOT RECORDED for a reason having nothing to do with the record — a key
-# that can only ever report absence. Only a structural assert pins this: every hermetic case runs
-# with the fixture branch checked out, so the stub answers either way.
-_jm_supp=$(sed -n '/^read_machine_fact() {/,/^}/p' "$WRAPPER_REAL")
-if [ -z "$_jm_supp" ]; then
-  bad 'case (jm12) could not locate read_machine_fact to inspect'
-elif printf '%s\n' "$_jm_supp" | grep -qE 'roborev list --json .*--branch "\$job_branch"'; then
-  ok 'case (jm12) the supplementary machine read is scoped to the RECORD'"'"'s own branch'
-  # AND NEVER TO THE AMBIENT ONE. `$BRANCH` is the branch this invocation is running on, which is
-  # not the job's fact; scoping by it answers about a different branch on exactly the recheck path
-  # the operator mitigation is documented for. A fallback to it is as wrong as using it outright,
-  # so the function must not mention it at all.
-  if printf '%s\n' "$_jm_supp" | grep -q 'BRANCH'; then
-    bad 'case (jm12) read_machine_fact still refers to the ambient $BRANCH — scoping (or falling back) to it answers about a branch other than the job own'
-  else
-    ok 'case (jm12) it never falls back to the ambient $BRANCH'
-  fi
-else
-  bad 'case (jm12) the supplementary machine read is not scoped to the record'"'"'s own branch ($job_branch) — it would answer about whatever branch the invocation happens to be on'
-fi
-# AND THE RECORD READ IS DELIBERATELY LEFT ALONE: `sha-assert` depends on it, and naming the branch
-# there is behaviour-neutral only while the invoking cwd's branch equals $BRANCH. Pinned so a future
-# "consistency" edit has to argue with this line rather than silently change a load-bearing read.
-if grep -qE '^ *list\) json=\$\(roborev list --json --limit 50 --repo "\$REPO" 2>/dev/null' "$WRAPPER_REAL"; then
-  ok 'case (jm12) the RECORD read is unchanged (no --branch) — that read is sha-assert'"'"'s, and out of scope here'
-else
-  bad 'case (jm12) the job-record list read has changed shape — sha-assert depends on it, and #3654 must not have touched it'
-fi
-
 printf '== the summary header is distinct from every agent-gate header ==\n'
 reset_stub
 work=$(make_fixture case_hdr pushed)
@@ -6587,6 +5852,65 @@ assert_says 'header: roborev block present' '^==== ROBOREV REVIEW SUMMARY ====$'
 assert_lacks 'header: no AGENT-GATE SUMMARY header' '==== AGENT-GATE SUMMARY ===='
 assert_lacks 'header: no AGENT-GATE LITE SUMMARY header' '==== AGENT-GATE LITE SUMMARY ===='
 assert_lacks 'header: no AGENT-GATE DELTA SUMMARY header' '==== AGENT-GATE DELTA SUMMARY ===='
+
+printf '== (jd1) #3654: --help documents that job ids are PER-DAEMON, and how to settle it ==\n'
+# THE INCIDENT: two lanes on two boxes requested absence waivers 50 minutes apart, both naming
+# `job=265` for DIFFERENT reviews (different ranges, branches and token counts). Both were correct
+# — ids are sequential PER DAEMON, not global — but the coordination lead read the repetition as a
+# collision and WITHHELD a valid waiver. The failure is symmetric: a lead who then treats `job=` as
+# uninformative discards the one field binding an authorization to a REVIEW rather than to a RANGE.
+#
+# SCOPE (#3654 narrowed to asks 1+2): what ships is the DOCUMENTED FACT plus a check that settles
+# it. The emitted `job-machine:` key and the cross-box residual are #3825; waiver evidence policy
+# is #3826. This case therefore pins the doctrine and the payload traps, and nothing about a key.
+CASE_N=$((CASE_N + 1))
+OUT="$tmp/out-$CASE_N.txt"
+bash "$WRAPPER_REAL" --help >"$OUT" 2>"$tmp/jd1-help-err.txt"
+if [ -s "$tmp/jd1-help-err.txt" ]; then
+  bad "case (jd1) --help wrote to stderr: $(head -2 "$tmp/jd1-help-err.txt")"
+else
+  ok 'case (jd1) --help is clean on stderr'
+fi
+assert_says 'case (jd1) --help states that job ids are per-daemon' 'JOB IDS ARE PER-DAEMON, NOT GLOBAL'
+assert_says 'case (jd1) --help says to verify git_ref, never the id alone' "VERIFY THE RECORD'S git_ref AND NEVER THE ID"
+assert_says 'case (jd1) --help records the measurement behind it' "'job=265' on two lanes"
+# THE PRESCRIBED COMMANDS MUST BE ONES THAT WORK. `show <id> --json` NESTS the fields under `.job`,
+# so a top-level jq over that payload prints nulls — a check whose output cannot show what it claims.
+assert_says 'case (jd1) --help prescribes the NESTED .job projection' \
+  "roborev show <id> --json | jq '\.job |"
+assert_says 'case (jd1) --help names the nesting trap' "NESTS git_ref/status/token_usage"
+# THE TOP-LEVEL id IS THE REVIEW ROW'S OWN SEQUENCE, measured over ten records: asking for 9
+# returns id=8 with job_id=9. A human reading it manufactures the very doubt the check removes.
+assert_says 'case (jd1) --help warns that a show payload top-level id is not the job asked for' \
+  "TOP-LEVEL 'id' of a 'show' payload is the REVIEW"
+assert_says 'case (jd1) --help gives the measured id-divergence' 'asking for 9 returns id=8'
+# THE LIST DEFAULT FOLLOWS THE --repo PATH'S HEAD, not the invoking shell's branch. The earlier
+# claim here named the cwd's branch and was FALSE: its evidence was a null from a --repo sitting on
+# main, which BOTH readings explain identically — a probe that cannot distinguish what it asserts.
+assert_says 'case (jd1) --help states the list default follows the --repo HEAD' \
+  'defaults its branch filter to the CURRENT HEAD OF THE --repo PATH'
+assert_lacks 'case (jd1) --help no longer claims the list filters by the shell branch' \
+  'filters by the CURRENT BRANCH by default'
+# A LOCAL ROW COUNT IS NOT EVIDENCE OF UNIQUENESS: `list` only ever sees the LOCAL daemon, so the
+# length probe returns 1 whether or not another box holds the same id — identical output under the
+# two states it claims to separate.
+assert_says 'case (jd1) --help refuses the row-count probe as a collision check' \
+  'A LOCAL ROW COUNT IS NOT EVIDENCE OF UNIQUENESS'
+assert_says 'case (jd1) --help says why the probe cannot work' 'only ever sees the LOCAL daemon'
+# ASK 5, FACTUAL HALF ONLY (policy is #3826): what each signal can and cannot establish.
+assert_says 'case (jd1) --help scopes the after-the-fact cost to a HUMAN reading the record' \
+  'ONLY FOR A HUMAN READING'
+assert_says 'case (jd1) --help says the prompt is NOT self-authenticating' 'IS NOT SELF-AUTHENTICATING'
+# Fragment kept to ONE line: the full phrase wraps in the rendered help, and a pattern spanning the
+# break matches nothing — the same line-wrapping trap that made an earlier assert pass by accident.
+assert_says 'case (jd1) --help says the counts are daemon-recorded but NOT independent' \
+  'IS DAEMON-RECORDED BUT NOT'
+assert_says 'case (jd1) --help says NEITHER signal establishes provenance' 'NEITHER SIGNAL ESTABLISHES'
+# AND NO PREFERENCE SHIPS. The narrowing keeps the limits and drops every recommendation; a
+# reintroduced "lead with it" would be policy this change deliberately does not decide.
+assert_says 'case (jd1) --help defers the evidence policy to #3826' 'TRACKED AS #3826'
+assert_lacks 'case (jd1) --help recommends no ordering between the signals' 'should LEAD with'
+reset_stub
 
 printf '== --help documents the exit codes and the live worktree probe ==\n'
 reset_stub

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -5977,6 +5977,24 @@ assert_says 'case (jd1) --help says NEITHER signal establishes provenance' 'NEIT
 # reintroduced "lead with it" would be policy this change deliberately does not decide.
 assert_says 'case (jd1) --help defers the evidence policy to #3826' 'TRACKED AS #3826'
 assert_lacks 'case (jd1) --help recommends no ordering between the signals' 'should LEAD with'
+# WHAT DELETING THE CLASSIFIER BOUGHT, AND WHAT IT DID NOT. The surviving claim is the PARSER one —
+# no automated verdict is derived from injectable prompt text, and nothing may be added that does —
+# and it is load-bearing: a future reader must not read the limit below as licence to resurrect the
+# classifier. The claim that was DELETED said there was "nothing to spoof into a PASS", which was
+# false and contradicted the sentence above it: the human is IN the path, so spoofed prompt text can
+# mislead an authorizer into issuing the marker that makes `--recheck-job` pass. Third overstatement
+# in this one paragraph across the issue's rounds, so it went by SUBTRACTION, not a third rewrite —
+# subtraction cannot introduce a false claim. Both halves are pinned, so neither can creep back.
+assert_says 'case (jd1) --help keeps the parser-exploit claim, which is the true one' \
+  'the direct PARSER exploit is gone'
+assert_says 'case (jd1) --help still forbids parsing the prompt for delivery mode' \
+  'parses the prompt for delivery mode, and nothing may be added that does'
+assert_says 'case (jd1) --help bounds what that buys' 'THAT IS ALL IT BUYS'
+assert_says 'case (jd1) --help puts the human IN the path' 'human is IN the path, not outside it'
+assert_says 'case (jd1) --help leaves the human-spoofing exposure to #3826' \
+  "#3826's subject and is"
+assert_lacks 'case (jd1) --help no longer claims there is nothing to spoof into a PASS' \
+  'nothing to spoof'
 reset_stub
 
 printf '== --help documents the exit codes and the live worktree probe ==\n'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -272,6 +272,16 @@ emit_job_object() {
   if [ -n "${STUB_VERDICT_FIELD:-}" ]; then
     extra="$extra,\"verdict\":\"${STUB_VERDICT_FIELD}\""
   fi
+  # ===== `source_machine_id` IS CARRIED BY `list` ROWS ONLY (#3654) =====
+  # MEASURED on roborev v0.61.2: `roborev list --json` rows carry it at top level, and
+  # `roborev show <id> --json` does not carry it ANYWHERE — not at top level, not in its nested
+  # `job` object. The stub reproduces that asymmetry rather than emitting the field everywhere,
+  # because it is exactly what makes `NOT RECORDED` a REAL state and what forces the wrapper's
+  # supplementary `list` read: a stub that answered on `show` too would make the `list` path
+  # untested and the key look correct while reporting nothing on a real run.
+  if [ -n "${STUB_SOURCE_MACHINE_ID:-}" ] && [ "${_EMIT_MACHINE:-0}" = 1 ]; then
+    extra="$extra,\"source_machine_id\":\"${STUB_SOURCE_MACHINE_ID}\""
+  fi
   # The review TEXT the record carries (#3312 job 24). On the JOB row as well as the review row, so every
   # payload shape a recheck may read from carries it, exactly as roborev's own payloads do.
   if [ -n "${STUB_RECORD_OUTPUT:-}" ]; then
@@ -358,6 +368,7 @@ case "$cmd" in
   list)
     record_read_blank && { printf 'null\n'; exit 0; }
     [ "${STUB_LIST_JSON:-array}" != none ] || { printf 'null\n'; exit 0; }
+    _EMIT_MACHINE=1
     printf '['; emit_job_object; printf ']\n'
     exit 0
     ;;
@@ -1190,6 +1201,9 @@ export STUB_GH_ISSUES=''
 export STUB_GH_ISSUES_CLOSED=''
 export STUB_GH_ISSUE_ERR=''
 export STUB_ON_REVIEW=''
+# #3654: the DAEMON-ID knob. Empty by default, and the stub emits it on the `list` payload ONLY,
+# which is where roborev v0.61.2 actually carries `source_machine_id`.
+export STUB_SOURCE_MACHINE_ID=''
 reset_stub() {
   STUB_JOB=4656
   STUB_VERDICT=$'No issues found.\nSummary: reviewed the diff; no issues found.'
@@ -1217,6 +1231,9 @@ reset_stub() {
   STUB_GH_ISSUES_CLOSED=''
   STUB_GH_ISSUE_ERR=''
   STUB_ON_REVIEW=''
+  # No daemon id by default: the FAIL-CLOSED direction for the `job-machine:` key (#3654) — a case
+  # that wants the uuid arm has to SAY so, so no case passes because the double happened to answer.
+  STUB_SOURCE_MACHINE_ID=''
 }
 
 printf '== case (a): enqueued sha == base ref ==\n'
@@ -5839,6 +5856,262 @@ assert_says 'case (mb8b) the tip-bound marker is STALE' \
 assert_lacks 'case (mb8b) and it grants nothing' '^prompt-content: WAIVED'
 assert_says 'case (mb8b) the absence FAIL stands' \
   '^prompt-content: FAIL \(1/1 code census paths absent from the prompt\)$'
+reset_stub
+
+# ============================================================================
+# (jm*) #3654: ROBOREV JOB IDS ARE PER-DAEMON, AND THE BLOCK SAYS WHICH DAEMON
+# ----------------------------------------------------------------------------
+# THE INCIDENT: two lanes on two boxes requested absence waivers 50 minutes apart, both
+# naming `job=265` for DIFFERENT reviews (different ranges, branches and token counts).
+# Both were correct — ids are sequential PER DAEMON — but the coordination lead read the
+# repetition as a collision and WITHHELD a valid waiver. So the block now NAMES the
+# issuing daemon beside the id it disambiguates.
+#
+# THE KEY IS INFORMATIONAL AND THAT IS THE PROPERTY MOST WORTH PINNING: it is in neither
+# the verdict-grammar scan nor the affirmation backstop, so none of its three states can
+# red an otherwise-clean run. A decorative key that can fail a correct review is the guard
+# agents learn to waive.
+JM_UUID='db07281a-b8e0-4c8f-99dc-37ca88a0a54c'
+jm_work=$(make_fixture case_jm pushed)
+jm_head=$(git -C "$jm_work" rev-parse HEAD)
+# The three renderings OBSERVED by the cases below, collected for the closed-set assert
+# (jm6). Collected rather than predicted: a closed set asserted against literals someone
+# typed proves only that the literals were typed.
+jm_seen_uuid=''
+jm_seen_not_recorded=''
+jm_seen_unavailable=''
+jm_render() { grep -E '^job-machine: ' "$OUT" | head -1 || printf ''; }
+
+printf '== (jm1) #3654: the daemon id is surfaced even when `show` alone answered the record ==\n'
+# THE CASE THAT MAKES THE KEY MORE THAN DECORATION. `read_job_record` STOPS at the first payload
+# that carries the required fields, and on a healthy daemon that is `show` — which does not carry
+# `source_machine_id` at all. Read only through that loop the key would be `NOT RECORDED` on EVERY
+# real run: a key reporting nothing while looking like it reports something. So the wrapper takes
+# one supplementary `list` read, and this case is the only thing that proves it happens.
+reset_stub
+STUB_ANNOUNCE_SHA="$jm_head"
+STUB_SOURCE_MACHINE_ID="$JM_UUID"
+run_wrapper "$jm_work"
+assert_verdict 'case (jm1)' PASS 0
+assert_says 'case (jm1) the block names the issuing daemon' "^job-machine: $JM_UUID \(source_machine_id; job ids are per-daemon\)$"
+assert_says 'case (jm1) it sits beside the id it disambiguates' '^job: 4656$'
+jm_seen_uuid=$(jm_render)
+reset_stub
+
+printf '== (jm2) #3654: the same id when the RECORD ITSELF came from the `list` payload ==\n'
+# The other route to the fact: a `show` that returns the REVIEW row (no git_ref) makes the record
+# loop fall through to `list`, so `source_machine_id` is already in the facts file and no
+# supplementary read is needed. Both routes must render identically — otherwise the value a reader
+# sees would depend on which payload happened to answer.
+reset_stub
+STUB_ANNOUNCE_SHA="$jm_head"
+STUB_SOURCE_MACHINE_ID="$JM_UUID"
+STUB_SHOW_JSON=review-row
+run_wrapper "$jm_work"
+assert_verdict 'case (jm2)' PASS 0
+assert_says 'case (jm2) the daemon id is the same on the record-from-list route' "^job-machine: $JM_UUID \(source_machine_id; job ids are per-daemon\)$"
+reset_stub
+
+printf '== (jm3) #3654: NO daemon id anywhere is NOT RECORDED — and still PASSes ==\n'
+# A REAL state, not a defensive one: a roborev build whose payloads carry no `source_machine_id`
+# reaches it on every run. It must therefore be AFFIRMATIVE (never blank, never a bare `-`) and it
+# must never cost a correct review its PASS — this case asserts both at once.
+reset_stub
+STUB_ANNOUNCE_SHA="$jm_head"
+run_wrapper "$jm_work"
+assert_verdict 'case (jm3) an unrecorded daemon never fails a clean run' PASS 0
+assert_says 'case (jm3) the state is affirmative and names the payload that carries the field' \
+  "^job-machine: NOT RECORDED \(a job record was read but carries no source_machine_id; 'roborev list --json' rows carry that field, 'roborev show <id> --json' does not\. Identify the review by the record's git_ref, never by the id alone\)$"
+assert_lacks 'case (jm3) the key is never blank' '^job-machine: *$'
+jm_seen_not_recorded=$(jm_render)
+reset_stub
+
+printf '== (jm4) #3654: the key is emitted in --recheck-job mode too ==\n'
+# THE MODE THAT MATTERS MOST: `--recheck-job` is the only path an absence waiver travels, and the
+# waiver names a job id — so this is precisely where a reader has to know WHICH daemon issued it.
+reset_stub
+STUB_ANNOUNCE_SHA="$jm_head"
+STUB_SOURCE_MACHINE_ID="$JM_UUID"
+STUB_VERDICT_FIELD='P'
+STUB_RECORD_OUTPUT="$CLEAN_TEXT"
+run_wrapper "$jm_work" --recheck-job 4656
+assert_verdict 'case (jm4)' PASS 0
+assert_says 'case (jm4) a recheck names the issuing daemon' "^job-machine: $JM_UUID \(source_machine_id; job ids are per-daemon\)$"
+assert_says 'case (jm4) and the recheck mode is still declared' '^MODE: recheck '
+reset_stub
+
+printf '== (jm5) #3654: NO readable record at all is UNAVAILABLE, naming what it inherits ==\n'
+# Distinct from (jm3) BECAUSE THEY ARE DIFFERENT OPERATOR ACTIONS: "this roborev build does not
+# record the field" and "no record could be read" send a reader to different places. The run FAILs
+# here — sha-assert cannot verify a range with no record — and the assert below pins that the FAIL
+# is NOT attributed to this key.
+reset_stub
+STUB_ANNOUNCE_SHA="$jm_head"
+STUB_SHOW_JSON=none
+STUB_LIST_JSON=none
+run_wrapper "$jm_work"
+assert_verdict 'case (jm5)' FAIL 1
+assert_says 'case (jm5) the key names the job-record state it inherits' \
+  '^job-machine: UNAVAILABLE \(no job record could be read, so the issuing daemon is unknown — job-record: DEGRADED'
+assert_says 'case (jm5) the FAIL belongs to sha-assert, not to job-machine' \
+  '^sha-assert: FAIL \(job record unavailable'
+assert_lacks 'case (jm5) no diagnostic blames the informational key' 'ERROR: job-machine'
+jm_seen_unavailable=$(jm_render)
+reset_stub
+
+printf '== (jm6) #3654: the renderings are a CLOSED SET OF THREE, matched on the state token ==\n'
+# PINNED AS A SET, NOT AS ONE LITERAL, which is the idiom this repo already uses for the gate's
+# component-set `src_note`: pinning ONE literal reds on correct input (which arm fires depends on
+# which payload answered), and pinning NOTHING lets a wording pass delete the key. So all three
+# observed values are reduced to their STATE TOKEN and the set is compared by string equality.
+jm_token() { # jm_token <rendered "job-machine: <value>" line> -> the state token
+  local v="${1#job-machine: }"
+  case "$v" in
+    "$JM_UUID "*) printf '<uuid>' ;;
+    'NOT RECORDED ('*) printf 'NOT RECORDED' ;;
+    'UNAVAILABLE ('*) printf 'UNAVAILABLE' ;;
+    '') printf '<absent>' ;;
+    *) printf '<unrecognised:%s>' "${v%% *}" ;;
+  esac
+}
+jm_set="$(jm_token "$jm_seen_uuid")|$(jm_token "$jm_seen_not_recorded")|$(jm_token "$jm_seen_unavailable")"
+if [ "$jm_set" = '<uuid>|NOT RECORDED|UNAVAILABLE' ]; then
+  ok 'case (jm6) the observed renderings are exactly the closed set {<uuid>, NOT RECORDED, UNAVAILABLE}'
+else
+  bad "case (jm6) the job-machine: renderings are not the closed set of three: observed '$jm_set' (expected '<uuid>|NOT RECORDED|UNAVAILABLE')"
+fi
+# AND EVERY ONE OF THEM CARRIES A REASON, never a bare token: an operator reading a pasted block
+# has to be able to act on it without opening this file.
+for _jm_r in "$jm_seen_uuid" "$jm_seen_not_recorded" "$jm_seen_unavailable"; do
+  case "$_jm_r" in
+    'job-machine: '*' ('*')'*) ok "case (jm6) the rendering carries its own explanation: ${_jm_r%% (*} (...)" ;;
+    *) bad "case (jm6) a job-machine: rendering carries no parenthesised explanation: '$_jm_r'" ;;
+  esac
+done
+
+printf '== (jm7) #3654 structural: job-machine is in NEITHER failing-capable key set ==\n'
+# A BEHAVIOURAL CASE ONLY COVERS THE VALUES SOMEONE THOUGHT OF. (jm3)/(jm5) show that the two
+# non-uuid states do not red a run TODAY; only a structural assert stops a future edit registering
+# the key in the verdict scan or the affirmation backstop, where a `NOT RECORDED` — a routine state
+# on a roborev build that does not carry the field — would fail every review on the fleet.
+# Read from the two STATEMENTS, never from a file-wide grep: `emit_kv 'job-machine' "$JOB_MACHINE"`
+# would satisfy a file-wide search with the key registered in both scans.
+_jm_scan_keys=$(sed -n '/^[[:space:]]*for scan_keyed in /,/; do$/p' "$WRAPPER_REAL")
+_jm_aff_keys=$(sed -n '/^[[:space:]]*for keyed in "push-assert=/,/; do$/p' "$WRAPPER_REAL")
+if [ -z "$_jm_scan_keys" ] || [ -z "$_jm_aff_keys" ]; then
+  bad 'case (jm7) could not extract the verdict-scan and affirmation key lists to inspect'
+else
+  if printf '%s\n' "$_jm_scan_keys" | grep -q 'job-machine'; then
+    bad 'case (jm7) job-machine is registered in the failing-capable verdict scan — an informational key would then red a correct run whenever the daemon id is NOT RECORDED (a routine state)'
+  else
+    ok 'case (jm7) job-machine is absent from the failing-capable verdict scan'
+  fi
+  if printf '%s\n' "$_jm_aff_keys" | grep -q 'job-machine'; then
+    bad 'case (jm7) job-machine is registered in the affirmation backstop — a PASS would then require it to read PASS, which it never does'
+  else
+    ok 'case (jm7) job-machine is absent from the affirmation backstop'
+  fi
+fi
+# AND IT IS ACTUALLY EMITTED, unconditionally. Without this the two asserts above are satisfied by
+# DELETING the key, which is the decorative-assert trap this suite has ruled on before.
+if grep -qE "^[[:space:]]*emit_kv 'job-machine' \"\\\$JOB_MACHINE\"" "$WRAPPER_REAL"; then
+  ok 'case (jm7) the key is emitted through the ONE value boundary (emit_kv), unconditionally'
+else
+  bad 'case (jm7) job-machine is not emitted via emit_kv — either it is gone, or its value bypasses the neutralisation boundary'
+fi
+
+printf '== (jm8) #3654 structural: NO machine field was added to either marker grammar ==\n'
+# ASK 4 OF THE ISSUE, PINNED. The authorizer would have to know the value, it is derivable from the
+# record, and every field in a hand-typed control line is one more way for a legitimate
+# authorization to read MALFORMED. The two marker patterns are the grammar, so they are the subject.
+_jm_scan_py="$SCRIPT_DIR/../flow/roborev-waiver-scan.py"
+if [ ! -f "$_jm_scan_py" ]; then
+  bad 'case (jm8) the waiver scanner is missing, so the marker grammar could not be inspected'
+else
+  _jm_patterns=$(grep -nE '^[[:space:]]*r"' "$_jm_scan_py" || printf '')
+  if [ -z "$_jm_patterns" ]; then
+    bad 'case (jm8) no marker pattern fragments found in the scanner — the extraction is stale'
+  elif printf '%s\n' "$_jm_patterns" | grep -qiE 'machine'; then
+    bad 'case (jm8) a machine field appears in a marker pattern — the marker grammar must stay unchanged (#3654 ask 4)'
+  else
+    ok 'case (jm8) neither marker pattern names a machine field — the grammar is unchanged'
+  fi
+fi
+
+printf '== (jm9) #3654: the facts tool extracts source_machine_id from `list`, and NOTHING from `show` ==\n'
+# THE PAYLOAD ASYMMETRY AT ITS SOURCE. A `show`-shaped payload must yield NO fact rather than an
+# empty-string one: `source_machine_id=` in the facts file would render as a BLANK uuid, which is
+# the unmeasured-value-as-a-value defect this repository fails runs for.
+_jm_tool="$SCRIPT_DIR/../flow/roborev-job-facts.py"
+_jm_facts="$tmp/jm-facts.txt"
+_jm_prompt="$tmp/jm-facts-prompt.txt"
+if [ ! -f "$_jm_tool" ] || ! command -v python3 >/dev/null 2>&1; then
+  printf 'SKIP - roborev-job-facts.py or python3 unavailable; the fact-extraction cases did not run\n'
+else
+  printf '[{"id":4656,"git_ref":"aaa..bbb","status":"done","source_machine_id":"%s"}]' "$JM_UUID" \
+    | python3 "$_jm_tool" 4656 "$_jm_facts" "$_jm_prompt" >/dev/null 2>&1 || true
+  if [ "$(sed -n 's/^source_machine_id=//p' "$_jm_facts" | head -1)" = "$JM_UUID" ]; then
+    ok 'case (jm9) a list-shaped row yields source_machine_id as a string fact'
+  else
+    bad "case (jm9) the list-shaped row did not yield source_machine_id (facts: $(tr '\n' ' ' <"$_jm_facts"))"
+  fi
+  printf '{"id":4656,"job_id":4656,"agent":"codex","prompt":"p","job":{"id":4656,"git_ref":"aaa..bbb","status":"done"}}' \
+    | python3 "$_jm_tool" 4656 "$_jm_facts" "$_jm_prompt" >/dev/null 2>&1 || true
+  if grep -q '^source_machine_id=' "$_jm_facts"; then
+    bad "case (jm9) a show-shaped payload emitted a source_machine_id fact — an empty one renders as a blank uuid (facts: $(tr '\n' ' ' <"$_jm_facts"))"
+  else
+    ok 'case (jm9) a show-shaped payload yields NO source_machine_id fact at all, not an empty one'
+  fi
+  # AND THE ROW SELECTION IS UNCHANGED: adding a string fact must not be able to move `find_job`
+  # onto a different row. The review row here answers to the same id and carries no git_ref, so a
+  # regression that let the new fact influence selection would surface as the wrong git_ref.
+  printf '{"id":4656,"job_id":4656,"source_machine_id":"decoy","job":{"id":4656,"git_ref":"aaa..bbb","status":"done","model":"m"}}' \
+    | python3 "$_jm_tool" 4656 "$_jm_facts" "$_jm_prompt" >/dev/null 2>&1 || true
+  if [ "$(sed -n 's/^git_ref=//p' "$_jm_facts" | head -1)" = 'aaa..bbb' ]; then
+    ok 'case (jm9) the git_ref-bearing row is still the one selected (the new fact cannot move find_job)'
+  else
+    bad 'case (jm9) adding source_machine_id changed which row find_job selects — the required facts now come from the wrong object'
+  fi
+fi
+
+printf '== (jm10) #3654: --help documents the per-daemon scope, a WORKING check, and the prompt evidence ==\n'
+CASE_N=$((CASE_N + 1))
+OUT="$tmp/out-$CASE_N.txt"
+bash "$WRAPPER_REAL" --help >"$OUT" 2>"$tmp/jm-help-err.txt"
+if [ -s "$tmp/jm-help-err.txt" ]; then
+  bad "case (jm10) --help wrote to stderr: $(head -2 "$tmp/jm-help-err.txt")"
+else
+  ok 'case (jm10) --help is clean on stderr'
+fi
+assert_says 'case (jm10) --help states that job ids are per-daemon' 'JOB IDS ARE PER-DAEMON, NOT GLOBAL'
+assert_says 'case (jm10) --help says to verify git_ref, never the id alone' "VERIFY THE RECORD'S git_ref AND NEVER THE ID"
+# THE PRESCRIBED COMMAND MUST BE ONE THAT WORKS. The issue and its addendum both prescribed
+# `roborev show <id> --json | jq '{id, git_ref, branch, source_machine_id, token_usage}'`, which
+# MEASURES four nulls: show nests those fields under `.job` and carries no source_machine_id at all.
+# Documenting it unchanged would reproduce the very defect the addendum diagnoses.
+assert_says 'case (jm10) --help reads git_ref from the payload that HAS it (.job on show)' \
+  "roborev show <id> --json \| jq '\.job \| \{id, git_ref"
+assert_says 'case (jm10) --help reads the daemon id from the LIST payload' \
+  "roborev list --json --repo <abs-repo> --branch <branch>"
+assert_lacks 'case (jm10) --help does NOT prescribe the top-level jq that measures nulls' \
+  "show <id> --json \| jq '\{id, git_ref"
+assert_says 'case (jm10) --help warns that list defaults to the current branch' \
+  'filters by the CURRENT BRANCH by default'
+assert_says 'case (jm10) --help states that a local row count proves nothing' \
+  'A LOCAL ROW COUNT IS NOT EVIDENCE OF UNIQUENESS'
+assert_says 'case (jm10) --help names the failure class the row count belongs to' \
+  'IDENTICAL under the two states it claims'
+assert_says 'case (jm10) --help makes the stored prompt the PREFERRED absence evidence' \
+  "stored prompt is the PREFERRED"
+assert_says 'case (jm10) --help names the retrieval command' 'roborev show <id> --prompt'
+assert_says 'case (jm10) --help keeps token accounting as the FALLBACK' 'the FALLBACK, for when the prompt cannot be retrieved'
+assert_says 'case (jm10) --help says why this is not the deleted classifier' \
+  'RESURRECTS NOTHING OF THE DELETED DELIVERY CLASSIFIER'
+assert_says 'case (jm10) --help records that the marker grammar is unchanged' \
+  'THE MARKER GRAMMAR IS DELIBERATELY UNCHANGED'
+# NOTE: `assert_no_marker_form` is deliberately NOT applied here. `--help` is the ONE sanctioned
+# place the marker form is written out — the diagnostics refuse to print it and point here instead
+# — so a run of it necessarily carries the stem.
 reset_stub
 
 printf '== the summary header is distinct from every agent-gate header ==\n'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -6114,6 +6114,55 @@ assert_says 'case (jm10) --help records that the marker grammar is unchanged' \
 # — so a run of it necessarily carries the stem.
 reset_stub
 
+printf '== (jm11) #3654: a `show` payload whose TOP-LEVEL id is NOT the asked job ==\n'
+# MEASURED SHAPE (ten records): top-level `id` is the REVIEW row's own sequence and can differ from
+# the job asked for — asking for 9 returns id=8, job_id=9, job.id=9. Two things must hold, and the
+# second is what this change could have broken: the facts must still come from the JOB row (find_job
+# matches id/job_id/job and then PREFERS the object carrying git_ref), and the OUTER row's own
+# `source_machine_id` must NOT leak into the facts — a decoy machine id attributed to the wrong row
+# is worse than none, because it reads as a measurement.
+if [ ! -f "$_jm_tool" ] || ! command -v python3 >/dev/null 2>&1; then
+  printf 'SKIP - roborev-job-facts.py or python3 unavailable; the id-divergence case did not run\n'
+else
+  printf '{"id":8,"job_id":9,"uuid":"outer-uuid","source_machine_id":"DECOY","prompt":"p","job":{"id":9,"git_ref":"aaa..bbb","status":"done","model":"m"}}' \
+    | python3 "$_jm_tool" 9 "$_jm_facts" "$_jm_prompt" >/dev/null 2>&1 || true
+  if [ "$(sed -n 's/^git_ref=//p' "$_jm_facts" | head -1)" = 'aaa..bbb' ]; then
+    ok 'case (jm11) the nested job row is still selected when the top-level id names another review'
+  else
+    bad 'case (jm11) the id-divergent payload selected the wrong row — the required facts would come from the review row'
+  fi
+  if grep -q '^source_machine_id=DECOY$' "$_jm_facts"; then
+    bad 'case (jm11) the OUTER review row supplied source_machine_id — the daemon id would be attributed to a row that is not the job'
+  else
+    ok 'case (jm11) no source_machine_id leaks from the outer review row (the fact follows the selected row)'
+  fi
+fi
+
+printf '== (jm12) #3654 structural: the supplementary machine read NAMES THE BRANCH ==\n'
+# `roborev list` filters by the CURRENT BRANCH by default (measured: a bare list from a branch with
+# no jobs returns null, while --branch <other> returns that branch's rows), and this wrapper is
+# invoked from arbitrary directories with an explicit --repo. A default-scoped machine read would
+# therefore resolve NOTHING whenever the invoking cwd's branch is not the branch under review, and
+# `job-machine:` would read NOT RECORDED for a reason having nothing to do with the record — a key
+# that can only ever report absence. Only a structural assert pins this: every hermetic case runs
+# with the fixture branch checked out, so the stub answers either way.
+_jm_supp=$(sed -n '/^read_machine_fact() {/,/^}/p' "$WRAPPER_REAL")
+if [ -z "$_jm_supp" ]; then
+  bad 'case (jm12) could not locate read_machine_fact to inspect'
+elif printf '%s\n' "$_jm_supp" | grep -qE 'roborev list --json .*--branch "\$BRANCH"'; then
+  ok 'case (jm12) the supplementary machine read is scoped to the branch under review'
+else
+  bad 'case (jm12) the supplementary machine read does not name --branch "$BRANCH" — it would inherit roborev list'"'"'s current-branch default and resolve nothing whenever cwd is not on the branch under review'
+fi
+# AND THE RECORD READ IS DELIBERATELY LEFT ALONE: `sha-assert` depends on it, and naming the branch
+# there is behaviour-neutral only while the invoking cwd's branch equals $BRANCH. Pinned so a future
+# "consistency" edit has to argue with this line rather than silently change a load-bearing read.
+if grep -qE '^ *list\) json=\$\(roborev list --json --limit 50 --repo "\$REPO" 2>/dev/null' "$WRAPPER_REAL"; then
+  ok 'case (jm12) the RECORD read is unchanged (no --branch) — that read is sha-assert'"'"'s, and out of scope here'
+else
+  bad 'case (jm12) the job-record list read has changed shape — sha-assert depends on it, and #3654 must not have touched it'
+fi
+
 printf '== the summary header is distinct from every agent-gate header ==\n'
 reset_stub
 work=$(make_fixture case_hdr pushed)

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -5983,7 +5983,7 @@ STUB_LIST_JSON=none
 run_wrapper "$jm_work"
 assert_verdict 'case (jm5)' FAIL 1
 assert_says 'case (jm5) the key names the job-record state it inherits' \
-  '^job-machine: UNAVAILABLE \(no job record could be read, so the issuing daemon is unknown — job-record: DEGRADED'
+  '^job-machine: UNAVAILABLE \(no job record could be read at all, so the issuing daemon is unknown — job-record: DEGRADED'
 assert_says 'case (jm5) the FAIL belongs to sha-assert, not to job-machine' \
   '^sha-assert: FAIL \(job record unavailable'
 assert_lacks 'case (jm5) no diagnostic blames the informational key' 'ERROR: job-machine'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -6130,11 +6130,11 @@ assert_lacks 'case (jm10) --help no longer demotes token accounting to a fallbac
 assert_says 'case (jm10) --help declares the cross-box boundary' 'DECLARED BOUNDARY'
 assert_says 'case (jm10) --help says what is NOT claimed' 'NOT CLAIMED: that a marker cannot cross boxes'
 assert_says 'case (jm10) --help names the channel the marker actually travels' \
-  'travels\s*through GITHUB, not through the daemon'
+  'through GITHUB, not through the daemon'
 assert_says 'case (jm10) --help refuses the issue-body argument as irrelevant to the marker' \
   'true of the RECORD and'
 assert_says 'case (jm10) --help records the escalation rather than deciding it' \
-  'escalated to\s*the owner and PENDING on #3654'
+  'PENDING on #3654'
 assert_says 'case (jm10) --help states the mitigation is operational, not mechanical' \
   'OPERATIONAL, NOT MECHANICAL|is informational and CANNOT enforce'
 assert_says 'case (jm10) --help says why this is not the deleted classifier' \

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -6064,8 +6064,8 @@ printf '== (jm7) #3654 structural: job-machine is in NEITHER failing-capable key
 # non-uuid states do not red a run TODAY; only a structural assert stops a future edit registering
 # the key in the verdict scan or the affirmation backstop, where a `NOT RECORDED` — a routine state
 # on a roborev build that does not carry the field — would fail every review on the fleet.
-# Read from the two STATEMENTS, never from a file-wide grep: `emit_kv 'job-machine' "$JOB_MACHINE"`
-# would satisfy a file-wide search with the key registered in both scans.
+# Read from the two STATEMENTS, never from a file-wide grep: the key's own `emit_kv` line would
+# satisfy a file-wide search even with the key registered in both scans.
 _jm_scan_keys=$(sed -n '/^[[:space:]]*for scan_keyed in /,/; do$/p' "$WRAPPER_REAL")
 _jm_aff_keys=$(sed -n '/^[[:space:]]*for keyed in "push-assert=/,/; do$/p' "$WRAPPER_REAL")
 if [ -z "$_jm_scan_keys" ] || [ -z "$_jm_aff_keys" ]; then
@@ -6084,7 +6084,11 @@ else
 fi
 # AND IT IS ACTUALLY EMITTED, unconditionally. Without this the two asserts above are satisfied by
 # DELETING the key, which is the decorative-assert trap this suite has ruled on before.
-if grep -qE "^[[:space:]]*emit_kv 'job-machine' \"\\\$JOB_MACHINE\"" "$WRAPPER_REAL"; then
+# The VALUE EXPRESSION is deliberately not pinned: since #3654 round 3 the fallback is built at
+# emit time (`$(job_machine_value)`) rather than captured at initialization, so pinning the old
+# `"$JOB_MACHINE"` spelling would red on correct code. What must hold is unchanged and is what is
+# asserted — the key goes through `emit_kv`, the ONE neutralisation boundary, unconditionally.
+if grep -qE "^[[:space:]]*emit_kv 'job-machine' \"[^\"]+\"$" "$WRAPPER_REAL"; then
   ok 'case (jm7) the key is emitted through the ONE value boundary (emit_kv), unconditionally'
 else
   bad 'case (jm7) job-machine is not emitted via emit_kv — either it is gone, or its value bypasses the neutralisation boundary'
@@ -6309,6 +6313,51 @@ assert_says 'case (jm18) the miss names the depth reached and that the list ende
   'searched to a depth of [0-9]+ rows and to the end of what the daemon returns'
 assert_lacks 'case (jm18) it never claims a fixed 50-job window' "latest 50 jobs"
 reset_stub
+
+printf '== (jm19) #3654 r3: an abort AFTER the record poll never emits a stale job-record state ==\n'
+# THE PAIR OF KEYS MUST NOT CONTRADICT EACH OTHER. `job-machine:`'s UNAVAILABLE fallback names the
+# `job-record:` state it inherits, and it used to be a fully-formed string built at INITIALIZATION,
+# where `$JOB_RECORD` is `SKIP`. The `on_exit` EXIT trap emits the block on ANY abort, so a run that
+# died after the record poll printed `job-record: PASS` beside
+# `job-machine: UNAVAILABLE (... job-record: SKIP)` — an artifact stating two different things about
+# one fact. Interpolating at that same early site does NOT fix it (the expansion still captures
+# SKIP), which is why the value is built at EMIT time instead.
+#
+# Fixtured by injecting an abort between the poll and the recompute, into a SCRATCH COPY of the
+# wrapper — the one place that window is reachable on demand.
+_jmb_dir="$tmp/jm-abort"
+mkdir -p "$_jmb_dir"
+cp "$WRAPPER_REAL" "$SCRIPT_DIR/../flow/roborev-review-oracles.sh" \
+  "$SCRIPT_DIR/../flow/roborev-review-checks.sh" "$SCAN_TOOL" "$_jmb_dir/"
+if [ -f "$SCRIPT_DIR/../flow/roborev-job-facts.py" ]; then
+  cp "$SCRIPT_DIR/../flow/roborev-job-facts.py" "$_jmb_dir/"
+fi
+if sed_inplace_verified "$_jmb_dir/roborev-review.sh" \
+     's/^JOB_VERDICT=\$(fact verdict)$/exit 9\nJOB_VERDICT=$(fact verdict)/' \
+     'exit 9' ; then
+  reset_stub
+  STUB_ANNOUNCE_SHA="$jm_head"
+  run_wrapper --wrapper "$_jmb_dir/roborev-review.sh" "$jm_work"
+  # The run aborted, so job-record: reached PASS while job-machine: never recomputed. The ONE
+  # property: whatever job-record: says, job-machine: must say the SAME thing.
+  _jmb_rec=$(sed -n 's/^job-record: //p' "$OUT" | head -1)
+  _jmb_mach=$(sed -n 's/^job-machine: //p' "$OUT" | head -1)
+  if [ -z "$_jmb_mach" ]; then
+    bad "case (jm19) no job-machine: line was emitted on the abort path (job-record: '${_jmb_rec:-<none>}')"
+  elif [ -z "$_jmb_rec" ]; then
+    bad 'case (jm19) no job-record: line was emitted, so the two keys could not be compared'
+  else
+    case "$_jmb_mach" in
+      *"job-record: $_jmb_rec"*)
+        ok "case (jm19) job-machine: names the CURRENT job-record state ($_jmb_rec) on an abort" ;;
+      *)
+        bad "case (jm19) the two keys contradict each other: job-record: '$_jmb_rec' but job-machine: '$_jmb_mach'" ;;
+    esac
+  fi
+  reset_stub
+else
+  bad 'case (jm19) could not inject the abort into the scratch wrapper, so the stale-state path was never exercised (a green here would be a probe failing in the direction that looks like success)'
+fi
 
 printf '== (jm15) #3654 r2: NO ambient-branch fallback when the record does not name its branch ==\n'
 # THE FALLBACK THAT MUST NOT EXIST. Here the daemon WOULD answer for the fixture's own branch, so a

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -267,6 +267,13 @@ emit_job_object() {
   if [ "${STUB_TOKEN_USAGE:-NONE}" != "NONE" ]; then
     usage=",\"token_usage\":\"${STUB_TOKEN_USAGE}\""
   fi
+  # THE JOB'S OWN BRANCH (#3654 round 2). Real payloads carry it — `.job.branch` on `show`, top
+  # level on `list` — and the supplementary machine lookup is scoped BY IT rather than by the
+  # branch the invocation happens to be on. `none` suppresses it, which is how the
+  # "record does not name its branch" state is fixtured.
+  if [ -n "${STUB_JOB_BRANCH:-}" ] && [ "${STUB_JOB_BRANCH:-}" != none ]; then
+    extra="$extra,\"branch\":\"${STUB_JOB_BRANCH}\""
+  fi
   local git_ref="${STUB_GIT_REF:-${STUB_ANNOUNCE_SHA:-}}"
   if [ "${STUB_GIT_REF:-}" = none ]; then git_ref=""; fi
   if [ -n "${STUB_VERDICT_FIELD:-}" ]; then
@@ -368,6 +375,17 @@ case "$cmd" in
   list)
     record_read_blank && { printf 'null\n'; exit 0; }
     [ "${STUB_LIST_JSON:-array}" != none ] || { printf 'null\n'; exit 0; }
+    # ===== `roborev list` IS BRANCH-FILTERED, AND THE STUB HONOURS THAT (#3654 round 2) =====
+    # Measured: a bare list from a branch with no jobs returns `null` while `--branch <other>`
+    # returns that branch's rows. Modelling it is what makes the branch-scoping cases REAL — a stub
+    # that answered whatever branch it was asked would pass both before and after the fix, i.e. the
+    # cases would test nothing. STUB_LIST_BRANCH is the branch this daemon has jobs for.
+    if [ -n "${STUB_LIST_BRANCH:-}" ]; then
+      case " $* " in
+        *" --branch ${STUB_LIST_BRANCH} "*|*" --branch ${STUB_LIST_BRANCH}") ;;
+        *" --branch "*) printf 'null\n'; exit 0 ;;
+      esac
+    fi
     _EMIT_MACHINE=1
     printf '['; emit_job_object; printf ']\n'
     exit 0
@@ -1056,6 +1074,11 @@ run_wrapper() { # run_wrapper [--wrapper <path>] <work-dir> [extra wrapper args.
   # git_ref is "<base40>..<head40>". Default the stub to the correct range unless the
   # case pinned git_ref itself (or asked for it to be absent with `none`).
   if [ -z "${STUB_GIT_REF:-}" ]; then STUB_GIT_REF=$(range_ref "$work"); fi
+  # The job row reports the branch it was enqueued for, and the daemon lists that branch's jobs —
+  # which, for an ordinary run, is the fixture's own branch (#3654 round 2). Defaulted here, beside
+  # STUB_GIT_REF, for the same reason: a case pins it only when the DIVERGENCE is the subject.
+  if [ -z "${STUB_JOB_BRANCH:-}" ]; then STUB_JOB_BRANCH=$(git -C "$work" rev-parse --abbrev-ref HEAD); fi
+  if [ -z "${STUB_LIST_BRANCH:-}" ]; then STUB_LIST_BRANCH="$STUB_JOB_BRANCH"; fi
   # HOME is redirected to a throwaway directory: nothing in the wrapper reads a roborev
   # config any more (#3283), but HERMETICITY is asserted structurally at the bottom of this
   # file and a host `$HOME/.roborev/` must never be able to influence a fixture run.
@@ -1204,6 +1227,12 @@ export STUB_ON_REVIEW=''
 # #3654: the DAEMON-ID knob. Empty by default, and the stub emits it on the `list` payload ONLY,
 # which is where roborev v0.61.2 actually carries `source_machine_id`.
 export STUB_SOURCE_MACHINE_ID=''
+# #3654 round 2: the BRANCH knobs. STUB_JOB_BRANCH is the branch the job row reports as its own
+# (`none` suppresses the field); STUB_LIST_BRANCH is the branch the daemon's list will answer for.
+# Both default, in run_wrapper, to the fixture's own current branch — the ordinary case — so a case
+# that wants them to DIVERGE has to say so.
+export STUB_JOB_BRANCH=''
+export STUB_LIST_BRANCH=''
 reset_stub() {
   STUB_JOB=4656
   STUB_VERDICT=$'No issues found.\nSummary: reviewed the diff; no issues found.'
@@ -1234,6 +1263,8 @@ reset_stub() {
   # No daemon id by default: the FAIL-CLOSED direction for the `job-machine:` key (#3654) — a case
   # that wants the uuid arm has to SAY so, so no case passes because the double happened to answer.
   STUB_SOURCE_MACHINE_ID=''
+  STUB_JOB_BRANCH=''
+  STUB_LIST_BRANCH=''
 }
 
 printf '== case (a): enqueued sha == base ref ==\n'
@@ -6146,6 +6177,77 @@ assert_says 'case (jm10) --help records that the marker grammar is unchanged' \
 # — so a run of it necessarily carries the stem.
 reset_stub
 
+printf '== (jm13) #3654 r2: the lookup is scoped to the JOB record'"'"'s branch, not the ambient one ==\n'
+# THE DAEMON'S JOB LIST IS BRANCH-FILTERED, so the branch used to scope the supplementary read
+# decides whether the key resolves at all. Scoping by the branch the INVOCATION is on answers about
+# a DIFFERENT branch whenever the job was enqueued under another name — and then `job-machine:`
+# reads NOT RECORDED for a record that HAS a source_machine_id. Fixtured by making the two diverge:
+# the daemon holds jobs for the RECORD's branch only, and the fixture is checked out on another.
+reset_stub
+STUB_ANNOUNCE_SHA="$jm_head"
+STUB_SOURCE_MACHINE_ID="$JM_UUID"
+STUB_JOB_BRANCH='issue-earlier-lane'
+STUB_LIST_BRANCH='issue-earlier-lane'
+run_wrapper "$jm_work"
+assert_verdict 'case (jm13)' PASS 0
+assert_says 'case (jm13) the daemon is still named when the job'"'"'s branch is not the current one' \
+  "^job-machine: $JM_UUID \(source_machine_id; job ids are per-daemon\)$"
+reset_stub
+
+printf '== (jm14) #3654 r2: --recheck-job of an OLDER job on another branch still names the daemon ==\n'
+# THE MODE THE MITIGATION IS DOCUMENTED FOR, and the one most likely to miss: a waiver is applied
+# by rechecking a job that may have been enqueued before a rename or a rebase. Before the fix this
+# rendered NOT RECORDED and the documented "compare job-machine: between the request and the
+# recheck" would silently not work in the only mode it exists for — a claim the implementation did
+# not deliver, which is worse than claiming nothing.
+reset_stub
+STUB_ANNOUNCE_SHA="$jm_head"
+STUB_SOURCE_MACHINE_ID="$JM_UUID"
+STUB_JOB_BRANCH='issue-earlier-lane'
+STUB_LIST_BRANCH='issue-earlier-lane'
+STUB_VERDICT_FIELD='P'
+STUB_RECORD_OUTPUT="$CLEAN_TEXT"
+run_wrapper "$jm_work" --recheck-job 4656
+assert_verdict 'case (jm14)' PASS 0
+assert_says 'case (jm14) a recheck of an older, differently-branched job names its daemon' \
+  "^job-machine: $JM_UUID \(source_machine_id; job ids are per-daemon\)$"
+assert_says 'case (jm14) and it is still a recheck' '^MODE: recheck '
+reset_stub
+
+printf '== (jm15) #3654 r2: NO ambient-branch fallback when the record does not name its branch ==\n'
+# THE FALLBACK THAT MUST NOT EXIST. Here the daemon WOULD answer for the fixture's own branch, so a
+# retry against it would produce a uuid — one belonging to whatever that branch's job is, presented
+# as this job's daemon. Silently answering about a different branch is the same defect one layer
+# down, so the state must say what it could not do instead.
+reset_stub
+STUB_ANNOUNCE_SHA="$jm_head"
+STUB_SOURCE_MACHINE_ID="$JM_UUID"
+STUB_JOB_BRANCH='none'
+STUB_LIST_BRANCH=$(git -C "$jm_work" rev-parse --abbrev-ref HEAD)
+run_wrapper "$jm_work"
+assert_verdict 'case (jm15) an unscopeable lookup never fails a clean run' PASS 0
+assert_says 'case (jm15) the state names what could not be scoped' \
+  '^job-machine: NOT RECORDED \(the job record does not name its own branch'
+assert_says 'case (jm15) and says the ambient fallback was refused, with the reason' \
+  'deliberately NOT retried against the branch this invocation is on, which would answer about a different branch'
+assert_lacks 'case (jm15) no uuid is invented from the ambient branch' "^job-machine: $JM_UUID"
+reset_stub
+
+printf '== (jm16) #3654 r2: a record that WAS read but is incomplete is NOT RECORDED, not UNAVAILABLE ==\n'
+# THE STATE THAT COULD LIE. The rendering used to branch on `record_required_present`, which asks
+# about COMPLETENESS — so a record that was read and is merely nonterminal rendered
+# 'UNAVAILABLE (no job record could be read)', which is FALSE: one was read. The three states are
+# only worth having if each is an affirmative TRUE statement about what happened.
+reset_stub
+STUB_ANNOUNCE_SHA="$jm_head"
+STUB_STATUS='running'
+run_wrapper "$jm_work"
+assert_verdict 'case (jm16)' FAIL 1
+assert_says 'case (jm16) an incomplete-but-READ record is NOT RECORDED' '^job-machine: NOT RECORDED \('
+assert_lacks 'case (jm16) it never claims no record could be read' '^job-machine: UNAVAILABLE'
+assert_says 'case (jm16) the job-record key independently reports the incompleteness' '^job-record: DEGRADED'
+reset_stub
+
 printf '== (jm11) #3654: a `show` payload whose TOP-LEVEL id is NOT the asked job ==\n'
 # MEASURED SHAPE (ten records): top-level `id` is the REVIEW row's own sequence and can differ from
 # the job asked for — asking for 9 returns id=8, job_id=9, job.id=9. Two things must hold, and the
@@ -6181,10 +6283,19 @@ printf '== (jm12) #3654 structural: the supplementary machine read NAMES THE BRA
 _jm_supp=$(sed -n '/^read_machine_fact() {/,/^}/p' "$WRAPPER_REAL")
 if [ -z "$_jm_supp" ]; then
   bad 'case (jm12) could not locate read_machine_fact to inspect'
-elif printf '%s\n' "$_jm_supp" | grep -qE 'roborev list --json .*--branch "\$BRANCH"'; then
-  ok 'case (jm12) the supplementary machine read is scoped to the branch under review'
+elif printf '%s\n' "$_jm_supp" | grep -qE 'roborev list --json .*--branch "\$job_branch"'; then
+  ok 'case (jm12) the supplementary machine read is scoped to the RECORD'"'"'s own branch'
+  # AND NEVER TO THE AMBIENT ONE. `$BRANCH` is the branch this invocation is running on, which is
+  # not the job's fact; scoping by it answers about a different branch on exactly the recheck path
+  # the operator mitigation is documented for. A fallback to it is as wrong as using it outright,
+  # so the function must not mention it at all.
+  if printf '%s\n' "$_jm_supp" | grep -q 'BRANCH'; then
+    bad 'case (jm12) read_machine_fact still refers to the ambient $BRANCH — scoping (or falling back) to it answers about a branch other than the job own'
+  else
+    ok 'case (jm12) it never falls back to the ambient $BRANCH'
+  fi
 else
-  bad 'case (jm12) the supplementary machine read does not name --branch "$BRANCH" — it would inherit roborev list'"'"'s current-branch default and resolve nothing whenever cwd is not on the branch under review'
+  bad 'case (jm12) the supplementary machine read is not scoped to the record'"'"'s own branch ($job_branch) — it would answer about whatever branch the invocation happens to be on'
 fi
 # AND THE RECORD READ IS DELIBERATELY LEFT ALONE: `sha-assert` depends on it, and naming the branch
 # there is behaviour-neutral only while the invoking cwd's branch equals $BRANCH. Pinned so a future

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -6317,6 +6317,13 @@ run_wrapper "$jm_work"
 assert_says 'case (jm18) the miss names the depth reached and that the list ended' \
   'searched to a depth of [0-9]+ rows and to the end of what the daemon returns'
 assert_lacks 'case (jm18) it never claims a fixed 50-job window' "latest 50 jobs"
+# AND IT MUST NOT MIS-ATTRIBUTE. "We did not read far enough" and "the row carries no
+# source_machine_id" are different facts about different rows, and collapsing them into one
+# affirmative sentence is the round-2 finding repeating one layer down: the row may well exist and
+# carry the field. Separated causes are the whole value of the depth fix — closing the
+# reachability while leaving the sentence would fix the bound and keep the lie.
+assert_lacks 'case (jm18) a depth miss is never reported as field-absence' \
+  'carries no source_machine_id'
 reset_stub
 
 printf '== (jm19) #3654 r3: an abort AFTER the record poll never emits a stale job-record state ==\n'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -5951,8 +5951,13 @@ reset_stub
 STUB_ANNOUNCE_SHA="$jm_head"
 run_wrapper "$jm_work"
 assert_verdict 'case (jm3) an unrecorded daemon never fails a clean run' PASS 0
-assert_says 'case (jm3) the state is affirmative and names the payload that carries the field' \
-  "^job-machine: NOT RECORDED \(a job record was read but carries no source_machine_id; 'roborev list --json' rows carry that field, 'roborev show <id> --json' does not\. Identify the review by the record's git_ref, never by the id alone\)$"
+# THE CAUSE IS THE ONE THIS RUN MEASURED, not a generic sentence: the record was read, the daemon's
+# list for the job's OWN branch was consulted, and neither carried the field. Asserted with the tail
+# that names WHICH payload carries it, because a cause without a remedy is half a diagnostic.
+assert_says 'case (jm3) the state names the cause it actually measured' \
+  "^job-machine: NOT RECORDED \(neither the job record nor the daemon's job list for branch 'feature' carries source_machine_id;"
+assert_says 'case (jm3) and still names the payload that DOES carry the field' \
+  "'roborev list --json' rows carry that field, 'roborev show <id> --json' does not\. Identify the review by the record's git_ref, never by the id alone\)$"
 assert_lacks 'case (jm3) the key is never blank' '^job-machine: *$'
 jm_seen_not_recorded=$(jm_render)
 reset_stub

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -6101,10 +6101,42 @@ assert_says 'case (jm10) --help states that a local row count proves nothing' \
   'A LOCAL ROW COUNT IS NOT EVIDENCE OF UNIQUENESS'
 assert_says 'case (jm10) --help names the failure class the row count belongs to' \
   'IDENTICAL under the two states it claims'
-assert_says 'case (jm10) --help makes the stored prompt the PREFERRED absence evidence' \
-  "stored prompt is the PREFERRED"
+assert_says 'case (jm10) --help names the prompt as the DIRECT ARTIFACT to lead with' \
+  'That is the DIRECT ARTIFACT'
 assert_says 'case (jm10) --help names the retrieval command' 'roborev show <id> --prompt'
-assert_says 'case (jm10) --help keeps token accounting as the FALLBACK' 'the FALLBACK, for when the prompt cannot be retrieved'
+# THE CORRECTED EVIDENCE AXIS (roborev job 39, finding 2). The first version called the prompt
+# DIRECT EVIDENCE and token accounting a mere FALLBACK, which inverts the trust properties: the
+# prompt is PARTLY BRANCH-INFLUENCED (roborev embeds repository-controlled content at positions
+# indistinguishable from its own text, so a branch can mimic the delivery wording), while the token
+# counts are recorded BY THE DAEMON and unwritable by the reviewed branch. Both halves are asserted
+# — the qualification AND the corroboration property — because dropping either one restores a claim
+# an authorizer would act on.
+assert_says 'case (jm10) --help says the prompt is NOT self-authenticating' \
+  'IT IS NOT SELF-AUTHENTICATING'
+assert_says 'case (jm10) --help names the repository-controlled content that makes it so' \
+  'EMBEDS repository-controlled content'
+assert_says 'case (jm10) --help refuses "a human reads it" as a channel separation' \
+  'not a channel separation'
+assert_says 'case (jm10) --help gives token accounting its daemon-recorded corroboration property' \
+  'recorded BY THE DAEMON and nothing'
+assert_says 'case (jm10) --help ranks neither: they are complementary' \
+  'COMPLEMENTARY rather than ranked'
+assert_lacks 'case (jm10) --help no longer demotes token accounting to a fallback' \
+  'the FALLBACK, for when the prompt cannot be retrieved'
+# THE DECLARED CROSS-BOX BOUNDARY (roborev job 39, finding 1). The marker travels through GitHub
+# while --recheck-job reads the LOCAL daemon, so a same-id/same-range collision across two boxes
+# lets an authorization cross reviews. It is NOT closed here (that needs a marker field, which ask 4
+# forbids) — so what must never regress is that the text DECLARES it rather than implying safety.
+assert_says 'case (jm10) --help declares the cross-box boundary' 'DECLARED BOUNDARY'
+assert_says 'case (jm10) --help says what is NOT claimed' 'NOT CLAIMED: that a marker cannot cross boxes'
+assert_says 'case (jm10) --help names the channel the marker actually travels' \
+  'travels\s*through GITHUB, not through the daemon'
+assert_says 'case (jm10) --help refuses the issue-body argument as irrelevant to the marker' \
+  'true of the RECORD and'
+assert_says 'case (jm10) --help records the escalation rather than deciding it' \
+  'escalated to\s*the owner and PENDING on #3654'
+assert_says 'case (jm10) --help states the mitigation is operational, not mechanical' \
+  'OPERATIONAL, NOT MECHANICAL|is informational and CANNOT enforce'
 assert_says 'case (jm10) --help says why this is not the deleted classifier' \
   'RESURRECTS NOTHING OF THE DELETED DELIVERY CLASSIFIER'
 assert_says 'case (jm10) --help records that the marker grammar is unchanged' \

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -6203,23 +6203,38 @@ assert_says 'case (jm10) --help names the failure class the row count belongs to
 assert_says 'case (jm10) --help names the prompt as the DIRECT ARTIFACT to lead with' \
   'That is the DIRECT ARTIFACT'
 assert_says 'case (jm10) --help names the retrieval command' 'roborev show <id> --prompt'
-# THE CORRECTED EVIDENCE AXIS (roborev job 39, finding 2). The first version called the prompt
-# DIRECT EVIDENCE and token accounting a mere FALLBACK, which inverts the trust properties: the
-# prompt is PARTLY BRANCH-INFLUENCED (roborev embeds repository-controlled content at positions
-# indistinguishable from its own text, so a branch can mimic the delivery wording), while the token
-# counts are recorded BY THE DAEMON and unwritable by the reviewed branch. Both halves are asserted
-# — the qualification AND the corroboration property — because dropping either one restores a claim
-# an authorizer would act on.
+# THE EVIDENCE AXIS, CORRECTED TWICE (roborev job 39 finding 2, then job 43 finding 1). Version 1
+# called the prompt DIRECT EVIDENCE and the token counts a mere FALLBACK. Version 2 fixed that and
+# overshot, asserting the counts were "recorded BY THE DAEMON and nothing the reviewed branch can
+# write changes it", i.e. unforgeable corroboration. THAT WAS FALSE IN THE HALF THAT MATTERED: the
+# counts measure THE PROMPT, and the prompt embeds repository-controlled content, so a branch cannot
+# forge the RECORD but can move the MAGNITUDE — and the counts exist to separate a real review from
+# one that received nothing (vacuous baseline ~18.7k input / 0 cached), so padding non-diff prompt
+# content defeats exactly that use. What is asserted now is capability AND limit for each signal,
+# plus the two claims that stop the overshoot returning: neither establishes provenance, and the two
+# are not independent.
 assert_says 'case (jm10) --help says the prompt is NOT self-authenticating' \
   'IT IS NOT SELF-AUTHENTICATING'
 assert_says 'case (jm10) --help names the repository-controlled content that makes it so' \
   'EMBEDS repository-controlled content'
 assert_says 'case (jm10) --help refuses "a human reads it" as a channel separation' \
   'not a channel separation'
-assert_says 'case (jm10) --help gives token accounting its daemon-recorded corroboration property' \
+assert_says 'case (jm10) --help says the counts are daemon-recorded but NOT independent' \
+  'DAEMON-RECORDED BUT NOT INDEPENDENT'
+assert_says 'case (jm10) --help says the branch moves their MAGNITUDE without forging the record' \
+  'MAGNITUDE without forging anything'
+assert_says 'case (jm10) --help says NEITHER signal establishes provenance' \
+  'NEITHER SIGNAL ESTABLISHES'
+assert_says 'case (jm10) --help records the evidence policy as an open question, not settled here' \
+  'is an OPEN QUESTION'
+# THE OVERSHOOT MUST NOT COME BACK. An authorizer acting on "unforgeable" would grant on a number a
+# branch can inflate, so the retired claim is pinned ABSENT as well as the replacement pinned present.
+# ONE assert, on the retired sentence itself. A second one on "unforgeable corroboration" was written
+# and REMOVED: the replacement text contains those two words wrapped across a line break, so the
+# assert would have passed on a LINE-WRAPPING ACCIDENT and reddened on a reflow — a test passing for
+# a reason unrelated to its claim, which is the defect class this file exists to catch.
+assert_lacks 'case (jm10) --help never calls the counts unwritable by the branch' \
   'recorded BY THE DAEMON and nothing'
-assert_says 'case (jm10) --help ranks neither: they are complementary' \
-  'COMPLEMENTARY rather than ranked'
 assert_lacks 'case (jm10) --help no longer demotes token accounting to a fallback' \
   'the FALLBACK, for when the prompt cannot be retrieved'
 # THE DECLARED CROSS-BOX BOUNDARY (roborev job 39, finding 1). The marker travels through GitHub

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -5935,6 +5935,22 @@ assert_lacks 'case (jd1) --help no longer claims the list filters by the shell b
 assert_says 'case (jd1) --help refuses the row-count probe as a collision check' \
   'A LOCAL ROW COUNT IS NOT EVIDENCE OF UNIQUENESS'
 assert_says 'case (jd1) --help says why the probe cannot work' 'only ever sees the LOCAL daemon'
+# AND THE PROCEDURE MUST DECLARE ITS OWN LIMIT. Checking `job` plus `git_ref` settles that the id
+# names the review you think it does ON THIS DAEMON — it does NOT bind a waiver to one BOX: two
+# daemons can hold the same id for the SAME range, so an authorization for machine A's review is
+# accepted by `--recheck-job` against machine B's different review, undetectably from here. This
+# declaration was DELETED once, together with the (#3825) key it had been written beside, and the
+# residual was re-reported in one round — presenting the git_ref check as settling the question
+# with no statement of its limit IS the defect. It needs no key to be true, so it is pinned here.
+assert_says 'case (jd1) --help declares what the git_ref check does NOT claim' \
+  'WHAT THE git_ref CHECK SETTLES, AND WHAT IS NOT CLAIMED'
+assert_says 'case (jd1) --help scopes what it settles to one daemon' \
+  'names the review you think it does ON THIS DAEMON'
+assert_says 'case (jd1) --help says two daemons can share an id for the same range' \
+  'the SAME id for the SAME git_ref range'
+assert_says 'case (jd1) --help says no local lookup can detect it' 'no local lookup can detect it'
+assert_says 'case (jd1) --help declares the residual not closed here, and names #3825' \
+  'NOT CLAIMED and NOT closed here: closing it is #3825'
 # THE PRESCRIBED LOOKUP MUST REACH AN OLDER RECORD. `roborev list` returns a BOUNDED WINDOW —
 # `--limit` defaults to 50 (measured: `roborev list --help`, v0.61.2) — so a limitless documented
 # command answers NOTHING for a job outside it, an absence indistinguishable from "no such job",

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -239,6 +239,9 @@ summary_key_order() { # summary_key_order <file> <extended-regex-of-keys> -> "k1
 #                        returns the REAL review-row shape (id/prompt, no git_ref or
 #                        status), forcing the richer `list --json` source; otherwise the
 #                        `list --json` fallback path
+#   STUB_REVIEW_ROW_ID   top-level `id` of the `show --json` REVIEW row; empty => the job id
+#                        (the agreeing shape), a DIFFERENT number => the measured divergence
+#                        where only job_id / job.id name the job asked for (#3654)
 #   STUB_INVOKED         file the stub appends its argv to (empty => never run)
 # ---------------------------------------------------------------------------
 stubbin="$tmp/bin"
@@ -329,8 +332,13 @@ case "$cmd" in
     # `review-completed`, the vacuity tiers and `findings` against (#3312 job 24). Empty means the record
     # has none, which a recheck must read as "not re-establishable" rather than inherit.
     if [ "${STUB_SHOW_JSON:-object}" = nested ]; then
-      # The MEASURED `roborev show <id> --json` shape: a REVIEW row carrying its own
-      # `id` (equal to the job id) that NESTS the job row under a "job" key.
+      # The MEASURED `roborev show <id> --json` shape: a REVIEW row carrying its OWN `id` that
+      # NESTS the job row under a "job" key. That top-level `id` is the REVIEW row's own sequence
+      # and NEED NOT equal the job asked for (#3654) — measured over records 1-10 on v0.61.2, six
+      # agree and two PAIRS swap (asking for 8 returns id=9, asking for 9 returns id=8), while
+      # `job_id` and the nested `job.id` name the requested job in every one. STUB_REVIEW_ROW_ID
+      # expresses that divergence; it defaults to the job id, so the AGREEING shape stays
+      # fixtured too and a case has to opt in to the divergent one.
       # `verdict_bool` is the SOURCE COLUMN the `verdict` letter is synthesised FROM, so the two
       # must AGREE or the fixture is a record roborev cannot emit: `P` <=> 1, `F` <=> 0 (measured —
       # job 154 clean/verdict_bool=1, job 162 findings-bearing/verdict_bool=0). Hard-coding 0 while
@@ -340,7 +348,7 @@ case "$cmd" in
       stub_verdict_bool=0
       [ "${STUB_VERDICT_FIELD:-}" != P ] || stub_verdict_bool=1
       printf '{"id":%s,"job_id":%s,"agent":"codex","verdict_bool":%s,"%s":"%s","prompt":"%s","job":' \
-        "${STUB_JOB:-4600}" "${STUB_JOB:-4600}" "$stub_verdict_bool" "${STUB_RECORD_OUTPUT_FIELD:-output}" "${STUB_RECORD_OUTPUT:-}" "$(json_prompt)"
+        "${STUB_REVIEW_ROW_ID:-${STUB_JOB:-4600}}" "${STUB_JOB:-4600}" "$stub_verdict_bool" "${STUB_RECORD_OUTPUT_FIELD:-output}" "${STUB_RECORD_OUTPUT:-}" "$(json_prompt)"
       emit_job_object
       printf '}\n'
       exit 0
@@ -349,7 +357,7 @@ case "$cmd" in
       # The REAL `show --json` shape: the REVIEW row — id/agent/prompt, and no
       # git_ref / status / verdict / token_usage.
       printf '{"id":%s,"job_id":%s,"agent":"codex","prompt":"%s"}\n' \
-        "${STUB_JOB:-4600}" "${STUB_JOB:-4600}" "$(json_prompt)"
+        "${STUB_REVIEW_ROW_ID:-${STUB_JOB:-4600}}" "${STUB_JOB:-4600}" "$(json_prompt)"
       exit 0
     fi
     emit_job_object; printf '\n'
@@ -1168,6 +1176,10 @@ export STUB_HAS_TOKEN_DATA=''
 export STUB_VERDICT_FIELD=''
 export STUB_RECORD_BLANK_FOR=0
 export STUB_PAYLOAD_JOB=''
+# #3654: the top-level `id` of a `show --json` REVIEW row. Defaults to the job id (the agreeing
+# shape); a case sets it to a DIFFERENT number to fixture the measured divergence, where only
+# `job_id` and the nested `job.id` name the job asked for.
+export STUB_REVIEW_ROW_ID=''
 export STUB_LIST_JSON=array
 export STUB_REVIEW_RC=0
 export STUB_ANNOUNCE_SHA=''
@@ -1206,6 +1218,7 @@ reset_stub() {
   STUB_VERDICT_FIELD=''
   STUB_RECORD_BLANK_FOR=0
   STUB_PAYLOAD_JOB=''
+  STUB_REVIEW_ROW_ID=''
   STUB_LIST_JSON=array
   STUB_RECORD_OUTPUT=''
   STUB_RECORD_OUTPUT_FIELD=''
@@ -3614,17 +3627,29 @@ assert_says 'case (w4) names the undefined check function' 'did not define robor
 assert_never_enqueued 'case (w4)'
 
 if [ "$HAVE_PYTHON3" -eq 1 ]; then
-printf '== case (x10): the NESTED job row in show --json is read as a first-class source ==\n'
+printf '== case (x10): the NESTED job row is selected even when the review row id DIVERGES ==\n'
 reset_stub
-# MEASURED (round 6): `roborev show <id> --json` returns a REVIEW row whose own `id`
-# equals the job id and which NESTS the job row — git_ref, status, model,
-# requested_model, token_usage, verdict — under a "job" key. Returning the FIRST id
-# match handed back the outer row, which has none of those fields; that looked like an
+# MEASURED (round 6): `roborev show <id> --json` returns a REVIEW row that NESTS the job row —
+# git_ref, status, model, requested_model, token_usage, verdict — under a "job" key. Returning the
+# FIRST id match handed back the outer row, which has none of those fields; that looked like an
 # async durability problem and silently downgraded sha-assert, tier 2 and model.
-# `list --json` is disabled here so `show` is the ONLY source.
+#
+# AND THE REVIEW ROW'S OWN `id` NEED NOT EQUAL THE JOB (#3654): measured over records 1-10 on
+# v0.61.2, six agree and two PAIRS swap (asking for 8 returns id=9, asking for 9 returns id=8),
+# while `job_id` and `job.id` name the requested job in every one. Every fixture here used
+# MATCHING ids, so the divergent shape roborev really emits executed NOWHERE. Under divergence the
+# two objects answer through DIFFERENT keys — the review row only through `job_id`, the nested job
+# row only through `id` — so this case pins that `find_job` still lands on the job row when the
+# match keys differ, which the equal-id shape cannot distinguish. Measured, not assumed: with the
+# "prefer the object carrying git_ref" arm removed, the outer row is selected and the facts come
+# back with NO git_ref, NO status and token_state=absent, which the wrapper reports as job-record
+# DEGRADED — so this case goes RED on job-record / sha-assert / tier 2 / model at once. (That
+# break reds the equal-id shape too; what is new here is the payload shape, not the tie-break.)
+# `list --json` is disabled so `show` is the ONLY source.
 work=$(make_fixture case_x10 pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
 STUB_SHOW_JSON=nested
+STUB_REVIEW_ROW_ID=$((STUB_JOB - 1))   # the measured divergence: review row 4655, job 4656
 STUB_LIST_JSON=none
 run_wrapper "$work"
 assert_verdict 'case (x10)' PASS 0
@@ -3632,6 +3657,19 @@ assert_says 'case (x10) the nested job row was used' '^job-record: PASS$'
 assert_says 'case (x10) the range oracle worked from the nested row' '^sha-assert: PASS$'
 assert_says 'case (x10) tokens came from the nested row' '^vacuity-tier2: PASS$'
 assert_says 'case (x10) the model was confirmed from the nested row' '^model: gpt-5\.6-sol$'
+
+printf '== case (x10b): the AGREEING review/job id shape still reads complete ==\n'
+reset_stub
+# The majority shape (six of the ten measured records), kept so the divergent fixture above does
+# not silently REPLACE the coverage it was derived from.
+work=$(make_fixture case_x10b pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
+STUB_SHOW_JSON=nested
+STUB_LIST_JSON=none
+run_wrapper "$work"
+assert_verdict 'case (x10b)' PASS 0
+assert_says 'case (x10b) the nested job row was used' '^job-record: PASS$'
+assert_says 'case (x10b) the range oracle worked from the nested row' '^sha-assert: PASS$'
 fi  # HAVE_PYTHON3
 
 printf '== case (w): a MISSING oracles file FAILs closed, never silently no-ops ==\n'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -3188,6 +3188,12 @@ STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" HOME="$FIXTURE_HOME" \
 RC=$?
 assert_verdict 'case (t9)' FAIL 1
 assert_says 'case (t9) the abort is reported, not silent' 'terminated unexpectedly'
+# THE COMPLEMENT OF (jm19), added with the JOB_RECORD_READ branch (#3654 round 4). This abort lands
+# BEFORE any record read, so UNAVAILABLE is the TRUE state here. Pinning it stops the new branch
+# over-reporting NOT RECORDED on a run that genuinely read nothing: a conditional with only one side
+# pinned is a conditional half-tested, and jm19 pins the other side.
+assert_says 'case (t9) an abort before any record read is UNAVAILABLE, which is true there' \
+  '^job-machine: UNAVAILABLE \(no job record was read'
 assert_one_block 'case (t9)'
 
 printf '== case (u1): token accounting present but UNPARSEABLE is drift, and FAILs ==\n'
@@ -6374,11 +6380,32 @@ if sed_inplace_verified "$_jmb_dir/roborev-review.sh" \
   elif [ -z "$_jmb_rec" ]; then
     bad 'case (jm19) no job-record: line was emitted, so the two keys could not be compared'
   else
+    # (1) THE INTERPOLATED NEIGHBOUR IS CURRENT. This was ONCE THE WHOLE CASE, and that was too
+    # narrow: the value can name the right job-record state inside a sentence whose STATE and
+    # EXPLANATION are both false, so the case passed while the artifact still lied.
     case "$_jmb_mach" in
       *"job-record: $_jmb_rec"*)
         ok "case (jm19) job-machine: names the CURRENT job-record state ($_jmb_rec) on an abort" ;;
       *)
         bad "case (jm19) the two keys contradict each other: job-record: '$_jmb_rec' but job-machine: '$_jmb_mach'" ;;
+    esac
+    # (2) THE STATE TOKEN ITSELF. A record WAS read here, so UNAVAILABLE — whose whole meaning is
+    # "no record could be read" — is the wrong state, whatever it interpolates.
+    case "$_jmb_mach" in
+      'NOT RECORDED ('*)
+        ok 'case (jm19) the state is NOT RECORDED, which is true: a record WAS read and only the lookup is missing' ;;
+      *)
+        bad "case (jm19) the abort path reports state '${_jmb_mach%% (*}' after a record WAS read — only NOT RECORDED is true here" ;;
+    esac
+    # (3) THE EXPLANATION. The sentence a reader actually acts on must not assert the opposite of
+    # what happened; pinned separately because (2) can hold while the prose still says "no record".
+    case "$_jmb_mach" in
+      *'no job record was read'*)
+        bad "case (jm19) the explanation claims no job record was read, but one was: '$_jmb_mach'" ;;
+      *'job record WAS read'*)
+        ok 'case (jm19) the explanation says a record was read and names the lookup as the missing step' ;;
+      *)
+        bad "case (jm19) the explanation neither affirms nor denies the record read, so a reader cannot tell what happened: '$_jmb_mach'" ;;
     esac
   fi
   reset_stub

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -366,6 +366,14 @@ mechanism below, under *"the unwaivable rule made one merge unobtainable"*.
    `mergeable: MERGEABLE` on a marker-bearing merge commit). Run on both `job=265` lanes it gave the right
    answer for a reason that did not hold.
 
+   **What the `git_ref` check settles is scoped to one daemon; the rest is not claimed.** It settles
+   that the id names the review you think it does *on this daemon*. It does **not** settle the cross-box
+   case: two daemons can hold the same id for the **same `git_ref` range**, so a waiver authorized
+   against machine A's review can be accepted by `--recheck-job` against machine B's different review of
+   that range — and **no local lookup can detect it**, because `roborev list` only ever sees the local
+   daemon while the marker travels through GitHub. Same-range cross-daemon collisions therefore remain
+   **unprotected**: declared here, not closed here.
+
    **Whether the block should name the issuing daemon — and the cross-box question that comes with it,
    since the marker travels through GitHub while `--recheck-job` reads the *local* daemon — is tracked as
    [#3825](https://github.com/pmcfadin/cqlite/issues/3825), together with the marker-grammar question it

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -333,6 +333,15 @@ mechanism below, under *"the unwaivable rule made one merge unobtainable"*.
    roborev list --json --repo <abs> --branch <branch> | jq '.[] | select(.id==<id>) | {id, source_machine_id, git_ref}'
    ```
 
+   **Read `.job`, never a `show` payload's top-level `id`.** That field is the *review* row's own
+   sequence and need not be the job you asked for — measured over ten records, asking for 9 returns
+   `id=8` with `job_id=9` and `job.id=9` — so a top-level jq manufactures exactly the "is this the right
+   review?" doubt the check exists to remove. The wrapper is unaffected (`find_job` matches
+   `id`/`job_id`/`job` and then **prefers the object carrying `git_ref`**, so it lands on the job row
+   either way): this is a trap for the human running the check by hand, not a live false `STALE`. For the
+   same reason, do not reach for the top-level `uuid` as a machine proxy — `job.uuid` does not exist, the
+   nested row is what is selected, and the fact would render blank.
+
    **A local row count is not evidence of uniqueness.** `roborev list … | jq '[.[] | select(.id==N)] |
    length'` returns `1` whether or not another box holds that id, because `list` only ever sees the **local**
    daemon — one more probe whose output is **identical under the two states it claims to separate** (the

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -327,11 +327,12 @@ mechanism below, under *"the unwaivable rule made one merge unobtainable"*.
    other, or any ordering between them. **It resurrects nothing of the deleted delivery classifier, and that distinction is
    load-bearing rather than a caveat:** the classifier read injectable prompt text *at decision time* to
    produce an **automated verdict**, while this is a **human** reading a **stored record** as evidence for a
-   **hand-granted** waiver, so the direct **parser** exploit is gone: nothing in the wrapper parses the
-   prompt for delivery mode, and nothing may be added that does. **That is all it buys** — the human is
-   *in* the path, not outside it, so spoofed repository-controlled prompt text can still mislead an
-   authorizer into issuing the marker, and the marker is what makes `--recheck-job` pass. That exposure is
-   [#3826](https://github.com/pmcfadin/cqlite/issues/3826)'s subject and is not settled here.
+   **hand-granted** waiver — there is no automated verdict to spoof. Nothing in the wrapper parses the
+   prompt for delivery mode, and nothing may be added that does. **That closes the PARSER path and not
+   the HUMAN one, and keeping the two separate is what makes this true:** the human is *in* the path, so
+   spoofed repository-controlled prompt text can still mislead an authorizer into posting the marker, and
+   the marker is what makes `--recheck-job` pass. That exposure is real, is
+   [#3826](https://github.com/pmcfadin/cqlite/issues/3826)'s subject, and is **not** settled here.
 
    **And `job=` is daemon-scoped, which nobody had written down (#3654).** Each fleet box runs its own
    roborev daemon with its own database and its own sequential ids, so **two boxes can legitimately present

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -327,8 +327,11 @@ mechanism below, under *"the unwaivable rule made one merge unobtainable"*.
    other, or any ordering between them. **It resurrects nothing of the deleted delivery classifier, and that distinction is
    load-bearing rather than a caveat:** the classifier read injectable prompt text *at decision time* to
    produce an **automated verdict**, while this is a **human** reading a **stored record** as evidence for a
-   **hand-granted** waiver — there is no automated verdict to spoof. Nothing in the wrapper parses the
-   prompt for delivery mode, and nothing may be added that does.
+   **hand-granted** waiver, so the direct **parser** exploit is gone: nothing in the wrapper parses the
+   prompt for delivery mode, and nothing may be added that does. **That is all it buys** — the human is
+   *in* the path, not outside it, so spoofed repository-controlled prompt text can still mislead an
+   authorizer into issuing the marker, and the marker is what makes `--recheck-job` pass. That exposure is
+   [#3826](https://github.com/pmcfadin/cqlite/issues/3826)'s subject and is not settled here.
 
    **And `job=` is daemon-scoped, which nobody had written down (#3654).** Each fleet box runs its own
    roborev daemon with its own database and its own sequential ids, so **two boxes can legitimately present

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -338,7 +338,8 @@ mechanism below, under *"the unwaivable rule made one merge unobtainable"*.
    # git_ref / status / token_usage are NESTED under .job on this payload:
    roborev show <id> --json | jq '.job | {id, git_ref, branch, status, token_usage}'
    # the issuing daemon is on the LIST row — `show --json` carries source_machine_id NOWHERE.
-   # `roborev list` filters by the CURRENT BRANCH by default, so name it:
+   # `roborev list` defaults its branch filter to the --repo path's CURRENT HEAD, not to the
+   # branch your shell is on — so name --branch when that checkout is not on the job's branch:
    roborev list --json --repo <abs> --branch <branch> | jq '.[] | select(.id==<id>) | {id, source_machine_id, git_ref}'
    ```
 

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -307,9 +307,8 @@ mechanism below, under *"the unwaivable rule made one merge unobtainable"*.
    **That cost is true at review time, and false after the fact only for a *human* reading the stored
    record — it stays true of the *machine*, and must (#3654).** The prompt roborev *sent* is **retained in the job record** and retrievable later —
    `roborev show <id> --prompt` — even though the snapshot file it names is transient and already deleted,
-   and a delivery-by-path prompt says so in its own words under `### Combined Diff`. That is **direct**
-   **direct artifact** — roborev's *actual prompt* rather than a statistic about it — and an absence-waiver
-   request should **lead with it**.
+   and a delivery-by-path prompt says so in its own words under `### Combined Diff`. That is **the direct
+   artifact** — roborev's *actual prompt* rather than a statistic about it.
 
    **It is not self-authenticating, and the trust properties run the opposite way from the obvious
    reading.** roborev's prompt **embeds repository-controlled content** at positions indistinguishable from
@@ -322,10 +321,10 @@ mechanism below, under *"the unwaivable rule made one merge unobtainable"*.
    influences their *magnitude* without forging anything. That bites exactly where the counts are used:
    the vacuous baseline is ~18.7k input / 0 cached, so padding non-diff prompt content can make a review
    that received **no diff** look token-rich. **Neither signal establishes provenance, and the two are not
-   independent** — both are functions of the same repository-influenced prompt. The prompt still *leads*,
-   and a request should still lead with it, with the counts read *alongside* it as a consistency check —
-   never as unforgeable corroboration. What evidence *should* be required before granting is an **open
-   question, pending on #3654**, and is deliberately not settled here. **It resurrects nothing of the deleted delivery classifier, and that distinction is
+   independent** — both are functions of the same repository-influenced prompt. **Which evidence a waiver
+   should rest on is an open question, tracked as
+   [#3826](https://github.com/pmcfadin/cqlite/issues/3826)** — nothing here recommends one signal over the
+   other, or any ordering between them. **It resurrects nothing of the deleted delivery classifier, and that distinction is
    load-bearing rather than a caveat:** the classifier read injectable prompt text *at decision time* to
    produce an **automated verdict**, while this is a **human** reading a **stored record** as evidence for a
    **hand-granted** waiver — there is no automated verdict to spoof. Nothing in the wrapper parses the
@@ -342,10 +341,9 @@ mechanism below, under *"the unwaivable rule made one merge unobtainable"*.
    ```bash
    # git_ref / status / token_usage are NESTED under .job on this payload:
    roborev show <id> --json | jq '.job | {id, git_ref, branch, status, token_usage}'
-   # the issuing daemon is on the LIST row — `show --json` carries source_machine_id NOWHERE.
    # `roborev list` defaults its branch filter to the --repo path's CURRENT HEAD, not to the
    # branch your shell is on — so name --branch when that checkout is not on the job's branch:
-   roborev list --json --repo <abs> --branch <branch> | jq '.[] | select(.id==<id>) | {id, source_machine_id, git_ref}'
+   roborev list --json --repo <abs> --branch <branch> | jq '.[] | select(.id==<id>) | {id, git_ref, branch}'
    ```
 
    **Read `.job`, never a `show` payload's top-level `id`.** That field is the *review* row's own
@@ -365,32 +363,10 @@ mechanism below, under *"the unwaivable rule made one merge unobtainable"*.
    `mergeable: MERGEABLE` on a marker-bearing merge commit). Run on both `job=265` lanes it gave the right
    answer for a reason that did not hold.
 
-   **The block therefore names the daemon: `job-machine:`, beside `job:`.** It is **informational** — in
-   neither the verdict scan nor the affirmation backstop, so no state of it can red a correct run — with
-   three affirmative renderings: the uuid when a record carried `source_machine_id`; `NOT RECORDED` when a
-   record **was** read and carries none (a real state, since `show --json` never carries the field — hence
-   the wrapper's one supplementary `list` read, without which the key would report nothing on every real
-   run); and `UNAVAILABLE` when no record could be read, naming the `job-record:` state it inherits. **The
-   marker grammar is unchanged**: no machine field was added to either kind — the authorizer would have to
-   know it, it is derivable from the record, and every field in a hand-typed control line is one more way
-   for a legitimate authorization to read `MALFORMED`.
-
-   **Declared boundary — what the `job=` binding does not close (#3654).** *Claimed:* within **one** daemon,
-   base+head+job names one review and `--recheck-job` re-decides that record. *Not claimed:* that a marker
-   cannot cross boxes. **The marker travels through GitHub, not through the daemon**, while
-   `--recheck-job <id>` reads the **local** daemon's record — so if two boxes hold the same id for the same
-   `git_ref` range, a waiver granted after an authorizer inspected box A's review is **accepted on box B
-   against box B's different review**: `sha-assert` passes, the id matches, and the authorization crosses
-   reviews. "A repeated id cannot reach another box's recheck" is true of the *record* and irrelevant to the
-   *marker*, which is what actually travels — and on this fleet it is not exotic: ids have already collided
-   at 265, and two lanes reviewing one branch has happened (2026-09-01, a peer session and this lane both
-   landing on #3654 within seconds; cause tracked as [#3810](https://github.com/pmcfadin/cqlite/issues/3810)
-   — `CLAIM_ACTOR` defaults to the literal `flow`, so `claim.sh` answers `VERIFY-OK` to both lanes on one box). **It is not closed here** because closing it
-   means adding a field to a hand-typed control line, which this issue's disposition forbids: a **design
-   call, escalated to the owner and pending on #3654**. The mitigation that exists today is **operational,
-   not mechanical** — the block names the issuing daemon, so an authorizer comparing `job-machine:` between
-   the request and the recheck **sees** a cross-box mismatch. That is why the key exists; being
-   informational, it stops nobody who does not look.
+   **Whether the block should name the issuing daemon — and the cross-box question that comes with it,
+   since the marker travels through GitHub while `--recheck-job` reads the *local* daemon — is tracked as
+   [#3825](https://github.com/pmcfadin/cqlite/issues/3825), together with the marker-grammar question it
+   raises.**
 
    **THE ABSENCE WAIVER — the break-glass, its four constraints, and why the documentation is not the
    credential (#3312 job 23).** The **OWNER or the coordination LEAD** may excuse an absence FAIL with a

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -342,8 +342,10 @@ mechanism below, under *"the unwaivable rule made one merge unobtainable"*.
    # git_ref / status / token_usage are NESTED under .job on this payload:
    roborev show <id> --json | jq '.job | {id, git_ref, branch, status, token_usage}'
    # `roborev list` defaults its branch filter to the --repo path's CURRENT HEAD, not to the
-   # branch your shell is on — so name --branch when that checkout is not on the job's branch:
-   roborev list --json --repo <abs> --branch <branch> | jq '.[] | select(.id==<id>) | {id, git_ref, branch}'
+   # branch your shell is on — so name --branch when that checkout is not on the job's branch.
+   # --limit defaults to 50 (measured, v0.61.2): RAISE it until the job appears, or until the
+   # returned row count stops growing. An empty result at a still-growing limit is UNMEASURED.
+   roborev list --json --limit 200 --repo <abs> --branch <branch> | jq '.[] | select(.id==<id>) | {id, git_ref, branch}'
    ```
 
    **Read `.job`, never a `show` payload's top-level `id`.** That field is the *review* row's own
@@ -357,8 +359,9 @@ mechanism below, under *"the unwaivable rule made one merge unobtainable"*.
    case — the writer emits no line at all for an empty value, so the key would read `NOT RECORDED`.)
 
    **A local row count is not evidence of uniqueness.** `roborev list … | jq '[.[] | select(.id==N)] |
-   length'` returns `1` whether or not another box holds that id, because `list` only ever sees the **local**
-   daemon — one more probe whose output is **identical under the two states it claims to separate** (the
+   length'` returns `1` whether or not another box holds that id — and `0` when the row fell outside the
+   `--limit` window, so the count says nothing about the window it was taken over — because `list` only
+   ever sees the **local** daemon — one more probe whose output is **identical under the two states it claims to separate** (the
    `RESULT: INCOMPLETE` launch sentinel read as a verdict; a gate run dir found by `ls -t`;
    `mergeable: MERGEABLE` on a marker-bearing merge commit). Run on both `job=265` lanes it gave the right
    answer for a reason that did not hold.

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -316,11 +316,16 @@ mechanism below, under *"the unwaivable rule made one merge unobtainable"*.
    roborev's own text, so a reviewed branch can carry text *mimicking* that delivery wording and an
    authorizer would read it as roborev's — a human in the loop is not a channel separation, it is the same
    shared channel with a slower parser. So the prompt is read for the **structural fact** it reports, never
-   as proof of its own provenance. The **token accounting has the opposite property**: it is recorded **by
-   the daemon** and nothing the reviewed branch can write changes it, so it **corroborates** where the
-   prompt cannot — it is *not* a mere fallback for a missing prompt. The two are **complementary, not
-   ranked**: where both exist an authorizer should want both, and a request offering only one should say
-   which is missing and why. **It resurrects nothing of the deleted delivery classifier, and that distinction is
+   as proof of its own provenance. The **token accounting is daemon-recorded but not independent, and
+   it does not establish delivery either**: the *record* is authentic (the branch cannot rewrite it), but
+   the counts measure **the prompt**, and the prompt embeds repository-controlled content — so a branch
+   influences their *magnitude* without forging anything. That bites exactly where the counts are used:
+   the vacuous baseline is ~18.7k input / 0 cached, so padding non-diff prompt content can make a review
+   that received **no diff** look token-rich. **Neither signal establishes provenance, and the two are not
+   independent** — both are functions of the same repository-influenced prompt. The prompt still *leads*,
+   and a request should still lead with it, with the counts read *alongside* it as a consistency check —
+   never as unforgeable corroboration. What evidence *should* be required before granting is an **open
+   question, pending on #3654**, and is deliberately not settled here. **It resurrects nothing of the deleted delivery classifier, and that distinction is
    load-bearing rather than a caveat:** the classifier read injectable prompt text *at decision time* to
    produce an **automated verdict**, while this is a **human** reading a **stored record** as evidence for a
    **hand-granted** waiver — there is no automated verdict to spoof. Nothing in the wrapper parses the

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -304,8 +304,8 @@ mechanism below, under *"the unwaivable rule made one merge unobtainable"*.
    cached; vacuous baseline ~18.7k / 0). That trade was chosen deliberately over a machine guessing from
    injectable text.
 
-   **That cost is true at review time and false after the fact, which is where the best absence evidence
-   lives (#3654).** The prompt roborev *sent* is **retained in the job record** and retrievable later —
+   **That cost is true at review time, and false after the fact only for a *human* reading the stored
+   record — it stays true of the *machine*, and must (#3654).** The prompt roborev *sent* is **retained in the job record** and retrievable later —
    `roborev show <id> --prompt` — even though the snapshot file it names is transient and already deleted,
    and a delivery-by-path prompt says so in its own words under `### Combined Diff`. That is **direct**
    **direct artifact** — roborev's *actual prompt* rather than a statistic about it — and an absence-waiver
@@ -349,8 +349,9 @@ mechanism below, under *"the unwaivable rule made one merge unobtainable"*.
    review?" doubt the check exists to remove. The wrapper is unaffected (`find_job` matches
    `id`/`job_id`/`job` and then **prefers the object carrying `git_ref`**, so it lands on the job row
    either way): this is a trap for the human running the check by hand, not a live false `STALE`. For the
-   same reason, do not reach for the top-level `uuid` as a machine proxy — `job.uuid` does not exist, the
-   nested row is what is selected, and the fact would render blank.
+   same reason, do not reach for the top-level `uuid` as a machine proxy: it identifies the **review row**,
+   not the daemon, so it answers a different question however it renders. (It would not render blank in any
+   case — the writer emits no line at all for an empty value, so the key would read `NOT RECORDED`.)
 
    **A local row count is not evidence of uniqueness.** `roborev list … | jq '[.[] | select(.id==N)] |
    length'` returns `1` whether or not another box holds that id, because `list` only ever sees the **local**
@@ -377,7 +378,9 @@ mechanism below, under *"the unwaivable rule made one merge unobtainable"*.
    against box B's different review**: `sha-assert` passes, the id matches, and the authorization crosses
    reviews. "A repeated id cannot reach another box's recheck" is true of the *record* and irrelevant to the
    *marker*, which is what actually travels — and on this fleet it is not exotic: ids have already collided
-   at 265, and two lanes reviewing one branch has happened. **It is not closed here** because closing it
+   at 265, and two lanes reviewing one branch has happened (2026-09-01, a peer session and this lane both
+   landing on #3654 within seconds; cause tracked as [#3810](https://github.com/pmcfadin/cqlite/issues/3810)
+   — `CLAIM_ACTOR` defaults to the literal `flow`, so `claim.sh` answers `VERIFY-OK` to both lanes on one box). **It is not closed here** because closing it
    means adding a field to a hand-typed control line, which this issue's disposition forbids: a **design
    call, escalated to the owner and pending on #3654**. The mitigation that exists today is **operational,
    not mechanical** — the block names the issuing daemon, so an authorizer comparing `job-machine:` between

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -308,10 +308,19 @@ mechanism below, under *"the unwaivable rule made one merge unobtainable"*.
    lives (#3654).** The prompt roborev *sent* is **retained in the job record** and retrievable later —
    `roborev show <id> --prompt` — even though the snapshot file it names is transient and already deleted,
    and a delivery-by-path prompt says so in its own words under `### Combined Diff`. That is **direct**
-   evidence a diff was delivered, where token accounting is **inference** (a large number is merely
-   *consistent* with a real review). So the **stored prompt is the PREFERRED evidence in an absence-waiver
-   request and a request leads with it**; token accounting is the **fallback**, for when the prompt cannot
-   be retrieved. **It resurrects nothing of the deleted delivery classifier, and that distinction is
+   **direct artifact** — roborev's *actual prompt* rather than a statistic about it — and an absence-waiver
+   request should **lead with it**.
+
+   **It is not self-authenticating, and the trust properties run the opposite way from the obvious
+   reading.** roborev's prompt **embeds repository-controlled content** at positions indistinguishable from
+   roborev's own text, so a reviewed branch can carry text *mimicking* that delivery wording and an
+   authorizer would read it as roborev's — a human in the loop is not a channel separation, it is the same
+   shared channel with a slower parser. So the prompt is read for the **structural fact** it reports, never
+   as proof of its own provenance. The **token accounting has the opposite property**: it is recorded **by
+   the daemon** and nothing the reviewed branch can write changes it, so it **corroborates** where the
+   prompt cannot — it is *not* a mere fallback for a missing prompt. The two are **complementary, not
+   ranked**: where both exist an authorizer should want both, and a request offering only one should say
+   which is missing and why. **It resurrects nothing of the deleted delivery classifier, and that distinction is
    load-bearing rather than a caveat:** the classifier read injectable prompt text *at decision time* to
    produce an **automated verdict**, while this is a **human** reading a **stored record** as evidence for a
    **hand-granted** waiver — there is no automated verdict to spoof. Nothing in the wrapper parses the
@@ -358,6 +367,21 @@ mechanism below, under *"the unwaivable rule made one merge unobtainable"*.
    marker grammar is unchanged**: no machine field was added to either kind — the authorizer would have to
    know it, it is derivable from the record, and every field in a hand-typed control line is one more way
    for a legitimate authorization to read `MALFORMED`.
+
+   **Declared boundary — what the `job=` binding does not close (#3654).** *Claimed:* within **one** daemon,
+   base+head+job names one review and `--recheck-job` re-decides that record. *Not claimed:* that a marker
+   cannot cross boxes. **The marker travels through GitHub, not through the daemon**, while
+   `--recheck-job <id>` reads the **local** daemon's record — so if two boxes hold the same id for the same
+   `git_ref` range, a waiver granted after an authorizer inspected box A's review is **accepted on box B
+   against box B's different review**: `sha-assert` passes, the id matches, and the authorization crosses
+   reviews. "A repeated id cannot reach another box's recheck" is true of the *record* and irrelevant to the
+   *marker*, which is what actually travels — and on this fleet it is not exotic: ids have already collided
+   at 265, and two lanes reviewing one branch has happened. **It is not closed here** because closing it
+   means adding a field to a hand-typed control line, which this issue's disposition forbids: a **design
+   call, escalated to the owner and pending on #3654**. The mitigation that exists today is **operational,
+   not mechanical** — the block names the issuing daemon, so an authorizer comparing `job-machine:` between
+   the request and the recheck **sees** a cross-box mismatch. That is why the key exists; being
+   informational, it stops nobody who does not look.
 
    **THE ABSENCE WAIVER — the break-glass, its four constraints, and why the documentation is not the
    credential (#3312 job 23).** The **OWNER or the coordination LEAD** may excuse an absence FAIL with a

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -304,6 +304,52 @@ mechanism below, under *"the unwaivable rule made one merge unobtainable"*.
    cached; vacuous baseline ~18.7k / 0). That trade was chosen deliberately over a machine guessing from
    injectable text.
 
+   **That cost is true at review time and false after the fact, which is where the best absence evidence
+   lives (#3654).** The prompt roborev *sent* is **retained in the job record** and retrievable later —
+   `roborev show <id> --prompt` — even though the snapshot file it names is transient and already deleted,
+   and a delivery-by-path prompt says so in its own words under `### Combined Diff`. That is **direct**
+   evidence a diff was delivered, where token accounting is **inference** (a large number is merely
+   *consistent* with a real review). So the **stored prompt is the PREFERRED evidence in an absence-waiver
+   request and a request leads with it**; token accounting is the **fallback**, for when the prompt cannot
+   be retrieved. **It resurrects nothing of the deleted delivery classifier, and that distinction is
+   load-bearing rather than a caveat:** the classifier read injectable prompt text *at decision time* to
+   produce an **automated verdict**, while this is a **human** reading a **stored record** as evidence for a
+   **hand-granted** waiver — there is no automated verdict to spoof. Nothing in the wrapper parses the
+   prompt for delivery mode, and nothing may be added that does.
+
+   **And `job=` is daemon-scoped, which nobody had written down (#3654).** Each fleet box runs its own
+   roborev daemon with its own database and its own sequential ids, so **two boxes can legitimately present
+   the same id for different reviews** — measured: `job=265` on two lanes 50 minutes apart, different
+   ranges, branches and token counts, both correct — and the coordination lead read the repetition as a
+   collision and **withheld a valid waiver**. The failure is symmetric and the other direction is worse: a
+   lead who therefore treats `job=` as uninformative discards the one field binding an authorization to a
+   *review* rather than to a *range*. So **verify the record's `git_ref`, never the id alone**:
+
+   ```bash
+   # git_ref / status / token_usage are NESTED under .job on this payload:
+   roborev show <id> --json | jq '.job | {id, git_ref, branch, status, token_usage}'
+   # the issuing daemon is on the LIST row — `show --json` carries source_machine_id NOWHERE.
+   # `roborev list` filters by the CURRENT BRANCH by default, so name it:
+   roborev list --json --repo <abs> --branch <branch> | jq '.[] | select(.id==<id>) | {id, source_machine_id, git_ref}'
+   ```
+
+   **A local row count is not evidence of uniqueness.** `roborev list … | jq '[.[] | select(.id==N)] |
+   length'` returns `1` whether or not another box holds that id, because `list` only ever sees the **local**
+   daemon — one more probe whose output is **identical under the two states it claims to separate** (the
+   `RESULT: INCOMPLETE` launch sentinel read as a verdict; a gate run dir found by `ls -t`;
+   `mergeable: MERGEABLE` on a marker-bearing merge commit). Run on both `job=265` lanes it gave the right
+   answer for a reason that did not hold.
+
+   **The block therefore names the daemon: `job-machine:`, beside `job:`.** It is **informational** — in
+   neither the verdict scan nor the affirmation backstop, so no state of it can red a correct run — with
+   three affirmative renderings: the uuid when a record carried `source_machine_id`; `NOT RECORDED` when a
+   record **was** read and carries none (a real state, since `show --json` never carries the field — hence
+   the wrapper's one supplementary `list` read, without which the key would report nothing on every real
+   run); and `UNAVAILABLE` when no record could be read, naming the `job-record:` state it inherits. **The
+   marker grammar is unchanged**: no machine field was added to either kind — the authorizer would have to
+   know it, it is derivable from the record, and every field in a hand-typed control line is one more way
+   for a legitimate authorization to read `MALFORMED`.
+
    **THE ABSENCE WAIVER — the break-glass, its four constraints, and why the documentation is not the
    credential (#3312 job 23).** The **OWNER or the coordination LEAD** may excuse an absence FAIL with a
    **dedicated, column-zero line** of a PR comment:


### PR DESCRIPTION
## Summary

roborev job ids are **per-daemon, not global**. Each fleet box runs its own daemon with its own database and its own sequential ids, so two boxes can legitimately present the same `job=<id>` for two different reviews. That is exactly what happened: PR #3651 (`lane-3515`) and PR #3555 (`lane-3493`) both presented **`job=265`**, 50 minutes apart, for different `git_ref`s. Reading the repeat as a collision, the coordination lead **withheld a valid absence waiver**. Nothing in CLAUDE.md, in `--help`, or in the wrapper said the id was daemon-scoped.

This PR documents the scope and the verification procedure that settles such a question. **A lead who had read it would not have withheld the waiver.**

Closes #3654.

## Scope — asks 1+2 only, by lead ruling

#3654 carried four asks. Five review rounds produced nine findings, and **both recurring sites lay outside asks 1+2**. Per the lead's ruling on `req-3654-01` (option D, CLAUDE.md's #3544 *split-don't-carve* precedent), this PR ships the documentation and the rest was split out:

- **#3825** — the `job-machine:` summary-block key, the cross-box marker residual, and the marker-grammar design question. It names this branch's implementation as its starting point.
- **#3826** — waiver evidence policy: what evidence may support an absence waiver.

## What ships

| file | what |
|---|---|
| `scripts/flow/roborev-review.sh` | `--help`: daemon-scoped ids, a verification procedure that works, the row-count non-check; corrected stale comments |
| `CLAUDE.md` | the same doctrine in the waiver paragraph |
| `website/.../agents-developing/roborev-findings.md` | the published surface |
| `scripts/tests/test_roborev_review_guard.sh` | guard coverage for the above |
| `scripts/flow/roborev-job-facts.py` | comment correction only (no behaviour change) |

## Measured, not argued — and three of these contradict the issue as filed

Everything below was measured on roborev **v0.61.2**. They are recorded because the issue's own asks, implemented literally, would have shipped a procedure that misleads the operator it exists to help.

1. **The verification command the issue prescribes returns three nulls.** `roborev show <id> --json | jq '{id, git_ref, branch, source_machine_id, token_usage}'` — `git_ref` and `token_usage` are nested under `.job`, and `source_machine_id` is absent from that payload entirely (it is carried by `roborev list --json` rows only). The documented procedure names the payload that actually holds each field.

2. **Top-level `id` in `show --json` is NOT the job you asked for.** Over ten records: `asked 8 -> id=9, job_id=8`; `asked 9 -> id=8, job_id=9`; the other eight equal. Top-level `id` is the review row's own sequence; `job_id` and `.job.id` always equal the id asked for. Documenting the issue's jq verbatim would show an operator `id=8` when they asked for job 9 — manufacturing the very doubt this issue closes. **Not a wrapper defect**: `find_job` matches any of `id`/`job_id`/`job` and prefers the object carrying `git_ref`, so it lands on the job row regardless. The stale comments that claimed the two are equal are corrected here, and the fixture now uses **differing** ids so that preference is actually exercised.

3. **`roborev list`'s default filter follows the `--repo` path's CURRENT HEAD**, not the invoking shell's branch — so name `--branch` when that checkout is not on the job's branch, and raise `--limit` until the job appears or the row count stops growing. A bounded default window is why an older record can return nothing while existing.

4. **A local row count is not evidence of uniqueness.** `roborev list | select(.id==N) | length` returns `1` whether or not another box holds the same id, because `list` only ever sees the local daemon. It is structurally incapable of detecting the cross-box collision it was offered as proof against — and on the two `job=265` lanes it gave the right answer for a reason that did not hold.

## The evidence paragraph

CLAUDE.md recorded the cost of deleting the delivery classifier as *"a snapshot-delivered diff and a vacuous review that received NOTHING are IDENTICAL to the machine."* That is true at review time and false **for a human reading the stored record afterwards** — the prompt survives in the record (`roborev show <id> --prompt`) even though the snapshot file it names is already deleted. It stays true of the machine, and must.

This PR states what each signal can and cannot establish and **recommends nothing**: the prompt is the direct artifact but its content is repository-influenced; the token counts are daemon-recorded but measure the prompt, so a branch influences their magnitude; **neither establishes provenance, and they are not independent**. Which to require is #3826.

Nothing here resurrects the deleted classifier — that failed by inferring delivery mode from injectable prompt text **at decision time to produce an automated verdict**. No automated verdict derives from any of this.

## Verification

- **roborev: `findings: NONE`, `RESULT: PASS`** (job 47, `--agent codex --model gpt-5.6-sol`, 352,869 input / 288,000 cached). Seven rounds; every deterministic key PASS in all of them.
- Guard suites: `test_roborev_review_guard.sh` **1236 passed / 0 failed**; `test_roborev_guard_portability.sh` **129 / 0 / 0**. Note the portability suite is outside `--lite`'s blast radius and was run deliberately.
- `--lite`: PASS at `e8f0f83`, `tree-integrity: PASS`.
- Base staleness: `NO-STALENESS-RECOGNISED`, behind 0.
- **Gate of record: recorded below by `flow-closer`.**

## Residuals

- The **cross-box marker residual** is real, is NOT closed here, and is declared as such rather than papered over: the marker binds `base`+`head`+`job` and travels through GitHub, while `--recheck-job` reads the LOCAL daemon. It moved to #3825 with the key that mitigates it.
- Three follow-up candidates surfaced while working, none in scope: the guard suite is **not concurrency-safe** (measured twice — `1281/5` vs `1286/0`, and `1226/1` vs `1227/0`, sums equal both times, caused by fixed temp paths); that suite has **no case floor**, so an illegitimate case-count shrink would go unnoticed (#3544's recorded defect); and `.drive-issue-state.md` carries no ownership stamp, so a rehydrating session can read a peer's plan as its own.
