### PR TITLE
docs(#3893): product first — tooling reaches Ready only when blocking; scripts capped at two review rounds

### DIFF
--- a/.claude/commands/manager.md
+++ b/.claude/commands/manager.md
@@ -15,8 +15,11 @@ sequence workers with **signed issue comments**. That's it.
 ## Your only two channels
 1. **Board Ready column = the dispatch queue (the sole authority — Path A, #1886).** Move an issue to
    Ready by setting its **board `Status`**, not a label (`status:*` labels are decorative and are NOT how
-   workers select). Workers take the **oldest board-`Status=Ready`** item with no `issue-N-*` lock on
-   origin. A dependent issue stays **out of Ready** (hard gate) until its prerequisite merges — or goes to
+   workers select). Workers take the **oldest release-milestoned product item** at board-`Status=Ready`
+   with no claim on origin, and a delivery-tooling item only when no product item is Ready (#3893).
+   **You may move a tooling issue to Ready ONLY if its body cites a blocking cause** — a false PASS /
+   merge of bad code, a lane blocked > 1 h, or a second recurrence; otherwise it stays Backlog, however
+   well-scoped (owner ruling 2026-09-01). A dependent issue stays **out of Ready** (hard gate) until its prerequisite merges — or goes to
    Ready with a `HOLD` comment (soft gate) if you want it built early but merged late.
 2. **Signed issue comments = work orders.** Start every order with the marker so workers parse you, not
    human chatter:

--- a/.claude/commands/worker.md
+++ b/.claude/commands/worker.md
@@ -71,8 +71,11 @@ onto its own branch). Rules, non-negotiable:
    worktree you can resume. If one exists, **resume it**
    (`git fetch` the branch, `cd` the worktree, continue from its last commit — no re-claim, no dup work) and
    do NOT touch the Ready column this session. Only if there is no own resumable claim do you **pick up** a
-   new one (`flow-board` pickup rule): the **oldest issue whose board `Status=Ready`** with **no**
-   claim on origin. **Eligibility check (#2665):** the lock is now the slugless fixed-name ref
+   new one (`flow-board` pickup rule): the **oldest RELEASE-MILESTONED product issue whose board
+   `Status=Ready`** with **no** claim on origin; only when no product item is `Ready` do you take a
+   delivery-tooling item, oldest first (owner ruling 2026-09-01, #3893 — the queue is for the release,
+   not the tooling; a tooling item in `Ready` is there because it is blocking, which is the manager's
+   call to make, not yours). **Eligibility check (#2665):** the lock is now the slugless fixed-name ref
    `refs/claims/issue-<N>` — a model-chosen slug is NEVER the lock, so a different-slug or
    identical-SHA push can no longer double-claim (field: #1632). Check both the ref AND the legacy
    branch glob (older workers may still branch-lock):

--- a/.claude/skills/flow-board/SKILL.md
+++ b/.claude/skills/flow-board/SKILL.md
@@ -106,6 +106,10 @@ selection, no "next thing" happens without the board. The one-time fix is the ow
    Read each lifecycle column with its own filtered call. Do NOT switch to GraphQL `projectItems` to
    "avoid truncation" — that was a wrong diagnosis; and do NOT raise `-L` on an unfiltered list instead of
    filtering.
+   **Pick order (owner ruling 2026-09-01, #3893): release-milestoned product items FIRST.** Offer or
+   claim a delivery-tooling `Ready` item only when no product item is `Ready`, or the tooling item's body
+   cites a blocking cause (false PASS / lane blocked > 1 h / recurred twice). Render the two groups
+   separately so the split is visible.
    Show, per item: `#N (slug)  P?  Status  assignee  PR/CI  worktree`. Group by `Status`
    (`Backlog → Ready → In Progress → In Review → Done`); each `In Progress` item MUST show its assignee
    (the claiming session/owner). If `have_project=0`, you may render a **read-only** status view from

--- a/.claude/skills/flow-groom/SKILL.md
+++ b/.claude/skills/flow-groom/SKILL.md
@@ -36,10 +36,15 @@ You are the CQLite delivery lead. Turn a rough idea into exactly ONE well-scoped
    ```bash
    gh project item-add 1 --owner pmcfadin --url <issue-url>
    gh project item-edit --project-id <id> --id <item-id> --field-id <status-field> \
-     --single-select-option-id <Ready-or-Backlog>   # Ready if groomed-ready, else Backlog
+     --single-select-option-id <Ready-or-Backlog>   # Ready if groomed-ready AND (product OR blocking tooling), else Backlog
    gh project item-list 1 --owner pmcfadin --limit 1000 | grep "<issue-#>"   # confirm item + Status
    ```
    The item MUST appear with the intended `Status` before you report done.
+   **Product-first (owner ruling 2026-09-01, #3893):** a release-milestoned product issue goes `Ready`
+   when groomed. A delivery-tooling issue (gate, roborev, claim, bootstrap, fleet, telemetry, coord)
+   goes `Ready` ONLY if its body cites one of: (a) caused a false PASS / merge of bad code, (b) blocked a
+   lane > 1 h, (c) recurred twice. Otherwise `Backlog`, however well-scoped. Delivery-infra stays
+   unmilestoned; the release milestone carries product work only.
 6. **Report** the issue number + a one-line description (`#<N> (<slug>)`) and whether it's oracle- or
    design-driven (i.e. whether `flow-activate` or a direct `flow-implement` is next).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1816,6 +1816,13 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   target) → re-review` (#2087). **Nits** never trigger
   a re-verify round: batch all of a PR's nits into ONE linked follow-up issue at merge time. When in
   doubt, blocker. Every pre-roborev self-check class below is BLOCKER by definition.
+  **Scripts get a capped loop (#3893):** roborev on `scripts/**`, `.claude/**`, `.github/**` and
+  measurement-harness code (`docs/reports/*-artifacts/**`) is capped at **TWO rounds**; round-3 findings
+  are DISPOSED — one linked follow-up issue per PR, `roborev-defer` marker on the merits — not fixed,
+  UNLESS a finding is a **hang** or a **false verdict** (those two classes are exempt from every
+  convergence rule). Bash has no compiler, so each fix round seeds the next; measured 22/25/32 findings
+  over 7–12 rounds on three harness PRs in one day, most in the prior round's own fix. Tests and the full
+  gate still apply; only the review loop is capped.
   **A DEFERRED finding still has to get PAST roborev, and since #3626 that is mechanical rather than a
   matter of lead memory**: roborev re-reports a deferred finding on every later round, so batching nits
   into a follow-up issue does not by itself make `findings:` read `NONE`. The lead records the deferral
@@ -1886,6 +1893,19 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   (`Backlog/Ready/In Progress/In Review/Done`); exactly one `P0`–`P3` per issue. New issues auto-land
   at `Backlog`. Empty Ready column = no work ready → STOP. Board unreachable (auth/scope) → STOP and
   fix auth; never label-dispatch.
+- **PRODUCT FIRST — the dispatch queue is for the release, not the tooling (owner ruling 2026-09-01,
+  #3893).** Measured that night: Ready held 9 product items vs 38 delivery-tooling items; 13 of the day's
+  new issues were tooling; three bash-harness PRs ran 22/25/32 roborev findings, most in the previous
+  round's fix. Tooling had reached Ready with equal standing and starved the release lane. Rules:
+  **(1)** a worker pulling from Ready takes a **release-milestoned** item (currently `0.17`) whenever one
+  is Ready; delivery-tooling (gate, roborev, claim, bootstrap, fleet, telemetry, coord) is taken only when
+  no product item is Ready or the tooling item is BLOCKING under (2). **(2)** A tooling issue reaches
+  Ready ONLY if it (a) caused a **false PASS** or the merge of bad code, (b) **blocked a lane > 1 h**, or
+  (c) **recurred twice** — cite which in the issue body. Everything else lands `Backlog` (or is a one-line
+  doctrine note, or nothing). "Well-scoped" is no longer sufficient; the lead enforces this at triage
+  and does not promote tooling on scope alone. **(3)** Tooling is **feature-complete for the release**: a
+  tooling change needs a (2)-justification. **(4)** Finish in-flight tooling PRs on their merits; do not
+  feed the pipeline. **(5)** Retro metric: product share of merged PRs, target ≥ 70 % (≈ 45 % when ruled).
 - **How to READ the board — always `--query`, never an unfiltered page (#3055)**: the fresh board read
   the claim protocol requires is a **server-side filtered** `item-list`. This board is 900+ items, and
   an UNFILTERED `gh project item-list` **silently truncates** at the page limit — it returns a partial

--- a/docs/development/roborev-severity.md
+++ b/docs/development/roborev-severity.md
@@ -41,6 +41,14 @@ safety net for a mis-graded blocker that was waved through as cosmetic.
 - **Nits**: never trigger a re-verify round. All nits from one PR's roborev pass are
   batched into **one** linked follow-up issue (labeled, referencing the PR) opened at
   merge time, not fixed inline and not re-reviewed.
+- **Scripts and harnesses — two-round cap (owner ruling 2026-09-01, #3893)**: for diffs whose
+  code is `scripts/**`, `.claude/**`, `.github/**` or `docs/reports/*-artifacts/**`, the
+  fix → `--lite` → re-review loop runs at most **two** rounds. Round-3 findings are disposed
+  (one follow-up issue per PR + a `roborev-defer` marker requested on the merits), not fixed —
+  except a **hang** or a **false verdict**, which are always fixed regardless of round count.
+  Rationale: bash has no compiler, so fix rounds seed the next round's findings (22/25/32
+  findings over 7–12 rounds on three harness PRs in one day). Product code (`cqlite-*/src`,
+  bindings) keeps the uncapped blocker rule above.
 
 ## Telemetry
 

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -266,6 +266,25 @@ dispatch/claim authority**: it only narrows the candidate set — the selection 
 flow-* skills no longer write the board-derived labels (they set board Status only; the mirror follows);
 `status:spec-review`/`status:addressing` stay transient skill-managed sub-markers the mirror does not touch.
 
+### Product first: what may sit in Ready (owner ruling 2026-09-01, #3893)
+
+The board's `Ready` column is the sole dispatch authority, so what it holds is what the fleet builds.
+On 2026-09-01 it held 9 product items against 38 delivery-tooling items, and the release lane starved
+while workers iterated on bash harnesses (22/25/32 roborev findings over 7–12 rounds on three PRs).
+The standing rule since:
+
+1. **Workers take release-milestoned product items first.** Tooling (gate, roborev, claim, bootstrap,
+   fleet, telemetry, coord) is taken only when no product item is `Ready`, or the item is blocking.
+2. **A tooling issue reaches `Ready` only if it** caused a false PASS or the merge of bad code, blocked
+   a lane for more than an hour, or recurred twice — cited in the body. Everything else is `Backlog`,
+   a one-line doctrine note, or nothing. "Well-scoped" is not sufficient.
+3. **Scripts get a two-round review cap.** Round-3 roborev findings on `scripts/**`, `.claude/**`,
+   `.github/**` or `docs/reports/*-artifacts/**` are disposed (one follow-up issue, a deferral marker
+   on the merits), never fixed — except hangs and false verdicts, which are always fixed.
+4. **Tooling is feature-complete for the release.** A tooling change needs a rule-2 justification.
+5. **In-flight tooling PRs finish on their merits**; nothing new is promoted until the product queue
+   is empty. Retro metric: product share of merged PRs, target ≥ 70 %.
+
 ## The claim protocol (no duplicate work)
 
 Before working an item, a session claims it so no two sessions — **including two sessions authenticated


### PR DESCRIPTION
Closes #3893.

**Owner ruling 2026-09-01: the dispatch queue is for the release, not the tooling.** Measured that night: Ready held **9 product vs 38 delivery-tooling** items; open PRs 15 vs 18; 13 of the day's new issues were tooling; three bash-harness PRs ran **22 / 25 / 32** roborev findings over 7–12 rounds, most in the previous round's own fix.

## What changes (doctrine only — no code)
1. **Product-first dispatch**: workers take release-milestoned items first; tooling only when no product item is Ready or the item is blocking. (`CLAUDE.md` board bullet, `flow-board`, `worker`, `manager`.)
2. **Tooling → Ready criteria**: only if it caused a false PASS / merge of bad code, blocked a lane > 1 h, or recurred twice — cited in the body. (`CLAUDE.md`, `flow-groom`, `manager`.)
3. **Two-round review cap for scripts/harnesses**; round-3 findings are disposed, hangs and false verdicts exempt. (`CLAUDE.md` severity bullet, `docs/development/roborev-severity.md`.)
4. Tooling feature-complete for the release; in-flight tooling PRs finish; retro metric = product share of merged PRs ≥ 70 %.
5. Website `agents-developing/delivery-pipeline` page carries the same rule (acceptance: grep the served page for `Product first: what may sit in Ready` after deploy, not HTTP 200).

## Board actions already executed (#3893 body)
Demoted 19 tooling items Ready → Backlog; promoted #3809 #3805 #3815 #3846 (0.17 read-correctness) → Ready; blocking allowlist kept Ready: #3854 #3810 #3836 #3821 #3833 #3860.

## Certification
- `git diff --name-only origin/main...HEAD | bash scripts/ci/classify-docs-only.sh` → **exit 0, docs-only** (CLAUDE.md, three `.claude/**/*.md`, one `docs/development/*.md`, one website `.md`).
- **Code-free diff ⇒ cannot be roborev-certified; no roborev-clean claim is made.** Substitute: the ruling text is reproduced verbatim from the pinned owner issue #3893, and every number in it is from the lead census recorded there.
- Gate of record: running on the lead's Mac; SUMMARY block to be pasted below. Any red on this prose-only diff is cite-and-waive per #3042 with the classifier output above.

https://claude.ai/code/session_0125yfcchVUfMYtH7arzaD2f
