### PR TITLE
fix(#3822): ownership-stamp .drive-issue-state.md so a rehydrating session cannot adopt a peer's plan

### DIFF
--- a/.claude/commands/drive-issue.md
+++ b/.claude/commands/drive-issue.md
@@ -91,12 +91,16 @@ On start, BEFORE anything else: `git fetch origin`, then check whether this mach
     the turn. Do not "fix" it by rewriting the marker.
   - `LIVENESS-UNKNOWN` (7) → liveness could not be measured. STOP the same way and say so in your
     report; never adopt on unproven information.
-  - `ERROR` (1) → an I/O or internal failure: an unreadable marker, no `flock` on this host, the
+  - `ERROR` (1) → an I/O or internal failure: an unreadable marker, a SYMLINK at the marker or
+    lock path (dangling or not — a link is a deliberate artifact, so it is refused rather than
+    followed or replaced), no `flock` on this host, the
     shared liveness library missing, a helper the writer depends on failing, or an IDENTITY AXIS
     THAT COULD NOT BE MEASURED — the detail names it (`axis=machine`: `hostname -s` failed and
     `CLAIM_MACHINE` is unset, so the stamp would record the `unspecified` placeholder and alias
     every such box onto one owner; `axis=worktree`: `pwd -P` named no absolute directory, so the
-    marker path would be derived at the filesystem root). NOTHING was
+    marker path would be derived at the filesystem root — every subcommand, `adopt` included,
+    refuses on this axis BEFORE it derives a path or takes a lock, so the diagnostic does not
+    depend on which one you ran). NOTHING was
     decided and NOTHING was written. Do not proceed from the marker and do not write over it —
     report the `verdict-detail` line to the lead. **Every** exit of that script carries a verdict
     token, a fatal start-up failure included, so an EMPTY token means you are not reading its

--- a/.claude/commands/drive-issue.md
+++ b/.claude/commands/drive-issue.md
@@ -51,8 +51,12 @@ first issue comment. ALL upward communication goes through its protocol on issue
 When you are blocked on a lead/owner response (Seam-1 spec approval, a decision request, a HOLD):
 
 1. Post the coord request (marker + label) with your recommendation and a default.
-2. Record durable state in the worktree: `.drive-issue-state.md` — stage reached, open request ID,
-   PR/branch, timestamp (`date -u`).
+2. Record durable state in the worktree **through the script, never by hand** (#3822):
+   `bash scripts/flow/drive-issue-state.sh write <N> --stage <stage> --request-id <id> [--pr <n>]
+   [--branch <b>] [--body-file <notes.md>]`. It stamps the marker with this lane's ownership
+   identity (issue, machine, worktree, session, session pid + start window, actor) inside a bounded
+   prologue and REFUSES to overwrite a marker that is not yours — a hand-written marker carries no
+   stamp and Delta 4 will refuse to rehydrate from it.
 3. **Arm the cron**: `CronList` first — if a job named `drive-issue-<N>` already exists, do NOT
    create another. Else `CronCreate` name `drive-issue-<N>`, interval ~15 minutes, prompt exactly:
    `/drive-issue <N>`. The command is resume-safe (Delta 4), so each firing rehydrates, checks for
@@ -71,11 +75,27 @@ cron re-invokes forever. Deleting the cron is part of "done"; a report that omit
 On start, BEFORE anything else: `git fetch origin`, then check whether this machine already holds
 `refs/claims/issue-<N>` (`claim.sh verify <N>`) or has the issue worktree.
 
-- **Held → resume**: read `.drive-issue-state.md` + the issue thread. If a pairing response newer
-  than your open request exists → `CronDelete drive-issue-<N>`, clear the state marker's open
-  request, and continue the pipeline from the recorded stage. If not → beat the heartbeat, post
-  nothing, end the turn (the cron persists). Never re-ask an unanswered question — one marker, one
-  wait.
+- **Held → resume**: gate the rehydrate on
+  `bash scripts/flow/drive-issue-state.sh verify <N>` (#3822) — never read the marker's prose
+  first. `--help` is the authoritative contract; act on the `verdict` token:
+  - `OWNED` (0) → read the marker + the issue thread and resume from the recorded stage. If a
+    pairing response newer than your open request exists → `CronDelete drive-issue-<N>`, `write`
+    the marker again with the cleared request, and continue. If not → beat the heartbeat, post
+    nothing, end the turn (the cron persists). Never re-ask an unanswered question.
+  - `ABSENT` (3) → no durable state; treat as a fresh start of this stage and `write` one.
+  - `ADOPTABLE` (5) → the recorded writer is provably gone (the normal cron re-invoke on a new
+    session id). Take it EXPLICITLY: `drive-issue-state.sh adopt <N> --reason <what the resume is>`,
+    which rewrites the stamp and records the prior session. Then resume.
+  - `LIVE-PEER` (6) → a live peer session owns this lane. STOP: post nothing, adopt nothing, end
+    the turn. Do not "fix" it by rewriting the marker.
+  - `LIVENESS-UNKNOWN` (7) → liveness could not be measured. STOP the same way and say so in your
+    report; never adopt on unproven information.
+  - `FOREIGN-ISSUE`/`FOREIGN-MACHINE`/`FOREIGN-WORKTREE` (4) → this marker is not about this
+    lane's work (a reused lane, a copied tree, a marker that travelled with a branch). Escalate to
+    the lead rather than adopting or deleting it.
+  - `UNSTAMPED`/`MALFORMED`/`DUPLICATE-SENTINEL` (8) → the marker predates #3822 or was hand-edited,
+    so its plan could belong to any session. Do NOT adopt its contents; re-`write` a stamped marker
+    only if this lane's work genuinely IS the issue it describes.
 - **Not held → fresh start**: claim per worker.md step 3, then route (oracle-driven → straight to
   implement; design-driven → `flow-activate` to Seam 1, render the spec INLINE in an issue comment
   as the approval request, then Delta 3). The spec render and the coord request are **ONE combined

--- a/.claude/commands/drive-issue.md
+++ b/.claude/commands/drive-issue.md
@@ -91,9 +91,14 @@ On start, BEFORE anything else: `git fetch origin`, then check whether this mach
     the turn. Do not "fix" it by rewriting the marker.
   - `LIVENESS-UNKNOWN` (7) → liveness could not be measured. STOP the same way and say so in your
     report; never adopt on unproven information.
-  - `ERROR` (1) → an I/O or internal failure: an unreadable marker, a SYMLINK at the marker or
-    lock path (dangling or not — a link is a deliberate artifact, so it is refused rather than
-    followed or replaced), no `flock` on this host, the
+  - `ERROR` (1) → an I/O or internal failure: an unreadable marker, a NON-REGULAR entry at the
+    marker or lock path — a symlink (dangling or not), FIFO, socket, device or directory: the
+    detail names which one, and the rule is over the TYPE rather than a list, because this
+    script owns those paths and never follows, opens or replaces what it did not create. (A
+    FIFO is the reason it is fatal rather than tidy: opening one BLOCKS FOREVER, which is a
+    verdict-less stall in an unattended lane.) A non-regular `--body-file` is a `USAGE` (64)
+    refusal for the same reason, asking what the path RESOLVES to, so a symlink to a real
+    notes file still works. Also: no `flock` on this host, the
     shared liveness library missing, a helper the writer depends on failing, or an IDENTITY AXIS
     THAT COULD NOT BE MEASURED — the detail names it (`axis=machine`: `hostname -s` failed and
     `CLAIM_MACHINE` is unset, so the stamp would record the `unspecified` placeholder and alias

--- a/.claude/commands/drive-issue.md
+++ b/.claude/commands/drive-issue.md
@@ -92,7 +92,11 @@ On start, BEFORE anything else: `git fetch origin`, then check whether this mach
   - `LIVENESS-UNKNOWN` (7) → liveness could not be measured. STOP the same way and say so in your
     report; never adopt on unproven information.
   - `ERROR` (1) → an I/O or internal failure: an unreadable marker, no `flock` on this host, the
-    shared liveness library missing, or a helper the writer depends on failing. NOTHING was
+    shared liveness library missing, a helper the writer depends on failing, or an IDENTITY AXIS
+    THAT COULD NOT BE MEASURED — the detail names it (`axis=machine`: `hostname -s` failed and
+    `CLAIM_MACHINE` is unset, so the stamp would record the `unspecified` placeholder and alias
+    every such box onto one owner; `axis=worktree`: `pwd -P` named no absolute directory, so the
+    marker path would be derived at the filesystem root). NOTHING was
     decided and NOTHING was written. Do not proceed from the marker and do not write over it —
     report the `verdict-detail` line to the lead. **Every** exit of that script carries a verdict
     token, a fatal start-up failure included, so an EMPTY token means you are not reading its

--- a/.claude/commands/drive-issue.md
+++ b/.claude/commands/drive-issue.md
@@ -97,6 +97,11 @@ On start, BEFORE anything else: `git fetch origin`, then check whether this mach
     report the `verdict-detail` line to the lead. **Every** exit of that script carries a verdict
     token, a fatal start-up failure included, so an EMPTY token means you are not reading its
     output (redirection, a shell wrapper) — never that the run was fine.
+  - `USAGE` (64) → the invocation itself was wrong (a bad issue number, an option with no
+    value, an unknown subcommand). NOTHING was read and NOTHING was written; fix the command.
+  - A signal (`INT`/`TERM`/`HUP`, exit 130/143/129) still carries exactly ONE token, chosen by
+    how far the write got: `ERROR` before the atomic rename (nothing written), and the run's own
+    `WRITTEN`/`ADOPTED` after it (the marker WAS replaced — do not re-run blindly).
   - `FOREIGN-ISSUE`/`FOREIGN-MACHINE`/`FOREIGN-WORKTREE` (4) → this marker is not about this
     lane's work (a reused lane, a copied tree, a marker that travelled with a branch). Escalate to
     the lead rather than adopting or deleting it.

--- a/.claude/commands/drive-issue.md
+++ b/.claude/commands/drive-issue.md
@@ -79,8 +79,9 @@ On start, BEFORE anything else: `git fetch origin`, then check whether this mach
   `bash scripts/flow/drive-issue-state.sh verify <N>` (#3822) — never read the marker's prose
   first. `--help` is the authoritative contract; act on the `verdict` token:
   - `OWNED` (0) → read the marker + the issue thread and resume from the recorded stage. If a
-    pairing response newer than your open request exists → `CronDelete drive-issue-<N>`, `write`
-    the marker again with the cleared request, and continue. If not → beat the heartbeat, post
+    pairing response newer than your open request exists → `CronDelete drive-issue-<N>`,
+    `drive-issue-state.sh write <N> --stage <stage> --clear request-id` (omitting a flag
+    PRESERVES the recorded field — `--clear` is the only eraser), and continue. If not → beat the heartbeat, post
     nothing, end the turn (the cron persists). Never re-ask an unanswered question.
   - `ABSENT` (3) → no durable state; treat as a fresh start of this stage and `write` one.
   - `ADOPTABLE` (5) → the recorded writer is provably gone (the normal cron re-invoke on a new

--- a/.claude/commands/drive-issue.md
+++ b/.claude/commands/drive-issue.md
@@ -93,9 +93,15 @@ On start, BEFORE anything else: `git fetch origin`, then check whether this mach
   - `FOREIGN-ISSUE`/`FOREIGN-MACHINE`/`FOREIGN-WORKTREE` (4) → this marker is not about this
     lane's work (a reused lane, a copied tree, a marker that travelled with a branch). Escalate to
     the lead rather than adopting or deleting it.
-  - `UNSTAMPED`/`MALFORMED`/`DUPLICATE-SENTINEL` (8) → the marker predates #3822 or was hand-edited,
-    so its plan could belong to any session. Do NOT adopt its contents; re-`write` a stamped marker
-    only if this lane's work genuinely IS the issue it describes.
+  - `UNSTAMPED` (8) → the marker predates #3822 (the state EVERY existing lane is in on rollout),
+    so its plan could belong to any session. Do NOT read its contents as your plan. The route
+    forward IS `drive-issue-state.sh write <N> --stage <stage>`, which succeeds over an unstamped
+    marker, DISCARDS its body and says so — save anything you need out of the file first, then
+    resume as a fresh start of that stage.
+  - `MALFORMED`/`DUPLICATE-SENTINEL` (8) → the file CLAIMS an identity that cannot be read, which
+    may be a live peer's, so it is NOT overwritten for you. Move it aside deliberately
+    (`mv .drive-issue-state.md .drive-issue-state.md.unreadable`); the lane then reads `ABSENT` and
+    you write a fresh stamped marker on the normal path. Say in your report that you did it.
 - **Not held → fresh start**: claim per worker.md step 3, then route (oracle-driven → straight to
   implement; design-driven → `flow-activate` to Seam 1, render the spec INLINE in an issue comment
   as the approval request, then Delta 3). The spec render and the coord request are **ONE combined

--- a/.claude/commands/drive-issue.md
+++ b/.claude/commands/drive-issue.md
@@ -91,6 +91,12 @@ On start, BEFORE anything else: `git fetch origin`, then check whether this mach
     the turn. Do not "fix" it by rewriting the marker.
   - `LIVENESS-UNKNOWN` (7) → liveness could not be measured. STOP the same way and say so in your
     report; never adopt on unproven information.
+  - `ERROR` (1) → an I/O or internal failure: an unreadable marker, no `flock` on this host, the
+    shared liveness library missing, or a helper the writer depends on failing. NOTHING was
+    decided and NOTHING was written. Do not proceed from the marker and do not write over it —
+    report the `verdict-detail` line to the lead. **Every** exit of that script carries a verdict
+    token, a fatal start-up failure included, so an EMPTY token means you are not reading its
+    output (redirection, a shell wrapper) — never that the run was fine.
   - `FOREIGN-ISSUE`/`FOREIGN-MACHINE`/`FOREIGN-WORKTREE` (4) → this marker is not about this
     lane's work (a reused lane, a copied tree, a marker that travelled with a branch). Escalate to
     the lead rather than adopting or deleting it.

--- a/.gitignore
+++ b/.gitignore
@@ -350,3 +350,7 @@ trino-connector/docker/field-repro-artifacts/
 
 # Cross-binding parity harness artifacts (issue #1455)
 bindings/parity/out/
+
+# Sidecar files of the per-lane drive-issue state marker (#3822): the flock lockfile and
+# the atomic-replace temporaries. The marker itself is ignored above.
+.drive-issue-state.md.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1935,7 +1935,20 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   of those review rounds is a second place to lose them). `machine` is the same notion `claim.sh`
   records — same env var, same default, same sanitizer — and the agreement is pinned BEHAVIOURALLY
   by `scripts/tests/test_drive_issue_state.sh`, which extracts claim.sh's own definition and
-  compares, rather than by care.
+  compares, rather than by care. **`write` MUST succeed over an UNSTAMPED marker, and that is a
+  correctness requirement rather than a convenience**: every lane holds an unstamped marker on
+  rollout BY DEFINITION, so refusing it made the whole marker path a dead letter fleet-wide while
+  the refusal text named the very command that refused — the #3312-job-24 shape, where a
+  break-glass ships that no sequence of actions can reach. An unstamped marker asserts NO
+  ownership, so refusing protects no identifiable party; its body is DISCARDED (never carried
+  forward) and the discard is ANNOUNCED. A MALFORMED/DUPLICATE-SENTINEL marker gets no such
+  exception — it CLAIMS an identity that merely cannot be READ, which may be a live peer's — so a
+  human moves it aside and the lane then takes the ABSENT path. **Generalised, and pinned by a
+  DERIVED test case rather than per-verdict prose: no refusal text may name a subcommand of the
+  script that returns the SAME refusal in that state** — including a two-step remedy, because the
+  readers of these texts run printed commands literally. Naming no mechanical remedy is fine
+  (`FOREIGN-*` say "escalate"); naming one that refuses is the defect, and that case caught two
+  further instances in the same round it was written.
   **The lock is a plain `git push`, so git — not just `gh` — must be authenticated (#2942).** They
   are separate credential paths: an authenticated `gh` with an unwired git fails every claim with
   `fatal: could not read Username`, and `claim.sh` now calls that `ERROR reason=auth (NOT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2009,6 +2009,27 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   site that prints a verdict line and ONE that sets the flag, and the race is pinned by a
   structural order assert plus a signal PLANTED at the window in a scratch copy — with the
   pre-fix ordering kept as the positive control, because a race cannot be pinned by a timed test.
+  (9) **An identity is recorded and compared LOSSLESSLY or the run REFUSES, naming its axis** —
+  the third instance of H1's family (unmeasurable axis committed as a placeholder; then the
+  worktree axis; now a MEASURABLE identity committed LOSSILY). The shared `sanitize_field`
+  maps space to `-`, collapses runs and TRUNCATES at 120, so `CLAIM_MACHINE='build box'`
+  recorded `build-box` and a genuinely different `build-box` verified as OWNED — and two names
+  sharing a 120-char prefix were one owner. Enforced at the USE SITE by requiring
+  `sanitize_field(v) == v` (one comparison covering charset AND length, needing no second copy
+  of the sanitizer's rules), never in the sanitizer, which stays pinned against claim.sh's own
+  definition — that agreement case now compares the two EXTRACTED functions over a TABLE, since
+  a lossy value no longer reaches a marker to be read back out of. It covers `machine` and
+  `session` (an EQUAL session id is OWNED outright, so a lossy one aliases two sessions);
+  `worktree` was already verbatim; `actor`, the durable fields and the `prior-*` provenance are
+  DECLARED lossy and deliberately not refused, because nothing COMPARES them so a collision
+  cannot grant ownership. Same round, two more: a supplied body is **READ, never stat-gated** —
+  an `[ -s ]` before the copy let a source deleted or truncated in between commit an EMPTY body
+  under `WRITTEN`, so the caller's file is snapshotted ONCE and every later step reads those
+  bytes (a check before the act can only describe a file that no longer has to be the one acted
+  on); and an **unrecognised prologue key is PRESERVED**, because accepting it "for forward
+  compatibility" while the rewrite path dropped it made an OLDER script silently DELETE a field
+  a NEWER one introduced — preserve beats refuse, which would brick every touched lane on a
+  fleet mid-rollout.
   **The lock is a plain `git push`, so git — not just `gh` — must be authenticated (#2942).** They
   are separate credential paths: an authenticated `gh` with an unwired git fails every claim with
   `fatal: could not read Username`, and `claim.sh` now calls that `ERROR reason=auth (NOT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1988,7 +1988,10 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   `BASHOPTS`, so by a caller and not only by the invoker. Every `shift` now validates `$#`
   FIRST. **The transferable rule from (4)-(6): when a round's fix names a site, sweep the
   CLASS and add coverage driven by a TABLE, or the next round finds the same defect one exit
-  path over** — which is what happened here three times running.
+  path over** — which is what happened here three times running. That table immediately paid
+  out on a site none of the three findings named: a FAILED REDIRECTION is a native diagnostic
+  too, and bash applies redirections LEFT TO RIGHT, so `: >>"$lock" 2>/dev/null` printed its own
+  unprefixed `Permission denied` before stderr was diverted — the suppressor must come FIRST.
   **The lock is a plain `git push`, so git — not just `gh` — must be authenticated (#2942).** They
   are separate credential paths: an authenticated `gh` with an unwired git fails every claim with
   `fatal: could not read Username`, and `claim.sh` now calls that `ERROR reason=auth (NOT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1973,7 +1973,16 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   and an unmeasurable classification is its own `ERROR` class every caller refuses on, which is
   CLAUDE.md's standing rule (a positive verdict requires an AFFIRMATIVE MEASUREMENT; never
   derive a pass from the ABSENCE of a bad signal) applied where its permissive branch DELETES
-  DATA.
+  DATA. (5) Correction (1) reached ONE exit path, and the SIGNAL traps and USAGE errors still
+  exited with no token — the fix not reaching every site of its own class — so contract (c) is
+  now enforced by a FLAG rather than by reviewing each `exit`: `verdict()` records that it
+  fired, an EXIT-trap backstop emits `ERROR` for any path that would leave with none, `USAGE`
+  joins the closed set, and the signal handlers pick their one token from an explicit
+  COMMIT_PHASE (`ERROR` before the atomic rename, the run's own success token after it,
+  DEFERRED across it). That phase is only OBSERVABLE because the rename moved OUT of a `$( )`:
+  measured on bash 5.2, a trapped signal arriving while the shell waits for a COMMAND
+  SUBSTITUTION inside a FUNCTION is DISCARDED — the trap never runs — while the same signal
+  during a plain command is delivered normally.
   **The lock is a plain `git push`, so git — not just `gh` — must be authenticated (#2942).** They
   are separate credential paths: an authenticated `gh` with an unwired git fails every claim with
   `fatal: could not read Username`, and `claim.sh` now calls that `ERROR reason=auth (NOT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1992,6 +1992,15 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   out on a site none of the three findings named: a FAILED REDIRECTION is a native diagnostic
   too, and bash applies redirections LEFT TO RIGHT, so `: >>"$lock" 2>/dev/null` printed its own
   unprefixed `Permission denied` before stderr was diverted — the suppressor must come FIRST.
+  (7) The marker BODY is copied BY BYTE OFFSET, never by a line-oriented tool: `awk '{print}'`
+  ALWAYS terminates the record it prints, so a body whose last line had no newline GAINED one on
+  every carry-forward write (measured 19 → 20 bytes) under a header promising byte-for-byte
+  preservation — and the case meant to catch that extracted through awk TOO, so **a verification
+  sharing the defect's blind spot is not a verification**; the test helper now reads a `grep -b`
+  byte offset and copies with `tail -c`, a different mechanism from the script's, with the
+  retired helper kept as the positive control. `$( )` capture is the same class (it strips
+  trailing newlines), which is why body bytes are streamed to a redirected stdout and never
+  captured into a variable.
   **The lock is a plain `git push`, so git — not just `gh` — must be authenticated (#2942).** They
   are separate credential paths: an authenticated `gh` with an unwired git fails every claim with
   `fatal: could not read Username`, and `claim.sh` now calls that `ERROR reason=auth (NOT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2063,6 +2063,18 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   pre-planted entry of any type. **And a test whose subject is a HANG must be BOUNDED and must
   assert rc != 124 explicitly**: unbounded, a regression does not fail the suite, it hangs it,
   and the thing that notices is the gate's stall watchdog minutes later.
+  (12) **EXTRACTING A SHARED LIBRARY MOVES A `source` INTO A SCRIPT THAT NEVER HAD ONE, AND
+  THE GUARD WRITTEN FOR IT WAS WEAKER THAN THE ONE THIS SAME CHANGE HAD ALREADY WRITTEN NEXT
+  DOOR.** Pulling the liveness predicates out of `claim-heartbeat.sh` into
+  `lib/process-liveness.sh` gave that script its first `.` — a NEW open, hence a new exposure —
+  and it was guarded `-r` only, while `drive-issue-state.sh`'s guard on the SAME library
+  already required `-f` as well. A FIFO there passed `-r` and the `.` BLOCKED FOREVER
+  (measured: `timeout 10` ⇒ rc 124, **no output at all**), in the script the fleet reaper runs
+  unattended. So: **an extraction's DEDUPLICATION is not complete until the GUARDS around the
+  new dependency are deduplicated too** — the second call site is where the review rounds get
+  lost, exactly as the predicates themselves would have been. `-f` is the whole class in one
+  predicate (false for FIFO, socket, device and directory alike) and FOLLOWS a symlink on
+  purpose, since a symlinked checkout is a legitimate layout.
   **The lock is a plain `git push`, so git — not just `gh` — must be authenticated (#2942).** They
   are separate credential paths: an authenticated `gh` with an unwired git fails every claim with
   `fatal: could not read Username`, and `claim.sh` now calls that `ERROR reason=auth (NOT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1949,6 +1949,24 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   readers of these texts run printed commands literally. Naming no mechanical remedy is fine
   (`FOREIGN-*` say "escalate"); naming one that refuses is the defect, and that case caught two
   further instances in the same round it was written.
+  **Three later corrections, one shape: a guarantee that stops short of what a consumer
+  actually reads.** (1) A fatal start-up failure printed an ANCHORED line and no
+  `verdict <TOKEN>`, so every caller the doctrine tells to `case` on the token fell through
+  every arm — the prefix is contract (a), the token is contract (c), and **(a) does not imply
+  (c)**; every exit now carries a token. (2) The anchor covers the EXTERNAL commands too: a
+  native `mktemp:`/`mv:` line has no prefix at all, so each call site either CAPTURES that text
+  into the anchored message or suppresses it, and a cleanup command carries `|| true` because a
+  failing command in a bash EXIT trap under `set -e` aborts the trap **and replaces the exit
+  status** (measured: a broken `rm` turned a legitimate `WRITTEN`(0) into an unexplained
+  non-zero). Same sweep, worse defect: a failing `date` committed a stamp with an EMPTY
+  required field — `set -e` cannot catch it, since the writer is called as `if ! write_marker`,
+  which suppresses `set -e` for its whole subtree — so the assembled bytes are now checked for
+  FIELD COMPLETENESS, not just sentinels, or the lane bricks itself. (3) The ADOPTION
+  PROVENANCE (`prior-session`, `prior-session-pid`, `prior-ts`, `adopt-reason`) is DURABLE
+  STATE: an ordinary `write` preserves it exactly as it preserves stage/request-id/pr/branch,
+  because a mandatory, validated `--reason` that the next stage update erases is no audit
+  record — and carrying a field forward requires READING it, so all four are parsed under the
+  same duplicate-key refusal as the identity keys.
   **The lock is a plain `git push`, so git — not just `gh` — must be authenticated (#2942).** They
   are separate credential paths: an authenticated `gh` with an unwired git fails every claim with
   `fatal: could not read Username`, and `claim.sh` now calls that `ERROR reason=auth (NOT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2000,7 +2000,15 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   byte offset and copies with `tail -c`, a different mechanism from the script's, with the
   retired helper kept as the positive control. `$( )` capture is the same class (it strips
   trailing newlines), which is why body bytes are streamed to a redirected stdout and never
-  captured into a variable.
+  captured into a variable. (8) Contract (c)'s own enforcer had a window inside it: `verdict()`
+  committed the "already emitted" flag BEFORE printing the line, so a signal landing between the
+  two made the handler AND the EXIT backstop both stay silent and the run exited with NO token —
+  over a possibly-committed write. **A flag that says a side effect HAPPENED must be set AFTER
+  the side effect, and the gap made unobservable**: the emission is now a signal-deferred
+  critical section (print, then commit, then deliver anything that arrived), there is exactly ONE
+  site that prints a verdict line and ONE that sets the flag, and the race is pinned by a
+  structural order assert plus a signal PLANTED at the window in a scratch copy — with the
+  pre-fix ordering kept as the positive control, because a race cannot be pinned by a timed test.
   **The lock is a plain `git push`, so git — not just `gh` — must be authenticated (#2942).** They
   are separate credential paths: an authenticated `gh` with an unwired git fails every claim with
   `fatal: could not read Username`, and `claim.sh` now calls that `ERROR reason=auth (NOT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1966,7 +1966,14 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   STATE: an ordinary `write` preserves it exactly as it preserves stage/request-id/pr/branch,
   because a mandatory, validated `--reason` that the next stage update erases is no audit
   record — and carrying a field forward requires READING it, so all four are parsed under the
-  same duplicate-key refusal as the identity keys.
+  same duplicate-key refusal as the identity keys. (4) And the marker CLASSIFIER read `grep`
+  two-valued: an unperformable scan counted as ZERO sentinels, so a DISPLACED stamp classified
+  as `legacy` and `write`'s migration path — the ONE branch licensed to discard a marker —
+  overwrote what may be a LIVE PEER's state. Every sentinel/field scan here is now three-valued
+  and an unmeasurable classification is its own `ERROR` class every caller refuses on, which is
+  CLAUDE.md's standing rule (a positive verdict requires an AFFIRMATIVE MEASUREMENT; never
+  derive a pass from the ABSENCE of a bad signal) applied where its permissive branch DELETES
+  DATA.
   **The lock is a plain `git push`, so git — not just `gh` — must be authenticated (#2942).** They
   are separate credential paths: an authenticated `gh` with an unwired git fails every claim with
   `fatal: could not read Username`, and `claim.sh` now calls that `ERROR reason=auth (NOT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2030,6 +2030,17 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   compatibility" while the rewrite path dropped it made an OLDER script silently DELETE a field
   a NEWER one introduced — preserve beats refuse, which would brick every touched lane on a
   fleet mid-rollout.
+  (10) **An `-e` existence probe is not an existence probe: it FOLLOWS the link, so a DANGLING
+  symlink at the marker path classified `absent` — the ONE class licensed to replace a file — and
+  `write` silently destroyed a link someone placed.** Existence is now `-e` **or** `-L`, the `-L`
+  test runs BEFORE `-f` (which also follows), and EVERY symlink, dangling or not, takes the
+  existing `not-regular` refusal; the class was swept to the script-owned lock sidecar, where
+  `: >>"$lock"` would have created a file OUTSIDE the lane. **And an axis guard must run before
+  anything that DERIVES A PATH OR TAKES A LOCK**: `adopt` locked first, so an unmeasurable
+  worktree yielded a generic "not writable" instead of the published `axis=worktree` refusal —
+  the same input answered differently by subcommand. Both were UNTESTED because the axis matrix
+  named `write verify show` by hand, so it is now DERIVED from the dispatch table and a
+  subcommand with no declared arguments REDS rather than joining uncovered.
   **The lock is a plain `git push`, so git — not just `gh` — must be authenticated (#2942).** They
   are separate credential paths: an authenticated `gh` with an unwired git fails every claim with
   `fatal: could not read Username`, and `claim.sh` now calls that `ERROR reason=auth (NOT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1905,6 +1905,37 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   deletes the ref (refuses under an open PR without `--force`). Maintain the liveness heartbeat
   (`scripts/flow/claim-heartbeat.sh beat <N>`, refreshed at claim + every stage transition);
   `flow-board` reaps deterministically (age > 4h AND no open PR) (#2089).
+  **The per-lane STATE MARKER is ownership-stamped too, and its session axis is deliberately NOT
+  fail-closed (#3822).** `/drive-issue`'s durable `.drive-issue-state.md` used to be prose with no
+  writer, no reader and no ownership stamp, so a session rehydrating in a shared or REUSED worktree
+  adopted a peer's plan wholesale. It is now written and read ONLY through
+  `scripts/flow/drive-issue-state.sh` (`write` / `verify` / `adopt --reason <why>` / `show`;
+  `--help` is the contract), which stamps issue, machine, worktree, session, the SESSION's pid + its
+  start window, and actor into a **bounded prologue** — an exact first-line sentinel, `key: value`
+  lines at column zero, an exact end sentinel — so identity is never grepped out of the free-form
+  body (#3312: remove the shared channel; a body line reproducing a sentinel at column zero is
+  REFUSED at write time, and a duplicate sentinel is its own read-time refusal). **The axis split is
+  the load-bearing decision and the thing a future agent will otherwise undo:** `issue`, `machine`
+  and `worktree` are FAIL-CLOSED and each refusal NAMES ITS AXIS, because they are stable across a
+  legitimate resume and distinct across lanes. `session` is RECORDED but not fail-closed, because
+  the marker's *intended consumer* is the Delta 3 cron re-invoke — a NEW `CLAUDE_CODE_SESSION_ID` in
+  the SAME lane on the SAME issue — so verifying it literally would red EVERY correct resume, and a
+  guard that reds on correct input is the guard agents learn to waive. A session difference alone is
+  resolved by the LIVENESS of the recorded writer, three-valued on `dead-lanes`' precedent: provably
+  GONE ⇒ `ADOPTABLE` and `verify` STILL exits non-zero (adoption is an explicit `adopt` gesture that
+  records the prior session, never an implicit inheritance); provably ALIVE ⇒ `LIVE-PEER`, which
+  **`adopt` also refuses** (an adopt that ignores liveness is a mute button for the whole guard);
+  UNMEASURABLE ⇒ `LIVENESS-UNKNOWN`, refused — a positive verdict requires an affirmative
+  measurement. **The pid recorded is the SESSION's (`CLAUDE_PID`), and there is deliberately NO `$$`
+  fallback**: `$$` is the transient bash that exits immediately, so recording it would make a LIVE
+  peer read as DEAD seconds later — the exact false-permissive this closes. PID reuse is defeated by
+  requiring the live pid's start window to still intersect the recorded one, measured by the
+  three-valued primitives now SHARED with `claim-heartbeat.sh` in
+  `scripts/flow/lib/process-liveness.sh` (one definition, sourced by both: a second implementation
+  of those review rounds is a second place to lose them). `machine` is the same notion `claim.sh`
+  records — same env var, same default, same sanitizer — and the agreement is pinned BEHAVIOURALLY
+  by `scripts/tests/test_drive_issue_state.sh`, which extracts claim.sh's own definition and
+  compares, rather than by care.
   **The lock is a plain `git push`, so git — not just `gh` — must be authenticated (#2942).** They
   are separate credential paths: an authenticated `gh` with an unwired git fails every claim with
   `fatal: could not read Username`, and `claim.sh` now calls that `ERROR reason=auth (NOT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1982,7 +1982,13 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   DEFERRED across it). That phase is only OBSERVABLE because the rename moved OUT of a `$( )`:
   measured on bash 5.2, a trapped signal arriving while the shell waits for a COMMAND
   SUBSTITUTION inside a FUNCTION is DISCARDED — the trap never runs — while the same signal
-  during a plain command is delivered normally.
+  during a plain command is delivered normally. (6) Same shape once more, at the SHELL's own
+  diagnostics: correction (2) captured 21 EXTERNAL commands' stderr and left `shift`'s, which
+  bash prints UNPREFIXED under `shift_verbose`/POSIX mode — both reachable from the inherited
+  `BASHOPTS`, so by a caller and not only by the invoker. Every `shift` now validates `$#`
+  FIRST. **The transferable rule from (4)-(6): when a round's fix names a site, sweep the
+  CLASS and add coverage driven by a TABLE, or the next round finds the same defect one exit
+  path over** — which is what happened here three times running.
   **The lock is a plain `git push`, so git — not just `gh` — must be authenticated (#2942).** They
   are separate credential paths: an authenticated `gh` with an unwired git fails every claim with
   `fatal: could not read Username`, and `claim.sh` now calls that `ERROR reason=auth (NOT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2041,6 +2041,28 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   the same input answered differently by subcommand. Both were UNTESTED because the axis matrix
   named `write verify show` by hand, so it is now DERIVED from the dispatch table and a
   subcommand with no declared arguments REDS rather than joining uncovered.
+  (11) **A `-L`-only refusal is a type rule with one row: the class is EVERY non-regular type,
+  and the FIFO is the one that HANGS.** Clause (10) taught the lock sidecar to refuse a symlink
+  and left FIFO, socket, device and directory accepted — the third consecutive round whose fix
+  reached one member of its own class. `: >>"$lock"` on a **FIFO BLOCKS INDEFINITELY** waiting
+  for a reader (measured: `timeout 10` ⇒ rc 124, **no verdict line at all**), which is the worst
+  available breach of contract (c) — not a wrong verdict but NO verdict, forever, in a lane
+  nobody is watching; a device would serialize NOTHING while appearing to succeed. So the rule
+  is stated over the TYPE — only `absent` or `regular` may be opened, everything else including
+  a type the probe cannot NAME is one refusal reporting what the entry actually is — and the
+  symlink check is FOLDED IN rather than kept beside it, because two checks are two messages to
+  keep true. The same sweep covers `--body-file`, where `-r` is TRUE for a FIFO and the `cat`
+  then blocks (and `/dev/zero` streams without end into the snapshot: a filled disk, not a
+  hang), but there the question is what the path **RESOLVES to**, since a symlink to a real
+  notes file is the caller's own ordinary artifact — **the same probe answering two different
+  questions would be a defect either way.** The probes are pure `test` builtins: they STAT and
+  never OPEN, so probing cannot itself block. Where a probe CANNOT close the gap it is replaced
+  rather than added to: the `mv`-diagnostic file was a redirection into the derived name
+  `$tmp.err`, and a stat before a redirect only describes a file that no longer has to be the
+  one opened — so it is now `mktemp`, which creates with `O_EXCL` and therefore cannot open a
+  pre-planted entry of any type. **And a test whose subject is a HANG must be BOUNDED and must
+  assert rc != 124 explicitly**: unbounded, a regression does not fail the suite, it hangs it,
+  and the thing that notices is the gate's stall watchdog minutes later.
   **The lock is a plain `git push`, so git — not just `gh` — must be authenticated (#2942).** They
   are separate credential paths: an authenticated `gh` with an unwired git fails every claim with
   `fatal: could not read Username`, and `claim.sh` now calls that `ERROR reason=auth (NOT

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -16476,7 +16476,7 @@ run_tooling_tests() {
     record_result "$name" "$status" 0
     return 0
   fi
-  echo ">>> [$name] bash scripts/tests/test_agent_gate_summary.sh; bash scripts/tests/test_agent_gate_notify.sh; bash scripts/tests/test_gate_notify_contract.sh; bash scripts/tests/test_agent_gate_smoke_target_dir.sh; bash scripts/tests/test_gate_concurrency_cap.sh; bash scripts/tests/test_bootstrap_agent_machine.sh; bash scripts/tests/test_perf_capability.sh; bash scripts/tests/test_perf_capability_bootstrap.sh; bash scripts/tests/test_claim_lock.sh; bash scripts/tests/test_claim_heartbeat.sh; bash scripts/flow/tests/claim-resume.test.sh; bash scripts/tests/test_premerge_assert.sh; bash scripts/tests/test_base_staleness.sh; bash scripts/tests/test_board_label_mirror.sh; bash scripts/tests/test_worker_supervisor.sh; bash scripts/tests/test_gate_failure_mode.sh; bash scripts/tests/test_cargo_output_parsers.sh"
+  echo ">>> [$name] bash scripts/tests/test_agent_gate_summary.sh; bash scripts/tests/test_agent_gate_notify.sh; bash scripts/tests/test_gate_notify_contract.sh; bash scripts/tests/test_agent_gate_smoke_target_dir.sh; bash scripts/tests/test_gate_concurrency_cap.sh; bash scripts/tests/test_bootstrap_agent_machine.sh; bash scripts/tests/test_perf_capability.sh; bash scripts/tests/test_perf_capability_bootstrap.sh; bash scripts/tests/test_claim_lock.sh; bash scripts/tests/test_claim_heartbeat.sh; bash scripts/tests/test_drive_issue_state.sh; bash scripts/flow/tests/claim-resume.test.sh; bash scripts/tests/test_premerge_assert.sh; bash scripts/tests/test_base_staleness.sh; bash scripts/tests/test_board_label_mirror.sh; bash scripts/tests/test_worker_supervisor.sh; bash scripts/tests/test_gate_failure_mode.sh; bash scripts/tests/test_cargo_output_parsers.sh"
   if bash "$REPO_ROOT/scripts/tests/test_agent_gate_summary.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_agent_gate_notify.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_gate_notify_contract.sh" >>"$log" 2>&1 &&
@@ -16487,6 +16487,7 @@ run_tooling_tests() {
      bash "$REPO_ROOT/scripts/tests/test_perf_capability_bootstrap.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_claim_lock.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_claim_heartbeat.sh" >>"$log" 2>&1 &&
+     bash "$REPO_ROOT/scripts/tests/test_drive_issue_state.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/flow/tests/claim-resume.test.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_premerge_assert.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_base_staleness.sh" >>"$log" 2>&1 &&

--- a/scripts/flow/claim-heartbeat.sh
+++ b/scripts/flow/claim-heartbeat.sh
@@ -1113,8 +1113,17 @@ cmd_should_reap() {
 # Behaviour here is unchanged; the library is the single definition. A MISSING library
 # is fatal and named — never a silent continue with the predicates undefined, which
 # would make every liveness answer an empty string.
-[ -r "$SCRIPT_HOME/lib/process-liveness.sh" ] || {
-  echo "$prog: cannot read $SCRIPT_HOME/lib/process-liveness.sh (the shared process-liveness primitives, #3822) — NOTHING was measured" >&2
+# `-f` AS WELL AS `-r`, matching drive-issue-state.sh's guard on the SAME library (roborev
+# job 57). `-r` alone is TRUE for a FIFO, and the `.` below then BLOCKS FOREVER waiting for a
+# writer: MEASURED, `mkfifo lib/process-liveness.sh` made this script run until killed
+# (`timeout 10` -> rc 124) with NO diagnostic at all — no verdict, no timeout, in a script the
+# fleet reaper runs unattended. A socket, a device or a directory is the same class. `-f` is
+# false for every one of them, so ONE predicate covers the class rather than a list of types to
+# keep complete. Both predicates FOLLOW a symlink, which is deliberate: a symlinked checkout is
+# a legitimate layout. This exposure is NEW with the library extraction — before it, the
+# predicates were inline here and there was no `source` to guard.
+{ [ -f "$SCRIPT_HOME/lib/process-liveness.sh" ] && [ -r "$SCRIPT_HOME/lib/process-liveness.sh" ]; } || {
+  echo "$prog: cannot read $SCRIPT_HOME/lib/process-liveness.sh as a regular file (the shared process-liveness primitives, #3822) — NOTHING was measured" >&2
   exit 1
 }
 # shellcheck source=lib/process-liveness.sh

--- a/scripts/flow/claim-heartbeat.sh
+++ b/scripts/flow/claim-heartbeat.sh
@@ -295,6 +295,10 @@ set -euo pipefail
 
 prog="$(basename "$0")"
 
+# SCRIPT_HOME — this script's own directory, for locating lib/ (issue #3822). Resolved
+# from BASH_SOURCE (not $0) so it is correct whether the script is executed or sourced.
+SCRIPT_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 die_usage() { echo "$prog: $*" >&2; exit 64; }
 note()      { echo "[claim-heartbeat] $*" >&2; }
 
@@ -1101,161 +1105,20 @@ cmd_should_reap() {
   return 0
 }
 
-# process_start_window <pid> — echo `<earliest> <latest>` epoch seconds bracketing when <pid>
-# started, or EMPTY when it cannot be determined. Empty is a THIRD answer and is never folded
-# onto "consistent".
-#
-# DERIVED FROM ELAPSED TIME, NOT A WALL-CLOCK STRING (roborev round 3, Medium). The first cut
-# read `ps -o lstart=` and parsed it with `date -u`, but `lstart` is LOCAL wall time with no
-# zone in it, so on any non-UTC host the epoch came out shifted by the offset — MEASURED: the
-# same lstart parses 19,800s apart between UTC and Asia/Kolkata, far past the tolerance, which
-# would falsely declare a live supervisor DEAD-PID-REUSED. Elapsed seconds carry no timezone at
-# all, so the whole class is gone rather than corrected.
-#
-# AN INTERVAL, NOT A POINT (roborev round 15, Medium). `start = now - elapsed` needs `now` and
-# `elapsed` to refer to the same instant, and they cannot: one is read before the other. The
-# first cut sampled `now` BEFORE running `ps`, so a slow `ps` shifted the computed start
-# BACKWARD — and a start that looks earlier than it is makes a REUSED pid look like it predates
-# the claim, i.e. a false ALIVE. That delay is most likely on exactly the resource-exhausted
-# hosts this command exists for. So the query is bracketed and both bounds are returned; the
-# caller must decide UNKNOWN when the interval straddles its decision boundary.
-process_start_window() {
-  local pid="$1" secs t0 t1
-  t0="$(date -u +%s)"
-  secs="$(ps -o etimes= -p "$pid" 2>/dev/null | tr -d ' ')"
-  case "$secs" in
-    '' | *[!0-9]*) secs="" ;;
-  esac
-  if [ -z "$secs" ]; then
-    # Fall back to `etime` ([[DD-]HH:]MM:SS), which POSIX ps provides where `etimes` is
-    # absent. Still elapsed, still timezone-free.
-    local et d hms h m sec
-    et="$(ps -o etime= -p "$pid" 2>/dev/null | tr -d ' ')"
-    [ -n "$et" ] || return 0
-    case "$et" in
-      *-*) d="${et%%-*}"; hms="${et#*-}" ;;
-      *)   d=0;           hms="$et" ;;
-    esac
-    case "$hms" in
-      *:*:*) h="${hms%%:*}"; m="$(printf '%s' "$hms" | cut -d: -f2)"; sec="${hms##*:}" ;;
-      *:*)   h=0;            m="${hms%%:*}";                          sec="${hms##*:}" ;;
-      *)     return 0 ;;
-    esac
-    case "$d$h$m$sec" in
-      *[!0-9]*) return 0 ;;
-    esac
-    secs=$(( (10#$d * 86400) + (10#$h * 3600) + (10#$m * 60) + 10#$sec ))
-  fi
-  t1="$(date -u +%s)"
-  # The elapsed reading was taken at some instant in [t0, t1], so the start lies in
-  # [t0 - secs, t1 - secs]. Earliest first.
-  printf '%s %s\n' "$((t0 - secs))" "$((t1 - secs))"
+# PROCESS-LIVENESS PRIMITIVES: sourced, not defined here (issue #3822).
+# `process_start_window`, `ps_usable`, `signal_probe_class`, `process_presence` and
+# `process_state_class` moved VERBATIM to scripts/flow/lib/process-liveness.sh so
+# drive-issue-state.sh can answer the same "is that process still running" question
+# without a SECOND implementation of the review rounds encoded in their comments.
+# Behaviour here is unchanged; the library is the single definition. A MISSING library
+# is fatal and named — never a silent continue with the predicates undefined, which
+# would make every liveness answer an empty string.
+[ -r "$SCRIPT_HOME/lib/process-liveness.sh" ] || {
+  echo "$prog: cannot read $SCRIPT_HOME/lib/process-liveness.sh (the shared process-liveness primitives, #3822) — NOTHING was measured" >&2
+  exit 1
 }
-
-# ps_usable — exit 0 iff `ps` can be trusted to answer an existence question here.
-#
-# SELF-VALIDATING, because "nonzero" is not the same as "absent" (roborev round 8, Medium).
-# A `ps` that is missing, unsupported, or simply unable to run would otherwise turn every
-# claim into DEAD-NO-PROCESS and exit 3 — a fleet-wide false DEAD. That failure mode is not
-# hypothetical on the boxes this issue is about: under the memory exhaustion #3393 records,
-# a process that cannot fork cannot run `ps` either, so the ONE moment the report matters
-# most is when the probe is most likely to fail. So the tool is validated against a pid
-# that is certainly present — our own — before any of its answers are believed. This is
-# necessary but NOT sufficient; see `process_presence` for why a per-TARGET vote is also
-# needed (round 9).
-ps_usable() {
-  ps -p "$$" >/dev/null 2>&1
-}
-
-# signal_probe_class <pid> — echo `present` | `absent` | `denied` | `unknown`.
-#
-# `kill -0` is the ONE probe here that is not visibility-based, which is why its failure mode
-# has to be decoded rather than abstained on (roborev round 10, Medium). EPERM means the
-# process EXISTS and is simply not ours; ESRCH means it is gone. Treating both as "no
-# opinion" made every remaining voter a VISIBILITY probe — `ps` and `/proc/<pid>` are
-# correlated, both hidden by `hidepid=2` — so a different user's live process was unanimously
-# "absent" and reported DEAD.
-#
-# `LC_ALL=C` is load-bearing: the distinction is drawn from the error text, so the message
-# has to be in a known language. An unrecognised message is `unknown`, never folded onto
-# either answer.
-signal_probe_class() {
-  local pid="$1" err
-  if kill -0 "$pid" 2>/dev/null; then
-    printf 'present\n'
-    return 0
-  fi
-  err="$(LC_ALL=C kill -0 "$pid" 2>&1 || true)"
-  case "$err" in
-    *"not permitted"* | *"Not permitted"* | *"Operation not permitted"*) printf 'denied\n' ;;
-    *"No such process"* | *"no such process"*)                           printf 'absent\n' ;;
-    *)                                                                   printf 'unknown\n' ;;
-  esac
-}
-
-# process_presence <pid> — echo `present` | `absent` | `unknown`.
-#
-# BUILT FROM AGREEING VOTES, because a NEGATIVE answer from one probe is not proof of
-# absence (roborev round 9, Medium). `ps -p` exiting nonzero can mean the process is gone,
-# but it can equally mean a transient failure under load or that the target is not visible
-# to us — and reading that as absence reports a LIVE supervisor as DEAD. Validating `ps`
-# against our OWN pid (round 8) was necessary but not sufficient: it proves the tool runs,
-# not that it can see THIS target.
-#
-# THE VOTERS MUST NOT ALL MEASURE THE SAME THING (round 10). `ps -p` and `/proc/<pid>` are
-# both VISIBILITY probes and are hidden together by `hidepid=2`, so on their own they can be
-# unanimously and confidently wrong about a live process owned by another user. The signal
-# probe is the independent one, and its EPERM answer is affirmative evidence of EXISTENCE —
-# which is exactly the case the other two get wrong.
-#
-# Unanimous present => present. Unanimous absent => absent. DISAGREEMENT => unknown: our view
-# of the process table is not self-consistent, so nothing is claimed either way.
-process_presence() {
-  local pid="$1" yes=0 no=0 sig
-  if ps -p "$pid" >/dev/null 2>&1; then yes=$((yes + 1)); else no=$((no + 1)); fi
-  if [ -d /proc ]; then
-    if [ -e "/proc/$pid" ]; then yes=$((yes + 1)); else no=$((no + 1)); fi
-  fi
-  sig="$(signal_probe_class "$pid")"
-  case "$sig" in
-    present | denied) yes=$((yes + 1)) ;;   # denied == EPERM == it exists
-    absent)           no=$((no + 1)) ;;
-    unknown)          : ;;                  # genuinely no opinion; abstains
-  esac
-
-  if [ "$yes" -gt 0 ] && [ "$no" -eq 0 ]; then
-    printf 'present\n'
-  elif [ "$yes" -eq 0 ] && [ "$no" -gt 0 ] && [ "$sig" = absent ]; then
-    # ABSENCE REQUIRES THE INDEPENDENT PROBE TO SAY SO (roborev round 15, Medium). Round 10
-    # fixed the case where the signal probe answered `denied`, but when it answers `unknown`
-    # the only remaining voters are `ps` and `/proc` — which are BOTH visibility probes,
-    # hidden together by `hidepid=2`. They can then be unanimously and confidently wrong
-    # about a live process, and this function would call it absent: a false DEAD. So a
-    # declaration of absence needs the one non-visibility probe to have affirmed it.
-    printf 'absent\n'
-  else
-    printf 'unknown\n'
-  fi
-}
-
-# process_state_class <pid> — echo `zombie` | `running` | `unreadable`.
-#
-# THREE-VALUED, and that is the whole point (roborev round 7, Medium). The first cut was a
-# two-valued `process_is_zombie` that returned "not a zombie" when the state could not be
-# read — after which a readable start time produced ALIVE and exit 0. So an unreadable
-# state became a CLEAN result, which is the same "unknown folded onto the permissive
-# answer" shape this command exists to avoid, reintroduced one level down in the fix for
-# the previous round. The unreadable case must be neither: not `zombie` (a false DEAD on a
-# healthy fleet is how a monitor gets ignored) and not `running` (that is the false-clean).
-process_state_class() {
-  local st
-  st="$(ps -o stat= -p "$1" 2>/dev/null | tr -d ' ')"
-  case "$st" in
-    '') printf 'unreadable\n' ;;
-    Z*) printf 'zombie\n' ;;
-    *)  printf 'running\n' ;;
-  esac
-}
+# shellcheck source=lib/process-liveness.sh
+. "$SCRIPT_HOME/lib/process-liveness.sh"
 
 # open_pr_state <issue> — echo `yes` | `no` | `unknown`. THREE-VALUED on purpose
 # (roborev round 2, Low): `issue_has_open_pr` is fail-SAFE for the REAPER — a gh outage

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -137,7 +137,8 @@
 #   ADOPTABLE           session differs and the recorded writer is provably GONE
 #   LIVE-PEER           session differs and the recorded writer is provably ALIVE
 #   LIVENESS-UNKNOWN    session differs and liveness could NOT be measured
-#   ERROR               an I/O or internal failure — nothing was decided
+#   ERROR               an I/O or internal failure, or an identity axis that could not be
+#                       MEASURED (axis=machine) — nothing was decided
 #   USAGE               the invocation itself was wrong — nothing was read and nothing written
 #
 # SUBCOMMANDS
@@ -195,6 +196,15 @@
 #             mirrored here and the AGREEMENT is pinned BEHAVIOURALLY by
 #             scripts/tests/test_drive_issue_state.sh, which extracts claim.sh's own
 #             definition and compares the two in one environment.
+#             IT MUST BE MEASURABLE OR THE RUN REFUSES (`verdict ERROR`, exit 1, detail naming
+#             `axis=machine`), on `write`, on `adopt` and on `verify` — the sanitizer maps an
+#             empty or unrecordable value onto the `unspecified` PLACEHOLDER, and COMMITTING
+#             that placeholder as an identity would (transiently) lock the lane out of its own
+#             marker once hostname resolution recovers and (persistently) ALIAS EVERY
+#             UNMEASURABLE BOX ONTO ONE OWNER, so lane A's marker would verify as OWNED on
+#             machine B. The refusal is at the USE SITE, never in the sanitizer: the shared
+#             placeholder is claim.sh's behaviour and stays pinned. Where no marker exists
+#             nothing is compared, so `verify`/`adopt` still report ABSENT.
 #   worktree  `pwd -P` — the physical directory holding the marker.
 #   session   CLAUDE_CODE_SESSION_ID, sanitized. `unrecorded` when unset, which makes the
 #             session axis UNMEASURED and routes to the liveness resolution.
@@ -212,7 +222,7 @@
 #
 # EXIT CODES
 #   0   OWNED / WRITTEN / ADOPTED / SHOWN
-#   1   ERROR — I/O or internal failure; nothing was decided
+#   1   ERROR — I/O or internal failure, or an unmeasurable machine axis; nothing was decided
 #   3   ABSENT — no marker; a legitimate fresh start (textually AND numerically distinct
 #       from every refusal, so a caller can tell "nothing to resume" from "refused")
 #   4   FOREIGN-ISSUE / FOREIGN-MACHINE / FOREIGN-WORKTREE
@@ -458,9 +468,71 @@ sanitize_field() {
   printf '%s\n' "$s"
 }
 
-# `hostname`'s stderr is suppressed (roborev job 26 F2): its failure is already visible as a
-# degraded machine value, and an unprefixed 'hostname: not found' would break the anchor.
-this_machine() { sanitize_field "${CLAIM_MACHINE:-$(hostname -s 2>/dev/null)}"; }
+# THE MACHINE AXIS, RESOLVED ONCE, WITH ITS MEASURABILITY CARRIED ALONGSIDE (roborev job 34 H1).
+#
+# `sanitize_field` maps an EMPTY value onto the `unspecified` PLACEHOLDER — deliberately, and
+# that behaviour is claim.sh's, mirrored here and pinned by case 11, so it is NOT changed. What
+# was wrong was COMMITTING the placeholder as an identity: with `hostname -s` failing (or
+# printing nothing) and CLAIM_MACHINE unset, the writer stamped `machine: unspecified`. A
+# TRANSIENT failure then writes a marker that turns FOREIGN-MACHINE the moment resolution
+# recovers (the lane locks itself out), and a PERSISTENT one ALIASES EVERY BOX ONTO ONE OWNER,
+# so lane A's marker verifies as OWNED on machine B — the peer-adoption defect this file exists
+# to close, arriving through the identity it was supposed to enforce.
+#
+# So the REFUSAL lives at the USE SITE (`require_machine_axis`), not in the sanitizer: the
+# claim.sh agreement is a property of the recorded VALUE, and this is a property of whether the
+# value was MEASURED at all. Resolved ONCE and cached, because two calls to `hostname` can give
+# two answers and an identity that changes mid-run is no identity.
+#
+# `hostname`'s stderr is suppressed (roborev job 26 F2): its failure is reported through the
+# anchored refusal below, and an unprefixed 'hostname: not found' would break contract (a).
+MACHINE_AXIS_VALUE=''
+MACHINE_AXIS_STATE=''   # ok | unmeasured | unrecordable
+resolve_machine_axis() {
+  [ -z "$MACHINE_AXIS_STATE" ] || return 0
+  local raw
+  # THE MIRRORED EXPRESSION — same env var, same default, same sanitizer as claim.sh's
+  # `this_machine` (see IDENTITY in the header; case 11 pins the agreement behaviourally).
+  # `|| true` INSIDE the substitution is load-bearing, and it is what the mirrored expression
+  # needs HERE that claim.sh's does not need THERE: claim.sh calls it as an ARGUMENT (a failing
+  # substitution in a word leaves the command's own status 0), while this is a plain ASSIGNMENT,
+  # whose status IS the substitution's — so under `set -e` a failing `hostname` killed the shell
+  # before the anchored refusal below could name the axis (measured: the EXIT-trap backstop's
+  # generic ERROR, with no axis=machine detail). The value is unchanged either way: empty.
+  raw="${CLAIM_MACHINE:-$(hostname -s 2>/dev/null || true)}"
+  MACHINE_AXIS_VALUE="$(sanitize_field "$raw")"
+  if [ -z "$raw" ]; then
+    MACHINE_AXIS_STATE=unmeasured
+  elif [ "$MACHINE_AXIS_VALUE" = unspecified ]; then
+    # The source said SOMETHING and none of it survives as a token (an all-punctuation
+    # CLAIM_MACHINE, or a host whose `tr` is broken, which is the fail-open case 30 used to
+    # declare as a residual). Recorded, it is the same alias, so it is refused the same way.
+    MACHINE_AXIS_STATE=unrecordable
+  else
+    MACHINE_AXIS_STATE=ok
+  fi
+}
+
+this_machine() { resolve_machine_axis; printf '%s\n' "$MACHINE_AXIS_VALUE"; }
+
+# require_machine_axis — refuse unless this box's own machine identity was MEASURED.
+# Called from the main shell ONLY (never inside `$( )`, where the refusal would exit the
+# subshell and its verdict line would be captured into a variable — the defect case 17 pins),
+# wherever the axis is about to be RECORDED or COMPARED: `write` before any mutation, and
+# `check_ownership`, which is verify's and adopt's one door. Where there is no marker at all
+# nothing is compared and ABSENT is unaffected.
+require_machine_axis() {
+  resolve_machine_axis
+  case "$MACHINE_AXIS_STATE" in
+    ok) return 0 ;;
+    unmeasured)
+      refuse ERROR 1 "axis=machine could NOT BE MEASURED: CLAIM_MACHINE is unset or empty and \`hostname -s\` produced nothing. The machine axis is fail-closed identity, and recording the 'unspecified' placeholder would ALIAS every unmeasurable box onto ONE owner (this lane's marker would then verify as OWNED on any other box) — so nothing is written, nothing is compared and nothing was decided. Set CLAIM_MACHINE to this box's unique identity, or repair hostname resolution." ;;
+    unrecordable)
+      refuse ERROR 1 "axis=machine is NOT RECORDABLE: the machine identity resolved to a value that records as the 'unspecified' placeholder (it carries no recordable characters [A-Za-z0-9._:/#-], or the sanitizer itself could not run) and would ALIAS every such box onto ONE owner. Nothing was written, nothing was compared and nothing was decided. Set CLAIM_MACHINE to this box's unique identity." ;;
+    *)
+      refuse ERROR 1 "internal: machine-axis state '$(sane "$MACHINE_AXIS_STATE")' is not one of ok|unmeasured|unrecordable — nothing was decided" ;;
+  esac
+}
 
 # this_session — the current session id, or the `unrecorded` sentinel. An unrecorded
 # session makes the session axis UNMEASURED (never "equal"), which routes to the liveness
@@ -827,6 +899,10 @@ writer_liveness() {
 check_ownership() {
   local issue="$1" mode="$2"
   local machine session
+  # An identity that could not be MEASURED is never read as MATCHING (roborev job 34 H1): with
+  # the placeholder on both sides the axis comparison SUCCEEDS, so an unmeasurable box would own
+  # every marker recorded by another unmeasurable box. Refused before any comparison.
+  require_machine_axis
   machine="$(this_machine)"; session="$(this_session)"
 
   read_marker
@@ -987,6 +1063,13 @@ write_marker() {
   # and its failure is reported through WRITE_ERR: `set -e` cannot be relied on here because
   # every caller invokes this function as `if ! write_marker ...`, which suppresses it for the
   # whole subtree (roborev job 26 F2).
+  # THE MACHINE AXIS IS RE-ASSERTED OVER THE BYTES ABOUT TO BE COMMITTED (roborev job 34 H1).
+  # The callers refuse an unmeasurable axis before they mutate anything; this is the backstop at
+  # the site that ASSEMBLES the stamp, in the same posture as the `ts` completeness check below,
+  # because a stamp with a placeholder identity is not a weaker stamp — it is an alias.
+  resolve_machine_axis
+  [ "$MACHINE_AXIS_STATE" = ok ] || {
+    WRITE_ERR="the machine axis is not recordable (state=$(sane "$MACHINE_AXIS_STATE")), so the stamp's \`machine\` field would record the 'unspecified' placeholder and alias this box onto every other unmeasurable one — nothing was written"; return 1; }
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)" || {
     WRITE_ERR="cannot read the current time (\`date\` failed), so the stamp's \`ts\` field cannot be recorded — refusing rather than committing a stamp with an empty required field; nothing was written"; return 1; }
   [ -n "$ts" ] || {
@@ -1013,7 +1096,7 @@ write_marker() {
   {
     printf '%s\n' "$STAMP_BEGIN"
     printf 'issue: %s\n' "$issue"
-    printf 'machine: %s\n' "$(this_machine)"
+    printf 'machine: %s\n' "$MACHINE_AXIS_VALUE"
     printf 'worktree: %s\n' "$wt"
     printf 'session: %s\n' "$session"
     printf 'session-pid: %s\n' "$pid"
@@ -1103,6 +1186,11 @@ cmd_write() {
   done
   cleared() { case " $clears " in *" $1 "*) return 0 ;; esac; return 1; }
   local actor; actor="$(resolve_actor "$actor_raw")"
+
+  # BEFORE ANY MUTATION, and before the lock: the fresh-start (ABSENT) path never reaches
+  # check_ownership, so this is the site that stops an unmeasurable machine axis being
+  # COMMITTED as the 'unspecified' placeholder (roborev job 34 H1).
+  require_machine_axis
 
   local body_src=''
   if [ -n "$bodyfile" ]; then

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -519,7 +519,12 @@ lock_marker() {
   # output anchor every consumer rests on, and emit no verdict at all.
   [ -w "$wt" ] || refuse ERROR 1 "the worktree directory $(sane "$wt") is not writable, so the marker lock cannot be taken — nothing was decided and nothing was written"
   command -v flock >/dev/null 2>&1 || refuse ERROR 1 "flock is not available on this host, so the ownership-verify -> replace sequence cannot be SERIALIZED. Refusing rather than mutating unserialized: two sessions in one lane could both pass verification and one clobber the other's stamp, which is the defect this marker exists to prevent. An unmeasurable guarantee is never read as satisfied."
-  : >>"$lock" 2>/dev/null || refuse ERROR 1 "cannot create the marker lock file $(sane "$lock") — nothing was decided"
+  # THE `2>/dev/null` COMES FIRST, AND THAT ORDER IS THE WHOLE POINT (roborev job 30, found by
+  # sweeping G3's class rather than by the finding). Bash applies redirections LEFT TO RIGHT, so
+  # `: >>"$lock" 2>/dev/null` attempts the failing redirection BEFORE stderr is diverted and
+  # prints its own UNPREFIXED `bash: <path>: Permission denied` (measured, both orders). A
+  # redirection is an external-command diagnostic in every way that matters to contract (a).
+  : 2>/dev/null >>"$lock" || refuse ERROR 1 "cannot create the marker lock file $(sane "$lock") — it may be a directory, or the lane may not permit creating it; nothing was decided"
   eval "exec ${MARKER_LOCK_FD}>>\"\$lock\""
   # flock's own stderr is SUPPRESSED rather than captured: capturing it would mean running
   # flock inside a command substitution, i.e. in a subshell, which is not a place to be
@@ -1024,7 +1029,7 @@ write_marker() {
     # nowhere to capture it to, and the group's non-zero status already routes to the
     # anchored WRITE_ERR below (roborev job 26 F2).
     if [ -n "$bodyfile" ] && [ -s "$bodyfile" ]; then cat "$bodyfile" 2>/dev/null; fi
-  } >"$tmp" || { rm -f "$tmp" 2>/dev/null || true; WRITE_ERR="failed writing the stamp to $(sane "$tmp") — nothing was replaced (the body could not be read, or the temporary file could not be written)"; return 1; }
+  } 2>/dev/null >"$tmp" || { rm -f "$tmp" 2>/dev/null || true; WRITE_ERR="failed writing the stamp to $(sane "$tmp") — nothing was replaced (the body could not be read, or the temporary file could not be written)"; return 1; }
   # The last thing before the atomic commit, over the committed bytes themselves.
   assert_assembled_marker "$tmp" || { rm -f "$tmp" 2>/dev/null || true; return 1; }
   # THE COMMIT. mv's NATIVE text is CAPTURED and FOLDED for the same reason as mktemp's:
@@ -1037,6 +1042,12 @@ write_marker() {
   # signal-OBSERVABLE, or the phase machinery below can never see it.
   local mverrf="$tmp.err" mverr=''
   register_tmp "$mverrf"
+  # PRE-CREATED, WITH `2>/dev/null` FIRST: the commit below redirects into this path, and a
+  # redirection bash cannot satisfy prints an UNPREFIXED diagnostic (see lock_marker). Proving
+  # the path creatable here keeps that diagnostic out of the one command that must not emit one.
+  : 2>/dev/null >"$mverrf" || {
+    rm -f "$tmp" 2>/dev/null || true
+    WRITE_ERR="cannot create the commit's diagnostic file next to $(sane "$path") — nothing was written"; return 1; }
   COMMIT_PHASE=committing
   if mv -f "$tmp" "$path" >"$mverrf" 2>&1; then
     COMMIT_PHASE=committed
@@ -1168,7 +1179,7 @@ cmd_write() {
         carried="$(mktemp "${TMPDIR:-/tmp}/drive-issue-body.XXXXXX" 2>&1)" || refuse ERROR 1 "cannot create a temporary file for the carried body under $(sane "${TMPDIR:-/tmp}") — nothing was written (mktemp: $(sane "$carried"))"
         { [ -n "$carried" ] && [ -f "$carried" ]; } || refuse ERROR 1 "mktemp exited 0 for the carried body but named no usable temporary file (it emitted: $(sane "$carried")) — nothing was written"
         register_tmp "$carried"
-        marker_body >"$carried" || refuse ERROR 1 "cannot read the existing marker's body from $(sane "$(marker_path)"), so it cannot be carried forward — refusing rather than silently replacing a plan with an empty one; nothing was written"
+        marker_body 2>/dev/null >"$carried" || refuse ERROR 1 "cannot read the existing marker's body from $(sane "$(marker_path)"), so it cannot be carried forward — refusing rather than silently replacing a plan with an empty one; nothing was written"
         assert_body_safe "$carried"
         body_src="$carried"
       fi
@@ -1290,7 +1301,7 @@ cmd_adopt() {
   carried="$(mktemp "${TMPDIR:-/tmp}/drive-issue-body.XXXXXX" 2>&1)" || refuse ERROR 1 "cannot create a temporary file for the carried body under $(sane "${TMPDIR:-/tmp}") — nothing was written (mktemp: $(sane "$carried"))"
   { [ -n "$carried" ] && [ -f "$carried" ]; } || refuse ERROR 1 "mktemp exited 0 for the carried body but named no usable temporary file (it emitted: $(sane "$carried")) — nothing was written"
   register_tmp "$carried"
-  marker_body >"$carried" || refuse ERROR 1 "cannot read the existing marker's body from $(sane "$(marker_path)"), so it cannot be carried across the adoption — refusing rather than transferring ownership onto an empty plan; nothing was written"
+  marker_body 2>/dev/null >"$carried" || refuse ERROR 1 "cannot read the existing marker's body from $(sane "$(marker_path)"), so it cannot be carried across the adoption — refusing rather than transferring ownership onto an empty plan; nothing was written"
   assert_body_safe "$carried"
   [ -z "$stage" ] || f_stage="stage: $stage"
   local f_request='' f_pr='' f_branch=''

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -404,16 +404,44 @@ count_sentinel() {
   printf '%s\n' "$n"
 }
 
+# marker_class <path> — echo absent | not-regular | stamped | displaced | legacy.
+#
+# ONE CLASSIFIER FOR EVERY CALLER, AND "LEGACY" REQUIRES THE WHOLE FILE TO BE SENTINEL-FREE.
+# The first cut inferred "carries no ownership stamp" from the FIRST LINE ALONE, and the
+# migration path then discarded and replaced such a file. So a stamped marker with a single
+# prepended blank line or comment — a ONE-BYTE mutation — was classified legacy, and A LIVE
+# PEER'S STATE WAS OVERWRITTEN: precisely the defect this file exists to close, wearing the
+# migration path's clothes. The inference "no stamp at line 1 => no identity asserted" is
+# valid ONLY if no sentinel exists ANYWHERE, so `legacy` is now the answer of last resort:
+#
+#   stamped   line 1 IS the begin sentinel — parse it (dup/grammar checks follow)
+#   displaced a sentinel exists at column zero but NOT as a valid prologue opener. The file
+#             DOES assert an identity, which merely cannot be READ, and an unreadable
+#             identity may be a live peer's => MALFORMED, never migratable.
+#   legacy    no sentinel anywhere => genuinely the pre-#3822 shape => UNSTAMPED
+marker_class() {
+  local path="$1" nb ne
+  [ -e "$path" ] || { printf 'absent\n'; return 0; }
+  { [ -f "$path" ] && [ -r "$path" ]; } || { printf 'not-regular\n'; return 0; }
+  if [ "$(head -1 "$path" 2>/dev/null || true)" = "$STAMP_BEGIN" ]; then
+    printf 'stamped\n'; return 0
+  fi
+  nb="$(count_sentinel "$path" "$STAMP_BEGIN")"
+  ne="$(count_sentinel "$path" "$STAMP_END")"
+  if [ "$nb" -gt 0 ] || [ "$ne" -gt 0 ]; then printf 'displaced\n'; else printf 'legacy\n'; fi
+}
+
 # read_marker — parse the stamp prologue of the marker in the current worktree.
 # Exits with a named refusal on every structural fault; returns 0 with S_* set otherwise.
 read_marker() {
-  local path; path="$(marker_path)"
-  [ -e "$path" ] || refuse ABSENT 3 "no $MARKER_NAME in $(sane "$(pwd -P)") — nothing to resume; this is a legitimate FRESH START, not a refusal"
-  [ -f "$path" ] && [ -r "$path" ] || refuse ERROR 1 "$(sane "$path") exists but is not a readable regular file — nothing was decided"
-
-  local first
-  first="$(head -1 "$path" 2>/dev/null || true)"
-  if [ "$first" != "$STAMP_BEGIN" ]; then
+  local path cls; path="$(marker_path)"
+  cls="$(marker_class "$path")"
+  [ "$cls" != absent ] || refuse ABSENT 3 "no $MARKER_NAME in $(sane "$(pwd -P)") — nothing to resume; this is a legitimate FRESH START, not a refusal"
+  [ "$cls" != not-regular ] || refuse ERROR 1 "$(sane "$path") exists but is not a readable regular file — nothing was decided"
+  if [ "$cls" = displaced ]; then
+    refuse MALFORMED 8 "$(sane "$path") contains a stamp sentinel at column zero but NOT as its first line, so it DOES assert an ownership identity and that identity cannot be READ — it is NOT treated as an unstamped legacy marker and is never replaced for you, because an unreadable identity may be a LIVE PEER's (a single prepended blank line or comment produces this shape). INSPECT it, and if it is genuinely corrupt remove it or move it aside (e.g. 'mv $MARKER_NAME $MARKER_NAME.corrupt'); with no marker present this lane takes the ABSENT fresh-start path and a new stamped marker is written normally."
+  fi
+  if [ "$cls" = legacy ]; then
     refuse UNSTAMPED 8 "$(sane "$path") carries NO ownership stamp (its first line is not the stamp sentinel) — this is the pre-#3822 marker shape, whose plan could belong to ANY session on ANY machine, so nothing is READ from it. The route forward is '$prog write <issue>', which SUCCEEDS over an unstamped marker and REPLACES it — DISCARDING its body, because an unstamped plan may belong to any session and is never carried forward. Save anything you need out of the file first."
   fi
 
@@ -488,6 +516,41 @@ marker_body() {
 # ---------------------------------------------------------------------------
 # Liveness of the RECORDED writer. Sets LIVE_STATE (gone|alive|unknown) + LIVE_DETAIL.
 # ---------------------------------------------------------------------------
+
+# epoch_is_canonical <value> — 0 iff <value> is a bounded canonical decimal usable as an
+# epoch second in `[ -le ]` and `$(( ))`: digits only, no sign, no leading zeros (so no
+# accidental octal in an arithmetic context), 1..12 digits (year 2286 needs 10; 12 leaves
+# headroom while staying far inside intmax_t, which is what stops `[` erroring out).
+epoch_is_canonical() {
+  case "${1:-}" in
+    '' | *[!0-9]*) return 1 ;;
+    0) return 0 ;;
+    0*) return 1 ;;
+  esac
+  [ "${#1}" -le 12 ] || return 1
+  return 0
+}
+
+# interval_is_usable <earliest> <latest> — 0 iff both endpoints are canonical AND ordered.
+# Sets INTERVAL_WHY to the reason on failure, so the refusal says WHICH property failed
+# rather than leaving the reader to guess.
+INTERVAL_WHY=''
+interval_is_usable() {
+  INTERVAL_WHY=''
+  if ! epoch_is_canonical "${1:-}"; then
+    INTERVAL_WHY="'earliest' is not a bounded canonical epoch second"
+    return 1
+  fi
+  if ! epoch_is_canonical "${2:-}"; then
+    INTERVAL_WHY="'latest' is not a bounded canonical epoch second"
+    return 1
+  fi
+  if [ "$1" -gt "$2" ]; then
+    INTERVAL_WHY="the interval is INVERTED (earliest > latest), so it describes no instant"
+    return 1
+  fi
+  return 0
+}
 LIVE_STATE=''; LIVE_DETAIL=''
 
 writer_liveness() {
@@ -499,11 +562,20 @@ writer_liveness() {
       LIVE_DETAIL="the stamp records session-pid=$(sane "$pid"), which is not a pid — the writing session's liveness is UNMEASURABLE. It is reported UNKNOWN and NOT 'gone': recording this script's own \$\$ instead would make a LIVE peer read as dead."
       return 0 ;;
   esac
-  case "$lo$hi" in
-    '' | *[!0-9]*)
-      LIVE_DETAIL="the stamp records no measured start window for pid $(sane "$pid") (earliest=$(sane "$lo") latest=$(sane "$hi")), so a pid that is alive NOW cannot be shown to be the process that stamped this marker — PID REUSE is indistinguishable, hence UNKNOWN"
-      return 0 ;;
-  esac
+  # THE RECORDED INTERVAL IS VALIDATED BEFORE ANYTHING IS PROBED, AND AN UNUSABLE ONE IS
+  # `unknown` — NEVER `gone`. A digit-only test on the two endpoints CONCATENATED was not
+  # enough, and the failure mode was the worst available: an INVERTED interval (earliest >
+  # latest) or one whose magnitude `[` cannot parse makes the intersection test below ERROR,
+  # an errored `[` inside `if A && B` reads as FALSE, and the false branch was `gone` — so a
+  # LIVE PEER became adoptable. Unmeasurable must never read as gone; that is the whole
+  # liveness axis. Each endpoint is checked SEPARATELY (concatenation let an empty endpoint
+  # hide behind a digit-bearing one), as a bounded canonical decimal (no sign, no leading
+  # zeros, <= 12 digits so `[ -le ]` and `$(( ))` cannot be handed an out-of-range value),
+  # and the interval must be ORDERED.
+  if ! interval_is_usable "$lo" "$hi"; then
+    LIVE_DETAIL="the stamp's start window for pid $(sane "$pid") is UNUSABLE (earliest=$(sane "$lo") latest=$(sane "$hi"): $INTERVAL_WHY), so a pid that is alive NOW cannot be shown to be the process that stamped this marker — PID REUSE is indistinguishable, hence UNKNOWN and never 'gone'"
+    return 0
+  fi
   if ! ps_usable; then
     LIVE_DETAIL="\`ps\` cannot answer an existence question on this host (it failed even for our own pid), so nothing about pid $(sane "$pid") was measured"
     return 0
@@ -538,6 +610,14 @@ writer_liveness() {
     return 0
   fi
   ce="${cur%% *}"; cl="${cur##* }"
+  # The MEASURED window gets the same treatment as the recorded one: it is derived as
+  # `now - elapsed`, so a nonsense `elapsed` yields a nonsense (even negative) endpoint, and
+  # an unparseable operand in the comparison below would ERROR — which reads as FALSE, whose
+  # branch is `gone`. Same false-permissive, other operand.
+  if ! interval_is_usable "$ce" "$cl"; then
+    LIVE_DETAIL="pid $(sane "$pid") is running but its MEASURED start window is unusable (earliest=$(sane "$ce") latest=$(sane "$cl"): $INTERVAL_WHY), so it cannot be compared with the recorded one — UNKNOWN, never 'gone'"
+    return 0
+  fi
   # Same process <=> the recorded interval and the live one INTERSECT (both are
   # `now - elapsed` brackets from this host's clock; the slack absorbs per-side rounding).
   if [ "$((ce - START_SLACK_SECS))" -le "$hi" ] && [ "$((cl + START_SLACK_SECS))" -ge "$lo" ]; then
@@ -620,6 +700,38 @@ assert_body_safe() {
   done
 }
 
+# assert_assembled_marker <tmp> — validate the FULLY ASSEMBLED file immediately before the
+# atomic rename. Sets WRITE_ERR and returns 1 on any fault.
+#
+# THE CHECK MUST BE INSIDE THE WINDOW IT CERTIFIES. `assert_body_safe` validates the body
+# FILE, and the body is READ AGAIN later when the marker is assembled — two different reads
+# of a file that can change in between, so the first cannot certify the second. The threat
+# model matters here: a hostile INVOKER is out of scope (they can edit the marker directly),
+# but this is reachable BY ACCIDENT — an agent's own notes file being rewritten while it
+# writes the marker — and "reachable by accident" is a defect. The consequence is the
+# dead-letter family again: a marker carrying a stray sentinel is refused by every later
+# read, i.e. it BRICKS ITSELF.
+#
+# Validating the assembled temporary subsumes the race instead of narrowing it: these are
+# EXACTLY the bytes that get committed, whatever route the body took to get there. It is a
+# second, independent layer — `assert_body_safe` stays, because it gives the common case a
+# clear usage error before any work is done.
+assert_assembled_marker() {
+  local tmp="$1" nb ne first
+  first="$(head -1 "$tmp" 2>/dev/null || true)"
+  if [ "$first" != "$STAMP_BEGIN" ]; then
+    WRITE_ERR="internal: the assembled marker's first line is not the stamp sentinel — refusing to commit a file that every later read would refuse"
+    return 1
+  fi
+  nb="$(count_sentinel "$tmp" "$STAMP_BEGIN")"
+  ne="$(count_sentinel "$tmp" "$STAMP_END")"
+  if [ "$nb" -ne 1 ] || [ "$ne" -ne 1 ]; then
+    WRITE_ERR="the assembled marker carries $nb stamp-begin and $ne stamp-end sentinels at column zero (exactly one of each is legal) — the body supplied at COMMIT time contains a line that can pose as a stamp boundary. Nothing was written. If a --body-file was named, it changed between validation and assembly, or it carries a sentinel at column zero: remove that line."
+    return 1
+  fi
+  return 0
+}
+
 # write_marker <issue> <actor> <body-file|''> [<extra key: value lines>...]
 #
 # Reports through GLOBALS (WROTE_PATH on success, WRITE_ERR + return 1 on failure) rather
@@ -673,6 +785,8 @@ write_marker() {
     printf '\n'
     if [ -n "$bodyfile" ] && [ -s "$bodyfile" ]; then cat "$bodyfile"; fi
   } >"$tmp" || { rm -f "$tmp"; WRITE_ERR="failed writing the stamp to $(sane "$tmp") — nothing was replaced"; return 1; }
+  # The last thing before the atomic commit, over the committed bytes themselves.
+  assert_assembled_marker "$tmp" || { rm -f "$tmp"; return 1; }
   mv -f "$tmp" "$path" || { rm -f "$tmp"; WRITE_ERR="failed replacing $(sane "$path")"; return 1; }
   WROTE_PATH="$path"
   return 0
@@ -730,10 +844,15 @@ cmd_write() {
   lock_marker
 
   local carried='' discarded=''
-  if [ -e "$(marker_path)" ]; then
-    local mpath; mpath="$(marker_path)"
-    [ -f "$mpath" ] && [ -r "$mpath" ] || refuse ERROR 1 "$(sane "$mpath") exists but is not a readable regular file — nothing was decided"
-    if [ "$(head -1 "$mpath" 2>/dev/null || true)" != "$STAMP_BEGIN" ]; then
+  local mpath mcls
+  mpath="$(marker_path)"
+  mcls="$(marker_class "$mpath")"
+  if [ "$mcls" != absent ]; then
+    [ "$mcls" != not-regular ] || refuse ERROR 1 "$(sane "$mpath") exists but is not a readable regular file — nothing was decided"
+    # ONLY the `legacy` class migrates. A `displaced` sentinel means the file DOES assert an
+    # identity (see marker_class), so it goes down the ownership path, where read_marker
+    # refuses it MALFORMED — never discarded as though it asserted nothing.
+    if [ "$mcls" = legacy ]; then
       local dl dbytes
       dl="$(LC_ALL=C wc -l <"$mpath" 2>/dev/null | tr -d ' ')"
       dbytes="$(LC_ALL=C wc -c <"$mpath" 2>/dev/null | tr -d ' ')"

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -131,6 +131,14 @@
 #              may not overwrite a live peer's plan either — so a foreign marker refuses
 #              with that marker's own verdict. The route past it is `adopt`, never a flag
 #              on `write`. Without --body-file an OWNED marker's body is PRESERVED.
+#              ONE EXCEPTION — the MIGRATION case: an UNSTAMPED marker (the pre-#3822
+#              shape) asserts NO ownership, so `write` REPLACES it, DISCARDS its body (an
+#              unstamped plan may belong to any session and is never carried forward) and
+#              ANNOUNCES the discard on a verdict-detail line. `verify` still REFUSES an
+#              unstamped marker; `write` is the one door, and it is the door the UNSTAMPED
+#              refusal names. MALFORMED / DUPLICATE-SENTINEL get no exception: they CLAIM
+#              an identity that cannot be READ, which may be a live peer's, so a human
+#              moves the file aside deliberately and `write` then takes the ABSENT path.
 #   verify <N> [--actor <id>]      the rehydrate gate (see the axes above)
 #   adopt  <N> --reason <why> [--actor <id>]
 #              The explicit adopt gesture. Resolves the SESSION axis ONLY: a fail-closed
@@ -348,16 +356,16 @@ read_marker() {
   local first
   first="$(head -1 "$path" 2>/dev/null || true)"
   if [ "$first" != "$STAMP_BEGIN" ]; then
-    refuse UNSTAMPED 8 "$(sane "$path") carries NO ownership stamp (its first line is not the stamp sentinel) — this is the pre-#3822 marker shape, whose plan could belong to ANY session on ANY machine, so it is refused rather than adopted. Re-stamp it with '$prog write <issue>' only if this lane's work IS the issue it describes."
+    refuse UNSTAMPED 8 "$(sane "$path") carries NO ownership stamp (its first line is not the stamp sentinel) — this is the pre-#3822 marker shape, whose plan could belong to ANY session on ANY machine, so nothing is READ from it. The route forward is '$prog write <issue>', which SUCCEEDS over an unstamped marker and REPLACES it — DISCARDING its body, because an unstamped plan may belong to any session and is never carried forward. Save anything you need out of the file first."
   fi
 
   local nb ne
   nb="$(count_sentinel "$path" "$STAMP_BEGIN")"
   ne="$(count_sentinel "$path" "$STAMP_END")"
   if [ "$nb" -ne 1 ] || [ "$ne" -gt 1 ]; then
-    refuse DUPLICATE-SENTINEL 8 "$(sane "$path") carries $nb stamp-begin and $ne stamp-end sentinels at column zero (exactly one of each is legal) — a second stamp cannot be told apart from the first, so no identity is read from this file"
+    refuse DUPLICATE-SENTINEL 8 "$(sane "$path") carries $nb stamp-begin and $ne stamp-end sentinels at column zero (exactly one of each is legal) — a second stamp cannot be told apart from the first, so no identity is read from this file. The route forward is to move the file aside DELIBERATELY (e.g. 'mv $MARKER_NAME $MARKER_NAME.unreadable'): with no marker present this lane takes the ABSENT fresh-start path and a new stamped marker is written normally. It is NOT overwritten for you — unlike an unstamped marker this file CLAIMS an identity, and an identity that cannot be READ may be a live peer's. (This text deliberately names no subcommand: naming one that refuses in THIS state is the dead-letter shape scripts/tests/test_drive_issue_state.sh case 22 forbids.)"
   fi
-  [ "$ne" -eq 1 ] || refuse MALFORMED 8 "$(sane "$path") has no stamp-end sentinel at column zero — the prologue is unterminated, so its extent (and therefore which lines are identity) is undecidable"
+  [ "$ne" -eq 1 ] || refuse MALFORMED 8 "$(sane "$path") has no stamp-end sentinel at column zero — the prologue is unterminated, so its extent (and therefore which lines are identity) is undecidable. The route forward is to move the file aside DELIBERATELY (e.g. 'mv $MARKER_NAME $MARKER_NAME.unreadable'): with no marker present this lane takes the ABSENT fresh-start path and a new stamped marker is written normally. It is NOT overwritten for you — unlike an unstamped marker this file CLAIMS an identity, and an identity that cannot be READ may be a live peer's. (This text deliberately names no subcommand: naming one that refuses in THIS state is the dead-letter shape scripts/tests/test_drive_issue_state.sh case 22 forbids.)"
 
   # Parse the CONTIGUOUS run of `key: value` lines between the two sentinels, and NOTHING
   # else in the file. `IFS=` + `-r` keeps each line byte-exact.
@@ -368,14 +376,14 @@ read_marker() {
     [ "$line" = "$STAMP_END" ] && break
     case "$line" in
       [a-z]*': '*) : ;;
-      *) refuse MALFORMED 8 "$(sane "$path") line $ln is inside the stamp prologue but is not a 'key: value' line at column zero — the prologue grammar is closed, so a line it cannot parse is a refusal rather than a guess" ;;
+      *) refuse MALFORMED 8 "$(sane "$path") line $ln is inside the stamp prologue but is not a 'key: value' line at column zero — the prologue grammar is closed, so a line it cannot parse is a refusal rather than a guess. The route forward is to move the file aside DELIBERATELY (e.g. 'mv $MARKER_NAME $MARKER_NAME.unreadable'): with no marker present this lane takes the ABSENT fresh-start path and a new stamped marker is written normally. It is NOT overwritten for you — unlike an unstamped marker this file CLAIMS an identity, and an identity that cannot be READ may be a live peer's. (This text deliberately names no subcommand: naming one that refuses in THIS state is the dead-letter shape scripts/tests/test_drive_issue_state.sh case 22 forbids.)" ;;
     esac
     key="${line%%: *}"
     val="${line#*: }"
     case "$key" in
-      *[!a-z0-9-]*) refuse MALFORMED 8 "$(sane "$path") line $ln has a stamp key outside [a-z0-9-] ('$(sane "$key")')" ;;
+      *[!a-z0-9-]*) refuse MALFORMED 8 "$(sane "$path") line $ln has a stamp key outside [a-z0-9-] ('$(sane "$key")'). The route forward is to move the file aside DELIBERATELY (e.g. 'mv $MARKER_NAME $MARKER_NAME.unreadable'): with no marker present this lane takes the ABSENT fresh-start path and a new stamped marker is written normally. It is NOT overwritten for you — unlike an unstamped marker this file CLAIMS an identity, and an identity that cannot be READ may be a live peer's. (This text deliberately names no subcommand: naming one that refuses in THIS state is the dead-letter shape scripts/tests/test_drive_issue_state.sh case 22 forbids.)" ;;
     esac
-    [ -n "$val" ] || refuse MALFORMED 8 "$(sane "$path") line $ln records an EMPTY value for '$(sane "$key")'"
+    [ -n "$val" ] || refuse MALFORMED 8 "$(sane "$path") line $ln records an EMPTY value for '$(sane "$key")'. The route forward is to move the file aside DELIBERATELY (e.g. 'mv $MARKER_NAME $MARKER_NAME.unreadable'): with no marker present this lane takes the ABSENT fresh-start path and a new stamped marker is written normally. It is NOT overwritten for you — unlike an unstamped marker this file CLAIMS an identity, and an identity that cannot be READ may be a live peer's. (This text deliberately names no subcommand: naming one that refuses in THIS state is the dead-letter shape scripts/tests/test_drive_issue_state.sh case 22 forbids.)"
     case "$key" in
       issue)                      dup="$S_issue";          S_issue="$val" ;;
       machine)                    dup="$S_machine";        S_machine="$val" ;;
@@ -393,7 +401,7 @@ read_marker() {
     esac
     # A DUPLICATE identity key would let the PARSER's choice decide identity, which is the
     # forgery shape this whole prologue exists to remove. Refused, not first-wins.
-    [ -z "$dup" ] || refuse MALFORMED 8 "$(sane "$path") records '$(sane "$key")' TWICE in the stamp prologue — which occurrence is the identity is undecidable"
+    [ -z "$dup" ] || refuse MALFORMED 8 "$(sane "$path") records '$(sane "$key")' TWICE in the stamp prologue — which occurrence is the identity is undecidable. The route forward is to move the file aside DELIBERATELY (e.g. 'mv $MARKER_NAME $MARKER_NAME.unreadable'): with no marker present this lane takes the ABSENT fresh-start path and a new stamped marker is written normally. It is NOT overwritten for you — unlike an unstamped marker this file CLAIMS an identity, and an identity that cannot be READ may be a live peer's. (This text deliberately names no subcommand: naming one that refuses in THIS state is the dead-letter shape scripts/tests/test_drive_issue_state.sh case 22 forbids.)"
   done <"$path"
 
   local missing=''
@@ -406,7 +414,7 @@ read_marker() {
   [ -n "$S_start_hi" ] || missing="$missing session-pid-start-latest"
   [ -n "$S_actor" ]    || missing="$missing actor"
   [ -n "$S_ts" ]       || missing="$missing ts"
-  [ -z "$missing" ] || refuse MALFORMED 8 "$(sane "$path") stamp prologue is missing required field(s):$(sane "$missing") — an incomplete stamp is not a weaker stamp, it is no stamp"
+  [ -z "$missing" ] || refuse MALFORMED 8 "$(sane "$path") stamp prologue is missing required field(s):$(sane "$missing") — an incomplete stamp is not a weaker stamp, it is no stamp. The route forward is to move the file aside DELIBERATELY (e.g. 'mv $MARKER_NAME $MARKER_NAME.unreadable'): with no marker present this lane takes the ABSENT fresh-start path and a new stamped marker is written normally. It is NOT overwritten for you — unlike an unstamped marker this file CLAIMS an identity, and an identity that cannot be READ may be a live peer's. (This text deliberately names no subcommand: naming one that refuses in THIS state is the dead-letter shape scripts/tests/test_drive_issue_state.sh case 22 forbids.)"
   return 0
 }
 
@@ -638,17 +646,40 @@ cmd_write() {
 
   # Writing OVER an existing marker passes the SAME ownership verification: you may not
   # overwrite a live peer's plan either. ABSENT is the legitimate fresh-start path.
-  local carried=''
+  #
+  # ONE EXCEPTION, AND IT IS THE MIGRATION CASE: an UNSTAMPED marker. It asserts NO
+  # ownership at all — that is what makes it the pre-#3822 shape — so refusing to replace it
+  # protects no identifiable party while BRICKING the only route forward. On rollout EVERY
+  # existing lane holds an unstamped marker, so the refusal made the whole marker path a
+  # dead letter fleet-wide, with the refusal text naming the very command that refused (the
+  # #3312-job-24 shape: a break-glass no sequence of actions can reach). So `write` REPLACES
+  # it and DISCARDS its body — silently carrying a foreign plan forward is the defect this
+  # issue exists to close — and ANNOUNCES the discard, because a quiet overwrite of someone's
+  # notes is unacceptable even where refusing is worse. A MALFORMED or DUPLICATE-SENTINEL
+  # marker gets NO such exception: it CLAIMS an identity that merely cannot be read, and an
+  # unreadable identity may be a live peer's, so it is moved aside by a human deliberately.
+  local carried='' discarded=''
   if [ -e "$(marker_path)" ]; then
-    check_ownership "$issue" strict
-    if [ -z "$body_src" ]; then
+    local mpath; mpath="$(marker_path)"
+    [ -f "$mpath" ] && [ -r "$mpath" ] || refuse ERROR 1 "$(sane "$mpath") exists but is not a readable regular file — nothing was decided"
+    if [ "$(head -1 "$mpath" 2>/dev/null || true)" != "$STAMP_BEGIN" ]; then
+      local dl dbytes
+      dl="$(LC_ALL=C wc -l <"$mpath" 2>/dev/null | tr -d ' ')"
+      dbytes="$(LC_ALL=C wc -c <"$mpath" 2>/dev/null | tr -d ' ')"
+      discarded="replaced an UNSTAMPED marker of unknown provenance and DISCARDED its body (${dl:-?} lines, ${dbytes:-?} bytes): an unstamped plan may belong to ANY session, so it is never carried forward"
+      # body_src stays as the caller supplied it (empty unless --body-file): the preserve
+      # branch below is UNREACHABLE from here, which is the point.
+    else
+      check_ownership "$issue" strict
+      if [ -z "$body_src" ]; then
       # Preserve an OWNED marker's body: `write` updates the stamp and the recorded stage,
       # not the author's notes.
-      carried="$(mktemp "${TMPDIR:-/tmp}/drive-issue-body.XXXXXX")" || refuse ERROR 1 "cannot create a temporary file for the carried body"
-      register_tmp "$carried"
-      marker_body >"$carried"
-      assert_body_safe "$carried"
-      body_src="$carried"
+        carried="$(mktemp "${TMPDIR:-/tmp}/drive-issue-body.XXXXXX")" || refuse ERROR 1 "cannot create a temporary file for the carried body"
+        register_tmp "$carried"
+        marker_body >"$carried"
+        assert_body_safe "$carried"
+        body_src="$carried"
+      fi
     fi
   fi
 
@@ -666,6 +697,7 @@ cmd_write() {
   fi
   [ -z "$carried" ] || rm -f "$carried"
   verdict WRITTEN
+  [ -z "$discarded" ] || detail "$discarded"
   detail "issue=$(sane "$issue") machine=$(sane "$(this_machine)") worktree=$(sane "$(pwd -P)") session=$(sane "$(this_session)") session-pid=$(sane "$(this_session_pid)") actor=$(sane "$actor") -> $(sane "$WROTE_PATH")"
 }
 

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -32,12 +32,15 @@
 #     copied tree, a foreign worktree means the file was copied.
 #
 #   SESSION AXIS — recorded (AC1), but NOT fail-closed on its own.
-#     A recorded session id equal to the current one (and recordable) is OWNED outright. So
-#     is a recorded pid that is ALIVE and EQUAL to our own session pid with an intersecting
-#     start window — a pid is unique among live processes, so that process IS us, and
-#     without this a session with CLAUDE_PID set but no CLAUDE_CODE_SESSION_ID would refuse
-#     its OWN marker as a live peer. It is an affirmative measurement of sameness (stronger
-#     than the id string it stands in for), never a permissive fallback.
+#     A recorded session id equal to the current one (and recordable) is OWNED outright
+#     (basis `session`). So is a recorded pid that is ALIVE and EQUAL to our own session pid
+#     with an intersecting start window (basis `same-live-pid`) — a pid is unique among live
+#     processes, so that process IS us, and without this a session with CLAUDE_PID set but no
+#     CLAUDE_CODE_SESSION_ID would refuse its OWN marker as a live peer. It is an affirmative
+#     measurement of sameness (stronger than the id string it stands in for), never a
+#     permissive fallback. THE TWO BASES ARE CARRIED, NOT COLLAPSED: `verify`/`write` accept
+#     both, and `adopt` treats both as ALREADY YOURS (a re-entrant no-op) rather than as
+#     something to hand over.
 #     A session difference alone is resolved by the LIVENESS OF THE RECORDED WRITER,
 #     three-valued, on `claim-heartbeat.sh dead-lanes`' precedent:
 #       writer provably GONE  -> ADOPTABLE. `verify` still exits NON-ZERO: adoption is an
@@ -172,6 +175,13 @@
 #   adopt  <N> --reason <why> [--actor <id>]
 #              The explicit adopt gesture. Resolves the SESSION axis ONLY: a fail-closed
 #              axis mismatch still refuses, and so does a live or unmeasurable writer.
+#              IT REWRITES ONLY WHEN THE RECORDED WRITER IS PROVABLY GONE. Where the marker
+#              is ALREADY YOURS — by either basis, the recorded session id being this one OR
+#              the recorded pid being THIS live process — it is a re-entrant NO-OP: it says so
+#              and changes NOTHING, because rewriting there would record a STILL-RUNNING
+#              process as the prior owner and print that it was "provably gone", a false
+#              statement in the audit record. The basis comes from the ownership verification
+#              itself, never re-derived from the fields by the caller.
 #              It RECORDS the provenance of the hand-over — `prior-session`,
 #              `prior-session-pid`, `prior-ts`, `adopt-reason` — which then survives later
 #              `write`s and is REPLACED (never accumulated) by a later adopt.
@@ -895,7 +905,22 @@ writer_liveness() {
 # Ownership verification, shared by verify / write / adopt.
 # `check_ownership <issue> <mode>` where mode = strict (verify/write) | adopt.
 # Returns 0 for OWNED. Every other outcome is a refusal that EXITS.
+#
+# THE RESULT CARRIES HOW IT WAS ESTABLISHED (roborev job 34 H2). Three DIFFERENT facts reach
+# `return 0`, and collapsing them into one undifferentiated success let `cmd_adopt` re-derive
+# "is it already mine?" from the session id alone — so a changed or unrecorded session with the
+# SAME LIVE PID took the ADOPTION path, rewrote the marker, recorded a STILL-RUNNING process as
+# `prior-session-pid` and printed that the writer was "provably gone": a false statement in the
+# audit record this script exists to produce, and precisely what LIVE-PEER refuses. So every
+# caller reads OWNERSHIP_BASIS rather than re-deriving the distinction from the fields:
+#   session         the recorded session id IS this session  -> already yours
+#   same-live-pid   the recorded pid is THIS live process     -> already yours
+#   adoptable-gone  the recorded writer is provably GONE      -> `adopt` may rewrite (only here)
+# `verify` and `write` treat the first two identically and by design (the pid measurement is
+# STRONGER than the id string it stands in for), and never see the third: `gone` is a refusal in
+# strict mode.
 # ---------------------------------------------------------------------------
+OWNERSHIP_BASIS=''
 check_ownership() {
   local issue="$1" mode="$2"
   local machine session
@@ -915,6 +940,7 @@ check_ownership() {
 
   # SESSION AXIS. Equal AND recordable => OWNED. Anything else is liveness-resolved.
   if [ "$S_session" = "$session" ] && [ "$session" != unrecorded ]; then
+    OWNERSHIP_BASIS=session
     return 0
   fi
 
@@ -929,6 +955,7 @@ check_ownership() {
   # measurement of sameness (pid identity + start-window intersection), strictly stronger
   # than the session-id string it stands in for — never a fallback to permissiveness.
   if [ "$LIVE_STATE" = alive ] && [ "$S_pid" = "$(this_session_pid)" ]; then
+    OWNERSHIP_BASIS=same-live-pid
     return 0
   fi
 
@@ -940,6 +967,7 @@ check_ownership() {
       refuse LIVENESS-UNKNOWN 7 "$why. Liveness was NOT measured, and an unmeasured liveness is never read as verified — refusing. Resolve the ambiguity (identify the session, or clear the marker deliberately) rather than adopting on unproven information." ;;
     gone)
       if [ "$mode" = adopt ]; then
+        OWNERSHIP_BASIS=adoptable-gone
         return 0
       fi
       refuse ADOPTABLE 5 "$why. The recorded writer is provably GONE, so this lane IS adoptable — but adoption is an EXPLICIT gesture: run '$prog adopt $(sane "$issue") --reason <what the resume is>', which rewrites the stamp and records the prior session." ;;
@@ -1316,7 +1344,7 @@ cmd_verify() {
   done
   check_ownership "$issue" strict
   verdict OWNED
-  detail "issue=$(sane "$issue") machine=$(sane "$S_machine") worktree=$(sane "$S_worktree") session=$(sane "$S_session") stage=$(sane "${S_stage:-none}") ts=$(sane "$S_ts") — this lane's marker, this session; resume from the recorded stage"
+  detail "issue=$(sane "$issue") machine=$(sane "$S_machine") worktree=$(sane "$S_worktree") session=$(sane "$S_session") stage=$(sane "${S_stage:-none}") ts=$(sane "$S_ts") basis=$(sane "$OWNERSHIP_BASIS") — this lane's marker, this session; resume from the recorded stage"
 }
 
 # assert_reason <raw> — claim.sh's `--reason` gate, same rules and same reasons. An
@@ -1379,11 +1407,22 @@ cmd_adopt() {
   # evaporate.
   local request="$S_request" pr="$S_pr" branch="$S_branch"
 
-  if [ "$prior_session" = "$(this_session)" ] && [ "$prior_session" != unrecorded ]; then
-    verdict ADOPTED
-    detail "re-entrant: this session already owns $(sane "$(marker_path)") — nothing to transfer"
-    return 0
-  fi
+  # RE-ENTRANT FOR BOTH OWNERSHIP BASES (roborev job 34 H2). This used to test the SESSION ID
+  # alone, which is only ONE of the two ways check_ownership says "already yours" — so the
+  # same-live-pid basis fell through to the rewrite below and recorded a running process as the
+  # prior owner. The basis is now read from the verification itself rather than re-derived here,
+  # and the ONLY basis licensed to rewrite is `adoptable-gone`; `alive` and `unknown` never reach
+  # this point (they refuse inside check_ownership) and an unrecognised basis is a refusal, not a
+  # rewrite — a positive action must never rest on an unrecognised state.
+  case "$OWNERSHIP_BASIS" in
+    session | same-live-pid)
+      verdict ADOPTED
+      detail "re-entrant: this session already owns $(sane "$(marker_path)") (basis=$(sane "$OWNERSHIP_BASIS")) — nothing to transfer, and NOTHING is recorded as a prior owner: the recorded writer is THIS session, not a gone one"
+      return 0 ;;
+    adoptable-gone) : ;;
+    *)
+      refuse ERROR 1 "internal: ownership basis '$(sane "$OWNERSHIP_BASIS")' is not one of session|same-live-pid|adoptable-gone — refusing to transfer ownership on an unrecognised basis; nothing was written" ;;
+  esac
 
   local carried f_stage=''
   carried="$(mktemp "${TMPDIR:-/tmp}/drive-issue-body.XXXXXX" 2>&1)" || refuse ERROR 1 "cannot create a temporary file for the carried body under $(sane "${TMPDIR:-/tmp}") — nothing was written (mktemp: $(sane "$carried"))"

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -101,7 +101,7 @@
 #   (a) EVERY line of a verdict-bearing invocation, stdout AND stderr, begins
 #       `DRIVE-STATE: `. `--help` is the one exemption: it emits no verdict line, so no
 #       consumer parses it. THAT COVERS THE EXTERNAL COMMANDS THIS SCRIPT RUNS: every one of
-#       them (mktemp, mv, rm, cat, date, wc, tr, hostname, flock, and the sourced liveness
+#       them (mktemp, mv, rm, cat, tail, awk, date, wc, tr, hostname, flock, and the sourced liveness
 #       library's ps/date/tr/cut) has its stderr either CAPTURED and FOLDED into the anchored
 #       message — preferred where the native text names the cause, as with mktemp and mv — or
 #       SUPPRESSED where the anchored message already names the failure fully. A native
@@ -837,13 +837,51 @@ read_marker() {
 # Returns NON-ZERO when the body could not be read, and its stderr is suppressed: every
 # caller must decide what an unreadable body means rather than inherit awk's unprefixed
 # diagnostic and an empty result (roborev job 26 F2).
+# THE BODY IS COPIED BY BYTE OFFSET, NEVER BY A LINE-ORIENTED TOOL (roborev job 35 I2). This
+# used to be `awk ... { print }`, and awk ALWAYS terminates the record it prints — so a body whose
+# LAST LINE HAD NO NEWLINE gained one on the next owned write or adoption (measured: a 19-byte
+# `no trailing newline` came back as 20 bytes), breaking the byte-for-byte preservation the header
+# promises one paragraph up. The class is "body bytes routed through a line-oriented tool", and it
+# also covers `$( )` capture, which strips trailing newlines the same way — which is why this
+# function writes to STDOUT for the caller to redirect into a file, and why the only other place
+# body bytes move (`write_marker`) uses `cat`.
+#
+# WHY THIS IS BYTE-EXACT: awk is used ONLY to count the bytes of the lines BEFORE the body — the
+# prologue, the end sentinel and the writer-owned separator, every one of which is newline
+# terminated in any file that HAS a body — and `tail -c +N` then copies raw bytes from that
+# offset to EOF, re-terminating nothing. `LC_ALL=C` is load-bearing: awk's `length()` counts
+# CHARACTERS, so a multi-byte prologue value under a UTF-8 locale would yield a short offset and
+# silently prepend stray bytes to the body.
 marker_body() {
-  local path; path="$(marker_path)"
-  awk -v s="$STAMP_END" '
-    body { print; next }
-    sep  { sep = 0; body = 1; if ($0 == "") next; print; next }
-    $0 == s { sep = 1 }
-  ' "$path" 2>/dev/null
+  local path off; path="$(marker_path)"
+  # Fail-closed: no end sentinel at all (or an unreadable file) is a body that could not be READ,
+  # never an empty one — every caller refuses rather than carrying an empty plan forward.
+  off="$(LC_ALL=C awk -v s="$STAMP_END" '
+    {
+      if (state == 1) {
+        # The line immediately after the sentinel. The writer ALWAYS emits exactly one blank
+        # separator (see write_marker); skip it, and ONLY it, when it is there.
+        if ($0 == "") pos += length($0) + 1
+        print pos + 1
+        done = 1
+        exit
+      }
+      pos += length($0) + 1
+      if ($0 == s) state = 1
+    }
+    END {
+      if (done) exit 0
+      # The sentinel was the LAST line: the body is empty, and the offset is one past EOF, which
+      # `tail -c` answers with nothing. No sentinel at all is a read failure, not an empty body.
+      if (state == 1) { print pos + 1; exit 0 }
+      exit 3
+    }
+  ' "$path" 2>/dev/null)" || return 1
+  case "$off" in '' | *[!0-9]*) return 1 ;; esac
+  [ "$off" -ge 1 ] || return 1
+  # `tail`'s stderr is suppressed for contract (a): its native `tail: cannot open ...` carries no
+  # prefix, and the non-zero return already routes to each caller's anchored refusal.
+  tail -c "+$off" "$path" 2>/dev/null
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -442,14 +442,39 @@ S_prior_session=''; S_prior_pid=''; S_prior_ts=''; S_adopt_reason=''
 
 marker_path() { printf '%s/%s\n' "$(pwd -P)" "$MARKER_NAME"; }
 
-# count_sentinel <path> <sentinel> — column-zero, WHOLE-LINE occurrences. `grep -Fx` is
-# what makes this a column-zero test: a sentinel appearing inside a `key: value` value or
-# mid-sentence in the body is not a whole line and cannot pose as a stamp boundary.
+# count_sentinel <path> <sentinel> — column-zero, WHOLE-LINE occurrences on stdout, or a
+# NON-ZERO return when the scan itself could not be performed. `grep -Fx` is what makes this a
+# column-zero test: a sentinel appearing inside a `key: value` value or mid-sentence in the
+# body is not a whole line and cannot pose as a stamp boundary.
+#
+# THREE-VALUED, BECAUSE grep IS (roborev job 30 G1). `grep -c` exits 0 when it matched, 1 when
+# it did not, and >1 when the scan COULD NOT BE PERFORMED. The first cut wrote
+# `... || true` + `case "$n" in *[!0-9]*) n=0`, collapsing those three onto two and taking the
+# PERMISSIVE answer for the error: an unperformed scan counted as ZERO sentinels. With a
+# DISPLACED sentinel that made `marker_class` answer `legacy`, and `write`'s MIGRATION path
+# then DISCARDED AND REPLACED a file that may be a LIVE PEER's stamped state — the exact defect
+# this script exists to prevent, arriving through the one branch allowed to destroy a marker.
+# CLAUDE.md's standing rule: a positive verdict requires an AFFIRMATIVE MEASUREMENT, and a pass
+# is never derived from the ABSENCE of a bad signal (`1699-find-tristate` lints the sibling
+# `[ -z "$(find …)" ]` shape). Callers must therefore branch on the RETURN, never on the text.
 count_sentinel() {
-  local n
-  n="$(LC_ALL=C grep -Fxc -- "$2" "$1" 2>/dev/null || true)"
-  case "$n" in '' | *[!0-9]*) n=0 ;; esac
+  local n rc=0
+  n="$(LC_ALL=C grep -Fxc -- "$2" "$1" 2>/dev/null)" || rc=$?
+  [ "$rc" -le 1 ] || return 1
+  case "$n" in '' | *[!0-9]*) return 1 ;; esac
   printf '%s\n' "$n"
+  return 0
+}
+
+# count_matching_lines <basic-regexp> — reads STDIN; the same three-valued discipline as
+# count_sentinel, for the assembled-prologue field census.
+count_matching_lines() {
+  local n rc=0
+  n="$(LC_ALL=C grep -c -- "$1" 2>/dev/null)" || rc=$?
+  [ "$rc" -le 1 ] || return 1
+  case "$n" in '' | *[!0-9]*) return 1 ;; esac
+  printf '%s\n' "$n"
+  return 0
 }
 
 # marker_class <path> — echo absent | not-regular | stamped | displaced | legacy.
@@ -467,15 +492,20 @@ count_sentinel() {
 #             DOES assert an identity, which merely cannot be READ, and an unreadable
 #             identity may be a live peer's => MALFORMED, never migratable.
 #   legacy    no sentinel anywhere => genuinely the pre-#3822 shape => UNSTAMPED
+#   error     the classification could NOT BE MEASURED (roborev job 30 G1). It is its own
+#             class rather than a fall-through to `legacy`, because `legacy` is the ONE class
+#             whose handler DESTROYS the file. Every caller must refuse on it.
 marker_class() {
-  local path="$1" nb ne
+  local path="$1" nb ne first rc=0
   [ -e "$path" ] || { printf 'absent\n'; return 0; }
   { [ -f "$path" ] && [ -r "$path" ]; } || { printf 'not-regular\n'; return 0; }
-  if [ "$(head -1 "$path" 2>/dev/null || true)" = "$STAMP_BEGIN" ]; then
+  first="$(head -1 "$path" 2>/dev/null)" || rc=$?
+  [ "$rc" -eq 0 ] || { printf 'error\n'; return 0; }
+  if [ "$first" = "$STAMP_BEGIN" ]; then
     printf 'stamped\n'; return 0
   fi
-  nb="$(count_sentinel "$path" "$STAMP_BEGIN")"
-  ne="$(count_sentinel "$path" "$STAMP_END")"
+  nb="$(count_sentinel "$path" "$STAMP_BEGIN")" || { printf 'error\n'; return 0; }
+  ne="$(count_sentinel "$path" "$STAMP_END")"   || { printf 'error\n'; return 0; }
   if [ "$nb" -gt 0 ] || [ "$ne" -gt 0 ]; then printf 'displaced\n'; else printf 'legacy\n'; fi
 }
 
@@ -486,6 +516,7 @@ read_marker() {
   cls="$(marker_class "$path")"
   [ "$cls" != absent ] || refuse ABSENT 3 "no $MARKER_NAME in $(sane "$(pwd -P)") — nothing to resume; this is a legitimate FRESH START, not a refusal"
   [ "$cls" != not-regular ] || refuse ERROR 1 "$(sane "$path") exists but is not a readable regular file — nothing was decided"
+  [ "$cls" != error ] || refuse ERROR 1 "$(sane "$path") exists but could NOT BE CLASSIFIED: reading its first line, or scanning it for column-zero stamp sentinels, FAILED. An unperformed scan is not an absence of sentinels, so nothing is inferred from it — NOTHING was decided and NOTHING was replaced."
   if [ "$cls" = displaced ]; then
     refuse MALFORMED 8 "$(sane "$path") contains a stamp sentinel at column zero but NOT as its first line, so it DOES assert an ownership identity and that identity cannot be READ — it is NOT treated as an unstamped legacy marker and is never replaced for you, because an unreadable identity may be a LIVE PEER's (a single prepended blank line or comment produces this shape). INSPECT it, and if it is genuinely corrupt remove it or move it aside (e.g. 'mv $MARKER_NAME $MARKER_NAME.corrupt'); with no marker present this lane takes the ABSENT fresh-start path and a new stamped marker is written normally."
   fi
@@ -494,8 +525,8 @@ read_marker() {
   fi
 
   local nb ne
-  nb="$(count_sentinel "$path" "$STAMP_BEGIN")"
-  ne="$(count_sentinel "$path" "$STAMP_END")"
+  nb="$(count_sentinel "$path" "$STAMP_BEGIN")" || refuse ERROR 1 "$(sane "$path") could not be SCANNED for stamp-begin sentinels, so how many identities it claims is unmeasured — NOTHING was decided and NOTHING was replaced."
+  ne="$(count_sentinel "$path" "$STAMP_END")" || refuse ERROR 1 "$(sane "$path") could not be SCANNED for stamp-end sentinels, so the extent of its prologue is unmeasured — NOTHING was decided and NOTHING was replaced."
   if [ "$nb" -ne 1 ] || [ "$ne" -gt 1 ]; then
     refuse DUPLICATE-SENTINEL 8 "$(sane "$path") carries $nb stamp-begin and $ne stamp-end sentinels at column zero (exactly one of each is legal) — a second stamp cannot be told apart from the first, so no identity is read from this file. The route forward is to move the file aside DELIBERATELY (e.g. 'mv $MARKER_NAME $MARKER_NAME.unreadable'): with no marker present this lane takes the ABSENT fresh-start path and a new stamped marker is written normally. It is NOT overwritten for you — unlike an unstamped marker this file CLAIMS an identity, and an identity that cannot be READ may be a live peer's. (This text deliberately names no subcommand: naming one that refuses in THIS state is the dead-letter shape scripts/tests/test_drive_issue_state.sh case 22 forbids.)"
   fi
@@ -746,11 +777,18 @@ check_ownership() {
 # cannot see what a RUNTIME value injects. Refused, never escaped — an escaped sentinel is
 # a second grammar, and two grammars is how a reader and a writer come to disagree.
 assert_body_safe() {
-  local f="$1" s
+  local f="$1" s rc
   for s in "$STAMP_BEGIN" "$STAMP_END"; do
-    if LC_ALL=C grep -Fxq -- "$s" "$f" 2>/dev/null; then
-      die_usage "the body carries a stamp sentinel as a whole line at column zero. It is REFUSED, not escaped: the stamp prologue is the only place identity is read from, and a body line that can pose as a boundary would break that. Remove the line (indent it, or drop the '<!--' comment) and retry. NOTHING was written."
-    fi
+    rc=0
+    LC_ALL=C grep -Fxq -- "$s" "$f" 2>/dev/null || rc=$?
+    # THREE-VALUED (roborev job 30 G1): 0 = the body carries a sentinel, 1 = it provably does
+    # not, >1 = the scan could not be performed. The last is NOT the second: assuming a body
+    # nobody could read carries no sentinel is a pass derived from the ABSENCE of a bad signal.
+    case "$rc" in
+      0) die_usage "the body carries a stamp sentinel as a whole line at column zero. It is REFUSED, not escaped: the stamp prologue is the only place identity is read from, and a body line that can pose as a boundary would break that. Remove the line (indent it, or drop the '<!--' comment) and retry. NOTHING was written." ;;
+      1) : ;;
+      *) refuse ERROR 1 "the body file $(sane "$f") could not be SCANNED for stamp sentinels, so whether it carries a line that can pose as a stamp boundary is UNMEASURED — refusing rather than assuming it does not; NOTHING was written." ;;
+    esac
   done
 }
 
@@ -771,14 +809,20 @@ assert_body_safe() {
 # second, independent layer — `assert_body_safe` stays, because it gives the common case a
 # clear usage error before any work is done.
 assert_assembled_marker() {
-  local tmp="$1" nb ne first
-  first="$(head -1 "$tmp" 2>/dev/null || true)"
+  local tmp="$1" nb ne first rc=0
+  first="$(head -1 "$tmp" 2>/dev/null)" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    WRITE_ERR="the assembled marker $(sane "$tmp") could not be READ back before the commit, so the bytes about to replace the marker are unverified — nothing was written"
+    return 1
+  fi
   if [ "$first" != "$STAMP_BEGIN" ]; then
     WRITE_ERR="internal: the assembled marker's first line is not the stamp sentinel — refusing to commit a file that every later read would refuse"
     return 1
   fi
-  nb="$(count_sentinel "$tmp" "$STAMP_BEGIN")"
-  ne="$(count_sentinel "$tmp" "$STAMP_END")"
+  nb="$(count_sentinel "$tmp" "$STAMP_BEGIN")" || {
+    WRITE_ERR="the assembled marker $(sane "$tmp") could not be SCANNED for stamp-begin sentinels, so it is UNVERIFIED — refusing to commit unverified bytes over the marker; nothing was written"; return 1; }
+  ne="$(count_sentinel "$tmp" "$STAMP_END")" || {
+    WRITE_ERR="the assembled marker $(sane "$tmp") could not be SCANNED for stamp-end sentinels, so it is UNVERIFIED — refusing to commit unverified bytes over the marker; nothing was written"; return 1; }
   if [ "$nb" -ne 1 ] || [ "$ne" -ne 1 ]; then
     WRITE_ERR="the assembled marker carries $nb stamp-begin and $ne stamp-end sentinels at column zero (exactly one of each is legal) — the body supplied at COMMIT time contains a line that can pose as a stamp boundary. Nothing was written. If a --body-file was named, it changed between validation and assembly, or it carries a sentinel at column zero: remove that line."
     return 1
@@ -792,11 +836,12 @@ assert_assembled_marker() {
   # Checked HERE because this is the only place that sees the committed bytes, and scoped to
   # the PROLOGUE (a free-form body may legitimately contain a `stage: ...` line).
   local pro k n
-  pro="$(awk -v e="$STAMP_END" 'NR==1{next} $0==e{exit} {print}' "$tmp" 2>/dev/null || true)"
+  pro="$(awk -v e="$STAMP_END" 'NR==1{next} $0==e{exit} {print}' "$tmp" 2>/dev/null)" || {
+    WRITE_ERR="the assembled marker's stamp prologue could not be EXTRACTED from $(sane "$tmp"), so its required fields are UNMEASURED — refusing to commit; nothing was written"; return 1; }
   for k in issue machine worktree session session-pid session-pid-start-earliest \
            session-pid-start-latest actor ts; do
-    n="$(printf '%s\n' "$pro" | LC_ALL=C grep -c "^$k: ." 2>/dev/null || true)"
-    case "$n" in '' | *[!0-9]*) n=0 ;; esac
+    n="$(printf '%s\n' "$pro" | count_matching_lines "^$k: .")" || {
+      WRITE_ERR="the assembled marker's stamp prologue could not be SCANNED for the required '$k:' field, so it is UNMEASURED — refusing to commit; nothing was written"; return 1; }
     if [ "$n" -ne 1 ]; then
       WRITE_ERR="the assembled marker records $n non-empty '$k:' line(s) in its stamp prologue (exactly one is required) — an incomplete stamp is not a weaker stamp, it is NO stamp, and every later read would refuse it, bricking this lane. The usual cause is a helper this writer depends on (date, tr, hostname) failing. NOTHING was written."
       return 1
@@ -946,6 +991,11 @@ cmd_write() {
   mcls="$(marker_class "$mpath")"
   if [ "$mcls" != absent ]; then
     [ "$mcls" != not-regular ] || refuse ERROR 1 "$(sane "$mpath") exists but is not a readable regular file — nothing was decided"
+    # THE ONE PLACE WHERE A PERMISSIVE MISCLASSIFICATION DESTROYS DATA (roborev job 30 G1):
+    # below, `legacy` DISCARDS and REPLACES the file. An unmeasurable classification must
+    # therefore never arrive here as `legacy` (it no longer can) and must never be treated as
+    # one — it could be a LIVE PEER's stamped marker whose sentinels simply could not be read.
+    [ "$mcls" != error ] || refuse ERROR 1 "$(sane "$mpath") exists but could NOT BE CLASSIFIED: reading its first line, or scanning it for column-zero stamp sentinels, FAILED. Refusing rather than taking the UNSTAMPED migration path, which DISCARDS and REPLACES the file: an unmeasurable classification may be a LIVE PEER's stamped marker. NOTHING was written."
     # ONLY the `legacy` class migrates. A `displaced` sentinel means the file DOES assert an
     # identity (see marker_class), so it goes down the ownership path, where read_marker
     # refuses it MALFORMED — never discarded as though it asserted nothing.

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -104,7 +104,10 @@
 #       else rests on.
 #   (c) The verdict appears ONLY on a `DRIVE-STATE: verdict ` line and is a single token
 #       from the CLOSED set below; prose goes on `verdict-detail` lines. An unrecognised
-#       token is not a thing this script can print — the set is the grammar.
+#       token is not a thing this script can print — the set is the grammar. EVERY exit
+#       carries one, INCLUDING a fatal start-up failure: callers branch on the TOKEN, so a
+#       prefixed line with no token is unreadable by every one of them and its `case` falls
+#       through — (a) does not imply (c), and only (c) is what a consumer reads.
 #
 # VERDICT TOKENS (closed set)
 #   OWNED               this lane, this issue, this session — proceed
@@ -291,10 +294,14 @@ register_tmp() { TMP_FILES+=("$1"); }
 # The shared three-valued process-liveness primitives (#3822). A MISSING library is fatal
 # and NAMED — never a silent continue with the predicates undefined, which would make
 # every liveness answer an empty string and (worse) could read as "gone".
-[ -r "$SCRIPT_HOME/lib/process-liveness.sh" ] || {
-  printf '%s ERROR cannot read %s/lib/process-liveness.sh (the shared process-liveness primitives) — NOTHING was measured\n' "$P" "$SCRIPT_HOME" >&2
-  exit 1
-}
+# ANCHORED IS NOT THE SAME AS VERDICT-BEARING (roborev job 26 F1). This guard used to
+# printf its own prefixed line and exit 1: contract (a) was satisfied and contract (c) was
+# NOT, so the ONE line every caller branches on — the closed-set token on the `verdict `
+# line — was absent, and a `case` on that token (which drive-issue.md's Delta 4 mandates)
+# fell through every arm on a FATAL failure. `refuse` is defined above precisely so that
+# every exit of this script carries a token; there is no exception for a fatal one.
+[ -r "$SCRIPT_HOME/lib/process-liveness.sh" ] || \
+  refuse ERROR 1 "cannot read $(sane "$SCRIPT_HOME/lib/process-liveness.sh") (the shared process-liveness primitives) — NOTHING was measured"
 # shellcheck source=lib/process-liveness.sh
 . "$SCRIPT_HOME/lib/process-liveness.sh"
 

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -218,7 +218,13 @@
 #             machine B. The refusal is at the USE SITE, never in the sanitizer: the shared
 #             placeholder is claim.sh's behaviour and stays pinned. Where no marker exists
 #             nothing is compared, so `verify`/`adopt` still report ABSENT.
-#   worktree  `pwd -P` — the physical directory holding the marker.
+#   worktree  `pwd -P` — the physical directory holding the marker. IT MUST BE MEASURABLE:
+#             a failed `pwd -P` (a deleted or unreadable lane directory) is `verdict ERROR`,
+#             exit 1, naming `axis=worktree`, on write/verify/adopt AND on `show` — the marker
+#             PATH is derived from this axis, so an unmeasurable one would read or write at the
+#             filesystem root. Unlike the machine axis it cannot ALIAS (an empty value equals no
+#             recorded absolute path), so what this closes is a misattributed diagnostic and a
+#             wrong path, not a false OWNED.
 #   session   CLAUDE_CODE_SESSION_ID, sanitized. `unrecorded` when unset, which makes the
 #             session axis UNMEASURED and routes to the liveness resolution.
 #   actor     --actor, else CLAIM_ACTOR, else `flow` — as claim.sh resolves it. NOTE: the
@@ -528,6 +534,41 @@ resolve_machine_axis() {
 
 this_machine() { resolve_machine_axis; printf '%s\n' "$MACHINE_AXIS_VALUE"; }
 
+# THE WORKTREE AXIS, THE SAME SHAPE, FOUND BY SWEEPING THE CLASS (roborev job 34 H1's class).
+# H1 is one instance of "a required identity axis silently degrades"; this is the other axis on
+# which the degradation is REACHABLE. `pwd -P` FAILS when the lane's working directory has been
+# deleted or become unreadable, and three things followed: bash's own UNPREFIXED
+# `pwd: error retrieving current directory` line broke contract (a); the assignment's non-zero
+# status killed the shell under `set -e`, so the run ended on the EXIT-trap's GENERIC ERROR with
+# no axis named; and `marker_path` composed `"/$MARKER_NAME"` — a read (and a would-be write) at
+# the FILESYSTEM ROOT, i.e. a marker belonging to nobody being read as this lane's.
+# Unlike the machine axis this one cannot ALIAS (an empty value can never equal a recorded
+# absolute path, and the writer already refuses a non-absolute worktree), so the defect is a
+# misattributed diagnostic and a wrong path — not a false OWNED. It is fixed the same way: one
+# resolution, its measurability carried, and a refusal that NAMES THE AXIS at the use site.
+WORKTREE_AXIS_VALUE=''
+WORKTREE_AXIS_STATE=''   # ok | unmeasured
+resolve_worktree_axis() {
+  [ -z "$WORKTREE_AXIS_STATE" ] || return 0
+  local wd
+  # `|| true` for the same reason as the machine axis's, and `2>/dev/null` because a failing
+  # `pwd` prints its own unprefixed diagnostic (contract (a)).
+  wd="$(pwd -P 2>/dev/null || true)"
+  WORKTREE_AXIS_VALUE="$wd"
+  case "$wd" in
+    /*) WORKTREE_AXIS_STATE=ok ;;
+    *)  WORKTREE_AXIS_STATE=unmeasured ;;
+  esac
+}
+
+this_worktree() { resolve_worktree_axis; printf '%s\n' "$WORKTREE_AXIS_VALUE"; }
+
+# require_worktree_axis — main shell only, same posture as require_machine_axis.
+require_worktree_axis() {
+  resolve_worktree_axis
+  [ "$WORKTREE_AXIS_STATE" = ok ] || refuse ERROR 1 "axis=worktree could NOT BE MEASURED: \`pwd -P\` named no absolute directory (the lane's working directory has probably been deleted or become unreadable). The marker PATH is derived from this axis, so continuing would read or write a marker at the filesystem root that belongs to nobody — nothing was read, nothing was written and nothing was decided. cd into the lane's worktree and re-run."
+}
+
 # require_machine_axis — refuse unless this box's own machine identity was MEASURED.
 # Called from the main shell ONLY (never inside `$( )`, where the refusal would exit the
 # subshell and its verdict line would be captured into a variable — the defect case 17 pins),
@@ -597,7 +638,7 @@ MARKER_LOCK_FD=9
 
 lock_marker() {
   local wt lock
-  wt="$(pwd -P)"
+  wt="$(this_worktree)"
   lock="$(marker_path).lock"
   # Probed BEFORE `exec`, because a redirection failure on a bare `exec` terminates a
   # non-interactive shell with bash's own unprefixed diagnostic — which would break the
@@ -629,7 +670,7 @@ S_request=''; S_pr=''; S_branch=''
 # to be able to carry them forward, and carrying forward what is never read is impossible.
 S_prior_session=''; S_prior_pid=''; S_prior_ts=''; S_adopt_reason=''
 
-marker_path() { printf '%s/%s\n' "$(pwd -P)" "$MARKER_NAME"; }
+marker_path() { printf '%s/%s\n' "$(this_worktree)" "$MARKER_NAME"; }
 
 # count_sentinel <path> <sentinel> — column-zero, WHOLE-LINE occurrences on stdout, or a
 # NON-ZERO return when the scan itself could not be performed. `grep -Fx` is what makes this a
@@ -703,7 +744,7 @@ marker_class() {
 read_marker() {
   local path cls; path="$(marker_path)"
   cls="$(marker_class "$path")"
-  [ "$cls" != absent ] || refuse ABSENT 3 "no $MARKER_NAME in $(sane "$(pwd -P)") — nothing to resume; this is a legitimate FRESH START, not a refusal"
+  [ "$cls" != absent ] || refuse ABSENT 3 "no $MARKER_NAME in $(sane "$(this_worktree)") — nothing to resume; this is a legitimate FRESH START, not a refusal"
   [ "$cls" != not-regular ] || refuse ERROR 1 "$(sane "$path") exists but is not a readable regular file — nothing was decided"
   [ "$cls" != error ] || refuse ERROR 1 "$(sane "$path") exists but could NOT BE CLASSIFIED: reading its first line, or scanning it for column-zero stamp sentinels, FAILED. An unperformed scan is not an absence of sentinels, so nothing is inferred from it — NOTHING was decided and NOTHING was replaced."
   if [ "$cls" = displaced ]; then
@@ -949,6 +990,7 @@ check_ownership() {
   # the placeholder on both sides the axis comparison SUCCEEDS, so an unmeasurable box would own
   # every marker recorded by another unmeasurable box. Refused before any comparison.
   require_machine_axis
+  require_worktree_axis
   machine="$(this_machine)"; session="$(this_session)"
 
   read_marker
@@ -957,7 +999,7 @@ check_ownership() {
   # SESSION axis only.
   [ "$S_issue" = "$issue" ] || refuse FOREIGN-ISSUE 4 "axis=issue recorded=$(sane "$S_issue") current=$(sane "$issue") — $(sane "$(marker_path)") is the durable state of a DIFFERENT issue; this lane is being reused. Move or remove it deliberately; it is never adopted for issue $(sane "$issue")."
   [ "$S_machine" = "$machine" ] || refuse FOREIGN-MACHINE 4 "axis=machine recorded=$(sane "$S_machine") current=$(sane "$machine") — this marker was stamped on another box (a copied tree, or a marker that travelled with a branch). Machine identity is not transferable, so it is refused rather than adopted."
-  [ "$S_worktree" = "$(pwd -P)" ] || refuse FOREIGN-WORKTREE 4 "axis=worktree recorded=$(sane "$S_worktree") current=$(sane "$(pwd -P)") — this marker was stamped for a different worktree and has been COPIED here; a peer lane's plan is not this lane's."
+  [ "$S_worktree" = "$(this_worktree)" ] || refuse FOREIGN-WORKTREE 4 "axis=worktree recorded=$(sane "$S_worktree") current=$(sane "$(this_worktree)") — this marker was stamped for a different worktree and has been COPIED here; a peer lane's plan is not this lane's."
 
   # SESSION AXIS. Equal AND recordable => OWNED. Anything else is liveness-resolved.
   if [ "$S_session" = "$session" ] && [ "$session" != unrecorded ]; then
@@ -1095,7 +1137,7 @@ write_marker() {
   fi
   local issue="$1" actor="$2" bodyfile="$3"; shift 3
   local wt path tmp ts session pid win lo hi
-  wt="$(pwd -P)"
+  wt="$(this_worktree)"
   path="$(marker_path)"
 
   # The worktree path is recorded VERBATIM (a path must compare EXACTLY; sanitizing would
@@ -1244,6 +1286,7 @@ cmd_write() {
   # check_ownership, so this is the site that stops an unmeasurable machine axis being
   # COMMITTED as the 'unspecified' placeholder (roborev job 34 H1).
   require_machine_axis
+  require_worktree_axis
 
   local body_src=''
   if [ -n "$bodyfile" ]; then
@@ -1349,7 +1392,7 @@ cmd_write() {
   [ -z "$carried" ] || rm -f "$carried" 2>/dev/null || true
   verdict WRITTEN
   [ -z "$discarded" ] || detail "$discarded"
-  detail "issue=$(sane "$issue") machine=$(sane "$(this_machine)") worktree=$(sane "$(pwd -P)") session=$(sane "$(this_session)") session-pid=$(sane "$(this_session_pid)") actor=$(sane "$actor") -> $(sane "$WROTE_PATH")"
+  detail "issue=$(sane "$issue") machine=$(sane "$(this_machine)") worktree=$(sane "$(this_worktree)") session=$(sane "$(this_session)") session-pid=$(sane "$(this_session_pid)") actor=$(sane "$actor") -> $(sane "$WROTE_PATH")"
   settle_pending_signal
 }
 
@@ -1483,6 +1526,10 @@ cmd_show() {
   local issue="${1:-}"
   [ "$#" -eq 0 ] || shift
   require_numeric_issue "$issue" show
+  # `show` asserts nothing about OWNERSHIP, so it needs no machine axis — but it DERIVES THE
+  # MARKER PATH from the worktree axis, and an unmeasurable one would make it print a marker
+  # from the filesystem root as though it were this lane's.
+  require_worktree_axis
   read_marker
   emit "field issue=$(sane "$S_issue")"
   emit "field machine=$(sane "$S_machine")"

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -175,6 +175,14 @@
 #              `--clear stage|request-id|pr|branch` (repeatable). Omitting a flag never
 #              erases durable state — dropping the open request id would make the next
 #              session re-ask, breaking "one marker, one wait".
+#              UNRECOGNISED PROLOGUE KEYS ARE PRESERVED VERBATIM, in order, across every
+#              rewrite (`write` and `adopt` alike). The parser accepts a key it does not know
+#              FOR FORWARD COMPATIBILITY, and an acceptance whose rewrite path silently DROPPED
+#              the field made an OLDER copy of this script DELETE a field a NEWER one had
+#              introduced — the same durable-state erasure as a dropped `request-id`. Preserving
+#              is chosen over REFUSING to mutate such a marker because refusal would make a
+#              newer marker unusable by an older script, bricking every touched lane on a fleet
+#              mid-rollout. They are written back byte-for-byte and are never re-sanitized.
 #              THE ADOPTION PROVENANCE IS DURABLE STATE TOO and is preserved the same way:
 #              `prior-session`, `prior-session-pid`, `prior-ts`, `adopt-reason`. There is no
 #              flag and no `--clear` for those four — only a LATER `adopt` replaces them (the
@@ -203,8 +211,9 @@
 #              still carrying an UNSUBSTITUTED `<…>` is a USAGE error (64), never a silent
 #              `reason=unspecified` — same gate, and same reasons, as claim.sh's.
 #   show   <N> print the recorded stamp fields, INCLUDING the adoption provenance when the
-#              marker carries it (`show` is the contract's window onto the marker, so it
-#              prints every field the reader parses). No ownership verdict.
+#              marker carries it, and any UNRECOGNISED keys this version preserves (on
+#              `field unrecognised <key>=<value>` lines) — `show` is the contract's window onto
+#              the marker, so it prints every field the reader parses. No ownership verdict.
 #   --help     this contract (authoritative)
 #
 # IDENTITY
@@ -807,6 +816,10 @@ S_request=''; S_pr=''; S_branch=''
 # durable state — the audit record of how this lane changed hands — so an ordinary `write` has
 # to be able to carry them forward, and carrying forward what is never read is impossible.
 S_prior_session=''; S_prior_pid=''; S_prior_ts=''; S_adopt_reason=''
+# UNRECOGNISED PROLOGUE KEYS, RETAINED VERBATIM (roborev job 37 J3). See the parser's `*)` arm
+# for the ruling; they are carried across `write` and `adopt` as raw `key: value` LINES, in the
+# order read, joined by newlines. Empty when the marker carries none.
+S_unknown=''
 
 marker_path() { printf '%s/%s\n' "$(this_worktree)" "$MARKER_NAME"; }
 
@@ -935,8 +948,26 @@ read_marker() {
       prior-session-pid)          dup="$S_prior_pid";      S_prior_pid="$val" ;;
       prior-ts)                   dup="$S_prior_ts";       S_prior_ts="$val" ;;
       adopt-reason)               dup="$S_adopt_reason";   S_adopt_reason="$val" ;;
-      *) dup='' ;;   # forward compatibility: an unrecognised KEY is ignored, but its
-                     # SHAPE was still enforced above, so it can never smuggle in a line.
+      # AN UNRECOGNISED KEY IS PRESERVED, NOT MERELY TOLERATED (roborev job 37 J3).
+      #
+      # THE CHOICE, AND WHY: accepting an unknown key "for forward compatibility" while the
+      # rewrite path DROPPED it was incoherent — an OLDER copy of this script would silently
+      # DELETE a field a NEWER one introduced, on the first stage update, which is the same
+      # durable-state-erasure defect as job 26 F3's dropped adoption provenance. The two
+      # coherent options were PRESERVE and REFUSE. PRESERVE wins: refusing would make a NEWER
+      # marker unusable by an OLDER script, so a fleet mid-rollout would brick every lane the
+      # new version had touched — strictly worse than the loss it prevents — and preservation is
+      # what the header's durable-field survival rule already promises everywhere else.
+      #
+      # SAFE BY CONSTRUCTION, not by trust: the line was read from the prologue, so it is ONE
+      # line (no newline can hide in it), its KEY passed the [a-z0-9-] gate, its VALUE is
+      # non-empty, and it cannot begin with '<' — so a preserved line can neither pose as a
+      # sentinel nor introduce a second grammar. It is written back BYTE-FOR-BYTE; nothing
+      # re-sanitizes it, because re-sanitizing a value we did not produce is exactly the lossy
+      # normalization J1 closes.
+      *) dup=''
+         if [ -z "$S_unknown" ]; then S_unknown="$line"; else S_unknown="$S_unknown
+$line"; fi ;;
     esac
     # A DUPLICATE identity key would let the PARSER's choice decide identity, which is the
     # forgery shape this whole prologue exists to remove. Refused, not first-wins.
@@ -1464,7 +1495,7 @@ cmd_write() {
   [ "$#" -eq 0 ] || shift
   require_numeric_issue "$issue" write
   local stage='' request='' pr='' branch='' bodyfile='' actor_raw='' clears=''
-  local prior_session='' prior_pid='' prior_ts='' adopt_reason=''
+  local prior_session='' prior_pid='' prior_ts='' adopt_reason='' unknown=''
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --stage)      [ "$#" -ge 2 ] || die_usage "--stage needs a value";      stage="$2";      shift 2 ;;
@@ -1575,6 +1606,9 @@ cmd_write() {
       # nothing invents them where no adoption happened.
       prior_session="$S_prior_session"; prior_pid="$S_prior_pid"
       prior_ts="$S_prior_ts";           adopt_reason="$S_adopt_reason"
+      # AND THE UNRECOGNISED KEYS (roborev job 37 J3) — see the parser's `*)` arm. Only on the
+      # OWNED path: the UNSTAMPED migration DISCARDS the file, so it has nothing to carry.
+      unknown="$S_unknown"
       if [ -z "$body_src" ]; then
       # Preserve an OWNED marker's body: `write` updates the stamp and the recorded stage,
       # not the author's notes.
@@ -1603,7 +1637,7 @@ cmd_write() {
   [ -z "$adopt_reason" ]  || f_ar="adopt-reason: $(sanitize_field "$adopt_reason")"
   COMMIT_VERDICT=WRITTEN
   if ! write_marker "$issue" "$actor" "$body_src" "$f_stage" "$f_request" "$f_pr" "$f_branch" \
-      "$f_ps" "$f_pp" "$f_pt" "$f_ar"; then
+      "$f_ps" "$f_pp" "$f_pt" "$f_ar" "$unknown"; then
     [ -z "$carried" ] || rm -f "$carried" 2>/dev/null || true
     refuse ERROR 1 "$WRITE_ERR"
   fi
@@ -1692,6 +1726,9 @@ cmd_adopt() {
   # cannot tell which request it awaits and re-asks. Ownership transfers; the state does not
   # evaporate.
   local request="$S_request" pr="$S_pr" branch="$S_branch"
+  # UNRECOGNISED KEYS SURVIVE AN ADOPT TOO (roborev job 37 J3): a hand-over transfers ownership,
+  # it does not discard fields a newer version of this script recorded.
+  local unknown="$S_unknown"
 
   # RE-ENTRANT FOR BOTH OWNERSHIP BASES (roborev job 34 H2). This used to test the SESSION ID
   # alone, which is only ONE of the two ways check_ownership says "already yours" — so the
@@ -1726,7 +1763,7 @@ cmd_adopt() {
       "prior-session: $prior_session" \
       "prior-session-pid: $prior_pid" \
       "prior-ts: $prior_ts" \
-      "adopt-reason: $reason_token"; then
+      "adopt-reason: $reason_token" "$unknown"; then
     rm -f "$carried" 2>/dev/null || true
     refuse ERROR 1 "$WRITE_ERR"
   fi
@@ -1769,6 +1806,18 @@ cmd_show() {
   [ -z "$S_prior_pid" ]     || emit "field prior-session-pid=$(sane "$S_prior_pid")"
   [ -z "$S_prior_ts" ]      || emit "field prior-ts=$(sane "$S_prior_ts")"
   [ -z "$S_adopt_reason" ]  || emit "field adopt-reason=$(sane "$S_adopt_reason")"
+  # AND THE UNRECOGNISED KEYS THIS VERSION PRESERVES (roborev job 37 J3). `show` is the window
+  # onto the marker and these are now RETAINED state, so hiding them would make a field this
+  # script carries forward readable only by opening the file.
+  if [ -n "$S_unknown" ]; then
+    local uline
+    while IFS= read -r uline; do
+      [ -n "$uline" ] || continue
+      emit "field unrecognised ${uline%%: *}=$(sane "${uline#*: }")"
+    done <<EOF
+$S_unknown
+EOF
+  fi
   verdict SHOWN
   detail "fields as recorded for issue $(sane "$issue"); SHOWN asserts NOTHING about ownership — use 'verify' for that"
 }

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -139,10 +139,18 @@
 #              refusal names. MALFORMED / DUPLICATE-SENTINEL get no exception: they CLAIM
 #              an identity that cannot be READ, which may be a live peer's, so a human
 #              moves the file aside deliberately and `write` then takes the ABSENT path.
+#              An OWNED marker's recorded `stage`/`request-id`/`pr`/`branch` are PRESERVED
+#              unless this call overrides them; erasing one is the explicit
+#              `--clear stage|request-id|pr|branch` (repeatable). Omitting a flag never
+#              erases durable state — dropping the open request id would make the next
+#              session re-ask, breaking "one marker, one wait".
 #   verify <N> [--actor <id>]      the rehydrate gate (see the axes above)
 #   adopt  <N> --reason <why> [--actor <id>]
 #              The explicit adopt gesture. Resolves the SESSION axis ONLY: a fail-closed
 #              axis mismatch still refuses, and so does a live or unmeasurable writer.
+#              The body and the durable fields (stage/request-id/pr/branch) SURVIVE: this is
+#              THE normal cron-resume path, so dropping them would destroy the open
+#              coordination request on every legitimate resume.
 #              --reason is REQUIRED and RECORDED. An empty/whitespace reason, one with
 #              nothing recordable in it, a bare PLACEHOLDER (`why`, `todo`, `tbd`, …) or one
 #              still carrying an UNSUBSTITUTED `<…>` is a USAGE error (64), never a silent
@@ -188,7 +196,9 @@
 #
 # CONSTRAINTS
 #   macOS bash 3.2 compatible (no associative arrays, no readarray/mapfile). No network, no
-#   gh, no git. `set -euo pipefail`, shellcheck-clean.
+#   gh, no git. `set -euo pipefail`, shellcheck-clean. The MUTATING subcommands additionally
+#   require `flock` (util-linux): they refuse without it rather than mutate unserialized, so
+#   on a host without flock `write`/`adopt` are unavailable while `verify`/`show` still work.
 #
 # ---END-HELP---
 set -euo pipefail
@@ -201,6 +211,12 @@ P='DRIVE-STATE:'
 MARKER_NAME='.drive-issue-state.md'
 STAMP_BEGIN='<!-- drive-issue-state:stamp:v1 -->'
 STAMP_END='<!-- drive-issue-state:stamp:end -->'
+
+# How long a mutating subcommand waits for the marker lock. HARD-CODED, no env override
+# (the constrained party must not choose its own enforcer); a test that needs a different
+# value SUBSTITUTES THE ARTIFACT — it rewrites this line in its own scratch copy of the
+# script — which is the repo's rule for exactly this situation.
+MARKER_LOCK_WAIT_SECS=30
 
 # Rounding tolerance when intersecting the recorded start window with the live one. Both
 # come from the SAME host and the SAME clock (`now - elapsed`, bracketed), so the only
@@ -247,20 +263,30 @@ print_help() {
 # `.drive-issue-state.md.XXXXXX` in the lane, which is exactly the kind of unexplained file
 # a later session reads as state. The handlers cover signals too: bash runs no EXIT trap
 # for a signal with its default disposition.
-TMP_FILES=''
+# An INDEXED ARRAY, not a space-separated string: `for f in $TMP_FILES` word-SPLITS and
+# GLOBS, so a path containing whitespace or a metacharacter would expand into several words
+# — and these words are fed to `rm -f`. `TMPDIR` is caller-influenced and shared on this
+# fleet, and this very script refuses a newline-bearing worktree path precisely because
+# paths here are not tame, so the one destructive command in the file must not depend on the
+# shape of a path. (Indexed arrays are bash 3.2; only ASSOCIATIVE arrays need 4.0.)
+TMP_FILES=()
 cleanup_tmp() {
   local f
-  for f in $TMP_FILES; do [ -z "$f" ] || rm -f "$f"; done
-  TMP_FILES=''
+  # `${#arr[@]}` is safe under `set -u` for an EMPTY array, whereas `"${arr[@]}"` is not on
+  # bash 3.2/4.3 — hence the count guard rather than an unguarded expansion.
+  if [ "${#TMP_FILES[@]}" -gt 0 ]; then
+    for f in "${TMP_FILES[@]}"; do [ -z "$f" ] || rm -f "$f"; done
+  fi
+  TMP_FILES=()
 }
 trap cleanup_tmp EXIT
 trap 'cleanup_tmp; exit 130' INT
 trap 'cleanup_tmp; exit 143' TERM
 trap 'cleanup_tmp; exit 129' HUP
 
-# register_tmp <path> — remember a temp file for cleanup. Paths here are always mktemp
-# output (no spaces, no newlines), so a space-separated list is safe.
-register_tmp() { TMP_FILES="$TMP_FILES $1"; }
+# register_tmp <path> — remember a temp file for cleanup. Stored as an array ELEMENT, so no
+# assumption is made about the path's shape (see TMP_FILES above).
+register_tmp() { TMP_FILES+=("$1"); }
 
 # The shared three-valued process-liveness primitives (#3822). A MISSING library is fatal
 # and NAMED — never a silent continue with the predicates undefined, which would make
@@ -328,11 +354,43 @@ require_numeric_issue() {
 }
 
 # ---------------------------------------------------------------------------
+# Serialization. A verify-then-replace sequence that is not atomic is a guard with a hole:
+# two sessions in ONE lane — the exact scenario this file exists for — can BOTH pass
+# ownership verification and the second can clobber the first's stamp. The ownership check
+# is sound; it just has to be indivisible from the replacement. So every MUTATING subcommand
+# holds an exclusive `flock` on a sidecar lockfile across existence-probe -> ownership-verify
+# -> body-capture -> replace, and `mv` remains the atomic commit INSIDE it.
+#
+# READERS (`verify`, `show`) deliberately take no lock: the commit is a rename, so a reader
+# sees either the whole old file or the whole new one, never a torn one.
+#
+# NO flock => REFUSE. An unserialized mutation is an UNMEASURABLE guarantee, and the rule
+# throughout this script is that an unknown is never read as satisfied. Consequence, stated
+# rather than discovered: this makes the mutating half LINUX/util-linux-only (macOS ships no
+# flock). The fleet is Linux; a host without flock gets a named refusal, not a silent race.
+# ---------------------------------------------------------------------------
+MARKER_LOCK_FD=9
+
+lock_marker() {
+  local wt lock
+  wt="$(pwd -P)"
+  lock="$(marker_path).lock"
+  # Probed BEFORE `exec`, because a redirection failure on a bare `exec` terminates a
+  # non-interactive shell with bash's own unprefixed diagnostic — which would break the
+  # output anchor every consumer rests on, and emit no verdict at all.
+  [ -w "$wt" ] || refuse ERROR 1 "the worktree directory $(sane "$wt") is not writable, so the marker lock cannot be taken — nothing was decided and nothing was written"
+  command -v flock >/dev/null 2>&1 || refuse ERROR 1 "flock is not available on this host, so the ownership-verify -> replace sequence cannot be SERIALIZED. Refusing rather than mutating unserialized: two sessions in one lane could both pass verification and one clobber the other's stamp, which is the defect this marker exists to prevent. An unmeasurable guarantee is never read as satisfied."
+  : >>"$lock" 2>/dev/null || refuse ERROR 1 "cannot create the marker lock file $(sane "$lock") — nothing was decided"
+  eval "exec ${MARKER_LOCK_FD}>>\"\$lock\""
+  flock -w "$MARKER_LOCK_WAIT_SECS" "$MARKER_LOCK_FD" || refuse ERROR 1 "another process holds the marker lock $(sane "$lock") (waited ${MARKER_LOCK_WAIT_SECS}s) — refusing rather than racing it; nothing was decided"
+}
+
+# ---------------------------------------------------------------------------
 # Marker reading. Sets S_* globals. Refuses (and exits) on any structural fault.
 # ---------------------------------------------------------------------------
 S_issue=''; S_machine=''; S_worktree=''; S_session=''; S_pid=''
 S_start_lo=''; S_start_hi=''; S_actor=''; S_ts=''; S_stage=''
-S_prior_session=''
+S_request=''; S_pr=''; S_branch=''; S_prior_session=''
 
 marker_path() { printf '%s/%s\n' "$(pwd -P)" "$MARKER_NAME"; }
 
@@ -395,6 +453,9 @@ read_marker() {
       actor)                      dup="$S_actor";          S_actor="$val" ;;
       ts)                         dup="$S_ts";             S_ts="$val" ;;
       stage)                      dup="$S_stage";          S_stage="$val" ;;
+      request-id)                 dup="$S_request";        S_request="$val" ;;
+      pr)                         dup="$S_pr";             S_pr="$val" ;;
+      branch)                     dup="$S_branch";         S_branch="$val" ;;
       prior-session)              dup="$S_prior_session";  S_prior_session="$val" ;;
       *) dup='' ;;   # forward compatibility: an unrecognised KEY is ignored, but its
                      # SHAPE was still enforced above, so it can never smuggle in a line.
@@ -623,7 +684,7 @@ write_marker() {
 cmd_write() {
   local issue="${1:-}"; shift || true
   require_numeric_issue "$issue" write
-  local stage='' request='' pr='' branch='' bodyfile='' actor_raw=''
+  local stage='' request='' pr='' branch='' bodyfile='' actor_raw='' clears=''
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --stage)      stage="${2:-}";      shift 2 || die_usage "--stage needs a value" ;;
@@ -632,9 +693,16 @@ cmd_write() {
       --branch)     branch="${2:-}";     shift 2 || die_usage "--branch needs a value" ;;
       --body-file)  bodyfile="${2:-}";   shift 2 || die_usage "--body-file needs a value" ;;
       --actor)      actor_raw="${2:-}";  shift 2 || die_usage "--actor needs a value" ;;
+      --clear)
+        case "${2:-}" in
+          stage | request-id | pr | branch) clears="$clears ${2}" ;;
+          *) die_usage "--clear takes one of stage|request-id|pr|branch (got '$(sane "${2:-<none>}")') — the field set is CLOSED so a typo erases nothing silently" ;;
+        esac
+        shift 2 || die_usage "--clear needs a field name" ;;
       *) die_usage "write: unknown option '$(sane "$1")'" ;;
     esac
   done
+  cleared() { case " $clears " in *" $1 "*) return 0 ;; esac; return 1; }
   local actor; actor="$(resolve_actor "$actor_raw")"
 
   local body_src=''
@@ -658,6 +726,9 @@ cmd_write() {
   # notes is unacceptable even where refusing is worse. A MALFORMED or DUPLICATE-SENTINEL
   # marker gets NO such exception: it CLAIMS an identity that merely cannot be read, and an
   # unreadable identity may be a live peer's, so it is moved aside by a human deliberately.
+  # From here to the `mv` is ONE critical section (see Serialization above).
+  lock_marker
+
   local carried='' discarded=''
   if [ -e "$(marker_path)" ]; then
     local mpath; mpath="$(marker_path)"
@@ -671,6 +742,17 @@ cmd_write() {
       # branch below is UNREACHABLE from here, which is the point.
     else
       check_ownership "$issue" strict
+      # PRESERVE THE RECORDED DURABLE FIELDS unless this call overrides or --clear's them.
+      # drive-issue.md's Delta 3 names "stage reached, open request ID, PR/branch" as the
+      # durable state, so a `write --stage x` that silently dropped the OPEN REQUEST ID
+      # would leave the next session unable to tell which request it is waiting on — it
+      # would re-ask, breaking "one marker, one wait", the rule the whole cron design rests
+      # on. Erasing a field is therefore an EXPLICIT gesture (`--clear <field>`), never a
+      # side effect of omitting a flag.
+      [ -n "$stage" ]   || cleared stage      || stage="$S_stage"
+      [ -n "$request" ] || cleared request-id || request="$S_request"
+      [ -n "$pr" ]      || cleared pr         || pr="$S_pr"
+      [ -n "$branch" ]  || cleared branch     || branch="$S_branch"
       if [ -z "$body_src" ]; then
       # Preserve an OWNED marker's body: `write` updates the stamp and the recorded stage,
       # not the author's notes.
@@ -754,8 +836,15 @@ cmd_adopt() {
   reason_token="$(assert_reason "$reason")"
   actor="$(resolve_actor "$actor_raw")"
 
+  lock_marker
   check_ownership "$issue" adopt
   local prior_session="$S_session" prior_pid="$S_pid" prior_ts="$S_ts" stage="$S_stage"
+  # THE DURABLE FIELDS SURVIVE AN ADOPT. `adopt` is THE normal cron-resume path (a new
+  # session id in the same lane), so dropping `request-id`/`pr`/`branch` here destroyed the
+  # open coordination request on EVERY legitimate resume — after which the resuming session
+  # cannot tell which request it awaits and re-asks. Ownership transfers; the state does not
+  # evaporate.
+  local request="$S_request" pr="$S_pr" branch="$S_branch"
 
   if [ "$prior_session" = "$(this_session)" ] && [ "$prior_session" != unrecorded ]; then
     verdict ADOPTED
@@ -769,7 +858,11 @@ cmd_adopt() {
   marker_body >"$carried"
   assert_body_safe "$carried"
   [ -z "$stage" ] || f_stage="stage: $stage"
-  if ! write_marker "$issue" "$actor" "$carried" "$f_stage" \
+  local f_request='' f_pr='' f_branch=''
+  [ -z "$request" ] || f_request="request-id: $request"
+  [ -z "$pr" ]      || f_pr="pr: $pr"
+  [ -z "$branch" ]  || f_branch="branch: $branch"
+  if ! write_marker "$issue" "$actor" "$carried" "$f_stage" "$f_request" "$f_pr" "$f_branch" \
       "prior-session: $prior_session" \
       "prior-session-pid: $prior_pid" \
       "prior-ts: $prior_ts" \
@@ -795,6 +888,9 @@ cmd_show() {
   emit "field actor=$(sane "$S_actor")"
   emit "field ts=$(sane "$S_ts")"
   emit "field stage=$(sane "${S_stage:-none}")"
+  emit "field request-id=$(sane "${S_request:-none}")"
+  emit "field pr=$(sane "${S_pr:-none}")"
+  emit "field branch=$(sane "${S_branch:-none}")"
   [ -z "$S_prior_session" ] || emit "field prior-session=$(sane "$S_prior_session")"
   verdict SHOWN
   detail "fields as recorded for issue $(sane "$issue"); SHOWN asserts NOTHING about ownership — use 'verify' for that"

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -513,6 +513,13 @@ assert_body_safe() {
 }
 
 # write_marker <issue> <actor> <body-file|''> [<extra key: value lines>...]
+#
+# Reports through GLOBALS (WROTE_PATH on success, WRITE_ERR + return 1 on failure) rather
+# than through stdout, and is therefore NEVER called inside a command substitution. A
+# `refuse` inside `$( )` exits only the SUBSHELL and its verdict line is CAPTURED by the
+# caller's variable — so the run would end up with no verdict on stdout and a verdict
+# string inside a path. Every emit site in this script is in the main shell for that reason.
+WROTE_PATH=''; WRITE_ERR=''
 write_marker() {
   local issue="$1" actor="$2" bodyfile="$3"; shift 3
   local wt path tmp ts session pid win lo hi
@@ -524,9 +531,9 @@ write_marker() {
   # carrying a CONTROL character cannot be recorded losslessly on one line, so it is
   # refused rather than recorded wrongly.
   case "$wt" in
-    *[[:cntrl:]]*) refuse ERROR 1 "the worktree path contains a control character, so it cannot be recorded on one line as the worktree axis — refusing to write a stamp whose identity would be lossy" ;;
+    *[[:cntrl:]]*) WRITE_ERR="the worktree path contains a control character, so it cannot be recorded on one line as the worktree axis — refusing to write a stamp whose identity would be lossy"; return 1 ;;
     /*) : ;;
-    *)  refuse ERROR 1 "the worktree path '$(sane "$wt")' is not absolute — refusing to write a stamp whose worktree axis cannot be compared" ;;
+    *)  WRITE_ERR="the worktree path '$(sane "$wt")' is not absolute — refusing to write a stamp whose worktree axis cannot be compared"; return 1 ;;
   esac
 
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -538,7 +545,8 @@ write_marker() {
     if [ -n "$win" ]; then lo="${win%% *}"; hi="${win##* }"; fi
   fi
 
-  tmp="$(mktemp "$path.XXXXXX")" || refuse ERROR 1 "cannot create a temporary file next to $(sane "$path") — nothing was written"
+  tmp="$(mktemp "$path.XXXXXX")" || {
+    WRITE_ERR="cannot create a temporary file next to $(sane "$path") — nothing was written"; return 1; }
   {
     printf '%s\n' "$STAMP_BEGIN"
     printf 'issue: %s\n' "$issue"
@@ -555,9 +563,10 @@ write_marker() {
     printf '%s\n' "$STAMP_END"
     printf '\n'
     if [ -n "$bodyfile" ] && [ -s "$bodyfile" ]; then cat "$bodyfile"; fi
-  } >"$tmp" || { rm -f "$tmp"; refuse ERROR 1 "failed writing $(sane "$tmp") — nothing was replaced"; }
-  mv -f "$tmp" "$path" || { rm -f "$tmp"; refuse ERROR 1 "failed replacing $(sane "$path")"; }
-  printf '%s\n' "$path"
+  } >"$tmp" || { rm -f "$tmp"; WRITE_ERR="failed writing the stamp to $(sane "$tmp") — nothing was replaced"; return 1; }
+  mv -f "$tmp" "$path" || { rm -f "$tmp"; WRITE_ERR="failed replacing $(sane "$path")"; return 1; }
+  WROTE_PATH="$path"
+  return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -602,16 +611,21 @@ cmd_write() {
     fi
   fi
 
-  local extras='' path
-  path="$(write_marker "$issue" "$actor" "$body_src" \
-      "$( [ -n "$stage" ]   && printf 'stage: %s' "$(sanitize_field "$stage")" )" \
-      "$( [ -n "$request" ] && printf 'request-id: %s' "$(sanitize_field "$request")" )" \
-      "$( [ -n "$pr" ]      && printf 'pr: %s' "$(sanitize_field "$pr")" )" \
-      "$( [ -n "$branch" ]  && printf 'branch: %s' "$(sanitize_field "$branch")" )")"
+  # Optional fields are built into a positional list first: an empty one contributes
+  # NOTHING (write_marker skips empty extras), so an omitted --stage leaves no `stage:`
+  # line rather than an empty-valued one the reader would refuse as MALFORMED.
+  local f_stage='' f_request='' f_pr='' f_branch=''
+  [ -z "$stage" ]   || f_stage="stage: $(sanitize_field "$stage")"
+  [ -z "$request" ] || f_request="request-id: $(sanitize_field "$request")"
+  [ -z "$pr" ]      || f_pr="pr: $(sanitize_field "$pr")"
+  [ -z "$branch" ]  || f_branch="branch: $(sanitize_field "$branch")"
+  if ! write_marker "$issue" "$actor" "$body_src" "$f_stage" "$f_request" "$f_pr" "$f_branch"; then
+    [ -z "$carried" ] || rm -f "$carried"
+    refuse ERROR 1 "$WRITE_ERR"
+  fi
   [ -z "$carried" ] || rm -f "$carried"
-  : "$extras"
   verdict WRITTEN
-  detail "issue=$(sane "$issue") machine=$(sane "$(this_machine)") worktree=$(sane "$(pwd -P)") session=$(sane "$(this_session)") session-pid=$(sane "$(this_session_pid)") actor=$(sane "$actor") -> $(sane "$path")"
+  detail "issue=$(sane "$issue") machine=$(sane "$(this_machine)") worktree=$(sane "$(pwd -P)") session=$(sane "$(this_session)") session-pid=$(sane "$(this_session_pid)") actor=$(sane "$actor") -> $(sane "$WROTE_PATH")"
 }
 
 cmd_verify() {
@@ -676,19 +690,22 @@ cmd_adopt() {
     return 0
   fi
 
-  local carried path
+  local carried f_stage=''
   carried="$(mktemp "${TMPDIR:-/tmp}/drive-issue-body.XXXXXX")" || refuse ERROR 1 "cannot create a temporary file for the carried body"
   marker_body >"$carried"
   assert_body_safe "$carried"
-  path="$(write_marker "$issue" "$actor" "$carried" \
-      "$( [ -n "$stage" ] && printf 'stage: %s' "$stage" )" \
+  [ -z "$stage" ] || f_stage="stage: $stage"
+  if ! write_marker "$issue" "$actor" "$carried" "$f_stage" \
       "prior-session: $prior_session" \
       "prior-session-pid: $prior_pid" \
       "prior-ts: $prior_ts" \
-      "adopt-reason: $reason_token")"
+      "adopt-reason: $reason_token"; then
+    rm -f "$carried"
+    refuse ERROR 1 "$WRITE_ERR"
+  fi
   rm -f "$carried"
   verdict ADOPTED
-  detail "issue=$(sane "$issue") prior-session=$(sane "$prior_session") prior-session-pid=$(sane "$prior_pid") new-session=$(sane "$(this_session)") reason=$(sane "$reason_token") -> $(sane "$path"); the recorded writer was provably gone: $LIVE_DETAIL"
+  detail "issue=$(sane "$issue") prior-session=$(sane "$prior_session") prior-session-pid=$(sane "$prior_pid") new-session=$(sane "$(this_session)") reason=$(sane "$reason_token") -> $(sane "$WROTE_PATH"); the recorded writer was provably gone: $LIVE_DETAIL"
 }
 
 cmd_show() {

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -228,6 +228,26 @@ print_help() {
   awk 'NR>=2 && /^# ---END-HELP---/{exit} NR>=2 {sub(/^# ?/,""); print}' "$0"
 }
 
+# TEMP FILES ARE REGISTERED THE MOMENT THEY EXIST, and the trap is installed BEFORE any of
+# them is created — otherwise a refusal between `mktemp` and `mv` leaves a stray
+# `.drive-issue-state.md.XXXXXX` in the lane, which is exactly the kind of unexplained file
+# a later session reads as state. The handlers cover signals too: bash runs no EXIT trap
+# for a signal with its default disposition.
+TMP_FILES=''
+cleanup_tmp() {
+  local f
+  for f in $TMP_FILES; do [ -z "$f" ] || rm -f "$f"; done
+  TMP_FILES=''
+}
+trap cleanup_tmp EXIT
+trap 'cleanup_tmp; exit 130' INT
+trap 'cleanup_tmp; exit 143' TERM
+trap 'cleanup_tmp; exit 129' HUP
+
+# register_tmp <path> — remember a temp file for cleanup. Paths here are always mktemp
+# output (no spaces, no newlines), so a space-separated list is safe.
+register_tmp() { TMP_FILES="$TMP_FILES $1"; }
+
 # The shared three-valued process-liveness primitives (#3822). A MISSING library is fatal
 # and NAMED — never a silent continue with the predicates undefined, which would make
 # every liveness answer an empty string and (worse) could read as "gone".
@@ -547,6 +567,7 @@ write_marker() {
 
   tmp="$(mktemp "$path.XXXXXX")" || {
     WRITE_ERR="cannot create a temporary file next to $(sane "$path") — nothing was written"; return 1; }
+  register_tmp "$tmp"
   {
     printf '%s\n' "$STAMP_BEGIN"
     printf 'issue: %s\n' "$issue"
@@ -605,6 +626,7 @@ cmd_write() {
       # Preserve an OWNED marker's body: `write` updates the stamp and the recorded stage,
       # not the author's notes.
       carried="$(mktemp "${TMPDIR:-/tmp}/drive-issue-body.XXXXXX")" || refuse ERROR 1 "cannot create a temporary file for the carried body"
+      register_tmp "$carried"
       marker_body >"$carried"
       assert_body_safe "$carried"
       body_src="$carried"
@@ -692,6 +714,7 @@ cmd_adopt() {
 
   local carried f_stage=''
   carried="$(mktemp "${TMPDIR:-/tmp}/drive-issue-body.XXXXXX")" || refuse ERROR 1 "cannot create a temporary file for the carried body"
+  register_tmp "$carried"
   marker_body >"$carried"
   assert_body_safe "$carried"
   [ -z "$stage" ] || f_stage="stage: $stage"

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -170,6 +170,11 @@
 #              refusal names. MALFORMED / DUPLICATE-SENTINEL get no exception: they CLAIM
 #              an identity that cannot be READ, which may be a live peer's, so a human
 #              moves the file aside deliberately and `write` then takes the ABSENT path.
+#              NEITHER DOES A SYMLINK AT THE MARKER PATH — dangling or not. It is classified
+#              `not-regular` and refused (`verdict ERROR`), never followed and never replaced:
+#              a link is an artifact someone placed deliberately, and `mv` would silently
+#              destroy it. A DANGLING one used to classify `absent` (`-e` follows the link),
+#              which took the fresh-start path and clobbered it (roborev job 43 K1).
 #              An OWNED marker's recorded `stage`/`request-id`/`pr`/`branch` are PRESERVED
 #              unless this call overrides them; erasing one is the explicit
 #              `--clear stage|request-id|pr|branch` (repeatable). Omitting a flag never
@@ -858,7 +863,10 @@ count_matching_lines() {
   return 0
 }
 
-# marker_class <path> — echo absent | not-regular | stamped | displaced | legacy.
+# marker_class <path> — echo absent | not-regular | stamped | displaced | legacy | error.
+#
+# `not-regular` covers a directory, an unreadable regular file, and ANY SYMLINK (dangling or
+# not) — see the `-L` note in the body.
 #
 # ONE CLASSIFIER FOR EVERY CALLER, AND "LEGACY" REQUIRES THE WHOLE FILE TO BE SENTINEL-FREE.
 # The first cut inferred "carries no ownership stamp" from the FIRST LINE ALONE, and the
@@ -878,7 +886,18 @@ count_matching_lines() {
 #             whose handler DESTROYS the file. Every caller must refuse on it.
 marker_class() {
   local path="$1" nb ne first rc=0
-  [ -e "$path" ] || { printf 'absent\n'; return 0; }
+  # EXISTENCE IS `-e` OR `-L`, AND A SYMLINK IS NEVER A MARKER THIS SCRIPT OWNS (roborev job 43
+  # K1). `-e` FOLLOWS the link, so it is FALSE for a DANGLING symlink — an entry that plainly
+  # EXISTS — and the classifier answered `absent`, which is the ONE class whose handler in
+  # `write` replaces the path without a word. A symlink is a deliberate artifact someone placed,
+  # so it is routed through `not-regular` (the refusal that already exists) whether its target
+  # exists or not: the `-L` test comes FIRST, before `-f`, because `-f` follows the link and a
+  # symlink to a real file would otherwise be indistinguishable from a marker we wrote. That
+  # order is what makes BOTH symlink shapes take one refusal rather than two behaviours. Same
+  # doctrine as count_sentinel's: a `test` file predicate is two-valued, so it collapses "cannot
+  # tell" onto one answer — and unswept it picks the permissive one.
+  if [ ! -e "$path" ] && [ ! -L "$path" ]; then printf 'absent\n'; return 0; fi
+  [ ! -L "$path" ] || { printf 'not-regular\n'; return 0; }
   { [ -f "$path" ] && [ -r "$path" ]; } || { printf 'not-regular\n'; return 0; }
   first="$(head -1 "$path" 2>/dev/null)" || rc=$?
   [ "$rc" -eq 0 ] || { printf 'error\n'; return 0; }
@@ -896,7 +915,7 @@ read_marker() {
   local path cls; path="$(marker_path)"
   cls="$(marker_class "$path")"
   [ "$cls" != absent ] || refuse ABSENT 3 "no $MARKER_NAME in $(sane "$(this_worktree)") — nothing to resume; this is a legitimate FRESH START, not a refusal"
-  [ "$cls" != not-regular ] || refuse ERROR 1 "$(sane "$path") exists but is not a readable regular file — nothing was decided"
+  [ "$cls" != not-regular ] || refuse ERROR 1 "$(sane "$path") exists but is not a readable regular file (a SYMLINK takes this path too, dangling or not: it is an artifact someone placed deliberately, so it is refused rather than followed or replaced) — nothing was decided"
   [ "$cls" != error ] || refuse ERROR 1 "$(sane "$path") exists but could NOT BE CLASSIFIED: reading its first line, or scanning it for column-zero stamp sentinels, FAILED. An unperformed scan is not an absence of sentinels, so nothing is inferred from it — NOTHING was decided and NOTHING was replaced."
   if [ "$cls" = displaced ]; then
     refuse MALFORMED 8 "$(sane "$path") contains a stamp sentinel at column zero but NOT as its first line, so it DOES assert an ownership identity and that identity cannot be READ — it is NOT treated as an unstamped legacy marker and is never replaced for you, because an unreadable identity may be a LIVE PEER's (a single prepended blank line or comment produces this shape). INSPECT it, and if it is genuinely corrupt remove it or move it aside (e.g. 'mv $MARKER_NAME $MARKER_NAME.corrupt'); with no marker present this lane takes the ABSENT fresh-start path and a new stamped marker is written normally."
@@ -1566,7 +1585,7 @@ cmd_write() {
   mpath="$(marker_path)"
   mcls="$(marker_class "$mpath")"
   if [ "$mcls" != absent ]; then
-    [ "$mcls" != not-regular ] || refuse ERROR 1 "$(sane "$mpath") exists but is not a readable regular file — nothing was decided"
+    [ "$mcls" != not-regular ] || refuse ERROR 1 "$(sane "$mpath") exists but is not a readable regular file (a SYMLINK takes this path too, dangling or not: it is an artifact someone placed deliberately, so it is refused rather than followed or replaced) — nothing was written"
     # THE ONE PLACE WHERE A PERMISSIVE MISCLASSIFICATION DESTROYS DATA (roborev job 30 G1):
     # below, `legacy` DISCARDS and REPLACES the file. An unmeasurable classification must
     # therefore never arrive here as `legacy` (it no longer can) and must never be treated as
@@ -1716,6 +1735,19 @@ cmd_adopt() {
   assert_reason "$reason"
   reason_token="$REASON_TOKEN"
   actor="$(resolve_actor "$actor_raw")"
+
+  # THE AXIS GUARDS RUN BEFORE ANYTHING DERIVES A PATH OR TAKES A LOCK (roborev job 43 K2).
+  # `lock_marker` derives its lockfile from `marker_path`, i.e. from the WORKTREE axis, so with
+  # that axis unmeasurable `adopt` used to compose a lock path at the FILESYSTEM ROOT and refuse
+  # with a generic "the worktree directory / is not writable" — while `write` and `show`, which
+  # guard first, refused by name with `axis=worktree`. Same input, two diagnostics depending on
+  # the subcommand, and the axis form is the one .claude/commands/drive-issue.md publishes as the
+  # ERROR arm of the consumer contract. `check_ownership` re-asserts all three (it is verify's and
+  # adopt's one door); these calls are the ones that make the refusal precede the lock, and they
+  # are idempotent — each axis resolves once and caches its state.
+  require_machine_axis
+  require_worktree_axis
+  require_session_axis
 
   lock_marker
   check_ownership "$issue" adopt

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -279,6 +279,10 @@ refuse() {
   exit "$code"
 }
 
+# THE ONE EXTERNAL CALL WHOSE STDERR IS DELIBERATELY *NOT* SUPPRESSED (roborev job 26 F2).
+# `--help` emits no verdict line and no consumer parses it — it is contract (a)'s stated
+# exemption — so there is no anchor to protect here, and a HUMAN who asks for the contract and
+# gets nothing is better served by awk's own diagnostic than by silence.
 print_help() {
   awk 'NR>=2 && /^# ---END-HELP---/{exit} NR>=2 {sub(/^# ?/,""); print}' "$0"
 }

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -1,0 +1,721 @@
+#!/usr/bin/env bash
+#
+# drive-issue-state.sh — the OWNERSHIP-STAMPED reader/writer for a lane's durable
+# `.drive-issue-state.md` marker (issue #3822).
+#
+# WHY THIS EXISTS
+# ---------------
+# `/drive-issue` records durable per-lane state in `.drive-issue-state.md` and
+# REHYDRATES from it on every invocation (its Delta 3 / Delta 4). Until this script
+# existed the marker had no writer and no reader at all: it was prose, produced and
+# consumed by an agent's judgement, and it carried NO ownership stamp. A session
+# rehydrating in a shared or REUSED worktree therefore adopted whatever plan it found
+# — including a PEER session's — because nothing in the file said whose plan it was.
+# An instruction to an LLM cannot be tested; a script can, so the marker is mechanized
+# here and the doctrine calls this script.
+#
+# THE IDENTITY AXES, AND WHY THEY ARE NOT ALL FAIL-CLOSED
+# ------------------------------------------------------
+# Read literally, "verify the stamp against the current machine/session and fail closed
+# on a mismatch" would red EVERY LEGITIMATE RESUME: `/drive-issue`'s Delta 3 cron
+# re-invoke is a NEW session id in the SAME lane on the SAME issue, and that resume is
+# the marker's intended consumer. A guard that reds on correct input is the guard agents
+# learn to waive. So the axes are split by whether they are STABLE across a legitimate
+# resume:
+#
+#   FAIL-CLOSED AXES — issue, machine, worktree.
+#     Stable across a resume and DISTINCT across lanes, so a mismatch on any of them
+#     means this marker is not about this lane's work. Refused, NAMING THE AXIS
+#     (`axis=issue` / `axis=machine` / `axis=worktree`), because the operator's next
+#     action differs per axis: a foreign issue means the lane is being reused for other
+#     work, a foreign machine means the marker travelled with a pushed branch or a
+#     copied tree, a foreign worktree means the file was copied.
+#
+#   SESSION AXIS — recorded (AC1), but NOT fail-closed on its own.
+#     A session difference alone is resolved by the LIVENESS OF THE RECORDED WRITER,
+#     three-valued, on `claim-heartbeat.sh dead-lanes`' precedent:
+#       writer provably GONE  -> ADOPTABLE. `verify` still exits NON-ZERO: adoption is an
+#                                EXPLICIT gesture (`adopt`), never an implicit inheritance,
+#                                and the rewritten stamp records the prior session.
+#       writer provably ALIVE -> LIVE-PEER. A live peer owns this lane. `adopt` REFUSES
+#                                here too: an adopt that ignores liveness is a mute button
+#                                for the whole guard.
+#       liveness UNMEASURABLE -> LIVENESS-UNKNOWN. Refused. Never permissive: a positive
+#                                verdict requires an AFFIRMATIVE MEASUREMENT, and an
+#                                unknown is never read as verified.
+#
+# WHOSE PID, AND WHY AN UNSET CLAUDE_PID IS *UNKNOWN* RATHER THAN *DEAD*
+# ---------------------------------------------------------------------
+# The liveness question is about the SESSION, so the recorded pid must be the session's:
+# `CLAUDE_PID`. When `CLAUDE_PID` is unset the pid is NOT RECORDABLE as a session-liveness
+# token and liveness MUST be UNKNOWN. There is deliberately NO `$$` fallback: `$$` is the
+# transient bash running this script, which exits immediately, so a marker stamped with it
+# would read as DEAD seconds later and make a LIVE PEER adoptable — the exact
+# false-permissive this issue exists to close. The same rule covers the start window: an
+# unmeasured window is UNKNOWN, never alive and never gone.
+#
+# PID REUSE is defeated by recording the pid's START WINDOW alongside it and requiring the
+# live pid's window to still INTERSECT the recorded one. The window is measured by
+# `process_start_window` from the SHARED library `lib/process-liveness.sh` — the same
+# three-valued primitives `claim-heartbeat.sh` uses, sourced rather than reimplemented,
+# because a second implementation of those review rounds is a second place to lose them.
+# It derives the start from ELAPSED time (`ps -o etimes=`), not a wall-clock string, and
+# returns an INTERVAL rather than a point; `/proc/<pid>/stat` field 22 would need a
+# clock-tick + boot-time conversion, i.e. a second implementation of a solved problem.
+#
+# THE STAMP DOES NOT SHARE A TEXT CHANNEL WITH THE BODY
+# ----------------------------------------------------
+# The marker BODY is free-form author/agent prose (stage notes, question text). Identity
+# read out of a shared text channel is forgeable — `claim.sh` records the class where a
+# value carrying `actor=` shifted the recorded actor — and the standing ruling (CLAUDE.md,
+# #3312) is to REMOVE the shared channel, not to pick a rarer delimiter. So:
+#
+#   * The stamp is a STRICTLY BOUNDED PROLOGUE. The file's FIRST line is the exact
+#     `<!-- drive-issue-state:stamp:v1 -->` sentinel; the stamp is the contiguous run of
+#     `key: value` lines at column zero immediately after it; it is terminated by the exact
+#     `<!-- drive-issue-state:stamp:end -->` sentinel. The reader parses ONLY that prologue
+#     and NEVER greps identity out of the body.
+#   * The writer REFUSES a body containing either sentinel as a whole line at column zero —
+#     REFUSED, not escaped. A structural source assert cannot see what a RUNTIME value
+#     injects, so the check belongs on the OUTPUT path.
+#   * At READ time a SECOND column-zero occurrence of either sentinel anywhere in the file
+#     is its OWN named refusal (DUPLICATE-SENTINEL), so a hand-edited file cannot smuggle a
+#     second stamp in behind the first.
+#   * Every stamp value except `worktree` is sanitized to ONE token from a closed charset
+#     that excludes space, newline, '<', '>', '!' and '=' — so no value can create a line,
+#     reproduce a sentinel, or introduce another `key:` pair. `worktree` is recorded
+#     VERBATIM (a path must compare exactly, and sanitizing would alias `/a b` onto `/a-b`),
+#     and a worktree path carrying a CONTROL character is refused at write time rather than
+#     recorded lossily.
+#
+# OUTPUT CONTRACT (mirrors scripts/flow/base-staleness.sh)
+#   (a) EVERY line of a verdict-bearing invocation, stdout AND stderr, begins
+#       `DRIVE-STATE: `. `--help` is the one exemption: it emits no verdict line, so no
+#       consumer parses it.
+#   (b) Every dynamic field is CONTROL-CHARACTER SANITIZED for display. Load-bearing: git
+#       and the filesystem PERMIT NEWLINES IN PATHS, and an unsanitized path printed
+#       verbatim emits a second line carrying no prefix, breaking the anchor everything
+#       else rests on.
+#   (c) The verdict appears ONLY on a `DRIVE-STATE: verdict ` line and is a single token
+#       from the CLOSED set below; prose goes on `verdict-detail` lines. An unrecognised
+#       token is not a thing this script can print — the set is the grammar.
+#
+# VERDICT TOKENS (closed set)
+#   OWNED               this lane, this issue, this session — proceed
+#   WRITTEN             the marker was written/replaced
+#   ADOPTED             ownership transferred to this session (prior session recorded)
+#   SHOWN               fields printed; asserts NOTHING about ownership
+#   ABSENT              no marker at all — a legitimate FRESH START, not a refusal
+#   UNSTAMPED           a marker exists but carries no stamp prologue (the pre-#3822 shape)
+#   MALFORMED           the prologue is unterminated, mis-shaped, duplicated or incomplete
+#   DUPLICATE-SENTINEL  a second stamp sentinel at column zero
+#   FOREIGN-ISSUE       fail-closed axis mismatch (axis=issue)
+#   FOREIGN-MACHINE     fail-closed axis mismatch (axis=machine)
+#   FOREIGN-WORKTREE    fail-closed axis mismatch (axis=worktree)
+#   ADOPTABLE           session differs and the recorded writer is provably GONE
+#   LIVE-PEER           session differs and the recorded writer is provably ALIVE
+#   LIVENESS-UNKNOWN    session differs and liveness could NOT be measured
+#   ERROR               an I/O or internal failure — nothing was decided
+#
+# SUBCOMMANDS
+#   write  <N> [--stage <s>] [--request-id <r>] [--pr <n>] [--branch <b>]
+#              [--body-file <path>] [--actor <id>]
+#              Write/replace the marker in the CURRENT worktree. Writing OVER an existing
+#              marker first passes the SAME ownership verification `verify` applies — you
+#              may not overwrite a live peer's plan either — so a foreign marker refuses
+#              with that marker's own verdict. The route past it is `adopt`, never a flag
+#              on `write`. Without --body-file an OWNED marker's body is PRESERVED.
+#   verify <N> [--actor <id>]      the rehydrate gate (see the axes above)
+#   adopt  <N> --reason <why> [--actor <id>]
+#              The explicit adopt gesture. Resolves the SESSION axis ONLY: a fail-closed
+#              axis mismatch still refuses, and so does a live or unmeasurable writer.
+#              --reason is REQUIRED and RECORDED. An empty/whitespace reason, one with
+#              nothing recordable in it, a bare PLACEHOLDER (`why`, `todo`, `tbd`, …) or one
+#              still carrying an UNSUBSTITUTED `<…>` is a USAGE error (64), never a silent
+#              `reason=unspecified` — same gate, and same reasons, as claim.sh's.
+#   show   <N> print the recorded stamp fields. No ownership verdict.
+#   --help     this contract (authoritative)
+#
+# IDENTITY
+#   issue     the issue number the marker is about.
+#   machine   CLAIM_MACHINE, else `hostname -s`, SANITIZED — deliberately the SAME notion
+#             `claim.sh` records (same env var, same default, same sanitizer), so a lane's
+#             claim ref and its state marker cannot disagree about which box holds it.
+#             claim.sh cannot be SOURCED (sourcing runs its dispatch), so the definition is
+#             mirrored here and the AGREEMENT is pinned BEHAVIOURALLY by
+#             scripts/tests/test_drive_issue_state.sh, which extracts claim.sh's own
+#             definition and compares the two in one environment.
+#   worktree  `pwd -P` — the physical directory holding the marker.
+#   session   CLAUDE_CODE_SESSION_ID, sanitized. `unrecorded` when unset, which makes the
+#             session axis UNMEASURED and routes to the liveness resolution.
+#   actor     --actor, else CLAIM_ACTOR, else `flow` — as claim.sh resolves it. NOTE: the
+#             actor is RECORDED but is NOT an ownership axis here; #3810 (claim-actor
+#             collision) is a separate, open issue and is not fixed or widened by this file.
+#
+# ENV
+#   CLAIM_MACHINE           machine identity (default `hostname -s`) — shared with claim.sh
+#   CLAIM_ACTOR             default actor when --actor is omitted (default: flow)
+#   CLAUDE_CODE_SESSION_ID  the current session id (recorded; the session axis)
+#   CLAUDE_PID              the SESSION's pid (the liveness token; no $$ fallback)
+#   There is deliberately NO env override for the marker path or the start-window slack:
+#   a knob that widens the guard is settable by the party the guard constrains.
+#
+# EXIT CODES
+#   0   OWNED / WRITTEN / ADOPTED / SHOWN
+#   1   ERROR — I/O or internal failure; nothing was decided
+#   3   ABSENT — no marker; a legitimate fresh start (textually AND numerically distinct
+#       from every refusal, so a caller can tell "nothing to resume" from "refused")
+#   4   FOREIGN-ISSUE / FOREIGN-MACHINE / FOREIGN-WORKTREE
+#   5   ADOPTABLE — session differs, writer provably gone; run `adopt`
+#   6   LIVE-PEER — a live peer owns this lane; do NOT proceed
+#   7   LIVENESS-UNKNOWN — could not measure; do NOT proceed
+#   8   UNSTAMPED / MALFORMED / DUPLICATE-SENTINEL
+#   64  usage error
+#
+# CONSTRAINTS
+#   macOS bash 3.2 compatible (no associative arrays, no readarray/mapfile). No network, no
+#   gh, no git. `set -euo pipefail`, shellcheck-clean.
+#
+# ---END-HELP---
+set -euo pipefail
+
+prog="$(basename "$0")"
+SCRIPT_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+P='DRIVE-STATE:'
+
+MARKER_NAME='.drive-issue-state.md'
+STAMP_BEGIN='<!-- drive-issue-state:stamp:v1 -->'
+STAMP_END='<!-- drive-issue-state:stamp:end -->'
+
+# Rounding tolerance when intersecting the recorded start window with the live one. Both
+# come from the SAME host and the SAME clock (`now - elapsed`, bracketed), so the only
+# error to absorb is second-resolution rounding on each side. HARD-CODED with no env
+# override on purpose: widening it is exactly what a caller wanting to adopt a live peer's
+# lane would do, and the constrained party must not choose its own enforcer.
+START_SLACK_SECS=2
+
+# ---------------------------------------------------------------------------
+# Output. Contract (a): every line, stdout and stderr, carries the ONE prefix.
+# ---------------------------------------------------------------------------
+emit()       { printf '%s %s\n' "$P" "$*"; }
+note()       { printf '%s note %s\n' "$P" "$*" >&2; }
+die_usage()  { printf '%s USAGE %s\n' "$P" "$*" >&2; exit 64; }
+
+# sane <string> — the string with every C0 control character and DEL replaced by '?'.
+# Applied to EVERY dynamic field before it is printed (contract (b)). This is the
+# load-bearing half of the anchor: a path or a hand-edited field value may contain a
+# NEWLINE, and printed verbatim that emits a second line with no `DRIVE-STATE: ` prefix.
+# Control characters ONLY are masked; everything else is printed verbatim, because
+# mangling a path for the reader buys nothing once the anchor holds.
+sane() {
+  printf '%s' "${1:-}" | LC_ALL=C tr -c '\040-\176\200-\377' '?'
+}
+
+# verdict <TOKEN> — contract (c): the ONE verdict line, one closed-set token, nothing else.
+verdict() { printf '%s verdict %s\n' "$P" "$1"; }
+detail()  { printf '%s verdict-detail %s\n' "$P" "$*"; }
+
+# refuse <TOKEN> <exit-code> <detail...> — emit a named refusal and exit.
+refuse() {
+  local token="$1" code="$2"; shift 2
+  verdict "$token"
+  [ "$#" -eq 0 ] || detail "$@"
+  exit "$code"
+}
+
+print_help() {
+  awk 'NR>=2 && /^# ---END-HELP---/{exit} NR>=2 {sub(/^# ?/,""); print}' "$0"
+}
+
+# The shared three-valued process-liveness primitives (#3822). A MISSING library is fatal
+# and NAMED — never a silent continue with the predicates undefined, which would make
+# every liveness answer an empty string and (worse) could read as "gone".
+[ -r "$SCRIPT_HOME/lib/process-liveness.sh" ] || {
+  printf '%s ERROR cannot read %s/lib/process-liveness.sh (the shared process-liveness primitives) — NOTHING was measured\n' "$P" "$SCRIPT_HOME" >&2
+  exit 1
+}
+# shellcheck source=lib/process-liveness.sh
+. "$SCRIPT_HOME/lib/process-liveness.sh"
+
+# ---------------------------------------------------------------------------
+# Identity
+# ---------------------------------------------------------------------------
+
+# sanitize_field <text> — collapse a free-text value into ONE parseable token. MIRRORS
+# claim.sh's function of the same name, deliberately and verbatim in behaviour (see
+# IDENTITY in the header for why it is mirrored rather than sourced, and where the
+# agreement is pinned). Keeps [A-Za-z0-9._:/#-]; note that space, newline, '=', '<', '>'
+# and '!' are all dropped, which is what makes a stamp value structurally unable to create
+# a line, a sentinel or another `key:` pair. Collapse -> trim -> cut(120) -> re-trim: the
+# cut happens BEFORE the final trim because trimming first can re-introduce the trailing
+# separator the trim promised to remove. LC_ALL=C on both tr and sed is load-bearing —
+# BSD/macOS tr aborts on non-ASCII input under a UTF-8 locale, and under `set -e` that
+# failure inside a command substitution kills the script with no verdict line at all.
+sanitize_field() {
+  local s
+  s="$(printf '%s' "${1:-}" | LC_ALL=C tr -c 'A-Za-z0-9._:/#-' '-' | LC_ALL=C sed -e 's/--*/-/g' -e 's/^-//' -e 's/-$//')"
+  s="$(LC_ALL=C printf '%.120s' "$s")"
+  s="${s%-}"
+  [ -n "$s" ] || s="unspecified"
+  printf '%s\n' "$s"
+}
+
+this_machine() { sanitize_field "${CLAIM_MACHINE:-$(hostname -s)}"; }
+
+# this_session — the current session id, or the `unrecorded` sentinel. An unrecorded
+# session makes the session axis UNMEASURED (never "equal"), which routes to the liveness
+# resolution rather than to a false OWNED.
+this_session() {
+  if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then
+    sanitize_field "$CLAUDE_CODE_SESSION_ID"
+  else
+    printf 'unrecorded\n'
+  fi
+}
+
+# this_session_pid — the SESSION's pid, or the `unrecordable` sentinel. NO `$$` FALLBACK:
+# see the header. `$$` is this transient bash, so recording it would make a live peer
+# adoptable seconds later.
+this_session_pid() {
+  case "${CLAUDE_PID:-}" in
+    '' | *[!0-9]*) printf 'unrecordable\n' ;;
+    *) if [ "${CLAUDE_PID}" -gt 0 ] 2>/dev/null; then printf '%s\n' "$CLAUDE_PID"
+       else printf 'unrecordable\n'; fi ;;
+  esac
+}
+
+resolve_actor() { sanitize_field "${1:-${CLAIM_ACTOR:-flow}}"; }
+
+require_numeric_issue() {
+  case "${1:-}" in
+    *[!0-9]* | '') die_usage "$2 requires a numeric issue number (got '$(sane "${1:-<none>}")')" ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Marker reading. Sets S_* globals. Refuses (and exits) on any structural fault.
+# ---------------------------------------------------------------------------
+S_issue=''; S_machine=''; S_worktree=''; S_session=''; S_pid=''
+S_start_lo=''; S_start_hi=''; S_actor=''; S_ts=''; S_stage=''
+S_prior_session=''
+
+marker_path() { printf '%s/%s\n' "$(pwd -P)" "$MARKER_NAME"; }
+
+# count_sentinel <path> <sentinel> — column-zero, WHOLE-LINE occurrences. `grep -Fx` is
+# what makes this a column-zero test: a sentinel appearing inside a `key: value` value or
+# mid-sentence in the body is not a whole line and cannot pose as a stamp boundary.
+count_sentinel() {
+  local n
+  n="$(LC_ALL=C grep -Fxc -- "$2" "$1" 2>/dev/null || true)"
+  case "$n" in '' | *[!0-9]*) n=0 ;; esac
+  printf '%s\n' "$n"
+}
+
+# read_marker — parse the stamp prologue of the marker in the current worktree.
+# Exits with a named refusal on every structural fault; returns 0 with S_* set otherwise.
+read_marker() {
+  local path; path="$(marker_path)"
+  [ -e "$path" ] || refuse ABSENT 3 "no $MARKER_NAME in $(sane "$(pwd -P)") — nothing to resume; this is a legitimate FRESH START, not a refusal"
+  [ -f "$path" ] && [ -r "$path" ] || refuse ERROR 1 "$(sane "$path") exists but is not a readable regular file — nothing was decided"
+
+  local first
+  first="$(head -1 "$path" 2>/dev/null || true)"
+  if [ "$first" != "$STAMP_BEGIN" ]; then
+    refuse UNSTAMPED 8 "$(sane "$path") carries NO ownership stamp (its first line is not the stamp sentinel) — this is the pre-#3822 marker shape, whose plan could belong to ANY session on ANY machine, so it is refused rather than adopted. Re-stamp it with '$prog write <issue>' only if this lane's work IS the issue it describes."
+  fi
+
+  local nb ne
+  nb="$(count_sentinel "$path" "$STAMP_BEGIN")"
+  ne="$(count_sentinel "$path" "$STAMP_END")"
+  if [ "$nb" -ne 1 ] || [ "$ne" -gt 1 ]; then
+    refuse DUPLICATE-SENTINEL 8 "$(sane "$path") carries $nb stamp-begin and $ne stamp-end sentinels at column zero (exactly one of each is legal) — a second stamp cannot be told apart from the first, so no identity is read from this file"
+  fi
+  [ "$ne" -eq 1 ] || refuse MALFORMED 8 "$(sane "$path") has no stamp-end sentinel at column zero — the prologue is unterminated, so its extent (and therefore which lines are identity) is undecidable"
+
+  # Parse the CONTIGUOUS run of `key: value` lines between the two sentinels, and NOTHING
+  # else in the file. `IFS=` + `-r` keeps each line byte-exact.
+  local line key val ln=0 dup=''
+  while IFS= read -r line; do
+    ln=$((ln + 1))
+    [ "$ln" -eq 1 ] && continue          # the begin sentinel, already verified
+    [ "$line" = "$STAMP_END" ] && break
+    case "$line" in
+      [a-z]*': '*) : ;;
+      *) refuse MALFORMED 8 "$(sane "$path") line $ln is inside the stamp prologue but is not a 'key: value' line at column zero — the prologue grammar is closed, so a line it cannot parse is a refusal rather than a guess" ;;
+    esac
+    key="${line%%: *}"
+    val="${line#*: }"
+    case "$key" in
+      *[!a-z0-9-]*) refuse MALFORMED 8 "$(sane "$path") line $ln has a stamp key outside [a-z0-9-] ('$(sane "$key")')" ;;
+    esac
+    [ -n "$val" ] || refuse MALFORMED 8 "$(sane "$path") line $ln records an EMPTY value for '$(sane "$key")'"
+    case "$key" in
+      issue)                      dup="$S_issue";          S_issue="$val" ;;
+      machine)                    dup="$S_machine";        S_machine="$val" ;;
+      worktree)                   dup="$S_worktree";       S_worktree="$val" ;;
+      session)                    dup="$S_session";        S_session="$val" ;;
+      session-pid)                dup="$S_pid";            S_pid="$val" ;;
+      session-pid-start-earliest) dup="$S_start_lo";       S_start_lo="$val" ;;
+      session-pid-start-latest)   dup="$S_start_hi";       S_start_hi="$val" ;;
+      actor)                      dup="$S_actor";          S_actor="$val" ;;
+      ts)                         dup="$S_ts";             S_ts="$val" ;;
+      stage)                      dup="$S_stage";          S_stage="$val" ;;
+      prior-session)              dup="$S_prior_session";  S_prior_session="$val" ;;
+      *) dup='' ;;   # forward compatibility: an unrecognised KEY is ignored, but its
+                     # SHAPE was still enforced above, so it can never smuggle in a line.
+    esac
+    # A DUPLICATE identity key would let the PARSER's choice decide identity, which is the
+    # forgery shape this whole prologue exists to remove. Refused, not first-wins.
+    [ -z "$dup" ] || refuse MALFORMED 8 "$(sane "$path") records '$(sane "$key")' TWICE in the stamp prologue — which occurrence is the identity is undecidable"
+  done <"$path"
+
+  local missing=''
+  [ -n "$S_issue" ]    || missing="$missing issue"
+  [ -n "$S_machine" ]  || missing="$missing machine"
+  [ -n "$S_worktree" ] || missing="$missing worktree"
+  [ -n "$S_session" ]  || missing="$missing session"
+  [ -n "$S_pid" ]      || missing="$missing session-pid"
+  [ -n "$S_start_lo" ] || missing="$missing session-pid-start-earliest"
+  [ -n "$S_start_hi" ] || missing="$missing session-pid-start-latest"
+  [ -n "$S_actor" ]    || missing="$missing actor"
+  [ -n "$S_ts" ]       || missing="$missing ts"
+  [ -z "$missing" ] || refuse MALFORMED 8 "$(sane "$path") stamp prologue is missing required field(s):$(sane "$missing") — an incomplete stamp is not a weaker stamp, it is no stamp"
+  return 0
+}
+
+# marker_body — the marker's body (everything AFTER the end sentinel) on stdout.
+marker_body() {
+  local path; path="$(marker_path)"
+  awk -v s="$STAMP_END" 'seen{print} $0==s{seen=1}' "$path"
+}
+
+# ---------------------------------------------------------------------------
+# Liveness of the RECORDED writer. Sets LIVE_STATE (gone|alive|unknown) + LIVE_DETAIL.
+# ---------------------------------------------------------------------------
+LIVE_STATE=''; LIVE_DETAIL=''
+
+writer_liveness() {
+  LIVE_STATE=unknown; LIVE_DETAIL=''
+  local pid="$S_pid" lo="$S_start_lo" hi="$S_start_hi"
+
+  case "$pid" in
+    '' | *[!0-9]*)
+      LIVE_DETAIL="the stamp records session-pid=$(sane "$pid"), which is not a pid — the writing session's liveness is UNMEASURABLE. It is reported UNKNOWN and NOT 'gone': recording this script's own \$\$ instead would make a LIVE peer read as dead."
+      return 0 ;;
+  esac
+  case "$lo$hi" in
+    '' | *[!0-9]*)
+      LIVE_DETAIL="the stamp records no measured start window for pid $(sane "$pid") (earliest=$(sane "$lo") latest=$(sane "$hi")), so a pid that is alive NOW cannot be shown to be the process that stamped this marker — PID REUSE is indistinguishable, hence UNKNOWN"
+      return 0 ;;
+  esac
+  if ! ps_usable; then
+    LIVE_DETAIL="\`ps\` cannot answer an existence question on this host (it failed even for our own pid), so nothing about pid $(sane "$pid") was measured"
+    return 0
+  fi
+
+  local presence state cur ce cl
+  presence="$(process_presence "$pid")"
+  case "$presence" in
+    absent)
+      LIVE_STATE=gone
+      LIVE_DETAIL="pid $(sane "$pid") is absent from the process table and the independent signal probe affirms it (ESRCH) — the writing session is gone"
+      return 0 ;;
+    unknown)
+      LIVE_DETAIL="the process-table probes DISAGREE about pid $(sane "$pid") (our view is not self-consistent — e.g. hidepid, or a transient probe failure), so neither alive nor gone was established"
+      return 0 ;;
+  esac
+
+  state="$(process_state_class "$pid")"
+  case "$state" in
+    zombie)
+      LIVE_STATE=gone
+      LIVE_DETAIL="pid $(sane "$pid") is a ZOMBIE — visible to ps and /proc but not running; the writing session is gone"
+      return 0 ;;
+    unreadable)
+      LIVE_DETAIL="pid $(sane "$pid") is present but its process STATE could not be read — neither a confirmed zombie nor a confirmed live process"
+      return 0 ;;
+  esac
+
+  cur="$(process_start_window "$pid")"
+  if [ -z "$cur" ]; then
+    LIVE_DETAIL="pid $(sane "$pid") is running but its start time could not be measured, so it cannot be shown to be the process that stamped this marker"
+    return 0
+  fi
+  ce="${cur%% *}"; cl="${cur##* }"
+  # Same process <=> the recorded interval and the live one INTERSECT (both are
+  # `now - elapsed` brackets from this host's clock; the slack absorbs per-side rounding).
+  if [ "$((ce - START_SLACK_SECS))" -le "$hi" ] && [ "$((cl + START_SLACK_SECS))" -ge "$lo" ]; then
+    LIVE_STATE=alive
+    LIVE_DETAIL="pid $(sane "$pid") is running and its start window [$ce,$cl] still intersects the recorded [$(sane "$lo"),$(sane "$hi")] — it IS the session that stamped this marker"
+  else
+    LIVE_STATE=gone
+    LIVE_DETAIL="pid $(sane "$pid") is running but its start window [$ce,$cl] is DISJOINT from the recorded [$(sane "$lo"),$(sane "$hi")] — the pid was REUSED, so the writing session is gone and this live process is unrelated"
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Ownership verification, shared by verify / write / adopt.
+# `check_ownership <issue> <mode>` where mode = strict (verify/write) | adopt.
+# Returns 0 for OWNED. Every other outcome is a refusal that EXITS.
+# ---------------------------------------------------------------------------
+check_ownership() {
+  local issue="$1" mode="$2"
+  local machine session
+  machine="$(this_machine)"; session="$(this_session)"
+
+  read_marker
+
+  # FAIL-CLOSED AXES first, and they are fail-closed in `adopt` too: adopt resolves the
+  # SESSION axis only.
+  [ "$S_issue" = "$issue" ] || refuse FOREIGN-ISSUE 4 "axis=issue recorded=$(sane "$S_issue") current=$(sane "$issue") — $(sane "$(marker_path)") is the durable state of a DIFFERENT issue; this lane is being reused. Move or remove it deliberately; it is never adopted for issue $(sane "$issue")."
+  [ "$S_machine" = "$machine" ] || refuse FOREIGN-MACHINE 4 "axis=machine recorded=$(sane "$S_machine") current=$(sane "$machine") — this marker was stamped on another box (a copied tree, or a marker that travelled with a branch). Machine identity is not transferable, so it is refused rather than adopted."
+  [ "$S_worktree" = "$(pwd -P)" ] || refuse FOREIGN-WORKTREE 4 "axis=worktree recorded=$(sane "$S_worktree") current=$(sane "$(pwd -P)") — this marker was stamped for a different worktree and has been COPIED here; a peer lane's plan is not this lane's."
+
+  # SESSION AXIS. Equal AND recordable => OWNED. Anything else is liveness-resolved.
+  if [ "$S_session" = "$session" ] && [ "$session" != unrecorded ]; then
+    return 0
+  fi
+
+  writer_liveness
+  local why="axis=session recorded=$(sane "$S_session") current=$(sane "$session"); $LIVE_DETAIL"
+  case "$LIVE_STATE" in
+    alive)
+      refuse LIVE-PEER 6 "$why. A LIVE PEER owns this lane — do NOT proceed and do NOT adopt: an adopt that ignores liveness is a mute button for this guard." ;;
+    unknown)
+      refuse LIVENESS-UNKNOWN 7 "$why. Liveness was NOT measured, and an unmeasured liveness is never read as verified — refusing. Resolve the ambiguity (identify the session, or clear the marker deliberately) rather than adopting on unproven information." ;;
+    gone)
+      if [ "$mode" = adopt ]; then
+        return 0
+      fi
+      refuse ADOPTABLE 5 "$why. The recorded writer is provably GONE, so this lane IS adoptable — but adoption is an EXPLICIT gesture: run '$prog adopt $(sane "$issue") --reason <what the resume is>', which rewrites the stamp and records the prior session." ;;
+    *)
+      refuse ERROR 1 "internal: liveness state '$(sane "$LIVE_STATE")' is not one of gone|alive|unknown — nothing was decided" ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Writing
+# ---------------------------------------------------------------------------
+
+# stamp_body_is_safe <body-file> — REFUSE (exit 64) a body carrying either sentinel as a
+# whole line at column zero. On the OUTPUT path deliberately: a structural source assert
+# cannot see what a RUNTIME value injects. Refused, never escaped — an escaped sentinel is
+# a second grammar, and two grammars is how a reader and a writer come to disagree.
+assert_body_safe() {
+  local f="$1" s
+  for s in "$STAMP_BEGIN" "$STAMP_END"; do
+    if LC_ALL=C grep -Fxq -- "$s" "$f" 2>/dev/null; then
+      die_usage "the body carries a stamp sentinel as a whole line at column zero. It is REFUSED, not escaped: the stamp prologue is the only place identity is read from, and a body line that can pose as a boundary would break that. Remove the line (indent it, or drop the '<!--' comment) and retry. NOTHING was written."
+    fi
+  done
+}
+
+# write_marker <issue> <actor> <body-file|''> [<extra key: value lines>...]
+write_marker() {
+  local issue="$1" actor="$2" bodyfile="$3"; shift 3
+  local wt path tmp ts session pid win lo hi
+  wt="$(pwd -P)"
+  path="$(marker_path)"
+
+  # The worktree path is recorded VERBATIM (a path must compare EXACTLY; sanitizing would
+  # alias '/a b' onto '/a-b' and let two lanes verify each other's markers). A path
+  # carrying a CONTROL character cannot be recorded losslessly on one line, so it is
+  # refused rather than recorded wrongly.
+  case "$wt" in
+    *[[:cntrl:]]*) refuse ERROR 1 "the worktree path contains a control character, so it cannot be recorded on one line as the worktree axis — refusing to write a stamp whose identity would be lossy" ;;
+    /*) : ;;
+    *)  refuse ERROR 1 "the worktree path '$(sane "$wt")' is not absolute — refusing to write a stamp whose worktree axis cannot be compared" ;;
+  esac
+
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  session="$(this_session)"
+  pid="$(this_session_pid)"
+  lo=unmeasured; hi=unmeasured
+  if [ "$pid" != unrecordable ]; then
+    win="$(process_start_window "$pid" || true)"
+    if [ -n "$win" ]; then lo="${win%% *}"; hi="${win##* }"; fi
+  fi
+
+  tmp="$(mktemp "$path.XXXXXX")" || refuse ERROR 1 "cannot create a temporary file next to $(sane "$path") — nothing was written"
+  {
+    printf '%s\n' "$STAMP_BEGIN"
+    printf 'issue: %s\n' "$issue"
+    printf 'machine: %s\n' "$(this_machine)"
+    printf 'worktree: %s\n' "$wt"
+    printf 'session: %s\n' "$session"
+    printf 'session-pid: %s\n' "$pid"
+    printf 'session-pid-start-earliest: %s\n' "$lo"
+    printf 'session-pid-start-latest: %s\n' "$hi"
+    printf 'actor: %s\n' "$actor"
+    printf 'ts: %s\n' "$ts"
+    local kv
+    for kv in "$@"; do [ -z "$kv" ] || printf '%s\n' "$kv"; done
+    printf '%s\n' "$STAMP_END"
+    printf '\n'
+    if [ -n "$bodyfile" ] && [ -s "$bodyfile" ]; then cat "$bodyfile"; fi
+  } >"$tmp" || { rm -f "$tmp"; refuse ERROR 1 "failed writing $(sane "$tmp") — nothing was replaced"; }
+  mv -f "$tmp" "$path" || { rm -f "$tmp"; refuse ERROR 1 "failed replacing $(sane "$path")"; }
+  printf '%s\n' "$path"
+}
+
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
+cmd_write() {
+  local issue="${1:-}"; shift || true
+  require_numeric_issue "$issue" write
+  local stage='' request='' pr='' branch='' bodyfile='' actor_raw=''
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --stage)      stage="${2:-}";      shift 2 || die_usage "--stage needs a value" ;;
+      --request-id) request="${2:-}";    shift 2 || die_usage "--request-id needs a value" ;;
+      --pr)         pr="${2:-}";         shift 2 || die_usage "--pr needs a value" ;;
+      --branch)     branch="${2:-}";     shift 2 || die_usage "--branch needs a value" ;;
+      --body-file)  bodyfile="${2:-}";   shift 2 || die_usage "--body-file needs a value" ;;
+      --actor)      actor_raw="${2:-}";  shift 2 || die_usage "--actor needs a value" ;;
+      *) die_usage "write: unknown option '$(sane "$1")'" ;;
+    esac
+  done
+  local actor; actor="$(resolve_actor "$actor_raw")"
+
+  local body_src=''
+  if [ -n "$bodyfile" ]; then
+    [ -r "$bodyfile" ] || die_usage "--body-file '$(sane "$bodyfile")' is not readable — nothing was written"
+    assert_body_safe "$bodyfile"
+    body_src="$bodyfile"
+  fi
+
+  # Writing OVER an existing marker passes the SAME ownership verification: you may not
+  # overwrite a live peer's plan either. ABSENT is the legitimate fresh-start path.
+  local carried=''
+  if [ -e "$(marker_path)" ]; then
+    check_ownership "$issue" strict
+    if [ -z "$body_src" ]; then
+      # Preserve an OWNED marker's body: `write` updates the stamp and the recorded stage,
+      # not the author's notes.
+      carried="$(mktemp "${TMPDIR:-/tmp}/drive-issue-body.XXXXXX")" || refuse ERROR 1 "cannot create a temporary file for the carried body"
+      marker_body >"$carried"
+      assert_body_safe "$carried"
+      body_src="$carried"
+    fi
+  fi
+
+  local extras='' path
+  path="$(write_marker "$issue" "$actor" "$body_src" \
+      "$( [ -n "$stage" ]   && printf 'stage: %s' "$(sanitize_field "$stage")" )" \
+      "$( [ -n "$request" ] && printf 'request-id: %s' "$(sanitize_field "$request")" )" \
+      "$( [ -n "$pr" ]      && printf 'pr: %s' "$(sanitize_field "$pr")" )" \
+      "$( [ -n "$branch" ]  && printf 'branch: %s' "$(sanitize_field "$branch")" )")"
+  [ -z "$carried" ] || rm -f "$carried"
+  : "$extras"
+  verdict WRITTEN
+  detail "issue=$(sane "$issue") machine=$(sane "$(this_machine)") worktree=$(sane "$(pwd -P)") session=$(sane "$(this_session)") session-pid=$(sane "$(this_session_pid)") actor=$(sane "$actor") -> $(sane "$path")"
+}
+
+cmd_verify() {
+  local issue="${1:-}"; shift || true
+  require_numeric_issue "$issue" verify
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --actor) shift 2 || die_usage "--actor needs a value" ;;
+      *) die_usage "verify: unknown option '$(sane "$1")'" ;;
+    esac
+  done
+  check_ownership "$issue" strict
+  verdict OWNED
+  detail "issue=$(sane "$issue") machine=$(sane "$S_machine") worktree=$(sane "$S_worktree") session=$(sane "$S_session") stage=$(sane "${S_stage:-none}") ts=$(sane "$S_ts") — this lane's marker, this session; resume from the recorded stage"
+}
+
+# assert_reason <raw> — claim.sh's `--reason` gate, same rules and same reasons. An
+# UNSUBSTITUTED template is refused on the RAW text (before sanitization), because
+# `resume:<branch>` sanitizes to a non-sentinel token and would otherwise record an
+# unresolved placeholder as the audit reason. These commands are read by agents that run
+# printed text LITERALLY.
+assert_reason() {
+  local raw="$1" tok
+  case "$raw" in
+    *'<'*'>'*) die_usage "adopt: --reason '$(sane "$raw")' still carries an UNSUBSTITUTED placeholder (<…>) — substitute it, e.g. --reason cron-reinvoke:writer-pid-gone" ;;
+  esac
+  tok="$(sanitize_field "$raw")"
+  if [ "$tok" = unspecified ] || [ "${#tok}" -lt 3 ]; then
+    die_usage "adopt: --reason must carry at least 3 recordable characters ([A-Za-z0-9._:/#-]); '$(sane "$raw")' records as '$(sane "$tok")', which is indistinguishable from no reason at all"
+  fi
+  case "$(printf '%s' "$tok" | LC_ALL=C tr 'A-Z' 'a-z')" in
+    why | reason | todo | tbd | tba | xxx | xxxx | placeholder | fixme | none | foo | bar | baz | n/a)
+      die_usage "adopt: --reason '$(sane "$raw")' records as the PLACEHOLDER '$(sane "$tok")' — as uninformative as no reason at all. Say what the resume IS, e.g. --reason cron-reinvoke:writer-pid-gone" ;;
+  esac
+  printf '%s\n' "$tok"
+}
+
+cmd_adopt() {
+  local issue="${1:-}"; shift || true
+  require_numeric_issue "$issue" adopt
+  local reason='' reason_given=0 actor_raw=''
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --reason) reason="${2-}"; reason_given=1; shift 2 || die_usage "--reason needs a value" ;;
+      --actor)  actor_raw="${2:-}"; shift 2 || die_usage "--actor needs a value" ;;
+      *) die_usage "adopt: unknown option '$(sane "$1")'" ;;
+    esac
+  done
+  # ARGUMENTS ARE VALIDATED BEFORE ANY STATE IS READ, so a placeholder reason is exit 64
+  # whatever the lane looks like — a usage error must not depend on the marker's state.
+  [ "$reason_given" -eq 1 ] || die_usage "adopt requires --reason saying what the resume IS (it is recorded in the stamp next to who took it), e.g. --reason cron-reinvoke:writer-pid-gone"
+  local reason_token actor
+  reason_token="$(assert_reason "$reason")"
+  actor="$(resolve_actor "$actor_raw")"
+
+  check_ownership "$issue" adopt
+  local prior_session="$S_session" prior_pid="$S_pid" prior_ts="$S_ts" stage="$S_stage"
+
+  if [ "$prior_session" = "$(this_session)" ] && [ "$prior_session" != unrecorded ]; then
+    verdict ADOPTED
+    detail "re-entrant: this session already owns $(sane "$(marker_path)") — nothing to transfer"
+    return 0
+  fi
+
+  local carried path
+  carried="$(mktemp "${TMPDIR:-/tmp}/drive-issue-body.XXXXXX")" || refuse ERROR 1 "cannot create a temporary file for the carried body"
+  marker_body >"$carried"
+  assert_body_safe "$carried"
+  path="$(write_marker "$issue" "$actor" "$carried" \
+      "$( [ -n "$stage" ] && printf 'stage: %s' "$stage" )" \
+      "prior-session: $prior_session" \
+      "prior-session-pid: $prior_pid" \
+      "prior-ts: $prior_ts" \
+      "adopt-reason: $reason_token")"
+  rm -f "$carried"
+  verdict ADOPTED
+  detail "issue=$(sane "$issue") prior-session=$(sane "$prior_session") prior-session-pid=$(sane "$prior_pid") new-session=$(sane "$(this_session)") reason=$(sane "$reason_token") -> $(sane "$path"); the recorded writer was provably gone: $LIVE_DETAIL"
+}
+
+cmd_show() {
+  local issue="${1:-}"; shift || true
+  require_numeric_issue "$issue" show
+  read_marker
+  emit "field issue=$(sane "$S_issue")"
+  emit "field machine=$(sane "$S_machine")"
+  emit "field worktree=$(sane "$S_worktree")"
+  emit "field session=$(sane "$S_session")"
+  emit "field session-pid=$(sane "$S_pid")"
+  emit "field session-pid-start=$(sane "$S_start_lo")..$(sane "$S_start_hi")"
+  emit "field actor=$(sane "$S_actor")"
+  emit "field ts=$(sane "$S_ts")"
+  emit "field stage=$(sane "${S_stage:-none}")"
+  [ -z "$S_prior_session" ] || emit "field prior-session=$(sane "$S_prior_session")"
+  verdict SHOWN
+  detail "fields as recorded for issue $(sane "$issue"); SHOWN asserts NOTHING about ownership — use 'verify' for that"
+}
+
+SUB="${1:-}"
+case "$SUB" in
+  write)  shift; cmd_write  "$@" ;;
+  verify) shift; cmd_verify "$@" ;;
+  adopt)  shift; cmd_adopt  "$@" ;;
+  show)   shift; cmd_show   "$@" ;;
+  -h | --help) print_help ;;
+  '') die_usage "a subcommand is required: write <N> | verify <N> | adopt <N> --reason <why> | show <N> (see --help)" ;;
+  *)  die_usage "unknown subcommand: $(sane "$SUB") (expected write|verify|adopt|show)" ;;
+esac

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -123,7 +123,10 @@
 #       USAGE error and a SIGNAL: an EXIT-trap backstop emits `verdict ERROR` for any path that
 #       would otherwise leave with none, and the INT/TERM/HUP handlers emit exactly one token
 #       chosen by COMMIT_PHASE — ERROR before the atomic rename, the run's own success token
-#       after it, and a DEFERRED delivery across it.
+#       after it, and a DEFERRED delivery across it. THE EMISSION ITSELF IS A DEFERRAL WINDOW
+#       TOO: the line is printed BEFORE the "already emitted" state is committed, and a signal
+#       landing between the two is HELD rather than delivered — otherwise both readers see
+#       "already emitted" for a line that does not exist yet and the run exits with NO token.
 #
 # VERDICT TOKENS (closed set)
 #   OWNED               this lane, this issue, this session — proceed
@@ -291,6 +294,12 @@ START_SLACK_SECS=2
 # parser picks first. `verdict()` records that it fired, the signal handlers consult the flag so
 # they cannot add a second, and the EXIT trap consults it so no path can leave with none.
 VERDICT_EMITTED=0
+# VERDICT_EMITTING is the CRITICAL-SECTION half of the same contract (roborev job 35 I1): 1 while
+# a verdict line is being emitted, so no reader can observe "already emitted" before the line is
+# actually on stdout. VERDICT_SIG_PENDING carries a signal that arrived inside that window, held
+# until the state is consistent (see verdict/settle_verdict_signal).
+VERDICT_EMITTING=0
+VERDICT_SIG_PENDING=''
 # `--help` is contract (a)'s stated exemption: it emits no verdict line because no consumer
 # parses it. It is the ONLY exemption, and it is a flag rather than an inference.
 VERDICT_EXEMPT=0
@@ -319,7 +328,32 @@ sane() {
 # It records that it fired so nothing downstream can print a second one, and so the EXIT trap
 # can tell "decided" from "left without deciding". NEVER call it inside `$( )`: the flag would
 # be set in the subshell and the line captured into a variable (the defect case 17 pins).
-verdict() { VERDICT_EMITTED=1; printf '%s verdict %s\n' "$P" "$1"; }
+#
+# THE EMISSION IS A SIGNAL-DEFERRED CRITICAL SECTION (roborev job 35 I1). This was
+# `VERDICT_EMITTED=1; printf ...` — the flag committed BEFORE the line was printed — and a signal
+# arriving between those two commands produced the one state neither reader can recover from:
+# `on_signal` saw "already emitted" and stayed silent, the EXIT-trap backstop saw it and stayed
+# silent, and the run exited having printed NO verdict at all, possibly over a COMMITTED write.
+# That is contract (c) broken from inside the function installed to enforce it (round 6's G2),
+# so the two commands must not be observable in that order:
+#   * VERDICT_EMITTING marks the section. Nothing may conclude "already emitted" while it is set.
+#   * The line is PRINTED, and only THEN is VERDICT_EMITTED committed. The ordering is asserted
+#     structurally by scripts/tests/test_drive_issue_state.sh case 42, because a race cannot be
+#     pinned by a timed test; the behavioural half plants the signal AT the window in a scratch
+#     copy of this file rather than hoping the scheduler puts it there.
+#   * A signal that lands anywhere inside is DEFERRED (recorded, not delivered) and settled the
+#     instant the state is consistent — the same shape as the deferral across the atomic rename,
+#     and for the same reason: the run reports the outcome it ACHIEVED instead of losing it.
+# THE FIRST deferred signal wins: a second one during the same few commands would only overwrite
+# an exit code we are already about to deliver, and one exit is all there is to deliver.
+verdict() {
+  local token="${1:-}"
+  VERDICT_EMITTING=1
+  printf '%s verdict %s\n' "$P" "$token"
+  VERDICT_EMITTED=1
+  VERDICT_EMITTING=0
+  settle_verdict_signal
+}
 detail()  { printf '%s verdict-detail %s\n' "$P" "$*"; }
 
 # refuse <TOKEN> <exit-code> <detail...> — emit a named refusal and exit.
@@ -328,9 +362,12 @@ refuse() {
   # end prints bash's own UNPREFIXED `shift count out of range` under `shift_verbose`/POSIX mode,
   # which breaks contract (a) from inside the function that exists to satisfy contract (c).
   if [ "$#" -lt 2 ]; then
-    VERDICT_EMITTED=1
-    printf '%s verdict ERROR\n' "$P"
-    printf '%s verdict-detail internal: refuse was called with %s argument(s); a token and an exit code are required\n' "$P" "$#"
+    # ROUTED THROUGH `verdict`, not a hand-rolled flag-then-printf pair (roborev job 35 I1 class
+    # sweep): this guard had its own copy of the exact ordering the finding names, and a second
+    # emitter is a second place for the window to reappear. `verdict` takes no `shift`, so it is
+    # safe to call from the function that exists because a `shift` is not.
+    verdict ERROR
+    detail "internal: refuse was called with $# argument(s); a token and an exit code are required"
     exit 1
   fi
   local token="$1" code="$2"; shift 2
@@ -396,6 +433,14 @@ SIG_PENDING=''
 # on_signal <name> <exit-code>
 on_signal() {
   local sig="$1" code="$2"
+  # THE VERDICT-EMISSION WINDOW COMES FIRST (roborev job 35 I1). While a verdict line is being
+  # printed, neither branch below may run: reading VERDICT_EMITTED here is exactly the read that
+  # used to observe a flag set before its line existed. Deferred, never dropped — settled by
+  # `verdict` itself the moment the state is consistent.
+  if [ "$VERDICT_EMITTING" -eq 1 ]; then
+    [ -n "$VERDICT_SIG_PENDING" ] || VERDICT_SIG_PENDING="$sig:$code"
+    return 0
+  fi
   if [ "$COMMIT_PHASE" = committing ]; then
     # DEFERRED, NOT IGNORED. The commit is a single rename; letting it finish costs one syscall
     # and lets the run report the outcome it ACHIEVED instead of an "undetermined". The exit
@@ -419,6 +464,18 @@ trap 'on_signal INT 130'  INT
 trap 'on_signal TERM 143' TERM
 trap 'on_signal HUP 129'  HUP
 
+# settle_verdict_signal — deliver a signal that was deferred across the VERDICT EMISSION, now
+# that the line is on stdout and VERDICT_EMITTED is committed. Called by `verdict` itself, so
+# every emitter gets it without remembering to (roborev job 35 I1).
+settle_verdict_signal() {
+  [ -n "$VERDICT_SIG_PENDING" ] || return 0
+  local sig="${VERDICT_SIG_PENDING%%:*}" code="${VERDICT_SIG_PENDING##*:}"
+  VERDICT_SIG_PENDING=''
+  trap '' INT TERM HUP
+  detail "SIG$sig arrived DURING the verdict emission and was DEFERRED across it, so the verdict above was printed IN FULL rather than lost. Exiting $code."
+  exit "$code"
+}
+
 # settle_pending_signal — deliver a signal that was deferred across the commit, AFTER the
 # verdict is out. Called at the end of every mutating subcommand.
 settle_pending_signal() {
@@ -437,6 +494,10 @@ settle_pending_signal() {
 # trap AND REPLACES the exit status (measured on roborev job 26 F2).
 on_exit() {
   local rc=$?
+  # DISARMED FIRST (roborev job 35 I1). The backstop below calls `verdict`, which parks a signal
+  # arriving mid-emission and then EXITs to deliver it — from inside the EXIT trap that would
+  # skip `cleanup_tmp`. Nothing this trap does needs to be interruptible, so nothing is.
+  trap '' INT TERM HUP 2>/dev/null || true
   if [ "$VERDICT_EXEMPT" -eq 0 ] && [ "$VERDICT_EMITTED" -eq 0 ]; then
     verdict ERROR || true
     detail "the run ended at exit $rc without reaching any decision point, so NOTHING was decided and NOTHING was written. This is a defect in $(sane "$prog"), not a state of the marker: report it with the command you ran." || true

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -144,7 +144,8 @@
 #   LIVE-PEER           session differs and the recorded writer is provably ALIVE
 #   LIVENESS-UNKNOWN    session differs and liveness could NOT be measured
 #   ERROR               an I/O or internal failure, or an identity axis that could not be
-#                       MEASURED (axis=machine) — nothing was decided
+#                       MEASURED (axis=machine / axis=worktree) or could not be recorded
+#                       LOSSLESSLY (axis=machine / axis=session) — nothing was decided
 #   USAGE               the invocation itself was wrong — nothing was read and nothing written
 #
 # SUBCOMMANDS
@@ -221,6 +222,14 @@
 #             machine B. The refusal is at the USE SITE, never in the sanitizer: the shared
 #             placeholder is claim.sh's behaviour and stays pinned. Where no marker exists
 #             nothing is compared, so `verify`/`adopt` still report ABSENT.
+#             IT MUST ALSO BE RECORDABLE **LOSSLESSLY**, and that is the SAME rule one step on
+#             (`verdict ERROR`, exit 1, `axis=machine`). The sanitizer maps space -> '-',
+#             collapses runs of separators and TRUNCATES at 120 characters, so `build box` and
+#             `build-box` record ONE token and two names sharing a 120-character prefix record
+#             ONE token — after which two DISTINCT boxes are one owner, which is the same defect
+#             as the placeholder wearing different clothes. So the axis is required to ALREADY
+#             be what the sanitizer would make of it: recorded != measured is a refusal naming
+#             the axis. Again at the USE SITE — the sanitizer is claim.sh's and does not change.
 #   worktree  `pwd -P` — the physical directory holding the marker. IT MUST BE MEASURABLE:
 #             a failed `pwd -P` (a deleted or unreadable lane directory) is `verdict ERROR`,
 #             exit 1, naming `axis=worktree`, on write/verify/adopt AND on `show` — the marker
@@ -230,9 +239,21 @@
 #             wrong path, not a false OWNED.
 #   session   CLAUDE_CODE_SESSION_ID, sanitized. `unrecorded` when unset, which makes the
 #             session axis UNMEASURED and routes to the liveness resolution.
+#             IT TOO MUST BE RECORDABLE LOSSLESSLY (`verdict ERROR`, exit 1, `axis=session`).
+#             The session axis is not fail-closed on a MISMATCH, but an EQUAL session id is
+#             OWNED outright, so a lossy one lets two distinct sessions own each other's
+#             markers — the machine axis's defect one axis over. `unrecorded` is the ABSENCE of
+#             a value, not a lossy one, and is unaffected.
 #   actor     --actor, else CLAIM_ACTOR, else `flow` — as claim.sh resolves it. NOTE: the
 #             actor is RECORDED but is NOT an ownership axis here; #3810 (claim-actor
 #             collision) is a separate, open issue and is not fixed or widened by this file.
+#             It is therefore sanitized LOSSILY and DELIBERATELY NOT refused (roborev job 37
+#             J1's axis census): nothing compares it, so a collision cannot grant ownership,
+#             and refusing `--actor 'flow lead'` would red on input claim.sh accepts — a guard
+#             that reds on correct input is the guard agents learn to waive. The same holds for
+#             `stage`/`request-id`/`pr`/`branch` and the four `prior-*` provenance fields: they
+#             are recorded state, never compared, so lossiness there costs fidelity in the
+#             audit record and can never alias one lane onto another.
 #
 # ENV
 #   CLAIM_MACHINE           machine identity (default `hostname -s`) — shared with claim.sh
@@ -567,7 +588,8 @@ sanitize_field() {
 # `hostname`'s stderr is suppressed (roborev job 26 F2): its failure is reported through the
 # anchored refusal below, and an unprefixed 'hostname: not found' would break contract (a).
 MACHINE_AXIS_VALUE=''
-MACHINE_AXIS_STATE=''   # ok | unmeasured | unrecordable
+MACHINE_AXIS_STATE=''   # ok | unmeasured | unrecordable | lossy
+MACHINE_AXIS_RAW=''
 resolve_machine_axis() {
   [ -z "$MACHINE_AXIS_STATE" ] || return 0
   local raw
@@ -580,6 +602,7 @@ resolve_machine_axis() {
   # before the anchored refusal below could name the axis (measured: the EXIT-trap backstop's
   # generic ERROR, with no axis=machine detail). The value is unchanged either way: empty.
   raw="${CLAIM_MACHINE:-$(hostname -s 2>/dev/null || true)}"
+  MACHINE_AXIS_RAW="$raw"
   MACHINE_AXIS_VALUE="$(sanitize_field "$raw")"
   if [ -z "$raw" ]; then
     MACHINE_AXIS_STATE=unmeasured
@@ -588,6 +611,17 @@ resolve_machine_axis() {
     # CLAIM_MACHINE, or a host whose `tr` is broken, which is the fail-open case 30 used to
     # declare as a residual). Recorded, it is the same alias, so it is refused the same way.
     MACHINE_AXIS_STATE=unrecordable
+  elif [ "$MACHINE_AXIS_VALUE" != "$raw" ]; then
+    # AN IDENTITY THAT SURVIVES SANITIZATION ONLY IN PART IS AN ALIAS (roborev job 37 J1, the
+    # THIRD instance of one family: H1 committed the `unspecified` placeholder for an
+    # UNMEASURABLE axis, the round-7 class sweep found the same shape on the worktree axis, and
+    # this is a MEASURABLE identity committed LOSSILY). The sanitizer maps space -> '-',
+    # collapses runs and TRUNCATES at 120 characters, so `build box` and `build-box` record the
+    # SAME token and two boxes sharing a 120-character prefix record the same token — after
+    # which lane A's marker verifies as OWNED on machine B, the precise defect this file exists
+    # to prevent. Detected by requiring the recorded value to EQUAL the measured one: that one
+    # comparison covers charset AND length, and it needs no second copy of the sanitizer's rules.
+    MACHINE_AXIS_STATE=lossy
   else
     MACHINE_AXIS_STATE=ok
   fi
@@ -644,20 +678,60 @@ require_machine_axis() {
       refuse ERROR 1 "axis=machine could NOT BE MEASURED: CLAIM_MACHINE is unset or empty and \`hostname -s\` produced nothing. The machine axis is fail-closed identity, and recording the 'unspecified' placeholder would ALIAS every unmeasurable box onto ONE owner (this lane's marker would then verify as OWNED on any other box) — so nothing is written, nothing is compared and nothing was decided. Set CLAIM_MACHINE to this box's unique identity, or repair hostname resolution." ;;
     unrecordable)
       refuse ERROR 1 "axis=machine is NOT RECORDABLE: the machine identity resolved to a value that records as the 'unspecified' placeholder (it carries no recordable characters [A-Za-z0-9._:/#-], or the sanitizer itself could not run) and would ALIAS every such box onto ONE owner. Nothing was written, nothing was compared and nothing was decided. Set CLAIM_MACHINE to this box's unique identity." ;;
+    lossy)
+      refuse ERROR 1 "axis=machine is NOT RECORDABLE LOSSLESSLY: the machine identity '$(sane "$MACHINE_AXIS_RAW")' records as '$(sane "$MACHINE_AXIS_VALUE")', which is a DIFFERENT string. An identity that is normalized before it is compared ALIASES distinct machines onto one owner ('build box' and 'build-box' record the same token; so do two names sharing a 120-character prefix), and this lane's marker would then verify as OWNED on the other box. Nothing was written, nothing was compared and nothing was decided. Set CLAIM_MACHINE to a value that is already one token of [A-Za-z0-9._:/#-] and at most 120 characters." ;;
     *)
-      refuse ERROR 1 "internal: machine-axis state '$(sane "$MACHINE_AXIS_STATE")' is not one of ok|unmeasured|unrecordable — nothing was decided" ;;
+      refuse ERROR 1 "internal: machine-axis state '$(sane "$MACHINE_AXIS_STATE")' is not one of ok|unmeasured|unrecordable|lossy — nothing was decided" ;;
   esac
+}
+
+# THE SESSION AXIS, RESOLVED ONCE, WITH ITS LOSSLESSNESS CARRIED ALONGSIDE (roborev job 37 J1).
+#
+# The session axis is NOT fail-closed on a MISMATCH (see the header: a legitimate cron resume is
+# a new session id in the same lane, so a literal mismatch check would red every correct resume).
+# But an EQUAL session id is OWNED OUTRIGHT — basis `session`, the strongest verdict this script
+# emits — so the same lossy-normalization defect the machine axis has lands here with the same
+# consequence, one axis over: two DISTINCT session ids that sanitize to one token grant each
+# other ownership. The remedy is the same and lives at the USE SITE for the same reason: the
+# sanitizer is claim.sh's, pinned by the agreement case, and is not changed.
+#
+# `unrecorded` is not lossy — it is the ABSENCE of a value, which routes to the liveness
+# resolution rather than to any comparison.
+SESSION_AXIS_VALUE=''
+SESSION_AXIS_STATE=''   # ok | unrecorded | lossy
+SESSION_AXIS_RAW=''
+resolve_session_axis() {
+  [ -z "$SESSION_AXIS_STATE" ] || return 0
+  SESSION_AXIS_RAW="${CLAUDE_CODE_SESSION_ID:-}"
+  if [ -z "$SESSION_AXIS_RAW" ]; then
+    SESSION_AXIS_VALUE='unrecorded'
+    SESSION_AXIS_STATE=unrecorded
+    return 0
+  fi
+  SESSION_AXIS_VALUE="$(sanitize_field "$SESSION_AXIS_RAW")"
+  if [ "$SESSION_AXIS_VALUE" = "$SESSION_AXIS_RAW" ]; then
+    SESSION_AXIS_STATE=ok
+  else
+    SESSION_AXIS_STATE=lossy
+  fi
 }
 
 # this_session — the current session id, or the `unrecorded` sentinel. An unrecorded
 # session makes the session axis UNMEASURED (never "equal"), which routes to the liveness
 # resolution rather than to a false OWNED.
-this_session() {
-  if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then
-    sanitize_field "$CLAUDE_CODE_SESSION_ID"
-  else
-    printf 'unrecorded\n'
-  fi
+this_session() { resolve_session_axis; printf '%s\n' "$SESSION_AXIS_VALUE"; }
+
+# require_session_axis — main shell only, same posture as require_machine_axis: called wherever
+# the session axis is about to be RECORDED or COMPARED.
+require_session_axis() {
+  resolve_session_axis
+  case "$SESSION_AXIS_STATE" in
+    ok | unrecorded) return 0 ;;
+    lossy)
+      refuse ERROR 1 "axis=session is NOT RECORDABLE LOSSLESSLY: CLAUDE_CODE_SESSION_ID '$(sane "$SESSION_AXIS_RAW")' records as '$(sane "$SESSION_AXIS_VALUE")', which is a DIFFERENT string. An equal session id grants OWNED outright, so two distinct session ids that normalize to one token would own each other's markers. Nothing was written, nothing was compared and nothing was decided. Set CLAUDE_CODE_SESSION_ID to a value that is already one token of [A-Za-z0-9._:/#-] and at most 120 characters." ;;
+    *)
+      refuse ERROR 1 "internal: session-axis state '$(sane "$SESSION_AXIS_STATE")' is not one of ok|unrecorded|lossy — nothing was decided" ;;
+  esac
 }
 
 # this_session_pid — the SESSION's pid, or the `unrecordable` sentinel. NO `$$` FALLBACK:
@@ -1090,6 +1164,9 @@ check_ownership() {
   # every marker recorded by another unmeasurable box. Refused before any comparison.
   require_machine_axis
   require_worktree_axis
+  # AND THE SESSION AXIS MUST BE LOSSLESS BEFORE IT IS COMPARED (roborev job 37 J1). An equal
+  # session id returns OWNED on the spot, so a lossy one aliases two sessions onto one owner.
+  require_session_axis
   machine="$(this_machine)"; session="$(this_session)"
 
   read_marker
@@ -1259,7 +1336,14 @@ write_marker() {
   # because a stamp with a placeholder identity is not a weaker stamp — it is an alias.
   resolve_machine_axis
   [ "$MACHINE_AXIS_STATE" = ok ] || {
-    WRITE_ERR="the machine axis is not recordable (state=$(sane "$MACHINE_AXIS_STATE")), so the stamp's \`machine\` field would record the 'unspecified' placeholder and alias this box onto every other unmeasurable one — nothing was written"; return 1; }
+    WRITE_ERR="the machine axis is not recordable (state=$(sane "$MACHINE_AXIS_STATE")), so the stamp's \`machine\` field would record a value that is not this box's measured identity — an 'unspecified' placeholder, or a LOSSILY normalized name — and either aliases this box onto another; nothing was written"; return 1; }
+  # THE SAME BACKSTOP FOR THE SESSION AXIS (roborev job 37 J1), at the site that ASSEMBLES the
+  # stamp: a lossily-recorded session id is an alias, not a weaker stamp.
+  resolve_session_axis
+  case "$SESSION_AXIS_STATE" in
+    ok | unrecorded) : ;;
+    *) WRITE_ERR="the session axis is not recordable losslessly (state=$(sane "$SESSION_AXIS_STATE")), so the stamp's \`session\` field would record a value that is not this session's id and could grant OWNED to a different session — nothing was written"; return 1 ;;
+  esac
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)" || {
     WRITE_ERR="cannot read the current time (\`date\` failed), so the stamp's \`ts\` field cannot be recorded — refusing rather than committing a stamp with an empty required field; nothing was written"; return 1; }
   [ -n "$ts" ] || {
@@ -1386,6 +1470,7 @@ cmd_write() {
   # COMMITTED as the 'unspecified' placeholder (roborev job 34 H1).
   require_machine_axis
   require_worktree_axis
+  require_session_axis
 
   local body_src=''
   if [ -n "$bodyfile" ]; then

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -116,7 +116,11 @@
 #       token is not a thing this script can print — the set is the grammar. EVERY exit
 #       carries one, INCLUDING a fatal start-up failure: callers branch on the TOKEN, so a
 #       prefixed line with no token is unreadable by every one of them and its `case` falls
-#       through — (a) does not imply (c), and only (c) is what a consumer reads.
+#       through — (a) does not imply (c), and only (c) is what a consumer reads. That includes a
+#       USAGE error and a SIGNAL: an EXIT-trap backstop emits `verdict ERROR` for any path that
+#       would otherwise leave with none, and the INT/TERM/HUP handlers emit exactly one token
+#       chosen by COMMIT_PHASE — ERROR before the atomic rename, the run's own success token
+#       after it, and a DEFERRED delivery across it.
 #
 # VERDICT TOKENS (closed set)
 #   OWNED               this lane, this issue, this session — proceed
@@ -134,6 +138,7 @@
 #   LIVE-PEER           session differs and the recorded writer is provably ALIVE
 #   LIVENESS-UNKNOWN    session differs and liveness could NOT be measured
 #   ERROR               an I/O or internal failure — nothing was decided
+#   USAGE               the invocation itself was wrong — nothing was read and nothing written
 #
 # SUBCOMMANDS
 #   write  <N> [--stage <s>] [--request-id <r>] [--pr <n>] [--branch <b>]
@@ -215,7 +220,7 @@
 #   6   LIVE-PEER — a live peer owns this lane; do NOT proceed
 #   7   LIVENESS-UNKNOWN — could not measure; do NOT proceed
 #   8   UNSTAMPED / MALFORMED / DUPLICATE-SENTINEL
-#   64  usage error
+#   64  USAGE — usage error
 #
 # CONSTRAINTS
 #   macOS bash 3.2 compatible (no associative arrays, no readarray/mapfile). No network, no
@@ -251,9 +256,23 @@ START_SLACK_SECS=2
 # ---------------------------------------------------------------------------
 # Output. Contract (a): every line, stdout and stderr, carries the ONE prefix.
 # ---------------------------------------------------------------------------
+# CONTRACT (c) IS ENFORCED BY A FLAG, NOT BY DISCIPLINE (roborev job 30 G2). Every exit must
+# carry exactly ONE `verdict <TOKEN>` line: zero makes a consumer's `case` fall through every
+# arm (round 5's F1, at the liveness-library guard), and two lets a consumer read whichever its
+# parser picks first. `verdict()` records that it fired, the signal handlers consult the flag so
+# they cannot add a second, and the EXIT trap consults it so no path can leave with none.
+VERDICT_EMITTED=0
+# `--help` is contract (a)'s stated exemption: it emits no verdict line because no consumer
+# parses it. It is the ONLY exemption, and it is a flag rather than an inference.
+VERDICT_EXEMPT=0
+
 emit()       { printf '%s %s\n' "$P" "$*"; }
 note()       { printf '%s note %s\n' "$P" "$*" >&2; }
-die_usage()  { printf '%s USAGE %s\n' "$P" "$*" >&2; exit 64; }
+# A USAGE error is an EXIT, so contract (c) covers it: it carries the `USAGE` token (a member of
+# the closed set) as well as the human-readable line. Before job 30 G2 it carried the anchored
+# line alone, so `drive-issue-state.sh write <N> --stage` — a plain typo — was unreadable by
+# every caller the doctrine tells to branch on the token.
+die_usage()  { verdict USAGE; printf '%s USAGE %s\n' "$P" "$*" >&2; exit 64; }
 
 # sane <string> — the string with every C0 control character and DEL replaced by '?'.
 # Applied to EVERY dynamic field before it is printed (contract (b)). This is the
@@ -268,11 +287,23 @@ sane() {
 }
 
 # verdict <TOKEN> — contract (c): the ONE verdict line, one closed-set token, nothing else.
-verdict() { printf '%s verdict %s\n' "$P" "$1"; }
+# It records that it fired so nothing downstream can print a second one, and so the EXIT trap
+# can tell "decided" from "left without deciding". NEVER call it inside `$( )`: the flag would
+# be set in the subshell and the line captured into a variable (the defect case 17 pins).
+verdict() { VERDICT_EMITTED=1; printf '%s verdict %s\n' "$P" "$1"; }
 detail()  { printf '%s verdict-detail %s\n' "$P" "$*"; }
 
 # refuse <TOKEN> <exit-code> <detail...> — emit a named refusal and exit.
 refuse() {
+  # ARGUMENT-COUNT GUARD BEFORE THE SHIFT (roborev job 30 G3, internal site): a `shift` past the
+  # end prints bash's own UNPREFIXED `shift count out of range` under `shift_verbose`/POSIX mode,
+  # which breaks contract (a) from inside the function that exists to satisfy contract (c).
+  if [ "$#" -lt 2 ]; then
+    VERDICT_EMITTED=1
+    printf '%s verdict ERROR\n' "$P"
+    printf '%s verdict-detail internal: refuse was called with %s argument(s); a token and an exit code are required\n' "$P" "$#"
+    exit 1
+  fi
   local token="$1" code="$2"; shift 2
   verdict "$token"
   [ "$#" -eq 0 ] || detail "$@"
@@ -284,6 +315,7 @@ refuse() {
 # exemption — so there is no anchor to protect here, and a HUMAN who asks for the contract and
 # gets nothing is better served by awk's own diagnostic than by silence.
 print_help() {
+  VERDICT_EXEMPT=1
   awk 'NR>=2 && /^# ---END-HELP---/{exit} NR>=2 {sub(/^# ?/,""); print}' "$0"
 }
 
@@ -313,10 +345,77 @@ cleanup_tmp() {
   fi
   TMP_FILES=()
 }
-trap cleanup_tmp EXIT
-trap 'cleanup_tmp; exit 130' INT
-trap 'cleanup_tmp; exit 143' TERM
-trap 'cleanup_tmp; exit 129' HUP
+# ---------------------------------------------------------------------------
+# SIGNAL AND EXIT HANDLING (roborev job 30 G2).
+#
+# The traps used to be `cleanup_tmp; exit 130|143|129`, which satisfied nothing: no verdict
+# token at all, so a consumer branching on the token (drive-issue.md's Delta 4 mandates it) got
+# an empty string — the SAME shape as round 5's F1 at the liveness-library guard, one exit path
+# over. And they were PHASE-BLIND: a signal arriving after the atomic rename left the marker
+# CHANGED while the caller was told nothing whatsoever.
+#
+# COMMIT_PHASE is set immediately around the one rename that changes durable state:
+#   idle       nothing has been committed -> the honest verdict is ERROR, nothing was written
+#   committing the rename is in flight -> the signal is DEFERRED across it (below)
+#   committed  the rename returned -> the run's own success token is the honest verdict
+# COMMIT_VERDICT is the success token the CURRENT mutating subcommand would emit (WRITTEN /
+# ADOPTED), set by the subcommand rather than guessed by the handler.
+COMMIT_PHASE=idle
+COMMIT_VERDICT=''
+SIG_PENDING=''
+
+# on_signal <name> <exit-code>
+on_signal() {
+  local sig="$1" code="$2"
+  if [ "$COMMIT_PHASE" = committing ]; then
+    # DEFERRED, NOT IGNORED. The commit is a single rename; letting it finish costs one syscall
+    # and lets the run report the outcome it ACHIEVED instead of an "undetermined". The exit
+    # code is still the signal's — settle_pending_signal delivers it once the verdict is out.
+    SIG_PENDING="$sig:$code"
+    return 0
+  fi
+  trap '' INT TERM HUP     # no second entry, and therefore no second verdict
+  if [ "$VERDICT_EMITTED" -eq 0 ]; then
+    if [ "$COMMIT_PHASE" = committed ] && [ -n "$COMMIT_VERDICT" ]; then
+      verdict "$COMMIT_VERDICT"
+      detail "SIG$sig arrived AFTER the atomic rename COMPLETED: the marker WAS replaced and records what this run assembled. Exiting $code."
+    else
+      verdict ERROR
+      detail "SIG$sig arrived before any atomic rename: NOTHING was written and NOTHING was decided. Exiting $code."
+    fi
+  fi
+  exit "$code"
+}
+trap 'on_signal INT 130'  INT
+trap 'on_signal TERM 143' TERM
+trap 'on_signal HUP 129'  HUP
+
+# settle_pending_signal — deliver a signal that was deferred across the commit, AFTER the
+# verdict is out. Called at the end of every mutating subcommand.
+settle_pending_signal() {
+  [ -n "$SIG_PENDING" ] || return 0
+  local sig="${SIG_PENDING%%:*}" code="${SIG_PENDING##*:}"
+  SIG_PENDING=''
+  trap '' INT TERM HUP
+  detail "SIG$sig arrived DURING the atomic rename and was DEFERRED across it, so the verdict above is the TRUE outcome rather than an 'undetermined'. Exiting $code."
+  exit "$code"
+}
+
+# THE BACKSTOP. Contract (c) says EVERY exit carries a token, and a rule enforced only by
+# reviewing each `exit` is the rule that grows a new exception every round — that is precisely
+# how the signal traps came to have none. Any path that leaves without deciding now says so.
+# NOTHING IN THIS TRAP MAY FAIL: a failing command in a bash EXIT trap under `set -e` aborts the
+# trap AND REPLACES the exit status (measured on roborev job 26 F2).
+on_exit() {
+  local rc=$?
+  if [ "$VERDICT_EXEMPT" -eq 0 ] && [ "$VERDICT_EMITTED" -eq 0 ]; then
+    verdict ERROR || true
+    detail "the run ended at exit $rc without reaching any decision point, so NOTHING was decided and NOTHING was written. This is a defect in $(sane "$prog"), not a state of the marker: report it with the command you ran." || true
+  fi
+  cleanup_tmp
+  return 0
+}
+trap on_exit EXIT
 
 # register_tmp <path> — remember a temp file for cleanup. Stored as an array ELEMENT, so no
 # assumption is made about the path's shape (see TMP_FILES above).
@@ -923,12 +1022,34 @@ write_marker() {
   } >"$tmp" || { rm -f "$tmp" 2>/dev/null || true; WRITE_ERR="failed writing the stamp to $(sane "$tmp") — nothing was replaced (the body could not be read, or the temporary file could not be written)"; return 1; }
   # The last thing before the atomic commit, over the committed bytes themselves.
   assert_assembled_marker "$tmp" || { rm -f "$tmp" 2>/dev/null || true; return 1; }
-  # mv's NATIVE text is CAPTURED and FOLDED for the same reason as mktemp's: "cannot move ...
-  # Permission denied" vs "Device or resource busy" are different operator actions.
-  local mverr
-  mverr="$(mv -f "$tmp" "$path" 2>&1)" || {
-    rm -f "$tmp" 2>/dev/null || true
-    WRITE_ERR="failed replacing $(sane "$path")${mverr:+ (mv: $(sane "$mverr"))}"; return 1; }
+  # THE COMMIT. mv's NATIVE text is CAPTURED and FOLDED for the same reason as mktemp's:
+  # "cannot move ... Permission denied" vs "Device or resource busy" are different operator
+  # actions. It is captured to a FILE and run as a PLAIN command rather than inside `$( )`,
+  # which is the roborev job 30 G2 change and is load-bearing: MEASURED on bash 5.2, a trapped
+  # signal arriving while the shell waits for a COMMAND SUBSTITUTION inside a FUNCTION is
+  # DISCARDED — the trap never runs at all — while the same signal during a plain command is
+  # delivered normally. The one window whose interruption changes durable state must be
+  # signal-OBSERVABLE, or the phase machinery below can never see it.
+  local mverrf="$tmp.err" mverr=''
+  register_tmp "$mverrf"
+  COMMIT_PHASE=committing
+  if mv -f "$tmp" "$path" >"$mverrf" 2>&1; then
+    COMMIT_PHASE=committed
+  else
+    COMMIT_PHASE=idle
+    mverr="$(cat "$mverrf" 2>/dev/null || true)"
+    rm -f "$tmp" "$mverrf" 2>/dev/null || true
+    WRITE_ERR="failed replacing $(sane "$path")${mverr:+ (mv: $(sane "$mverr"))}"; return 1
+  fi
+  # RESIDUAL, STATED RATHER THAN CLAIMED AWAY: bash defers a trap until the current command
+  # completes, so a signal arriving during the rename runs the handler HERE — with the phase
+  # still `committing` — and the deferral above is what makes that report the truth. The window
+  # between `mv` returning and the phase assignment above is NOT eliminated, only narrowed to
+  # two shell assignments; a signal landing exactly there is reported as a completed write,
+  # which is correct, because the rename HAS returned. What is genuinely NOT atomic is the pair
+  # (rename, phase update) when the rename FAILS: a pending signal is then dropped in favour of
+  # the anchored ERROR verdict above, so the exit status is 1 rather than the signal's.
+  rm -f "$mverrf" 2>/dev/null || true
   WROTE_PATH="$path"
   return 0
 }
@@ -1056,6 +1177,7 @@ cmd_write() {
   [ -z "$prior_pid" ]     || f_pp="prior-session-pid: $(sanitize_field "$prior_pid")"
   [ -z "$prior_ts" ]      || f_pt="prior-ts: $(sanitize_field "$prior_ts")"
   [ -z "$adopt_reason" ]  || f_ar="adopt-reason: $(sanitize_field "$adopt_reason")"
+  COMMIT_VERDICT=WRITTEN
   if ! write_marker "$issue" "$actor" "$body_src" "$f_stage" "$f_request" "$f_pr" "$f_branch" \
       "$f_ps" "$f_pp" "$f_pt" "$f_ar"; then
     [ -z "$carried" ] || rm -f "$carried" 2>/dev/null || true
@@ -1065,6 +1187,7 @@ cmd_write() {
   verdict WRITTEN
   [ -z "$discarded" ] || detail "$discarded"
   detail "issue=$(sane "$issue") machine=$(sane "$(this_machine)") worktree=$(sane "$(pwd -P)") session=$(sane "$(this_session)") session-pid=$(sane "$(this_session_pid)") actor=$(sane "$actor") -> $(sane "$WROTE_PATH")"
+  settle_pending_signal
 }
 
 cmd_verify() {
@@ -1086,6 +1209,7 @@ cmd_verify() {
 # `resume:<branch>` sanitizes to a non-sentinel token and would otherwise record an
 # unresolved placeholder as the audit reason. These commands are read by agents that run
 # printed text LITERALLY.
+REASON_TOKEN=''
 assert_reason() {
   local raw="$1" tok
   case "$raw" in
@@ -1099,7 +1223,7 @@ assert_reason() {
     why | reason | todo | tbd | tba | xxx | xxxx | placeholder | fixme | none | foo | bar | baz | n/a)
       die_usage "adopt: --reason '$(sane "$raw")' records as the PLACEHOLDER '$(sane "$tok")' — as uninformative as no reason at all. Say what the resume IS, e.g. --reason cron-reinvoke:writer-pid-gone" ;;
   esac
-  printf '%s\n' "$tok"
+  REASON_TOKEN="$tok"
 }
 
 cmd_adopt() {
@@ -1117,7 +1241,12 @@ cmd_adopt() {
   # whatever the lane looks like — a usage error must not depend on the marker's state.
   [ "$reason_given" -eq 1 ] || die_usage "adopt requires --reason saying what the resume IS (it is recorded in the stamp next to who took it), e.g. --reason cron-reinvoke:writer-pid-gone"
   local reason_token actor
-  reason_token="$(assert_reason "$reason")"
+  # REPORTED THROUGH A GLOBAL, NEVER `$( )`. assert_reason can `die_usage`, and a die/refuse
+  # inside a command substitution exits only the SUBSHELL: its `verdict USAGE` line would be
+  # CAPTURED into this variable instead of reaching stdout, leaving the run with no verdict at
+  # all — exactly the defect case 17 pins for write_marker.
+  assert_reason "$reason"
+  reason_token="$REASON_TOKEN"
   actor="$(resolve_actor "$actor_raw")"
 
   lock_marker
@@ -1147,6 +1276,7 @@ cmd_adopt() {
   [ -z "$request" ] || f_request="request-id: $request"
   [ -z "$pr" ]      || f_pr="pr: $pr"
   [ -z "$branch" ]  || f_branch="branch: $branch"
+  COMMIT_VERDICT=ADOPTED
   if ! write_marker "$issue" "$actor" "$carried" "$f_stage" "$f_request" "$f_pr" "$f_branch" \
       "prior-session: $prior_session" \
       "prior-session-pid: $prior_pid" \
@@ -1158,6 +1288,7 @@ cmd_adopt() {
   rm -f "$carried" 2>/dev/null || true
   verdict ADOPTED
   detail "issue=$(sane "$issue") prior-session=$(sane "$prior_session") prior-session-pid=$(sane "$prior_pid") new-session=$(sane "$(this_session)") reason=$(sane "$reason_token") -> $(sane "$WROTE_PATH"); the recorded writer was provably gone: $LIVE_DETAIL"
+  settle_pending_signal
 }
 
 cmd_show() {

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -558,8 +558,13 @@ register_tmp() { TMP_FILES+=("$1"); }
 # line — was absent, and a `case` on that token (which drive-issue.md's Delta 4 mandates)
 # fell through every arm on a FATAL failure. `refuse` is defined above precisely so that
 # every exit of this script carries a token; there is no exception for a fatal one.
-[ -r "$SCRIPT_HOME/lib/process-liveness.sh" ] || \
-  refuse ERROR 1 "cannot read $(sane "$SCRIPT_HOME/lib/process-liveness.sh") (the shared process-liveness primitives) — NOTHING was measured"
+# `-f` AS WELL AS `-r` (roborev job 51's sweep). `.` on a FIFO would BLOCK FOREVER waiting for a
+# writer, and `-r` is true for one. The path is repo-owned, so reaching that state means the
+# checkout was tampered with — invoker-class, out of the threat model — but the guard is one
+# token and a hang here has no verdict and no timeout. Both predicates FOLLOW a symlink, which
+# is deliberate: a symlinked checkout is a legitimate layout.
+{ [ -f "$SCRIPT_HOME/lib/process-liveness.sh" ] && [ -r "$SCRIPT_HOME/lib/process-liveness.sh" ]; } || \
+  refuse ERROR 1 "cannot read $(sane "$SCRIPT_HOME/lib/process-liveness.sh") as a regular file (the shared process-liveness primitives) — NOTHING was measured"
 # shellcheck source=lib/process-liveness.sh
 . "$SCRIPT_HOME/lib/process-liveness.sh"
 
@@ -771,6 +776,60 @@ require_numeric_issue() {
 }
 
 # ---------------------------------------------------------------------------
+# FILESYSTEM ENTRY TYPES (roborev job 51, and the sweep of its class).
+#
+# WHY A TYPE PROBE EXISTS AT ALL: a `test -e`/`test -r` answers whether a path is THERE, and
+# every path this script opens then assumes it is a REGULAR FILE. It is not the same question,
+# and the gap is not cosmetic — the three failure modes differ by type:
+#
+#   FIFO      opening one for write BLOCKS INDEFINITELY until a reader appears. MEASURED: with
+#             a FIFO at the lock path, `write` ran until killed (`timeout 10` -> rc 124). In an
+#             unattended lane that is a PERMANENT STALL, and it is the worst possible breach of
+#             contract (c): not a wrong verdict, NO verdict, forever.
+#   device    a char/block device accepts the open and the write, so the run would appear to
+#             succeed while the bytes went to the device and the `flock` serialized nothing.
+#   socket    opening one fails with ENXIO — a refusal, but under a message naming the wrong
+#             cause ("it may be a directory").
+#   directory an open-for-write fails cleanly.
+#   symlink   FOLLOWED by every predicate except `-L`, so it redirects the open OUTSIDE the lane
+#             (roborev job 43 K1, whose fix reached only the symlink half of this same class).
+#
+# Both helpers are pure `test` builtins: they STAT, they never OPEN, so probing is itself
+# incapable of blocking. The fall-through is `unknown`, never `regular` — a type nothing here
+# recognises is not licensed to be opened, which is this file's standing rule that a positive
+# verdict requires an affirmative measurement.
+#
+# TWO functions, because the two call sites want different questions and answering the wrong
+# one is a defect either way. The LOCK sidecar is script-owned: the entry ITSELF must be
+# regular, so a symlink is refused whatever it points at. A caller's `--body-file` is the
+# caller's own artifact: a symlink to a real file is ordinary and must keep working, so THERE
+# the question is what the path RESOLVES to.
+# ---------------------------------------------------------------------------
+
+# path_kind_followed <path> — the type the path RESOLVES to (symlinks followed).
+path_kind_followed() {
+  local p="$1"
+  [ -e "$p" ]  || { printf 'absent\n'; return 0; }
+  [ ! -f "$p" ] || { printf 'regular\n'; return 0; }
+  [ ! -d "$p" ] || { printf 'directory\n'; return 0; }
+  [ ! -p "$p" ] || { printf 'fifo\n'; return 0; }
+  [ ! -S "$p" ] || { printf 'socket\n'; return 0; }
+  [ ! -b "$p" ] || { printf 'block-device\n'; return 0; }
+  [ ! -c "$p" ] || { printf 'char-device\n'; return 0; }
+  printf 'unknown\n'
+}
+
+# path_kind <path> — the type of the ENTRY, never its target's. The `-L` test comes FIRST
+# because every other predicate follows a link, and a DANGLING symlink is `-L` true / `-e`
+# false — the shape that made an earlier `-e` probe answer `absent` for an entry that plainly
+# exists (roborev job 43 K1).
+path_kind() {
+  local p="$1"
+  [ ! -L "$p" ] || { printf 'symlink\n'; return 0; }
+  path_kind_followed "$p"
+}
+
+# ---------------------------------------------------------------------------
 # Serialization. A verify-then-replace sequence that is not atomic is a guard with a hole:
 # two sessions in ONE lane — the exact scenario this file exists for — can BOTH pass
 # ownership verification and the second can clobber the first's stamp. The ownership check
@@ -796,20 +855,32 @@ lock_marker() {
   # non-interactive shell with bash's own unprefixed diagnostic — which would break the
   # output anchor every consumer rests on, and emit no verdict at all.
   [ -w "$wt" ] || refuse ERROR 1 "the worktree directory $(sane "$wt") is not writable, so the marker lock cannot be taken — nothing was decided and nothing was written"
-  # THE LOCK PATH IS SCRIPT-OWNED, SO A SYMLINK THERE IS REFUSED TOO (roborev job 43 K1's class,
-  # swept rather than waited for). The `: >>"$lock"` below FOLLOWS a link, so a link planted at
-  # this path — by a peer lane, not only by the invoker — would make this script create a file
-  # OUTSIDE the lane, and a DANGLING one is invisible to `-e` exactly as the marker's was. Same
-  # ruling as the marker's: a link is a deliberate artifact, and this script neither follows one
-  # nor replaces one.
-  [ ! -L "$lock" ] || refuse ERROR 1 "the marker lock path $(sane "$lock") is a SYMLINK (dangling or not) — this script owns that path and neither follows nor replaces a link there, so the ownership-verify -> replace sequence cannot be serialized on it; nothing was decided and nothing was written"
+  # THE LOCK PATH IS SCRIPT-OWNED, SO ANY NON-REGULAR ENTRY THERE IS REFUSED (roborev job 51,
+  # and the third round running in which a fix reached one member of its class: job 43 K1 taught
+  # this path to refuse a SYMLINK and left every other non-regular type accepted). The FIFO is
+  # the one that must never reach the open below — `: >>"$lock"` on a FIFO BLOCKS FOREVER — but
+  # the rule is stated over the TYPE rather than over the list of types that hang today: this
+  # script owns this path, it did not create what is there, and it neither follows, opens nor
+  # replaces someone else's artifact. `absent` is the ordinary case (we create it); `regular` is
+  # our own sidecar from a previous run. Everything else, INCLUDING a type this probe cannot
+  # name, is a refusal. The symlink half is folded in here rather than kept as a second check,
+  # so there is ONE rule and one message to keep true.
+  local lkind; lkind="$(path_kind "$lock")"
+  case "$lkind" in
+    absent | regular) : ;;
+    *) refuse ERROR 1 "the marker lock path $(sane "$lock") exists and is NOT a regular file (it is a $lkind) — this script owns that path, so it neither follows, opens nor replaces what someone else put there. Opening a FIFO there would BLOCK FOREVER waiting for a reader (an unattended lane would stall with no verdict at all); a device or socket would serialize NOTHING while appearing to succeed. Inspect the path and remove it deliberately. Nothing was decided and nothing was written." ;;
+  esac
   command -v flock >/dev/null 2>&1 || refuse ERROR 1 "flock is not available on this host, so the ownership-verify -> replace sequence cannot be SERIALIZED. Refusing rather than mutating unserialized: two sessions in one lane could both pass verification and one clobber the other's stamp, which is the defect this marker exists to prevent. An unmeasurable guarantee is never read as satisfied."
   # THE `2>/dev/null` COMES FIRST, AND THAT ORDER IS THE WHOLE POINT (roborev job 30, found by
   # sweeping G3's class rather than by the finding). Bash applies redirections LEFT TO RIGHT, so
   # `: >>"$lock" 2>/dev/null` attempts the failing redirection BEFORE stderr is diverted and
   # prints its own UNPREFIXED `bash: <path>: Permission denied` (measured, both orders). A
   # redirection is an external-command diagnostic in every way that matters to contract (a).
-  : 2>/dev/null >>"$lock" || refuse ERROR 1 "cannot create the marker lock file $(sane "$lock") — it may be a directory, or the lane may not permit creating it; nothing was decided"
+  # The type check above has already refused every non-regular entry BY NAME, so what remains
+  # here is a permission/quota failure, or an entry that changed type between the probe and this
+  # open. It is deliberately NOT removed as redundant: the probe is a stat and this is the act,
+  # and a check before an act can only describe a file that no longer has to be the one acted on.
+  : 2>/dev/null >>"$lock" || refuse ERROR 1 "cannot create or append to the marker lock file $(sane "$lock") — the lane may not permit creating it, or it was replaced after its type was probed; nothing was decided"
   eval "exec ${MARKER_LOCK_FD}>>\"\$lock\""
   # flock's own stderr is SUPPRESSED rather than captured: capturing it would mean running
   # flock inside a command substitution, i.e. in a subshell, which is not a place to be
@@ -1479,14 +1550,24 @@ write_marker() {
   # DISCARDED — the trap never runs at all — while the same signal during a plain command is
   # delivered normally. The one window whose interruption changes durable state must be
   # signal-OBSERVABLE, or the phase machinery below can never see it.
-  local mverrf="$tmp.err" mverr=''
-  register_tmp "$mverrf"
-  # PRE-CREATED, WITH `2>/dev/null` FIRST: the commit below redirects into this path, and a
-  # redirection bash cannot satisfy prints an UNPREFIXED diagnostic (see lock_marker). Proving
-  # the path creatable here keeps that diagnostic out of the one command that must not emit one.
-  : 2>/dev/null >"$mverrf" || {
+  # CREATED BY `mktemp`, NOT BY A REDIRECTION INTO A DERIVED NAME (roborev job 51's sweep). The
+  # commit below redirects into this path, and a redirection bash cannot satisfy prints an
+  # UNPREFIXED diagnostic (see lock_marker) — so the path must be proven creatable BEFORE that
+  # one command. This used to be `mverrf="$tmp.err"` plus `: >"$mverrf"`, which proves
+  # creatability but opens whatever is already at that name: a FIFO there BLOCKS FOREVER, the
+  # lock path's defect at a second site. A type probe cannot close it (the probe is a stat, the
+  # redirect is the act), but `mktemp` can: it creates with O_EXCL, so it can never open an
+  # existing entry of ANY type. That the name is unpredictable makes the race narrow; it does
+  # not make it absent, and the fix costs one call.
+  local mverrf mverrout mverr=''
+  mverrout="$(mktemp "$path.err.XXXXXX" 2>&1)" || {
     rm -f "$tmp" 2>/dev/null || true
-    WRITE_ERR="cannot create the commit's diagnostic file next to $(sane "$path") — nothing was written"; return 1; }
+    WRITE_ERR="cannot create the commit's diagnostic file next to $(sane "$path") — nothing was written (mktemp: $(sane "$mverrout"))"; return 1; }
+  mverrf="$mverrout"
+  register_tmp "$mverrf"
+  { [ -n "$mverrf" ] && [ -f "$mverrf" ]; } || {
+    rm -f "$tmp" 2>/dev/null || true
+    WRITE_ERR="mktemp exited 0 for the commit's diagnostic file next to $(sane "$path") but named no usable temporary file (it emitted: $(sane "$mverrout")) — nothing was written"; return 1; }
   COMMIT_PHASE=committing
   if mv -f "$tmp" "$path" >"$mverrf" 2>&1; then
     COMMIT_PHASE=committed
@@ -1560,6 +1641,18 @@ cmd_write() {
   local body_src='' body_snap=''
   if [ -n "$bodyfile" ]; then
     [ -r "$bodyfile" ] || die_usage "--body-file '$(sane "$bodyfile")' is not readable — nothing was written"
+    # AND IT MUST BE A REGULAR FILE — the same class as the lock sidecar's, at the one path a
+    # CALLER names (roborev job 51's sweep). `-r` is TRUE for a FIFO, and the `cat` below then
+    # BLOCKS FOREVER waiting for a writer: MEASURED, `--body-file <a fifo>` ran until killed
+    # (`timeout 8` -> rc 124), the same permanent unattended stall as the lock path's. A
+    # CHARACTER DEVICE is worse than a stall and was also measured: `--body-file /dev/zero`
+    # streams without end into the snapshot, so the failure is a filled disk rather than a hang.
+    # The question here is what the path RESOLVES to, not what the entry is: a symlink to a real
+    # notes file is an ordinary thing for a caller to pass and keeps working. USAGE rather than
+    # ERROR because the path came from the invocation — the same verdict as the `-r` line above,
+    # and the documented contract is `--body-file <notes.md>`, a file.
+    local bkind; bkind="$(path_kind_followed "$bodyfile")"
+    [ "$bkind" = regular ] || die_usage "--body-file '$(sane "$bodyfile")' is not a REGULAR file (it resolves to a $bkind) — reading a FIFO would BLOCK FOREVER waiting for a writer and a device would stream without end, so it is refused rather than opened. Pass a file. NOTHING was written."
     body_snap="$(mktemp "${TMPDIR:-/tmp}/drive-issue-body.XXXXXX" 2>&1)" || refuse ERROR 1 "cannot create a temporary file for the --body-file snapshot under $(sane "${TMPDIR:-/tmp}") — nothing was written (mktemp: $(sane "$body_snap"))"
     { [ -n "$body_snap" ] && [ -f "$body_snap" ]; } || refuse ERROR 1 "mktemp exited 0 for the --body-file snapshot but named no usable temporary file (it emitted: $(sane "$body_snap")) — nothing was written"
     register_tmp "$body_snap"

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -958,6 +958,11 @@ assert_assembled_marker() {
 # string inside a path. Every emit site in this script is in the main shell for that reason.
 WROTE_PATH=''; WRITE_ERR=''
 write_marker() {
+  # ARGUMENT-COUNT GUARD BEFORE THE SHIFT (roborev job 30 G3, internal site) — see `refuse`.
+  if [ "$#" -lt 3 ]; then
+    WRITE_ERR="internal: write_marker was called with $# argument(s); an issue, an actor and a body-file slot are required"
+    return 1
+  fi
   local issue="$1" actor="$2" bodyfile="$3"; shift 3
   local wt path tmp ts session pid win lo hi
   wt="$(pwd -P)"
@@ -1058,24 +1063,30 @@ write_marker() {
 # Subcommands
 # ---------------------------------------------------------------------------
 cmd_write() {
-  local issue="${1:-}"; shift || true
+  # COUNT-CHECKED, NOT `shift || true` (roborev job 30 G3): a `shift` past the end prints
+  # bash's own UNPREFIXED diagnostic under `shift_verbose`/POSIX mode — both settable from the
+  # ENVIRONMENT (`BASHOPTS`) by a caller who never touches this file — which breaks contract
+  # (a) before the anchored USAGE line is ever reached.
+  local issue="${1:-}"
+  [ "$#" -eq 0 ] || shift
   require_numeric_issue "$issue" write
   local stage='' request='' pr='' branch='' bodyfile='' actor_raw='' clears=''
   local prior_session='' prior_pid='' prior_ts='' adopt_reason=''
   while [ "$#" -gt 0 ]; do
     case "$1" in
-      --stage)      stage="${2:-}";      shift 2 || die_usage "--stage needs a value" ;;
-      --request-id) request="${2:-}";    shift 2 || die_usage "--request-id needs a value" ;;
-      --pr)         pr="${2:-}";         shift 2 || die_usage "--pr needs a value" ;;
-      --branch)     branch="${2:-}";     shift 2 || die_usage "--branch needs a value" ;;
-      --body-file)  bodyfile="${2:-}";   shift 2 || die_usage "--body-file needs a value" ;;
-      --actor)      actor_raw="${2:-}";  shift 2 || die_usage "--actor needs a value" ;;
+      --stage)      [ "$#" -ge 2 ] || die_usage "--stage needs a value";      stage="$2";      shift 2 ;;
+      --request-id) [ "$#" -ge 2 ] || die_usage "--request-id needs a value"; request="$2";    shift 2 ;;
+      --pr)         [ "$#" -ge 2 ] || die_usage "--pr needs a value";         pr="$2";         shift 2 ;;
+      --branch)     [ "$#" -ge 2 ] || die_usage "--branch needs a value";     branch="$2";     shift 2 ;;
+      --body-file)  [ "$#" -ge 2 ] || die_usage "--body-file needs a value";  bodyfile="$2";   shift 2 ;;
+      --actor)      [ "$#" -ge 2 ] || die_usage "--actor needs a value";      actor_raw="$2";  shift 2 ;;
       --clear)
-        case "${2:-}" in
-          stage | request-id | pr | branch) clears="$clears ${2}" ;;
-          *) die_usage "--clear takes one of stage|request-id|pr|branch (got '$(sane "${2:-<none>}")') — the field set is CLOSED so a typo erases nothing silently" ;;
+        [ "$#" -ge 2 ] || die_usage "--clear needs a field name"
+        case "$2" in
+          stage | request-id | pr | branch) clears="$clears $2" ;;
+          *) die_usage "--clear takes one of stage|request-id|pr|branch (got '$(sane "$2")') — the field set is CLOSED so a typo erases nothing silently" ;;
         esac
-        shift 2 || die_usage "--clear needs a field name" ;;
+        shift 2 ;;
       *) die_usage "write: unknown option '$(sane "$1")'" ;;
     esac
   done
@@ -1191,11 +1202,16 @@ cmd_write() {
 }
 
 cmd_verify() {
-  local issue="${1:-}"; shift || true
+  # COUNT-CHECKED, NOT `shift || true` (roborev job 30 G3): a `shift` past the end prints
+  # bash's own UNPREFIXED diagnostic under `shift_verbose`/POSIX mode — both settable from the
+  # ENVIRONMENT (`BASHOPTS`) by a caller who never touches this file — which breaks contract
+  # (a) before the anchored USAGE line is ever reached.
+  local issue="${1:-}"
+  [ "$#" -eq 0 ] || shift
   require_numeric_issue "$issue" verify
   while [ "$#" -gt 0 ]; do
     case "$1" in
-      --actor) shift 2 || die_usage "--actor needs a value" ;;
+      --actor) [ "$#" -ge 2 ] || die_usage "--actor needs a value"; shift 2 ;;
       *) die_usage "verify: unknown option '$(sane "$1")'" ;;
     esac
   done
@@ -1227,13 +1243,18 @@ assert_reason() {
 }
 
 cmd_adopt() {
-  local issue="${1:-}"; shift || true
+  # COUNT-CHECKED, NOT `shift || true` (roborev job 30 G3): a `shift` past the end prints
+  # bash's own UNPREFIXED diagnostic under `shift_verbose`/POSIX mode — both settable from the
+  # ENVIRONMENT (`BASHOPTS`) by a caller who never touches this file — which breaks contract
+  # (a) before the anchored USAGE line is ever reached.
+  local issue="${1:-}"
+  [ "$#" -eq 0 ] || shift
   require_numeric_issue "$issue" adopt
   local reason='' reason_given=0 actor_raw=''
   while [ "$#" -gt 0 ]; do
     case "$1" in
-      --reason) reason="${2-}"; reason_given=1; shift 2 || die_usage "--reason needs a value" ;;
-      --actor)  actor_raw="${2:-}"; shift 2 || die_usage "--actor needs a value" ;;
+      --reason) [ "$#" -ge 2 ] || die_usage "--reason needs a value"; reason="$2"; reason_given=1; shift 2 ;;
+      --actor)  [ "$#" -ge 2 ] || die_usage "--actor needs a value"; actor_raw="$2"; shift 2 ;;
       *) die_usage "adopt: unknown option '$(sane "$1")'" ;;
     esac
   done
@@ -1292,7 +1313,12 @@ cmd_adopt() {
 }
 
 cmd_show() {
-  local issue="${1:-}"; shift || true
+  # COUNT-CHECKED, NOT `shift || true` (roborev job 30 G3): a `shift` past the end prints
+  # bash's own UNPREFIXED diagnostic under `shift_verbose`/POSIX mode — both settable from the
+  # ENVIRONMENT (`BASHOPTS`) by a caller who never touches this file — which breaks contract
+  # (a) before the anchored USAGE line is ever reached.
+  local issue="${1:-}"
+  [ "$#" -eq 0 ] || shift
   require_numeric_issue "$issue" show
   read_marker
   emit "field issue=$(sane "$S_issue")"
@@ -1320,6 +1346,9 @@ cmd_show() {
 }
 
 SUB="${1:-}"
+# The four `shift`s below cannot fail: `$SUB` is non-empty only when `$#` >= 1, and an empty
+# `$SUB` takes the `''` arm. Stated rather than guarded, because a guard whose condition is
+# unreachable is a guard nobody can test (roborev job 30 G3 swept every OTHER site).
 case "$SUB" in
   write)  shift; cmd_write  "$@" ;;
   verify) shift; cmd_verify "$@" ;;

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -32,6 +32,12 @@
 #     copied tree, a foreign worktree means the file was copied.
 #
 #   SESSION AXIS — recorded (AC1), but NOT fail-closed on its own.
+#     A recorded session id equal to the current one (and recordable) is OWNED outright. So
+#     is a recorded pid that is ALIVE and EQUAL to our own session pid with an intersecting
+#     start window — a pid is unique among live processes, so that process IS us, and
+#     without this a session with CLAUDE_PID set but no CLAUDE_CODE_SESSION_ID would refuse
+#     its OWN marker as a live peer. It is an affirmative measurement of sameness (stronger
+#     than the id string it stands in for), never a permissive fallback.
 #     A session difference alone is resolved by the LIVENESS OF THE RECORDED WRITER,
 #     three-valued, on `claim-heartbeat.sh dead-lanes`' precedent:
 #       writer provably GONE  -> ADOPTABLE. `verify` still exits NON-ZERO: adoption is an
@@ -499,6 +505,19 @@ check_ownership() {
   fi
 
   writer_liveness
+
+  # SAME PROCESS => OWNED, EVEN WHEN THE SESSION ID DOES NOT MATCH. A pid is unique among
+  # LIVE processes, so a recorded pid that is alive AND equal to our own session pid (with
+  # its start window still intersecting) is not a peer — it IS us. Without this branch a
+  # session with CLAUDE_PID set but CLAUDE_CODE_SESSION_ID UNSET wrote a marker and then
+  # refused its OWN marker as a LIVE-PEER on the very next command: a guard that reds on
+  # correct input, which is the guard agents learn to waive. This is an AFFIRMATIVE
+  # measurement of sameness (pid identity + start-window intersection), strictly stronger
+  # than the session-id string it stands in for — never a fallback to permissiveness.
+  if [ "$LIVE_STATE" = alive ] && [ "$S_pid" = "$(this_session_pid)" ]; then
+    return 0
+  fi
+
   local why="axis=session recorded=$(sane "$S_session") current=$(sane "$session"); $LIVE_DETAIL"
   case "$LIVE_STATE" in
     alive)

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -156,10 +156,19 @@
 #              `--clear stage|request-id|pr|branch` (repeatable). Omitting a flag never
 #              erases durable state — dropping the open request id would make the next
 #              session re-ask, breaking "one marker, one wait".
+#              THE ADOPTION PROVENANCE IS DURABLE STATE TOO and is preserved the same way:
+#              `prior-session`, `prior-session-pid`, `prior-ts`, `adopt-reason`. There is no
+#              flag and no `--clear` for those four — only a LATER `adopt` replaces them (the
+#              newest hand-over is the record), and a fresh write over an ABSENT marker, or
+#              the UNSTAMPED migration, INVENTS none. A mandatory, validated `--reason` that
+#              the next stage update erases is no audit record at all.
 #   verify <N> [--actor <id>]      the rehydrate gate (see the axes above)
 #   adopt  <N> --reason <why> [--actor <id>]
 #              The explicit adopt gesture. Resolves the SESSION axis ONLY: a fail-closed
 #              axis mismatch still refuses, and so does a live or unmeasurable writer.
+#              It RECORDS the provenance of the hand-over — `prior-session`,
+#              `prior-session-pid`, `prior-ts`, `adopt-reason` — which then survives later
+#              `write`s and is REPLACED (never accumulated) by a later adopt.
 #              The body and the durable fields (stage/request-id/pr/branch) SURVIVE: this is
 #              THE normal cron-resume path, so dropping them would destroy the open
 #              coordination request on every legitimate resume.
@@ -167,7 +176,9 @@
 #              nothing recordable in it, a bare PLACEHOLDER (`why`, `todo`, `tbd`, …) or one
 #              still carrying an UNSUBSTITUTED `<…>` is a USAGE error (64), never a silent
 #              `reason=unspecified` — same gate, and same reasons, as claim.sh's.
-#   show   <N> print the recorded stamp fields. No ownership verdict.
+#   show   <N> print the recorded stamp fields, INCLUDING the adoption provenance when the
+#              marker carries it (`show` is the contract's window onto the marker, so it
+#              prints every field the reader parses). No ownership verdict.
 #   --help     this contract (authoritative)
 #
 # IDENTITY
@@ -419,7 +430,11 @@ lock_marker() {
 # ---------------------------------------------------------------------------
 S_issue=''; S_machine=''; S_worktree=''; S_session=''; S_pid=''
 S_start_lo=''; S_start_hi=''; S_actor=''; S_ts=''; S_stage=''
-S_request=''; S_pr=''; S_branch=''; S_prior_session=''
+S_request=''; S_pr=''; S_branch=''
+# ADOPTION PROVENANCE (roborev job 26 F3). All FOUR are PARSED, not merely written: they are
+# durable state — the audit record of how this lane changed hands — so an ordinary `write` has
+# to be able to carry them forward, and carrying forward what is never read is impossible.
+S_prior_session=''; S_prior_pid=''; S_prior_ts=''; S_adopt_reason=''
 
 marker_path() { printf '%s/%s\n' "$(pwd -P)" "$MARKER_NAME"; }
 
@@ -514,6 +529,9 @@ read_marker() {
       pr)                         dup="$S_pr";             S_pr="$val" ;;
       branch)                     dup="$S_branch";         S_branch="$val" ;;
       prior-session)              dup="$S_prior_session";  S_prior_session="$val" ;;
+      prior-session-pid)          dup="$S_prior_pid";      S_prior_pid="$val" ;;
+      prior-ts)                   dup="$S_prior_ts";       S_prior_ts="$val" ;;
+      adopt-reason)               dup="$S_adopt_reason";   S_adopt_reason="$val" ;;
       *) dup='' ;;   # forward compatibility: an unrecognised KEY is ignored, but its
                      # SHAPE was still enforced above, so it can never smuggle in a line.
     esac
@@ -873,6 +891,7 @@ cmd_write() {
   local issue="${1:-}"; shift || true
   require_numeric_issue "$issue" write
   local stage='' request='' pr='' branch='' bodyfile='' actor_raw='' clears=''
+  local prior_session='' prior_pid='' prior_ts='' adopt_reason=''
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --stage)      stage="${2:-}";      shift 2 || die_usage "--stage needs a value" ;;
@@ -948,6 +967,15 @@ cmd_write() {
       [ -n "$request" ] || cleared request-id || request="$S_request"
       [ -n "$pr" ]      || cleared pr         || pr="$S_pr"
       [ -n "$branch" ]  || cleared branch     || branch="$S_branch"
+      # ADOPTION PROVENANCE IS DURABLE STATE TOO (roborev job 26 F3, the same class as job
+      # 18's dropped durable fields, reappearing at the adopt fields). `adopt` records WHO
+      # held this lane, WHEN, and WHY it was taken; rebuilding the prologue from the write
+      # path's field list alone erased all of it on the very next stage update, which makes
+      # the mandatory, validated `--reason` worthless. There is no flag and no `--clear` for
+      # these: only a LATER `adopt` replaces them (the newest hand-over is the record), and
+      # nothing invents them where no adoption happened.
+      prior_session="$S_prior_session"; prior_pid="$S_prior_pid"
+      prior_ts="$S_prior_ts";           adopt_reason="$S_adopt_reason"
       if [ -z "$body_src" ]; then
       # Preserve an OWNED marker's body: `write` updates the stamp and the recorded stage,
       # not the author's notes.
@@ -969,7 +997,13 @@ cmd_write() {
   [ -z "$request" ] || f_request="request-id: $(sanitize_field "$request")"
   [ -z "$pr" ]      || f_pr="pr: $(sanitize_field "$pr")"
   [ -z "$branch" ]  || f_branch="branch: $(sanitize_field "$branch")"
-  if ! write_marker "$issue" "$actor" "$body_src" "$f_stage" "$f_request" "$f_pr" "$f_branch"; then
+  local f_ps='' f_pp='' f_pt='' f_ar=''
+  [ -z "$prior_session" ] || f_ps="prior-session: $(sanitize_field "$prior_session")"
+  [ -z "$prior_pid" ]     || f_pp="prior-session-pid: $(sanitize_field "$prior_pid")"
+  [ -z "$prior_ts" ]      || f_pt="prior-ts: $(sanitize_field "$prior_ts")"
+  [ -z "$adopt_reason" ]  || f_ar="adopt-reason: $(sanitize_field "$adopt_reason")"
+  if ! write_marker "$issue" "$actor" "$body_src" "$f_stage" "$f_request" "$f_pr" "$f_branch" \
+      "$f_ps" "$f_pp" "$f_pt" "$f_ar"; then
     [ -z "$carried" ] || rm -f "$carried" 2>/dev/null || true
     refuse ERROR 1 "$WRITE_ERR"
   fi
@@ -1088,7 +1122,14 @@ cmd_show() {
   emit "field request-id=$(sane "${S_request:-none}")"
   emit "field pr=$(sane "${S_pr:-none}")"
   emit "field branch=$(sane "${S_branch:-none}")"
+  # `show` is the contract's WINDOW onto the marker, so it prints every provenance field it
+  # parses — printing one of the four and hiding three would make the audit record readable
+  # only by opening the file, which is the state this script exists to replace. Each is
+  # conditional: a lane that was never adopted has no provenance to show.
   [ -z "$S_prior_session" ] || emit "field prior-session=$(sane "$S_prior_session")"
+  [ -z "$S_prior_pid" ]     || emit "field prior-session-pid=$(sane "$S_prior_pid")"
+  [ -z "$S_prior_ts" ]      || emit "field prior-ts=$(sane "$S_prior_ts")"
+  [ -z "$S_adopt_reason" ]  || emit "field adopt-reason=$(sane "$S_adopt_reason")"
   verdict SHOWN
   detail "fields as recorded for issue $(sane "$issue"); SHOWN asserts NOTHING about ownership — use 'verify' for that"
 }

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -796,6 +796,13 @@ lock_marker() {
   # non-interactive shell with bash's own unprefixed diagnostic — which would break the
   # output anchor every consumer rests on, and emit no verdict at all.
   [ -w "$wt" ] || refuse ERROR 1 "the worktree directory $(sane "$wt") is not writable, so the marker lock cannot be taken — nothing was decided and nothing was written"
+  # THE LOCK PATH IS SCRIPT-OWNED, SO A SYMLINK THERE IS REFUSED TOO (roborev job 43 K1's class,
+  # swept rather than waited for). The `: >>"$lock"` below FOLLOWS a link, so a link planted at
+  # this path — by a peer lane, not only by the invoker — would make this script create a file
+  # OUTSIDE the lane, and a DANGLING one is invisible to `-e` exactly as the marker's was. Same
+  # ruling as the marker's: a link is a deliberate artifact, and this script neither follows one
+  # nor replaces one.
+  [ ! -L "$lock" ] || refuse ERROR 1 "the marker lock path $(sane "$lock") is a SYMLINK (dangling or not) — this script owns that path and neither follows nor replaces a link there, so the ownership-verify -> replace sequence cannot be serialized on it; nothing was decided and nothing was written"
   command -v flock >/dev/null 2>&1 || refuse ERROR 1 "flock is not available on this host, so the ownership-verify -> replace sequence cannot be SERIALIZED. Refusing rather than mutating unserialized: two sessions in one lane could both pass verification and one clobber the other's stamp, which is the defect this marker exists to prevent. An unmeasurable guarantee is never read as satisfied."
   # THE `2>/dev/null` COMES FIRST, AND THAT ORDER IS THE WHOLE POINT (roborev job 30, found by
   # sweeping G3's class rather than by the finding). Bash applies redirections LEFT TO RIGHT, so

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -151,6 +151,9 @@
 # SUBCOMMANDS
 #   write  <N> [--stage <s>] [--request-id <r>] [--pr <n>] [--branch <b>]
 #              [--body-file <path>] [--actor <id>]
+#              A --body-file is READ EXACTLY ONCE, into a private snapshot, and everything
+#              downstream validates and copies THOSE bytes; a read failure is `verdict ERROR`,
+#              never a silently EMPTY body.
 #              Write/replace the marker in the CURRENT worktree. Writing OVER an existing
 #              marker first passes the SAME ownership verification `verify` applies — you
 #              may not overwrite a live peer's plan either — so a foreign marker refuses
@@ -938,7 +941,12 @@ read_marker() {
     # A DUPLICATE identity key would let the PARSER's choice decide identity, which is the
     # forgery shape this whole prologue exists to remove. Refused, not first-wins.
     [ -z "$dup" ] || refuse MALFORMED 8 "$(sane "$path") records '$(sane "$key")' TWICE in the stamp prologue — which occurrence is the identity is undecidable. The route forward is to move the file aside DELIBERATELY (e.g. 'mv $MARKER_NAME $MARKER_NAME.unreadable'): with no marker present this lane takes the ABSENT fresh-start path and a new stamped marker is written normally. It is NOT overwritten for you — unlike an unstamped marker this file CLAIMS an identity, and an identity that cannot be READ may be a live peer's. (This text deliberately names no subcommand: naming one that refuses in THIS state is the dead-letter shape scripts/tests/test_drive_issue_state.sh case 22 forbids.)"
-  done <"$path"
+    # THE SUPPRESSOR COMES FIRST (roborev job 37 J2's stat-then-act sweep). `marker_class`
+    # established this path a moment ago, and the file can be gone by now — a failed input
+    # redirection makes bash print its OWN unprefixed diagnostic, breaking contract (a), and
+    # bash applies redirections LEFT TO RIGHT, so `<"$path" 2>/dev/null` would leak it. The
+    # failure itself still ends the run through the EXIT-trap backstop's tokened ERROR.
+  done 2>/dev/null <"$path"
 
   local missing=''
   [ -n "$S_issue" ]    || missing="$missing issue"
@@ -1389,7 +1397,20 @@ write_marker() {
     # `cat`'s stderr is SUPPRESSED, not captured: inside a `{ ... } >"$tmp"` group there is
     # nowhere to capture it to, and the group's non-zero status already routes to the
     # anchored WRITE_ERR below (roborev job 26 F2).
-    if [ -n "$bodyfile" ] && [ -s "$bodyfile" ]; then cat "$bodyfile" 2>/dev/null; fi
+    #
+    # THE BODY IS ALWAYS READ; IT IS NEVER STAT-GATED (roborev job 37 J2). This used to be
+    # `[ -n "$bodyfile" ] && [ -s "$bodyfile" ]`, and the `-s` was a STAT STANDING IN FOR A
+    # READ: between that probe and the copy the source can be deleted, truncated, replaced or
+    # be a zero-sized nonregular file, and the false branch then contributed NOTHING while the
+    # run reported `WRITTEN` — a silently EMPTY body in the one file whose whole job is durable
+    # state. It is the same shape as the assembled-marker race: a check placed before the act
+    # can only describe a file that no longer has to be the one acted on. Now the read is the
+    # act — `cat` runs unconditionally, an empty source contributes nothing (which is what an
+    # empty body IS), and a read FAILURE makes the group non-zero and routes to the anchored
+    # WRITE_ERR below, so "the body could not be read" can never be committed as "there was no
+    # body". The caller-supplied file is additionally SNAPSHOTTED once in cmd_write, which
+    # removes the window rather than narrowing it.
+    if [ -n "$bodyfile" ]; then cat "$bodyfile" 2>/dev/null; fi
   } 2>/dev/null >"$tmp" || { rm -f "$tmp" 2>/dev/null || true; WRITE_ERR="failed writing the stamp to $(sane "$tmp") — nothing was replaced (the body could not be read, or the temporary file could not be written)"; return 1; }
   # The last thing before the atomic commit, over the committed bytes themselves.
   assert_assembled_marker "$tmp" || { rm -f "$tmp" 2>/dev/null || true; return 1; }
@@ -1472,11 +1493,24 @@ cmd_write() {
   require_worktree_axis
   require_session_axis
 
-  local body_src=''
+  # THE CALLER'S BODY FILE IS READ EXACTLY ONCE, INTO A SNAPSHOT WE OWN (roborev job 37 J2).
+  # Everything downstream — the sentinel scan, the assembled-marker validation and the copy into
+  # the marker — then reads THE SAME BYTES. Validating one file and copying another is what let
+  # a body vanish between the two; snapshotting SUBSUMES that window instead of narrowing it,
+  # exactly as `assert_assembled_marker` does for the commit. The `-r` probe is kept for the
+  # ordinary typo, as a friendly USAGE error before any work — it is NOT the guarantee: the
+  # guarantee is that the copy below is an ACT whose failure is checked, not a stat.
+  local body_src='' body_snap=''
   if [ -n "$bodyfile" ]; then
     [ -r "$bodyfile" ] || die_usage "--body-file '$(sane "$bodyfile")' is not readable — nothing was written"
-    assert_body_safe "$bodyfile"
-    body_src="$bodyfile"
+    body_snap="$(mktemp "${TMPDIR:-/tmp}/drive-issue-body.XXXXXX" 2>&1)" || refuse ERROR 1 "cannot create a temporary file for the --body-file snapshot under $(sane "${TMPDIR:-/tmp}") — nothing was written (mktemp: $(sane "$body_snap"))"
+    { [ -n "$body_snap" ] && [ -f "$body_snap" ]; } || refuse ERROR 1 "mktemp exited 0 for the --body-file snapshot but named no usable temporary file (it emitted: $(sane "$body_snap")) — nothing was written"
+    register_tmp "$body_snap"
+    # `cat`'s own stderr is suppressed (contract (a): its native `cat: ...: No such file or
+    # directory` carries no prefix) and its FAILURE is the refusal — never a silent empty body.
+    cat "$bodyfile" 2>/dev/null >"$body_snap" || refuse ERROR 1 "the --body-file $(sane "$bodyfile") could not be READ (it was deleted, replaced or became unreadable after it was named) — refusing rather than committing an EMPTY body over this lane's durable state; nothing was written"
+    assert_body_safe "$body_snap"
+    body_src="$body_snap"
   fi
 
   # Writing OVER an existing marker passes the SAME ownership verification: you may not

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -97,7 +97,16 @@
 # OUTPUT CONTRACT (mirrors scripts/flow/base-staleness.sh)
 #   (a) EVERY line of a verdict-bearing invocation, stdout AND stderr, begins
 #       `DRIVE-STATE: `. `--help` is the one exemption: it emits no verdict line, so no
-#       consumer parses it.
+#       consumer parses it. THAT COVERS THE EXTERNAL COMMANDS THIS SCRIPT RUNS: every one of
+#       them (mktemp, mv, rm, cat, date, wc, tr, hostname, flock, and the sourced liveness
+#       library's ps/date/tr/cut) has its stderr either CAPTURED and FOLDED into the anchored
+#       message — preferred where the native text names the cause, as with mktemp and mv — or
+#       SUPPRESSED where the anchored message already names the failure fully. A native
+#       `mktemp: failed to create file via template ...` line carries no prefix, and the
+#       failure itself is ALREADY reported through the anchored WRITE_ERR/refuse path, so the
+#       native line is pure contract breakage. Cleanup commands additionally carry `|| true`:
+#       they run AFTER the verdict, and a failing command in a bash EXIT trap under `set -e`
+#       aborts the trap AND replaces the exit status.
 #   (b) Every dynamic field is CONTROL-CHARACTER SANITIZED for display. Load-bearing: git
 #       and the filesystem PERMIT NEWLINES IN PATHS, and an unsanitized path printed
 #       verbatim emits a second line carrying no prefix, breaking the anchor everything
@@ -241,8 +250,10 @@ die_usage()  { printf '%s USAGE %s\n' "$P" "$*" >&2; exit 64; }
 # NEWLINE, and printed verbatim that emits a second line with no `DRIVE-STATE: ` prefix.
 # Control characters ONLY are masked; everything else is printed verbatim, because
 # mangling a path for the reader buys nothing once the anchor holds.
+# `tr`'s OWN stderr is suppressed: a diagnostic from the tool that exists to PROTECT the
+# anchor would be the one line breaking it (roborev job 26 F2).
 sane() {
-  printf '%s' "${1:-}" | LC_ALL=C tr -c '\040-\176\200-\377' '?'
+  printf '%s' "${1:-}" | LC_ALL=C tr -c '\040-\176\200-\377' '?' 2>/dev/null
 }
 
 # verdict <TOKEN> — contract (c): the ONE verdict line, one closed-set token, nothing else.
@@ -278,7 +289,12 @@ cleanup_tmp() {
   # `${#arr[@]}` is safe under `set -u` for an EMPTY array, whereas `"${arr[@]}"` is not on
   # bash 3.2/4.3 — hence the count guard rather than an unguarded expansion.
   if [ "${#TMP_FILES[@]}" -gt 0 ]; then
-    for f in "${TMP_FILES[@]}"; do [ -z "$f" ] || rm -f "$f"; done
+    # `2>/dev/null || true`: cleanup is BEST-EFFORT and runs AFTER the verdict, so it may
+    # neither emit an unprefixed line nor change the outcome. MEASURED, not assumed — a
+    # failing command in a bash EXIT trap under `set -e` aborts the trap and REPLACES the
+    # exit status, so a broken `rm` turned a legitimate WRITTEN(0) into an unexplained
+    # non-zero (roborev job 26 F2).
+    for f in "${TMP_FILES[@]}"; do [ -z "$f" ] || rm -f "$f" 2>/dev/null || true; done
   fi
   TMP_FILES=()
 }
@@ -321,14 +337,16 @@ register_tmp() { TMP_FILES+=("$1"); }
 # failure inside a command substitution kills the script with no verdict line at all.
 sanitize_field() {
   local s
-  s="$(printf '%s' "${1:-}" | LC_ALL=C tr -c 'A-Za-z0-9._:/#-' '-' | LC_ALL=C sed -e 's/--*/-/g' -e 's/^-//' -e 's/-$//')"
+  s="$(printf '%s' "${1:-}" | LC_ALL=C tr -c 'A-Za-z0-9._:/#-' '-' 2>/dev/null | LC_ALL=C sed -e 's/--*/-/g' -e 's/^-//' -e 's/-$//' 2>/dev/null)"
   s="$(LC_ALL=C printf '%.120s' "$s")"
   s="${s%-}"
   [ -n "$s" ] || s="unspecified"
   printf '%s\n' "$s"
 }
 
-this_machine() { sanitize_field "${CLAIM_MACHINE:-$(hostname -s)}"; }
+# `hostname`'s stderr is suppressed (roborev job 26 F2): its failure is already visible as a
+# degraded machine value, and an unprefixed 'hostname: not found' would break the anchor.
+this_machine() { sanitize_field "${CLAIM_MACHINE:-$(hostname -s 2>/dev/null)}"; }
 
 # this_session — the current session id, or the `unrecorded` sentinel. An unrecorded
 # session makes the session axis UNMEASURED (never "equal"), which routes to the liveness
@@ -389,7 +407,11 @@ lock_marker() {
   command -v flock >/dev/null 2>&1 || refuse ERROR 1 "flock is not available on this host, so the ownership-verify -> replace sequence cannot be SERIALIZED. Refusing rather than mutating unserialized: two sessions in one lane could both pass verification and one clobber the other's stamp, which is the defect this marker exists to prevent. An unmeasurable guarantee is never read as satisfied."
   : >>"$lock" 2>/dev/null || refuse ERROR 1 "cannot create the marker lock file $(sane "$lock") — nothing was decided"
   eval "exec ${MARKER_LOCK_FD}>>\"\$lock\""
-  flock -w "$MARKER_LOCK_WAIT_SECS" "$MARKER_LOCK_FD" || refuse ERROR 1 "another process holds the marker lock $(sane "$lock") (waited ${MARKER_LOCK_WAIT_SECS}s) — refusing rather than racing it; nothing was decided"
+  # flock's own stderr is SUPPRESSED rather than captured: capturing it would mean running
+  # flock inside a command substitution, i.e. in a subshell, which is not a place to be
+  # subtle about which open file description holds the lock. The anchored detail below names
+  # both causes instead (roborev job 26 F2).
+  flock -w "$MARKER_LOCK_WAIT_SECS" "$MARKER_LOCK_FD" 2>/dev/null || refuse ERROR 1 "another process holds the marker lock $(sane "$lock") (waited ${MARKER_LOCK_WAIT_SECS}s), or it could not be acquired — refusing rather than racing it; nothing was decided. (flock's own diagnostic is suppressed: it carries no DRIVE-STATE: prefix, and an unprefixed line breaks the output anchor every consumer rests on.)"
 }
 
 # ---------------------------------------------------------------------------
@@ -515,9 +537,12 @@ read_marker() {
 }
 
 # marker_body — the marker's body (everything AFTER the end sentinel) on stdout.
+# Returns NON-ZERO when the body could not be read, and its stderr is suppressed: every
+# caller must decide what an unreadable body means rather than inherit awk's unprefixed
+# diagnostic and an empty result (roborev job 26 F2).
 marker_body() {
   local path; path="$(marker_path)"
-  awk -v s="$STAMP_END" 'seen{print} $0==s{seen=1}' "$path"
+  awk -v s="$STAMP_END" 'seen{print} $0==s{seen=1}' "$path" 2>/dev/null
 }
 
 # ---------------------------------------------------------------------------
@@ -736,6 +761,25 @@ assert_assembled_marker() {
     WRITE_ERR="the assembled marker carries $nb stamp-begin and $ne stamp-end sentinels at column zero (exactly one of each is legal) — the body supplied at COMMIT time contains a line that can pose as a stamp boundary. Nothing was written. If a --body-file was named, it changed between validation and assembly, or it carries a sentinel at column zero: remove that line."
     return 1
   fi
+  # AND THE REQUIRED FIELDS MUST BE THERE, NON-EMPTY (roborev job 26 F2, found by its own
+  # test). The identity values are produced by external helpers — `date`, `tr` inside
+  # sanitize_field, `hostname` — and write_marker is called from `if ! write_marker`, which
+  # SUPPRESSES `set -e` for its whole subtree, so a helper failing inside a command
+  # substitution yielded an EMPTY value and the marker committed anyway. Every later read
+  # then refuses it MALFORMED: the lane BRICKS ITSELF, which is the dead-letter family again.
+  # Checked HERE because this is the only place that sees the committed bytes, and scoped to
+  # the PROLOGUE (a free-form body may legitimately contain a `stage: ...` line).
+  local pro k n
+  pro="$(awk -v e="$STAMP_END" 'NR==1{next} $0==e{exit} {print}' "$tmp" 2>/dev/null || true)"
+  for k in issue machine worktree session session-pid session-pid-start-earliest \
+           session-pid-start-latest actor ts; do
+    n="$(printf '%s\n' "$pro" | LC_ALL=C grep -c "^$k: ." 2>/dev/null || true)"
+    case "$n" in '' | *[!0-9]*) n=0 ;; esac
+    if [ "$n" -ne 1 ]; then
+      WRITE_ERR="the assembled marker records $n non-empty '$k:' line(s) in its stamp prologue (exactly one is required) — an incomplete stamp is not a weaker stamp, it is NO stamp, and every later read would refuse it, bricking this lane. The usual cause is a helper this writer depends on (date, tr, hostname) failing. NOTHING was written."
+      return 1
+    fi
+  done
   return 0
 }
 
@@ -763,7 +807,14 @@ write_marker() {
     *)  WRITE_ERR="the worktree path '$(sane "$wt")' is not absolute — refusing to write a stamp whose worktree axis cannot be compared"; return 1 ;;
   esac
 
-  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  # A FAILING `date` is a REFUSAL, not an empty `ts`. Its stderr is suppressed (unprefixed)
+  # and its failure is reported through WRITE_ERR: `set -e` cannot be relied on here because
+  # every caller invokes this function as `if ! write_marker ...`, which suppresses it for the
+  # whole subtree (roborev job 26 F2).
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)" || {
+    WRITE_ERR="cannot read the current time (\`date\` failed), so the stamp's \`ts\` field cannot be recorded — refusing rather than committing a stamp with an empty required field; nothing was written"; return 1; }
+  [ -n "$ts" ] || {
+    WRITE_ERR="\`date\` exited 0 but produced no timestamp, so the stamp's \`ts\` field cannot be recorded — nothing was written"; return 1; }
   session="$(this_session)"
   pid="$(this_session_pid)"
   lo=unmeasured; hi=unmeasured
@@ -772,8 +823,16 @@ write_marker() {
     if [ -n "$win" ]; then lo="${win%% *}"; hi="${win##* }"; fi
   fi
 
-  tmp="$(mktemp "$path.XXXXXX")" || {
-    WRITE_ERR="cannot create a temporary file next to $(sane "$path") — nothing was written"; return 1; }
+  # mktemp's NATIVE text is CAPTURED and FOLDED into the anchored detail rather than
+  # suppressed: "failed to create file via template" names the cause (a full disk, a
+  # read-only lane) and the anchored message alone cannot. `2>&1` merges the streams, so a
+  # SUCCESS that nevertheless printed something is not trusted as a path either.
+  local mkout
+  mkout="$(mktemp "$path.XXXXXX" 2>&1)" || {
+    WRITE_ERR="cannot create a temporary file next to $(sane "$path") — nothing was written (mktemp: $(sane "$mkout"))"; return 1; }
+  tmp="$mkout"
+  { [ -n "$tmp" ] && [ -f "$tmp" ]; } || {
+    WRITE_ERR="mktemp exited 0 next to $(sane "$path") but named no usable temporary file (it emitted: $(sane "$mkout")) — nothing was written"; return 1; }
   register_tmp "$tmp"
   {
     printf '%s\n' "$STAMP_BEGIN"
@@ -790,11 +849,19 @@ write_marker() {
     for kv in "$@"; do [ -z "$kv" ] || printf '%s\n' "$kv"; done
     printf '%s\n' "$STAMP_END"
     printf '\n'
-    if [ -n "$bodyfile" ] && [ -s "$bodyfile" ]; then cat "$bodyfile"; fi
-  } >"$tmp" || { rm -f "$tmp"; WRITE_ERR="failed writing the stamp to $(sane "$tmp") — nothing was replaced"; return 1; }
+    # `cat`'s stderr is SUPPRESSED, not captured: inside a `{ ... } >"$tmp"` group there is
+    # nowhere to capture it to, and the group's non-zero status already routes to the
+    # anchored WRITE_ERR below (roborev job 26 F2).
+    if [ -n "$bodyfile" ] && [ -s "$bodyfile" ]; then cat "$bodyfile" 2>/dev/null; fi
+  } >"$tmp" || { rm -f "$tmp" 2>/dev/null || true; WRITE_ERR="failed writing the stamp to $(sane "$tmp") — nothing was replaced (the body could not be read, or the temporary file could not be written)"; return 1; }
   # The last thing before the atomic commit, over the committed bytes themselves.
-  assert_assembled_marker "$tmp" || { rm -f "$tmp"; return 1; }
-  mv -f "$tmp" "$path" || { rm -f "$tmp"; WRITE_ERR="failed replacing $(sane "$path")"; return 1; }
+  assert_assembled_marker "$tmp" || { rm -f "$tmp" 2>/dev/null || true; return 1; }
+  # mv's NATIVE text is CAPTURED and FOLDED for the same reason as mktemp's: "cannot move ...
+  # Permission denied" vs "Device or resource busy" are different operator actions.
+  local mverr
+  mverr="$(mv -f "$tmp" "$path" 2>&1)" || {
+    rm -f "$tmp" 2>/dev/null || true
+    WRITE_ERR="failed replacing $(sane "$path")${mverr:+ (mv: $(sane "$mverr"))}"; return 1; }
   WROTE_PATH="$path"
   return 0
 }
@@ -861,8 +928,10 @@ cmd_write() {
     # refuses it MALFORMED — never discarded as though it asserted nothing.
     if [ "$mcls" = legacy ]; then
       local dl dbytes
-      dl="$(LC_ALL=C wc -l <"$mpath" 2>/dev/null | tr -d ' ')"
-      dbytes="$(LC_ALL=C wc -c <"$mpath" 2>/dev/null | tr -d ' ')"
+      # `tr`'s stderr is suppressed alongside `wc`'s: an unreadable count degrades to the
+      # '?' the message already prints, and neither tool may emit an unprefixed line.
+      dl="$(LC_ALL=C wc -l <"$mpath" 2>/dev/null | tr -d ' ' 2>/dev/null || true)"
+      dbytes="$(LC_ALL=C wc -c <"$mpath" 2>/dev/null | tr -d ' ' 2>/dev/null || true)"
       discarded="replaced an UNSTAMPED marker of unknown provenance and DISCARDED its body (${dl:-?} lines, ${dbytes:-?} bytes): an unstamped plan may belong to ANY session, so it is never carried forward"
       # body_src stays as the caller supplied it (empty unless --body-file): the preserve
       # branch below is UNREACHABLE from here, which is the point.
@@ -882,9 +951,10 @@ cmd_write() {
       if [ -z "$body_src" ]; then
       # Preserve an OWNED marker's body: `write` updates the stamp and the recorded stage,
       # not the author's notes.
-        carried="$(mktemp "${TMPDIR:-/tmp}/drive-issue-body.XXXXXX")" || refuse ERROR 1 "cannot create a temporary file for the carried body"
+        carried="$(mktemp "${TMPDIR:-/tmp}/drive-issue-body.XXXXXX" 2>&1)" || refuse ERROR 1 "cannot create a temporary file for the carried body under $(sane "${TMPDIR:-/tmp}") — nothing was written (mktemp: $(sane "$carried"))"
+        { [ -n "$carried" ] && [ -f "$carried" ]; } || refuse ERROR 1 "mktemp exited 0 for the carried body but named no usable temporary file (it emitted: $(sane "$carried")) — nothing was written"
         register_tmp "$carried"
-        marker_body >"$carried"
+        marker_body >"$carried" || refuse ERROR 1 "cannot read the existing marker's body from $(sane "$(marker_path)"), so it cannot be carried forward — refusing rather than silently replacing a plan with an empty one; nothing was written"
         assert_body_safe "$carried"
         body_src="$carried"
       fi
@@ -900,10 +970,10 @@ cmd_write() {
   [ -z "$pr" ]      || f_pr="pr: $(sanitize_field "$pr")"
   [ -z "$branch" ]  || f_branch="branch: $(sanitize_field "$branch")"
   if ! write_marker "$issue" "$actor" "$body_src" "$f_stage" "$f_request" "$f_pr" "$f_branch"; then
-    [ -z "$carried" ] || rm -f "$carried"
+    [ -z "$carried" ] || rm -f "$carried" 2>/dev/null || true
     refuse ERROR 1 "$WRITE_ERR"
   fi
-  [ -z "$carried" ] || rm -f "$carried"
+  [ -z "$carried" ] || rm -f "$carried" 2>/dev/null || true
   verdict WRITTEN
   [ -z "$discarded" ] || detail "$discarded"
   detail "issue=$(sane "$issue") machine=$(sane "$(this_machine)") worktree=$(sane "$(pwd -P)") session=$(sane "$(this_session)") session-pid=$(sane "$(this_session_pid)") actor=$(sane "$actor") -> $(sane "$WROTE_PATH")"
@@ -937,7 +1007,7 @@ assert_reason() {
   if [ "$tok" = unspecified ] || [ "${#tok}" -lt 3 ]; then
     die_usage "adopt: --reason must carry at least 3 recordable characters ([A-Za-z0-9._:/#-]); '$(sane "$raw")' records as '$(sane "$tok")', which is indistinguishable from no reason at all"
   fi
-  case "$(printf '%s' "$tok" | LC_ALL=C tr 'A-Z' 'a-z')" in
+  case "$(printf '%s' "$tok" | LC_ALL=C tr 'A-Z' 'a-z' 2>/dev/null)" in
     why | reason | todo | tbd | tba | xxx | xxxx | placeholder | fixme | none | foo | bar | baz | n/a)
       die_usage "adopt: --reason '$(sane "$raw")' records as the PLACEHOLDER '$(sane "$tok")' — as uninformative as no reason at all. Say what the resume IS, e.g. --reason cron-reinvoke:writer-pid-gone" ;;
   esac
@@ -979,9 +1049,10 @@ cmd_adopt() {
   fi
 
   local carried f_stage=''
-  carried="$(mktemp "${TMPDIR:-/tmp}/drive-issue-body.XXXXXX")" || refuse ERROR 1 "cannot create a temporary file for the carried body"
+  carried="$(mktemp "${TMPDIR:-/tmp}/drive-issue-body.XXXXXX" 2>&1)" || refuse ERROR 1 "cannot create a temporary file for the carried body under $(sane "${TMPDIR:-/tmp}") — nothing was written (mktemp: $(sane "$carried"))"
+  { [ -n "$carried" ] && [ -f "$carried" ]; } || refuse ERROR 1 "mktemp exited 0 for the carried body but named no usable temporary file (it emitted: $(sane "$carried")) — nothing was written"
   register_tmp "$carried"
-  marker_body >"$carried"
+  marker_body >"$carried" || refuse ERROR 1 "cannot read the existing marker's body from $(sane "$(marker_path)"), so it cannot be carried across the adoption — refusing rather than transferring ownership onto an empty plan; nothing was written"
   assert_body_safe "$carried"
   [ -z "$stage" ] || f_stage="stage: $stage"
   local f_request='' f_pr='' f_branch=''
@@ -993,10 +1064,10 @@ cmd_adopt() {
       "prior-session-pid: $prior_pid" \
       "prior-ts: $prior_ts" \
       "adopt-reason: $reason_token"; then
-    rm -f "$carried"
+    rm -f "$carried" 2>/dev/null || true
     refuse ERROR 1 "$WRITE_ERR"
   fi
-  rm -f "$carried"
+  rm -f "$carried" 2>/dev/null || true
   verdict ADOPTED
   detail "issue=$(sane "$issue") prior-session=$(sane "$prior_session") prior-session-pid=$(sane "$prior_pid") new-session=$(sane "$(this_session)") reason=$(sane "$reason_token") -> $(sane "$WROTE_PATH"); the recorded writer was provably gone: $LIVE_DETAIL"
 }

--- a/scripts/flow/drive-issue-state.sh
+++ b/scripts/flow/drive-issue-state.sh
@@ -151,7 +151,10 @@
 #              marker first passes the SAME ownership verification `verify` applies — you
 #              may not overwrite a live peer's plan either — so a foreign marker refuses
 #              with that marker's own verdict. The route past it is `adopt`, never a flag
-#              on `write`. Without --body-file an OWNED marker's body is PRESERVED.
+#              on `write`. Without --body-file an OWNED marker's body is PRESERVED
+#              BYTE-FOR-BYTE, across any number of writes and across an `adopt`: the blank
+#              separator between the prologue and the body is the WRITER's, and the reader
+#              skips it, so the body neither grows nor shrinks.
 #              ONE EXCEPTION — the MIGRATION case: an UNSTAMPED marker (the pre-#3822
 #              shape) asserts NO ownership, so `write` REPLACES it, DISCARDS its body (an
 #              unstamped plan may belong to any session and is never carried forward) and
@@ -775,13 +778,31 @@ read_marker() {
   return 0
 }
 
-# marker_body — the marker's body (everything AFTER the end sentinel) on stdout.
+# marker_body — the marker's body on stdout, EXCLUDING the writer-owned blank separator.
+#
+# THE WRITER OWNS THE SEPARATOR (roborev job 34 H3). `write_marker` ALWAYS emits exactly one
+# blank line after the end sentinel, so the canonical file is `<stamp>\n<END>\n\n<body>`. This
+# reader must therefore SKIP that one blank line, or the round trip that carries an owned
+# marker's body forward (write -> marker_body -> write_marker) adds a blank line on EVERY write:
+# measured 1, then 2, then 3 across three successive writes of the same body — unbounded growth
+# on a long-running lane, and a body that MUTATES under a contract promising it SURVIVES.
+# Exactly one of the two may own it; it is the WRITER, because the writer is what makes the
+# separator canonical (a body supplied by --body-file gets one too, so the shape does not depend
+# on where the body came from). Do NOT also strip it there, and do not add one here.
+# Only the FIRST blank line is skipped, and only when it is the one immediately after the
+# sentinel: a body that genuinely BEGINS with a blank line keeps it, because the separator is
+# consumed before the body starts.
+#
 # Returns NON-ZERO when the body could not be read, and its stderr is suppressed: every
 # caller must decide what an unreadable body means rather than inherit awk's unprefixed
 # diagnostic and an empty result (roborev job 26 F2).
 marker_body() {
   local path; path="$(marker_path)"
-  awk -v s="$STAMP_END" 'seen{print} $0==s{seen=1}' "$path" 2>/dev/null
+  awk -v s="$STAMP_END" '
+    body { print; next }
+    sep  { sep = 0; body = 1; if ($0 == "") next; print; next }
+    $0 == s { sep = 1 }
+  ' "$path" 2>/dev/null
 }
 
 # ---------------------------------------------------------------------------
@@ -1135,6 +1156,10 @@ write_marker() {
     local kv
     for kv in "$@"; do [ -z "$kv" ] || printf '%s\n' "$kv"; done
     printf '%s\n' "$STAMP_END"
+    # THE WRITER OWNS THIS SEPARATOR — the one blank line between the prologue and the body
+    # (roborev job 34 H3). `marker_body` therefore SKIPS it when reading a body back; if both
+    # sides emit one, every carry-forward write grows the body by a line. Exactly one owner:
+    # change this only together with the reader, and read that function's comment first.
     printf '\n'
     # `cat`'s stderr is SUPPRESSED, not captured: inside a `{ ... } >"$tmp"` group there is
     # nowhere to capture it to, and the group's non-zero status already routes to the

--- a/scripts/flow/lib/process-liveness.sh
+++ b/scripts/flow/lib/process-liveness.sh
@@ -31,6 +31,11 @@
 #   macOS bash 3.2 compatible. SOURCED, never executed: it defines functions and nothing
 #   else — no `set -e`, no side effects, no output at source time — so it cannot change a
 #   sourcing script's shell options or emit an unanchored line into its output.
+#
+#   EVERY external tool here has its stderr SUPPRESSED (#3822, roborev job 26 F2). Both callers
+#   publish a strictly ANCHORED output (`DRIVE-STATE: ` / claim-heartbeat's own prefix), and a
+#   native `date:`/`tr:`/`cut:` diagnostic from inside a sourced function is a line with no
+#   prefix on the caller's stream — breaking an anchor these functions cannot see.
 
 # process_start_window <pid> — echo `<earliest> <latest>` epoch seconds bracketing when <pid>
 # started, or EMPTY when it cannot be determined. Empty is a THIRD answer and is never folded
@@ -52,8 +57,8 @@
 # caller must decide UNKNOWN when the interval straddles its decision boundary.
 process_start_window() {
   local pid="$1" secs t0 t1
-  t0="$(date -u +%s)"
-  secs="$(ps -o etimes= -p "$pid" 2>/dev/null | tr -d ' ')"
+  t0="$(date -u +%s 2>/dev/null)"
+  secs="$(ps -o etimes= -p "$pid" 2>/dev/null | tr -d ' ' 2>/dev/null)"
   case "$secs" in
     '' | *[!0-9]*) secs="" ;;
   esac
@@ -61,14 +66,14 @@ process_start_window() {
     # Fall back to `etime` ([[DD-]HH:]MM:SS), which POSIX ps provides where `etimes` is
     # absent. Still elapsed, still timezone-free.
     local et d hms h m sec
-    et="$(ps -o etime= -p "$pid" 2>/dev/null | tr -d ' ')"
+    et="$(ps -o etime= -p "$pid" 2>/dev/null | tr -d ' ' 2>/dev/null)"
     [ -n "$et" ] || return 0
     case "$et" in
       *-*) d="${et%%-*}"; hms="${et#*-}" ;;
       *)   d=0;           hms="$et" ;;
     esac
     case "$hms" in
-      *:*:*) h="${hms%%:*}"; m="$(printf '%s' "$hms" | cut -d: -f2)"; sec="${hms##*:}" ;;
+      *:*:*) h="${hms%%:*}"; m="$(printf '%s' "$hms" | cut -d: -f2 2>/dev/null)"; sec="${hms##*:}" ;;
       *:*)   h=0;            m="${hms%%:*}";                          sec="${hms##*:}" ;;
       *)     return 0 ;;
     esac
@@ -77,7 +82,7 @@ process_start_window() {
     esac
     secs=$(( (10#$d * 86400) + (10#$h * 3600) + (10#$m * 60) + 10#$sec ))
   fi
-  t1="$(date -u +%s)"
+  t1="$(date -u +%s 2>/dev/null)"
   # The elapsed reading was taken at some instant in [t0, t1], so the start lies in
   # [t0 - secs, t1 - secs]. Earliest first.
   printf '%s %s\n' "$((t0 - secs))" "$((t1 - secs))"
@@ -180,7 +185,7 @@ process_presence() {
 # healthy fleet is how a monitor gets ignored) and not `running` (that is the false-clean).
 process_state_class() {
   local st
-  st="$(ps -o stat= -p "$1" 2>/dev/null | tr -d ' ')"
+  st="$(ps -o stat= -p "$1" 2>/dev/null | tr -d ' ' 2>/dev/null)"
   case "$st" in
     '') printf 'unreadable\n' ;;
     Z*) printf 'zombie\n' ;;

--- a/scripts/flow/lib/process-liveness.sh
+++ b/scripts/flow/lib/process-liveness.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+#
+# lib/process-liveness.sh — the THREE-VALUED process-liveness primitives shared by
+# scripts/flow/claim-heartbeat.sh and scripts/flow/drive-issue-state.sh (issue #3822).
+#
+# WHY THIS FILE EXISTS
+# --------------------
+# These five functions are the accumulated result of ~8 review rounds on #3393, and
+# every one encodes a specific way a two-valued liveness probe reports a LIVE process
+# as DEAD (or the reverse). #3822 needs the same question answered — "is the session
+# that stamped this marker still running?" — and a SECOND implementation would be a
+# second place for those rounds to be re-lost: a second implementation's correctness is
+# only knowable by differential testing against the first, so there is ONE definition
+# and both callers source it.
+#
+# They were MOVED here VERBATIM from claim-heartbeat.sh, comments included, because the
+# comments ARE the contract: each names the review round and the false verdict it closes.
+#
+# CONTRACT FOR CALLERS
+#   Every function is THREE-VALUED (or returns EMPTY for "could not tell"). A caller must
+#   never fold the unknown answer onto the permissive one — a positive verdict requires an
+#   affirmative measurement.
+#
+#     ps_usable                    exit 0 iff `ps` can answer an existence question here
+#     signal_probe_class   <pid>   present | absent | denied | unknown
+#     process_presence     <pid>   present | absent | unknown
+#     process_state_class  <pid>   zombie  | running | unreadable
+#     process_start_window <pid>   "<earliest> <latest>" epoch secs, or EMPTY
+#
+# CONSTRAINTS
+#   macOS bash 3.2 compatible. SOURCED, never executed: it defines functions and nothing
+#   else — no `set -e`, no side effects, no output at source time — so it cannot change a
+#   sourcing script's shell options or emit an unanchored line into its output.
+
+# process_start_window <pid> — echo `<earliest> <latest>` epoch seconds bracketing when <pid>
+# started, or EMPTY when it cannot be determined. Empty is a THIRD answer and is never folded
+# onto "consistent".
+#
+# DERIVED FROM ELAPSED TIME, NOT A WALL-CLOCK STRING (roborev round 3, Medium). The first cut
+# read `ps -o lstart=` and parsed it with `date -u`, but `lstart` is LOCAL wall time with no
+# zone in it, so on any non-UTC host the epoch came out shifted by the offset — MEASURED: the
+# same lstart parses 19,800s apart between UTC and Asia/Kolkata, far past the tolerance, which
+# would falsely declare a live supervisor DEAD-PID-REUSED. Elapsed seconds carry no timezone at
+# all, so the whole class is gone rather than corrected.
+#
+# AN INTERVAL, NOT A POINT (roborev round 15, Medium). `start = now - elapsed` needs `now` and
+# `elapsed` to refer to the same instant, and they cannot: one is read before the other. The
+# first cut sampled `now` BEFORE running `ps`, so a slow `ps` shifted the computed start
+# BACKWARD — and a start that looks earlier than it is makes a REUSED pid look like it predates
+# the claim, i.e. a false ALIVE. That delay is most likely on exactly the resource-exhausted
+# hosts this command exists for. So the query is bracketed and both bounds are returned; the
+# caller must decide UNKNOWN when the interval straddles its decision boundary.
+process_start_window() {
+  local pid="$1" secs t0 t1
+  t0="$(date -u +%s)"
+  secs="$(ps -o etimes= -p "$pid" 2>/dev/null | tr -d ' ')"
+  case "$secs" in
+    '' | *[!0-9]*) secs="" ;;
+  esac
+  if [ -z "$secs" ]; then
+    # Fall back to `etime` ([[DD-]HH:]MM:SS), which POSIX ps provides where `etimes` is
+    # absent. Still elapsed, still timezone-free.
+    local et d hms h m sec
+    et="$(ps -o etime= -p "$pid" 2>/dev/null | tr -d ' ')"
+    [ -n "$et" ] || return 0
+    case "$et" in
+      *-*) d="${et%%-*}"; hms="${et#*-}" ;;
+      *)   d=0;           hms="$et" ;;
+    esac
+    case "$hms" in
+      *:*:*) h="${hms%%:*}"; m="$(printf '%s' "$hms" | cut -d: -f2)"; sec="${hms##*:}" ;;
+      *:*)   h=0;            m="${hms%%:*}";                          sec="${hms##*:}" ;;
+      *)     return 0 ;;
+    esac
+    case "$d$h$m$sec" in
+      *[!0-9]*) return 0 ;;
+    esac
+    secs=$(( (10#$d * 86400) + (10#$h * 3600) + (10#$m * 60) + 10#$sec ))
+  fi
+  t1="$(date -u +%s)"
+  # The elapsed reading was taken at some instant in [t0, t1], so the start lies in
+  # [t0 - secs, t1 - secs]. Earliest first.
+  printf '%s %s\n' "$((t0 - secs))" "$((t1 - secs))"
+}
+
+# ps_usable — exit 0 iff `ps` can be trusted to answer an existence question here.
+#
+# SELF-VALIDATING, because "nonzero" is not the same as "absent" (roborev round 8, Medium).
+# A `ps` that is missing, unsupported, or simply unable to run would otherwise turn every
+# claim into DEAD-NO-PROCESS and exit 3 — a fleet-wide false DEAD. That failure mode is not
+# hypothetical on the boxes this issue is about: under the memory exhaustion #3393 records,
+# a process that cannot fork cannot run `ps` either, so the ONE moment the report matters
+# most is when the probe is most likely to fail. So the tool is validated against a pid
+# that is certainly present — our own — before any of its answers are believed. This is
+# necessary but NOT sufficient; see `process_presence` for why a per-TARGET vote is also
+# needed (round 9).
+ps_usable() {
+  ps -p "$$" >/dev/null 2>&1
+}
+
+# signal_probe_class <pid> — echo `present` | `absent` | `denied` | `unknown`.
+#
+# `kill -0` is the ONE probe here that is not visibility-based, which is why its failure mode
+# has to be decoded rather than abstained on (roborev round 10, Medium). EPERM means the
+# process EXISTS and is simply not ours; ESRCH means it is gone. Treating both as "no
+# opinion" made every remaining voter a VISIBILITY probe — `ps` and `/proc/<pid>` are
+# correlated, both hidden by `hidepid=2` — so a different user's live process was unanimously
+# "absent" and reported DEAD.
+#
+# `LC_ALL=C` is load-bearing: the distinction is drawn from the error text, so the message
+# has to be in a known language. An unrecognised message is `unknown`, never folded onto
+# either answer.
+signal_probe_class() {
+  local pid="$1" err
+  if kill -0 "$pid" 2>/dev/null; then
+    printf 'present\n'
+    return 0
+  fi
+  err="$(LC_ALL=C kill -0 "$pid" 2>&1 || true)"
+  case "$err" in
+    *"not permitted"* | *"Not permitted"* | *"Operation not permitted"*) printf 'denied\n' ;;
+    *"No such process"* | *"no such process"*)                           printf 'absent\n' ;;
+    *)                                                                   printf 'unknown\n' ;;
+  esac
+}
+
+# process_presence <pid> — echo `present` | `absent` | `unknown`.
+#
+# BUILT FROM AGREEING VOTES, because a NEGATIVE answer from one probe is not proof of
+# absence (roborev round 9, Medium). `ps -p` exiting nonzero can mean the process is gone,
+# but it can equally mean a transient failure under load or that the target is not visible
+# to us — and reading that as absence reports a LIVE supervisor as DEAD. Validating `ps`
+# against our OWN pid (round 8) was necessary but not sufficient: it proves the tool runs,
+# not that it can see THIS target.
+#
+# THE VOTERS MUST NOT ALL MEASURE THE SAME THING (round 10). `ps -p` and `/proc/<pid>` are
+# both VISIBILITY probes and are hidden together by `hidepid=2`, so on their own they can be
+# unanimously and confidently wrong about a live process owned by another user. The signal
+# probe is the independent one, and its EPERM answer is affirmative evidence of EXISTENCE —
+# which is exactly the case the other two get wrong.
+#
+# Unanimous present => present. Unanimous absent => absent. DISAGREEMENT => unknown: our view
+# of the process table is not self-consistent, so nothing is claimed either way.
+process_presence() {
+  local pid="$1" yes=0 no=0 sig
+  if ps -p "$pid" >/dev/null 2>&1; then yes=$((yes + 1)); else no=$((no + 1)); fi
+  if [ -d /proc ]; then
+    if [ -e "/proc/$pid" ]; then yes=$((yes + 1)); else no=$((no + 1)); fi
+  fi
+  sig="$(signal_probe_class "$pid")"
+  case "$sig" in
+    present | denied) yes=$((yes + 1)) ;;   # denied == EPERM == it exists
+    absent)           no=$((no + 1)) ;;
+    unknown)          : ;;                  # genuinely no opinion; abstains
+  esac
+
+  if [ "$yes" -gt 0 ] && [ "$no" -eq 0 ]; then
+    printf 'present\n'
+  elif [ "$yes" -eq 0 ] && [ "$no" -gt 0 ] && [ "$sig" = absent ]; then
+    # ABSENCE REQUIRES THE INDEPENDENT PROBE TO SAY SO (roborev round 15, Medium). Round 10
+    # fixed the case where the signal probe answered `denied`, but when it answers `unknown`
+    # the only remaining voters are `ps` and `/proc` — which are BOTH visibility probes,
+    # hidden together by `hidepid=2`. They can then be unanimously and confidently wrong
+    # about a live process, and this function would call it absent: a false DEAD. So a
+    # declaration of absence needs the one non-visibility probe to have affirmed it.
+    printf 'absent\n'
+  else
+    printf 'unknown\n'
+  fi
+}
+
+# process_state_class <pid> — echo `zombie` | `running` | `unreadable`.
+#
+# THREE-VALUED, and that is the whole point (roborev round 7, Medium). The first cut was a
+# two-valued `process_is_zombie` that returned "not a zombie" when the state could not be
+# read — after which a readable start time produced ALIVE and exit 0. So an unreadable
+# state became a CLEAN result, which is the same "unknown folded onto the permissive
+# answer" shape this command exists to avoid, reintroduced one level down in the fix for
+# the previous round. The unreadable case must be neither: not `zombie` (a false DEAD on a
+# healthy fleet is how a monitor gets ignored) and not `running` (that is the false-clean).
+process_state_class() {
+  local st
+  st="$(ps -o stat= -p "$1" 2>/dev/null | tr -d ' ')"
+  case "$st" in
+    '') printf 'unreadable\n' ;;
+    Z*) printf 'zombie\n' ;;
+    *)  printf 'running\n' ;;
+  esac
+}

--- a/scripts/tests/test_claim_heartbeat.sh
+++ b/scripts/tests/test_claim_heartbeat.sh
@@ -11,6 +11,11 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HB="$SCRIPT_DIR/../flow/claim-heartbeat.sh"
+# The process-liveness primitives now live in a library SHARED with
+# drive-issue-state.sh (issue #3822) — one definition, sourced by both. The
+# function-level cases below extract them from THAT file; extracting from $HB would
+# silently find nothing and, since the extracted file would be empty, assert nothing.
+LIVENESS_LIB="$SCRIPT_DIR/../flow/lib/process-liveness.sh"
 
 PASS=0
 FAIL=0
@@ -1465,11 +1470,11 @@ echo "TEST 50: the signal probe decodes EPERM as PRESENT (round 10, Medium)"
 # rather than reimplemented here — the script cannot be sourced, since sourcing runs its
 # dispatch — so this exercises the real code, and it fails outright if the function is gone.
 probe_fn="$T/signal-probe.sh"
-sed -n '/^signal_probe_class()/,/^}/p' "$HB" >"$probe_fn"
+sed -n '/^signal_probe_class()/,/^}/p' "$LIVENESS_LIB" >"$probe_fn"
 if [ -s "$probe_fn" ]; then
   ok "extracted signal_probe_class from the shipped script ($(wc -l <"$probe_fn" | tr -d ' ') lines)"
 else
-  bad "signal_probe_class is missing from $HB — the EPERM decode does not exist"
+  bad "signal_probe_class is missing from $LIVENESS_LIB — the EPERM decode does not exist"
 fi
 # shellcheck disable=SC1090
 . "$probe_fn" 2>/dev/null || true
@@ -1761,8 +1766,8 @@ echo "TEST 54: absence needs the INDEPENDENT probe to affirm it (round 15, Mediu
 # was alone again and could still establish absence: a false DEAD for a live supervisor.
 # Driven by a ps that hides the pid AND a kill whose failure message is unrecognisable.
 pp_body="$T/presence.sh"
-sed -n '/^signal_probe_class()/,/^}/p' "$HB" >"$pp_body"
-sed -n '/^process_presence()/,/^}/p' "$HB" >>"$pp_body"
+sed -n '/^signal_probe_class()/,/^}/p' "$LIVENESS_LIB" >"$pp_body"
+sed -n '/^process_presence()/,/^}/p' "$LIVENESS_LIB" >>"$pp_body"
 # shellcheck disable=SC1090
 . "$pp_body" 2>/dev/null || true
 if [ "$(type -t process_presence 2>/dev/null)" = "function" ]; then
@@ -2205,6 +2210,13 @@ _bad_copy="$T/hdr-probe.sh"
 # line it can never emit. Getting that wrong is what made my first two probe attempts fail.
 { printf '%s\n' '# displaced header line one' '# leaked_marker_67 this line is above the shebang' \
     'leaked_fn() { :; }'; cat "$HB"; } >"$_bad_copy"
+# The copy needs its SIBLING library alongside it (issue #3822): the script sources
+# lib/process-liveness.sh from its OWN directory and — deliberately — fails closed when
+# that file is unreadable, rather than continuing with the liveness predicates
+# undefined. Without this the probe would measure the missing library, not the header
+# leak it is about, and its NON-VACUITY would silently become vacuous.
+mkdir -p "$T/lib"
+cp "$LIVENESS_LIB" "$T/lib/process-liveness.sh"
 # CAPTURED, NOT PIPED. `bash … | grep -q` under this file's `pipefail` is the #3387 flake: grep -q
 # exits at the first match, SIGPIPEs the upstream, and the PIPELINE status becomes 141 — so a
 # SUCCESSFUL match reads as a failed condition, non-deterministically depending on whether the

--- a/scripts/tests/test_claim_heartbeat.sh
+++ b/scripts/tests/test_claim_heartbeat.sh
@@ -3018,6 +3018,77 @@ $l_out"
 fi
 kill "${zparent:-0}" 2>/dev/null || true
 
+
+echo
+echo "TEST 81: a NON-REGULAR shared library is REFUSED, never sourced (roborev job 57, Medium)"
+# The regression this pins is one the library extraction INTRODUCED: before it, the liveness
+# predicates were inline in claim-heartbeat.sh and there was no `source` at all. The guard
+# written for the new `source` was `-r` only — and `-r` is TRUE for a FIFO, so `.` BLOCKED
+# FOREVER waiting for a writer. MEASURED before the fix: `timeout 10` -> rc 124 with NO output
+# whatsoever. That is the worst breach available in a script the fleet reaper runs unattended:
+# not a wrong verdict but NO verdict, indefinitely.
+#
+# EVERY CASE IS BOUNDED BY `timeout` AND ASSERTS rc != 124 EXPLICITLY. Unbounded, a regression
+# would not FAIL this suite, it would HANG it, and the thing that noticed would be the gate's
+# stall watchdog minutes later — the same rule drive-issue-state.sh's hang cases follow.
+#
+# The table is over the TYPE, not over one member of it: the fix is `-f`, which is false for a
+# FIFO, a socket, a device and a directory alike, so the class is covered by one predicate
+# rather than by a list of types someone has to keep complete.
+hb81_run() { # hb81_run <case-dir> -> sets HB81_RC / HB81_OUT
+  HB81_RC=0
+  HB81_OUT="$(timeout 10 bash "$1/claim-heartbeat.sh" --help 2>&1)" || HB81_RC=$?
+}
+HB81="$T/nonregular-lib"
+for hb81_kind in fifo directory dangling-symlink symlink-to-device; do
+  rm -rf "$HB81"
+  mkdir -p "$HB81/lib"
+  cp "$HB" "$HB81/claim-heartbeat.sh"
+  hb81_target="$HB81/lib/process-liveness.sh"
+  case "$hb81_kind" in
+    fifo)              mkfifo "$hb81_target" 2>/dev/null || { skip "TEST 81/$hb81_kind: mkfifo unavailable"; continue; } ;;
+    directory)         mkdir -p "$hb81_target" ;;
+    dangling-symlink)  ln -s "$HB81/lib/nothing-here" "$hb81_target" ;;
+    symlink-to-device) [ -c /dev/null ] || { skip "TEST 81/$hb81_kind: no /dev/null char device"; continue; }
+                       ln -s /dev/null "$hb81_target" ;;
+  esac
+  hb81_run "$HB81"
+  if [ "$HB81_RC" -eq 124 ]; then
+    bad "TEST 81/$hb81_kind: the run HUNG (timeout 10 -> rc 124) — the \`source\` guard let a non-regular library be opened. Output: $HB81_OUT"
+  elif [ "$HB81_RC" -eq 0 ]; then
+    bad "TEST 81/$hb81_kind: the run SUCCEEDED (rc=0) with a $hb81_kind at lib/process-liveness.sh — the library was not required to be a regular file"
+  elif printf '%s\n' "$HB81_OUT" | grep -q 'process-liveness.sh as a regular file'; then
+    ok "TEST 81/$hb81_kind: refused (rc=$HB81_RC, not 124) with a diagnostic naming the library and the regular-file requirement"
+  else
+    bad "TEST 81/$hb81_kind: rc=$HB81_RC but the diagnostic does not name the regular-file requirement. Output: $HB81_OUT"
+  fi
+done
+# POSITIVE CONTROL 1 — the same harness with a REAL library must SUCCEED. Without it every case
+# above is satisfied by a script that is simply broken, which is the vacuity this suite's other
+# non-vacuity arms exist to exclude.
+rm -rf "$HB81"; mkdir -p "$HB81/lib"
+cp "$HB" "$HB81/claim-heartbeat.sh"
+cp "$SCRIPT_DIR/../flow/lib/process-liveness.sh" "$HB81/lib/process-liveness.sh"
+hb81_run "$HB81"
+if [ "$HB81_RC" -eq 0 ]; then
+  ok "TEST 81/control: a REGULAR library still sources and --help succeeds — the cases above are about the TYPE, not a broken harness"
+else
+  bad "NON-VACUITY broken: a regular library gave rc=$HB81_RC — TEST 81 cannot attribute its refusals to the guard. Output: $HB81_OUT"
+fi
+# POSITIVE CONTROL 2 — a SYMLINK to a regular library must still WORK. Both `-f` and `-r`
+# FOLLOW a symlink, deliberately: a symlinked checkout is a legitimate layout, and a guard that
+# reds on correct input is the guard agents learn to waive.
+rm -rf "$HB81"; mkdir -p "$HB81/lib"
+cp "$HB" "$HB81/claim-heartbeat.sh"
+cp "$SCRIPT_DIR/../flow/lib/process-liveness.sh" "$HB81/lib/real-liveness.sh"
+ln -s "$HB81/lib/real-liveness.sh" "$HB81/lib/process-liveness.sh"
+hb81_run "$HB81"
+if [ "$HB81_RC" -eq 0 ]; then
+  ok "TEST 81/symlink-to-regular: a symlinked library is FOLLOWED and still works — the refusal is about the resolved TYPE, not about links"
+else
+  bad "TEST 81/symlink-to-regular: a symlink to a regular library was refused (rc=$HB81_RC) — that is a false refusal on a legitimate layout. Output: $HB81_OUT"
+fi
+rm -rf "$HB81"
 echo
 echo "=== claim-heartbeat.sh: $PASS passed, $FAIL failed, $SKIP skipped ==="
 [ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -71,8 +71,13 @@ verdict_in_set() {
 }
 
 # all_lines_anchored <output> — 0 iff every non-empty line begins `DRIVE-STATE: `.
+# COUNTED, NOT PIPED THROUGH grep -q: `grep -c` exits 1 when it selects nothing, and
+# under this file's `pipefail` that makes a CLEAN result read as a failed condition —
+# the #3387 shape, and it cost a round here.
 all_lines_anchored() {
-  printf '%s\n' "$1" | grep -v '^$' | grep -cv '^DRIVE-STATE: ' | grep -q '^0$'
+  local bad
+  bad="$(printf '%s\n' "$1" | grep -v '^$' | grep -cv '^DRIVE-STATE: ' || true)"
+  [ "${bad:-1}" = 0 ]
 }
 
 SESS_A="sess-aaaaaaaa"

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -3001,6 +3001,23 @@ if all_lines_anchored "$d46_w" && all_lines_anchored "$d46_v" && all_lines_ancho
 else
   bad "a symlink refusal leaked an unprefixed line"
 fi
+# CLASS SWEEP, SAME ROUND: the lock sidecar is a SCRIPT-OWNED path too, and `: >>"$lock"`
+# FOLLOWS a link — so a link planted there (by a peer lane, not only by the invoker) would have
+# this script create a file OUTSIDE the lane. Refused by name, link intact, target not created.
+L46c=$(lane lane46c)
+K46C_TARGET="$T/no-such-lock-target-46"
+ln -s "$K46C_TARGET" "$L46c/$MARKER.lock"
+c46_w=$(run "$L46c" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 2>&1); c46_wrc=$?
+c46_link_after=$(readlink "$L46c/$MARKER.lock" 2>/dev/null || true)
+if [ "$c46_wrc" -ne 0 ] && [ "$(verdict_of "$c46_w")" = ERROR ] \
+   && printf '%s\n' "$c46_w" | grep -q 'lock path .* is a SYMLINK' \
+   && [ -L "$L46c/$MARKER.lock" ] && [ "$c46_link_after" = "$K46C_TARGET" ] \
+   && [ ! -e "$K46C_TARGET" ] && [ ! -e "$L46c/$MARKER" ]; then
+  ok "a SYMLINK at the lock path is refused by name; the link survives, its target was NOT created, and no marker was written"
+else
+  bad "the lock-path symlink sweep regressed: rc=$c46_wrc verdict=$(verdict_of "$c46_w") readlink='$c46_link_after' target-created=$([ -e "$K46C_TARGET" ] && echo yes || echo no) marker=$([ -e "$L46c/$MARKER" ] && echo yes || echo no)
+$c46_w"
+fi
 # POSITIVE CONTROL, by ARTIFACT SUBSTITUTION: with the `-L` existence handling reverted in a
 # scratch copy, the same write DESTROYS the dangling symlink — so the assertions above measure
 # the fix and not the fixture. (A test-only seam is never used for this; the artifact is
@@ -3064,10 +3081,10 @@ if [ "$executed" -ge "$CASE_FLOOR" ] && [ -z "$missing" ]; then
 else
   bad "case floor breached: executed=$executed floor=$CASE_FLOOR missing:$missing"
 fi
-if [ "$PASS" -ge 170 ]; then
-  ok "assertion floor: $PASS assertions passed (>= 170)"
+if [ "$PASS" -ge 172 ]; then
+  ok "assertion floor: $PASS assertions passed (>= 172)"
 else
-  bad "assertion floor breached: only $PASS assertions passed (floor 170)"
+  bad "assertion floor breached: only $PASS assertions passed (floor 172)"
 fi
 
 # ===========================================================================

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -355,26 +355,76 @@ fi
 case_begin 11-machine-agrees-with-claim-sh "machine identity is the SAME notion claim.sh records (anti-drift pin)"
 # ===========================================================================
 L11=$(lane lane11)
-# Extract claim.sh's OWN machine resolution from the shipped script and run it in
-# this environment: the agreement is measured, never asserted by care.
+# Extract claim.sh's OWN machine resolution from the shipped script AND this script's own,
+# then run BOTH in one environment over a TABLE of inputs: the agreement is measured, never
+# asserted by care.
+#
+# WHY THE COMPARISON MOVED FROM THE MARKER TO THE FUNCTIONS (roborev job 37 J1): the USE SITE
+# now REFUSES a machine identity that does not survive sanitization unchanged, so a
+# space-bearing CLAIM_MACHINE never reaches the marker and the old single end-to-end value
+# could no longer be read out of it. The SANITIZER itself is untouched, and this pins strictly
+# MORE of it than one recorded value did — every row below compares claim.sh's answer with this
+# script's for the same input, INCLUDING the lossy and unrecordable ones. The end-to-end leg is
+# kept below, on a canonical value.
 cm_body="$T/claim-machine.sh"
 {
   sed -n '/^sanitize_field()/,/^}/p' "$CLAIM"
   sed -n '/^this_machine()/,/^}/p' "$CLAIM"
   printf 'this_machine\n'
 } >"$cm_body"
-claim_machine=$(CLAIM_MACHINE='build box' bash "$cm_body")
-run "$L11" "CLAIM_MACHINE=build box" "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 >/dev/null 2>&1
-ds_machine=$(sed -n 's/^machine: //p' "$L11/$MARKER" | head -1)
-if [ -n "$claim_machine" ] && [ "$claim_machine" = "$ds_machine" ]; then
-  ok "machine agrees with claim.sh's recorded machine in the same environment ('$ds_machine')"
+# This script's `this_machine` is a ONE-LINE function, so a `/^}/` range would swallow the rest
+# of the file: the two MULTI-LINE definitions it delegates to are extracted and driven directly.
+ds_body="$T/ds-machine.sh"
+{
+  sed -n '/^sanitize_field()/,/^}/p' "$DS"
+  sed -n '/^resolve_machine_axis()/,/^}/p' "$DS"
+  printf 'MACHINE_AXIS_VALUE=; MACHINE_AXIS_STATE=; MACHINE_AXIS_RAW=\n'
+  printf 'resolve_machine_axis\n'
+  printf 'printf "%%s %%s\\n" "$MACHINE_AXIS_VALUE" "$MACHINE_AXIS_STATE"\n'
+} >"$ds_body"
+long120=$(printf 'a%.0s' $(seq 1 120))
+long121a="${long120}X"
+long121b="${long120}Y"
+agree_fail=0
+# input <US> expected-state
+for row in "boxA:ok" "build box:lossy" "box@A:lossy" "$long120:ok" "$long121a:lossy" "***:unrecordable"; do
+  in_v="${row%:*}"; want_state="${row##*:}"
+  cm_v=$(CLAIM_MACHINE="$in_v" bash "$cm_body")
+  ds_pair=$(CLAIM_MACHINE="$in_v" bash "$ds_body")
+  ds_v="${ds_pair% *}"; ds_state="${ds_pair##* }"
+  if [ "$cm_v" != "$ds_v" ]; then
+    agree_fail=$((agree_fail + 1))
+    printf 'note   sanitizer drift for %q: claim.sh=%q drive-issue-state=%q\n' "$in_v" "$cm_v" "$ds_v"
+  fi
+  if [ "$ds_state" != "$want_state" ]; then
+    agree_fail=$((agree_fail + 1))
+    printf 'note   axis state for %q: got=%s want=%s\n' "$in_v" "$ds_state" "$want_state"
+  fi
+done
+if [ "$agree_fail" -eq 0 ]; then
+  ok "machine sanitizer agrees with claim.sh's on every table row, and each row's measurability state is classified as expected"
 else
-  bad "machine identity drifted from claim.sh: claim.sh='$claim_machine' drive-issue-state='$ds_machine'"
+  bad "machine identity drifted from claim.sh (or was misclassified) on $agree_fail check(s)"
 fi
-if [ "$ds_machine" != "build box" ]; then
-  ok "NON-VACUITY: the value is SANITIZED (a space-bearing CLAIM_MACHINE cannot forge a stamp line)"
+# NON-VACUITY of the table: the sanitizer really is LOSSY on these inputs (which is WHY the use
+# site refuses them), and the 120-character cut really does collide two distinct names.
+cm_space=$(CLAIM_MACHINE='build box' bash "$cm_body")
+cm_l121a=$(CLAIM_MACHINE="$long121a" bash "$cm_body")
+cm_l121b=$(CLAIM_MACHINE="$long121b" bash "$cm_body")
+if [ "$cm_space" = 'build-box' ] && [ "$cm_space" != 'build box' ] \
+   && [ -n "$cm_l121a" ] && [ "$cm_l121a" = "$cm_l121b" ]; then
+  ok "NON-VACUITY: the shared sanitizer maps 'build box' onto 'build-box' AND collapses two names differing only past 120 chars onto ONE token — the collisions the use site now refuses are real"
 else
-  bad "machine value was recorded unsanitized: '$ds_machine'"
+  bad "the sanitizer did not behave as the table assumes: space='$cm_space' l121a='$cm_l121a' l121b='$cm_l121b'"
+fi
+# END-TO-END, on a CANONICAL value: what the marker records IS what claim.sh would record.
+cm_canon=$(CLAIM_MACHINE='build-box' bash "$cm_body")
+run "$L11" "CLAIM_MACHINE=build-box" "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 >/dev/null 2>&1
+ds_machine=$(sed -n 's/^machine: //p' "$L11/$MARKER" | head -1)
+if [ -n "$cm_canon" ] && [ "$cm_canon" = "$ds_machine" ]; then
+  ok "end-to-end: the value RECORDED in the marker equals claim.sh's this_machine in the same environment ('$ds_machine')"
+else
+  bad "recorded machine drifted from claim.sh: claim.sh='$cm_canon' marker='$ds_machine'"
 fi
 
 # ===========================================================================
@@ -1746,6 +1796,8 @@ duplicate-sentinel:DUPLICATE-SENTINEL:8
 foreign-issue:FOREIGN-ISSUE:4
 foreign-machine:FOREIGN-MACHINE:4
 unmeasurable-machine:ERROR:1
+lossy-machine:ERROR:1
+lossy-session:ERROR:1
 foreign-worktree:FOREIGN-WORKTREE:4
 adoptable:ADOPTABLE:5
 live-peer:LIVE-PEER:6
@@ -1825,6 +1877,15 @@ inv_run() {  # inv_run <row-name> — set the state up, run it, print output, re
       ( cd "$d" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID -u CLAIM_MACHINE \
           "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" "PATH=$sd:$PATH" \
           bash "$DS" write 3822 2>&1 ) ;;
+    lossy-machine)
+      # roborev job 37 J1, added to the TABLE and not only to its own case: on this lane the
+      # class lesson is that a fix reaches one site and the next round finds the same defect one
+      # exit path over, so every new failure mode joins the one-verdict/anchor sweep.
+      ( cd "$d" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID "CLAIM_MACHINE=build box" \
+          "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" bash "$DS" write 3822 2>&1 ) ;;
+    lossy-session)
+      ( cd "$d" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+          "CLAUDE_CODE_SESSION_ID=sess a" "CLAUDE_PID=$$" bash "$DS" write 3822 2>&1 ) ;;
     foreign-worktree)
       other=$(lane "inv-$n-other")
       inv_exec "$other" "$DS" '' "$SESS_A" $$ write 3822 >/dev/null 2>&1
@@ -1925,8 +1986,8 @@ else
 fi
 # ROW FLOOR, the same idea as the case floor: a span-replacing edit that silently drops rows
 # otherwise leaves a green tally over a shrunken table.
-if [ "$inv_count" -ge 30 ]; then
-  ok "TABLE FLOOR: $inv_count failure modes exercised (floor 30) — including all four success verdicts, both signal phases and every refusal token"
+if [ "$inv_count" -ge 32 ]; then
+  ok "TABLE FLOOR: $inv_count failure modes exercised (floor 32) — including all four success verdicts, both signal phases and every refusal token"
 else
   bad "table floor breached: only $inv_count rows ran"
 fi
@@ -2498,6 +2559,118 @@ $p42n"
 fi
 
 # ===========================================================================
+case_begin 43-identity-recorded-losslessly "an identity axis is recorded and compared LOSSLESSLY, or the run refuses (roborev job 37 J1)"
+# ===========================================================================
+# THE THIRD INSTANCE OF ONE FAMILY, pinned as a family rather than as a point fix: H1 committed
+# the `unspecified` PLACEHOLDER for an UNMEASURABLE axis, the round-7 class sweep found the same
+# shape on the worktree axis, and this is a MEASURABLE identity committed LOSSILY. Same
+# consequence every time — two distinct lanes alias onto ONE owner.
+L43=$(lane lane43)
+# (i) THE DEMONSTRATED COLLISION: CLAIM_MACHINE='build box' records as 'build-box', so a
+#     genuinely different box named 'build-box' used to verify as OWNED. The lossy write is now
+#     refused outright, so the alias cannot be created in the first place.
+lm_w=$(run "$L43" "CLAIM_MACHINE=build box" "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 2>&1); lm_wrc=$?
+if [ "$lm_wrc" -eq 1 ] && [ "$(verdict_of "$lm_w")" = ERROR ] \
+   && [ "$(verdict_count "$lm_w")" = 1 ] \
+   && printf '%s\n' "$lm_w" | grep -q 'axis=machine' \
+   && all_lines_anchored "$lm_w" && [ ! -f "$L43/$MARKER" ]; then
+  ok "a LOSSY machine identity ('build box') is ERROR(1) naming axis=machine, exactly one verdict, and NOTHING is written"
+else
+  bad "lossy machine identity was not refused: rc=$lm_wrc marker=$([ -f "$L43/$MARKER" ] && echo present || echo absent)
+$lm_w"
+fi
+# The other direction of the SAME collision: a canonical 'build-box' marker must not be OWNED
+# by a session whose CLAIM_MACHINE is the distinct value 'build box'.
+run "$L43" "CLAIM_MACHINE=build-box" "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 >/dev/null 2>&1
+lm_v=$(run "$L43" "CLAIM_MACHINE=build box" "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- verify 3822 2>&1); lm_vrc=$?
+lm_ok=$(run "$L43" "CLAIM_MACHINE=build-box" "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- verify 3822 2>&1); lm_okrc=$?
+if [ "$lm_vrc" -ne 0 ] && [ "$(verdict_of "$lm_v")" != OWNED ] \
+   && [ "$lm_okrc" -eq 0 ] && [ "$(verdict_of "$lm_ok")" = OWNED ]; then
+  ok "THE COLLISION IS CLOSED: 'build box' does NOT verify as OWNED against a 'build-box' marker (got $(verdict_of "$lm_v")), while the genuine owner still does"
+else
+  bad "the machine collision is still reachable: lossy-rc=$lm_vrc/$(verdict_of "$lm_v") owner-rc=$lm_okrc/$(verdict_of "$lm_ok")"
+fi
+# (ii) THE LENGTH AXIS OF THE SAME DEFECT: two machines sharing a 120-character prefix.
+L43b=$(lane lane43b)
+l43_120=$(printf 'm%.0s' $(seq 1 120))
+la_out=$(run "$L43b" "CLAIM_MACHINE=${l43_120}A" "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 2>&1); la_rc=$?
+lb_out=$(run "$L43b" "CLAIM_MACHINE=${l43_120}B" "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 2>&1); lb_rc=$?
+if [ "$la_rc" -eq 1 ] && [ "$(verdict_of "$la_out")" = ERROR ] \
+   && [ "$lb_rc" -eq 1 ] && [ "$(verdict_of "$lb_out")" = ERROR ] \
+   && [ ! -f "$L43b/$MARKER" ]; then
+  ok "two machine names differing ONLY past the 120-character cut are BOTH refused, so they can never record the same owner"
+else
+  bad "the truncation collision is still reachable: a-rc=$la_rc/$(verdict_of "$la_out") b-rc=$lb_rc/$(verdict_of "$lb_out")"
+fi
+# A 120-character name is NOT lossy and must still work — a guard that reds on correct input is
+# the guard agents learn to waive.
+L43c=$(lane lane43c)
+l120_out=$(run "$L43c" "CLAIM_MACHINE=$l43_120" "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 2>&1); l120_rc=$?
+if [ "$l120_rc" -eq 0 ] && [ "$(verdict_of "$l120_out")" = WRITTEN ]; then
+  ok "NON-VACUITY: a canonical 120-character machine name is ACCEPTED (the bound is refused only where it CHANGES the value)"
+else
+  bad "a canonical 120-character machine name was refused: rc=$l120_rc
+$l120_out"
+fi
+# (iii) THE SESSION AXIS, the same defect one axis over: an EQUAL session id is OWNED outright.
+L43d=$(lane lane43d)
+ls_w=$(run "$L43d" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=sess a" "CLAUDE_PID=$$" -- write 3822 2>&1); ls_wrc=$?
+if [ "$ls_wrc" -eq 1 ] && [ "$(verdict_of "$ls_w")" = ERROR ] \
+   && [ "$(verdict_count "$ls_w")" = 1 ] \
+   && printf '%s\n' "$ls_w" | grep -q 'axis=session' \
+   && all_lines_anchored "$ls_w" && [ ! -f "$L43d/$MARKER" ]; then
+  ok "a LOSSY session id ('sess a') is ERROR(1) naming axis=session, exactly one verdict, and NOTHING is written"
+else
+  bad "lossy session id was not refused: rc=$ls_wrc
+$ls_w"
+fi
+run "$L43d" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=sess-a" "CLAUDE_PID=$$" -- write 3822 >/dev/null 2>&1
+ls_v=$(run "$L43d" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=sess a" "CLAUDE_PID=$$" -- verify 3822 2>&1); ls_vrc=$?
+if [ "$ls_vrc" -ne 0 ] && [ "$(verdict_of "$ls_v")" != OWNED ]; then
+  ok "THE SESSION COLLISION IS CLOSED: 'sess a' does NOT verify as OWNED against a 'sess-a' marker (got $(verdict_of "$ls_v"))"
+else
+  bad "the session collision is still reachable: rc=$ls_vrc verdict=$(verdict_of "$ls_v")"
+fi
+# An UNSET session id is the ABSENCE of a value, not a lossy one: it must still write.
+L43e=$(lane lane43e)
+lu_out=$(run "$L43e" CLAIM_MACHINE=boxA "CLAUDE_PID=$$" -- write 3822 2>&1); lu_rc=$?
+if [ "$lu_rc" -eq 0 ] && [ "$(verdict_of "$lu_out")" = WRITTEN ] \
+   && grep -q '^session: unrecorded$' "$L43e/$MARKER"; then
+  ok "NON-VACUITY: an UNSET session id still records the 'unrecorded' sentinel and writes (absence is not lossiness)"
+else
+  bad "an unset session id was misread as lossy: rc=$lu_rc
+$lu_out"
+fi
+# (iv) THE WORKTREE AXIS IS ALREADY VERBATIM — confirmed rather than assumed, because the
+#      census that named it has to be measurable. A space-bearing lane path must be recorded
+#      WITH its space and must NOT be owned from the '-'-substituted sibling.
+L43f=$(lane "lane43 f")
+L43g=$(lane "lane43-f")
+wv_w=$(run "$L43f" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 2>&1); wv_wrc=$?
+wv_rec=$(sed -n 's/^worktree: //p' "$L43f/$MARKER" | head -1)
+cp "$L43f/$MARKER" "$L43g/$MARKER"
+wv_v=$(run "$L43g" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- verify 3822 2>&1); wv_vrc=$?
+if [ "$wv_wrc" -eq 0 ] && [ "$wv_rec" = "$L43f" ] && [ "$wv_rec" != "$L43g" ] \
+   && [ "$wv_vrc" -eq 4 ] && [ "$(verdict_of "$wv_v")" = FOREIGN-WORKTREE ]; then
+  ok "the worktree axis is recorded VERBATIM (space preserved) and the '-'-substituted sibling is FOREIGN-WORKTREE, not an alias"
+else
+  bad "worktree axis lossiness: w-rc=$wv_wrc recorded='$wv_rec' expected='$L43f' sibling-rc=$wv_vrc/$(verdict_of "$wv_v")"
+fi
+# (v) THE ACTOR AXIS IS DECLARED LOSSY AND DELIBERATELY NOT REFUSED. Nothing compares it, so a
+#     collision there cannot grant ownership; refusing input claim.sh accepts would red on
+#     correct input. Asserted so the DECISION is measurable and cannot be undone silently.
+L43h=$(lane lane43h)
+ac_out=$(run "$L43h" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 --actor 'flow lead' 2>&1); ac_rc=$?
+if [ "$ac_rc" -eq 0 ] && [ "$(verdict_of "$ac_out")" = WRITTEN ] \
+   && grep -q '^actor: flow-lead$' "$L43h/$MARKER"; then
+  ok "DECLARED: the actor is sanitized LOSSILY and accepted — it is recorded state, never an ownership axis (#3810 owns actor collisions)"
+else
+  bad "the actor axis decision changed without the contract changing: rc=$ac_rc
+$ac_out
+$(cat "$L43h/$MARKER" 2>/dev/null)"
+fi
+
+# ===========================================================================
 case_begin 28-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
 # ===========================================================================
 REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
@@ -2518,8 +2691,9 @@ REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-iss
 38-adopt-never-calls-a-live-owner-gone
 39-body-bytes-survive-repeated-writes
 40-worktree-axis-must-be-measurable 41-body-without-trailing-newline
-42-verdict-emission-is-a-critical-section 28-case-floor"
-CASE_FLOOR=42
+42-verdict-emission-is-a-critical-section
+43-identity-recorded-losslessly 28-case-floor"
+CASE_FLOOR=43
 executed=0
 for _c in $CASES; do executed=$((executed + 1)); done
 missing=""
@@ -2531,10 +2705,10 @@ if [ "$executed" -ge "$CASE_FLOOR" ] && [ -z "$missing" ]; then
 else
   bad "case floor breached: executed=$executed floor=$CASE_FLOOR missing:$missing"
 fi
-if [ "$PASS" -ge 139 ]; then
-  ok "assertion floor: $PASS assertions passed (>= 139)"
+if [ "$PASS" -ge 149 ]; then
+  ok "assertion floor: $PASS assertions passed (>= 149)"
 else
-  bad "assertion floor breached: only $PASS assertions passed (floor 139)"
+  bad "assertion floor breached: only $PASS assertions passed (floor 149)"
 fi
 
 # ===========================================================================

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -2061,6 +2061,84 @@ $d37_out"
 fi
 
 # ===========================================================================
+case_begin 38-adopt-never-calls-a-live-owner-gone "adopt is a re-entrant NO-OP for BOTH ownership bases; it may only rewrite when the writer is provably GONE (roborev job 34 H2)"
+# ===========================================================================
+# THE DEFECT: `check_ownership` returns success for THREE different facts — the recorded
+# session IS me, the recorded pid is MY OWN LIVE pid (round 5's same-process branch), and
+# (adopt mode) the recorded writer is provably GONE — and collapsed them into one undifferentiated
+# `return 0`. `cmd_adopt` then re-derived "is it already mine?" from the SESSION ID ALONE, so a
+# changed or unrecorded session with the SAME LIVE PID took the adoption path: it rewrote the
+# marker, recorded a STILL-RUNNING process as `prior-session-pid`, and printed that the writer
+# was "provably gone". That is a FALSE STATEMENT in the audit record this script exists to
+# produce, and recording a live owner as the prior one is exactly what LIVE-PEER refuses.
+GONE_TEXT='provably gone'
+# (A) recorded session differs, recorded pid is THIS live process.
+L38A=$(lane lane38-a)
+run "$L38A" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 --stage implement >/dev/null 2>&1
+cp "$L38A/$MARKER" "$T/38a-before.md"
+a38_out=$(run "$L38A" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- adopt 3822 --reason cron-reinvoke:same-process); a38_rc=$?
+# (B) NO session id recorded at all, recorded pid is THIS live process (the same-process branch
+# exists precisely for a session with CLAUDE_PID set and CLAUDE_CODE_SESSION_ID unset).
+L38B=$(lane lane38-b)
+( cd "$L38B" && env -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA "CLAUDE_PID=$$" bash "$DS" write 3822 >/dev/null 2>&1 )
+cp "$L38B/$MARKER" "$T/38b-before.md"
+b38_out=$( cd "$L38B" && env -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA "CLAUDE_PID=$$" \
+  bash "$DS" adopt 3822 --reason cron-reinvoke:same-process-no-session 2>&1 ); b38_rc=$?
+for probe in A B; do
+  case "$probe" in
+    A) p_out="$a38_out"; p_rc="$a38_rc"; p_lane="$L38A"; p_before="$T/38a-before.md" ;;
+    B) p_out="$b38_out"; p_rc="$b38_rc"; p_lane="$L38B"; p_before="$T/38b-before.md" ;;
+  esac
+  if [ "$p_rc" -eq 0 ] && [ "$(verdict_of "$p_out")" = ADOPTED ] \
+     && ! printf '%s\n' "$p_out" | grep -q "$GONE_TEXT"; then
+    ok "($probe) adopt over a marker whose writer is THIS LIVE PROCESS does NOT claim the writer was gone"
+  else
+    bad "($probe) adopt claimed a live writer was gone (or did not succeed re-entrantly): rc=$p_rc verdict=$(verdict_of "$p_out")
+$p_out"
+  fi
+  if cmp -s "$p_before" "$p_lane/$MARKER"; then
+    ok "($probe) the re-entrant adopt changed NOTHING — the marker is byte-identical"
+  else
+    bad "($probe) the re-entrant adopt rewrote the marker:
+$(diff "$p_before" "$p_lane/$MARKER" || true)"
+  fi
+  if grep -q "^prior-session-pid: $$\$" "$p_lane/$MARKER" 2>/dev/null; then
+    bad "($probe) a STILL-RUNNING process ($$) was recorded as prior-session-pid:
+$(cat "$p_lane/$MARKER")"
+  else
+    ok "($probe) no live process was recorded as prior-session-pid"
+  fi
+done
+# NEGATIVE CONTROL — a GENUINELY DEAD writer still adopts, with the provenance recorded. Without
+# this the case above would pass by simply disabling adoption.
+L38C=$(lane lane38-c)
+sleep 30 & dead38=$!
+run "$L38C" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$dead38" -- write 3822 --stage implement >/dev/null 2>&1
+kill "$dead38" 2>/dev/null; wait "$dead38" 2>/dev/null
+c38_out=$(run "$L38C" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- adopt 3822 --reason cron-reinvoke:writer-pid-gone); c38_rc=$?
+if [ "$c38_rc" -eq 0 ] && [ "$(verdict_of "$c38_out")" = ADOPTED ] \
+   && printf '%s\n' "$c38_out" | grep -q "$GONE_TEXT" \
+   && grep -q "^prior-session: $SESS_A\$" "$L38C/$MARKER" \
+   && grep -q "^prior-session-pid: $dead38\$" "$L38C/$MARKER"; then
+  ok "NEGATIVE CONTROL: a provably GONE writer is still adopted, and the hand-over provenance IS recorded — the distinction is real, not a disabled adopt"
+else
+  bad "the dead-writer adoption regressed: rc=$c38_rc verdict=$(verdict_of "$c38_out")
+$c38_out
+$(cat "$L38C/$MARKER" 2>/dev/null)"
+fi
+# The OTHER caller of the same result: `write` treats BOTH ownership bases as OWNED, and must
+# keep doing so — the same-process basis is an AFFIRMATIVE measurement of sameness, not a
+# weaker one, so making adopt re-entrant must not make write refuse its own marker.
+w38_out=$(run "$L38A" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- write 3822 --stage address); w38_rc=$?
+if [ "$w38_rc" -eq 0 ] && [ "$(verdict_of "$w38_out")" = WRITTEN ] \
+   && grep -q '^stage: address$' "$L38A/$MARKER"; then
+  ok "SWEEP: the same-process basis is still OWNED for `write` (the fix differentiates the bases, it does not narrow ownership)"
+else
+  bad "write over the same-process basis regressed: rc=$w38_rc verdict=$(verdict_of "$w38_out")
+$w38_out"
+fi
+
+# ===========================================================================
 case_begin 28-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
 # ===========================================================================
 REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
@@ -2077,8 +2155,9 @@ REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-iss
 32-failed-scan-is-not-no-match 33-signals-emit-one-verdict
 34-shift-never-leaks-bash-diagnostics 35-one-verdict-per-failure-mode
 36-anchor-holds-on-every-stream
-37-machine-axis-must-be-measurable 28-case-floor"
-CASE_FLOOR=37
+37-machine-axis-must-be-measurable
+38-adopt-never-calls-a-live-owner-gone 28-case-floor"
+CASE_FLOOR=38
 executed=0
 for _c in $CASES; do executed=$((executed + 1)); done
 missing=""

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -1302,22 +1302,22 @@ else
   bad "a failing date committed a self-bricking marker or emitted no verdict: rc=$d30_rc verdict=$(verdict_of "$d30_out")
 $(printf '%s' "$d30_out" | cat -v)"
 fi
-# DECLARED RESIDUAL, MEASURED rather than implied: with `tr` shimmed the identity sanitizer
-# cannot run, and because it is called from inside `$( )` it CANNOT refuse (a `refuse` there is
-# captured, the defect case 17 pins) — so every sanitized field degrades to sanitize_field's
-# `unspecified` sentinel and the write SUCCEEDS. That is a fail-open on the machine/session
-# axes, reachable only on a host whose `tr` is broken, and it is NOT what job 26 F2 is about:
-# the sentinel is mirrored from claim.sh (case 11 pins that agreement), so changing it is a
-# separate decision. What THIS case owns is the anchor, which must hold either way.
+# THE RESIDUAL THIS CASE ONCE DECLARED IS NOW CLOSED (roborev job 34 H1). With `tr` shimmed the
+# identity sanitizer cannot run, so every sanitized field degraded to sanitize_field's
+# `unspecified` sentinel and the write SUCCEEDED — a fail-open on the machine axis, reachable on
+# any host whose `tr` is broken. The sentinel is still claim.sh's (case 11 pins that agreement)
+# and is unchanged; what changed is that COMMITTING it as an identity is refused at the USE
+# SITE, so the same shim now produces an anchored ERROR naming axis=machine and NO marker at
+# all. What this case still owns is the anchor, which must hold either way.
 tr_dir="$(shim_dir_for tr)"; L30T=$(lane leak-tr2)
 tr_out=$( cd "$L30T" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
   "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" "PATH=$tr_dir:$PATH" \
   bash "$DS" write 3822 2>&1 ) || true
-if all_lines_anchored "$tr_out" \
-   && grep -q '^machine: unspecified$' "$L30T/$MARKER" 2>/dev/null; then
-  ok "DECLARED RESIDUAL: a failing 'tr' leaks nothing, and the identity fields degrade to the 'unspecified' sentinel rather than to an empty (self-bricking) value"
+if all_lines_anchored "$tr_out" && [ ! -e "$L30T/$MARKER" ] \
+   && [ "$(verdict_of "$tr_out")" = ERROR ] && printf '%s\n' "$tr_out" | grep -q 'axis=machine'; then
+  ok "a failing 'tr' leaks nothing AND no longer fails open: the machine axis is refused (ERROR, axis=machine) and NO marker with a placeholder identity is committed"
 else
-  bad "a failing tr leaked a line, or the degraded marker is not the shape this residual declares:
+  bad "a failing tr leaked a line, or committed a placeholder identity instead of refusing:
 $(printf '%s' "$tr_out" | cat -v)
 $(cat "$L30T/$MARKER" 2>/dev/null | cat -v)"
 fi
@@ -1745,6 +1745,7 @@ malformed-marker:MALFORMED:8
 duplicate-sentinel:DUPLICATE-SENTINEL:8
 foreign-issue:FOREIGN-ISSUE:4
 foreign-machine:FOREIGN-MACHINE:4
+unmeasurable-machine:ERROR:1
 foreign-worktree:FOREIGN-WORKTREE:4
 adoptable:ADOPTABLE:5
 live-peer:LIVE-PEER:6
@@ -1816,6 +1817,14 @@ inv_run() {  # inv_run <row-name> — set the state up, run it, print output, re
       inv_exec "$d" "$DS" '' "$SESS_A" $$ write 3822 >/dev/null 2>&1
       ( cd "$d" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxB \
           "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" bash "$DS" verify 3822 2>&1 ) ;;
+    unmeasurable-machine)
+      # roborev job 34 H1, added to the TABLE rather than only to its own case: the class
+      # lesson on this lane is that a fix reaches one site and the next round finds the same
+      # defect one exit path over, so every new failure mode joins the one-verdict/anchor sweep.
+      sd=$(inv_bin hostname 'exit 1')
+      ( cd "$d" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID -u CLAIM_MACHINE \
+          "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" "PATH=$sd:$PATH" \
+          bash "$DS" write 3822 2>&1 ) ;;
     foreign-worktree)
       other=$(lane "inv-$n-other")
       inv_exec "$other" "$DS" '' "$SESS_A" $$ write 3822 >/dev/null 2>&1
@@ -1966,6 +1975,92 @@ else
 fi
 
 # ===========================================================================
+case_begin 37-machine-axis-must-be-measurable "an UNMEASURABLE machine axis is refused, never committed as the 'unspecified' placeholder (roborev job 34 H1)"
+# ===========================================================================
+# THE DEFECT: `hostname -s` failing (or printing nothing) with CLAIM_MACHINE unset made the
+# machine axis sanitize to the `unspecified` PLACEHOLDER, and the writer COMMITTED it. Two
+# consequences in a file whose whole subject is ownership: a transient failure writes a stamp
+# that becomes FOREIGN-MACHINE the moment hostname resolution recovers (the lane locks ITSELF
+# out), and a PERSISTENT failure ALIASES EVERY BOX ONTO ONE OWNER — lane A's marker then
+# verifies as OWNED on machine B, which is the peer-adoption defect this issue exists to close.
+# THE ARTIFACT IS SUBSTITUTED (a PATH shim), never a settable seam.
+mkm_fail=0
+hostname_shim() {  # hostname_shim <kind> -> a PATH dir whose `hostname` fails|prints nothing|works
+  local kind="$1" d="$T/hnbin-$1"
+  mkdir -p "$d"
+  case "$kind" in
+    fail)  { printf '#!/bin/sh\n'; printf 'exit 1\n'; } >"$d/hostname" ;;
+    empty) { printf '#!/bin/sh\n'; printf 'printf ""\n'; printf 'exit 0\n'; } >"$d/hostname" ;;
+    real)  { printf '#!/bin/sh\n'; printf 'printf "realbox\\n"\n'; } >"$d/hostname" ;;
+  esac
+  chmod +x "$d/hostname"
+  printf '%s\n' "$d"
+}
+run_nomachine() {  # run_nomachine <dir> <shim-dir> <args...> — CLAIM_MACHINE UNSET
+  local dir="$1" sd="$2"; shift 2
+  ( cd "$dir" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID -u CLAIM_MACHINE \
+      "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" "PATH=$sd:$PATH" \
+      bash "$DS" "$@" 2>&1 )
+}
+for hk in fail empty; do
+  hsd="$(hostname_shim "$hk")"
+  L37=$(lane "lane37-$hk")
+  m37_out=$(run_nomachine "$L37" "$hsd" write 3822); m37_rc=$?
+  if [ "$m37_rc" -ne 0 ] && [ "$(verdict_of "$m37_out")" = ERROR ] \
+     && [ ! -e "$L37/$MARKER" ] && all_lines_anchored "$m37_out"; then
+    ok "hostname '$hk' + no CLAIM_MACHINE: write refuses ERROR and commits NO marker"
+  else
+    mkm_fail=1
+    bad "hostname '$hk': write did not refuse, or committed a marker: rc=$m37_rc verdict=$(verdict_of "$m37_out") marker=$([ -e "$L37/$MARKER" ] && echo present || echo absent)
+$m37_out"
+  fi
+  if printf '%s\n' "$m37_out" | grep -q 'axis=machine'; then
+    ok "hostname '$hk': the refusal NAMES the axis (axis=machine)"
+  else
+    bad "hostname '$hk': the refusal does not name the axis:
+$m37_out"
+  fi
+done
+# NON-VACUITY: the SAME lane, the same everything, with a WORKING hostname shim, writes.
+hsd_ok="$(hostname_shim real)"
+L37OK=$(lane lane37-real)
+m37ok_out=$(run_nomachine "$L37OK" "$hsd_ok" write 3822); m37ok_rc=$?
+if [ "$m37ok_rc" -eq 0 ] && [ "$(verdict_of "$m37ok_out")" = WRITTEN ] \
+   && grep -q '^machine: realbox$' "$L37OK/$MARKER" 2>/dev/null; then
+  ok "NON-VACUITY: a WORKING hostname writes normally (machine: realbox) — the refusals above are about the unmeasurable value, not the shim"
+else
+  bad "the working-hostname control did not write: rc=$m37ok_rc verdict=$(verdict_of "$m37ok_out")
+$m37ok_out"
+fi
+# THE ALIAS, DEMONSTRATED: a marker RECORDING the placeholder must NOT verify as OWNED just
+# because this box cannot measure its own name either. Without the use-site refusal both sides
+# read `unspecified` and the axis comparison SUCCEEDS — every box owning every marker.
+L37A=$(lane lane37-alias)
+run "$L37A" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 >/dev/null 2>&1
+LC_ALL=C sed -i.bak 's/^machine: boxA$/machine: unspecified/' "$L37A/$MARKER" && rm -f "$L37A/$MARKER.bak"
+cp "$L37A/$MARKER" "$T/alias-before.md"
+hsd_f="$(hostname_shim fail)"
+a37_out=$(run_nomachine "$L37A" "$hsd_f" verify 3822); a37_rc=$?
+if [ "$a37_rc" -ne 0 ] && [ "$(verdict_of "$a37_out")" = ERROR ]; then
+  ok "a recorded 'unspecified' machine does NOT alias onto an unmeasurable current machine: verify refuses ERROR (not OWNED)"
+else
+  bad "the placeholder ALIASED: verify rc=$a37_rc verdict=$(verdict_of "$a37_out") (OWNED here means every box owns every marker)
+$a37_out"
+fi
+# NOTHING IS MUTATED BY A REFUSAL — byte-for-byte, not a line count.
+w37_out=$(run_nomachine "$L37A" "$hsd_f" write 3822 --stage implement); w37_rc=$?
+d37_out=$(run_nomachine "$L37A" "$hsd_f" adopt 3822 --reason cron-reinvoke:machine-unmeasurable); d37_rc=$?
+if [ "$w37_rc" -ne 0 ] && [ "$(verdict_of "$w37_out")" = ERROR ] \
+   && [ "$d37_rc" -ne 0 ] && [ "$(verdict_of "$d37_out")" = ERROR ] \
+   && cmp -s "$T/alias-before.md" "$L37A/$MARKER"; then
+  ok "write AND adopt both refuse ERROR and the marker is BYTE-IDENTICAL afterwards (nothing was committed)"
+else
+  bad "a refused write/adopt mutated the marker or produced a non-ERROR verdict: w_rc=$w37_rc w=$(verdict_of "$w37_out") a_rc=$d37_rc a=$(verdict_of "$d37_out")
+$w37_out
+$d37_out"
+fi
+
+# ===========================================================================
 case_begin 28-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
 # ===========================================================================
 REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
@@ -1981,8 +2076,9 @@ REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-iss
 31-adoption-provenance-survives
 32-failed-scan-is-not-no-match 33-signals-emit-one-verdict
 34-shift-never-leaks-bash-diagnostics 35-one-verdict-per-failure-mode
-36-anchor-holds-on-every-stream 28-case-floor"
-CASE_FLOOR=36
+36-anchor-holds-on-every-stream
+37-machine-axis-must-be-measurable 28-case-floor"
+CASE_FLOOR=37
 executed=0
 for _c in $CASES; do executed=$((executed + 1)); done
 missing=""

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -1107,6 +1107,64 @@ $pr_ok"
 fi
 
 # ===========================================================================
+case_begin 29-missing-liveness-library "a MISSING shared liveness library emits the ERROR verdict TOKEN, not a bare prefixed line"
+# ===========================================================================
+# roborev job 26 F1. The guard was anchored (it carried the DRIVE-STATE: prefix) but was NOT
+# the `verdict ERROR` shape, so the ONE line every caller branches on — the closed-set token
+# on the `verdict ` line — was ABSENT. drive-issue.md's Delta 4 tells callers to `case` on
+# that token, so this failure fell through every arm: a fatal, unreadable-by-construction
+# refusal. The prefix is contract (a); the token is contract (c), and (a) does not imply (c).
+#
+# THE ARTIFACT IS SUBSTITUTED, never a path seam: the script is COPIED to a scratch directory
+# WITHOUT its lib/, exactly as cases 22/27 substitute the artifact. A settable SCRIPT_HOME (or
+# any test-only override) would be one more thing a real invoker can set.
+SCRATCH29="$T/scratch29"; mkdir -p "$SCRATCH29"
+cp "$DS" "$SCRATCH29/drive-issue-state.sh"
+L29=$(lane lane29)
+ml_out=$( cd "$L29" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+  "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" \
+  bash "$SCRATCH29/drive-issue-state.sh" verify 3822 2>&1 ); ml_rc=$?
+ml_v="$(verdict_of "$ml_out")"
+if [ "$ml_rc" -eq 1 ] && [ "$ml_v" = ERROR ] && verdict_in_set "$ml_v" \
+   && all_lines_anchored "$ml_out" \
+   && printf '%s\n' "$ml_out" | grep -q 'process-liveness.sh'; then
+  ok "an ABSENT lib/process-liveness.sh yields exit 1 AND a closed-set 'verdict ERROR' line naming the unreadable path"
+else
+  bad "the missing-liveness-library guard emitted no usable verdict token: rc=$ml_rc verdict='$ml_v'
+$ml_out"
+fi
+# NON-VACUITY: the SAME scratch copy works once the library is beside it, so the refusal
+# above is about the missing library and not about the copy being broken.
+mkdir -p "$SCRATCH29/lib"
+cp "$SCRIPT_DIR/../flow/lib/process-liveness.sh" "$SCRATCH29/lib/process-liveness.sh"
+ml_ok=$( cd "$L29" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+  "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" \
+  bash "$SCRATCH29/drive-issue-state.sh" write 3822 2>&1 ); ml_okrc=$?
+if [ "$ml_okrc" -eq 0 ] && [ "$(verdict_of "$ml_ok")" = WRITTEN ]; then
+  ok "NON-VACUITY: the same scratch copy writes normally with the library present"
+else
+  bad "the scratch copy is broken independently of the library, so the refusal above proves nothing: rc=$ml_okrc
+$ml_ok"
+fi
+# THE UNREADABLE (as opposed to absent) ROUTE INTO THE SAME GUARD. Root bypasses file
+# permissions, so under root the probe is DECLARED unavailable rather than passing vacuously.
+if [ "$(id -u)" -eq 0 ]; then
+  ok "unreadable-library probe DECLARED unavailable under root (permissions are bypassed) — the absent-library route above is what was measured"
+else
+  chmod 000 "$SCRATCH29/lib/process-liveness.sh"
+  ml_u=$( cd "$L29" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+    "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" \
+    bash "$SCRATCH29/drive-issue-state.sh" verify 3822 2>&1 ); ml_urc=$?
+  chmod 644 "$SCRATCH29/lib/process-liveness.sh" 2>/dev/null || true
+  if [ "$ml_urc" -eq 1 ] && [ "$(verdict_of "$ml_u")" = ERROR ] && all_lines_anchored "$ml_u"; then
+    ok "an UNREADABLE lib/process-liveness.sh takes the same guard: exit 1 with a 'verdict ERROR' line"
+  else
+    bad "an unreadable library did not emit the ERROR verdict: rc=$ml_urc verdict=$(verdict_of "$ml_u")
+$ml_u"
+  fi
+fi
+
+# ===========================================================================
 case_begin 28-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
 # ===========================================================================
 REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
@@ -1118,8 +1176,9 @@ REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-iss
 20-same-process-is-owned 21-write-over-unstamped-migrates
 22-no-dead-letter-remedies 23-durable-fields-survive 24-serialization
 25-displaced-sentinel-is-not-legacy 26-unusable-start-window 27-pre-rename-validation
+29-missing-liveness-library
 28-case-floor"
-CASE_FLOOR=28
+CASE_FLOOR=29
 executed=0
 for _c in $CASES; do executed=$((executed + 1)); done
 missing=""
@@ -1131,8 +1190,8 @@ if [ "$executed" -ge "$CASE_FLOOR" ] && [ -z "$missing" ]; then
 else
   bad "case floor breached: executed=$executed floor=$CASE_FLOOR missing:$missing"
 fi
-if [ "$PASS" -ge 68 ]; then
-  ok "assertion floor: $PASS assertions passed (>= 68)"
+if [ "$PASS" -ge 71 ]; then
+  ok "assertion floor: $PASS assertions passed (>= 71)"
 else
   bad "assertion floor breached: only $PASS assertions passed"
 fi

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -1308,6 +1308,114 @@ $(cat "$L30T/$MARKER" 2>/dev/null | cat -v)"
 fi
 
 # ===========================================================================
+case_begin 31-adoption-provenance-survives "adoption provenance (prior-session/-pid/-ts, adopt-reason) survives a later write"
+# ===========================================================================
+# roborev job 26 F3, and the SAME CLASS as job 18 finding 2 (dropped durable fields)
+# reappearing at the adopt fields: `adopt` records HOW this lane changed hands, and the very
+# next `write --stage x` rebuilt the prologue from the write path's field list — which carried
+# only stage/request-id/pr/branch — so the provenance VANISHED on the first stage update. A
+# `--reason` that is mandatory, validated and then erased by the next command is worthless.
+L31=$(lane lane31)
+sleep 30 & ap_d1=$!
+run "$L31" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$ap_d1" -- \
+  write 3822 --stage implement --request-id coord-3822-31 --pr 4031 --branch issue-3822-ap >/dev/null 2>&1
+kill "$ap_d1" 2>/dev/null; wait "$ap_d1" 2>/dev/null
+# The adopting session records a pid that is ALSO gone, so a THIRD session can adopt later
+# (the overwrite half below). Its own `write` is OWNED by session equality, which needs no
+# liveness at all.
+# It stays ALIVE across its own adopt and write (so both stamps record a MEASURABLE start
+# window) and is killed only afterwards, which is what makes the third session's adopt reach
+# the `gone` branch rather than LIVENESS-UNKNOWN.
+sleep 300 & ap_d2=$!
+ap_ad=$(run "$L31" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$ap_d2" -- \
+  adopt 3822 --reason cron-reinvoke:writer-pid-gone-31); ap_adrc=$?
+ap_ts1="$(sed -n 's/^prior-ts: //p' "$L31/$MARKER" | head -1)"
+if [ "$ap_adrc" -eq 0 ] && [ "$(verdict_of "$ap_ad")" = ADOPTED ] \
+   && grep -q "^prior-session: $SESS_A\$" "$L31/$MARKER" \
+   && grep -q "^prior-session-pid: $ap_d1\$" "$L31/$MARKER" \
+   && [ -n "$ap_ts1" ] \
+   && grep -q '^adopt-reason: cron-reinvoke:writer-pid-gone-31$' "$L31/$MARKER"; then
+  ok "the adopt recorded all four provenance fields (prior-session/-pid/-ts, adopt-reason)"
+else
+  bad "the adopt did not record the provenance this case is about: rc=$ap_adrc
+$(cat "$L31/$MARKER")"
+fi
+# THE SUBJECT: an ordinary stage update by the now-owning session.
+ap_w=$(run "$L31" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$ap_d2" -- \
+  write 3822 --stage review); ap_wrc=$?
+ap_show=$(run "$L31" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$ap_d2" -- show 3822 2>&1)
+if [ "$ap_wrc" -eq 0 ] && [ "$(verdict_of "$ap_w")" = WRITTEN ] \
+   && printf '%s\n' "$ap_show" | grep -q "prior-session=$SESS_A" \
+   && printf '%s\n' "$ap_show" | grep -q "prior-session-pid=$ap_d1" \
+   && printf '%s\n' "$ap_show" | grep -q "prior-ts=$ap_ts1" \
+   && printf '%s\n' "$ap_show" | grep -q 'adopt-reason=cron-reinvoke:writer-pid-gone-31' \
+   && printf '%s\n' "$ap_show" | grep -q 'stage=review' \
+   && printf '%s\n' "$ap_show" | grep -q 'request-id=coord-3822-31'; then
+  ok "a later 'write --stage' PRESERVES all four adoption-provenance fields AND still updates the stage"
+else
+  bad "the stage update erased the adoption provenance: rc=$ap_wrc
+$ap_show"
+fi
+# A LATER ADOPT OVERWRITES them — the NEWEST hand-over is the one recorded, not the first.
+kill "$ap_d2" 2>/dev/null; wait "$ap_d2" 2>/dev/null
+ap_ad2=$(run "$L31" CLAIM_MACHINE=boxA CLAUDE_CODE_SESSION_ID=sess-cccccccc "CLAUDE_PID=$$" -- \
+  adopt 3822 --reason second-handover:31); ap_ad2rc=$?
+ap_show2=$(run "$L31" CLAIM_MACHINE=boxA CLAUDE_CODE_SESSION_ID=sess-cccccccc "CLAUDE_PID=$$" -- show 3822 2>&1)
+if [ "$ap_ad2rc" -eq 0 ] && [ "$(verdict_of "$ap_ad2")" = ADOPTED ] \
+   && printf '%s\n' "$ap_show2" | grep -q "prior-session=$SESS_B" \
+   && printf '%s\n' "$ap_show2" | grep -q "prior-session-pid=$ap_d2" \
+   && printf '%s\n' "$ap_show2" | grep -q 'adopt-reason=second-handover:31' \
+   && ! printf '%s\n' "$ap_show2" | grep -q 'cron-reinvoke:writer-pid-gone-31'; then
+  ok "a LATER adopt OVERWRITES the provenance with the newest hand-over (it is not accumulated)"
+else
+  bad "a second adopt did not replace the provenance: rc=$ap_ad2rc
+$ap_show2"
+fi
+# NEGATIVE HALF: a fresh write over an ABSENT marker must INVENT none of them, and neither
+# must the UNSTAMPED migration branch (which asserts no ownership and carries nothing forward).
+L31B=$(lane lane31b)
+run "$L31B" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 --stage implement >/dev/null 2>&1
+L31C=$(lane lane31c); printf 'legacy hand-written plan\n' >"$L31C/$MARKER"
+run "$L31C" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 >/dev/null 2>&1
+ap_negshow=$(run "$L31B" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- show 3822 2>&1)
+if ! grep -qE '^(prior-session|prior-session-pid|prior-ts|adopt-reason): ' "$L31B/$MARKER" \
+   && ! grep -qE '^(prior-session|prior-session-pid|prior-ts|adopt-reason): ' "$L31C/$MARKER" \
+   && ! printf '%s\n' "$ap_negshow" | grep -q 'prior-' \
+   && ! printf '%s\n' "$ap_negshow" | grep -q 'adopt-reason'; then
+  ok "a fresh write (ABSENT marker) and the UNSTAMPED migration invent NO provenance fields, and show prints none"
+else
+  bad "provenance fields were invented where there was no adoption:
+$(cat "$L31B/$MARKER")
+--
+$(cat "$L31C/$MARKER")
+--
+$ap_negshow"
+fi
+# A DUPLICATE provenance key is a MALFORMED refusal like every other stamp key: which
+# occurrence is the record must not be the parser's choice.
+L31D=$(lane lane31d)
+sleep 30 & ap_d3=$!
+run "$L31D" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$ap_d3" -- write 3822 >/dev/null 2>&1
+kill "$ap_d3" 2>/dev/null; wait "$ap_d3" 2>/dev/null
+run "$L31D" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- adopt 3822 --reason dup-probe:31 >/dev/null 2>&1
+ap_dupfail=0
+for dk in prior-session-pid prior-ts adopt-reason; do
+  cp "$L31D/$MARKER" "$T/m31d.bak"
+  awk -v k="$dk" '{print} $0 ~ "^"k": " && !d {print; d=1}' "$T/m31d.bak" >"$L31D/$MARKER"
+  ap_du=$(run "$L31D" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- show 3822 2>&1); ap_durc=$?
+  if [ "$ap_durc" -ne 0 ] && [ "$(verdict_of "$ap_du")" = MALFORMED ]; then :; else
+    ap_dupfail=$((ap_dupfail + 1))
+    printf 'note   duplicate %s was not refused: rc=%s verdict=%s\n' "$dk" "$ap_durc" "$(verdict_of "$ap_du")"
+  fi
+  cp "$T/m31d.bak" "$L31D/$MARKER"
+done
+if [ "$ap_dupfail" -eq 0 ]; then
+  ok "a DUPLICATE prior-session-pid / prior-ts / adopt-reason is refused MALFORMED — these keys are PARSED, not merely written"
+else
+  bad "$ap_dupfail provenance keys accept a duplicate (they are written but not parsed)"
+fi
+
+# ===========================================================================
 case_begin 28-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
 # ===========================================================================
 REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
@@ -1320,8 +1428,9 @@ REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-iss
 22-no-dead-letter-remedies 23-durable-fields-survive 24-serialization
 25-displaced-sentinel-is-not-legacy 26-unusable-start-window 27-pre-rename-validation
 29-missing-liveness-library 30-native-diagnostics-stay-anchored
+31-adoption-provenance-survives
 28-case-floor"
-CASE_FLOOR=30
+CASE_FLOOR=31
 executed=0
 for _c in $CASES; do executed=$((executed + 1)); done
 missing=""
@@ -1333,8 +1442,8 @@ if [ "$executed" -ge "$CASE_FLOOR" ] && [ -z "$missing" ]; then
 else
   bad "case floor breached: executed=$executed floor=$CASE_FLOOR missing:$missing"
 fi
-if [ "$PASS" -ge 78 ]; then
-  ok "assertion floor: $PASS assertions passed (>= 78)"
+if [ "$PASS" -ge 83 ]; then
+  ok "assertion floor: $PASS assertions passed (>= 83)"
 else
   bad "assertion floor breached: only $PASS assertions passed"
 fi

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -1165,6 +1165,149 @@ $ml_u"
 fi
 
 # ===========================================================================
+case_begin 30-native-diagnostics-stay-anchored "a FAILING external command's NATIVE stderr never reaches the terminal unprefixed"
+# ===========================================================================
+# roborev job 26 F2. `mktemp`, `mv`, `rm`, `cat`, `date`, `wc`, `tr`, `hostname` were invoked
+# with their stderr unredirected, so on failure the NATIVE diagnostic ("mktemp: failed to
+# create file via template ...") reached the terminal with NO `DRIVE-STATE: ` prefix — pure
+# contract-(a) breakage, since the failure itself is already reported through the anchored
+# WRITE_ERR/refuse path.
+#
+# THE SHIM MUST WRITE TO STDERR AND THEN FAIL. Case 17's shim exits SILENTLY, which is why it
+# could not see this: a silent failure exercises the error PATH without exercising the output
+# CONTRACT. Each command is shimmed ON ITS OWN (shimming all of them at once would kill the
+# script before it reached most of the sites) and the property is asserted over BOTH STREAMS
+# COMBINED, because contract (a) is about stdout AND stderr.
+LEAK='NATIVE-LEAK-MARKER'
+shim_dir_for() {  # shim_dir_for <cmd> — a PATH dir whose <cmd> is noisy AND failing
+  local c="$1" d="$T/leakbin-$1"
+  mkdir -p "$d"
+  { printf '#!/bin/sh\n'
+    printf 'echo "%s: %s simulated failure" >&2\n' "$c" "$LEAK"
+    printf 'exit 1\n'; } >"$d/$c"
+  chmod +x "$d/$c"
+  printf '%s\n' "$d"
+}
+leak_fail=0; leak_probed=0
+# probe <cmd> <lane-setup-fn> <extra-args...> — run `write` with <cmd> shimmed and assert the
+# combined output is fully anchored.
+leak_probe() {
+  local c="$1" d="$2"; shift 2
+  local sd out rc
+  sd="$(shim_dir_for "$c")"
+  out=$( cd "$d" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+    "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" "PATH=$sd:$PATH" \
+    bash "$DS" "$@" 2>&1 ); rc=$?
+  leak_probed=$((leak_probed + 1))
+  LEAK_OUT="$out"; LEAK_RC="$rc"
+  if all_lines_anchored "$out"; then
+    return 0
+  fi
+  leak_fail=$((leak_fail + 1))
+  printf 'note   LEAK via %s (rc=%s):\n%s\n' "$c" "$rc" "$(printf '%s' "$out" | cat -v)"
+  return 1
+}
+# mktemp / mv / date / tr / hostname: reached by an ordinary write in a fresh lane.
+for lc in mktemp mv date tr; do
+  leak_probe "$lc" "$(lane "leak-$lc")" write 3822 || true
+done
+# hostname is only consulted when CLAIM_MACHINE is UNSET, so it needs its own invocation.
+lh_dir="$(shim_dir_for hostname)"; L30H=$(lane leak-hostname)
+lh_out=$( cd "$L30H" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID -u CLAIM_MACHINE \
+  "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" "PATH=$lh_dir:$PATH" \
+  bash "$DS" write 3822 2>&1 ) || true
+leak_probed=$((leak_probed + 1))
+if all_lines_anchored "$lh_out"; then :; else
+  leak_fail=$((leak_fail + 1))
+  printf 'note   LEAK via hostname:\n%s\n' "$(printf '%s' "$lh_out" | cat -v)"
+fi
+# cat: only reached with a non-empty --body-file.
+L30C=$(lane leak-cat); body30="$T/body30.md"; printf 'lane notes\n' >"$body30"
+leak_probe cat "$L30C" write 3822 --body-file "$body30" || true
+# wc: only reached on the UNSTAMPED migration branch.
+L30W=$(lane leak-wc); printf 'legacy hand-written plan\n' >"$L30W/$MARKER"
+leak_probe wc "$L30W" write 3822 || true
+if [ "$leak_fail" -eq 0 ]; then
+  ok "no native diagnostic escaped the anchor across $leak_probed failing-command probes (both streams combined)"
+else
+  bad "$leak_fail of $leak_probed failing-command probes leaked an unprefixed native diagnostic"
+fi
+if [ "$leak_probed" -ge 7 ]; then
+  ok "NON-VACUITY: $leak_probed distinct external commands were actually shimmed and reached"
+else
+  bad "only $leak_probed probes ran — the sweep cannot have covered the named call sites"
+fi
+# CAPTURE, NOT MERELY SUPPRESSION, where the native text is diagnostically useful: a failing
+# mktemp's own words must be FOLDED into the anchored ERROR detail, so the operator still
+# learns WHY. Suppression alone would satisfy the anchor and lose the diagnosis.
+if leak_probe mktemp "$(lane leak-mktemp2)" write 3822; then :; fi
+if [ "$LEAK_RC" -ne 0 ] && [ "$(verdict_of "$LEAK_OUT")" = ERROR ] \
+   && printf '%s\n' "$LEAK_OUT" | grep -q "$LEAK"; then
+  ok "a failing mktemp's NATIVE text is FOLDED into the anchored ERROR detail (captured, not merely suppressed)"
+else
+  bad "the failing mktemp's native diagnostic was lost entirely: rc=$LEAK_RC verdict=$(verdict_of "$LEAK_OUT")
+$LEAK_OUT"
+fi
+if leak_probe mv "$(lane leak-mv2)" write 3822; then :; fi
+if [ "$LEAK_RC" -ne 0 ] && [ "$(verdict_of "$LEAK_OUT")" = ERROR ] \
+   && printf '%s\n' "$LEAK_OUT" | grep -q "$LEAK"; then
+  ok "a failing mv's NATIVE text is FOLDED into the anchored ERROR detail"
+else
+  bad "the failing mv's native diagnostic was lost entirely: rc=$LEAK_RC verdict=$(verdict_of "$LEAK_OUT")
+$LEAK_OUT"
+fi
+# `rm` is the one whose failure lands in the EXIT TRAP, AFTER the verdict. MEASURED, not
+# assumed: a failing command in a bash EXIT trap under `set -e` aborts the trap AND replaces
+# the exit status (verified: a successful body plus a failing trap exits 1). So a broken `rm`
+# turned a legitimate WRITTEN(0) into an unexplained non-zero with an unprefixed line after
+# the verdict — cleanup is best-effort and must not be able to change either.
+rm_dir="$(shim_dir_for rm)"; L30R=$(lane leak-rm)
+rm_out=$( cd "$L30R" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+  "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" "PATH=$rm_dir:$PATH" \
+  bash "$DS" write 3822 2>&1 ); rm_rc=$?
+if [ "$rm_rc" -eq 0 ] && [ "$(verdict_of "$rm_out")" = WRITTEN ] && all_lines_anchored "$rm_out" \
+   && [ -f "$L30R/$MARKER" ]; then
+  ok "a failing (noisy) rm in the cleanup trap neither leaks a line nor changes the WRITTEN(0) verdict"
+else
+  bad "the cleanup trap's rm changed the outcome or leaked: rc=$rm_rc verdict=$(verdict_of "$rm_out")
+$(printf '%s' "$rm_out" | cat -v)"
+fi
+# A FAILING `date` MUST NOT COMMIT A SELF-BRICKING MARKER. Found by this very case: because
+# every caller invokes write_marker as `if ! write_marker ...`, `set -e` is suppressed for its
+# whole subtree, so a failing `date` inside `$( )` left `ts` EMPTY and the marker committed —
+# after which every read refuses it MALFORMED (missing required field). The lane bricks itself.
+date_dir="$(shim_dir_for date)"; L30D=$(lane leak-date2)
+d30_out=$( cd "$L30D" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+  "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" "PATH=$date_dir:$PATH" \
+  bash "$DS" write 3822 2>&1 ); d30_rc=$?
+if [ "$d30_rc" -ne 0 ] && [ "$(verdict_of "$d30_out")" = ERROR ] && all_lines_anchored "$d30_out" \
+   && [ ! -f "$L30D/$MARKER" ]; then
+  ok "a failing 'date' refuses with an anchored ERROR and commits NOTHING — no marker with an empty required field"
+else
+  bad "a failing date committed a self-bricking marker or emitted no verdict: rc=$d30_rc verdict=$(verdict_of "$d30_out")
+$(printf '%s' "$d30_out" | cat -v)"
+fi
+# DECLARED RESIDUAL, MEASURED rather than implied: with `tr` shimmed the identity sanitizer
+# cannot run, and because it is called from inside `$( )` it CANNOT refuse (a `refuse` there is
+# captured, the defect case 17 pins) — so every sanitized field degrades to sanitize_field's
+# `unspecified` sentinel and the write SUCCEEDS. That is a fail-open on the machine/session
+# axes, reachable only on a host whose `tr` is broken, and it is NOT what job 26 F2 is about:
+# the sentinel is mirrored from claim.sh (case 11 pins that agreement), so changing it is a
+# separate decision. What THIS case owns is the anchor, which must hold either way.
+tr_dir="$(shim_dir_for tr)"; L30T=$(lane leak-tr2)
+tr_out=$( cd "$L30T" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+  "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" "PATH=$tr_dir:$PATH" \
+  bash "$DS" write 3822 2>&1 ) || true
+if all_lines_anchored "$tr_out" \
+   && grep -q '^machine: unspecified$' "$L30T/$MARKER" 2>/dev/null; then
+  ok "DECLARED RESIDUAL: a failing 'tr' leaks nothing, and the identity fields degrade to the 'unspecified' sentinel rather than to an empty (self-bricking) value"
+else
+  bad "a failing tr leaked a line, or the degraded marker is not the shape this residual declares:
+$(printf '%s' "$tr_out" | cat -v)
+$(cat "$L30T/$MARKER" 2>/dev/null | cat -v)"
+fi
+
+# ===========================================================================
 case_begin 28-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
 # ===========================================================================
 REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
@@ -1176,9 +1319,9 @@ REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-iss
 20-same-process-is-owned 21-write-over-unstamped-migrates
 22-no-dead-letter-remedies 23-durable-fields-survive 24-serialization
 25-displaced-sentinel-is-not-legacy 26-unusable-start-window 27-pre-rename-validation
-29-missing-liveness-library
+29-missing-liveness-library 30-native-diagnostics-stay-anchored
 28-case-floor"
-CASE_FLOOR=29
+CASE_FLOOR=30
 executed=0
 for _c in $CASES; do executed=$((executed + 1)); done
 missing=""
@@ -1190,8 +1333,8 @@ if [ "$executed" -ge "$CASE_FLOOR" ] && [ -z "$missing" ]; then
 else
   bad "case floor breached: executed=$executed floor=$CASE_FLOOR missing:$missing"
 fi
-if [ "$PASS" -ge 71 ]; then
-  ok "assertion floor: $PASS assertions passed (>= 71)"
+if [ "$PASS" -ge 78 ]; then
+  ok "assertion floor: $PASS assertions passed (>= 78)"
 else
   bad "assertion floor breached: only $PASS assertions passed"
 fi

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -434,7 +434,10 @@ p15=$!
 run "$L15" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$p15" -- write 3822 >/dev/null 2>&1
 # Rewrite the recorded start window into the distant past: the pid is LIVE but it
 # cannot be the process that stamped this marker (pid reuse).
-sed -i 's/^session-pid-start-earliest: .*/session-pid-start-earliest: 1000000000/; s/^session-pid-start-latest: .*/session-pid-start-latest: 1000000002/' "$L15/$MARKER"
+# `sed -i` is NOT portable (BSD/macOS requires an argument to -i), so rewrite via a temp.
+sed -e 's/^session-pid-start-earliest: .*/session-pid-start-earliest: 1000000000/' \
+    -e 's/^session-pid-start-latest: .*/session-pid-start-latest: 1000000002/' \
+    "$L15/$MARKER" >"$T/marker15" && mv "$T/marker15" "$L15/$MARKER"
 ru_out=$(run "$L15" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- verify 3822); ru_rc=$?
 kill "$p15" 2>/dev/null; wait "$p15" 2>/dev/null
 ru_v=$(verdict_of "$ru_out")
@@ -484,7 +487,7 @@ else
 fi
 
 # ===========================================================================
-case_begin 18-write-failure-emits-a-verdict "an I/O failure emits ERROR on STDOUT — the verdict is never captured into a variable"
+case_begin 17-write-failure-emits-a-verdict "an I/O failure emits ERROR on STDOUT — the verdict is never captured into a variable"
 # ===========================================================================
 # Regression pin for a real defect in the first cut: the writer printed its path on
 # stdout and was called inside `$( )`, so a `refuse` inside it exited only the SUBSHELL
@@ -492,26 +495,81 @@ case_begin 18-write-failure-emits-a-verdict "an I/O failure emits ERROR on STDOU
 # verdict at all and put a verdict string inside a path. Every emit site must be in the
 # main shell, which this case measures rather than asserts.
 L18=$(lane lane18)
-chmod 500 "$L18"
-wf_out=$(run "$L18" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 2>/dev/null); wf_rc=$?
-chmod 700 "$L18"
-if [ "$wf_rc" -ne 0 ] && [ "$(verdict_of "$wf_out")" = ERROR ] && all_lines_anchored "$wf_out"; then
-  ok "an unwritable worktree yields ERROR(rc=$wf_rc) on stdout, anchored — not a swallowed verdict"
+wf_probe="unwritable-worktree"
+if [ "$(id -u)" -eq 0 ]; then
+  # ROOT BYPASSES DIRECTORY PERMISSIONS, so the chmod probe would silently SUCCEED and the
+  # case would pass having measured nothing. Under root the probe is DECLARED unavailable
+  # and replaced by the other route into the same emit path: a marker path that is not a
+  # regular file. Narrower coverage, NAMED rather than hidden.
+  wf_probe="non-regular-marker(root: permission probe unavailable)"
+  mkdir -p "$L18/$MARKER"
 else
-  bad "write failure did not surface a verdict: rc=$wf_rc verdict=$(verdict_of "$wf_out")
+  chmod 500 "$L18"
+fi
+wf_out=$(run "$L18" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 2>/dev/null); wf_rc=$?
+chmod 700 "$L18" 2>/dev/null || true
+if [ "$wf_rc" -ne 0 ] && [ "$(verdict_of "$wf_out")" = ERROR ] && all_lines_anchored "$wf_out"; then
+  ok "an I/O failure ($wf_probe) yields ERROR(rc=$wf_rc) on stdout, anchored — not a swallowed verdict"
+else
+  bad "write failure did not surface a verdict ($wf_probe): rc=$wf_rc verdict=$(verdict_of "$wf_out")
 $wf_out"
 fi
 
 # ===========================================================================
-case_begin 19-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
+case_begin 18-control-chars-stay-anchored "a hand-edited stamp value carrying control characters cannot break the output anchor"
+# ===========================================================================
+# Contract (b), and the load-bearing half of the anchor: a path (or any hand-edited field)
+# may contain a NEWLINE or an escape sequence, and printed verbatim it emits a line with no
+# DRIVE-STATE: prefix — which every consumer and every case above rests on.
+L17=$(lane lane17)
+run "$L17" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 >/dev/null 2>&1
+python3 - "$L17/$MARKER" <<'PYEOF'
+import sys
+p = sys.argv[1]
+s = open(p).read()
+s = s.replace('machine: boxA', 'machine: box\x1b[31mA\x07\x0b')
+open(p, 'w').write(s)
+PYEOF
+cc_out=$(run "$L17" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- verify 3822 2>&1); cc_rc=$?
+if [ "$cc_rc" -ne 0 ] && [ "$(verdict_of "$cc_out")" = FOREIGN-MACHINE ] && all_lines_anchored "$cc_out" \
+   && ! printf '%s' "$cc_out" | grep -q $'\x1b'; then
+  ok "control characters in a recorded value are masked for display; every line stays anchored"
+else
+  bad "control-character value broke the anchor: rc=$cc_rc
+$(printf '%s' "$cc_out" | cat -v)"
+fi
+
+# ===========================================================================
+case_begin 19-control-char-worktree-refused "a worktree path that cannot be recorded on one line is REFUSED, not recorded lossily"
+# ===========================================================================
+# The worktree axis is stored VERBATIM (a path must compare EXACTLY; sanitizing would alias
+# '/a b' onto '/a-b' and let two lanes verify each other's markers). The filesystem PERMITS
+# a NEWLINE in a directory name, and such a path cannot be recorded on one line at all — so
+# the writer refuses rather than recording an identity it would later mis-compare.
+nl_dir="$T/lane$(printf '20\nnewline')"
+if mkdir -p "$nl_dir" 2>/dev/null; then
+  nl_out=$(run "$nl_dir" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 2>&1); nl_rc=$?
+  if [ "$nl_rc" -ne 0 ] && [ "$(verdict_of "$nl_out")" = ERROR ] \
+     && all_lines_anchored "$nl_out" && [ ! -f "$nl_dir/$MARKER" ]; then
+    ok "a newline-bearing worktree path is refused (rc=$nl_rc) with an anchored ERROR and nothing written"
+  else
+    bad "newline-bearing worktree path was not refused: rc=$nl_rc
+$(printf '%s' "$nl_out" | cat -v)"
+  fi
+else
+  bad "could not create a newline-bearing directory, so the worktree-recordability refusal was NOT measured (this is a gap, not a pass)"
+fi
+
+# ===========================================================================
+case_begin 20-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
 # ===========================================================================
 REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
 5-foreign-worktree 6-session-gone-adoptable 7-session-live-peer 8-pid-unrecordable-unknown
 9-writer-refuses-sentinel-body 10-reader-refuses-duplicate-sentinel 11-machine-agrees-with-claim-sh
 12-placeholder-reason-refused 13-write-over-foreign-refuses 14-absent-is-distinct
-15-pid-reuse-recognised 16-closed-verdict-grammar 19-case-floor
-18-write-failure-emits-a-verdict"
-CASE_FLOOR=18
+15-pid-reuse-recognised 16-closed-verdict-grammar 17-write-failure-emits-a-verdict
+18-control-chars-stay-anchored 19-control-char-worktree-refused 20-case-floor"
+CASE_FLOOR=20
 executed=0
 for _c in $CASES; do executed=$((executed + 1)); done
 missing=""

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -60,9 +60,14 @@ verdict_of() {
   printf '%s\n' "$1" | sed -n 's/^DRIVE-STATE: verdict \([^ ]*\).*/\1/p' | head -1
 }
 
+# verdict_count <output> — how many `verdict ` lines the run emitted. Contract (c) says
+# EXACTLY ONE, so both zero (a consumer's `case` falls through every arm) and two (a consumer
+# reads whichever its parser picks first) are failures.
+verdict_count() { printf '%s\n' "$1" | grep -c '^DRIVE-STATE: verdict ' || true; }
+
 # The CLOSED verdict token set (the script's own grammar). An unrecognised token is
 # a refusal, so the test pins the set rather than accepting whatever is printed.
-VERDICT_SET="OWNED WRITTEN ADOPTED SHOWN ABSENT UNSTAMPED MALFORMED DUPLICATE-SENTINEL FOREIGN-ISSUE FOREIGN-MACHINE FOREIGN-WORKTREE ADOPTABLE LIVE-PEER LIVENESS-UNKNOWN ERROR"
+VERDICT_SET="OWNED WRITTEN ADOPTED SHOWN ABSENT UNSTAMPED MALFORMED DUPLICATE-SENTINEL FOREIGN-ISSUE FOREIGN-MACHINE FOREIGN-WORKTREE ADOPTABLE LIVE-PEER LIVENESS-UNKNOWN ERROR USAGE"
 verdict_in_set() {
   local v="$1" t
   [ -n "$v" ] || return 1
@@ -696,7 +701,7 @@ case_begin 22-no-dead-letter-remedies "DERIVED: no refusal may name a subcommand
 # LITERALLY. Such a remedy must describe the STATE CHANGE and let the normal path follow —
 # which is how MALFORMED/DUPLICATE-SENTINEL are worded. This case caught two such texts
 # the moment it was written, in the same round as the UNSTAMPED dead letter itself.
-DL_STATES="absent unstamped malformed displaced-sentinel duplicate-sentinel foreign-issue foreign-machine foreign-worktree adoptable live-peer liveness-unknown error"
+DL_STATES="absent unstamped malformed displaced-sentinel duplicate-sentinel foreign-issue foreign-machine foreign-worktree adoptable live-peer liveness-unknown error usage"
 expected_for() {
   case "$1" in
     absent)             printf 'ABSENT\n' ;;
@@ -711,13 +716,14 @@ expected_for() {
     live-peer)          printf 'LIVE-PEER\n' ;;
     liveness-unknown)   printf 'LIVENESS-UNKNOWN\n' ;;
     error)              printf 'ERROR\n' ;;
+    usage)              printf 'USAGE\n' ;;
     *)                  printf '\n' ;;
   esac
 }
 # setup_state <state> <dir> — build the state and set PROBE_* (+ SLEEPER when a live process
 # is part of the state).
 setup_state() {
-  PROBE_MACHINE=boxA; PROBE_SESSION="$SESS_A"; PROBE_PID=$$; SLEEPER=''
+  PROBE_MACHINE=boxA; PROBE_SESSION="$SESS_A"; PROBE_PID=$$; SLEEPER=''; PROBE_ARGS_BAD=0
   local st="$1" d="$2" other
   case "$st" in
     absent) : ;;
@@ -756,10 +762,19 @@ setup_state() {
       run "$d" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" -- write 3822 >/dev/null 2>&1
       PROBE_SESSION="$SESS_B" ;;
     error) mkdir -p "$d/$MARKER" ;;
+    # USAGE is an ARGUMENT-shaped refusal, not a marker state (roborev job 30 G2 added the
+    # token). It still belongs in this table: the completeness assert below requires EVERY
+    # non-success verdict to be reachable from a state here, so a token that joins the closed
+    # set without a state would silently escape the dead-letter rule.
+    usage) PROBE_ARGS_BAD=1 ;;
   esac
 }
 dl_probe() {  # dl_probe <dir> <subcommand-or-verify>
   local d="$1" sub="$2"
+  if [ "${PROBE_ARGS_BAD:-0}" = 1 ]; then
+    run "$d" "CLAIM_MACHINE=$PROBE_MACHINE" "CLAUDE_CODE_SESSION_ID=$PROBE_SESSION" "CLAUDE_PID=$PROBE_PID" -- "$sub" 3822 --actor 2>&1
+    return
+  fi
   case "$sub" in
     adopt) run "$d" "CLAIM_MACHINE=$PROBE_MACHINE" "CLAUDE_CODE_SESSION_ID=$PROBE_SESSION" "CLAUDE_PID=$PROBE_PID" -- adopt 3822 --reason no-dead-letter-probe:derived 2>&1 ;;
     write) run "$d" "CLAIM_MACHINE=$PROBE_MACHINE" "CLAUDE_CODE_SESSION_ID=$PROBE_SESSION" "CLAUDE_PID=$PROBE_PID" -- write 3822 2>&1 ;;
@@ -792,7 +807,7 @@ for st in $DL_STATES; do
   [ -z "$SLEEPER" ] || { kill "$SLEEPER" 2>/dev/null; wait "$SLEEPER" 2>/dev/null; }
 done
 if [ "$dl_fail" -eq 0 ]; then
-  ok "12 refusal states reproduce their expected verdict, and every remedy they NAME ($dl_named invocation(s)) escapes that refusal"
+  ok "13 refusal states reproduce their expected verdict, and every remedy they NAME ($dl_named invocation(s)) escapes that refusal"
 else
   bad "$dl_fail dead-letter/verdict failures across the refusal states"
 fi
@@ -1501,6 +1516,121 @@ else
 fi
 
 # ===========================================================================
+case_begin 33-signals-emit-one-verdict "a SIGNAL emits exactly ONE anchored verdict describing what is KNOWN about the commit"
+# ===========================================================================
+# roborev job 30 G2, and the SECOND instance of round 5's F1 class: that round made the
+# missing-liveness-library guard emit a verdict TOKEN, and left the three SIGNAL traps exiting
+# 130/143/129 with no token at all — the same guarantee stopping short of what a consumer
+# reads, one exit path over. Worse, the traps were phase-blind: a signal arriving AFTER the
+# atomic rename left the state CHANGED while the caller was told nothing at all.
+#
+# EVERY PROBE IS DETERMINISTIC, NOT TIMED. A PATH-shimmed external command signals the script
+# itself (`kill -TERM $PPID`, which inside a command substitution IS the script — measured), so
+# the signal lands at a KNOWN point in the sequence rather than after a sleep the scheduler may
+# reorder. The artifact is substituted; no seam is added to the shipped script.
+sig_shim() {  # sig_shim <cmd> <when: before|after> [<arg-substring-filter>]
+  local c="$1" when="$2" filt="${3:-}" d="$T/sigbin-$1-$2"
+  mkdir -p "$d"
+  { printf '#!/bin/sh\n'
+    if [ -n "$filt" ]; then
+      printf 'case "$*" in *%s*) : ;; *) exec %s "$@" ;; esac\n' "$filt" "$(command -v "$c")"
+      printf '[ ! -f "%s/fired" ] || exec %s "$@"\n' "$d" "$(command -v "$c")"
+      printf ': >"%s/fired"\n' "$d"
+    fi
+    if [ "$when" = before ]; then
+      printf 'kill -TERM "$PPID"\n'
+      printf 'exec %s "$@"\n' "$(command -v "$c")"
+    else
+      printf '%s "$@"; rc=$?\n' "$(command -v "$c")"
+      printf 'kill -TERM "$PPID"\n'
+      printf 'exit "$rc"\n'
+    fi; } >"$d/$c"
+  chmod +x "$d/$c"
+  printf '%s\n' "$d"
+}
+# sig_run <dir> <shimdir> <args...> — prints the combined output and RETURNS the run's exit
+# status. Deliberately not a global: this function is called inside `$( )`, so a global set
+# here would be set in the SUBSHELL and lost — the same shape the script's own case 17 pins.
+sig_run() {
+  local d="$1" sd="$2"; shift 2
+  local out rc
+  out=$( cd "$d" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+    "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" "PATH=$sd:$PATH" \
+    bash "$DS" "$@" 2>&1 ); rc=$?
+  printf '%s\n' "$out"
+  return "$rc"
+}
+# PHASE 1 — BEFORE the rename. `flock` is the last external command before any bytes are
+# assembled, so nothing has been committed: the honest verdict is ERROR and the lane must be
+# untouched. It is chosen over `mktemp` for the reason the DECLARED RESIDUAL below measures —
+# `flock` is a PLAIN command, so the trap actually runs.
+L33A=$(lane lane33-pre)
+s33a=$(sig_run "$L33A" "$(sig_shim flock before)" write 3822 --stage implement); r33a=$?
+if [ "$r33a" -eq 143 ] && [ "$(verdict_count "$s33a")" = 1 ] && [ "$(verdict_of "$s33a")" = ERROR ] \
+   && all_lines_anchored "$s33a" && [ ! -f "$L33A/$MARKER" ]; then
+  ok "SIGTERM BEFORE the atomic rename: exactly one anchored 'verdict ERROR', exit 143, and NOTHING written"
+else
+  bad "pre-rename signal: rc=$r33a verdicts=$(verdict_count "$s33a") token=$(verdict_of "$s33a") marker=$([ -f "$L33A/$MARKER" ] && echo present || echo absent)
+$s33a"
+fi
+# PHASE 2 — DURING the rename. The signal is DEFERRED across the single commit so the run can
+# report the outcome it actually achieved, instead of an 'undetermined'. Exactly one verdict,
+# and it is the TRUE one; the exit code is still the signal's.
+L33B=$(lane lane33-mid)
+s33b=$(sig_run "$L33B" "$(sig_shim mv after)" write 3822 --stage implement); r33b=$?
+if [ "$r33b" -eq 143 ] && [ "$(verdict_count "$s33b")" = 1 ] && [ "$(verdict_of "$s33b")" = WRITTEN ] \
+   && all_lines_anchored "$s33b" && [ -f "$L33B/$MARKER" ]; then
+  ok "SIGTERM DURING the atomic rename is DEFERRED across it: one anchored 'verdict WRITTEN', exit 143, and the marker IS on disk"
+else
+  bad "mid-rename signal: rc=$r33b verdicts=$(verdict_count "$s33b") token=$(verdict_of "$s33b") marker=$([ -f "$L33B/$MARKER" ] && echo present || echo absent)
+$s33b"
+fi
+# PHASE 3 — AFTER the rename, before the verdict. This is the window the finding names: the
+# state is CHANGED and the caller used to be told nothing. The `rm` of the carried body runs
+# there, and only on a write over an ALREADY-OWNED marker, so the lane is primed first.
+L33C=$(lane lane33-post)
+run "$L33C" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 --stage groom >/dev/null 2>&1
+s33c=$(sig_run "$L33C" "$(sig_shim rm before drive-issue-body)" write 3822 --stage implement); r33c=$?
+if [ "$r33c" -eq 143 ] && [ "$(verdict_count "$s33c")" = 1 ] && [ "$(verdict_of "$s33c")" = WRITTEN ] \
+   && all_lines_anchored "$s33c" && grep -q '^stage: implement$' "$L33C/$MARKER"; then
+  ok "SIGTERM AFTER the atomic rename reports the COMPLETED write: one anchored 'verdict WRITTEN', exit 143, and the new stage is on disk"
+else
+  bad "post-rename signal: rc=$r33c verdicts=$(verdict_count "$s33c") token=$(verdict_of "$s33c")
+$s33c
+$(cat "$L33C/$MARKER" 2>/dev/null)"
+fi
+# DECLARED RESIDUAL, MEASURED RATHER THAN REASONED ABOUT. On bash 5.2 a trapped signal that
+# arrives while the shell waits for a COMMAND SUBSTITUTION inside a FUNCTION is DISCARDED: the
+# trap never runs, and the only trace is that the substitution reports failure — so a TERM
+# during `mkout="$(mktemp ...)"` surfaces as a spurious "cannot create a temporary file". This
+# is a bash property, not something this script can fix from inside, and it is why the ONE
+# window that changes durable state (the rename) was moved OUT of a command substitution. What
+# is asserted here is that the CONTRACT still holds on that path: exactly one anchored verdict,
+# and nothing written.
+L33D=$(lane lane33-substitution)
+s33d=$(sig_run "$L33D" "$(sig_shim mktemp before)" write 3822); r33d=$?
+if [ "$(verdict_count "$s33d")" = 1 ] && [ "$(verdict_of "$s33d")" = ERROR ] \
+   && all_lines_anchored "$s33d" && [ ! -f "$L33D/$MARKER" ]; then
+  ok "DECLARED RESIDUAL: a signal during a command substitution is swallowed by bash (rc=$r33d, not 143) — the contract still holds: one anchored ERROR, nothing written"
+else
+  bad "the swallowed-signal path broke the contract: rc=$r33d verdicts=$(verdict_count "$s33d") token=$(verdict_of "$s33d")
+$s33d"
+fi
+# NON-VACUITY: the same shim WITHOUT the kill lets the write complete normally, so the three
+# results above are about the signal and not about a shim that breaks the command.
+L33N=$(lane lane33-nv)
+nv33="$T/sigbin-nokill"; mkdir -p "$nv33"
+{ printf '#!/bin/sh\n'; printf 'exec %s "$@"\n' "$(command -v mktemp)"; } >"$nv33/mktemp"
+chmod +x "$nv33/mktemp"
+s33n=$(sig_run "$L33N" "$nv33" write 3822); r33n=$?
+if [ "$r33n" -eq 0 ] && [ "$(verdict_of "$s33n")" = WRITTEN ] && [ "$(verdict_count "$s33n")" = 1 ]; then
+  ok "NON-VACUITY: the same PATH shim without the kill writes normally (rc 0, one WRITTEN verdict)"
+else
+  bad "the signal fixture is broken independently of the signal: rc=$r33n token=$(verdict_of "$s33n")
+$s33n"
+fi
+
+# ===========================================================================
 case_begin 28-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
 # ===========================================================================
 REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
@@ -1514,7 +1644,7 @@ REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-iss
 25-displaced-sentinel-is-not-legacy 26-unusable-start-window 27-pre-rename-validation
 29-missing-liveness-library 30-native-diagnostics-stay-anchored
 31-adoption-provenance-survives
-32-failed-scan-is-not-no-match
+32-failed-scan-is-not-no-match 33-signals-emit-one-verdict
 28-case-floor"
 CASE_FLOOR=31
 executed=0

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -2300,9 +2300,49 @@ wt_gone_run() {  # wt_gone_run <subcommand...> — run with a DELETED working di
   ( cd "$g" && rmdir "$g" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
       "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" bash "$DS" "$@" 2>&1 )
 }
+# THE MATRIX IS DERIVED FROM THE SCRIPT'S OWN DISPATCH TABLE, NEVER CURATED (roborev job 43
+# K2). This loop used to read `for sub in write verify show` — `adopt` was simply absent, which
+# is how `adopt` came to call `lock_marker` BEFORE `require_worktree_axis` (deriving a lock path
+# at the filesystem root and refusing with a generic "not writable" instead of the axis form the
+# consumer contract in .claude/commands/drive-issue.md publishes) with a green suite. The names
+# now come from the `case "$SUB"` arms, so a NEW subcommand joins this matrix with no test edit —
+# and if its extra arguments are not declared in wt_extra_args it REDS rather than not being
+# covered. A FAILED derivation is a FAIL, never a fallback to an empty set: an empty loop is a
+# vacuous green, which is this file's standing rule (a positive verdict needs an affirmative
+# measurement).
+WT_SUBS=$(LC_ALL=C sed -n 's/^  \([a-z][a-z-]*\)) *shift; cmd_.*/\1/p' "$DS" | tr '\n' ' ')
+wt_nsubs=0
+for _s in $WT_SUBS; do wt_nsubs=$((wt_nsubs + 1)); done
+wt_missing=''
+for _req in write verify adopt show; do
+  case " $WT_SUBS " in *" $_req "*) : ;; *) wt_missing="$wt_missing $_req" ;; esac
+done
+if [ "$wt_nsubs" -ge 4 ] && [ -z "$wt_missing" ]; then
+  ok "DERIVED: the axis matrix took its $wt_nsubs subcommands from the script's own dispatch table ($WT_SUBS)"
+else
+  bad "the subcommand derivation FAILED (n=$wt_nsubs missing:$wt_missing set='$WT_SUBS') — the matrix below would run vacuously"
+fi
+
+# wt_extra_args <sub> — the arguments a subcommand needs to REACH its axis guard, or return 1
+# for a subcommand nobody has declared. Declared per subcommand, so a new one cannot join the
+# matrix silently: the loop below FAILs on a `return 1`.
+wt_extra_args() {
+  case "$1" in
+    write | verify | show) printf '%s\n' '' ;;
+    adopt) printf '%s\n' '--reason cron-reinvoke:writer-pid-gone' ;;
+    *) return 1 ;;
+  esac
+}
+
 wt_fail=0
-for sub in write verify show; do
-  g_out=$(wt_gone_run "$sub" 3822); g_rc=$?
+for sub in $WT_SUBS; do
+  if ! wt_xargs=$(wt_extra_args "$sub"); then
+    wt_fail=1
+    bad "subcommand '$sub' exists in the dispatch table but declares no arguments in wt_extra_args — it is NOT covered by the unmeasurable-worktree matrix"
+    continue
+  fi
+  # shellcheck disable=SC2086 -- deliberate word splitting: the extra args are a token list
+  g_out=$(wt_gone_run "$sub" 3822 $wt_xargs); g_rc=$?
   if [ "$g_rc" -ne 0 ] && [ "$(verdict_of "$g_out")" = ERROR ] \
      && printf '%s\n' "$g_out" | grep -q 'axis=worktree' \
      && [ "$(verdict_count "$g_out")" = 1 ]; then
@@ -2337,11 +2377,28 @@ L40=$(lane lane40)
 run "$L40" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 >/dev/null 2>&1
 n40_v=$(run "$L40" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- verify 3822); n40_vrc=$?
 n40_s=$(run "$L40" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- show 3822); n40_src=$?
+# `adopt` in a LIVE lane it already owns is the re-entrant no-op (ADOPTED, nothing transferred) —
+# which is exactly what proves the adopt row above refused for the AXIS and not because adopt
+# refuses everywhere.
+n40_a=$(run "$L40" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- adopt 3822 --reason cron-reinvoke:writer-pid-gone); n40_arc=$?
 if [ "$wt_fail" -eq 0 ] && [ "$n40_vrc" -eq 0 ] && [ "$(verdict_of "$n40_v")" = OWNED ] \
-   && [ "$n40_src" -eq 0 ] && [ "$(verdict_of "$n40_s")" = SHOWN ]; then
-  ok "NON-VACUITY: verify and show still work normally in a live worktree — the refusals are about the unmeasurable axis"
+   && [ "$n40_src" -eq 0 ] && [ "$(verdict_of "$n40_s")" = SHOWN ] \
+   && [ "$n40_arc" -eq 0 ] && [ "$(verdict_of "$n40_a")" = ADOPTED ]; then
+  ok "NON-VACUITY: verify, show and adopt still work normally in a live worktree — the refusals are about the unmeasurable axis"
 else
-  bad "the live-worktree control regressed: v_rc=$n40_vrc v=$(verdict_of "$n40_v") s_rc=$n40_src s=$(verdict_of "$n40_s")"
+  bad "the live-worktree control regressed: v_rc=$n40_vrc v=$(verdict_of "$n40_v") s_rc=$n40_src s=$(verdict_of "$n40_s") a_rc=$n40_arc a=$(verdict_of "$n40_a")"
+fi
+# THE ORDERING IS ALSO PINNED STRUCTURALLY, because the behavioural row above can only see the
+# CURRENT arrangement: in `cmd_adopt` the worktree-axis guard must appear BEFORE `lock_marker`
+# (which derives its path from that axis). A reordering that reintroduces K2 reds here even if a
+# future refactor changes the refusal text.
+adopt_body=$(LC_ALL=C sed -n '/^cmd_adopt() {/,/^}/p' "$DS")
+a_axis_ln=$(printf '%s\n' "$adopt_body" | grep -n '^  require_worktree_axis$' | head -1 | cut -d: -f1)
+a_lock_ln=$(printf '%s\n' "$adopt_body" | grep -n '^  lock_marker$' | head -1 | cut -d: -f1)
+if [ -n "$a_axis_ln" ] && [ -n "$a_lock_ln" ] && [ "$a_axis_ln" -lt "$a_lock_ln" ]; then
+  ok "STRUCTURAL: cmd_adopt calls require_worktree_axis (line $a_axis_ln of the function) BEFORE lock_marker (line $a_lock_ln)"
+else
+  bad "cmd_adopt's axis guard does not precede its lock: axis='$a_axis_ln' lock='$a_lock_ln' (an absent line means the pin lost its subject)"
 fi
 
 # ===========================================================================
@@ -2880,6 +2937,98 @@ else
 fi
 
 # ===========================================================================
+case_begin 46-symlink-marker-is-never-clobbered "roborev job 43 K1: a SYMLINK at the marker path — DANGLING or not — is refused as not-regular and is NEVER replaced"
+# ===========================================================================
+# THE DEFECT: `marker_class` detected absence with `[ -e "$path" ]`, and `-e` FOLLOWS the link,
+# so it is FALSE for a DANGLING symlink — an entry that plainly EXISTS. That classified as
+# `absent`, the ONE class whose handler in `write` REPLACES the path without a word, so `mv`
+# destroyed the link. A symlink is a deliberate artifact someone placed; in a file whose whole
+# job is refusing to clobber what it does not own, silently replacing one is the wrong default.
+#
+# VERIFICATION DISCIPLINE: every assertion below uses `-L` and `readlink`, never `-f` or `cat` —
+# both of those FOLLOW the link and would normalize away the very property under test.
+L46=$(lane lane46)
+K46_DANGLING="$T/no-such-target-46"
+ln -s "$K46_DANGLING" "$L46/$MARKER"
+[ ! -e "$K46_DANGLING" ] || bad "fixture: the dangling target $K46_DANGLING unexpectedly exists"
+d46_w=$(run "$L46" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 --stage implement 2>&1); d46_wrc=$?
+d46_link_after=$(readlink "$L46/$MARKER" 2>/dev/null || true)
+if [ "$d46_wrc" -ne 0 ] && [ "$(verdict_of "$d46_w")" = ERROR ] \
+   && [ "$(verdict_count "$d46_w")" = 1 ] \
+   && printf '%s\n' "$d46_w" | grep -q 'not a readable regular file'; then
+  ok "write over a DANGLING symlink: exactly ONE verdict, ERROR, naming the not-regular refusal (it used to classify absent and replace it)"
+else
+  bad "write over a dangling symlink did not refuse: rc=$d46_wrc verdict=$(verdict_of "$d46_w") count=$(verdict_count "$d46_w")
+$d46_w"
+fi
+if [ -L "$L46/$MARKER" ] && [ "$d46_link_after" = "$K46_DANGLING" ] && [ ! -e "$K46_DANGLING" ]; then
+  ok "the SYMLINK ITSELF survives, still pointing at the same target, and nothing was created at that target (asserted with -L/readlink, never -f/cat)"
+else
+  bad "the symlink was clobbered: is-link=$([ -L "$L46/$MARKER" ] && echo yes || echo no) readlink='$d46_link_after' expected='$K46_DANGLING' target-exists=$([ -e "$K46_DANGLING" ] && echo yes || echo no)"
+fi
+# A DANGLING SYMLINK IS NOT A FRESH START. The readers used to answer ABSENT (exit 3) — the
+# verdict that means "resume nothing, this lane is clean" — for an entry that exists.
+d46_v=$(run "$L46" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- verify 3822 2>&1); d46_vrc=$?
+d46_s=$(run "$L46" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- show 3822 2>&1); d46_src=$?
+if [ "$d46_vrc" -ne 0 ] && [ "$(verdict_of "$d46_v")" = ERROR ] \
+   && [ "$d46_src" -ne 0 ] && [ "$(verdict_of "$d46_s")" = ERROR ]; then
+  ok "verify and show over a dangling symlink report ERROR, never ABSENT — an entry that exists is not a clean lane"
+else
+  bad "a dangling symlink still reads as absent: v_rc=$d46_vrc v=$(verdict_of "$d46_v") s_rc=$d46_src s=$(verdict_of "$d46_s")
+$d46_v
+$d46_s"
+fi
+# THE NON-DANGLING SHAPE, which `-e` DID see but `-f` FOLLOWED: it must take the SAME refusal,
+# and the TARGET's bytes must be untouched. That is why the `-L` test precedes `-f`.
+L46b=$(lane lane46b)
+K46_TARGET="$T/real-target-46.md"
+printf 'peer plan, do not touch\n' >"$K46_TARGET"
+ln -s "$K46_TARGET" "$L46b/$MARKER"
+b46_w=$(run "$L46b" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 2>&1); b46_wrc=$?
+b46_link_after=$(readlink "$L46b/$MARKER" 2>/dev/null || true)
+b46_bytes=$(cat "$K46_TARGET" 2>/dev/null || true)
+if [ "$b46_wrc" -ne 0 ] && [ "$(verdict_of "$b46_w")" = ERROR ] \
+   && printf '%s\n' "$b46_w" | grep -q 'not a readable regular file' \
+   && [ -L "$L46b/$MARKER" ] && [ "$b46_link_after" = "$K46_TARGET" ] \
+   && [ "$b46_bytes" = 'peer plan, do not touch' ]; then
+  ok "write over a symlink to a REAL file takes the same not-regular refusal; the link and the target's bytes are both untouched"
+else
+  bad "a non-dangling symlink was not refused, or was followed: rc=$b46_wrc verdict=$(verdict_of "$b46_w") readlink='$b46_link_after' target-bytes='$b46_bytes'
+$b46_w"
+fi
+if all_lines_anchored "$d46_w" && all_lines_anchored "$d46_v" && all_lines_anchored "$d46_s" && all_lines_anchored "$b46_w"; then
+  ok "every line of all four symlink refusals carries the anchored DRIVE-STATE: prefix"
+else
+  bad "a symlink refusal leaked an unprefixed line"
+fi
+# POSITIVE CONTROL, by ARTIFACT SUBSTITUTION: with the `-L` existence handling reverted in a
+# scratch copy, the same write DESTROYS the dangling symlink — so the assertions above measure
+# the fix and not the fixture. (A test-only seam is never used for this; the artifact is
+# substituted, per this file's own idiom.)
+mkdir -p "$T/k1-scratch/lib"
+cp "$SCRIPT_DIR/../flow/lib/process-liveness.sh" "$T/k1-scratch/lib/"
+k1_pre="$T/k1-scratch/drive-issue-state.sh"
+LC_ALL=C awk -v q="'" '
+  index($0, "&& [ ! -L \"$path\" ]; then printf") { print "  [ -e \"$path\" ] || { printf " q "absent\\n" q "; return 0; }"; next }
+  index($0, "[ ! -L \"$path\" ] || { printf " q "not-regular") { next }
+  { print }
+' "$DS" >"$k1_pre"
+k1_pin=0
+grep -q '^  \[ -e "\$path" \] || { printf .absent' "$k1_pre" || k1_pin=$((k1_pin + 1))
+[ "$(grep -c '! -L "\$path"' "$k1_pre" || true)" = 0 ] || k1_pin=$((k1_pin + 1))
+bash -n "$k1_pre" 2>/dev/null || k1_pin=$((k1_pin + 1))
+L46p=$(lane lane46p)
+K46P_TARGET="$T/no-such-target-46p"
+ln -s "$K46P_TARGET" "$L46p/$MARKER"
+( cd "$L46p" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+    "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" bash "$k1_pre" write 3822 ) >/dev/null 2>&1
+if [ "$k1_pin" -eq 0 ] && [ ! -L "$L46p/$MARKER" ] && [ -f "$L46p/$MARKER" ]; then
+  ok "POSITIVE CONTROL: with the -L handling reverted, the same write REPLACES the dangling symlink with a regular file — the silent clobber is real"
+else
+  bad "the positive control did not reproduce the clobber: pin-failures=$k1_pin still-a-link=$([ -L "$L46p/$MARKER" ] && echo yes || echo no) regular-file=$([ -f "$L46p/$MARKER" ] && echo yes || echo no)"
+fi
+
+# ===========================================================================
 case_begin 28-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
 # ===========================================================================
 REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
@@ -2902,8 +3051,8 @@ REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-iss
 40-worktree-axis-must-be-measurable 41-body-without-trailing-newline
 42-verdict-emission-is-a-critical-section
 43-identity-recorded-losslessly 44-body-file-is-read-not-stat-gated
-45-unknown-prologue-keys-survive 28-case-floor"
-CASE_FLOOR=45
+45-unknown-prologue-keys-survive 46-symlink-marker-is-never-clobbered 28-case-floor"
+CASE_FLOOR=46
 executed=0
 for _c in $CASES; do executed=$((executed + 1)); done
 missing=""
@@ -2915,10 +3064,10 @@ if [ "$executed" -ge "$CASE_FLOOR" ] && [ -z "$missing" ]; then
 else
   bad "case floor breached: executed=$executed floor=$CASE_FLOOR missing:$missing"
 fi
-if [ "$PASS" -ge 160 ]; then
-  ok "assertion floor: $PASS assertions passed (>= 160)"
+if [ "$PASS" -ge 170 ]; then
+  ok "assertion floor: $PASS assertions passed (>= 170)"
 else
-  bad "assertion floor breached: only $PASS assertions passed (floor 160)"
+  bad "assertion floor breached: only $PASS assertions passed (floor 170)"
 fi
 
 # ===========================================================================

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -484,14 +484,34 @@ else
 fi
 
 # ===========================================================================
-case_begin 17-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
+case_begin 18-write-failure-emits-a-verdict "an I/O failure emits ERROR on STDOUT — the verdict is never captured into a variable"
+# ===========================================================================
+# Regression pin for a real defect in the first cut: the writer printed its path on
+# stdout and was called inside `$( )`, so a `refuse` inside it exited only the SUBSHELL
+# and its verdict line was CAPTURED into the caller's variable — the run would emit no
+# verdict at all and put a verdict string inside a path. Every emit site must be in the
+# main shell, which this case measures rather than asserts.
+L18=$(lane lane18)
+chmod 500 "$L18"
+wf_out=$(run "$L18" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 2>/dev/null); wf_rc=$?
+chmod 700 "$L18"
+if [ "$wf_rc" -ne 0 ] && [ "$(verdict_of "$wf_out")" = ERROR ] && all_lines_anchored "$wf_out"; then
+  ok "an unwritable worktree yields ERROR(rc=$wf_rc) on stdout, anchored — not a swallowed verdict"
+else
+  bad "write failure did not surface a verdict: rc=$wf_rc verdict=$(verdict_of "$wf_out")
+$wf_out"
+fi
+
+# ===========================================================================
+case_begin 19-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
 # ===========================================================================
 REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
 5-foreign-worktree 6-session-gone-adoptable 7-session-live-peer 8-pid-unrecordable-unknown
 9-writer-refuses-sentinel-body 10-reader-refuses-duplicate-sentinel 11-machine-agrees-with-claim-sh
 12-placeholder-reason-refused 13-write-over-foreign-refuses 14-absent-is-distinct
-15-pid-reuse-recognised 16-closed-verdict-grammar 17-case-floor"
-CASE_FLOOR=17
+15-pid-reuse-recognised 16-closed-verdict-grammar 19-case-floor
+18-write-failure-emits-a-verdict"
+CASE_FLOOR=18
 executed=0
 for _c in $CASES; do executed=$((executed + 1)); done
 missing=""
@@ -503,8 +523,8 @@ if [ "$executed" -ge "$CASE_FLOOR" ] && [ -z "$missing" ]; then
 else
   bad "case floor breached: executed=$executed floor=$CASE_FLOOR missing:$missing"
 fi
-if [ "$PASS" -ge 25 ]; then
-  ok "assertion floor: $PASS assertions passed (>= 25)"
+if [ "$PASS" -ge 30 ]; then
+  ok "assertion floor: $PASS assertions passed (>= 30)"
 else
   bad "assertion floor breached: only $PASS assertions passed"
 fi

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -696,12 +696,13 @@ case_begin 22-no-dead-letter-remedies "DERIVED: no refusal may name a subcommand
 # LITERALLY. Such a remedy must describe the STATE CHANGE and let the normal path follow —
 # which is how MALFORMED/DUPLICATE-SENTINEL are worded. This case caught two such texts
 # the moment it was written, in the same round as the UNSTAMPED dead letter itself.
-DL_STATES="absent unstamped malformed duplicate-sentinel foreign-issue foreign-machine foreign-worktree adoptable live-peer liveness-unknown error"
+DL_STATES="absent unstamped malformed displaced-sentinel duplicate-sentinel foreign-issue foreign-machine foreign-worktree adoptable live-peer liveness-unknown error"
 expected_for() {
   case "$1" in
     absent)             printf 'ABSENT\n' ;;
     unstamped)          printf 'UNSTAMPED\n' ;;
     malformed)          printf 'MALFORMED\n' ;;
+    displaced-sentinel) printf 'MALFORMED\n' ;;
     duplicate-sentinel) printf 'DUPLICATE-SENTINEL\n' ;;
     foreign-issue)      printf 'FOREIGN-ISSUE\n' ;;
     foreign-machine)    printf 'FOREIGN-MACHINE\n' ;;
@@ -724,6 +725,12 @@ setup_state() {
     malformed)
       run "$d" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 >/dev/null 2>&1
       grep -vFx -- "$sentinel_end" "$d/$MARKER" >"$T/dl-mal" && mv "$T/dl-mal" "$d/$MARKER" ;;
+    displaced-sentinel)
+      # The NEW refusal shape from B1: a valid stamp displaced off line 1. It must be covered
+      # by the dead-letter rule like every other refusal, not left to the states that existed
+      # when the case was written.
+      run "$d" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 >/dev/null 2>&1
+      { printf '\n'; cat "$d/$MARKER"; } >"$T/dl-disp" && mv "$T/dl-disp" "$d/$MARKER" ;;
     duplicate-sentinel)
       run "$d" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 >/dev/null 2>&1
       { printf '%s\n' "$sentinel"; printf 'issue: 3822\n'; } >>"$d/$MARKER" ;;
@@ -785,7 +792,7 @@ for st in $DL_STATES; do
   [ -z "$SLEEPER" ] || { kill "$SLEEPER" 2>/dev/null; wait "$SLEEPER" 2>/dev/null; }
 done
 if [ "$dl_fail" -eq 0 ]; then
-  ok "11 refusal states reproduce their expected verdict, and every remedy they NAME ($dl_named invocation(s)) escapes that refusal"
+  ok "12 refusal states reproduce their expected verdict, and every remedy they NAME ($dl_named invocation(s)) escapes that refusal"
 else
   bad "$dl_fail dead-letter/verdict failures across the refusal states"
 fi
@@ -954,7 +961,153 @@ $sc_show"
 fi
 
 # ===========================================================================
-case_begin 25-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
+case_begin 25-displaced-sentinel-is-not-legacy "a DISPLACED stamp is MALFORMED, never migrated — a one-byte mutation must not overwrite a live peer"
+# ===========================================================================
+# The migration path decided "carries no ownership stamp" from the FIRST LINE ALONE, so a
+# stamped marker with one prepended blank line or comment was classified legacy, DISCARDED
+# and REPLACED — overwriting a live peer's state, which is the defect this whole file exists
+# to close, reachable by a one-byte mutation. "No stamp at line 1 => no identity asserted" is
+# valid only if no sentinel exists ANYWHERE.
+disp_fail=0
+for disp_kind in blank comment; do
+  Ld=$(lane "lane25-$disp_kind")
+  dsleep=''
+  sleep 300 & dsleep=$!
+  run "$Ld" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$dsleep" -- \
+    write 3822 --stage peer-plan --request-id coord-3822-live >/dev/null 2>&1
+  case "$disp_kind" in
+    blank)   { printf '\n';                    cat "$Ld/$MARKER"; } >"$T/d25" ;;
+    comment) { printf '%s\n' '<!-- note -->';  cat "$Ld/$MARKER"; } >"$T/d25" ;;
+  esac
+  mv "$T/d25" "$Ld/$MARKER"
+  before=$(cksum <"$Ld/$MARKER")
+  dv=$(run "$Ld" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- verify 3822); dvrc=$?
+  dw=$(run "$Ld" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- write 3822 --stage my-plan); dwrc=$?
+  da=$(run "$Ld" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- adopt 3822 --reason displaced-probe:take-over); darc=$?
+  after=$(cksum <"$Ld/$MARKER")
+  kill "$dsleep" 2>/dev/null; wait "$dsleep" 2>/dev/null
+  if [ "$dvrc" -ne 0 ] && [ "$(verdict_of "$dv")" = MALFORMED ] \
+     && [ "$dwrc" -ne 0 ] && [ "$(verdict_of "$dw")" = MALFORMED ] \
+     && [ "$darc" -ne 0 ] && [ "$(verdict_of "$da")" = MALFORMED ] \
+     && [ "$before" = "$after" ]; then
+    ok "a stamp displaced by a prepended $disp_kind is MALFORMED on verify AND write AND adopt, and the peer's file is byte-identical afterwards"
+  else
+    disp_fail=$((disp_fail + 1))
+    bad "displaced-by-$disp_kind was mishandled: verify=$dvrc/$(verdict_of "$dv") write=$dwrc/$(verdict_of "$dw") adopt=$darc/$(verdict_of "$da") file-changed=$([ "$before" = "$after" ] && echo no || echo YES)
+$dw"
+  fi
+done
+# NON-VACUITY: a file with NO sentinel anywhere is still the migratable legacy shape, so the
+# fix narrowed the migration path rather than closing it.
+L25N=$(lane lane25n)
+printf 'legacy plan, no sentinel anywhere\n' >"$L25N/$MARKER"
+nv=$(run "$L25N" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822); nvrc=$?
+if [ "$nvrc" -eq 0 ] && [ "$(verdict_of "$nv")" = WRITTEN ]; then
+  ok "NON-VACUITY: a genuinely sentinel-free legacy marker still migrates (WRITTEN) — the migration path was narrowed, not closed"
+else
+  bad "the legacy migration path was closed by the displaced-sentinel fix: rc=$nvrc verdict=$(verdict_of "$nv")
+$nv"
+fi
+
+# ===========================================================================
+case_begin 26-unusable-start-window "an INVERTED or out-of-range start window is LIVENESS-UNKNOWN, never GONE"
+# ===========================================================================
+# The worst of the three: a false-permissive on the LIVENESS axis. Endpoints were only
+# digit-checked (and CONCATENATED, so one could hide behind the other), and an inverted or
+# out-of-range interval made `[` ERROR inside `if A && B` — an errored `[` reads as FALSE,
+# and the false branch was `gone`, so a LIVE PEER became adoptable. Unmeasurable must never
+# read as gone.
+uw_fail=0
+for uw_kind in inverted huge negative leading-zero; do
+  Lu=$(lane "lane26-$uw_kind")
+  sleep 300 & upid=$!
+  run "$Lu" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$upid" -- write 3822 >/dev/null 2>&1
+  case "$uw_kind" in
+    inverted)     ulo=2000000000; uhi=1000000000 ;;
+    huge)         ulo=999999999999999999999999;  uhi=999999999999999999999999 ;;
+    negative)     ulo=-5;         uhi=10 ;;
+    leading-zero) ulo=0000000001; uhi=0000000002 ;;
+  esac
+  sed -e "s/^session-pid-start-earliest: .*/session-pid-start-earliest: $ulo/" \
+      -e "s/^session-pid-start-latest: .*/session-pid-start-latest: $uhi/" \
+      "$Lu/$MARKER" >"$T/m26" && mv "$T/m26" "$Lu/$MARKER"
+  uv=$(run "$Lu" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- verify 3822 2>&1); uvrc=$?
+  ua=$(run "$Lu" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- adopt 3822 --reason unusable-window-probe 2>&1); uarc=$?
+  kill "$upid" 2>/dev/null; wait "$upid" 2>/dev/null
+  uvv="$(verdict_of "$uv")"
+  # LIVENESS-UNKNOWN (the MEASUREMENT is unusable) — and specifically NOT ADOPTABLE, which
+  # is the false-permissive, and NOT MALFORMED, since the marker itself is well-formed.
+  if [ "$uvrc" -ne 0 ] && [ "$uvv" = LIVENESS-UNKNOWN ] \
+     && [ "$uarc" -ne 0 ] && [ "$(verdict_of "$ua")" = LIVENESS-UNKNOWN ]; then
+    ok "a $uw_kind start window yields LIVENESS-UNKNOWN on verify AND adopt — the live peer is not adoptable"
+  else
+    uw_fail=$((uw_fail + 1))
+    bad "a $uw_kind start window was mis-resolved: verify=$uvrc/$uvv adopt=$uarc/$(verdict_of "$ua") (ADOPTABLE here would mean a LIVE peer could be taken over)
+$uv"
+  fi
+done
+if [ "$uw_fail" -eq 0 ]; then
+  ok "all 4 unusable-interval shapes refuse on the UNKNOWN branch"
+else
+  bad "$uw_fail unusable-interval shapes were not refused as UNKNOWN"
+fi
+
+# ===========================================================================
+case_begin 27-pre-rename-validation "the ASSEMBLED bytes are validated immediately before the atomic rename"
+# ===========================================================================
+# `--body-file` was validated once and READ AGAIN at assembly, so a body changing in between
+# committed an unchecked sentinel — reachable by accident (an agent rewriting its own notes),
+# which makes it a defect, and the result is a marker every later read refuses: self-bricking.
+# The fix validates the committed bytes themselves, so it holds however the body arrived.
+#
+# THE RACE ITSELF IS NOT DETERMINISTICALLY REPRODUCIBLE, so this case measures the LAYER that
+# closes it: a scratch copy with the EARLY body check neutered must still refuse at the
+# pre-rename check. That proves the two layers are independent (defence in depth) rather than
+# one check moved. It does NOT prove a timed interleaving is caught — nothing cheap can.
+SCRATCH2="$T/scratch2"; mkdir -p "$SCRATCH2/lib"
+sed 's/^assert_body_safe() {$/assert_body_safe() { return 0; # NEUTERED for this case/' \
+  "$DS" >"$SCRATCH2/drive-issue-state.sh"
+cp "$SCRIPT_DIR/../flow/lib/process-liveness.sh" "$SCRATCH2/lib/process-liveness.sh"
+if grep -q 'NEUTERED for this case' "$SCRATCH2/drive-issue-state.sh"; then
+  ok "the early-body-check neutering took in the scratch copy (so the pre-rename layer is what is being measured)"
+else
+  bad "could not neuter the early body check — this case would measure the early check, not the pre-rename one"
+fi
+L27=$(lane lane27)
+body27="$T/body27.md"
+{ printf 'notes\n'; printf '%s\n' "$sentinel"; printf 'issue: 1\n'; } >"$body27"
+pr_out=$( cd "$L27" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+  "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" \
+  bash "$SCRATCH2/drive-issue-state.sh" write 3822 --body-file "$body27" 2>&1 ); pr_rc=$?
+# The `.lock` sidecar is a LEGITIMATE artifact of serialization, so the stray count must
+# exclude it — counting it made this assert fail on correct behaviour, which is the
+# "guard that reds on correct input" shape. What must be absent is an abandoned
+# atomic-replace TEMPORARY.
+stray27=$(find "$L27" -name "$MARKER.*" ! -name "$MARKER.lock" 2>/dev/null | wc -l | tr -d ' ')
+lock27=$([ -f "$L27/$MARKER.lock" ] && echo yes || echo no)
+if [ "$pr_rc" -ne 0 ] && [ "$(verdict_of "$pr_out")" = ERROR ] \
+   && [ ! -f "$L27/$MARKER" ] && [ "$stray27" = 0 ] && [ "$lock27" = yes ] \
+   && all_lines_anchored "$pr_out"; then
+  ok "with the early check bypassed, the pre-rename validation refuses (ERROR), commits nothing and leaves no abandoned temporary (the .lock sidecar is expected and present)"
+else
+  bad "the assembled marker was committed unvalidated: rc=$pr_rc verdict=$(verdict_of "$pr_out") marker=$([ -f "$L27/$MARKER" ] && echo yes || echo no) strays=$stray27
+$pr_out"
+fi
+# NON-VACUITY: the same neutered script writes a CLEAN body fine, so the refusal above is
+# about the sentinel and not about the neutering having broken the script.
+body27ok="$T/body27ok.md"; printf 'clean notes\n' >"$body27ok"
+pr_ok=$( cd "$L27" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+  "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" \
+  bash "$SCRATCH2/drive-issue-state.sh" write 3822 --body-file "$body27ok" 2>&1 ); pr_okrc=$?
+if [ "$pr_okrc" -eq 0 ] && [ "$(verdict_of "$pr_ok")" = WRITTEN ]; then
+  ok "NON-VACUITY: the same scratch script writes a clean body successfully"
+else
+  bad "the scratch script cannot write at all, so the refusal above proves nothing: rc=$pr_okrc
+$pr_ok"
+fi
+
+# ===========================================================================
+case_begin 28-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
 # ===========================================================================
 REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
 5-foreign-worktree 6-session-gone-adoptable 7-session-live-peer 8-pid-unrecordable-unknown
@@ -963,8 +1116,10 @@ REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-iss
 15-pid-reuse-recognised 16-closed-verdict-grammar 17-write-failure-emits-a-verdict
 18-control-chars-stay-anchored 19-control-char-worktree-refused
 20-same-process-is-owned 21-write-over-unstamped-migrates
-22-no-dead-letter-remedies 23-durable-fields-survive 24-serialization 25-case-floor"
-CASE_FLOOR=25
+22-no-dead-letter-remedies 23-durable-fields-survive 24-serialization
+25-displaced-sentinel-is-not-legacy 26-unusable-start-window 27-pre-rename-validation
+28-case-floor"
+CASE_FLOOR=28
 executed=0
 for _c in $CASES; do executed=$((executed + 1)); done
 missing=""
@@ -976,8 +1131,8 @@ if [ "$executed" -ge "$CASE_FLOOR" ] && [ -z "$missing" ]; then
 else
   bad "case floor breached: executed=$executed floor=$CASE_FLOOR missing:$missing"
 fi
-if [ "$PASS" -ge 55 ]; then
-  ok "assertion floor: $PASS assertions passed (>= 55)"
+if [ "$PASS" -ge 68 ]; then
+  ok "assertion floor: $PASS assertions passed (>= 68)"
 else
   bad "assertion floor breached: only $PASS assertions passed"
 fi

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -288,6 +288,7 @@ case_begin 9-writer-refuses-sentinel-body "the writer REFUSES a body carrying a 
 L9=$(lane lane9)
 body="$T/body9.md"
 sentinel=$(sed -n 's/^STAMP_BEGIN=.\(.*\).$/\1/p' "$DS" | head -1)
+sentinel_end=$(sed -n 's/^STAMP_END=.\(.*\).$/\1/p' "$DS" | head -1)
 {
   printf 'plan notes\n'
   printf '%s\n' "$sentinel"
@@ -593,7 +594,186 @@ $sp_p"
 fi
 
 # ===========================================================================
-case_begin 21-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
+case_begin 21-write-over-unstamped-migrates "MIGRATION: write SUCCEEDS over an UNSTAMPED marker, discards its body, and announces it"
+# ===========================================================================
+# The dead letter this case exists for: `verify` refused an UNSTAMPED marker (correctly)
+# and so did `write` and `adopt`, while the refusal text named `write` as the remedy — so on
+# rollout EVERY existing lane, all of which hold an unstamped marker by definition, had NO
+# route forward. An unstamped marker asserts no ownership, so refusing to replace it
+# protects no identifiable party.
+L21=$(lane lane21)
+cat >"$L21/$MARKER" <<'LEGACY'
+# drive-issue state for #3822 (hand-written, pre-stamp)
+- stage: implement
+- note: DISTINCTIVE_LEGACY_BODY_MARKER must not survive the restamp
+LEGACY
+mig_v=$(run "$L21" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- verify 3822); mig_vrc=$?
+mig_w=$(run "$L21" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 --stage implement); mig_wrc=$?
+mig_v2=$(run "$L21" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- verify 3822); mig_v2rc=$?
+if [ "$mig_vrc" -eq 8 ] && [ "$(verdict_of "$mig_v")" = UNSTAMPED ] \
+   && [ "$mig_wrc" -eq 0 ] && [ "$(verdict_of "$mig_w")" = WRITTEN ] \
+   && [ "$mig_v2rc" -eq 0 ] && [ "$(verdict_of "$mig_v2")" = OWNED ]; then
+  ok "the end-to-end migration path works: verify UNSTAMPED(8) -> write WRITTEN(0) -> verify OWNED(0)"
+else
+  bad "migration path broken: verify=$mig_vrc/$(verdict_of "$mig_v") write=$mig_wrc/$(verdict_of "$mig_w") reverify=$mig_v2rc/$(verdict_of "$mig_v2")
+$mig_w"
+fi
+# The old body must be provably GONE — asserted on a DISTINCTIVE STRING, not on a length,
+# because a length can coincide while the foreign plan survives.
+if ! grep -q 'DISTINCTIVE_LEGACY_BODY_MARKER' "$L21/$MARKER"; then
+  ok "the unstamped body is provably ABSENT from the restamped marker (a foreign plan is never carried forward)"
+else
+  bad "the unstamped body SURVIVED the restamp:
+$(cat "$L21/$MARKER")"
+fi
+if printf '%s\n' "$mig_w" | grep -q 'DISCARDED its body' && all_lines_anchored "$mig_w"; then
+  ok "the discard is ANNOUNCED on an anchored verdict-detail line (a quiet overwrite of someone's notes is not acceptable)"
+else
+  bad "the discard was not announced:
+$mig_w"
+fi
+# NON-VACUITY: the exception is for UNSTAMPED ONLY. A marker that CLAIMS an identity which
+# merely cannot be READ may be a live peer's, so write must still refuse it.
+L21B=$(lane lane21b)
+run "$L21B" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 >/dev/null 2>&1
+grep -vFx -- "$sentinel_end" "$L21B/$MARKER" >"$T/m21b" && mv "$T/m21b" "$L21B/$MARKER"
+mal_w=$(run "$L21B" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822); mal_wrc=$?
+if [ "$mal_wrc" -ne 0 ] && [ "$(verdict_of "$mal_w")" = MALFORMED ]; then
+  ok "NON-VACUITY: write still REFUSES a MALFORMED marker — the exception is scoped to UNSTAMPED"
+else
+  bad "write overwrote a marker whose stamp merely could not be READ: rc=$mal_wrc verdict=$(verdict_of "$mal_w")
+$mal_w"
+fi
+
+# ===========================================================================
+case_begin 22-no-dead-letter-remedies "DERIVED: no refusal may name a subcommand of this script that returns the same refusal"
+# ===========================================================================
+# Generalized from the UNSTAMPED dead letter. Derived from the verdict set rather than
+# hand-copied per verdict, so a NEW refusal verdict cannot join without being covered: the
+# table below must account for every non-success token in VERDICT_SET, and each state's
+# refusal text is SCANNED for `drive-issue-state.sh <sub>` mentions which are then INVOKED
+# on that same state. A verdict that names no mechanical remedy is fine (FOREIGN-* say
+# "escalate"); naming a command that refuses identically is the defect.
+#
+# THE RULE IS DELIBERATELY STRICT ABOUT TWO-STEP REMEDIES: a text may not name a
+# subcommand that only works AFTER the reader does something else first (e.g. "move the
+# file aside, then `write`"), because the reader of these texts runs printed commands
+# LITERALLY. Such a remedy must describe the STATE CHANGE and let the normal path follow —
+# which is how MALFORMED/DUPLICATE-SENTINEL are worded. This case caught two such texts
+# the moment it was written, in the same round as the UNSTAMPED dead letter itself.
+DL_STATES="absent unstamped malformed duplicate-sentinel foreign-issue foreign-machine foreign-worktree adoptable live-peer liveness-unknown error"
+expected_for() {
+  case "$1" in
+    absent)             printf 'ABSENT\n' ;;
+    unstamped)          printf 'UNSTAMPED\n' ;;
+    malformed)          printf 'MALFORMED\n' ;;
+    duplicate-sentinel) printf 'DUPLICATE-SENTINEL\n' ;;
+    foreign-issue)      printf 'FOREIGN-ISSUE\n' ;;
+    foreign-machine)    printf 'FOREIGN-MACHINE\n' ;;
+    foreign-worktree)   printf 'FOREIGN-WORKTREE\n' ;;
+    adoptable)          printf 'ADOPTABLE\n' ;;
+    live-peer)          printf 'LIVE-PEER\n' ;;
+    liveness-unknown)   printf 'LIVENESS-UNKNOWN\n' ;;
+    error)              printf 'ERROR\n' ;;
+    *)                  printf '\n' ;;
+  esac
+}
+# setup_state <state> <dir> — build the state and set PROBE_* (+ SLEEPER when a live process
+# is part of the state).
+setup_state() {
+  PROBE_MACHINE=boxA; PROBE_SESSION="$SESS_A"; PROBE_PID=$$; SLEEPER=''
+  local st="$1" d="$2" other
+  case "$st" in
+    absent) : ;;
+    unstamped) printf 'legacy hand-written plan\n' >"$d/$MARKER" ;;
+    malformed)
+      run "$d" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 >/dev/null 2>&1
+      grep -vFx -- "$sentinel_end" "$d/$MARKER" >"$T/dl-mal" && mv "$T/dl-mal" "$d/$MARKER" ;;
+    duplicate-sentinel)
+      run "$d" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 >/dev/null 2>&1
+      { printf '%s\n' "$sentinel"; printf 'issue: 3822\n'; } >>"$d/$MARKER" ;;
+    foreign-issue)
+      run "$d" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 9999 >/dev/null 2>&1 ;;
+    foreign-machine)
+      run "$d" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 >/dev/null 2>&1
+      PROBE_MACHINE=boxB ;;
+    foreign-worktree)
+      other=$(lane "dl-other-$$")
+      run "$other" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 >/dev/null 2>&1
+      cp "$other/$MARKER" "$d/$MARKER" ;;
+    adoptable)
+      sleep 30 & local dead=$!
+      run "$d" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$dead" -- write 3822 >/dev/null 2>&1
+      kill "$dead" 2>/dev/null; wait "$dead" 2>/dev/null
+      PROBE_SESSION="$SESS_B" ;;
+    live-peer)
+      sleep 300 & SLEEPER=$!
+      run "$d" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$SLEEPER" -- write 3822 >/dev/null 2>&1
+      PROBE_SESSION="$SESS_B" ;;
+    liveness-unknown)
+      run "$d" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" -- write 3822 >/dev/null 2>&1
+      PROBE_SESSION="$SESS_B" ;;
+    error) mkdir -p "$d/$MARKER" ;;
+  esac
+}
+dl_probe() {  # dl_probe <dir> <subcommand-or-verify>
+  local d="$1" sub="$2"
+  case "$sub" in
+    adopt) run "$d" "CLAIM_MACHINE=$PROBE_MACHINE" "CLAUDE_CODE_SESSION_ID=$PROBE_SESSION" "CLAUDE_PID=$PROBE_PID" -- adopt 3822 --reason no-dead-letter-probe:derived 2>&1 ;;
+    write) run "$d" "CLAIM_MACHINE=$PROBE_MACHINE" "CLAUDE_CODE_SESSION_ID=$PROBE_SESSION" "CLAUDE_PID=$PROBE_PID" -- write 3822 2>&1 ;;
+    *)     run "$d" "CLAIM_MACHINE=$PROBE_MACHINE" "CLAUDE_CODE_SESSION_ID=$PROBE_SESSION" "CLAUDE_PID=$PROBE_PID" -- "$sub" 3822 2>&1 ;;
+  esac
+}
+dl_fail=0; dl_covered=''; dl_named=0
+for st in $DL_STATES; do
+  d=$(lane "dl-$st")
+  setup_state "$st" "$d"
+  exp="$(expected_for "$st")"
+  out="$(dl_probe "$d" verify)"; got="$(verdict_of "$out")"
+  if [ "$got" != "$exp" ]; then
+    dl_fail=$((dl_fail + 1))
+    printf 'note   state %s: expected verdict %s, got %s\n' "$st" "$exp" "$got"
+  fi
+  dl_covered="$dl_covered $exp"
+  # Every subcommand of THIS script named in the refusal text must not return the same
+  # refusal when invoked on the same state.
+  subs="$(printf '%s\n' "$out" | grep -oE 'drive-issue-state\.sh [a-z]+' | awk '{print $2}' | sort -u)"
+  for sub in $subs; do
+    case "$sub" in write | verify | adopt | show) : ;; *) continue ;; esac
+    dl_named=$((dl_named + 1))
+    rout="$(dl_probe "$d" "$sub")"; rgot="$(verdict_of "$rout")"
+    if [ "$rgot" = "$exp" ]; then
+      dl_fail=$((dl_fail + 1))
+      printf 'note   DEAD LETTER: %s names "%s", which returns %s again\n' "$exp" "$sub" "$rgot"
+    fi
+  done
+  [ -z "$SLEEPER" ] || { kill "$SLEEPER" 2>/dev/null; wait "$SLEEPER" 2>/dev/null; }
+done
+if [ "$dl_fail" -eq 0 ]; then
+  ok "11 refusal states reproduce their expected verdict, and every remedy they NAME ($dl_named invocation(s)) escapes that refusal"
+else
+  bad "$dl_fail dead-letter/verdict failures across the refusal states"
+fi
+if [ "$dl_named" -ge 2 ]; then
+  ok "NON-VACUITY: the scan actually FOUND named remedies ($dl_named) — it is not passing on an empty subject set"
+else
+  bad "the remedy scan found $dl_named named subcommands: it cannot have measured the dead-letter property"
+fi
+# COMPLETENESS: every non-success verdict token must appear in the state table, so a new
+# refusal verdict cannot be added without a state that reaches it.
+dl_missing=''
+for t in $VERDICT_SET; do
+  case "$t" in OWNED | WRITTEN | ADOPTED | SHOWN) continue ;; esac
+  case " $dl_covered " in *" $t "*) : ;; *) dl_missing="$dl_missing $t" ;; esac
+done
+if [ -z "$dl_missing" ]; then
+  ok "every non-success verdict in the closed set is reached by a state in this table"
+else
+  bad "verdict tokens reached by NO state here (a new refusal joined uncovered):$dl_missing"
+fi
+
+# ===========================================================================
+case_begin 23-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
 # ===========================================================================
 REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
 5-foreign-worktree 6-session-gone-adoptable 7-session-live-peer 8-pid-unrecordable-unknown
@@ -601,8 +781,9 @@ REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-iss
 12-placeholder-reason-refused 13-write-over-foreign-refuses 14-absent-is-distinct
 15-pid-reuse-recognised 16-closed-verdict-grammar 17-write-failure-emits-a-verdict
 18-control-chars-stay-anchored 19-control-char-worktree-refused
-20-same-process-is-owned 21-case-floor"
-CASE_FLOOR=21
+20-same-process-is-owned 21-write-over-unstamped-migrates
+22-no-dead-letter-remedies 23-case-floor"
+CASE_FLOOR=23
 executed=0
 for _c in $CASES; do executed=$((executed + 1)); done
 missing=""
@@ -614,8 +795,8 @@ if [ "$executed" -ge "$CASE_FLOOR" ] && [ -z "$missing" ]; then
 else
   bad "case floor breached: executed=$executed floor=$CASE_FLOOR missing:$missing"
 fi
-if [ "$PASS" -ge 30 ]; then
-  ok "assertion floor: $PASS assertions passed (>= 30)"
+if [ "$PASS" -ge 40 ]; then
+  ok "assertion floor: $PASS assertions passed (>= 40)"
 else
   bad "assertion floor breached: only $PASS assertions passed"
 fi

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -561,15 +561,48 @@ else
 fi
 
 # ===========================================================================
-case_begin 20-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
+case_begin 20-same-process-is-owned "the SAME process owns its own marker even with no session id — no false LIVE-PEER"
+# ===========================================================================
+# A guard that reds on correct input is the guard agents learn to waive. With CLAUDE_PID
+# set but CLAUDE_CODE_SESSION_ID UNSET the session axis is UNMEASURED, and before this
+# branch existed the writer's own next command was refused as a LIVE-PEER against itself.
+# Sameness is measured affirmatively (pid identity + intersecting start window), which is
+# strictly stronger than the session-id string it stands in for.
+L20=$(lane lane20)
+sp_w=$(run "$L20" CLAIM_MACHINE=boxA "CLAUDE_PID=$$" -- write 3822 --stage implement); sp_wrc=$?
+sp_v=$(run "$L20" CLAIM_MACHINE=boxA "CLAUDE_PID=$$" -- verify 3822); sp_vrc=$?
+if [ "$sp_wrc" -eq 0 ] && [ "$sp_vrc" -eq 0 ] && [ "$(verdict_of "$sp_v")" = OWNED ]; then
+  ok "an unrecorded session id does not make a process a peer to itself (write 0, verify OWNED)"
+else
+  bad "the same process was refused its own marker: write-rc=$sp_wrc verify-rc=$sp_vrc verdict=$(verdict_of "$sp_v")
+$sp_v"
+fi
+# NON-VACUITY: the branch is keyed on PID IDENTITY, not on 'the session id was unrecorded'.
+# A DIFFERENT live pid with an unrecorded session id must still be a LIVE-PEER.
+sleep 300 &
+sp_peer=$!
+L20B=$(lane lane20b)
+run "$L20B" CLAIM_MACHINE=boxA "CLAUDE_PID=$sp_peer" -- write 3822 >/dev/null 2>&1
+sp_p=$(run "$L20B" CLAIM_MACHINE=boxA "CLAUDE_PID=$$" -- verify 3822); sp_prc=$?
+kill "$sp_peer" 2>/dev/null; wait "$sp_peer" 2>/dev/null
+if [ "$sp_prc" -ne 0 ] && [ "$(verdict_of "$sp_p")" = LIVE-PEER ]; then
+  ok "NON-VACUITY: a DIFFERENT live pid is still a LIVE-PEER when neither side records a session id"
+else
+  bad "an unrecorded session id let a foreign live pid through: rc=$sp_prc verdict=$(verdict_of "$sp_p")
+$sp_p"
+fi
+
+# ===========================================================================
+case_begin 21-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
 # ===========================================================================
 REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
 5-foreign-worktree 6-session-gone-adoptable 7-session-live-peer 8-pid-unrecordable-unknown
 9-writer-refuses-sentinel-body 10-reader-refuses-duplicate-sentinel 11-machine-agrees-with-claim-sh
 12-placeholder-reason-refused 13-write-over-foreign-refuses 14-absent-is-distinct
 15-pid-reuse-recognised 16-closed-verdict-grammar 17-write-failure-emits-a-verdict
-18-control-chars-stay-anchored 19-control-char-worktree-refused 20-case-floor"
-CASE_FLOOR=20
+18-control-chars-stay-anchored 19-control-char-worktree-refused
+20-same-process-is-owned 21-case-floor"
+CASE_FLOOR=21
 executed=0
 for _c in $CASES; do executed=$((executed + 1)); done
 missing=""

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -2139,6 +2139,67 @@ $w38_out"
 fi
 
 # ===========================================================================
+case_begin 39-body-bytes-survive-repeated-writes "the BODY survives an owned write BYTE-FOR-BYTE, repeatedly and across an adopt (roborev job 34 H3)"
+# ===========================================================================
+# THE DEFECT: `marker_body` returned everything after the end sentinel — INCLUDING the canonical
+# blank separator the WRITER emits — and `write_marker` then always emitted its own separator
+# before copying that body back. So every ordinary write added one blank line: measured 1, then
+# 2, then 3 across three successive writes of the SAME body. The header promises the body
+# SURVIVES an owned write; it survived but MUTATED, and it grew without bound over a long-running
+# lane. Asserted BYTE-FOR-BYTE with cmp, never as a line count — the finding is that the bytes
+# change.
+after_sentinel() {  # after_sentinel <marker> <out> — everything AFTER the end sentinel, verbatim
+  awk -v s="$sentinel_end" 'seen{print} $0==s{seen=1}' "$1" >"$2"
+}
+L39=$(lane lane39)
+body39="$T/body39.md"
+printf '## plan\n\n- step one\n- step two\n' >"$body39"
+run "$L39" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 --body-file "$body39" >/dev/null 2>&1
+after_sentinel "$L39/$MARKER" "$T/39-r1"
+# The canonical shape, stated once: exactly ONE writer-owned blank separator, then the body bytes.
+{ printf '\n'; cat "$body39"; } >"$T/39-canonical"
+if cmp -s "$T/39-r1" "$T/39-canonical"; then
+  ok "the first write lays down exactly one writer-owned separator followed by the body verbatim"
+else
+  bad "the first write's post-sentinel bytes are not the canonical shape:
+$(cmp -l "$T/39-canonical" "$T/39-r1" | head -5)
+$(cat -A "$T/39-r1" | head -8)"
+fi
+b39_fail=0
+i=2
+while [ "$i" -le 4 ]; do
+  run "$L39" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 --stage "round$i" >/dev/null 2>&1
+  after_sentinel "$L39/$MARKER" "$T/39-r$i"
+  cmp -s "$T/39-r1" "$T/39-r$i" || { b39_fail=1; printf 'note   write #%s changed the body bytes:\n%s\n' "$i" "$(cat -A "$T/39-r$i" | head -8)"; }
+  i=$((i + 1))
+done
+if [ "$b39_fail" -eq 0 ]; then
+  ok "FOUR successive owned writes leave the post-sentinel bytes IDENTICAL (no monotonic separator growth)"
+else
+  bad "the body mutated across repeated writes — the separator is owned twice"
+fi
+# ACROSS AN ADOPT, which carries the body through the same path.
+L39A=$(lane lane39-adopt)
+sleep 30 & dead39=$!
+run "$L39A" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$dead39" -- write 3822 --body-file "$body39" >/dev/null 2>&1
+kill "$dead39" 2>/dev/null; wait "$dead39" 2>/dev/null
+after_sentinel "$L39A/$MARKER" "$T/39a-before"
+run "$L39A" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- adopt 3822 --reason cron-reinvoke:writer-pid-gone >/dev/null 2>&1
+after_sentinel "$L39A/$MARKER" "$T/39a-after"
+if cmp -s "$T/39a-before" "$T/39a-after" && cmp -s "$T/39a-after" "$T/39-canonical"; then
+  ok "an adopt carries the body across BYTE-FOR-BYTE and adds no separator of its own"
+else
+  bad "the adopt mutated the body bytes:
+$(cat -A "$T/39a-after" | head -8)"
+fi
+# NON-VACUITY: the comparisons above are over a REAL body, not an empty one.
+if [ -s "$T/39-r1" ] && grep -q 'step two' "$T/39-r1"; then
+  ok "NON-VACUITY: the compared region is the real body ($(wc -c <"$T/39-r1" | tr -d ' ') bytes), not an empty file"
+else
+  bad "the compared region is empty — the byte comparisons above prove nothing"
+fi
+
+# ===========================================================================
 case_begin 28-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
 # ===========================================================================
 REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
@@ -2156,8 +2217,9 @@ REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-iss
 34-shift-never-leaks-bash-diagnostics 35-one-verdict-per-failure-mode
 36-anchor-holds-on-every-stream
 37-machine-axis-must-be-measurable
-38-adopt-never-calls-a-live-owner-gone 28-case-floor"
-CASE_FLOOR=38
+38-adopt-never-calls-a-live-owner-gone
+39-body-bytes-survive-repeated-writes 28-case-floor"
+CASE_FLOOR=39
 executed=0
 for _c in $CASES; do executed=$((executed + 1)); done
 missing=""

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -2200,6 +2200,66 @@ else
 fi
 
 # ===========================================================================
+case_begin 40-worktree-axis-must-be-measurable "CLASS SWEEP of job 34 H1: an UNMEASURABLE worktree axis is refused by name, and derives no marker path at the filesystem root"
+# ===========================================================================
+# H1 is one instance of "a required identity axis silently degrades"; the sweep asked which OTHER
+# axis can degrade. `issue` is a validated CLI argument, `session`/`session-pid` have DELIBERATE
+# sentinels that route to the liveness resolution (never to a match), and `actor` is recorded but
+# is not an ownership axis. The worktree axis was the reachable one: with the lane's directory
+# deleted `pwd -P` fails, which (1) leaked bash's own unprefixed diagnostic, (2) killed the shell
+# under `set -e` so the run ended on the EXIT-trap's GENERIC ERROR naming no axis, and (3) made
+# marker_path compose "/$MARKER" — a read, and a would-be write, at the FILESYSTEM ROOT.
+wt_gone_run() {  # wt_gone_run <subcommand...> — run with a DELETED working directory
+  local g="$T/gone-$1-$RANDOM"
+  mkdir -p "$g"
+  ( cd "$g" && rmdir "$g" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+      "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" bash "$DS" "$@" 2>&1 )
+}
+wt_fail=0
+for sub in write verify show; do
+  g_out=$(wt_gone_run "$sub" 3822); g_rc=$?
+  if [ "$g_rc" -ne 0 ] && [ "$(verdict_of "$g_out")" = ERROR ] \
+     && printf '%s\n' "$g_out" | grep -q 'axis=worktree' \
+     && [ "$(verdict_count "$g_out")" = 1 ]; then
+    ok "'$sub' with a deleted worktree: exactly ONE verdict, ERROR, and it NAMES axis=worktree"
+  else
+    wt_fail=1
+    bad "'$sub' with a deleted worktree did not refuse by name: rc=$g_rc verdict=$(verdict_of "$g_out") count=$(verdict_count "$g_out")
+$g_out"
+  fi
+  # DECLARED RESIDUAL, MEASURED: bash prints `shell-init:` / `chdir:` for a deleted cwd BEFORE
+  # the script's first line runs, so those two are the INTERPRETER's and cannot be suppressed
+  # from inside the script. Every line the SCRIPT itself emits must still carry the anchor.
+  ours=$(printf '%s\n' "$g_out" | grep -v '^shell-init: ' | grep -v '^chdir: ' || true)
+  if all_lines_anchored "$ours"; then
+    ok "'$sub': every line the SCRIPT emits is anchored (bash's own pre-exec shell-init/chdir lines are a DECLARED, unsuppressable residual)"
+  else
+    bad "'$sub' leaked an unprefixed line of its own:
+$(printf '%s' "$ours" | cat -v)"
+  fi
+done
+# NOTHING IS DERIVED AT THE ROOT: a marker at / must never be consulted or created. Asserted by
+# the refusal above happening BEFORE any marker access — measured here as the absence of a
+# root-level marker after a write attempt (this test never has permission to create one, so the
+# assertion is that the attempt is not even made: rc/verdict above, plus this belt).
+if [ ! -e "/$MARKER" ]; then
+  ok "no marker was derived or created at the filesystem root"
+else
+  bad "/$MARKER exists — a root-level marker is in play and this case cannot distinguish it from one this run created"
+fi
+# NON-VACUITY: the same three subcommands work in a LIVE worktree.
+L40=$(lane lane40)
+run "$L40" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 >/dev/null 2>&1
+n40_v=$(run "$L40" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- verify 3822); n40_vrc=$?
+n40_s=$(run "$L40" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- show 3822); n40_src=$?
+if [ "$wt_fail" -eq 0 ] && [ "$n40_vrc" -eq 0 ] && [ "$(verdict_of "$n40_v")" = OWNED ] \
+   && [ "$n40_src" -eq 0 ] && [ "$(verdict_of "$n40_s")" = SHOWN ]; then
+  ok "NON-VACUITY: verify and show still work normally in a live worktree — the refusals are about the unmeasurable axis"
+else
+  bad "the live-worktree control regressed: v_rc=$n40_vrc v=$(verdict_of "$n40_v") s_rc=$n40_src s=$(verdict_of "$n40_s")"
+fi
+
+# ===========================================================================
 case_begin 28-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
 # ===========================================================================
 REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
@@ -2218,8 +2278,9 @@ REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-iss
 36-anchor-holds-on-every-stream
 37-machine-axis-must-be-measurable
 38-adopt-never-calls-a-live-owner-gone
-39-body-bytes-survive-repeated-writes 28-case-floor"
-CASE_FLOOR=39
+39-body-bytes-survive-repeated-writes
+40-worktree-axis-must-be-measurable 28-case-floor"
+CASE_FLOOR=40
 executed=0
 for _c in $CASES; do executed=$((executed + 1)); done
 missing=""
@@ -2231,10 +2292,10 @@ if [ "$executed" -ge "$CASE_FLOOR" ] && [ -z "$missing" ]; then
 else
   bad "case floor breached: executed=$executed floor=$CASE_FLOOR missing:$missing"
 fi
-if [ "$PASS" -ge 100 ]; then
-  ok "assertion floor: $PASS assertions passed (>= 100)"
+if [ "$PASS" -ge 125 ]; then
+  ok "assertion floor: $PASS assertions passed (>= 125)"
 else
-  bad "assertion floor breached: only $PASS assertions passed"
+  bad "assertion floor breached: only $PASS assertions passed (floor 125)"
 fi
 
 # ===========================================================================

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -83,6 +83,16 @@ all_lines_anchored() {
 SESS_A="sess-aaaaaaaa"
 SESS_B="sess-bbbbbbbb"
 
+# ENVIRONMENT PRECONDITIONS, asserted rather than assumed. The case FLOOR counts cases
+# EXECUTED, which does not prove each one reached its subject — so anything this suite needs
+# from the host is named here and FAILS loudly if absent, instead of surfacing as a puzzling
+# verdict mismatch ten cases later (or, worse, as a case that quietly proves nothing).
+if command -v flock >/dev/null 2>&1; then
+  ok "precondition: flock is available, so the MUTATING subcommands can run at all"
+else
+  bad "precondition: flock is MISSING — write/adopt refuse by design without it, so most cases below cannot reach their subject. NOTHING here is measured."
+fi
+
 # ===========================================================================
 case_begin 1-write-verify-owned "write then verify in the SAME lane and session -> OWNED"
 # ===========================================================================
@@ -289,6 +299,14 @@ L9=$(lane lane9)
 body="$T/body9.md"
 sentinel=$(sed -n 's/^STAMP_BEGIN=.\(.*\).$/\1/p' "$DS" | head -1)
 sentinel_end=$(sed -n 's/^STAMP_END=.\(.*\).$/\1/p' "$DS" | head -1)
+# BOTH sentinels are load-bearing for cases 9, 10, 21 and 22. An empty extraction would make
+# `grep -vFx ""` strip blank lines instead of the end sentinel, so the state under test would
+# not be the state named — a case passing for the wrong reason. Asserted, not assumed.
+if [ -n "$sentinel" ] && [ -n "$sentinel_end" ] && [ "$sentinel" != "$sentinel_end" ]; then
+  ok "both stamp sentinels were extracted from the shipped script and are distinct"
+else
+  bad "sentinel extraction failed (begin='$sentinel' end='$sentinel_end') — the cases that plant them measure nothing"
+fi
 {
   printf 'plan notes\n'
   printf '%s\n' "$sentinel"
@@ -515,6 +533,24 @@ else
   bad "write failure did not surface a verdict ($wf_probe): rc=$wf_rc verdict=$(verdict_of "$wf_out")
 $wf_out"
 fi
+# THE PROBE ABOVE IS UID-DEPENDENT, so it is not the only one. A directory permission is
+# bypassed by root and, since the flock pre-probe now refuses an unwritable worktree before
+# `write_marker` is entered, that probe no longer reaches the WRITE path it is named for on
+# ANY uid. This one does, on every uid: a PATH-shimmed failing `mktemp` fails inside
+# `write_marker` itself, which is where the swallowed-verdict defect lived.
+L17B=$(lane lane17b)
+wf_bin="$T/fakebin17"; mkdir -p "$wf_bin"
+printf '#!/bin/sh\nexit 1\n' >"$wf_bin/mktemp"; chmod +x "$wf_bin/mktemp"
+wf2_out=$(run "$L17B" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" \
+  "PATH=$wf_bin:$PATH" -- write 3822 2>/dev/null); wf2_rc=$?
+if [ "$wf2_rc" -ne 0 ] && [ "$(verdict_of "$wf2_out")" = ERROR ] \
+   && printf '%s\n' "$wf2_out" | grep -q 'temporary file' \
+   && all_lines_anchored "$wf2_out" && [ ! -f "$L17B/$MARKER" ]; then
+  ok "a failing mktemp inside write_marker yields ERROR(rc=$wf2_rc) naming the cause, on stdout, with nothing written — the path the uid-dependent probe cannot reach"
+else
+  bad "the injected mktemp failure did not reach write_marker's error path: rc=$wf2_rc verdict=$(verdict_of "$wf2_out")
+$wf2_out"
+fi
 
 # ===========================================================================
 case_begin 18-control-chars-stay-anchored "a hand-edited stamp value carrying control characters cannot break the output anchor"
@@ -524,13 +560,12 @@ case_begin 18-control-chars-stay-anchored "a hand-edited stamp value carrying co
 # DRIVE-STATE: prefix — which every consumer and every case above rests on.
 L17=$(lane lane17)
 run "$L17" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 >/dev/null 2>&1
-python3 - "$L17/$MARKER" <<'PYEOF'
-import sys
-p = sys.argv[1]
-s = open(p).read()
-s = s.replace('machine: boxA', 'machine: box\x1b[31mA\x07\x0b')
-open(p, 'w').write(s)
-PYEOF
+# Built with printf + awk rather than python3: a missing interpreter would leave the marker
+# UNEDITED, the verdict would be OWNED, and this case would report a failure whose cause is
+# nowhere in its message. No interpreter, no dependency.
+cc_val=$(printf 'box\033[31mA\007\013')
+awk -v new="machine: $cc_val" '/^machine: /{print new; next} {print}' "$L17/$MARKER" >"$T/m17cc" \
+  && mv "$T/m17cc" "$L17/$MARKER"
 cc_out=$(run "$L17" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- verify 3822 2>&1); cc_rc=$?
 if [ "$cc_rc" -ne 0 ] && [ "$(verdict_of "$cc_out")" = FOREIGN-MACHINE ] && all_lines_anchored "$cc_out" \
    && ! printf '%s' "$cc_out" | grep -q $'\x1b'; then
@@ -773,7 +808,153 @@ else
 fi
 
 # ===========================================================================
-case_begin 23-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
+case_begin 23-durable-fields-survive "stage/request-id/pr/branch survive a later write AND an adopt; --clear is the only eraser"
+# ===========================================================================
+# drive-issue.md's Delta 3 names "stage reached, open request ID, PR/branch" as THE durable
+# state, and `adopt` is the normal cron-resume path — so silently dropping request-id on a
+# resume left the next session unable to tell which request it awaits, and it would re-ask,
+# breaking "one marker, one wait". Omitting a flag must never erase state.
+L23=$(lane lane23)
+run "$L23" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- \
+  write 3822 --stage implement --request-id coord-3822-7 --pr 4001 --branch issue-3822-slug >/dev/null 2>&1
+run "$L23" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- \
+  write 3822 --stage review >/dev/null 2>&1
+fp_show=$(run "$L23" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- show 3822)
+if printf '%s\n' "$fp_show" | grep -q 'request-id=coord-3822-7' \
+   && printf '%s\n' "$fp_show" | grep -q 'pr=4001' \
+   && printf '%s\n' "$fp_show" | grep -q 'branch=issue-3822-slug' \
+   && printf '%s\n' "$fp_show" | grep -q 'stage=review'; then
+  ok "a later 'write --stage' PRESERVES request-id/pr/branch and updates the stage"
+else
+  bad "a write with one flag erased the other durable fields:
+$fp_show"
+fi
+run "$L23" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- \
+  write 3822 --clear request-id >/dev/null 2>&1
+fp_show2=$(run "$L23" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- show 3822)
+fp_bad=$(run "$L23" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 --clear frobnicate 2>&1); fp_badrc=$?
+if printf '%s\n' "$fp_show2" | grep -q 'request-id=none' \
+   && printf '%s\n' "$fp_show2" | grep -q 'pr=4001' && [ "$fp_badrc" -eq 64 ]; then
+  ok "'--clear request-id' erases exactly that field (pr survives), and an unknown field name is exit 64 — the field set is CLOSED"
+else
+  bad "--clear misbehaved: unknown-field rc=$fp_badrc
+$fp_show2"
+fi
+# ADOPT is the cron-resume path: the durable fields must cross it.
+L23B=$(lane lane23b)
+sleep 30 & fp_dead=$!
+run "$L23B" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$fp_dead" -- \
+  write 3822 --stage implement --request-id coord-3822-9 --pr 4002 --branch issue-3822-b >/dev/null 2>&1
+kill "$fp_dead" 2>/dev/null; wait "$fp_dead" 2>/dev/null
+fp_ad=$(run "$L23B" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- \
+  adopt 3822 --reason cron-reinvoke:writer-pid-gone); fp_adrc=$?
+fp_show3=$(run "$L23B" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- show 3822)
+if [ "$fp_adrc" -eq 0 ] && printf '%s\n' "$fp_show3" | grep -q 'request-id=coord-3822-9' \
+   && printf '%s\n' "$fp_show3" | grep -q 'pr=4002' \
+   && printf '%s\n' "$fp_show3" | grep -q 'branch=issue-3822-b' \
+   && printf '%s\n' "$fp_show3" | grep -q 'stage=implement' \
+   && printf '%s\n' "$fp_show3" | grep -q "prior-session=$SESS_A"; then
+  ok "an adopt carries stage/request-id/pr/branch across the ownership transfer (and still records the prior session)"
+else
+  bad "adopt destroyed durable state: rc=$fp_adrc
+$fp_show3"
+fi
+
+# ===========================================================================
+case_begin 24-serialization "the verify->replace sequence is SERIALIZED: the lock is really taken, and two racers produce one winner"
+# ===========================================================================
+# The ownership check is sound but was not ATOMIC with the replacement, so two sessions in
+# ONE lane — the scenario this file exists for — could both pass verification and one clobber
+# the other. Demonstrated here on BEHAVIOUR, never on "a lock file appeared".
+L24=$(lane lane24)
+# (a) A SHORTENED wait proves the lock is genuinely acquired and waited on. The timeout is a
+# hard-coded constant with no env override, so the test SUBSTITUTES THE ARTIFACT: a scratch
+# copy of the script with the constant rewritten (and its sibling library alongside, which
+# the script sources from its own directory), with the substitution VERIFIED.
+SCRATCH="$T/scratch"; mkdir -p "$SCRATCH/lib"
+sed 's/^MARKER_LOCK_WAIT_SECS=30$/MARKER_LOCK_WAIT_SECS=1/' "$DS" >"$SCRATCH/drive-issue-state.sh"
+cp "$SCRIPT_DIR/../flow/lib/process-liveness.sh" "$SCRATCH/lib/process-liveness.sh"
+if grep -q '^MARKER_LOCK_WAIT_SECS=1$' "$SCRATCH/drive-issue-state.sh"; then
+  ok "the shortened-wait pin took in the scratch copy (a test-only env seam is deliberately not offered)"
+else
+  bad "the scratch copy still carries the shipped wait — the contention case below would measure nothing"
+fi
+lock24="$L24/$MARKER.lock"
+: >>"$lock24"
+held24="$T/held24"
+flock -x "$lock24" -c "touch '$held24'; sleep 5" &
+holder24=$!
+i=0
+while [ ! -f "$held24" ] && [ "$i" -lt 60 ]; do i=$((i + 1)); sleep 0.1; done
+if [ -f "$held24" ]; then
+  ok "the external holder confirmed it holds the lock (handshake on a flag file, not a sleep)"
+else
+  bad "the external lock holder never confirmed acquisition — the contention case measures nothing"
+fi
+ser_out=$( cd "$L24" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+  "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" bash "$SCRATCH/drive-issue-state.sh" write 3822 2>&1 ); ser_rc=$?
+if [ "$ser_rc" -ne 0 ] && [ "$(verdict_of "$ser_out")" = ERROR ] \
+   && printf '%s\n' "$ser_out" | grep -q 'holds the marker lock' && [ ! -f "$L24/$MARKER" ]; then
+  ok "with the lock held elsewhere, write REFUSES (rc=$ser_rc) rather than mutating unserialized, and writes nothing"
+else
+  bad "write ignored a held lock: rc=$ser_rc verdict=$(verdict_of "$ser_out")
+$ser_out"
+fi
+kill "$holder24" 2>/dev/null; wait "$holder24" 2>/dev/null
+# (b) NON-VACUITY: once the lock is free the very same call succeeds, so the refusal above is
+# about CONTENTION and not about the lock being permanently unobtainable.
+ser_ok=$(run "$L24" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822); ser_okrc=$?
+if [ "$ser_okrc" -eq 0 ] && [ "$(verdict_of "$ser_ok")" = WRITTEN ]; then
+  ok "NON-VACUITY: with the lock free the same write succeeds"
+else
+  bad "write cannot take a free lock: rc=$ser_okrc
+$ser_ok"
+fi
+# (c) TWO CONCURRENT ADOPTERS OF ONE ADOPTABLE LANE -> exactly ONE winner. Deterministic
+# whether or not the two overlap in time: serialized, the loser re-verifies INSIDE the lock,
+# sees the winner's live session and refuses.
+#
+# MEASURED, not assumed: run against a copy of the shipped script with `lock_marker`
+# neutered, this exact scenario produced ADOPTED / ADOPTED — both adopters winning and one
+# clobbering the other's stamp. So the assertion below discriminates the fix rather than
+# passing for free.
+L24C=$(lane lane24c)
+sleep 30 & sc_dead=$!
+run "$L24C" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$sc_dead" -- write 3822 --stage implement >/dev/null 2>&1
+kill "$sc_dead" 2>/dev/null; wait "$sc_dead" 2>/dev/null
+sleep 300 & sc_p1=$!
+sleep 300 & sc_p2=$!
+( run "$L24C" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$sc_p1" -- \
+    adopt 3822 --reason race-probe:adopter-one >"$T/race1.out" 2>&1 ) &
+sc_j1=$!
+( run "$L24C" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=sess-cccccccc" "CLAUDE_PID=$sc_p2" -- \
+    adopt 3822 --reason race-probe:adopter-two >"$T/race2.out" 2>&1 ) &
+sc_j2=$!
+wait "$sc_j1" 2>/dev/null; wait "$sc_j2" 2>/dev/null
+kill "$sc_p1" "$sc_p2" 2>/dev/null; wait "$sc_p1" 2>/dev/null; wait "$sc_p2" 2>/dev/null
+sc_v1=$(verdict_of "$(cat "$T/race1.out")"); sc_v2=$(verdict_of "$(cat "$T/race2.out")")
+sc_won=0
+[ "$sc_v1" = ADOPTED ] && sc_won=$((sc_won + 1))
+[ "$sc_v2" = ADOPTED ] && sc_won=$((sc_won + 1))
+if [ "$sc_won" -eq 1 ] && verdict_in_set "$sc_v1" && verdict_in_set "$sc_v2"; then
+  ok "two concurrent adopters of one adoptable lane produce EXACTLY ONE ADOPTED (verdicts: $sc_v1 / $sc_v2)"
+else
+  bad "concurrent adopters produced $sc_won winners (verdicts: $sc_v1 / $sc_v2) — the verify->replace sequence is not serialized
+$(cat "$T/race1.out")
+$(cat "$T/race2.out")"
+fi
+# The surviving stamp must be ONE coherent record: the winner's session, and the durable
+# stage it inherited. A clobber would show as a lost stage or a torn prologue.
+sc_show=$(run "$L24C" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- show 3822 2>&1); sc_shrc=$?
+if [ "$sc_shrc" -eq 0 ] && printf '%s\n' "$sc_show" | grep -q 'stage=implement'; then
+  ok "the surviving marker is one coherent stamp and kept the inherited stage — no torn or clobbered record"
+else
+  bad "the surviving marker is not readable/coherent: rc=$sc_shrc
+$sc_show"
+fi
+
+# ===========================================================================
+case_begin 25-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
 # ===========================================================================
 REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
 5-foreign-worktree 6-session-gone-adoptable 7-session-live-peer 8-pid-unrecordable-unknown
@@ -782,8 +963,8 @@ REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-iss
 15-pid-reuse-recognised 16-closed-verdict-grammar 17-write-failure-emits-a-verdict
 18-control-chars-stay-anchored 19-control-char-worktree-refused
 20-same-process-is-owned 21-write-over-unstamped-migrates
-22-no-dead-letter-remedies 23-case-floor"
-CASE_FLOOR=23
+22-no-dead-letter-remedies 23-durable-fields-survive 24-serialization 25-case-floor"
+CASE_FLOOR=25
 executed=0
 for _c in $CASES; do executed=$((executed + 1)); done
 missing=""
@@ -795,8 +976,8 @@ if [ "$executed" -ge "$CASE_FLOOR" ] && [ -z "$missing" ]; then
 else
   bad "case floor breached: executed=$executed floor=$CASE_FLOOR missing:$missing"
 fi
-if [ "$PASS" -ge 40 ]; then
-  ok "assertion floor: $PASS assertions passed (>= 40)"
+if [ "$PASS" -ge 55 ]; then
+  ok "assertion floor: $PASS assertions passed (>= 55)"
 else
   bad "assertion floor breached: only $PASS assertions passed"
 fi

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -2363,6 +2363,141 @@ else
 fi
 
 # ===========================================================================
+case_begin 42-verdict-emission-is-a-critical-section "the verdict line is PRINTED before the 'already emitted' state is committed — a signal in that window loses no verdict (roborev job 35 I1)"
+# ===========================================================================
+# THE DEFECT: `verdict()` was `VERDICT_EMITTED=1; printf ...` — the flag SET BEFORE the line was
+# printed. A signal arriving between those two commands left the worst possible state: `on_signal`
+# saw the flag and stayed silent, the EXIT-trap backstop saw it and stayed silent, and the run
+# exited having printed NO verdict at all — while a write may already have been committed. That is
+# contract (c) ("EVERY exit carries exactly one token") violated by round 6's own G2 fix, from
+# inside the function the fix installed to enforce it.
+#
+# HOW THIS IS TESTED WITHOUT A COIN FLIP. The window is between two SHELL commands, so no PATH
+# shim can reach it and no sleep can time it. Both halves below are deterministic:
+#   * STRUCTURAL — the print must PRECEDE the state commit, and `VERDICT_EMITTED=1` must exist at
+#     exactly ONE site in the whole script (the class sweep: `refuse`'s internal argument-count
+#     guard had its own copy of the same flag-then-print ordering).
+#   * BEHAVIOURAL, by ARTIFACT SUBSTITUTION — the signal is PLANTED into a scratch copy of the
+#     script AT the window (`kill -TERM $$` between the print and the commit), so it arrives
+#     exactly where the race would put it, every run. The POSITIVE CONTROL reconstructs the
+#     PRE-FIX ordering in a second copy with the SAME plant and requires it to emit ZERO verdicts
+#     — without it, a green here could mean the plant never reached the window.
+SCRATCH42="$T/scratch42"; mkdir -p "$SCRATCH42/lib"
+cp "$SCRIPT_DIR/../flow/lib/process-liveness.sh" "$SCRATCH42/lib/process-liveness.sh"
+
+# --- STRUCTURAL -------------------------------------------------------------------------
+# COMMENTS ARE STRIPPED BEFORE THE ORDER IS READ: these functions document the very identifiers
+# being located, so a prose mention would otherwise "occur" before the code and the assert would
+# be about the comment (measured — it did, on the first run of this case).
+uncomment() { printf '%s\n' "$1" | grep -v '^[[:space:]]*#'; }
+v42_body=$(awk '/^verdict\(\) \{$/{f=1} f{print} f && /^\}$/{exit}' "$DS")
+v42_code=$(uncomment "$v42_body")
+v42_print=$(printf '%s\n' "$v42_code" | grep -n "printf '%s verdict" | head -1 | cut -d: -f1)
+v42_flag=$(printf '%s\n' "$v42_code" | grep -n '^ *VERDICT_EMITTED=1$' | head -1 | cut -d: -f1)
+if [ -n "$v42_print" ] && [ -n "$v42_flag" ] && [ "$v42_print" -lt "$v42_flag" ]; then
+  ok "STRUCTURAL: inside verdict(), the verdict line is PRINTED (body line $v42_print) before VERDICT_EMITTED is committed (body line $v42_flag)"
+else
+  bad "STRUCTURAL: verdict() commits the 'already emitted' state before (or without) printing the line — print=${v42_print:-none} flag=${v42_flag:-none}
+$v42_code"
+fi
+v42_sites=$(grep -c '^ *VERDICT_EMITTED=1$' "$DS" || true)
+if [ "$v42_sites" = 1 ]; then
+  ok "CLASS SWEEP: VERDICT_EMITTED=1 is assigned at exactly ONE site — nothing else can claim 'already emitted' out of order"
+else
+  bad "VERDICT_EMITTED=1 is assigned at $v42_sites sites; every one that is not verdict()'s is a second copy of the job 35 I1 ordering:
+$(grep -n '^ *VERDICT_EMITTED=1$' "$DS")"
+fi
+# ONE EMITTER, pinned. The window can only exist where a `verdict ` line is printed, so a second
+# printf of one is a second place for it to come back — which is exactly what `refuse`'s internal
+# argument-count guard was.
+v42_emit=$(grep -c "printf '%s verdict %s" "$DS" || true)
+if [ "$v42_emit" = 1 ]; then
+  ok "CLASS SWEEP: exactly ONE site in the script prints a 'verdict ' line, so the ordering above is the only ordering there is"
+else
+  bad "$v42_emit sites print a 'verdict ' line; every one outside verdict() is a second copy of the window:
+$(grep -n "printf '%s verdict %s" "$DS")"
+fi
+s42_body=$(awk '/^on_signal\(\) \{$/{f=1} f{print} f && /^\}$/{exit}' "$DS")
+s42_code=$(uncomment "$s42_body")
+s42_ing=$(printf '%s\n' "$s42_code" | grep -n 'VERDICT_EMITTING' | head -1 | cut -d: -f1)
+s42_ed=$(printf '%s\n' "$s42_code" | grep -n 'VERDICT_EMITTED' | head -1 | cut -d: -f1)
+if [ -n "$s42_ing" ] && [ -n "$s42_ed" ] && [ "$s42_ing" -lt "$s42_ed" ]; then
+  ok "STRUCTURAL: on_signal consults the in-flight flag (body line $s42_ing) BEFORE it may conclude 'already emitted' (body line $s42_ed)"
+else
+  bad "on_signal can conclude 'already emitted' without first checking whether an emission is IN FLIGHT — emitting=${s42_ing:-none} emitted=${s42_ed:-none}
+$s42_code"
+fi
+
+# --- BEHAVIOURAL, by artifact substitution ----------------------------------------------
+# plant_verdict_window <fixed|prefix> <outfile> — copy the shipped script with `kill -TERM $$`
+# planted inside verdict(): `fixed` puts it in the SHIPPED window (after the print, before the
+# state commit); `prefix` first reconstructs the PRE-FIX body (commit, then print) and puts the
+# plant between them. Nothing but verdict() is touched, and no seam is added to the shipped file.
+plant_verdict_window() {
+  awk -v mode="$1" '
+    /^verdict\(\) \{$/ { inv = 1; print; next }
+    inv && /^\}$/       { inv = 0; print; next }
+    inv {
+      if (mode == "fixed") {
+        print
+        if ($0 ~ /printf .%s verdict/) print "  kill -TERM $$"
+        next
+      }
+      if ($0 ~ /^ *VERDICT_EMITTING=1$/) { print "  VERDICT_EMITTED=1"; print "  kill -TERM $$"; next }
+      if ($0 ~ /^ *VERDICT_EMITTED=1$/)  next
+      if ($0 ~ /^ *VERDICT_EMITTING=0$/) next
+      if ($0 ~ /settle_verdict_signal$/) next
+      print; next
+    }
+    { print }
+  ' "$DS" >"$2"
+}
+plant_run() {  # plant_run <script> <lane> — combined output on stdout, run's status returned
+  local sc="$1" d="$2" out rc
+  out=$( cd "$d" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+    "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" bash "$sc" write 3822 --stage implement 2>&1 ); rc=$?
+  printf '%s\n' "$out"
+  return "$rc"
+}
+plant_verdict_window fixed  "$SCRATCH42/fixed.sh"
+plant_verdict_window prefix "$SCRATCH42/prefix.sh"
+if grep -q 'kill -TERM \$\$' "$SCRATCH42/fixed.sh" && grep -q 'kill -TERM \$\$' "$SCRATCH42/prefix.sh" \
+   && bash -n "$SCRATCH42/fixed.sh" 2>/dev/null && bash -n "$SCRATCH42/prefix.sh" 2>/dev/null; then
+  ok "PLANT FIXTURE: both scratch copies parse and both carry the planted signal inside verdict()"
+else
+  bad "the plant did not take — this case cannot reach its subject:
+$(awk '/^verdict\(\) \{$/{f=1} f{print} f && /^\}$/{exit}' "$SCRATCH42/fixed.sh")"
+fi
+L42=$(lane lane42-fixed)
+p42a=$(plant_run "$SCRATCH42/fixed.sh" "$L42"); r42a=$?
+if [ "$(verdict_count "$p42a")" = 1 ] && [ "$(verdict_of "$p42a")" = WRITTEN ] \
+   && [ "$r42a" -eq 143 ] && all_lines_anchored "$p42a" && [ -f "$L42/$MARKER" ]; then
+  ok "BEHAVIOURAL: a SIGTERM planted IN the emission window still yields exactly ONE anchored 'verdict WRITTEN', exit 143, and the marker on disk"
+else
+  bad "a signal inside the emission window broke contract (c): rc=$r42a verdicts=$(verdict_count "$p42a") token=$(verdict_of "$p42a") marker=$([ -f "$L42/$MARKER" ] && echo present || echo absent)
+$p42a"
+fi
+L42P=$(lane lane42-prefix)
+p42b=$(plant_run "$SCRATCH42/prefix.sh" "$L42P"); r42b=$?
+if [ "$(verdict_count "$p42b")" = 0 ]; then
+  ok "POSITIVE CONTROL: the PRE-FIX ordering with the SAME plant emits ZERO verdicts (rc=$r42b) — the window is real and the plant reaches it"
+else
+  bad "the pre-fix reconstruction still emitted $(verdict_count "$p42b") verdict(s), so the green above may be about a plant that never landed:
+$p42b"
+fi
+# NON-VACUITY: the same scratch copy WITHOUT a plant writes normally, so both results above are
+# about the planted signal and not about a copy the rewrite broke.
+cp "$DS" "$SCRATCH42/clean.sh"
+L42N=$(lane lane42-clean)
+p42n=$(plant_run "$SCRATCH42/clean.sh" "$L42N"); r42n=$?
+if [ "$r42n" -eq 0 ] && [ "$(verdict_count "$p42n")" = 1 ] && [ "$(verdict_of "$p42n")" = WRITTEN ]; then
+  ok "NON-VACUITY: the unplanted scratch copy writes normally (rc 0, one WRITTEN verdict)"
+else
+  bad "the scratch fixture is broken independently of the plant: rc=$r42n token=$(verdict_of "$p42n")
+$p42n"
+fi
+
+# ===========================================================================
 case_begin 28-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
 # ===========================================================================
 REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
@@ -2382,8 +2517,9 @@ REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-iss
 37-machine-axis-must-be-measurable
 38-adopt-never-calls-a-live-owner-gone
 39-body-bytes-survive-repeated-writes
-40-worktree-axis-must-be-measurable 41-body-without-trailing-newline 28-case-floor"
-CASE_FLOOR=41
+40-worktree-axis-must-be-measurable 41-body-without-trailing-newline
+42-verdict-emission-is-a-critical-section 28-case-floor"
+CASE_FLOOR=42
 executed=0
 for _c in $CASES; do executed=$((executed + 1)); done
 missing=""
@@ -2395,10 +2531,10 @@ if [ "$executed" -ge "$CASE_FLOOR" ] && [ -z "$missing" ]; then
 else
   bad "case floor breached: executed=$executed floor=$CASE_FLOOR missing:$missing"
 fi
-if [ "$PASS" -ge 131 ]; then
-  ok "assertion floor: $PASS assertions passed (>= 131)"
+if [ "$PASS" -ge 139 ]; then
+  ok "assertion floor: $PASS assertions passed (>= 139)"
 else
-  bad "assertion floor breached: only $PASS assertions passed (floor 131)"
+  bad "assertion floor breached: only $PASS assertions passed (floor 139)"
 fi
 
 # ===========================================================================

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -1815,6 +1815,22 @@ verify-owned:OWNED:0
 show-fields:SHOWN:0
 adopt-succeeds:ADOPTED:0
 lock-file-unusable:ERROR:1"
+# THE BOUND, and the two rows that need it (roborev job 51). Both plant a FIFO, whose defect is
+# an indefinite block rather than a wrong answer — so they are only safe to run under a bound,
+# and the bound is DECLARED rather than assumed present.
+INV_TIMEOUT=""
+if command -v timeout >/dev/null 2>&1; then
+  INV_TIMEOUT="timeout 120"
+else
+  ok "DECLARED: \`timeout\` is unavailable on this host, so the invariant table runs UNBOUNDED and the two FIFO rows are omitted — a row whose defect is a hang may not be run without a bound"
+fi
+if [ -n "$INV_TIMEOUT" ] && command -v mkfifo >/dev/null 2>&1; then
+  INV_ROWS="$INV_ROWS
+lock-not-regular-fifo:ERROR:1
+body-file-not-regular:USAGE:64"
+else
+  ok "DECLARED: the two FIFO rows (lock-not-regular-fifo, body-file-not-regular) need both \`timeout\` and \`mkfifo\` — they are omitted rather than asserted vacuously"
+fi
 # An unwritable worktree is only measurable when permissions apply to us: root bypasses them,
 # so the row is DECLARED unavailable rather than passing vacuously.
 if [ "$(id -u)" -ne 0 ]; then
@@ -1831,8 +1847,16 @@ inv_bin() {  # inv_bin <cmd> <body-line> — a PATH dir holding one shim
   printf '%s\n' "$d"
 }
 inv_exec() {  # inv_exec <dir> <script> <shimdir|''> <session> <pid> <args...>
+  # BOUNDED (roborev job 51). Two rows below plant a FIFO, and the defect they pin is an
+  # INDEFINITE BLOCK — so an unbounded runner would not fail the suite, it would HANG it, and
+  # the thing that notices would be the gate's stall watchdog minutes later. A hanging test is
+  # worse than a failing one. The bound is generous (nothing here takes seconds) and applies to
+  # EVERY row, so a future row that learns to block reds too. `timeout` propagates the child's
+  # own status, so the rc every row asserts is unchanged; rc 124 is the bound firing and no row
+  # expects it. If `timeout` is unavailable the whole table is DECLARED unavailable above rather
+  # than run unbounded.
   local d="$1" sc="$2" sd="$3" ss="$4" sp="$5"; shift 5
-  ( cd "$d" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+  ( cd "$d" && ${INV_TIMEOUT} env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
       ${ss:+"CLAUDE_CODE_SESSION_ID=$ss"} ${sp:+"CLAUDE_PID=$sp"} ${sd:+"PATH=$sd:$PATH"} \
       bash "$sc" "$@" 2>&1 )
 }
@@ -1855,6 +1879,16 @@ inv_run() {  # inv_run <row-name> — set the state up, run it, print output, re
       sd=$(inv_bin cat 'case "$*" in *body-unreadable.md*) exit 1;; esac
 exec '"$(command -v cat)"' "$@"')
       inv_exec "$d" "$DS" "$sd" "$SESS_A" $$ write 3822 --body-file "$INV_DIR/body-unreadable.md" ;;
+    lock-not-regular-fifo)
+      # roborev job 51: a FIFO at the SCRIPT-OWNED lock path. `: >>"$lock"` on one blocks
+      # forever; the type refusal must reach it before the open.
+      mkfifo "$d/$MARKER.lock"
+      inv_exec "$d" "$DS" '' "$SESS_A" $$ write 3822 ;;
+    body-file-not-regular)
+      # The same class at the one path a CALLER names: `-r` is true for a FIFO and `cat` then
+      # blocks forever. USAGE, because the path came from the invocation.
+      rm -f "$INV_DIR/body-fifo"; mkfifo "$INV_DIR/body-fifo"
+      inv_exec "$d" "$DS" '' "$SESS_A" $$ write 3822 --body-file "$INV_DIR/body-fifo" ;;
     absent-marker)         inv_exec "$d" "$DS" '' "$SESS_A" $$ verify 3822 ;;
     marker-not-regular)    mkdir -p "$d/$MARKER"; inv_exec "$d" "$DS" '' "$SESS_A" $$ verify 3822 ;;
     unstamped-marker)      printf 'legacy plan\n' >"$d/$MARKER"; inv_exec "$d" "$DS" '' "$SESS_A" $$ verify 3822 ;;
@@ -1994,8 +2028,8 @@ else
 fi
 # ROW FLOOR, the same idea as the case floor: a span-replacing edit that silently drops rows
 # otherwise leaves a green tally over a shrunken table.
-if [ "$inv_count" -ge 33 ]; then
-  ok "TABLE FLOOR: $inv_count failure modes exercised (floor 33) — including all four success verdicts, both signal phases and every refusal token"
+if [ "$inv_count" -ge 35 ]; then
+  ok "TABLE FLOOR: $inv_count failure modes exercised (floor 35) — including all four success verdicts, both signal phases and every refusal token"
 else
   bad "table floor breached: only $inv_count rows ran"
 fi
@@ -3010,7 +3044,7 @@ ln -s "$K46C_TARGET" "$L46c/$MARKER.lock"
 c46_w=$(run "$L46c" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 2>&1); c46_wrc=$?
 c46_link_after=$(readlink "$L46c/$MARKER.lock" 2>/dev/null || true)
 if [ "$c46_wrc" -ne 0 ] && [ "$(verdict_of "$c46_w")" = ERROR ] \
-   && printf '%s\n' "$c46_w" | grep -q 'lock path .* is a SYMLINK' \
+   && printf '%s\n' "$c46_w" | grep -q 'lock path .* is NOT a regular file (it is a symlink)' \
    && [ -L "$L46c/$MARKER.lock" ] && [ "$c46_link_after" = "$K46C_TARGET" ] \
    && [ ! -e "$K46C_TARGET" ] && [ ! -e "$L46c/$MARKER" ]; then
   ok "a SYMLINK at the lock path is refused by name; the link survives, its target was NOT created, and no marker was written"
@@ -3046,6 +3080,179 @@ else
 fi
 
 # ===========================================================================
+case_begin 47-non-regular-paths-never-block "roborev job 51: NO path this script opens may be a FIFO/socket/device/directory — a FIFO BLOCKS FOREVER and emits NO verdict at all"
+# ===========================================================================
+# THE DEFECT, MEASURED BEFORE IT WAS FIXED: with a FIFO at `.drive-issue-state.md.lock`, `write`
+# ran until killed — `timeout 10` returned rc 124 having emitted no `verdict ` line. That is the
+# worst possible breach of contract (c): not a WRONG verdict, NO verdict, forever, in a lane
+# nobody is watching. Round 10 (job 43 K1) taught this same path to refuse a SYMLINK and stopped
+# there, which is the THIRD round running in which a fix reached one member of its class — so
+# this case is a TABLE over the TYPES, not a point fix for the FIFO.
+#
+# EVERY RUN HERE IS BOUNDED. A regression in the code under test is an indefinite hang, and an
+# unbounded case would not fail the suite, it would HANG it — the gate's stall watchdog noticing
+# minutes later. Each row therefore asserts rc != 124 explicitly, so "it did not time out" is a
+# measured property and not an inference from the suite finishing.
+if ! command -v timeout >/dev/null 2>&1; then
+  ok "DECLARED: \`timeout\` is unavailable on this host, so the non-regular-path table is OMITTED — a case whose defect is a hang may not be run unbounded"
+else
+
+# run47 <dir> <secs> -- <args...> — `run`, bounded, stderr merged.
+run47() {
+  local dir="$1" secs="$2"; shift 2
+  [ "${1:-}" = "--" ] && shift
+  ( cd "$dir" && timeout "$secs" env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+      "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" bash "$DS" "$@" 2>&1 )
+}
+mksock47() { python3 -c 'import socket,sys; s=socket.socket(socket.AF_UNIX); s.bind(sys.argv[1])' "$1" 2>/dev/null; }
+
+# --- THE LOCK SIDECAR. Script-owned, so the ENTRY ITSELF must be regular: a symlink is refused
+#     whatever it resolves to, which is why both symlink shapes are rows here.
+L47_ROWS="fifo directory symlink-dangling symlink-to-regular"
+command -v mkfifo >/dev/null 2>&1 || { L47_ROWS="directory symlink-dangling symlink-to-regular"; ok "DECLARED: \`mkfifo\` is unavailable, so the FIFO row of the lock table is omitted rather than asserted vacuously"; }
+if mksock47 "$T/probe47.sock"; then L47_ROWS="$L47_ROWS socket"; rm -f "$T/probe47.sock"
+else ok "DECLARED: a unix socket could not be created on this host (no python3, or the path is too long), so the socket row of the lock table is omitted rather than asserted vacuously"; fi
+ok "DECLARED: the block-device and char-device rows are NOT asserted — creating one needs root, and this suite does not run as root. They take the same code path as the rows above (the closed \`case\` admits only absent|regular), and the char-device shape IS measured below through --body-file /dev/zero."
+
+l47_fail=0; l47_rows=0
+for kind in $L47_ROWS; do
+  l47_rows=$((l47_rows + 1))
+  d=$(lane "lane47-lock-$kind"); lk="$d/$MARKER.lock"; tgt="$T/lock47-target-$kind"
+  case "$kind" in
+    fifo)               mkfifo "$lk" ;;
+    directory)          mkdir -p "$lk" ;;
+    socket)             mksock47 "$lk" ;;
+    symlink-dangling)   rm -f "$tgt"; ln -s "$tgt" "$lk" ;;
+    symlink-to-regular) printf 'peer\n' >"$tgt"; ln -s "$tgt" "$lk" ;;
+  esac
+  out=$(run47 "$d" 20 -- write 3822 --stage implement); rc=$?
+  why=''
+  [ "$rc" -ne 124 ] || why="$why TIMED-OUT(the hang is back)"
+  [ "$rc" -ne 0 ]   || why="$why rc=0"
+  [ "$(verdict_count "$out")" = 1 ] || why="$why verdicts=$(verdict_count "$out")"
+  [ "$(verdict_of "$out")" = ERROR ] || why="$why token=$(verdict_of "$out")"
+  all_lines_anchored "$out" || why="$why unanchored-line"
+  # The refusal NAMES what the path actually is — "not a regular file" alone would send an
+  # operator looking at the wrong thing.
+  case "$kind" in
+    symlink-*) printf '%s\n' "$out" | grep -q 'it is a symlink' || why="$why kind-unnamed" ;;
+    *)         printf '%s\n' "$out" | grep -q "it is a $kind"   || why="$why kind-unnamed" ;;
+  esac
+  # NOTHING was written, and the planted entry was neither opened nor replaced.
+  [ ! -e "$d/$MARKER" ] || why="$why marker-written"
+  case "$kind" in
+    symlink-dangling)   { [ -L "$lk" ] && [ ! -e "$tgt" ]; } || why="$why link-or-target-touched" ;;
+    symlink-to-regular) { [ -L "$lk" ] && [ "$(cat "$tgt" 2>/dev/null)" = peer ]; } || why="$why link-or-target-touched" ;;
+    fifo)               [ -p "$lk" ] || why="$why plant-replaced" ;;
+    socket)             [ -S "$lk" ] || why="$why plant-replaced" ;;
+    directory)          [ -d "$lk" ] || why="$why plant-replaced" ;;
+  esac
+  if [ -n "$why" ]; then
+    l47_fail=$((l47_fail + 1)); printf 'note   lock/%s ->%s\n%s\n' "$kind" "$why" "$out"
+  fi
+done
+if [ "$l47_fail" -eq 0 ]; then
+  ok "all $l47_rows non-regular lock-path types are refused with ONE anchored ERROR naming the type, WITHOUT blocking, and the planted entry survives untouched"
+else
+  bad "$l47_fail of $l47_rows lock-path types hung, were opened, or reported the wrong verdict"
+fi
+
+# NON-VACUITY: an ORDINARY leftover lock file from a previous run must still be used.
+L47ok=$(lane lane47-lock-regular); : >"$L47ok/$MARKER.lock"
+o47=$(run47 "$L47ok" 20 -- write 3822 --stage implement); rc47=$?
+if [ "$rc47" -eq 0 ] && [ "$(verdict_of "$o47")" = WRITTEN ]; then
+  ok "NON-VACUITY: a leftover REGULAR lock file from a previous run is still used (verdict WRITTEN) — the type rule refuses foreign artifacts, not our own sidecar"
+else
+  bad "the type rule broke the ordinary path: rc=$rc47 verdict=$(verdict_of "$o47")
+$o47"
+fi
+
+# --- THE CALLER'S --body-file. Here the question is what the path RESOLVES to: a symlink to a
+#     real notes file is an ordinary thing to pass and must keep working.
+B47_ROWS="directory char-device"
+command -v mkfifo >/dev/null 2>&1 && B47_ROWS="$B47_ROWS fifo symlink-to-fifo"
+[ -c /dev/zero ] || { B47_ROWS="directory"; ok "DECLARED: /dev/zero is not a character device on this host, so the char-device --body-file row is omitted"; }
+b47_fail=0; b47_rows=0
+for kind in $B47_ROWS; do
+  b47_rows=$((b47_rows + 1))
+  d=$(lane "lane47-body-$kind"); src=''
+  case "$kind" in
+    directory)       src="$T/body47-dir"; mkdir -p "$src" ;;
+    char-device)     src=/dev/zero ;;
+    fifo)            src="$T/body47.fifo"; rm -f "$src"; mkfifo "$src" ;;
+    symlink-to-fifo) src="$T/body47-link.fifo"; rm -f "$src" "$T/body47b.fifo"; mkfifo "$T/body47b.fifo"; ln -s "$T/body47b.fifo" "$src" ;;
+  esac
+  out=$(run47 "$d" 20 -- write 3822 --body-file "$src"); rc=$?
+  why=''
+  [ "$rc" -ne 124 ] || why="$why TIMED-OUT(the hang is back)"
+  [ "$rc" -eq 64 ]  || why="$why rc=$rc"
+  [ "$(verdict_count "$out")" = 1 ] || why="$why verdicts=$(verdict_count "$out")"
+  [ "$(verdict_of "$out")" = USAGE ] || why="$why token=$(verdict_of "$out")"
+  all_lines_anchored "$out" || why="$why unanchored-line"
+  printf '%s\n' "$out" | grep -q 'is not a REGULAR file' || why="$why reason-unnamed"
+  [ ! -e "$d/$MARKER" ] || why="$why marker-written"
+  if [ -n "$why" ]; then
+    b47_fail=$((b47_fail + 1)); printf 'note   body/%s ->%s\n%s\n' "$kind" "$why" "$out"
+  fi
+done
+if [ "$b47_fail" -eq 0 ]; then
+  ok "all $b47_rows non-regular --body-file types are refused with ONE anchored USAGE, WITHOUT blocking and WITHOUT streaming a device into the snapshot, and nothing is written"
+else
+  bad "$b47_fail of $b47_rows --body-file types hung, streamed, or reported the wrong verdict"
+fi
+
+# NON-VACUITY, and the property the FOLLOWED probe exists for: a SYMLINK to a real file is
+# still accepted, and its bytes still land in the marker.
+L47b=$(lane lane47-body-symlink); printf 'linked plan\n' >"$T/body47-real.md"
+rm -f "$T/body47-real-link.md"; ln -s "$T/body47-real.md" "$T/body47-real-link.md"
+o47b=$(run47 "$L47b" 20 -- write 3822 --body-file "$T/body47-real-link.md"); rc47b=$?
+if [ "$rc47b" -eq 0 ] && [ "$(verdict_of "$o47b")" = WRITTEN ] \
+   && grep -qFx 'linked plan' "$L47b/$MARKER"; then
+  ok "NON-VACUITY: a --body-file that is a SYMLINK to a real file is still accepted and its bytes still land in the marker (the body probe asks what the path RESOLVES to, not what the entry is)"
+else
+  bad "the body-file type rule rejected a legitimate symlink: rc=$rc47b verdict=$(verdict_of "$o47b")
+$o47b"
+fi
+
+# --- POSITIVE CONTROL, by ARTIFACT SUBSTITUTION. Both round-11 guards are removed in a scratch
+#     copy; the SAME FIFO plants must then HANG (rc 124) with no verdict. Without this the rows
+#     above prove only that a refusal exists, not that they reach the defect it prevents.
+if command -v mkfifo >/dev/null 2>&1; then
+  mkdir -p "$T/j51-scratch/lib"
+  cp "$SCRIPT_DIR/../flow/lib/process-liveness.sh" "$T/j51-scratch/lib/"
+  j51_pre="$T/j51-scratch/drive-issue-state.sh"
+  LC_ALL=C awk '
+    index($0, "local lkind; lkind=") { lskip = 1; next }
+    lskip && $0 == "  esac" { lskip = 0; next }
+    lskip { next }
+    index($0, "local bkind; bkind=") { bskip = 1; next }
+    bskip { bskip = 0; next }
+    { print }
+  ' "$DS" >"$j51_pre"
+  j51_pin=0
+  [ "$(grep -c 'lkind' "$j51_pre" || true)" = 0 ] || j51_pin=$((j51_pin + 1))
+  [ "$(grep -c 'bkind' "$j51_pre" || true)" = 0 ] || j51_pin=$((j51_pin + 1))
+  grep -q ': 2>/dev/null >>"\$lock"' "$j51_pre" || j51_pin=$((j51_pin + 1))
+  bash -n "$j51_pre" 2>/dev/null || j51_pin=$((j51_pin + 1))
+  L47p=$(lane lane47-pre-lock); mkfifo "$L47p/$MARKER.lock"
+  p47=$( cd "$L47p" && timeout 5 env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+      "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" bash "$j51_pre" write 3822 2>&1 ); p47rc=$?
+  L47q=$(lane lane47-pre-body); rm -f "$T/body47-pre.fifo"; mkfifo "$T/body47-pre.fifo"
+  q47=$( cd "$L47q" && timeout 5 env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+      "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" bash "$j51_pre" write 3822 --body-file "$T/body47-pre.fifo" 2>&1 ); q47rc=$?
+  if [ "$j51_pin" -eq 0 ] && [ "$p47rc" -eq 124 ] && [ "$q47rc" -eq 124 ]; then
+    ok "POSITIVE CONTROL: with both type guards reverted, the SAME FIFO plants HANG until killed (rc 124 at the lock path AND at --body-file) — the indefinite block is real and the plants reach it"
+  else
+    bad "the positive control did not reproduce the hang: pin-failures=$j51_pin lock-rc=$p47rc body-rc=$q47rc (124 expected for both)
+$p47
+$q47"
+  fi
+else
+  ok "DECLARED: \`mkfifo\` is unavailable, so the hang POSITIVE CONTROL is omitted — the rows above then prove a refusal exists but not that it prevents a measured hang"
+fi
+
+fi  # timeout available
+# ===========================================================================
 case_begin 28-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
 # ===========================================================================
 REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
@@ -3068,8 +3275,9 @@ REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-iss
 40-worktree-axis-must-be-measurable 41-body-without-trailing-newline
 42-verdict-emission-is-a-critical-section
 43-identity-recorded-losslessly 44-body-file-is-read-not-stat-gated
-45-unknown-prologue-keys-survive 46-symlink-marker-is-never-clobbered 28-case-floor"
-CASE_FLOOR=46
+45-unknown-prologue-keys-survive 46-symlink-marker-is-never-clobbered
+47-non-regular-paths-never-block 28-case-floor"
+CASE_FLOOR=47
 executed=0
 for _c in $CASES; do executed=$((executed + 1)); done
 missing=""
@@ -3081,10 +3289,10 @@ if [ "$executed" -ge "$CASE_FLOOR" ] && [ -z "$missing" ]; then
 else
   bad "case floor breached: executed=$executed floor=$CASE_FLOOR missing:$missing"
 fi
-if [ "$PASS" -ge 172 ]; then
-  ok "assertion floor: $PASS assertions passed (>= 172)"
+if [ "$PASS" -ge 178 ]; then
+  ok "assertion floor: $PASS assertions passed (>= 178)"
 else
-  bad "assertion floor breached: only $PASS assertions passed (floor 172)"
+  bad "assertion floor breached: only $PASS assertions passed (floor 178)"
 fi
 
 # ===========================================================================

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -2148,8 +2148,24 @@ case_begin 39-body-bytes-survive-repeated-writes "the BODY survives an owned wri
 # SURVIVES an owned write; it survived but MUTATED, and it grew without bound over a long-running
 # lane. Asserted BYTE-FOR-BYTE with cmp, never as a line count — the finding is that the bytes
 # change.
-after_sentinel() {  # after_sentinel <marker> <out> — everything AFTER the end sentinel, verbatim
-  awk -v s="$sentinel_end" 'seen{print} $0==s{seen=1}' "$1" >"$2"
+# after_sentinel <marker> <out> — the marker's bytes AFTER the end sentinel's newline, VERBATIM.
+#
+# BYTE-EXACT BY CONSTRUCTION, AND DELIBERATELY NOT THE SCRIPT'S OWN MECHANISM (roborev job 35 I2).
+# This helper used to be `awk -v s=... 'seen{print} $0==s{seen=1}'`, and awk ALWAYS terminates the
+# last record it prints — so a body whose final line carries NO trailing newline came back with one
+# ADDED. That is exactly the defect this case exists to catch, which means the verification shared
+# the blind spot of the thing it verified: four `cmp`s over awk-extracted bytes could not have
+# failed. Nothing here is line-oriented: `grep -b` reports a BYTE offset of the sentinel line and
+# `tail -c` copies BYTES from there on, so no final line is re-terminated, no CRLF is rewritten and
+# no trailing blank line is trimmed. It is also a DIFFERENT mechanism from the offset walk the
+# script now uses, so a defect in one cannot cancel a defect in the other.
+after_sentinel() {
+  local off
+  off=$(LC_ALL=C grep -abFx -e "$sentinel_end" "$1" 2>/dev/null | head -1 | cut -d: -f1)
+  case "$off" in ''|*[!0-9]*) : >"$2"; return 1 ;; esac
+  # `off` is the 0-based byte offset of the sentinel line's first byte; the body begins after the
+  # sentinel's own bytes AND its newline. `tail -c +N` is 1-based, hence the +2.
+  tail -c "+$(( off + ${#sentinel_end} + 2 ))" "$1" >"$2"
 }
 L39=$(lane lane39)
 body39="$T/body39.md"
@@ -2260,6 +2276,93 @@ else
 fi
 
 # ===========================================================================
+case_begin 41-body-without-trailing-newline "CLASS SWEEP of job 34 H3: a body whose LAST LINE HAS NO NEWLINE survives byte-for-byte (roborev job 35 I2)"
+# ===========================================================================
+# THE DEFECT: `marker_body` extracted the body with `awk '{ print }'`, and awk ALWAYS terminates
+# the record it prints. So a 19-byte body `no trailing newline` came back as the 20 bytes
+# `no trailing newline\n` on the NEXT owned write — the header promises the body SURVIVES a write,
+# and it did not. Case 39 could not see it: its body was newline-terminated AND its `after_sentinel`
+# helper extracted through awk too, so the comparison ran over bytes the extractor had already
+# normalised. A verification that shares the defect's blind spot is not a verification, so the
+# helper was rewritten (grep -b offset + tail -c, no line-oriented tool anywhere) before this case
+# was written.
+#
+# THE SWEEP: the class is "body bytes routed through a line-oriented tool", so this case measures
+# the four normalisations such a tool performs — a missing final newline, CRLF line endings,
+# trailing blank lines, and leading whitespace — over one body, end to end, through a write, three
+# carry-forward writes and an adopt.
+L41=$(lane lane41)
+body41="$T/body41.md"
+# One body carrying every normalisation hazard at once. Built with printf so the bytes are exact:
+# a CRLF line, a line of leading whitespace, two trailing blank lines, and a FINAL LINE WITH NO
+# NEWLINE. No sentinel, no column-zero `<!--`, so the writer's body guard is not the subject here.
+printf '## plan\r\n   indented note\n\n\nno trailing newline' >"$body41"
+b41_bytes=$(wc -c <"$body41" | tr -d ' ')
+{ printf '\n'; cat "$body41"; } >"$T/41-canonical"
+if [ "$b41_bytes" -eq 47 ] && [ "$(tail -c 1 "$body41" | od -An -c | tr -d ' \n')" != '\n' ]; then
+  ok "FIXTURE: the body is $b41_bytes bytes and its last byte is NOT a newline (the case's whole subject)"
+else
+  bad "FIXTURE BROKEN: the body is $b41_bytes bytes and ends $(tail -c 1 "$body41" | od -An -c) — this case would prove nothing"
+fi
+run "$L41" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 --body-file "$body41" >/dev/null 2>&1
+after_sentinel "$L41/$MARKER" "$T/41-r1"
+if cmp -s "$T/41-r1" "$T/41-canonical"; then
+  ok "the FIRST write lays the body down verbatim — no newline added, no CRLF rewritten, no blank line trimmed"
+else
+  bad "the first write already mutated the body:
+$(cmp -l "$T/41-canonical" "$T/41-r1" | head -5)
+$(cat -A "$T/41-r1" | tail -5)"
+fi
+b41_fail=0
+i=2
+while [ "$i" -le 4 ]; do
+  run "$L41" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 --stage "round$i" >/dev/null 2>&1
+  after_sentinel "$L41/$MARKER" "$T/41-r$i"
+  cmp -s "$T/41-canonical" "$T/41-r$i" || { b41_fail=1
+    printf 'note   carry-forward write #%s changed the body bytes (%s -> %s bytes):\n%s\n' \
+      "$i" "$(wc -c <"$T/41-canonical" | tr -d ' ')" "$(wc -c <"$T/41-r$i" | tr -d ' ')" \
+      "$(cmp -l "$T/41-canonical" "$T/41-r$i" | head -3)"; }
+  i=$((i + 1))
+done
+if [ "$b41_fail" -eq 0 ]; then
+  ok "THREE carry-forward writes leave the body IDENTICAL — the read-back path adds no terminator"
+else
+  bad "a carry-forward write mutated a body whose last line has no newline (the job 35 I2 defect)"
+fi
+# ACROSS AN ADOPT, which carries the body through the very same read-back path.
+L41A=$(lane lane41-adopt)
+sleep 30 & dead41=$!
+run "$L41A" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$dead41" -- write 3822 --body-file "$body41" >/dev/null 2>&1
+kill "$dead41" 2>/dev/null; wait "$dead41" 2>/dev/null
+run "$L41A" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- adopt 3822 --reason cron-reinvoke:writer-pid-gone >/dev/null 2>&1
+after_sentinel "$L41A/$MARKER" "$T/41a-after"
+if cmp -s "$T/41-canonical" "$T/41a-after"; then
+  ok "an ADOPT carries the unterminated body across byte-for-byte too"
+else
+  bad "the adopt mutated the body bytes ($(wc -c <"$T/41-canonical" | tr -d ' ') -> $(wc -c <"$T/41a-after" | tr -d ' ') bytes):
+$(cmp -l "$T/41-canonical" "$T/41a-after" | head -3)"
+fi
+# THE HELPER ITSELF IS PROVED BYTE-EXACT, or every cmp above is an assertion about the extractor.
+# A file whose post-sentinel region is KNOWN is extracted and compared to those known bytes.
+h41="$T/41-helper-fixture"
+{ printf '%s\n' "$sentinel"; printf 'issue: 3822\n'; printf '%s\n' "$sentinel_end"
+  printf '\n'; cat "$body41"; } >"$h41"
+after_sentinel "$h41" "$T/41-helper-out"
+if cmp -s "$T/41-canonical" "$T/41-helper-out"; then
+  ok "HELPER CONTROL: after_sentinel extracts a KNOWN unterminated region byte-for-byte (it no longer hides the defect it verifies)"
+else
+  bad "after_sentinel is still normalising: extracted $(wc -c <"$T/41-helper-out" | tr -d ' ') of $(wc -c <"$T/41-canonical" | tr -d ' ') bytes"
+fi
+# AND THE OLD HELPER IS THE POSITIVE CONTROL: the mechanism this case replaced must be SHOWN to
+# miss the defect, or "the verification shared the blind spot" is a claim rather than a measurement.
+awk -v s="$sentinel_end" 'seen{print} $0==s{seen=1}' "$h41" >"$T/41-old-helper-out"
+if ! cmp -s "$T/41-canonical" "$T/41-old-helper-out"; then
+  ok "POSITIVE CONTROL: the RETIRED awk helper returns $(wc -c <"$T/41-old-helper-out" | tr -d ' ') bytes for the same $(wc -c <"$T/41-canonical" | tr -d ' ')-byte region — it would have passed over the defect"
+else
+  bad "the retired awk helper is byte-exact here, so this case's premise is wrong and it proves nothing"
+fi
+
+# ===========================================================================
 case_begin 28-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
 # ===========================================================================
 REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
@@ -2279,8 +2382,8 @@ REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-iss
 37-machine-axis-must-be-measurable
 38-adopt-never-calls-a-live-owner-gone
 39-body-bytes-survive-repeated-writes
-40-worktree-axis-must-be-measurable 28-case-floor"
-CASE_FLOOR=40
+40-worktree-axis-must-be-measurable 41-body-without-trailing-newline 28-case-floor"
+CASE_FLOOR=41
 executed=0
 for _c in $CASES; do executed=$((executed + 1)); done
 missing=""
@@ -2292,10 +2395,10 @@ if [ "$executed" -ge "$CASE_FLOOR" ] && [ -z "$missing" ]; then
 else
   bad "case floor breached: executed=$executed floor=$CASE_FLOOR missing:$missing"
 fi
-if [ "$PASS" -ge 125 ]; then
-  ok "assertion floor: $PASS assertions passed (>= 125)"
+if [ "$PASS" -ge 131 ]; then
+  ok "assertion floor: $PASS assertions passed (>= 131)"
 else
-  bad "assertion floor breached: only $PASS assertions passed (floor 125)"
+  bad "assertion floor breached: only $PASS assertions passed (floor 131)"
 fi
 
 # ===========================================================================

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -1759,7 +1759,8 @@ signal-after-rename:WRITTEN:143
 write-succeeds:WRITTEN:0
 verify-owned:OWNED:0
 show-fields:SHOWN:0
-adopt-succeeds:ADOPTED:0"
+adopt-succeeds:ADOPTED:0
+lock-file-unusable:ERROR:1"
 # An unwritable worktree is only measurable when permissions apply to us: root bypasses them,
 # so the row is DECLARED unavailable rather than passing vacuously.
 if [ "$(id -u)" -ne 0 ]; then
@@ -1870,6 +1871,14 @@ inv_run() {  # inv_run <row-name> — set the state up, run it, print output, re
     show-fields)
       inv_exec "$d" "$DS" '' "$SESS_A" $$ write 3822 >/dev/null 2>&1
       inv_exec "$d" "$DS" '' "$SESS_A" $$ show 3822 ;;
+    lock-file-unusable)
+      # A FAILED REDIRECTION IS A NATIVE DIAGNOSTIC TOO — found by sweeping G3's class, not by
+      # the finding. `: >>"$lock" 2>/dev/null` applies the failing redirection BEFORE stderr is
+      # diverted, so bash prints its own unprefixed line. Making the lock path a DIRECTORY is
+      # the root-proof way to make the redirection fail (permissions are bypassed under root,
+      # `EISDIR` is not).
+      mkdir -p "$d/$MARKER.lock"
+      inv_exec "$d" "$DS" '' "$SESS_A" $$ write 3822 ;;
     unwritable-worktree)
       chmod 555 "$d"
       inv_exec "$d" "$DS" '' "$SESS_A" $$ write 3822; local wrc=$?
@@ -1907,8 +1916,8 @@ else
 fi
 # ROW FLOOR, the same idea as the case floor: a span-replacing edit that silently drops rows
 # otherwise leaves a green tally over a shrunken table.
-if [ "$inv_count" -ge 29 ]; then
-  ok "TABLE FLOOR: $inv_count failure modes exercised (floor 29) — including all four success verdicts, both signal phases and every refusal token"
+if [ "$inv_count" -ge 30 ]; then
+  ok "TABLE FLOOR: $inv_count failure modes exercised (floor 30) — including all four success verdicts, both signal phases and every refusal token"
 else
   bad "table floor breached: only $inv_count rows ran"
 fi

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -1,0 +1,510 @@
+#!/usr/bin/env bash
+#
+# Regression tests for scripts/flow/drive-issue-state.sh (issue #3822).
+#
+# Fast + hermetic: mktemp directories stand in for lane worktrees. No network, no
+# gh, no cargo, no datasets. Identity is supplied entirely through the environment
+# (CLAIM_MACHINE / CLAUDE_CODE_SESSION_ID / CLAUDE_PID) so one process can play
+# several lanes and several sessions.
+#
+# Run standalone:   bash scripts/tests/test_drive_issue_state.sh
+#
+# No wall-clock timing assertions: every verdict is a file state, an exit code or a
+# process-liveness answer about a pid this test itself controls.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DS="$SCRIPT_DIR/../flow/drive-issue-state.sh"
+CLAIM="$SCRIPT_DIR/../flow/claim.sh"
+
+PASS=0
+FAIL=0
+ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+# CASE FLOOR bookkeeping (#3544). A span-replacing edit that silently deletes cases
+# otherwise leaves a GREEN tally over a SHRUNKEN suite. Every case registers its
+# NAME here, and the final case asserts both a minimum count and the presence of
+# every required name — so a deleted case reds instead of greening.
+CASES=""
+case_begin() {
+  CASES="$CASES $1"
+  printf '\n'
+  printf '========================================================\n'
+  printf 'TEST %s: %s\n' "$1" "$2"
+  printf '========================================================\n'
+}
+
+T=$(mktemp -d "${TMPDIR:-/tmp}/drive-issue-state-test.XXXXXX")
+trap 'rm -rf "$T"' EXIT
+
+MARKER=".drive-issue-state.md"
+
+# lane <name> — make a lane worktree directory and echo its physical path.
+lane() { local d="$T/$1"; mkdir -p "$d"; ( cd "$d" && pwd -P ); }
+
+# run <dir> <env-assignments...> -- <args...>
+# Runs the script in <dir> with a CLEAN identity environment: CLAUDE_PID and
+# CLAUDE_CODE_SESSION_ID are UNSET unless the caller names them, so a value
+# inherited from the real agent session can never decide a test.
+run() {
+  local dir="$1"; shift
+  local -a envs=()
+  while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do envs+=("$1"); shift; done
+  [ "${1:-}" = "--" ] && shift
+  ( cd "$dir" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID "${envs[@]}" bash "$DS" "$@" )
+}
+
+# verdict_of <output> — echo the token from the single `verdict ` line.
+verdict_of() {
+  printf '%s\n' "$1" | sed -n 's/^DRIVE-STATE: verdict \([^ ]*\).*/\1/p' | head -1
+}
+
+# The CLOSED verdict token set (the script's own grammar). An unrecognised token is
+# a refusal, so the test pins the set rather than accepting whatever is printed.
+VERDICT_SET="OWNED WRITTEN ADOPTED SHOWN ABSENT UNSTAMPED MALFORMED DUPLICATE-SENTINEL FOREIGN-ISSUE FOREIGN-MACHINE FOREIGN-WORKTREE ADOPTABLE LIVE-PEER LIVENESS-UNKNOWN ERROR"
+verdict_in_set() {
+  local v="$1" t
+  [ -n "$v" ] || return 1
+  for t in $VERDICT_SET; do [ "$t" = "$v" ] && return 0; done
+  return 1
+}
+
+# all_lines_anchored <output> — 0 iff every non-empty line begins `DRIVE-STATE: `.
+all_lines_anchored() {
+  printf '%s\n' "$1" | grep -v '^$' | grep -cv '^DRIVE-STATE: ' | grep -q '^0$'
+}
+
+SESS_A="sess-aaaaaaaa"
+SESS_B="sess-bbbbbbbb"
+
+# ===========================================================================
+case_begin 1-write-verify-owned "write then verify in the SAME lane and session -> OWNED"
+# ===========================================================================
+L1=$(lane lane1)
+w_out=$(run "$L1" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 --stage implement); w_rc=$?
+v_out=$(run "$L1" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- verify 3822); v_rc=$?
+if [ "$w_rc" -eq 0 ] && [ "$(verdict_of "$w_out")" = WRITTEN ] \
+   && [ "$v_rc" -eq 0 ] && [ "$(verdict_of "$v_out")" = OWNED ] \
+   && [ -f "$L1/$MARKER" ]; then
+  ok "write -> WRITTEN(0), verify in same lane+session -> OWNED(0)"
+else
+  bad "write/verify same session: w_rc=$w_rc v_rc=$v_rc
+$w_out
+$v_out"
+fi
+if all_lines_anchored "$w_out" && all_lines_anchored "$v_out"; then
+  ok "every emitted line carries the single anchored DRIVE-STATE: prefix"
+else
+  bad "unanchored output line present:
+$w_out
+$v_out"
+fi
+if grep -q '^issue: 3822$' "$L1/$MARKER" \
+   && grep -q '^machine: boxA$' "$L1/$MARKER" \
+   && grep -q "^session: $SESS_A\$" "$L1/$MARKER" \
+   && grep -q '^actor: ' "$L1/$MARKER" \
+   && grep -q "^worktree: $L1\$" "$L1/$MARKER"; then
+  ok "AC1: the stamp records issue, machine, worktree, session and actor"
+else
+  bad "AC1 stamp fields missing:
+$(cat "$L1/$MARKER")"
+fi
+
+# ===========================================================================
+case_begin 2-ac3-unstamped-prose-refused "AC3 RED demonstration: the PRE-FIX marker shape is REFUSED, not adopted"
+# ===========================================================================
+# This case IS acceptance criterion 3. The file below is exactly what
+# .claude/commands/drive-issue.md prescribed BEFORE this change: free-form prose
+# with NO ownership stamp. A session rehydrating in a shared or reused worktree
+# used to adopt such a plan wholesale; the reader must now REFUSE it by name.
+L2=$(lane lane2)
+cat >"$L2/$MARKER" <<'PROSE'
+# drive-issue state for #3822
+
+- stage: implement
+- open request: coord-3822-1
+- branch: issue-3822-drive-issue-state-ownership-stamp
+- timestamp: 2026-09-01T10:00:00Z
+PROSE
+p_out=$(run "$L2" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- verify 3822); p_rc=$?
+if [ "$p_rc" -ne 0 ] && [ "$(verdict_of "$p_out")" = UNSTAMPED ]; then
+  ok "AC3: an UNSTAMPED prose marker is a NAMED refusal (UNSTAMPED, rc=$p_rc), never a silent adoption"
+else
+  bad "AC3: unstamped prose marker was not refused by name: rc=$p_rc
+$p_out"
+fi
+if printf '%s\n' "$p_out" | grep -q '3822'; then
+  ok "AC3 refusal names the issue it refused for"
+else
+  bad "AC3 refusal does not name the issue:
+$p_out"
+fi
+
+# ===========================================================================
+case_begin 3-foreign-issue "a stamp for ANOTHER issue is refused, naming the axis"
+# ===========================================================================
+L3=$(lane lane3)
+run "$L3" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 9999 >/dev/null 2>&1
+i_out=$(run "$L3" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- verify 3822); i_rc=$?
+if [ "$i_rc" -ne 0 ] && [ "$(verdict_of "$i_out")" = FOREIGN-ISSUE ] \
+   && printf '%s\n' "$i_out" | grep -q 'axis=issue'; then
+  ok "foreign issue -> FOREIGN-ISSUE(rc=$i_rc) naming axis=issue"
+else
+  bad "foreign issue not refused on the issue axis: rc=$i_rc
+$i_out"
+fi
+
+# ===========================================================================
+case_begin 4-foreign-machine "a stamp written on ANOTHER machine is refused, naming the axis"
+# ===========================================================================
+L4=$(lane lane4)
+run "$L4" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 >/dev/null 2>&1
+m_out=$(run "$L4" CLAIM_MACHINE=boxB "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- verify 3822); m_rc=$?
+if [ "$m_rc" -ne 0 ] && [ "$(verdict_of "$m_out")" = FOREIGN-MACHINE ] \
+   && printf '%s\n' "$m_out" | grep -q 'axis=machine'; then
+  ok "foreign machine -> FOREIGN-MACHINE(rc=$m_rc) naming axis=machine"
+else
+  bad "foreign machine not refused on the machine axis: rc=$m_rc
+$m_out"
+fi
+
+# ===========================================================================
+case_begin 5-foreign-worktree "a stamp copied from ANOTHER worktree is refused, naming the axis"
+# ===========================================================================
+L5=$(lane lane5)
+L5B=$(lane lane5b)
+run "$L5" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 >/dev/null 2>&1
+cp "$L5/$MARKER" "$L5B/$MARKER"
+wt_out=$(run "$L5B" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- verify 3822); wt_rc=$?
+if [ "$wt_rc" -ne 0 ] && [ "$(verdict_of "$wt_out")" = FOREIGN-WORKTREE ] \
+   && printf '%s\n' "$wt_out" | grep -q 'axis=worktree'; then
+  ok "foreign worktree -> FOREIGN-WORKTREE(rc=$wt_rc) naming axis=worktree"
+else
+  bad "foreign worktree not refused on the worktree axis: rc=$wt_rc
+$wt_out"
+fi
+
+# ===========================================================================
+case_begin 6-session-gone-adoptable "session differs + writer provably GONE -> non-zero ADOPTABLE, then adopt succeeds"
+# ===========================================================================
+L6=$(lane lane6)
+sleep 30 &
+gone_pid=$!
+run "$L6" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$gone_pid" -- write 3822 --stage implement >/dev/null 2>&1
+kill "$gone_pid" 2>/dev/null
+wait "$gone_pid" 2>/dev/null
+g_out=$(run "$L6" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- verify 3822); g_rc=$?
+if [ "$g_rc" -ne 0 ] && [ "$(verdict_of "$g_out")" = ADOPTABLE ]; then
+  ok "AC2: writer gone -> verify is NON-ZERO ADOPTABLE(rc=$g_rc); an explicit adopt gesture is required"
+else
+  bad "writer-gone did not yield a non-zero ADOPTABLE verdict: rc=$g_rc
+$g_out"
+fi
+a_out=$(run "$L6" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- adopt 3822 --reason writer-process-gone-cron-reinvoke); a_rc=$?
+if [ "$a_rc" -eq 0 ] && [ "$(verdict_of "$a_out")" = ADOPTED ]; then
+  ok "adopt over a provably-gone writer -> ADOPTED(0)"
+else
+  bad "adopt over a gone writer failed: rc=$a_rc
+$a_out"
+fi
+if grep -q "^prior-session: $SESS_A\$" "$L6/$MARKER" \
+   && grep -q "^session: $SESS_B\$" "$L6/$MARKER" \
+   && grep -q '^adopt-reason: writer-process-gone-cron-reinvoke$' "$L6/$MARKER"; then
+  ok "the rewritten stamp records the PRIOR session, the new session and the adopt reason"
+else
+  bad "adopt did not record prior session / reason:
+$(cat "$L6/$MARKER")"
+fi
+av_out=$(run "$L6" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- verify 3822); av_rc=$?
+if [ "$av_rc" -eq 0 ] && [ "$(verdict_of "$av_out")" = OWNED ]; then
+  ok "after adopt, verify from the adopting session is OWNED(0)"
+else
+  bad "post-adopt verify not OWNED: rc=$av_rc
+$av_out"
+fi
+
+# ===========================================================================
+case_begin 7-session-live-peer "session differs + writer provably ALIVE -> refused; adopt ALSO refuses"
+# ===========================================================================
+L7=$(lane lane7)
+sleep 300 &
+live_pid=$!
+run "$L7" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$live_pid" -- write 3822 >/dev/null 2>&1
+lp_out=$(run "$L7" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- verify 3822); lp_rc=$?
+la_out=$(run "$L7" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- adopt 3822 --reason peer-looks-idle-to-me); la_rc=$?
+kill "$live_pid" 2>/dev/null
+wait "$live_pid" 2>/dev/null
+if [ "$lp_rc" -ne 0 ] && [ "$(verdict_of "$lp_out")" = LIVE-PEER ]; then
+  ok "a LIVE recorded writer -> LIVE-PEER refusal (rc=$lp_rc)"
+else
+  bad "live writer was not refused as LIVE-PEER: rc=$lp_rc
+$lp_out"
+fi
+if [ "$la_rc" -ne 0 ] && [ "$(verdict_of "$la_out")" = LIVE-PEER ]; then
+  ok "adopt ALSO refuses over a live peer (rc=$la_rc) — adopt is not a mute button for the guard"
+else
+  bad "adopt over a LIVE peer was not refused: rc=$la_rc
+$la_out"
+fi
+
+# ===========================================================================
+case_begin 8-pid-unrecordable-unknown "CLAUDE_PID unset at write time -> liveness UNKNOWN, refused; adopt refuses"
+# ===========================================================================
+# The false-permissive this issue exists to close: falling back to $$ would record
+# the transient bash that exits immediately, so a LIVE peer would read as DEAD and
+# be adoptable. Unrecordable pid MUST mean liveness UNKNOWN, never DEAD.
+L8=$(lane lane8)
+run "$L8" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" -- write 3822 >/dev/null 2>&1
+u_out=$(run "$L8" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- verify 3822); u_rc=$?
+ua_out=$(run "$L8" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- adopt 3822 --reason no-pid-recorded-so-cannot-tell); ua_rc=$?
+if [ "$u_rc" -ne 0 ] && [ "$(verdict_of "$u_out")" = LIVENESS-UNKNOWN ]; then
+  ok "unrecordable writer pid -> LIVENESS-UNKNOWN refusal (rc=$u_rc), a token DISTINCT from LIVE-PEER"
+else
+  bad "unrecordable pid did not yield LIVENESS-UNKNOWN: rc=$u_rc
+$u_out"
+fi
+if [ "$ua_rc" -ne 0 ] && [ "$(verdict_of "$ua_out")" = LIVENESS-UNKNOWN ]; then
+  ok "adopt refuses on the UNKNOWN branch too — a positive verdict needs an affirmative measurement"
+else
+  bad "adopt on the UNKNOWN branch was not refused: rc=$ua_rc
+$ua_out"
+fi
+if [ -f "$L8/$MARKER" ] && ! grep -qE "^session-pid: $$\$" "$L8/$MARKER"; then
+  ok "NON-VACUITY: the writer did NOT fall back to its own \$\$ as the session pid"
+else
+  bad "the writer recorded its own transient \$\$ as the session pid:
+$(cat "$L8/$MARKER")"
+fi
+
+# ===========================================================================
+case_begin 9-writer-refuses-sentinel-body "the writer REFUSES a body carrying a sentinel at column zero"
+# ===========================================================================
+L9=$(lane lane9)
+body="$T/body9.md"
+sentinel=$(sed -n 's/^STAMP_BEGIN=.\(.*\).$/\1/p' "$DS" | head -1)
+{
+  printf 'plan notes\n'
+  printf '%s\n' "$sentinel"
+  printf 'issue: 1\n'
+} >"$body"
+s_out=$(run "$L9" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 --body-file "$body"); s_rc=$?
+if [ -n "$sentinel" ] && [ "$s_rc" -ne 0 ] && [ ! -f "$L9/$MARKER" ]; then
+  ok "a body line reproducing the stamp sentinel at column zero is REFUSED (rc=$s_rc), not escaped, and nothing is written"
+else
+  bad "sentinel-bearing body was not refused: rc=$s_rc sentinel='$sentinel' marker-exists=$([ -f "$L9/$MARKER" ] && echo yes || echo no)
+$s_out"
+fi
+body_ok="$T/body9ok.md"
+printf 'plan notes only\n' >"$body_ok"
+s2_out=$(run "$L9" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 --body-file "$body_ok"); s2_rc=$?
+if [ "$s2_rc" -eq 0 ] && grep -q '^plan notes only$' "$L9/$MARKER"; then
+  ok "NON-VACUITY: an ordinary body IS accepted and lands in the marker"
+else
+  bad "an ordinary body was rejected: rc=$s2_rc
+$s2_out"
+fi
+
+# ===========================================================================
+case_begin 10-reader-refuses-duplicate-sentinel "the reader REFUSES a file with a duplicate sentinel"
+# ===========================================================================
+L10=$(lane lane10)
+run "$L10" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 >/dev/null 2>&1
+{
+  printf '%s\n' "$sentinel"
+  printf 'issue: 3822\n'
+} >>"$L10/$MARKER"
+d_out=$(run "$L10" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- verify 3822); d_rc=$?
+if [ "$d_rc" -ne 0 ] && [ "$(verdict_of "$d_out")" = DUPLICATE-SENTINEL ]; then
+  ok "a hand-edited second sentinel at column zero is its OWN named refusal (rc=$d_rc)"
+else
+  bad "duplicate sentinel was not refused by name: rc=$d_rc
+$d_out"
+fi
+
+# ===========================================================================
+case_begin 11-machine-agrees-with-claim-sh "machine identity is the SAME notion claim.sh records (anti-drift pin)"
+# ===========================================================================
+L11=$(lane lane11)
+# Extract claim.sh's OWN machine resolution from the shipped script and run it in
+# this environment: the agreement is measured, never asserted by care.
+cm_body="$T/claim-machine.sh"
+{
+  sed -n '/^sanitize_field()/,/^}/p' "$CLAIM"
+  sed -n '/^this_machine()/,/^}/p' "$CLAIM"
+  printf 'this_machine\n'
+} >"$cm_body"
+claim_machine=$(CLAIM_MACHINE='build box' bash "$cm_body")
+run "$L11" "CLAIM_MACHINE=build box" "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 >/dev/null 2>&1
+ds_machine=$(sed -n 's/^machine: //p' "$L11/$MARKER" | head -1)
+if [ -n "$claim_machine" ] && [ "$claim_machine" = "$ds_machine" ]; then
+  ok "machine agrees with claim.sh's recorded machine in the same environment ('$ds_machine')"
+else
+  bad "machine identity drifted from claim.sh: claim.sh='$claim_machine' drive-issue-state='$ds_machine'"
+fi
+if [ "$ds_machine" != "build box" ]; then
+  ok "NON-VACUITY: the value is SANITIZED (a space-bearing CLAIM_MACHINE cannot forge a stamp line)"
+else
+  bad "machine value was recorded unsanitized: '$ds_machine'"
+fi
+
+# ===========================================================================
+case_begin 12-placeholder-reason-refused "adopt refuses placeholder --reason values as a USAGE error"
+# ===========================================================================
+L12=$(lane lane12)
+sleep 30 &
+p12=$!
+run "$L12" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$p12" -- write 3822 >/dev/null 2>&1
+kill "$p12" 2>/dev/null; wait "$p12" 2>/dev/null
+ph_fail=0
+for r in '' '   ' 'why' 'TODO' 'tbd' '<why>' 'resume-legacy:<branch>'; do
+  o=$(run "$L12" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- adopt 3822 --reason "$r" 2>&1); rc=$?
+  if [ "$rc" -ne 64 ]; then
+    ph_fail=$((ph_fail + 1))
+    printf 'note   placeholder reason %q was not a usage error: rc=%s\n' "$r" "$rc"
+  fi
+done
+o=$(run "$L12" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- adopt 3822 2>&1); rc_noreason=$?
+if [ "$ph_fail" -eq 0 ] && [ "$rc_noreason" -eq 64 ]; then
+  ok "empty / whitespace / placeholder / unsubstituted-template reasons AND a missing --reason are exit 64, never a silent 'unspecified'"
+else
+  bad "placeholder --reason gate leaks: failures=$ph_fail no-reason-rc=$rc_noreason"
+fi
+o=$(run "$L12" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- adopt 3822 --reason 'cron re-invoke, writer pid gone'); rc=$?
+if [ "$rc" -eq 0 ] && [ "$(verdict_of "$o")" = ADOPTED ]; then
+  ok "NON-VACUITY: a real reason IS accepted"
+else
+  bad "a real reason was rejected: rc=$rc
+$o"
+fi
+
+# ===========================================================================
+case_begin 13-write-over-foreign-refuses "write over a foreign marker refuses without an adopt gesture"
+# ===========================================================================
+L13=$(lane lane13)
+sleep 300 &
+p13=$!
+run "$L13" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$p13" -- write 3822 --stage peer-plan >/dev/null 2>&1
+ow_out=$(run "$L13" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- write 3822 --stage my-plan); ow_rc=$?
+ow_m_out=$(run "$L13" CLAIM_MACHINE=boxB "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$p13" -- write 3822 --stage my-plan); ow_m_rc=$?
+kill "$p13" 2>/dev/null; wait "$p13" 2>/dev/null
+if [ "$ow_rc" -ne 0 ] && [ "$(verdict_of "$ow_out")" = LIVE-PEER ] \
+   && [ "$ow_m_rc" -ne 0 ] && [ "$(verdict_of "$ow_m_out")" = FOREIGN-MACHINE ] \
+   && grep -q '^stage: peer-plan$' "$L13/$MARKER"; then
+  ok "write refuses over a live peer's plan AND over a foreign machine's, leaving the recorded plan intact"
+else
+  bad "write overwrote or misjudged a foreign marker: session-rc=$ow_rc machine-rc=$ow_m_rc
+$ow_out
+$ow_m_out
+$(cat "$L13/$MARKER")"
+fi
+
+# ===========================================================================
+case_begin 14-absent-is-distinct "no marker at all is ABSENT — textually and numerically distinct from a refusal"
+# ===========================================================================
+L14=$(lane lane14)
+ab_out=$(run "$L14" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- verify 3822); ab_rc=$?
+ab_v=$(verdict_of "$ab_out")
+if [ "$ab_v" = ABSENT ] && [ "$ab_rc" -ne 0 ] && [ "$ab_rc" -ne 1 ]; then
+  ok "ABSENT is its own verdict token and its own exit code ($ab_rc) — a fresh start, not a refusal"
+else
+  bad "absent marker not reported distinctly: rc=$ab_rc verdict=$ab_v
+$ab_out"
+fi
+# A fresh write in that lane must SUCCEED: ABSENT is legitimate.
+fw_out=$(run "$L14" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822); fw_rc=$?
+if [ "$fw_rc" -eq 0 ]; then
+  ok "NON-VACUITY: a fresh write into an unmarked lane succeeds"
+else
+  bad "fresh write into an unmarked lane failed: rc=$fw_rc
+$fw_out"
+fi
+
+# ===========================================================================
+case_begin 15-pid-reuse-recognised "a recorded start window disjoint from the live pid's is NOT read as ALIVE"
+# ===========================================================================
+L15=$(lane lane15)
+sleep 300 &
+p15=$!
+run "$L15" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$p15" -- write 3822 >/dev/null 2>&1
+# Rewrite the recorded start window into the distant past: the pid is LIVE but it
+# cannot be the process that stamped this marker (pid reuse).
+sed -i 's/^session-pid-start-earliest: .*/session-pid-start-earliest: 1000000000/; s/^session-pid-start-latest: .*/session-pid-start-latest: 1000000002/' "$L15/$MARKER"
+ru_out=$(run "$L15" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- verify 3822); ru_rc=$?
+kill "$p15" 2>/dev/null; wait "$p15" 2>/dev/null
+ru_v=$(verdict_of "$ru_out")
+if [ "$ru_rc" -ne 0 ] && [ "$ru_v" != LIVE-PEER ] && [ "$ru_v" != OWNED ] && verdict_in_set "$ru_v"; then
+  ok "a reused pid is not credited to the recorded writer (verdict=$ru_v, rc=$ru_rc)"
+else
+  bad "pid reuse was read as the recorded writer: rc=$ru_rc verdict=$ru_v
+$ru_out"
+fi
+
+# ===========================================================================
+case_begin 16-closed-verdict-grammar "every verdict token emitted in this run is in the CLOSED set; show + help behave"
+# ===========================================================================
+grammar_fail=0
+for v in "$(verdict_of "$w_out")" "$(verdict_of "$v_out")" "$(verdict_of "$p_out")" \
+         "$(verdict_of "$i_out")" "$(verdict_of "$m_out")" "$(verdict_of "$wt_out")" \
+         "$(verdict_of "$g_out")" "$(verdict_of "$a_out")" "$(verdict_of "$lp_out")" \
+         "$(verdict_of "$la_out")" "$(verdict_of "$u_out")" "$(verdict_of "$ua_out")" \
+         "$(verdict_of "$d_out")" "$(verdict_of "$ab_out")" "$(verdict_of "$ow_out")"; do
+  verdict_in_set "$v" || { grammar_fail=$((grammar_fail + 1)); printf 'note   out-of-grammar verdict: %q\n' "$v"; }
+done
+if [ "$grammar_fail" -eq 0 ]; then
+  ok "all 15 sampled verdict tokens are members of the closed grammar"
+else
+  bad "$grammar_fail verdict tokens outside the closed grammar"
+fi
+sh_out=$(run "$L1" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- show 3822); sh_rc=$?
+if [ "$sh_rc" -eq 0 ] && printf '%s\n' "$sh_out" | grep -q 'machine=boxA' \
+   && printf '%s\n' "$sh_out" | grep -q "session=$SESS_A" && all_lines_anchored "$sh_out"; then
+  ok "show prints the recorded stamp fields, anchored"
+else
+  bad "show output wrong: rc=$sh_rc
+$sh_out"
+fi
+h_out=$(run "$L1" -- --help); h_rc=$?
+if [ "$h_rc" -eq 0 ] && printf '%s\n' "$h_out" | grep -q 'ADOPTABLE' \
+   && printf '%s\n' "$h_out" | grep -q 'EXIT CODES'; then
+  ok "--help is authoritative: it documents the verdict tokens and the exit codes"
+else
+  bad "--help does not document the contract: rc=$h_rc"
+fi
+bad_out=$(run "$L1" -- frobnicate 3822 2>&1); bad_rc=$?
+if [ "$bad_rc" -eq 64 ]; then
+  ok "an unknown subcommand is a usage error (64)"
+else
+  bad "unknown subcommand rc=$bad_rc"
+fi
+
+# ===========================================================================
+case_begin 17-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
+# ===========================================================================
+REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
+5-foreign-worktree 6-session-gone-adoptable 7-session-live-peer 8-pid-unrecordable-unknown
+9-writer-refuses-sentinel-body 10-reader-refuses-duplicate-sentinel 11-machine-agrees-with-claim-sh
+12-placeholder-reason-refused 13-write-over-foreign-refuses 14-absent-is-distinct
+15-pid-reuse-recognised 16-closed-verdict-grammar 17-case-floor"
+CASE_FLOOR=17
+executed=0
+for _c in $CASES; do executed=$((executed + 1)); done
+missing=""
+for req in $REQUIRED_CASES; do
+  case " $CASES " in *" $req "*) : ;; *) missing="$missing $req" ;; esac
+done
+if [ "$executed" -ge "$CASE_FLOOR" ] && [ -z "$missing" ]; then
+  ok "$executed cases executed (floor $CASE_FLOOR) and every required case name is present"
+else
+  bad "case floor breached: executed=$executed floor=$CASE_FLOOR missing:$missing"
+fi
+if [ "$PASS" -ge 25 ]; then
+  ok "assertion floor: $PASS assertions passed (>= 25)"
+else
+  bad "assertion floor breached: only $PASS assertions passed"
+fi
+
+# ===========================================================================
+echo
+echo "==== DRIVE-ISSUE-STATE TEST SUMMARY: PASS=$PASS FAIL=$FAIL ===="
+if [ "$FAIL" -eq 0 ]; then echo "RESULT: PASS"; exit 0; else echo "RESULT: FAIL"; exit 1; fi

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -1631,6 +1631,93 @@ $s33n"
 fi
 
 # ===========================================================================
+case_begin 34-shift-never-leaks-bash-diagnostics "an option with a MISSING value emits the anchored USAGE line and nothing of bash's own"
+# ===========================================================================
+# roborev job 30 G3, and the SECOND instance of round 5's F2 class: that round captured or
+# suppressed 21 EXTERNAL commands' native stderr and left the SHELL's own. `shift 2` past the
+# end returns non-zero, and bash prints its own UNPREFIXED `shift: 2: shift count out of range`
+# BEFORE the anchored `|| die_usage` message whenever `shift_verbose` or POSIX mode is on.
+#
+# REACHABLE WITHOUT A HOSTILE INVOKER, which is what makes it a defect rather than a note:
+# `BASHOPTS` is read from the ENVIRONMENT by every non-interactive bash at startup, so a
+# caller (a wrapper script, a CI step, an exported shell profile) turns it on for every child
+# without touching this file. The fix is to validate the argument COUNT before shifting, which
+# makes the behaviour environment-independent; the shim here is only how the latent breakage is
+# made observable.
+sv_run() {  # sv_run <dir> <args...> — run under shift_verbose; prints output, returns rc
+  local d="$1"; shift
+  local out rc
+  out=$( cd "$d" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+    "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" BASHOPTS=shift_verbose \
+    bash "$DS" "$@" 2>&1 ); rc=$?
+  printf '%s\n' "$out"
+  return "$rc"
+}
+L34=$(lane lane34)
+# EVERY option site in the file, plus every subcommand invoked with NO issue argument (the
+# leading `shift`). Driven from a TABLE so a new option is covered by adding a row, not by
+# remembering to write a case.
+SHIFT_ROWS="write:--stage
+write:--request-id
+write:--pr
+write:--branch
+write:--body-file
+write:--actor
+write:--clear
+verify:--actor
+adopt:--reason
+adopt:--actor
+write:
+verify:
+adopt:
+show:"
+sv_fail=0; sv_rows=0
+for row in $SHIFT_ROWS; do
+  sub="${row%%:*}"; opt="${row#*:}"
+  sv_rows=$((sv_rows + 1))
+  if [ -n "$opt" ]; then
+    out=$(sv_run "$L34" "$sub" 3822 "$opt"); rc=$?
+  else
+    out=$(sv_run "$L34" "$sub"); rc=$?
+  fi
+  why=''
+  all_lines_anchored "$out" || why="$why unanchored-line"
+  [ "$(verdict_count "$out")" = 1 ] || why="$why verdicts=$(verdict_count "$out")"
+  [ "$(verdict_of "$out")" = USAGE ] || why="$why token=$(verdict_of "$out")"
+  [ "$rc" -eq 64 ] || why="$why rc=$rc"
+  if [ -n "$why" ]; then
+    sv_fail=$((sv_fail + 1))
+    printf 'note   %s %s ->%s\n%s\n' "$sub" "${opt:-<no-issue-arg>}" "$why" "$(printf '%s' "$out" | cat -v)"
+  fi
+done
+if [ "$sv_fail" -eq 0 ]; then
+  ok "all $sv_rows shift sites emit ONE anchored 'verdict USAGE' and exit 64 — no bash diagnostic escapes the anchor"
+else
+  bad "$sv_fail of $sv_rows shift sites leaked a bash diagnostic, emitted no/two verdicts, or used the wrong exit code"
+fi
+# NON-VACUITY IN TWO DIRECTIONS. (i) The shim really is on: an equivalent `shift 2` past the end
+# in a throwaway script DOES print bash's unprefixed diagnostic under the same environment, so a
+# clean sweep above is a property of the script and not of an inert fixture.
+sv_probe="$T/shift-probe.sh"; printf 'set -- one\nshift 2 || true\n' >"$sv_probe"
+sv_ctl=$(env BASHOPTS=shift_verbose bash "$sv_probe" 2>&1)
+if printf '%s\n' "$sv_ctl" | grep -q 'shift count out of range'; then
+  ok "POSITIVE CONTROL: the same environment DOES make bash print an unprefixed shift diagnostic, so the sweep above measured something"
+else
+  bad "shift_verbose did not reach the child at all — the sweep above proves nothing (control output: $sv_ctl)"
+fi
+# (ii) The COUNT guard did not turn a valid option into a usage error.
+sv_ok=$(sv_run "$L34" write 3822 --stage implement); sv_okrc=$?
+sv_ok2=$(sv_run "$L34" write 3822 --clear stage); sv_okrc2=$?
+sv_ok3=$(sv_run "$L34" show 3822); sv_okrc3=$?
+if [ "$sv_okrc" -eq 0 ] && [ "$(verdict_of "$sv_ok")" = WRITTEN ] \
+   && [ "$sv_okrc2" -eq 0 ] && [ "$(verdict_of "$sv_ok2")" = WRITTEN ] \
+   && [ "$sv_okrc3" -eq 0 ] && [ "$(verdict_of "$sv_ok3")" = SHOWN ]; then
+  ok "NON-VACUITY: options WITH their values still work under the same environment (write/--clear/show all succeed)"
+else
+  bad "the count guard rejects valid invocations: write=$sv_okrc/$(verdict_of "$sv_ok") clear=$sv_okrc2/$(verdict_of "$sv_ok2") show=$sv_okrc3/$(verdict_of "$sv_ok3")"
+fi
+
+# ===========================================================================
 case_begin 28-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
 # ===========================================================================
 REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
@@ -1645,6 +1732,7 @@ REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-iss
 29-missing-liveness-library 30-native-diagnostics-stay-anchored
 31-adoption-provenance-survives
 32-failed-scan-is-not-no-match 33-signals-emit-one-verdict
+34-shift-never-leaks-bash-diagnostics
 28-case-floor"
 CASE_FLOOR=31
 executed=0

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -1787,6 +1787,7 @@ unknown-option:USAGE:64
 unknown-subcommand:USAGE:64
 no-subcommand:USAGE:64
 body-carries-sentinel:USAGE:64
+unreadable-body-file:ERROR:1
 absent-marker:ABSENT:3
 marker-not-regular:ERROR:1
 unstamped-marker:UNSTAMPED:8
@@ -1847,6 +1848,13 @@ inv_run() {  # inv_run <row-name> — set the state up, run it, print output, re
     body-carries-sentinel)
       printf 'notes\n%s\nmore\n' "$sentinel" >"$INV_DIR/body-bad.md"
       inv_exec "$d" "$DS" '' "$SESS_A" $$ write 3822 --body-file "$INV_DIR/body-bad.md" ;;
+    unreadable-body-file)
+      # roborev job 37 J2, in the TABLE as well as its own case: a source whose READ fails must
+      # refuse with one anchored token, never commit an empty body.
+      printf 'plan\n' >"$INV_DIR/body-unreadable.md"
+      sd=$(inv_bin cat 'case "$*" in *body-unreadable.md*) exit 1;; esac
+exec '"$(command -v cat)"' "$@"')
+      inv_exec "$d" "$DS" "$sd" "$SESS_A" $$ write 3822 --body-file "$INV_DIR/body-unreadable.md" ;;
     absent-marker)         inv_exec "$d" "$DS" '' "$SESS_A" $$ verify 3822 ;;
     marker-not-regular)    mkdir -p "$d/$MARKER"; inv_exec "$d" "$DS" '' "$SESS_A" $$ verify 3822 ;;
     unstamped-marker)      printf 'legacy plan\n' >"$d/$MARKER"; inv_exec "$d" "$DS" '' "$SESS_A" $$ verify 3822 ;;
@@ -1986,8 +1994,8 @@ else
 fi
 # ROW FLOOR, the same idea as the case floor: a span-replacing edit that silently drops rows
 # otherwise leaves a green tally over a shrunken table.
-if [ "$inv_count" -ge 32 ]; then
-  ok "TABLE FLOOR: $inv_count failure modes exercised (floor 32) — including all four success verdicts, both signal phases and every refusal token"
+if [ "$inv_count" -ge 33 ]; then
+  ok "TABLE FLOOR: $inv_count failure modes exercised (floor 33) — including all four success verdicts, both signal phases and every refusal token"
 else
   bad "table floor breached: only $inv_count rows ran"
 fi
@@ -2671,6 +2679,125 @@ $(cat "$L43h/$MARKER" 2>/dev/null)"
 fi
 
 # ===========================================================================
+case_begin 44-body-file-is-read-not-stat-gated "a --body-file is READ, never stat-gated: a source that changes after validation can never commit an EMPTY body (roborev job 37 J2)"
+# ===========================================================================
+# THE RACE IS MADE DETERMINISTIC BY A SHIM, not by timing: `flock` runs AFTER the caller's body
+# file has been validated and BEFORE the marker is assembled in BOTH the pre-fix and the fixed
+# script, so a shim that truncates (or deletes) the body there lands exactly in the window the
+# finding names. A timing-based version of this test would prove nothing on a fast box.
+j2_real_flock="$(command -v flock || true)"
+j2_real_cat="$(command -v cat || true)"
+j2_shim() {  # j2_shim <op> <victim> — a PATH dir whose `flock` mutates <victim> then defers
+  # SPLIT DECLARATIONS ON PURPOSE: `local a="$1" d="$a"` expands EVERY word before the builtin
+  # assigns any of them, so the second reference is unbound under `set -u` — which made this
+  # helper return empty, the shim never fire, and the FIXED leg pass vacuously. The positive
+  # control is what caught it.
+  local op="$1"
+  local victim="$2"
+  local d="$T/j2-shim-$op-$RANDOM"
+  mkdir -p "$d"
+  {
+    printf '#!/bin/sh\n'
+    case "$op" in
+      truncate) printf ': > "%s"\n' "$victim" ;;
+      delete)   printf 'rm -f "%s"\n' "$victim" ;;
+    esac
+    printf 'exec %s "$@"\n' "$j2_real_flock"
+  } >"$d/flock"
+  chmod +x "$d/flock"
+  printf '%s\n' "$d"
+}
+# THE PRE-FIX ARTIFACT, substituted in a scratch copy (never a settable seam in the shipped
+# script) and VERIFIED to have taken: without it a green here would prove only that the plant
+# does nothing.
+mkdir -p "$T/j2-scratch/lib"
+cp "$SCRIPT_DIR/../flow/lib/process-liveness.sh" "$T/j2-scratch/lib/"
+j2_pre="$T/j2-scratch/drive-issue-state.sh"
+sed -e 's|^    if \[ -n "\$bodyfile" \]; then cat "\$bodyfile" 2>/dev/null; fi$|    if [ -n "$bodyfile" ] \&\& [ -s "$bodyfile" ]; then cat "$bodyfile" 2>/dev/null; fi|' \
+    -e 's|^    body_src="\$body_snap"$|    body_src="$bodyfile"|' "$DS" >"$j2_pre"
+j2_pin=0
+grep -q '^    if \[ -n "\$bodyfile" \] && \[ -s "\$bodyfile" \]; then cat' "$j2_pre" || j2_pin=$((j2_pin + 1))
+grep -q '^    body_src="\$bodyfile"$' "$j2_pre" || j2_pin=$((j2_pin + 1))
+bash -n "$j2_pre" 2>/dev/null || j2_pin=$((j2_pin + 1))
+if [ "$j2_pin" -eq 0 ]; then
+  ok "PRE-FIX FIXTURE: the scratch copy restores BOTH halves of the stat-then-act shape (the -s gate and the un-snapshotted body_src) and still parses"
+else
+  bad "the pre-fix substitution did not take ($j2_pin check(s) failed) — the positive control below would prove nothing"
+fi
+j2_fail=0
+for j2_op in truncate delete; do
+  # --- the FIXED script: the validated bytes reach the marker whatever happens to the source.
+  L44=$(lane "lane44-$j2_op")
+  body44="$T/body44-$j2_op.md"
+  printf '## plan\n\n- step one\n- step two\n' >"$body44"
+  cp "$body44" "$T/body44-$j2_op.orig"
+  sd44=$(j2_shim "$j2_op" "$body44")
+  o44=$( cd "$L44" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+           "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" "PATH=$sd44:$PATH" \
+           bash "$DS" write 3822 --body-file "$body44" 2>&1 ); rc44=$?
+  after_sentinel "$L44/$MARKER" "$T/44-$j2_op-body" || true
+  { printf '\n'; cat "$T/body44-$j2_op.orig"; } >"$T/44-$j2_op-canonical"
+  if [ "$rc44" -eq 0 ] && [ "$(verdict_of "$o44")" = WRITTEN ] \
+     && cmp -s "$T/44-$j2_op-body" "$T/44-$j2_op-canonical"; then
+    ok "a body file ${j2_op}d between validation and the copy still commits the VALIDATED bytes byte-for-byte (verdict WRITTEN)"
+  else
+    j2_fail=$((j2_fail + 1))
+    bad "body ${j2_op} race: rc=$rc44 verdict=$(verdict_of "$o44"); body bytes=$(wc -c <"$T/44-$j2_op-body" 2>/dev/null) want=$(wc -c <"$T/44-$j2_op-canonical")
+$o44"
+  fi
+  # --- the PRE-FIX script under the SAME plant: the body is committed EMPTY, silently.
+  L44p=$(lane "lane44p-$j2_op")
+  body44p="$T/body44p-$j2_op.md"
+  printf '## plan\n\n- step one\n- step two\n' >"$body44p"
+  sd44p=$(j2_shim "$j2_op" "$body44p")
+  o44p=$( cd "$L44p" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+            "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" "PATH=$sd44p:$PATH" \
+            bash "$j2_pre" write 3822 --body-file "$body44p" 2>&1 ); rc44p=$?
+  after_sentinel "$L44p/$MARKER" "$T/44p-$j2_op-body" || true
+  p_bytes=$(LC_ALL=C wc -c <"$T/44p-$j2_op-body" 2>/dev/null | tr -d ' ')
+  if [ "$rc44p" -eq 0 ] && [ "$(verdict_of "$o44p")" = WRITTEN ] && [ "${p_bytes:-0}" -le 1 ]; then
+    ok "POSITIVE CONTROL: the PRE-FIX script under the same ${j2_op} plant reports WRITTEN with an EMPTY body ($p_bytes byte(s)) — the silent data loss is real and the plant reaches it"
+  else
+    j2_fail=$((j2_fail + 1))
+    bad "the positive control did not reproduce the defect (${j2_op}): rc=$rc44p verdict=$(verdict_of "$o44p") body-bytes=$p_bytes"
+  fi
+done
+# --- THE READ-FAILURE PATH ITSELF: a source that cannot be read is a REFUSAL, never an empty
+#     body. Shimmed on `cat` (the snapshot's reader) so the failure is the READ and not a stat.
+L44r=$(lane lane44r)
+body44r="$T/body44r.md"
+printf 'plan text\n' >"$body44r"
+sd44r="$T/j2-shim-cat-$RANDOM"; mkdir -p "$sd44r"
+{
+  printf '#!/bin/sh\n'
+  printf 'case "$*" in *body44r.md*) exit 1;; esac\n'
+  printf 'exec %s "$@"\n' "$j2_real_cat"
+} >"$sd44r/cat"
+chmod +x "$sd44r/cat"
+o44r=$( cd "$L44r" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+          "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" "PATH=$sd44r:$PATH" \
+          bash "$DS" write 3822 --body-file "$body44r" 2>&1 ); rc44r=$?
+if [ "$rc44r" -eq 1 ] && [ "$(verdict_of "$o44r")" = ERROR ] \
+   && [ "$(verdict_count "$o44r")" = 1 ] && all_lines_anchored "$o44r" \
+   && [ ! -f "$L44r/$MARKER" ]; then
+  ok "a --body-file whose READ fails is ERROR(1) with exactly one anchored verdict and NOTHING written — 'could not be read' is never committed as 'there was no body'"
+else
+  j2_fail=$((j2_fail + 1))
+  bad "a failed body read was not refused: rc=$rc44r verdict=$(verdict_of "$o44r") marker=$([ -f "$L44r/$MARKER" ] && echo present || echo absent)
+$o44r"
+fi
+# --- NON-VACUITY: a genuinely EMPTY --body-file is still legal and writes an empty body.
+L44e=$(lane lane44e)
+: >"$T/body44e.md"
+o44e=$(run "$L44e" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 --body-file "$T/body44e.md" 2>&1); rc44e=$?
+if [ "$rc44e" -eq 0 ] && [ "$(verdict_of "$o44e")" = WRITTEN ]; then
+  ok "NON-VACUITY: an EMPTY --body-file is still accepted (an empty source IS an empty body; only a failed READ refuses)"
+else
+  bad "an empty --body-file was refused: rc=$rc44e
+$o44e"
+fi
+
+# ===========================================================================
 case_begin 28-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
 # ===========================================================================
 REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
@@ -2692,8 +2819,8 @@ REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-iss
 39-body-bytes-survive-repeated-writes
 40-worktree-axis-must-be-measurable 41-body-without-trailing-newline
 42-verdict-emission-is-a-critical-section
-43-identity-recorded-losslessly 28-case-floor"
-CASE_FLOOR=43
+43-identity-recorded-losslessly 44-body-file-is-read-not-stat-gated 28-case-floor"
+CASE_FLOOR=44
 executed=0
 for _c in $CASES; do executed=$((executed + 1)); done
 missing=""
@@ -2705,10 +2832,10 @@ if [ "$executed" -ge "$CASE_FLOOR" ] && [ -z "$missing" ]; then
 else
   bad "case floor breached: executed=$executed floor=$CASE_FLOOR missing:$missing"
 fi
-if [ "$PASS" -ge 149 ]; then
-  ok "assertion floor: $PASS assertions passed (>= 149)"
+if [ "$PASS" -ge 156 ]; then
+  ok "assertion floor: $PASS assertions passed (>= 156)"
 else
-  bad "assertion floor breached: only $PASS assertions passed (floor 149)"
+  bad "assertion floor breached: only $PASS assertions passed (floor 156)"
 fi
 
 # ===========================================================================

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -1416,6 +1416,91 @@ else
 fi
 
 # ===========================================================================
+case_begin 32-failed-scan-is-not-no-match "a FAILING sentinel scan is ERROR, never a permissive 'legacy' that overwrites a peer"
+# ===========================================================================
+# roborev job 30 G1. `count_sentinel` collapsed grep's THREE outcomes (0 = matched,
+# 1 = no match, >1 = the scan could not be performed) onto TWO and took the PERMISSIVE
+# answer for the error case: an errored scan counted as ZERO sentinels. With a DISPLACED
+# sentinel that made `marker_class` answer `legacy`, and `write`'s MIGRATION path then
+# DISCARDED AND REPLACED the file — which may be a LIVE PEER's stamped state. That is the
+# exact defect this whole script exists to prevent, arriving through the one branch that is
+# allowed to destroy a marker. CLAUDE.md states the rule this violates: a positive verdict
+# requires an AFFIRMATIVE MEASUREMENT, and a pass is never derived from the ABSENCE of a bad
+# signal (`1699-find-tristate` lints the sibling `[ -z "$(find …)" ]` shape).
+#
+# THE ARTIFACT IS SUBSTITUTED, never a seam: a PATH-shim `grep` that fails ONLY when the file
+# it is asked to scan is the marker itself. A blanket failing `grep` would red the assembled-
+# marker validation instead and never reach the migration branch, i.e. it would pass for the
+# wrong reason.
+G1SHIM="$T/g1bin"; mkdir -p "$G1SHIM"
+{ printf '#!/bin/sh\n'
+  printf 'for a in "$@"; do last="$a"; done\n'
+  printf 'case "$last" in *%s) exit 2 ;; esac\n' "$MARKER"
+  printf 'exec %s "$@"\n' "$(command -v grep)"; } >"$G1SHIM/grep"
+chmod +x "$G1SHIM/grep"
+g1_run() {  # g1_run <dir> <path-prefix|''> <args...>
+  local d="$1" pfx="$2"; shift 2
+  ( cd "$d" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+      "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" ${pfx:+"PATH=$pfx:$PATH"} \
+      bash "$DS" "$@" 2>&1 )
+}
+# The state: a VALID stamp displaced off line 1 (case 25's shape) — the file DOES assert an
+# identity, so misclassifying it as `legacy` is what destroys a peer's plan.
+L32=$(lane lane32)
+run "$L32" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 --stage implement >/dev/null 2>&1
+{ printf '\n'; cat "$L32/$MARKER"; } >"$T/m32" && mv "$T/m32" "$L32/$MARKER"
+cp "$L32/$MARKER" "$T/m32.expected"
+g32_w=$(g1_run "$L32" "$G1SHIM" write 3822 --stage groom); g32_wrc=$?
+if [ "$g32_wrc" -ne 0 ] && [ "$(verdict_of "$g32_w")" = ERROR ] && all_lines_anchored "$g32_w"; then
+  ok "an UNPERFORMABLE sentinel scan makes 'write' REFUSE with an anchored ERROR — the scan's failure is not read as 'no sentinels'"
+else
+  bad "a failed sentinel scan did not refuse: rc=$g32_wrc verdict=$(verdict_of "$g32_w")
+$g32_w"
+fi
+# THE ASSERTION THAT MATTERS: the peer's bytes are still there.
+if cmp -s "$T/m32.expected" "$L32/$MARKER"; then
+  ok "the marker is BYTE-IDENTICAL after the refusal — an unmeasurable classification never reaches the DESTRUCTIVE migration branch"
+else
+  bad "the marker was MODIFIED while its classification was unmeasurable (a peer's state would have been destroyed):
+$(cat "$L32/$MARKER" 2>/dev/null | cat -v)"
+fi
+# The same signal on the READ path: `verify` must not report UNSTAMPED (which tells the caller
+# to run `write`, i.e. to destroy it) when the scan never ran.
+g32_v=$(g1_run "$L32" "$G1SHIM" verify 3822); g32_vrc=$?
+if [ "$g32_vrc" -eq 1 ] && [ "$(verdict_of "$g32_v")" = ERROR ]; then
+  ok "'verify' reports ERROR(1) rather than UNSTAMPED(8) when the scan could not be performed"
+else
+  bad "verify derived a classification from an unperformed scan: rc=$g32_vrc verdict=$(verdict_of "$g32_v")
+$g32_v"
+fi
+# The genuinely UNSTAMPED file takes the same route: the migration branch is entered only on a
+# MEASURED absence of sentinels.
+L32L=$(lane lane32-legacy); printf 'legacy hand-written plan\n' >"$L32L/$MARKER"
+cp "$L32L/$MARKER" "$T/m32l.expected"
+g32_l=$(g1_run "$L32L" "$G1SHIM" write 3822); g32_lrc=$?
+if [ "$g32_lrc" -ne 0 ] && [ "$(verdict_of "$g32_l")" = ERROR ] && cmp -s "$T/m32l.expected" "$L32L/$MARKER"; then
+  ok "the UNSTAMPED migration branch is entered only on a MEASURED absence of sentinels — an unmeasurable one leaves the file untouched"
+else
+  bad "the migration branch ran on an unmeasured scan: rc=$g32_lrc verdict=$(verdict_of "$g32_l")
+$g32_l"
+fi
+# NON-VACUITY: with a WORKING grep the same two states reach their real verdicts, so the
+# refusals above are about the failed scan and not about a broken fixture. FRESH lanes, because
+# a probe that ran against a state an earlier probe may have destroyed proves nothing.
+L32N=$(lane lane32-nv)
+run "$L32N" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" -- write 3822 >/dev/null 2>&1
+{ printf '\n'; cat "$L32N/$MARKER"; } >"$T/m32n" && mv "$T/m32n" "$L32N/$MARKER"
+L32NL=$(lane lane32-nv-legacy); printf 'legacy hand-written plan\n' >"$L32NL/$MARKER"
+g32_nv=$(g1_run "$L32N" "" verify 3822); g32_nvrc=$?
+g32_nl=$(g1_run "$L32NL" "" write 3822); g32_nlrc=$?
+if [ "$g32_nvrc" -eq 8 ] && [ "$(verdict_of "$g32_nv")" = MALFORMED ] \
+   && [ "$g32_nlrc" -eq 0 ] && [ "$(verdict_of "$g32_nl")" = WRITTEN ]; then
+  ok "NON-VACUITY: with a working grep the displaced file is MALFORMED(8) and the unstamped one still MIGRATES — only the unmeasurable case changed"
+else
+  bad "the fixture is broken independently of the shim: displaced rc=$g32_nvrc/$(verdict_of "$g32_nv") legacy rc=$g32_nlrc/$(verdict_of "$g32_nl")"
+fi
+
+# ===========================================================================
 case_begin 28-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
 # ===========================================================================
 REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
@@ -1429,6 +1514,7 @@ REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-iss
 25-displaced-sentinel-is-not-legacy 26-unusable-start-window 27-pre-rename-validation
 29-missing-liveness-library 30-native-diagnostics-stay-anchored
 31-adoption-provenance-survives
+32-failed-scan-is-not-no-match
 28-case-floor"
 CASE_FLOOR=31
 executed=0

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -2798,6 +2798,88 @@ $o44e"
 fi
 
 # ===========================================================================
+case_begin 45-unknown-prologue-keys-survive "an UNRECOGNISED prologue key survives write AND adopt (roborev job 37 J3)"
+# ===========================================================================
+# The parser accepts an unknown key FOR FORWARD COMPATIBILITY. Until now the rewrite path
+# dropped it, so an OLDER copy of this script silently DELETED a field a NEWER one introduced —
+# the same durable-state erasure as a dropped `request-id`. PRESERVE was chosen over REFUSE
+# because refusing would make a newer marker unusable by an older script, bricking every
+# touched lane on a fleet mid-rollout; the header states the choice.
+L45=$(lane lane45)
+sleep 300 & p45=$!
+run "$L45" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$p45" -- \
+    write 3822 --stage implement --request-id req-7 --pr 3837 >/dev/null 2>&1
+# Inject two unknown keys the way a NEWER version of this script would have written them.
+LC_ALL=C awk '/^actor: /{print; print "future-field: keep-me"; print "x-9: v2"; next} {print}' \
+  "$L45/$MARKER" >"$T/45-injected" && cp "$T/45-injected" "$L45/$MARKER"
+u45_w=$(run "$L45" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$p45" -- \
+    write 3822 --stage review 2>&1); u45_wrc=$?
+u45_keep=$(LC_ALL=C grep -c '^future-field: keep-me$' "$L45/$MARKER" || true)
+u45_x=$(LC_ALL=C grep -c '^x-9: v2$' "$L45/$MARKER" || true)
+if [ "$u45_wrc" -eq 0 ] && [ "$(verdict_of "$u45_w")" = WRITTEN ] \
+   && [ "$u45_keep" = 1 ] && [ "$u45_x" = 1 ] \
+   && grep -q '^stage: review$' "$L45/$MARKER" \
+   && grep -q '^request-id: req-7$' "$L45/$MARKER" && grep -q '^pr: 3837$' "$L45/$MARKER"; then
+  ok "a write PRESERVES both unrecognised keys exactly once each, and the known durable fields still behave"
+else
+  bad "unknown keys did not survive a write: rc=$u45_wrc keep=$u45_keep x=$u45_x
+$(cat "$L45/$MARKER")"
+fi
+# A SECOND write must not ACCUMULATE them (the separator/body defect one field over).
+run "$L45" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$p45" -- write 3822 --stage gate >/dev/null 2>&1
+u45_keep2=$(LC_ALL=C grep -c '^future-field: keep-me$' "$L45/$MARKER" || true)
+u45_show=$(run "$L45" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$p45" -- show 3822 2>&1)
+if [ "$u45_keep2" = 1 ] \
+   && printf '%s\n' "$u45_show" | grep -q '^DRIVE-STATE: field unrecognised future-field=keep-me$' \
+   && printf '%s\n' "$u45_show" | grep -q '^DRIVE-STATE: field unrecognised x-9=v2$' \
+   && all_lines_anchored "$u45_show"; then
+  ok "repeated writes neither duplicate nor drop them, and 'show' reports each on an anchored 'field unrecognised' line"
+else
+  bad "accumulation or show gap: occurrences=$u45_keep2
+$u45_show"
+fi
+# ADOPT carries them across a hand-over too.
+kill "$p45" 2>/dev/null; wait "$p45" 2>/dev/null
+u45_a=$(run "$L45" CLAIM_MACHINE=boxA "CLAUDE_CODE_SESSION_ID=$SESS_B" "CLAUDE_PID=$$" -- \
+    adopt 3822 --reason j3-unknown-keys:cron-resume 2>&1); u45_arc=$?
+u45_keep3=$(LC_ALL=C grep -c '^future-field: keep-me$' "$L45/$MARKER" || true)
+u45_x3=$(LC_ALL=C grep -c '^x-9: v2$' "$L45/$MARKER" || true)
+if [ "$u45_arc" -eq 0 ] && [ "$(verdict_of "$u45_a")" = ADOPTED ] \
+   && [ "$u45_keep3" = 1 ] && [ "$u45_x3" = 1 ] \
+   && grep -q "^prior-session: $SESS_A\$" "$L45/$MARKER" \
+   && grep -q '^stage: gate$' "$L45/$MARKER"; then
+  ok "an adopt carries both unrecognised keys across the hand-over, alongside the provenance and the durable fields"
+else
+  bad "unknown keys did not survive an adopt: rc=$u45_arc keep=$u45_keep3 x=$u45_x3
+$u45_a
+$(cat "$L45/$MARKER")"
+fi
+# POSITIVE CONTROL, by artifact substitution: with the carry-forward reverted in a scratch copy,
+# the SAME sequence DELETES both keys — so the assertions above measure the fix, not the fixture.
+mkdir -p "$T/j3-scratch/lib"
+cp "$SCRIPT_DIR/../flow/lib/process-liveness.sh" "$T/j3-scratch/lib/"
+j3_pre="$T/j3-scratch/drive-issue-state.sh"
+sed -e 's|^      unknown="\$S_unknown"$|      unknown=""|' \
+    -e 's|^  local unknown="\$S_unknown"$|  local unknown=""|' "$DS" >"$j3_pre"
+j3_pin=0
+grep -q '^      unknown=""$' "$j3_pre" || j3_pin=$((j3_pin + 1))
+grep -q '^  local unknown=""$' "$j3_pre" || j3_pin=$((j3_pin + 1))
+bash -n "$j3_pre" 2>/dev/null || j3_pin=$((j3_pin + 1))
+L45p=$(lane lane45p)
+( cd "$L45p" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+    "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" bash "$j3_pre" write 3822 --stage implement ) >/dev/null 2>&1
+LC_ALL=C awk '/^actor: /{print; print "future-field: keep-me"; next} {print}' \
+  "$L45p/$MARKER" >"$T/45p-injected" && cp "$T/45p-injected" "$L45p/$MARKER"
+( cd "$L45p" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+    "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" bash "$j3_pre" write 3822 --stage review ) >/dev/null 2>&1
+j3_left=$(LC_ALL=C grep -c '^future-field: keep-me$' "$L45p/$MARKER" || true)
+if [ "$j3_pin" -eq 0 ] && [ "$j3_left" = 0 ]; then
+  ok "POSITIVE CONTROL: with the carry-forward reverted, the same write DELETES the unrecognised key — the silent field loss is real"
+else
+  bad "the positive control did not reproduce the loss: pin-failures=$j3_pin remaining=$j3_left"
+fi
+
+# ===========================================================================
 case_begin 28-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
 # ===========================================================================
 REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
@@ -2819,8 +2901,9 @@ REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-iss
 39-body-bytes-survive-repeated-writes
 40-worktree-axis-must-be-measurable 41-body-without-trailing-newline
 42-verdict-emission-is-a-critical-section
-43-identity-recorded-losslessly 44-body-file-is-read-not-stat-gated 28-case-floor"
-CASE_FLOOR=44
+43-identity-recorded-losslessly 44-body-file-is-read-not-stat-gated
+45-unknown-prologue-keys-survive 28-case-floor"
+CASE_FLOOR=45
 executed=0
 for _c in $CASES; do executed=$((executed + 1)); done
 missing=""
@@ -2832,10 +2915,10 @@ if [ "$executed" -ge "$CASE_FLOOR" ] && [ -z "$missing" ]; then
 else
   bad "case floor breached: executed=$executed floor=$CASE_FLOOR missing:$missing"
 fi
-if [ "$PASS" -ge 156 ]; then
-  ok "assertion floor: $PASS assertions passed (>= 156)"
+if [ "$PASS" -ge 160 ]; then
+  ok "assertion floor: $PASS assertions passed (>= 160)"
 else
-  bad "assertion floor breached: only $PASS assertions passed (floor 156)"
+  bad "assertion floor breached: only $PASS assertions passed (floor 160)"
 fi
 
 # ===========================================================================

--- a/scripts/tests/test_drive_issue_state.sh
+++ b/scripts/tests/test_drive_issue_state.sh
@@ -1718,6 +1718,245 @@ else
 fi
 
 # ===========================================================================
+case_begin 35-one-verdict-per-failure-mode "TABLE: every failure mode emits EXACTLY ONE closed-set verdict token, with the documented exit code"
+# ===========================================================================
+# THE CLASS COVERAGE, not another point fix. Rounds 5 and 6 both found a round-N fix that had
+# reached ONE site of its own class: F1 gave the liveness-library guard a token and left the
+# signal traps without one; F2 captured 21 external commands' stderr and left `shift`'s. What
+# stops that regenerating is not another per-site case but a TABLE over the INVARIANT — so a
+# NEW exit path is covered by adding a ROW, and a new exit path added with no row is what the
+# row-count floor below reds on.
+#
+# The table is EXECUTED ONCE and its outputs are kept on disk, because case 36 asserts a
+# DIFFERENT invariant over the SAME runs: two properties of one observation, never two
+# observations that might disagree about which run they describe.
+INV_DIR="$T/invariants"; mkdir -p "$INV_DIR"
+INV_ROWS="bad-issue:USAGE:64
+missing-option-value:USAGE:64
+unknown-option:USAGE:64
+unknown-subcommand:USAGE:64
+no-subcommand:USAGE:64
+body-carries-sentinel:USAGE:64
+absent-marker:ABSENT:3
+marker-not-regular:ERROR:1
+unstamped-marker:UNSTAMPED:8
+displaced-sentinel:MALFORMED:8
+malformed-marker:MALFORMED:8
+duplicate-sentinel:DUPLICATE-SENTINEL:8
+foreign-issue:FOREIGN-ISSUE:4
+foreign-machine:FOREIGN-MACHINE:4
+foreign-worktree:FOREIGN-WORKTREE:4
+adoptable:ADOPTABLE:5
+live-peer:LIVE-PEER:6
+liveness-unknown:LIVENESS-UNKNOWN:7
+missing-liveness-library:ERROR:1
+failing-sentinel-scan:ERROR:1
+no-flock:ERROR:1
+failing-date:ERROR:1
+failing-mktemp:ERROR:1
+signal-before-rename:ERROR:143
+signal-after-rename:WRITTEN:143
+write-succeeds:WRITTEN:0
+verify-owned:OWNED:0
+show-fields:SHOWN:0
+adopt-succeeds:ADOPTED:0"
+# An unwritable worktree is only measurable when permissions apply to us: root bypasses them,
+# so the row is DECLARED unavailable rather than passing vacuously.
+if [ "$(id -u)" -ne 0 ]; then
+  INV_ROWS="$INV_ROWS
+unwritable-worktree:ERROR:1"
+else
+  ok "DECLARED: the 'unwritable-worktree' row is unavailable under root (permissions are bypassed) — it is omitted rather than asserted vacuously"
+fi
+inv_bin() {  # inv_bin <cmd> <body-line> — a PATH dir holding one shim
+  local c="$1" body="$2" d="$INV_DIR/bin-$1-$$-$RANDOM"
+  mkdir -p "$d"
+  { printf '#!/bin/sh\n'; printf '%s\n' "$body"; } >"$d/$c"
+  chmod +x "$d/$c"
+  printf '%s\n' "$d"
+}
+inv_exec() {  # inv_exec <dir> <script> <shimdir|''> <session> <pid> <args...>
+  local d="$1" sc="$2" sd="$3" ss="$4" sp="$5"; shift 5
+  ( cd "$d" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxA \
+      ${ss:+"CLAUDE_CODE_SESSION_ID=$ss"} ${sp:+"CLAUDE_PID=$sp"} ${sd:+"PATH=$sd:$PATH"} \
+      bash "$sc" "$@" 2>&1 )
+}
+inv_run() {  # inv_run <row-name> — set the state up, run it, print output, return rc
+  local n="$1" d other dead sl scr sd
+  d=$(lane "inv-$n")
+  case "$n" in
+    bad-issue)             inv_exec "$d" "$DS" '' "$SESS_A" $$ verify not-a-number ;;
+    missing-option-value)  inv_exec "$d" "$DS" '' "$SESS_A" $$ write 3822 --stage ;;
+    unknown-option)        inv_exec "$d" "$DS" '' "$SESS_A" $$ verify 3822 --nope ;;
+    unknown-subcommand)    inv_exec "$d" "$DS" '' "$SESS_A" $$ frobnicate ;;
+    no-subcommand)         inv_exec "$d" "$DS" '' "$SESS_A" $$ ;;
+    body-carries-sentinel)
+      printf 'notes\n%s\nmore\n' "$sentinel" >"$INV_DIR/body-bad.md"
+      inv_exec "$d" "$DS" '' "$SESS_A" $$ write 3822 --body-file "$INV_DIR/body-bad.md" ;;
+    absent-marker)         inv_exec "$d" "$DS" '' "$SESS_A" $$ verify 3822 ;;
+    marker-not-regular)    mkdir -p "$d/$MARKER"; inv_exec "$d" "$DS" '' "$SESS_A" $$ verify 3822 ;;
+    unstamped-marker)      printf 'legacy plan\n' >"$d/$MARKER"; inv_exec "$d" "$DS" '' "$SESS_A" $$ verify 3822 ;;
+    displaced-sentinel)
+      inv_exec "$d" "$DS" '' "$SESS_A" $$ write 3822 >/dev/null 2>&1
+      { printf '\n'; cat "$d/$MARKER"; } >"$INV_DIR/t" && mv "$INV_DIR/t" "$d/$MARKER"
+      inv_exec "$d" "$DS" '' "$SESS_A" $$ verify 3822 ;;
+    malformed-marker)
+      inv_exec "$d" "$DS" '' "$SESS_A" $$ write 3822 >/dev/null 2>&1
+      grep -vFx -- "$sentinel_end" "$d/$MARKER" >"$INV_DIR/t" && mv "$INV_DIR/t" "$d/$MARKER"
+      inv_exec "$d" "$DS" '' "$SESS_A" $$ verify 3822 ;;
+    duplicate-sentinel)
+      inv_exec "$d" "$DS" '' "$SESS_A" $$ write 3822 >/dev/null 2>&1
+      { printf '%s\n' "$sentinel"; printf 'issue: 3822\n'; } >>"$d/$MARKER"
+      inv_exec "$d" "$DS" '' "$SESS_A" $$ verify 3822 ;;
+    foreign-issue)
+      inv_exec "$d" "$DS" '' "$SESS_A" $$ write 9999 >/dev/null 2>&1
+      inv_exec "$d" "$DS" '' "$SESS_A" $$ verify 3822 ;;
+    foreign-machine)
+      inv_exec "$d" "$DS" '' "$SESS_A" $$ write 3822 >/dev/null 2>&1
+      ( cd "$d" && env -u CLAUDE_PID -u CLAUDE_CODE_SESSION_ID CLAIM_MACHINE=boxB \
+          "CLAUDE_CODE_SESSION_ID=$SESS_A" "CLAUDE_PID=$$" bash "$DS" verify 3822 2>&1 ) ;;
+    foreign-worktree)
+      other=$(lane "inv-$n-other")
+      inv_exec "$other" "$DS" '' "$SESS_A" $$ write 3822 >/dev/null 2>&1
+      cp "$other/$MARKER" "$d/$MARKER"
+      inv_exec "$d" "$DS" '' "$SESS_A" $$ verify 3822 ;;
+    adoptable | adopt-succeeds)
+      sleep 30 & dead=$!
+      inv_exec "$d" "$DS" '' "$SESS_A" "$dead" write 3822 >/dev/null 2>&1
+      kill "$dead" 2>/dev/null; wait "$dead" 2>/dev/null
+      if [ "$n" = adoptable ]; then
+        inv_exec "$d" "$DS" '' "$SESS_B" $$ verify 3822
+      else
+        inv_exec "$d" "$DS" '' "$SESS_B" $$ adopt 3822 --reason invariant-table:writer-gone
+      fi ;;
+    live-peer)
+      sleep 300 & sl=$!
+      inv_exec "$d" "$DS" '' "$SESS_A" "$sl" write 3822 >/dev/null 2>&1
+      inv_exec "$d" "$DS" '' "$SESS_B" $$ verify 3822; local rc=$?
+      kill "$sl" 2>/dev/null; wait "$sl" 2>/dev/null
+      return "$rc" ;;
+    liveness-unknown)
+      inv_exec "$d" "$DS" '' "$SESS_A" '' write 3822 >/dev/null 2>&1
+      inv_exec "$d" "$DS" '' "$SESS_B" $$ verify 3822 ;;
+    missing-liveness-library)
+      scr="$INV_DIR/nolib"; mkdir -p "$scr"; cp "$DS" "$scr/drive-issue-state.sh"
+      inv_exec "$d" "$scr/drive-issue-state.sh" '' "$SESS_A" $$ verify 3822 ;;
+    failing-sentinel-scan)
+      inv_exec "$d" "$DS" '' "$SESS_A" $$ write 3822 >/dev/null 2>&1
+      { printf '\n'; cat "$d/$MARKER"; } >"$INV_DIR/t" && mv "$INV_DIR/t" "$d/$MARKER"
+      inv_exec "$d" "$DS" "$G1SHIM" "$SESS_A" $$ write 3822 ;;
+    no-flock)
+      sd=$(inv_bin flock 'exit 1')
+      inv_exec "$d" "$DS" "$sd" "$SESS_A" $$ write 3822 ;;
+    failing-date)
+      sd=$(inv_bin date 'echo "date: simulated" >&2; exit 1')
+      inv_exec "$d" "$DS" "$sd" "$SESS_A" $$ write 3822 ;;
+    failing-mktemp)
+      sd=$(inv_bin mktemp 'echo "mktemp: simulated" >&2; exit 1')
+      inv_exec "$d" "$DS" "$sd" "$SESS_A" $$ write 3822 ;;
+    signal-before-rename)
+      inv_exec "$d" "$DS" "$(sig_shim flock before)" "$SESS_A" $$ write 3822 ;;
+    signal-after-rename)
+      inv_exec "$d" "$DS" '' "$SESS_A" $$ write 3822 --stage groom >/dev/null 2>&1
+      # sig_shim's filtered form fires ONCE per shim directory, and case 33 already spent this
+      # one — a shared fixture that silently no-ops is a row that proves nothing, so the
+      # once-stamp is cleared explicitly rather than relied upon to be fresh.
+      sd=$(sig_shim rm before drive-issue-body); rm -f "$sd/fired"
+      inv_exec "$d" "$DS" "$sd" "$SESS_A" $$ write 3822 --stage implement ;;
+    write-succeeds)        inv_exec "$d" "$DS" '' "$SESS_A" $$ write 3822 --stage implement ;;
+    verify-owned)
+      inv_exec "$d" "$DS" '' "$SESS_A" $$ write 3822 >/dev/null 2>&1
+      inv_exec "$d" "$DS" '' "$SESS_A" $$ verify 3822 ;;
+    show-fields)
+      inv_exec "$d" "$DS" '' "$SESS_A" $$ write 3822 >/dev/null 2>&1
+      inv_exec "$d" "$DS" '' "$SESS_A" $$ show 3822 ;;
+    unwritable-worktree)
+      chmod 555 "$d"
+      inv_exec "$d" "$DS" '' "$SESS_A" $$ write 3822; local wrc=$?
+      chmod 755 "$d" 2>/dev/null || true
+      return "$wrc" ;;
+    *) printf 'DRIVE-STATE: verdict UNROUTED-TABLE-ROW\n'; return 99 ;;
+  esac
+}
+inv_names=''
+for row in $INV_ROWS; do
+  nm="${row%%:*}"
+  inv_run "$nm" >"$INV_DIR/$nm.out" 2>&1; printf '%s\n' "$?" >"$INV_DIR/$nm.rc"
+  inv_names="$inv_names $nm"
+done
+inv_fail=0; inv_count=0
+for row in $INV_ROWS; do
+  nm="${row%%:*}"; rest="${row#*:}"; want_v="${rest%%:*}"; want_rc="${rest##*:}"
+  inv_count=$((inv_count + 1))
+  out="$(cat "$INV_DIR/$nm.out")"; rc="$(cat "$INV_DIR/$nm.rc")"
+  why=''
+  [ "$(verdict_count "$out")" = 1 ] || why="$why verdicts=$(verdict_count "$out")"
+  got="$(verdict_of "$out")"
+  verdict_in_set "$got" || why="$why token-outside-closed-set='$got'"
+  [ "$got" = "$want_v" ] || why="$why token=$got(want $want_v)"
+  [ "$rc" = "$want_rc" ] || why="$why rc=$rc(want $want_rc)"
+  if [ -n "$why" ]; then
+    inv_fail=$((inv_fail + 1))
+    printf 'note   row %s ->%s\n%s\n' "$nm" "$why" "$(printf '%s' "$out" | cat -v)"
+  fi
+done
+if [ "$inv_fail" -eq 0 ]; then
+  ok "all $inv_count table rows emit EXACTLY ONE closed-set verdict token with the documented exit code"
+else
+  bad "$inv_fail of $inv_count table rows broke the one-verdict/closed-set/exit-code invariant"
+fi
+# ROW FLOOR, the same idea as the case floor: a span-replacing edit that silently drops rows
+# otherwise leaves a green tally over a shrunken table.
+if [ "$inv_count" -ge 29 ]; then
+  ok "TABLE FLOOR: $inv_count failure modes exercised (floor 29) — including all four success verdicts, both signal phases and every refusal token"
+else
+  bad "table floor breached: only $inv_count rows ran"
+fi
+# COMPLETENESS AGAINST THE GRAMMAR: every token in the CLOSED set must be produced by some row,
+# so a verdict added to the script without a row here reds instead of joining uncovered.
+inv_missing=''
+for t in $VERDICT_SET; do
+  found=0
+  for row in $INV_ROWS; do
+    nm="${row%%:*}"; [ "$(verdict_of "$(cat "$INV_DIR/$nm.out")")" = "$t" ] && { found=1; break; }
+  done
+  [ "$found" -eq 1 ] || inv_missing="$inv_missing $t"
+done
+if [ -z "$inv_missing" ]; then
+  ok "every token in the CLOSED verdict set is actually produced by a row in this table"
+else
+  bad "verdict tokens produced by NO row (a token joined the grammar uncovered):$inv_missing"
+fi
+
+# ===========================================================================
+case_begin 36-anchor-holds-on-every-stream "TABLE: the DRIVE-STATE: anchor holds on stdout AND stderr for every failure mode"
+# ===========================================================================
+# The second invariant over the SAME observations case 35 recorded. Contract (a) and contract
+# (c) are independent — round 5's F1 was a line that satisfied (a) and not (c) — so they get
+# independent assertions rather than one combined check that could pass on either.
+anch_fail=0; anch_rows=0; anch_lines=0
+for row in $INV_ROWS; do
+  nm="${row%%:*}"
+  anch_rows=$((anch_rows + 1))
+  out="$(cat "$INV_DIR/$nm.out")"
+  anch_lines=$((anch_lines + $(printf '%s\n' "$out" | grep -c '' || true)))
+  if all_lines_anchored "$out"; then :; else
+    anch_fail=$((anch_fail + 1))
+    printf 'note   row %s emitted an UNPREFIXED line:\n%s\n' "$nm" "$(printf '%s' "$out" | grep -v '^DRIVE-STATE: ' | grep -v '^$' | cat -v)"
+  fi
+done
+if [ "$anch_fail" -eq 0 ]; then
+  ok "no unprefixed line on stdout+stderr combined across all $anch_rows table rows"
+else
+  bad "$anch_fail of $anch_rows rows emitted at least one line without the DRIVE-STATE: anchor"
+fi
+if [ "$anch_lines" -ge 60 ]; then
+  ok "NON-VACUITY: $anch_lines output lines were actually inspected — the sweep is not passing on empty output"
+else
+  bad "only $anch_lines lines were inspected across $anch_rows rows: the rows cannot have produced real output"
+fi
+
+# ===========================================================================
 case_begin 28-case-floor "CASE FLOOR: a silently shrunken suite must RED, not green (#3544)"
 # ===========================================================================
 REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-issue 4-foreign-machine
@@ -1732,9 +1971,9 @@ REQUIRED_CASES="1-write-verify-owned 2-ac3-unstamped-prose-refused 3-foreign-iss
 29-missing-liveness-library 30-native-diagnostics-stay-anchored
 31-adoption-provenance-survives
 32-failed-scan-is-not-no-match 33-signals-emit-one-verdict
-34-shift-never-leaks-bash-diagnostics
-28-case-floor"
-CASE_FLOOR=31
+34-shift-never-leaks-bash-diagnostics 35-one-verdict-per-failure-mode
+36-anchor-holds-on-every-stream 28-case-floor"
+CASE_FLOOR=36
 executed=0
 for _c in $CASES; do executed=$((executed + 1)); done
 missing=""
@@ -1746,8 +1985,8 @@ if [ "$executed" -ge "$CASE_FLOOR" ] && [ -z "$missing" ]; then
 else
   bad "case floor breached: executed=$executed floor=$CASE_FLOOR missing:$missing"
 fi
-if [ "$PASS" -ge 83 ]; then
-  ok "assertion floor: $PASS assertions passed (>= 83)"
+if [ "$PASS" -ge 100 ]; then
+  ok "assertion floor: $PASS assertions passed (>= 100)"
 else
   bad "assertion floor breached: only $PASS assertions passed"
 fi


### PR DESCRIPTION
Closes #3822.

## What was wrong

`.drive-issue-state.md` — the durable per-lane state marker `/drive-issue` rehydrates from — carried no
ownership stamp, so a session rehydrating in a shared or reused worktree could adopt a **peer's** plan
wholesale.

Recon turned up the load-bearing fact: **the marker had no writer and no reader anywhere in the repo.**
It existed only as prose in `.claude/commands/drive-issue.md:54,74`. So AC3's "a test" was not
satisfiable against the existing shape — an instruction to an LLM is untestable, and a docs-only diff
cannot be roborev-certified at all. The fix therefore mechanizes the marker and updates the doctrine to
call it, in one diff.

## The axis split — the load-bearing decision

AC2 read literally ("verify against the current machine/**session**, fail closed on a mismatch") would
red **every legitimate resume**: the Delta 3 cron re-invoke can carry a new `CLAUDE_CODE_SESSION_ID` in
the same lane on the same issue, which is the marker's *intended consumer*. A guard that reds on correct
input is the guard agents learn to waive. So:

- **Fail-closed axes** — `issue`, `machine`, `worktree`. Stable across a legitimate resume, distinct
  across lanes. Each refusal NAMES its axis.
- **Session axis** — recorded per AC1, but a session difference alone is resolved by the **liveness of
  the recorded writer**, three-valued on `claim-heartbeat.sh dead-lanes`' precedent: provably GONE ⇒
  `ADOPTABLE` and `verify` still exits non-zero (adoption is an explicit `adopt` gesture that records
  the prior session, never implicit inheritance); provably ALIVE ⇒ `LIVE-PEER`, which **`adopt` also
  refuses** (an adopt that ignores liveness is a mute button for the whole guard); UNMEASURABLE ⇒
  `LIVENESS-UNKNOWN`, refused, because a positive verdict requires an affirmative measurement.

The pid recorded is the **session's** (`CLAUDE_PID`) with **no `$$` fallback**: `$$` is the transient
bash that exits immediately, so recording it would make a LIVE peer read as DEAD seconds later — the
exact false-permissive this issue exists to close. PID reuse is defeated by requiring the live pid's
start window to still intersect the recorded one.

The stamp is a **bounded prologue** (exact first-line sentinel, `key: value` at column zero, exact end
sentinel), so identity is never grepped out of the free-form body — #3312's rule. A body line
reproducing a sentinel at column zero is REFUSED at write time (refused, not escaped: a structural
source assert cannot see what a runtime value injects), and a duplicate sentinel is its own read-time
refusal.

## Acceptance criteria

| AC | Where |
|---|---|
| 1. Every write records machine, session, actor | `drive-issue-state.sh write` — plus issue, worktree, session pid + start window |
| 2. Rehydration verifies and fails closed / requires an adopt gesture | `verify`; closed verdict set, exit codes 0/1/3/4/5/6/7/8/64 |
| 3. A test shows the mismatch path RED before, named refusal after | `scripts/tests/test_drive_issue_state.sh` — RED **verified at `5d34025f0`** in a detached worktree: 32 FAIL / 2 PASS with the script absent; 58 assertions PASS after |

## Shared liveness primitives

The five three-valued liveness primitives moved **verbatim** out of `claim-heartbeat.sh` into
`scripts/flow/lib/process-liveness.sh`, sourced by both consumers (a missing library is FATAL in both,
never a silent degrade). Those functions carry many rounds of review findings — zombies, EPERM, PID
reuse — and a second copy is a second place to lose them. Behavioural proof the move was verbatim:
`test_claim_heartbeat.sh` still **183 passed / 0 failed**.

## Review record

- **roborev job 18** (`gpt-5.6-sol`): FAIL, 4 findings — genuine review, 463k input / 399k cached, every
  deterministic key PASS. All four fixed: the `for f in $TMP_FILES` split-and-glob into `rm -f` (now an
  indexed array), `adopt` dropping `request-id`/`pr`/`branch`, the unserialized verify→`mv`, and a
  root-only test case that never reached the path it claimed.
- **One blocker found by dogfooding, not by review**: `UNSTAMPED` was a **dead letter** — `write`
  refused, `adopt` refused, and the diagnostic advertised `write` as the remedy. Since every lane on the
  fleet carries an unstamped marker today, that bricked the marker path fleet-wide on rollout. `write`
  now migrates an unstamped marker (which asserts no ownership, so refusing protected no identifiable
  party), **discarding** its body rather than preserving it — silently carrying a foreign plan forward is
  the defect itself — and announcing the discard with line/byte counts. Generalized into a
  `22-no-dead-letter-remedies` case so no verdict can advertise a subcommand that refuses on that state.
- `--lite`: **PASS** at `94e966c`, tree-integrity PASS, `dirty: no`.
- Serialization is pinned on **behaviour with a positive control**: with `lock_marker` neutered the
  two-adopter scenario produces `ADOPTED / ADOPTED`, so the assertion discriminates the fix rather than
  passing for free.

## Wiring

`test_drive_issue_state.sh` joins the **existing** `tooling-tests` component (both the announce line and
the `&&`-chain) — no new gate component, so no `agent-gate.components` regeneration. Doctrine updated in
`.claude/commands/drive-issue.md` (per-verdict resume actions) and `CLAUDE.md` (the axis split and why the
session axis is liveness-resolved rather than fail-closed — the reasoning a future agent would otherwise
undo).

Out of scope, deliberately: **#3810**, the claim-actor half of this identity gap, is untouched.
