### PR TITLE
fix(#3772): stop quoting a hard-coded jest suite count in the gate and jest config (slice 1/2)

### DIFF
--- a/bindings/node/jest.config.js
+++ b/bindings/node/jest.config.js
@@ -22,11 +22,12 @@
  *     before adding a second lane that selects this project: two executions where
  *     only one is affirmed is what the recomposition removed.
  *
- *     NO FILE COUNT IS QUOTED (issue #3772). This note used to end "measured via
- *     `jest --listTests`: 28 files, no duplicates", repeating a number
- *     `scripts/agent-gate.sh` carried in four more places; the suite grew and every
- *     copy went stale, so the sentence asserted a false measurement in the one place
- *     a reader checks this composition against. Nothing here needs the count: the
+ *     NO FILE COUNT IS QUOTED (issue #3772). This note used to end with a hard-coded
+ *     file count "measured via `jest --listTests`", asserted as duplicate-free —
+ *     repeating a number `scripts/agent-gate.sh` carried in four more places; the
+ *     suite grew and every copy went stale, so the sentence asserted a false
+ *     measurement in the one place a reader checks this composition against. Nothing
+ *     here needs the count: the
  *     `node-bindings` gate component DERIVES it every run from two independent
  *     oracles and prints `suite set RECONCILED: N`.
  *

--- a/bindings/node/jest.config.js
+++ b/bindings/node/jest.config.js
@@ -17,11 +17,30 @@
  *     own (`--selectProjects leaks`, used by `npm run test:leaks`) and so a future
  *     lane-only option has somewhere to live. NOTE (round 9): a bare `npm test` runs
  *     BOTH projects, so the gate's whole-suite run already executes the leak file
- *     exactly once — measured via `jest --listTests`: 28 files, no duplicates. The
- *     gate therefore does NOT invoke `test:leaks`; it affirms the budget tests by
- *     name from the whole-suite `--json` report. Keep that in mind before adding a
- *     second lane that selects this project: two executions where only one is
- *     affirmed is what the recomposition removed.
+ *     exactly once. The gate therefore does NOT invoke `test:leaks`; it affirms the
+ *     budget tests by name from the whole-suite `--json` report. Keep that in mind
+ *     before adding a second lane that selects this project: two executions where
+ *     only one is affirmed is what the recomposition removed.
+ *
+ *     NO FILE COUNT IS QUOTED (issue #3772). This note used to end "measured via
+ *     `jest --listTests`: 28 files, no duplicates", repeating a number
+ *     `scripts/agent-gate.sh` carried in four more places; the suite grew and every
+ *     copy went stale, so the sentence asserted a false measurement in the one place
+ *     a reader checks this composition against. Nothing here needs the count: the
+ *     `node-bindings` gate component DERIVES it every run from two independent
+ *     oracles and prints `suite set RECONCILED: N`.
+ *
+ *     The "no duplicates" half was worse than stale — it named an oracle that cannot
+ *     see the violation. Measured on jest 29.7.0 (#3772), two projects both matching
+ *     one file: `jest --listTests` prints it ONCE while the run reports
+ *     `Test Suites: 2 passed, 2 total`. Deleting the `testPathIgnorePatterns` entry
+ *     below leaves this package's `--listTests` output unchanged, too. What actually
+ *     catches a double execution is the gate comparing jest's reported suite TOTAL
+ *     against the DEDUPLICATED disk inventory, plus the leak affirmation's refusal on
+ *     two suites at the leak path. So: if you change the projects' `testMatch` or the
+ *     ignore list, do not reason about it from `--listTests` — run the suite and read
+ *     the total. If you need today's file count, run `--listTests`; do not write the
+ *     answer down here.
  *
  * WHY NO `detectOpenHandles`/`detectLeaks` ANYWHERE (measured on jest 29.7.0, not
  * assumed):

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1894,13 +1894,13 @@ _fixture_status() {
 # leak budgets exactly once, and the second invocation was pure duplication.
 #
 # NO FILE COUNT IS QUOTED HERE, DELIBERATELY (issue #3772). This argument used to rest
-# on a one-off measurement -- "the all-projects list is 28 files with NO duplicates" --
-# and the suite then grew past it while the sentence stayed at 28. A stale number inside
-# the rationale for a composition decision is the failure mode CLAUDE.md names: a false
+# on a one-off measurement -- a hard-coded file count, asserted as "no duplicates" -- and
+# the suite then grew past it while the sentence stood still. A stale number inside the
+# rationale for a composition decision is the failure mode CLAUDE.md names: a false
 # statement in a gate log (or in the comment a reader checks it against) is worse than
-# none, because it is what stops the next person looking. Replacing 28 with today's
-# count would only restart the same clock -- which is why no number, not even the
-# current one and not even in this explanation, appears here or in the census.
+# none, because it is what stops the next person looking. Writing today's count here
+# instead would only restart the same clock, so no number appears -- not the old one,
+# not the current one, and not as an illustration inside this explanation.
 #
 # The number was never load-bearing, because both halves of the claim are DERIVED and
 # ENFORCED on every run -- which is what makes deleting it safe rather than a loss:
@@ -10830,11 +10830,11 @@ run_node_bindings() {
   census+=("       quoted: the file count is reconciled and printed below as \"suite set")
   census+=("       RECONCILED: N\", and a DOUBLE execution would fail check_jest_suites_ran (jest")
   census+=("       reported total vs the DEDUPLICATED disk inventory) and the affirmation itself")
-  census+=("       (suites.length !== 1 at the leak path). This line used to state \"28 files with")
-  census+=("       no duplicates\" as a measurement; it had gone stale as the suite grew, and its")
-  census+=("       cited oracle could not see a duplicate anyway (jest --listTests DEDUPES across")
-  census+=("       projects — measured, #3772). No replacement count is quoted, here or in the")
-  census+=("       jest config: a fresh one would only restart the same decay.")
+  census+=("       (suites.length !== 1 at the leak path). This line used to carry a hard-coded")
+  census+=("       file count asserted as duplicate-free; it had gone stale as the suite grew,")
+  census+=("       and its cited oracle could not see a duplicate anyway (jest --listTests")
+  census+=("       DEDUPES across projects — measured, #3772). No count is printed here now, in")
+  census+=("       either direction: a fresh one would only restart the same decay.")
   census+=("       Budgets run STRICT here: CQLITE_LEAK_BUDGET_RELAX is UNSET for every node")
   census+=("       invocation of this component (#1465 V1), so no inherited value — including a")
   census+=("       CI runner env — can double a ceiling in the gate of record.")

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -9885,9 +9885,10 @@ export -f check_unittest_targets_ran
 #
 # The jest ANALOGUE of check_unittest_targets_ran (issue #3522). A green `npm test` exit
 # is not evidence that anything ran: a suite whose every TEST is `test.skip`ped is
-# reported as a PASSED suite, so `Test Suites: 27 passed, 27 total` is reachable over
-# zero real assertions — the vacuous green this whole issue exists to remove, arriving
-# through the widened lane's own plumbing. (Jest's suite-level `skipped` count is a
+# reported as a PASSED suite, so a `Test Suites: N passed, N total` line covering EVERY
+# suite is reachable over zero real assertions — the vacuous green this whole issue
+# exists to remove, arriving through the widened lane's own plumbing. (The illustration
+# named a literal count until #3772; it was stale, and an EXAMPLE does not need one.) (Jest's suite-level `skipped` count is a
 # DIFFERENT and weaker signal: it catches a whole FILE being skipped, not a file whose
 # every test was. That is why the two are separate directions below rather than one.)
 #
@@ -10856,9 +10857,11 @@ run_node_bindings() {
   census+=("       below as \"suite set RECONCILED: N\"; and that the leak file executed EXACTLY")
   census+=("       ONCE — zero or twice would fail check_jest_suites_ran (jest reported total vs")
   census+=("       the DEDUPLICATED disk inventory) and the affirmation itself (suites.length")
-  census+=("       !== 1 at the leak path). Jest PROJECT identities are NOT checked by either")
-  census+=("       guard; both projects running is inferred from the leak file having executed,")
-  census+=("       which is weaker and is stated as such. This line used to carry a hard-coded")
+  census+=("       !== 1 at the leak path). No guard reads a jest PROJECT identity; that both")
+  census+=("       projects ran follows from the config plus the COMPLETE per-suite results —")
+  census+=("       the leak file evidences the leaks project, and the OTHER reconciled suites")
+  census+=("       evidence the default one. Neither half evidences the other. This line used")
+  census+=("       to carry a hard-coded")
   census+=("       file count asserted as duplicate-free; it had gone stale as the suite grew,")
   census+=("       and its cited oracle could not see a duplicate anyway (jest --listTests")
   census+=("       DEDUPES across projects — measured, #3772). No count is printed here now, in")

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1889,9 +1889,20 @@ _fixture_status() {
 # and #1465 had wired its exception-path/abandoned-iterator LEAK BUDGETS in as a
 # SECOND jest invocation (`npm run test:leaks`). Composed naively that runs the leak
 # budgets TWICE per component. Under the two-project jest config #1465 introduced a
-# bare `npm test` runs BOTH projects, and the all-projects `--listTests` set contains
-# leak-paths.test.js EXACTLY ONCE -- so #3522's whole-suite run already executes the
-# leak budgets exactly once, and the second invocation was pure duplication.
+# bare `npm test` runs BOTH projects, and the `testPathIgnorePatterns` entry in the
+# `default` project hands leak-paths.test.js to the `leaks` project ALONE -- so exactly
+# one project matches it, #3522's whole-suite run already executes the leak budgets
+# exactly once, and the second invocation was pure duplication.
+#
+# THAT "EXACTLY ONCE" IS GROUNDED IN THE CONFIG PLUS TWO RUN-TIME CHECKS, AND
+# DELIBERATELY NOT IN `--listTests` (#3772). An earlier draft of this very comment
+# cited the `--listTests` set as the evidence -- while the paragraph below it explains
+# that `--listTests` DEDUPLICATES and therefore cannot see a double execution at all.
+# The evidence is: the project exclusion above (config), `check_jest_suites_ran`'s
+# suite-TOTAL comparison, and the JSON affirmation's refusal on two suites at the leak
+# path (both run time). Naming the wrong oracle is the exact defect this issue is
+# about, so it is worth saying twice: reason about execution multiplicity from the
+# RUN, never from the listing.
 #
 # NO FILE COUNT IS QUOTED HERE, DELIBERATELY (issue #3772). This argument used to rest
 # on a one-off measurement -- a hard-coded file count, asserted as "no duplicates" -- and
@@ -10838,13 +10849,16 @@ run_node_bindings() {
   census+=("  AFFIRMED BY NAME (#1465): the 2 exception-path/abandoned-iterator LEAK BUDGET tests")
   census+=("       inside leak-paths.test.js, checked from this run's own jest --json report. The")
   census+=("       suite guards judge the file set and per-suite work; only this one knows WHICH")
-  census+=("       tests must have passed. ONE executor: the npm test above, which runs BOTH jest")
-  census+=("       projects and so executes the leak file exactly once — npm run test:leaks is a")
-  census+=("       human/debug entry point, not a lane. Both facts are DERIVED on this run, never")
-  census+=("       quoted: the file count is reconciled and printed below as \"suite set")
-  census+=("       RECONCILED: N\", and a DOUBLE execution would fail check_jest_suites_ran (jest")
-  census+=("       reported total vs the DEDUPLICATED disk inventory) and the affirmation itself")
-  census+=("       (suites.length !== 1 at the leak path). This line used to carry a hard-coded")
+  census+=("       tests must have passed. ONE executor: the npm test above (a bare npm test runs")
+  census+=("       both jest projects, and the config hands the leak file to exactly one of")
+  census+=("       them), so npm run test:leaks is a human/debug entry point, not a lane. What")
+  census+=("       THIS RUN establishes, rather than asserts: the reconciled file count, printed")
+  census+=("       below as \"suite set RECONCILED: N\"; and that the leak file executed EXACTLY")
+  census+=("       ONCE — zero or twice would fail check_jest_suites_ran (jest reported total vs")
+  census+=("       the DEDUPLICATED disk inventory) and the affirmation itself (suites.length")
+  census+=("       !== 1 at the leak path). Jest PROJECT identities are NOT checked by either")
+  census+=("       guard; both projects running is inferred from the leak file having executed,")
+  census+=("       which is weaker and is stated as such. This line used to carry a hard-coded")
   census+=("       file count asserted as duplicate-free; it had gone stale as the suite grew,")
   census+=("       and its cited oracle could not see a duplicate anyway (jest --listTests")
   census+=("       DEDUPES across projects — measured, #3772). No count is printed here now, in")

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -10651,6 +10651,20 @@ EOF
 # full suite adds ~15–35s on top of it — 504 passing tests across 27/27 suites, green
 # on two consecutive runs. That is not a cost worth 26 suites of blindness.
 #
+# THE COUNTS IN THE TWO PARAGRAPHS ABOVE ARE DATED MEASUREMENTS AND ARE KEPT ON PURPOSE
+# (issue #3772, which removed the stale ones elsewhere in this file). The line #3772
+# draws, so that a later reader does not "finish the job" by deleting these too:
+#   * a claim about WHAT IS TRUE NOW ("the list is N files", "they agree at N today")
+#     decays the moment a test file is added, so it is never written down -- every such
+#     claim in this component is DERIVED at run time instead;
+#   * a claim about WHAT WAS MEASURED THEN, attributed to the change that measured it
+#     (#1255 narrowed to 1 of 27; #3522 measured 504 passing tests across 27/27 and
+#     ~15-35s), is a dated record of a past state. It stays true however the suite
+#     grows, exactly like the measurement in a commit message, and deleting it would
+#     destroy the evidence for a decision rather than refresh it.
+# If you are unsure which kind you are writing: if adding one test file would make the
+# sentence false, it is the first kind -- derive it or drop it.
+#
 # THE CORPUS HALF IS NOW HONOURED, NOT AVOIDED — AND THE REASON IS NOT THE ONE THIS
 # COMMENT FIRST GAVE (roborev/rust-reviewer round 1, B4). 14 of the suite's files gate on
 # dataset availability, so node-bindings IS now in DATASET_COMPONENTS (it was NOT before,
@@ -10860,9 +10874,11 @@ run_node_bindings() {
   # WHY TWO, AND WHY ONE WAS NOT ENOUGH (roborev round 3, D1). `jest --listTests` is the
   # right oracle for the ACTUAL set — it applies this package's `testMatch`
   # (`**/__test__/**/*.test.js`, RECURSIVE) and jest's ignore patterns, which a
-  # `find -maxdepth 1` cannot reproduce (it agrees at 27 today and would silently
-  # UNDERCOUNT the day a subdirectory appears, false-redding healthy code). That argument
-  # stands and is why the find below is RECURSIVE and is NOT used to select what runs.
+  # `find -maxdepth 1` cannot reproduce: it agrees with jest's list for as long as
+  # __test__/ stays flat, and would silently UNDERCOUNT the day a subdirectory appears,
+  # false-redding healthy code. That argument stands and is why the find below is
+  # RECURSIVE and is NOT used to select what runs. (No count stated -- #3772: a
+  # "they agree at N today" is a claim about TODAY, and this one had gone stale.)
   #
   # But using it as the EXPECTED count too made the guard SELF-REFERENTIAL: the expectation
   # and the run both flow from jest's configuration, so a `testMatch` narrowing or an added
@@ -11211,8 +11227,9 @@ run_node_bindings() {
       cd "'"$REPO_ROOT"'/bindings/node"
       npm test -- --json --outputFile="$CQLITE_JEST_JSON"' >>"$log" 2>&1; then
     # A green `npm test` is NOT sufficient: jest reports a suite whose every describe
-    # was skipped as PASSED, so the exit code alone cannot distinguish 27 suites of
-    # assertions from 27 suites of nothing.
+    # was skipped as PASSED, so the exit code alone cannot distinguish a full suite of
+    # assertions from the same number of suites containing nothing. (The argument never
+    # needed a count and no longer states one -- #3772.)
     # BOTH halves are required and neither implies the other (roborev round 5, F1):
     # check_jest_suites_ran judges the FILE SET and the aggregate counts;
     # check_jest_per_suite_passed judges whether EACH reconciled suite did any work. A suite

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1888,11 +1888,43 @@ _fixture_status() {
 # #3522 widened node-bindings from one jest file to the WHOLE suite via `npm test`,
 # and #1465 had wired its exception-path/abandoned-iterator LEAK BUDGETS in as a
 # SECOND jest invocation (`npm run test:leaks`). Composed naively that runs the leak
-# budgets TWICE per component. MEASURED with `./node_modules/.bin/jest --listTests`
-# under the two-project jest config #1465 introduced: the all-projects list is 28
-# files with NO duplicates and it INCLUDES leak-paths.test.js, so #3522's whole-suite
-# run already executes the leak budgets exactly once. The second invocation was pure
-# duplication.
+# budgets TWICE per component. Under the two-project jest config #1465 introduced a
+# bare `npm test` runs BOTH projects, and the all-projects `--listTests` set contains
+# leak-paths.test.js EXACTLY ONCE -- so #3522's whole-suite run already executes the
+# leak budgets exactly once, and the second invocation was pure duplication.
+#
+# NO FILE COUNT IS QUOTED HERE, DELIBERATELY (issue #3772). This argument used to rest
+# on a one-off measurement -- "the all-projects list is 28 files with NO duplicates" --
+# and the suite then grew past it while the sentence stayed at 28. A stale number inside
+# the rationale for a composition decision is the failure mode CLAUDE.md names: a false
+# statement in a gate log (or in the comment a reader checks it against) is worse than
+# none, because it is what stops the next person looking. Replacing 28 with today's
+# count would only restart the same clock -- which is why no number, not even the
+# current one and not even in this explanation, appears here or in the census.
+#
+# The number was never load-bearing, because both halves of the claim are DERIVED and
+# ENFORCED on every run -- which is what makes deleting it safe rather than a loss:
+#   * the COUNT is reconciled in run_node_bindings from two INDEPENDENT oracles (a
+#     recursive find over __test__/ vs `jest --listTests`) and PRINTED as
+#     `suite set RECONCILED: N *.test.js file(s)`;
+#   * DOUBLE EXECUTION is caught by check_jest_suites_ran's `s_total -eq expected`:
+#     `expected` is the DEDUPLICATED inventory, so a file BOTH projects match makes
+#     jest report one suite MORE than the inventory holds, and FAILs;
+#   * leak-paths.test.js being executed EXACTLY ONCE is enforced by the affirmation
+#     below, which refuses outright on `suites.length !== 1` at that path.
+#
+# AND THE DELETED SENTENCE NAMED THE WRONG ORACLE, which is the better reason to
+# delete it than the stale count (measured on jest 29.7.0, #3772 -- two projects whose
+# testMatch both select one file):
+#     jest --listTests  ->  __test__/probe.test.js          (ONE line)
+#     jest             ->  Test Suites: 2 passed, 2 total   (executed TWICE)
+# `--listTests` DEDUPLICATES across projects, so it can never report the duplicate it
+# was cited as having ruled out; and the `sort -u` normalisation in run_node_bindings'
+# reconciliation would erase one anyway. Verified against this package too: deleting
+# the `testPathIgnorePatterns` entry that hands the leak file to the `leaks` project
+# leaves `--listTests` unchanged. So "no duplicates, measured via --listTests" was
+# unfalsifiable by its own stated method -- the run's suite TOTAL is the only oracle
+# that sees it. A number nobody re-measures is the smaller half of that defect.
 #
 # So there is ONE executor -- #3522's `npm test` -- and #1465 keeps the thing that
 # made its lane merge-gating rather than decorative: the NAMED-BUDGET AFFIRMATION,
@@ -1933,10 +1965,13 @@ abandoned streaming iterators stay under the leak budget"
 _NODE_LEAK_BUDGET_TITLE_SUFFIX="stay under the leak budget"
 
 # The SUITE the budget tests must live in. Load-bearing since the recomposition
-# (#1465 round 10, roborev R2): the affirmation now reads the WHOLE-SUITE report (28
-# suites), so a title namespace that was private to one file became shared. Without
-# this scope a same-titled `passed` test in ANY other suite would satisfy the
-# affirmation for a leak test that was skipped or failed.
+# (#1465 round 10, roborev R2): the affirmation now reads the WHOLE-SUITE report (every
+# suite, not just this one), so a title namespace that was private to one file became
+# shared. Without this scope a same-titled `passed` test in ANY other suite would
+# satisfy the affirmation for a leak test that was skipped or failed. (The suite count
+# is deliberately not quoted -- see the composition header above, issue #3772: what
+# makes the scope necessary is that the report covers OTHER suites at all, not how
+# many.)
 #
 # REPO-RELATIVE and matched with a LEADING SLASH (round 11, T1): a bare
 # `__test__/leak-paths.test.js` tail was satisfied by a file of that name in ANOTHER
@@ -1960,9 +1995,10 @@ _node_leak_lane_note() { # <RUN|SKIP-OPTOUT|NO-NODE|NOT-REACHED|ENTERED-FAILED|
                          # `AGENT_GATE_ALLOW_MISSING_FIXTURES=1 && !
                          # _node_bindings_corpus_present` branch governs, ALONE. It is
                          # strictly earlier (before `npm ci`) and strictly coarser (it
-                         # skips all 28 suites), so a second, lane-level dataset gate
-                         # could only ever be unreachable code that looks like a
-                         # control. #1465's own `_node_leak_lane_status` predicate was
+                         # skips the WHOLE suite, not just this lane -- #3772: no
+                         # count quoted, the coarseness is what matters), so a
+                         # second, lane-level dataset gate could only ever be
+                         # unreachable code that looks like a control. #1465's own `_node_leak_lane_status` predicate was
                          # therefore DELETED, not kept as a decoration; what remains is
                          # this note, which that branch writes as SKIP-OPTOUT so the
                          # SUMMARY still declares the leak budgets did not run.
@@ -2033,8 +2069,8 @@ _node_leak_lane_affirm() { # <note-file> <json-file>
           process.exit(1);
         }
         // SUITE-SCOPED (roborev R2): only assertions from the leak suite count. The
-        // report covers all 28 suites, so an unscoped title match would let another
-        // suite satisfy this check.
+        // report covers the WHOLE suite, so an unscoped title match would let another
+        // suite satisfy this check. (No file count quoted -- #3772.)
         const anchored = `/${suiteFile}`;
         const suites = (report.testResults || []).filter((s) =>
           typeof s.name === "string" && s.name.endsWith(anchored)
@@ -10788,9 +10824,17 @@ run_node_bindings() {
   census+=("  AFFIRMED BY NAME (#1465): the 2 exception-path/abandoned-iterator LEAK BUDGET tests")
   census+=("       inside leak-paths.test.js, checked from this run's own jest --json report. The")
   census+=("       suite guards judge the file set and per-suite work; only this one knows WHICH")
-  census+=("       tests must have passed. ONE executor: the npm test above (measured — the")
-  census+=("       all-projects jest --listTests is 28 files with no duplicates and includes the")
-  census+=("       leak file), so npm run test:leaks is a human/debug entry point, not a lane.")
+  census+=("       tests must have passed. ONE executor: the npm test above, which runs BOTH jest")
+  census+=("       projects and so executes the leak file exactly once — npm run test:leaks is a")
+  census+=("       human/debug entry point, not a lane. Both facts are DERIVED on this run, never")
+  census+=("       quoted: the file count is reconciled and printed below as \"suite set")
+  census+=("       RECONCILED: N\", and a DOUBLE execution would fail check_jest_suites_ran (jest")
+  census+=("       reported total vs the DEDUPLICATED disk inventory) and the affirmation itself")
+  census+=("       (suites.length !== 1 at the leak path). This line used to state \"28 files with")
+  census+=("       no duplicates\" as a measurement; it had gone stale as the suite grew, and its")
+  census+=("       cited oracle could not see a duplicate anyway (jest --listTests DEDUPES across")
+  census+=("       projects — measured, #3772). No replacement count is quoted, here or in the")
+  census+=("       jest config: a fresh one would only restart the same decay.")
   census+=("       Budgets run STRICT here: CQLITE_LEAK_BUDGET_RELAX is UNSET for every node")
   census+=("       invocation of this component (#1465 V1), so no inherited value — including a")
   census+=("       CI runner env — can double a ceiling in the gate of record.")


### PR DESCRIPTION
## What

Removes the hard-coded jest suite count (`28`) from the gate and the Node jest config, replacing it with the property plus a pointer to the run-time derivation.

**Slice 1 of 2 for #3772.** This PR deliberately does **not** carry `Closes #3772` — see "Why this closes nothing" below. That is an intentional deviation from the usual `Closes #<N>` mandate, not an omission.

## Why

`node-bindings` printed, on every gate run:

```
all-projects jest --listTests is 28 files with no duplicates and includes the leak file
```

Measured at `origin/main` (`ef083e2bf`), `bindings/node/__test__` holds **32** `*.test.js` files. The issue measured 31 when it was filed; it moved again while the issue sat, which is the decay argument demonstrating itself.

It changes no verdict — `check_jest_suites_ran` reconciles two run-time oracles, so the gate cannot go wrong on this line. What was wrong is that **a gate log stated a false measurement, inside the census whose entire job is to describe what ran**: *"a false rationale in a gate log is worse than none, because it is what stops the next person looking."*

## The number was in FIVE places, not two

| site | claim |
|---|---|
| `scripts/agent-gate.sh:1892` | `#1465` composition header — "the all-projects list is 28 files with NO duplicates" |
| `scripts/agent-gate.sh:1936` | `_NODE_LEAK_SUITE_FILE` scope note — "the WHOLE-SUITE report (28 suites)" |
| `scripts/agent-gate.sh:1985` | `_node_leak_lane_note` dataset-gate note — "skips all 28 suites" |
| `scripts/agent-gate.sh:10792` | the census line the issue reported |
| `bindings/node/jest.config.js:20` | "measured via `jest --listTests`: 28 files, no duplicates" |

Per the issue's own recommendation this is **not** `28` → `32`, which only resets the same clock. No replacement count is written anywhere — including inside the explanations of why it was removed.

## Deleting the number is safe because both halves are already derived

- **the COUNT** is reconciled in `run_node_bindings` from two independent oracles (recursive `find` over `__test__/` vs `jest --listTests`) and already printed as `suite set RECONCILED: N *.test.js file(s)`;
- **a DOUBLE execution** fails `check_jest_suites_ran`'s `s_total -eq expected`, where `expected` is the **deduplicated** disk inventory.

## And the deleted sentence named the wrong oracle — the better reason to delete it

I checked that something still measures "no duplicates" before deleting the words, because *drop the number, keep the property* is only honest if the property is still measured. It was not measured by the cited method. Measured on jest 29.7.0, two projects whose `testMatch` both select one file:

```
jest --listTests  ->  __test__/probe.test.js          (ONE line)
jest              ->  Test Suites: 2 passed, 2 total  (executed TWICE)
```

`jest --listTests` **deduplicates across projects**, so it can never report the duplicate it was cited as having ruled out. Verified against this package too: deleting the `testPathIgnorePatterns` entry that hands the leak file to the `leaks` project leaves `--listTests` byte-identical. The `sort -u` in the gate's own reconciliation would erase one as well.

So `"28 files with no duplicates, measured via --listTests"` was **unfalsifiable by its own stated method**. Only the run's suite TOTAL sees it, and the comments now send a reader there instead of to `--listTests`.

## No test is added, deliberately

The diff changes comments and one census string; it alters no control flow, and item 1 "changes no verdict" by construction. A test for the *duplicate-detection* property (plant a duplicate, assert `node-bindings` reds) would be worth having, but it needs `npm ci` + a napi build per run and belongs with the `#3522`/`#3493` census work rather than a comment-truthfulness fix. Flagging it rather than leaving it implied.

## Certification

```
==== AGENT-GATE LITE SUMMARY ====
MODE: lite   commit: 6eb27b4   dirty: no
tree-integrity: PASS
file-size: PASS (1s) | fmt: PASS (64s) | clippy: PASS (415s)
roborev-lints: PASS (64s) | scoped-tests: PASS (153s) [test cqlite-node default-features]
cpu-budget: max-concurrency=1(pinned)
RESULT: PASS
```

Full gate of record + C + final roborev run in `flow-closer` before merge.

## Why this closes nothing

#3772 batches two nits. Item 2 (`bindings/node/__test__/helpers.test.js` — a describe title that overstates its test, plus an exemption path) targets a file that **does not exist on `origin/main`**: it is added by #3771, which has not had its gate of record yet.

Holding this PR for that was my first plan and it was wrong on measurement: **item 2 is `--delta`-eligible (#1892 — a node binding test against an already-built module) and item 1 is not** (`scripts/agent-gate.sh` fails `--delta` closed). So *item 1 full gate → item 2 `--delta` re-cert* costs **one** full gate either way; holding only adds latency behind another lane's slot queue.

So #3772 stays **open** with item 2 in scope as slice 2 — the shape #3550/#3559 defines (one telemetry record per shipped PR, `--slice`, `closed_at: null`; a slice PR closes nothing). Item 2 is not dropped, split out, or re-scoped.

`git merge-tree --write-tree HEAD <3771-head>` is **clean** — #3771 also touches `scripts/agent-gate.sh`, so I verified that mechanically rather than by eye; the hunks are ~70 lines apart and neither lane blocks the other in either merge order.

Refs #3772
