### PR TITLE
fix(#3757): resolve HEAD unpeeled in the live repo, peel it in the isolated scratch

### DIFF
--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -2680,16 +2680,26 @@ apply_schemas_preflight() {
 #                                        DEFAULT object format, which is why a sha256 baseline
 #                                        advertisement is refused at the ref oracle rather than
 #                                        failing here as a mystery transfer error (job 309).
-#     git rev-parse --verify --quiet <rev>
+#     git rev-parse --verify --quiet <rev>^{commit}
 #                                        resolves a sha to a COMMIT in the isolated repository —
-#                                        the transfer assert and HEAD's own sha. Commits are
-#                                        never filtered out of a clone.
+#                                        the transfer assert, and the PEEL of HEAD's own sha
+#                                        (#3757: the LIVE side resolves the ref and does not peel
+#                                        it, so the only object read is here). Commits are never
+#                                        filtered out of a clone.
 #     git merge-base --is-ancestor       walks commit parents only.
 #     git rev-parse --is-shallow-repository / --git-path shallow / --git-path objects
 #                                        repository STATE reads (is the history truncated? where
 #                                        is the object store, so it can be offered to the
 #                                        isolated repo as an ALTERNATE?); no object access, no
 #                                        remote contact.
+#     git rev-parse --verify --quiet HEAD
+#                                        HEAD resolved to a sha, UNPEELED (#3757). A REF read, not
+#                                        an OBJECT read: measured in a promisor clone whose HEAD
+#                                        object was absent, this form invoked the remote helper
+#                                        ZERO times while the peeled `HEAD^{commit}` form it
+#                                        replaced invoked it TWICE (a lazy fetch under the LIVE
+#                                        repository's own config). The peel and the "is it a
+#                                        commit" validation happen in the isolated repository.
 #
 #   LOCAL UTILITIES (no network, no spawn, bounded work). THE AUTHORITATIVE SET IS
 #     `declared_externals` in scripts/tests/test_agent_gate_component_set.sh, which is checked
@@ -2745,8 +2755,14 @@ apply_schemas_preflight() {
 #     redefined.
 #
 # The rule that generalises all five: THIS PRE-FLIGHT ONLY EVER RESOLVES A URL INSIDE THE
-# ISOLATED SCRATCH REPOSITORY, AND ONLY EVER READS OBJECTS BY SHA IN THE LIVE ONE. A change that
-# breaks either half re-opens this list and belongs in review, not in a follow-up.
+# ISOLATED SCRATCH REPOSITORY, AND SINCE #3757 IT READS NO OBJECT IN THE LIVE ONE AT ALL — the
+# live repository is asked only for REFS, CONFIG and repository STATE, and every object read runs
+# BY SHA in the isolated repository with the lane's store attached as an ALTERNATE. The previous
+# wording — "only ever READS OBJECTS BY SHA in the live one" — is what licensed the peel #3757
+# removed: a sha-addressed read is still an OBJECT read, and in a promisor clone a missing object
+# is answered from the NETWORK under the live repository's own config, which is the one thing this
+# enumeration exists to forbid. A change that breaks either half re-opens this list and belongs in
+# review, not in a follow-up.
 
 # Probe state, set by _component_set_probe and read by the pure verdict/line helpers.
 # Globals rather than a parsed multi-line stdout: the probe does real I/O (fetch, git
@@ -2764,8 +2780,10 @@ _CS_READ_DIR=""    # THE REPOSITORY EVERY BASELINE/HEAD OBJECT READ RUNS IN (#35
 _CS_READ_ENV=()    # env fragment for those reads: `GIT_ALTERNATE_OBJECT_DIRECTORIES=<lane
                    # objects>` when reading in the scratch (HEAD's objects live in the lane),
                    # else EMPTY
-_CS_HEAD_SHA=""    # HEAD resolved to a sha IN THIS CHECKOUT, so the scratch can be asked about
-                   # it: `HEAD` inside the scratch would mean the SCRATCH's own unborn HEAD
+_CS_HEAD_SHA=""    # HEAD as a COMMIT sha, so the scratch can be asked about it: `HEAD` inside the
+                   # scratch would mean the SCRATCH's own unborn HEAD. The REF is resolved in this
+                   # checkout (unpeeled) and PEELED in the scratch (#3757) — peeling reads an
+                   # object, and in the live repository that read can lazily fetch
 _CS_SCRATCH_DIR="" # the isolated scratch repo the baseline fetch ran in (#3544 / job 242)
 _CS_BASE_OBJ=""    # HOW the baseline COMMIT was obtained: reused (already in this repository)
                    # | fetched (the isolated hop + verified transfer) — job 258
@@ -5146,15 +5164,74 @@ _component_set_probe_inner() {
   # is BOUNDED, because the objects it reads come from the shared store.
   # HEAD IS RESOLVED TO A SHA IN THIS CHECKOUT FIRST, because the ancestry walk now runs in
   # `$_CS_READ_DIR` — and inside the isolated scratch the ref `HEAD` would mean the SCRATCH's own
-  # (unborn) HEAD, silently answering a different question. Commit objects are never omitted by any
-  # partial-clone filter, so resolving it is genuinely local; an unresolvable HEAD (unborn, or a
+  # (unborn) HEAD, silently answering a different question. An unresolvable HEAD (unborn, or a
   # broken detached HEAD) is INDETERMINATE below, exactly as an unanswerable probe was before.
   # BOUNDED, not annotated local-only (job 312): same config read, same FIFO exposure; and the
   # `|| true` would have turned a kill into an empty sha, taking the rc=128 branch below with a
   # cause that names HEAD rather than the blocked read.
-  _cs_live_git --no-replace-objects -C "$REPO_ROOT" rev-parse --verify --quiet "HEAD^{commit}"
-  if _cs_live_refuse "HEAD's commit sha"; then return 0; fi
-  _CS_HEAD_SHA="$_CS_LIVE_OUT"
+  #
+  # THE LIVE CALL RESOLVES THE REF AND DOES NOT PEEL IT (#3757). It used to ask for
+  # `HEAD^{commit}`, and a PEEL is an OBJECT READ in the LIVE repository: in a promisor clone a
+  # missing object is answered by a LAZY FETCH under that repository's OWN local config, where a
+  # `url.*.insteadOf` rewrite invokes a remote HELPER — the route jobs 268/299 removed from every
+  # other read in this pre-flight. The comment this replaces argued the read was "genuinely local"
+  # because no partial-clone filter omits COMMITS; that is true and it answers the wrong question,
+  # because the hazard is what happens when the object is absent for any OTHER reason (a pruned or
+  # corrupted store, a hand-written ref, a peer lane's edit to the SHARED `.git`).
+  # `GIT_NO_LAZY_FETCH=1` is carried in `_CS_GIT_ENV` as a BELT (git >= 2.36, silently absent on an
+  # older supported host), which is exactly why it cannot BE the control.
+  #
+  # MEASURED, with a discriminating control, rather than reasoned from the docs. Promisor clones of
+  # a local bare origin (`--filter=blob:none` AND `--filter=tree:0`, `uploadpack.allowfilter=true`),
+  # HEAD pointed at a commit present on the remote and ABSENT locally (absence confirmed with
+  # `GIT_NO_LAZY_FETCH=1 cat-file -e`), the promisor URL replaced by an `ext::` recorder script that
+  # logs every invocation; git 2.43.0, both filters behaving identically:
+  #
+  #   rev-parse --verify --quiet HEAD              rc=0    4ms   helper invocations: 0  (sha printed)
+  #   rev-parse --verify --quiet 'HEAD^{commit}'   rc=1   10ms   helper invocations: 2  (LAZY FETCH)
+  #   cat-file -t <that sha>                       rc=128        helper invocations: 1  (LAZY FETCH)
+  #
+  # A second measurement separates the OBJECT READ from the network, in a plain repository with a
+  # FIFO planted at HEAD's LOOSE object path (this pre-flight's own FIFO idiom):
+  #
+  #   rev-parse --verify --quiet HEAD              rc=0    3ms   (sha printed)
+  #   rev-parse --verify --quiet 'HEAD^{commit}'   BLOCKED       (bound fired at 3s)
+  #
+  # So the unpeeled form resolves the REF without reading the OBJECT it names, and that is what
+  # makes the peel movable. The peel — and the "is it a COMMIT" validation — happen below, in the
+  # ISOLATED scratch, which configures no promisor and reaches HEAD's objects only through an
+  # alternate: pure object storage, no config, nothing for a helper to be invoked from.
+  _cs_live_git --no-replace-objects -C "$REPO_ROOT" rev-parse --verify --quiet HEAD
+  if _cs_live_refuse "HEAD's sha (the ref only — no object is peeled in the live repository)"; then return 0; fi
+  local head_unpeeled="$_CS_LIVE_OUT" peel_rc=0
+  if [ -n "$head_unpeeled" ]; then
+    # PEEL + COMMIT-VALIDATE IN THE ISOLATED SCRATCH, and BOUNDED there for the reason job 315
+    # recorded for the ancestry walk: this reads a commit object out of the LANE's SHARED object
+    # store through the alternate, and a LOOSE object is read as a stream, so a FIFO planted at an
+    # object path by a PEER LANE hangs it. 124/137/`$_CS_UNBOUNDABLE_RC` therefore take the SAME
+    # `repo-read-blocked` / UNBOUNDED refusals as every other read here — a missing capability must
+    # never inherit the permissive branch.
+    #
+    # The capture triple is already memoized IN THE PARENT by the earlier DIRECT `_cs_live_git`
+    # calls (the git-directory read at the top of this function), so this command substitution
+    # cannot leave capture files behind with nobody holding their paths — the leak
+    # `_cs_live_git`'s header records, and the same reasoning the slow path's `cssha=$( … )` relies on.
+    _CS_HEAD_SHA=$(_component_set_bounded "$_CS_BOUND_SECS" env -i "${_CS_GIT_ENV[@]}" ${_CS_READ_ENV[@]+"${_CS_READ_ENV[@]}"} git --no-replace-objects -C "$_CS_READ_DIR" rev-parse --verify --quiet "${head_unpeeled}^{commit}" 2>/dev/null); peel_rc=$?
+    if [ "$peel_rc" -eq 124 ] || [ "$peel_rc" -eq 137 ] || [ "$peel_rc" -eq "$_CS_UNBOUNDABLE_RC" ]; then
+      _CS_KIND=repo-read-blocked
+      if [ "$peel_rc" -eq "$_CS_UNBOUNDABLE_RC" ]; then
+        _CS_DETAIL="peeling HEAD ($head_unpeeled) to a commit could not be BOUNDED on this host (no timeout, no gtimeout, no sleep for the bash watchdog, or no capture file) — refusing to run an UNBOUNDED read of the lane's object store, which could hang the gate outright; a missing capability must not inherit the permissive branch"
+      else
+        _CS_DETAIL="peeling HEAD ($head_unpeeled) to a commit EXCEEDED its ${_CS_BOUND_HINT}s bound reading that object from this lane's SHARED object store — the read never returned. A LOOSE object there is read as a stream, so a FIFO planted at an object path hangs it, and on this fleet that store is shared by every lane on the box. Inspect it by resolving the object directory with \`git rev-parse --git-path objects\` and searching that directory for FIFOs with \`find <objdir> -type p\`"
+      fi
+      return 0
+    fi
+    # A PEEL THAT FAILED IS INDETERMINATE, NEVER A FALSE `BEHIND` — the rc=128 semantics below are
+    # unchanged. HEAD names no commit this run can READ: an unborn or broken HEAD, a ref naming a
+    # non-commit, or an object genuinely absent from the lane's store. Deliberately NOT fetched: a
+    # missing HEAD object is a broken checkout, not a reason for a pre-flight whose whole premise is
+    # that it reaches no network to reach one.
+  fi
   if [ -z "$_CS_HEAD_SHA" ]; then
     rc=128
   else

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -4985,6 +4985,26 @@ _component_set_probe_inner() {
   _cs_alt_q="${lane_objects//\\/\\\\}"; _cs_alt_q="${_cs_alt_q//\"/\\\"}"
   _CS_READ_DIR="$csdir/repo"
   _CS_READ_ENV=("GIT_ALTERNATE_OBJECT_DIRECTORIES=\"$_cs_alt_q\"")
+  # THE ISOLATION ASSERTION LIVES HERE, WHERE IT DOMINATES EVERY CONSUMER (roborev job 347). It
+  # used to sit immediately before the HEAD peel, and that was the repo's own standing error: a
+  # check placed AFTER the harmful effect can only REPORT it, never PREVENT it — the same family as
+  # job 264's transfer hop (where the sha assert sat downstream of the fetch it was meant to
+  # validate) and job 290's certification window. FOUR object reads run BEFORE the peel — the fast
+  # path's `cat-file -e` and `rev-list`, and the manifest `ls-tree`/`show` at the baseline rev — so
+  # an unisolated value performed prohibited LIVE reads and only then got reported.
+  #
+  # ONE PLACEMENT, NOT N SCATTERED ASSERTS, and this is the one line where that is expressible:
+  # `_CS_READ_DIR` is assigned in exactly three places (the global initialiser, the probe's own
+  # reset, and this line), nothing reassigns it afterwards, and every consumer — in this function
+  # and in the two helpers it calls — runs after this point. So a single assert here is a
+  # DOMINATOR: there is no path from an unisolated value to a git call.
+  #
+  # NOT MERELY A RESTATEMENT OF THE LINE ABOVE IT. What it catches is the assignment itself being
+  # wrong rather than absent: `$csdir` empty (the value would be the plausible-looking `/repo`),
+  # a future edit pointing it at the live checkout, or a stale `_CS_SCRATCH_DIR` from an earlier
+  # probe in the same process. The `-n "$_CS_SCRATCH_DIR"` half is what makes the empty-`csdir`
+  # case a refusal instead of an accidental match.
+  if _cs_read_dir_isolated_or_refuse "read objects for the component-set comparison"; then return 0; fi
 
   # ---- DO WE ALREADY HOLD THAT COMMIT? -----------------------------------------------------
   # If this repository already has the object, there is NOTHING to fetch: a git object is
@@ -5282,11 +5302,12 @@ _component_set_probe_inner() {
   if _cs_live_refuse "HEAD's sha (the ref only, unpeeled)"; then return 0; fi
   local head_unpeeled="$_CS_LIVE_OUT" peel_rc=0
   if [ -n "$head_unpeeled" ]; then
-    # THE READ REPOSITORY IS ASSERTED, NOT ASSUMED (#3757). Every path that reaches here has
-    # already set `$_CS_READ_DIR` to the scratch — that is exactly the kind of "happens to go
-    # first" reasoning job 314 ruled against, so it is CHECKED at the consumer that would
-    # otherwise hand the value to git.
-    if _cs_read_dir_isolated_or_refuse "peel HEAD ($head_unpeeled) to a commit"; then return 0; fi
+    # THE READ REPOSITORY IS ASSERTED, NOT ASSUMED (#3757) — and the assertion is UPSTREAM, at the
+    # scratch assignment, not here (roborev job 347). A check at this consumer could only report a
+    # prohibited read that the four earlier consumers had already performed. See the assertion at
+    # the `_CS_READ_DIR="$csdir/repo"` assignment for why one placement there dominates all of
+    # them; there is deliberately no second check at this site, because two checks on one property
+    # is the drift this region keeps removing.
     # PEEL + COMMIT-VALIDATE IN THE ISOLATED SCRATCH, and BOUNDED there for the reason job 315
     # recorded for the ancestry walk: this reads a commit object out of the LANE's SHARED object
     # store through the alternate, and a LOOSE object is read as a stream, so a FIFO planted at an

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -2776,12 +2776,24 @@ _CS_MISSING=""     # baseline components ABSENT from this tree's set (space sepa
 _CS_EXTRA=""       # branch-only components (NOT skew; recorded for audit only)
 _CS_UNCOMMITTED="" # of _CS_MISSING, those still PRESENT in the gate script AT HEAD, i.e.
                    # removed by an UNCOMMITTED working-tree edit (#3544 / job 215)
-# THE "NOT ESTABLISHED YET" VALUE FOR `_CS_READ_DIR`, AND IT IS A NON-EXISTENT PATH ON PURPOSE
+# THE "NOT ESTABLISHED YET" VALUE FOR `_CS_READ_DIR`, AND IT IS A NON-TRAVERSABLE PATH ON PURPOSE
 # (#3757). The obvious sentinels are both UNSAFE, measured rather than assumed (git 2.43.0, in a
 # real worktree):
 #   git -C ""            rev-parse --git-dir  -> rc 0, prints the LIVE worktree's git dir
 #   git -C ""            cat-file -e HEAD^{commit} -> rc 0  (a LIVE OBJECT READ)
 #   git -C <nonexistent> rev-parse --git-dir  -> rc 128, "cannot change to '…': No such file"
+# IT IS UNDER `/dev/null/` AND NOT A MERELY-ABSENT PATH (roborev job 372). An absent path is
+# absent only until someone creates it: `/nonexistent/` is not reserved, so root could make the
+# sentinel RESOLVE and a consumer reached before the scratch exists would then read a real
+# repository instead of failing. `/dev/null` is a CHARACTER DEVICE, so every path under it is
+# ENOTDIR for everyone including root — `mkdir /dev/null` itself fails "Not a directory" — which
+# makes the objection unexpressible rather than merely unlikely. Measured, same worktree:
+#   git -C /dev/null/<x> rev-parse --git-dir           -> rc 128, "cannot change to '…': Not a directory"
+#   git -C /dev/null/<x> cat-file -e HEAD^{commit}     -> rc 128, same
+#   git -C /dev/null/<x> merge-base --is-ancestor …    -> rc 128, same
+# NOTE this is defence in depth, NOT the control: the control is the AFFIRMATIVE test in
+# `_cs_read_dir_isolated_or_refuse`, which permits ONLY `$_CS_SCRATCH_DIR/repo`, so any other
+# value — resolvable or not — is already refused.
 # `-C ""` leaves the working directory UNCHANGED, so an EMPTY value silently MEANS this checkout —
 # the exact read the region's execution-route enumeration forbids — while a non-existent path
 # makes any consumer reached before the scratch exists fail CLOSED without touching the live
@@ -2789,7 +2801,7 @@ _CS_UNCOMMITTED="" # of _CS_MISSING, those still PRESENT in the gate script AT H
 # value is what bounds every OTHER consumer, including the ones whose bodies are defined earlier
 # in this file than the assignment (lexical position is not execution order for a function body,
 # so no source scan can decide that ordering — the sentinel makes it moot).
-_CS_READ_DIR_UNSET='/nonexistent/agent-gate-component-set-read-dir-not-established'
+_CS_READ_DIR_UNSET='/dev/null/agent-gate-component-set-read-dir-not-established'
 _CS_READ_DIR="$_CS_READ_DIR_UNSET"
                    # THE REPOSITORY EVERY BASELINE/HEAD OBJECT READ RUNS IN (#3544 / job 268).
                    # ALWAYS the isolated scratch — "else this checkout" was written here while

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -2769,14 +2769,22 @@ apply_schemas_preflight() {
 # show, a baseline `--list`), and routing its result through `$( )` would add a
 # newline-stripping value path for no benefit (the #3148 lesson, one guard over).
 _CS_KIND=""        # ok | no-tool | no-git | no-remote | unboundable | fetch-failed | baseline-*
-                   # | manifest-* | head-set-unmeasured
+                   # | manifest-* | head-set-unmeasured | repo-read-blocked
+                   # | read-dir-unisolated
 _CS_SHA="-"        # the origin/main sha40 the comparison actually used
 _CS_MISSING=""     # baseline components ABSENT from this tree's set (space separated)
 _CS_EXTRA=""       # branch-only components (NOT skew; recorded for audit only)
 _CS_UNCOMMITTED="" # of _CS_MISSING, those still PRESENT in the gate script AT HEAD, i.e.
                    # removed by an UNCOMMITTED working-tree edit (#3544 / job 215)
 _CS_READ_DIR=""    # THE REPOSITORY EVERY BASELINE/HEAD OBJECT READ RUNS IN (#3544 / job 268).
-                   # The isolated scratch when one exists, else this checkout.
+                   # ALWAYS the isolated scratch — "else this checkout" was written here while
+                   # the pre-flight still read objects live, and since #3757 it reads NONE
+                   # there, so that clause licensed exactly what the enumeration above forbids.
+                   # EMPTY until the scratch exists, and empty is NOT a safe fallback: `git -C
+                   # ""` leaves the working directory UNCHANGED (measured; documented in
+                   # git-config(1)'s `-C` entry), i.e. it silently means THIS checkout. So a
+                   # consumer must REFUSE on an unisolated value rather than pass it to git —
+                   # see `_cs_read_dir_isolated_or_refuse` (#3757).
 _CS_READ_ENV=()    # env fragment for those reads: `GIT_ALTERNATE_OBJECT_DIRECTORIES=<lane
                    # objects>` when reading in the scratch (HEAD's objects live in the lane),
                    # else EMPTY
@@ -4507,11 +4515,42 @@ _cs_live_refuse() {
   return 1
 }
 
+# _cs_read_dir_isolated_or_refuse <what>: assert that `$_CS_READ_DIR` names the ISOLATED scratch
+# before its value is handed to git, and set a NAMED refusal if it does not. Returns 0 when it SET
+# a refusal (the caller must return), 1 otherwise — the same contract as `_cs_live_refuse`, so the
+# two read alike at a call site.
+#
+# WHY A REFUSAL AND NOT AN ASSERTION-BY-COMMENT (#3757): the two states this rejects are the two
+# that would silently redirect an OBJECT read into the live repository, which is the one thing the
+# execution-route enumeration at the head of this region forbids — empty (because `git -C ""`
+# leaves the working directory unchanged, so it MEANS this checkout) and `$REPO_ROOT` itself. A
+# fall-through would be a lazy-fetch route re-opened by a future edit, reported as nothing.
+_cs_read_dir_isolated_or_refuse() {
+  case "$_CS_READ_DIR" in
+    "") : ;;
+    "$REPO_ROOT") : ;;
+    *) return 1 ;;
+  esac
+  _CS_KIND=read-dir-unisolated
+  _CS_DETAIL="refusing to $1: the isolated read repository was never established (\$_CS_READ_DIR is ${_CS_READ_DIR:+the LIVE checkout $_CS_READ_DIR}${_CS_READ_DIR:-EMPTY, which git reads as 'leave the working directory unchanged' — i.e. the LIVE checkout}), and an object read there can be answered from the NETWORK by a promisor remote under this repository's own config. This is a code-path defect in the pre-flight, not a state of your checkout: the scratch assignment was skipped or removed"
+  return 0
+}
+
 _component_set_probe_inner() {
   # `_CS_READ_ENV` now carries ONLY what is specific to a read location (the alternate). The
   # neutralisers — `GIT_NO_LAZY_FETCH`, `GIT_NO_REPLACE_OBJECTS`, the config suppressors — live in
   # the ONE allowlist (`_CS_GIT_ENV`) that every git call in this pre-flight now runs under.
-  _CS_READ_DIR="$REPO_ROOT"; _CS_READ_ENV=(); _CS_HEAD_SHA=""
+  # `_CS_READ_DIR` STARTS EMPTY, NOT AT `$REPO_ROOT` (#3757). The old initialiser made THE LIVE
+  # CHECKOUT the value every consumer would see if the scratch assignment were ever skipped, so
+  # "this pre-flight reads no object in the live repository" held only because every earlier
+  # failure `return 0`s before that assignment — an ORDERING property nothing checked. Job 314
+  # rejected the same reasoning in this same function ("relying on 'the parent happens to go
+  # first'... is made explicit instead"). There is no reachable route to it today; this is
+  # HARDENING, and the two halves that make it real are the runtime refusal
+  # (`_cs_read_dir_isolated_or_refuse`) and a structural ordering assert in
+  # scripts/tests/test_agent_gate_component_set.sh (`3757-read-dir-ordering`), because an empty
+  # value is NOT self-protecting: `git -C ""` means the current directory.
+  _CS_READ_DIR=""; _CS_READ_ENV=(); _CS_HEAD_SHA=""
   _CS_KIND=""; _CS_SHA="-"; _CS_MISSING=""; _CS_EXTRA=""; _CS_UNCOMMITTED=""
   _CS_ANCESTOR=unknown; _CS_BASE_N=0; _CS_DETAIL=""
   _CS_HEAD_SET=""; _CS_HEAD_ERR=""; _CS_BASE_SRC=""; _CS_HEAD_SRC=""; _CS_BASE_OBJ=""
@@ -5213,6 +5252,11 @@ _component_set_probe_inner() {
   if _cs_live_refuse "HEAD's sha (the ref only, unpeeled)"; then return 0; fi
   local head_unpeeled="$_CS_LIVE_OUT" peel_rc=0
   if [ -n "$head_unpeeled" ]; then
+    # THE READ REPOSITORY IS ASSERTED, NOT ASSUMED (#3757). Every path that reaches here has
+    # already set `$_CS_READ_DIR` to the scratch — that is exactly the kind of "happens to go
+    # first" reasoning job 314 ruled against, so it is CHECKED at the consumer that would
+    # otherwise hand the value to git.
+    if _cs_read_dir_isolated_or_refuse "peel HEAD ($head_unpeeled) to a commit"; then return 0; fi
     # PEEL + COMMIT-VALIDATE IN THE ISOLATED SCRATCH, and BOUNDED there for the reason job 315
     # recorded for the ancestry walk: this reads a commit object out of the LANE's SHARED object
     # store through the alternate, and a LOOSE object is read as a stream, so a FIFO planted at an
@@ -5228,6 +5272,17 @@ _component_set_probe_inner() {
     if [ "$peel_rc" -eq 124 ] || [ "$peel_rc" -eq 137 ] || [ "$peel_rc" -eq "$_CS_UNBOUNDABLE_RC" ]; then
       _CS_KIND=repo-read-blocked
       if [ "$peel_rc" -eq "$_CS_UNBOUNDABLE_RC" ]; then
+        # `repo-read-blocked`, NOT `unboundable`, AND THE PRECEDENT IS THE ADJACENT ANCESTRY WALK
+        # (roborev job 325, nit 4). Every `_cs_live_git` call maps this same condition to
+        # `unboundable`, and that kind's own comment argues against "a second spelling... two
+        # names for one fact" — so the choice is stated rather than left to be inferred. Two
+        # reasons for following the walk instead of the wrapper: this is a read of the LANE's
+        # SHARED OBJECT STORE (the walk's subject), not of the live repository's config (the
+        # wrapper's), so an operator reading the detail is being sent to `find <objdir> -type p`
+        # and not to `git config --get-all include.path`; and the walk 15 lines below already
+        # spells an unboundable object read this way, so matching the wrapper here would put TWO
+        # spellings on the SAME condition inside one block. No verdict changes either way —
+        # both kinds are non-`ok`, hence UNMEASURED.
         _CS_DETAIL="peeling HEAD ($head_unpeeled) to a commit could not be BOUNDED on this host (no timeout, no gtimeout, no sleep for the bash watchdog, or no capture file) — refusing to run an UNBOUNDED read of the lane's object store, which could hang the gate outright; a missing capability must not inherit the permissive branch"
       else
         _CS_DETAIL="peeling HEAD ($head_unpeeled) to a commit EXCEEDED its ${_CS_BOUND_HINT}s bound reading that object from this lane's SHARED object store — the read never returned. A LOOSE object there is read as a stream, so a FIFO planted at an object path hangs it, and on this fleet that store is shared by every lane on the box. Inspect it by resolving the object directory with \`git rev-parse --git-path objects\` and searching that directory for FIFOs with \`find <objdir> -type p\`"

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -5201,8 +5201,16 @@ _component_set_probe_inner() {
   # makes the peel movable. The peel — and the "is it a COMMIT" validation — happen below, in the
   # ISOLATED scratch, which configures no promisor and reaches HEAD's objects only through an
   # alternate: pure object storage, no config, nothing for a helper to be invoked from.
+  #
+  # THE ARGUMENT MUST STAY A BARE REF NAME, and this is the contract a future caller inherits: the
+  # measurement above says a REF resolution reads no object, and it says nothing about a rev
+  # EXPRESSION. `HEAD^{commit}`, `HEAD~1`, `<tag>^{}` and a tag name all DEREFERENCE — i.e. read
+  # objects — so any of them here re-opens the lazy-fetch route this replaced, whatever the
+  # `--verify --quiet` spelling suggests. A caller needing a peeled or walked rev must ask the
+  # SCRATCH, exactly as the block below does. `scripts/tests/test_agent_gate_component_set.sh::
+  # 3757-no-live-peel` fails the suite if any live call grows a peel operator.
   _cs_live_git --no-replace-objects -C "$REPO_ROOT" rev-parse --verify --quiet HEAD
-  if _cs_live_refuse "HEAD's sha (the ref only — no object is peeled in the live repository)"; then return 0; fi
+  if _cs_live_refuse "HEAD's sha (the ref only, unpeeled)"; then return 0; fi
   local head_unpeeled="$_CS_LIVE_OUT" peel_rc=0
   if [ -n "$head_unpeeled" ]; then
     # PEEL + COMMIT-VALIDATE IN THE ISOLATED SCRATCH, and BOUNDED there for the reason job 315

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -2790,7 +2790,8 @@ _CS_UNCOMMITTED="" # of _CS_MISSING, those still PRESENT in the gate script AT H
 # in this file than the assignment (lexical position is not execution order for a function body,
 # so no source scan can decide that ordering — the sentinel makes it moot).
 _CS_READ_DIR_UNSET='/nonexistent/agent-gate-component-set-read-dir-not-established'
-_CS_READ_DIR=""    # THE REPOSITORY EVERY BASELINE/HEAD OBJECT READ RUNS IN (#3544 / job 268).
+_CS_READ_DIR="$_CS_READ_DIR_UNSET"
+                   # THE REPOSITORY EVERY BASELINE/HEAD OBJECT READ RUNS IN (#3544 / job 268).
                    # ALWAYS the isolated scratch — "else this checkout" was written here while
                    # the pre-flight still read objects live, and since #3757 it reads NONE
                    # there, so that clause licensed exactly what the enumeration above forbids.
@@ -4532,18 +4533,31 @@ _cs_live_refuse() {
 # a refusal (the caller must return), 1 otherwise — the same contract as `_cs_live_refuse`, so the
 # two read alike at a call site.
 #
-# WHY A REFUSAL AND NOT AN ASSERTION-BY-COMMENT (#3757): the two states this rejects are the two
-# that would silently redirect an OBJECT read into the live repository, which is the one thing the
-# execution-route enumeration at the head of this region forbids — empty (because `git -C ""`
-# leaves the working directory unchanged, so it MEANS this checkout) and `$REPO_ROOT` itself. A
-# fall-through would be a lazy-fetch route re-opened by a future edit, reported as nothing.
+# WHY A REFUSAL AND NOT AN ASSERTION-BY-COMMENT (#3757): a wrong value here silently redirects an
+# OBJECT read into the live repository, which is the one thing the execution-route enumeration at
+# the head of this region forbids.
+#
+# AND WHY IT IS AFFIRMATIVE, NOT A LIST OF BAD STATES (roborev job 339, item 5). The first version
+# enumerated three: empty (because `git -C ""` leaves the working directory unchanged, so it MEANS
+# this checkout), the UNSET sentinel, and `$REPO_ROOT`. That was sound for the three assignment
+# sites that exist and NOTHING PINNED THE NUMBER OF SITES, so a future fourth
+# `_CS_READ_DIR=<some live-ish path>` would pass the `*)` arm silently — the permissive-default
+# shape this pre-flight keeps ruling against. The question is now asked the other way round: the
+# value must BE the scratch this run created. `_CS_SCRATCH_DIR` is set from `$csdir` at the top of
+# the scratch block, before `_CS_READ_DIR="$csdir/repo"` in the same function, so the two are
+# derived from one value and comparing them cannot go stale; a probe that never got that far
+# leaves them unequal and is refused. The three named states survive only as DIAGNOSTIC TEXT, so
+# an operator still reads a cause rather than a bare mismatch.
 _cs_read_dir_isolated_or_refuse() {
   local why
+  if [ -n "$_CS_SCRATCH_DIR" ] && [ "$_CS_READ_DIR" = "$_CS_SCRATCH_DIR/repo" ]; then
+    return 1
+  fi
   case "$_CS_READ_DIR" in
     "")                        why="EMPTY, and git reads \`-C \"\"\` as 'leave the working directory unchanged' — i.e. the LIVE checkout" ;;
     "$_CS_READ_DIR_UNSET")     why="still the 'not established' sentinel ($_CS_READ_DIR), so the isolated scratch was never created" ;;
     "$REPO_ROOT")              why="the LIVE checkout ($_CS_READ_DIR)" ;;
-    *) return 1 ;;
+    *)                         why="'$_CS_READ_DIR', which is not the scratch this run created (\$_CS_SCRATCH_DIR is ${_CS_SCRATCH_DIR:-EMPTY})" ;;
   esac
   _CS_KIND=read-dir-unisolated
   _CS_DETAIL="refusing to $1: the isolated read repository was never established (\$_CS_READ_DIR is $why), and an object read in the live repository can be answered from the NETWORK by a promisor remote under that repository's own config. This is a code-path defect in the pre-flight, not a state of your checkout: the scratch assignment was skipped or removed"
@@ -5262,7 +5276,8 @@ _component_set_probe_inner() {
   # objects — so any of them here re-opens the lazy-fetch route this replaced, whatever the
   # `--verify --quiet` spelling suggests. A caller needing a peeled or walked rev must ask the
   # SCRATCH, exactly as the block below does. `scripts/tests/test_agent_gate_component_set.sh::
-  # 3757-no-live-peel` fails the suite if any live call grows a peel operator.
+  # 3757-live-call-allowlist` fails the suite if any live call grows a peel operator (or any other
+  # undeclared argument shape).
   _cs_live_git --no-replace-objects -C "$REPO_ROOT" rev-parse --verify --quiet HEAD
   if _cs_live_refuse "HEAD's sha (the ref only, unpeeled)"; then return 0; fi
   local head_unpeeled="$_CS_LIVE_OUT" peel_rc=0

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -2776,15 +2776,27 @@ _CS_MISSING=""     # baseline components ABSENT from this tree's set (space sepa
 _CS_EXTRA=""       # branch-only components (NOT skew; recorded for audit only)
 _CS_UNCOMMITTED="" # of _CS_MISSING, those still PRESENT in the gate script AT HEAD, i.e.
                    # removed by an UNCOMMITTED working-tree edit (#3544 / job 215)
+# THE "NOT ESTABLISHED YET" VALUE FOR `_CS_READ_DIR`, AND IT IS A NON-EXISTENT PATH ON PURPOSE
+# (#3757). The obvious sentinels are both UNSAFE, measured rather than assumed (git 2.43.0, in a
+# real worktree):
+#   git -C ""            rev-parse --git-dir  -> rc 0, prints the LIVE worktree's git dir
+#   git -C ""            cat-file -e HEAD^{commit} -> rc 0  (a LIVE OBJECT READ)
+#   git -C <nonexistent> rev-parse --git-dir  -> rc 128, "cannot change to '…': No such file"
+# `-C ""` leaves the working directory UNCHANGED, so an EMPTY value silently MEANS this checkout —
+# the exact read the region's execution-route enumeration forbids — while a non-existent path
+# makes any consumer reached before the scratch exists fail CLOSED without touching the live
+# repository. The named refusal below still exists and is what a reader sees at the peel; this
+# value is what bounds every OTHER consumer, including the ones whose bodies are defined earlier
+# in this file than the assignment (lexical position is not execution order for a function body,
+# so no source scan can decide that ordering — the sentinel makes it moot).
+_CS_READ_DIR_UNSET='/nonexistent/agent-gate-component-set-read-dir-not-established'
 _CS_READ_DIR=""    # THE REPOSITORY EVERY BASELINE/HEAD OBJECT READ RUNS IN (#3544 / job 268).
                    # ALWAYS the isolated scratch — "else this checkout" was written here while
                    # the pre-flight still read objects live, and since #3757 it reads NONE
                    # there, so that clause licensed exactly what the enumeration above forbids.
-                   # EMPTY until the scratch exists, and empty is NOT a safe fallback: `git -C
-                   # ""` leaves the working directory UNCHANGED (measured; documented in
-                   # git-config(1)'s `-C` entry), i.e. it silently means THIS checkout. So a
-                   # consumer must REFUSE on an unisolated value rather than pass it to git —
-                   # see `_cs_read_dir_isolated_or_refuse` (#3757).
+                   # Set to `$_CS_READ_DIR_UNSET` at every probe entry (see above) and to the
+                   # scratch once it exists; a consumer must REFUSE any other value rather than
+                   # pass it to git — see `_cs_read_dir_isolated_or_refuse` (#3757).
 _CS_READ_ENV=()    # env fragment for those reads: `GIT_ALTERNATE_OBJECT_DIRECTORIES=<lane
                    # objects>` when reading in the scratch (HEAD's objects live in the lane),
                    # else EMPTY
@@ -4526,13 +4538,15 @@ _cs_live_refuse() {
 # leaves the working directory unchanged, so it MEANS this checkout) and `$REPO_ROOT` itself. A
 # fall-through would be a lazy-fetch route re-opened by a future edit, reported as nothing.
 _cs_read_dir_isolated_or_refuse() {
+  local why
   case "$_CS_READ_DIR" in
-    "") : ;;
-    "$REPO_ROOT") : ;;
+    "")                        why="EMPTY, and git reads \`-C \"\"\` as 'leave the working directory unchanged' — i.e. the LIVE checkout" ;;
+    "$_CS_READ_DIR_UNSET")     why="still the 'not established' sentinel ($_CS_READ_DIR), so the isolated scratch was never created" ;;
+    "$REPO_ROOT")              why="the LIVE checkout ($_CS_READ_DIR)" ;;
     *) return 1 ;;
   esac
   _CS_KIND=read-dir-unisolated
-  _CS_DETAIL="refusing to $1: the isolated read repository was never established (\$_CS_READ_DIR is ${_CS_READ_DIR:+the LIVE checkout $_CS_READ_DIR}${_CS_READ_DIR:-EMPTY, which git reads as 'leave the working directory unchanged' — i.e. the LIVE checkout}), and an object read there can be answered from the NETWORK by a promisor remote under this repository's own config. This is a code-path defect in the pre-flight, not a state of your checkout: the scratch assignment was skipped or removed"
+  _CS_DETAIL="refusing to $1: the isolated read repository was never established (\$_CS_READ_DIR is $why), and an object read in the live repository can be answered from the NETWORK by a promisor remote under that repository's own config. This is a code-path defect in the pre-flight, not a state of your checkout: the scratch assignment was skipped or removed"
   return 0
 }
 
@@ -4540,17 +4554,18 @@ _component_set_probe_inner() {
   # `_CS_READ_ENV` now carries ONLY what is specific to a read location (the alternate). The
   # neutralisers — `GIT_NO_LAZY_FETCH`, `GIT_NO_REPLACE_OBJECTS`, the config suppressors — live in
   # the ONE allowlist (`_CS_GIT_ENV`) that every git call in this pre-flight now runs under.
-  # `_CS_READ_DIR` STARTS EMPTY, NOT AT `$REPO_ROOT` (#3757). The old initialiser made THE LIVE
-  # CHECKOUT the value every consumer would see if the scratch assignment were ever skipped, so
-  # "this pre-flight reads no object in the live repository" held only because every earlier
-  # failure `return 0`s before that assignment — an ORDERING property nothing checked. Job 314
-  # rejected the same reasoning in this same function ("relying on 'the parent happens to go
-  # first'... is made explicit instead"). There is no reachable route to it today; this is
-  # HARDENING, and the two halves that make it real are the runtime refusal
-  # (`_cs_read_dir_isolated_or_refuse`) and a structural ordering assert in
-  # scripts/tests/test_agent_gate_component_set.sh (`3757-read-dir-ordering`), because an empty
-  # value is NOT self-protecting: `git -C ""` means the current directory.
-  _CS_READ_DIR=""; _CS_READ_ENV=(); _CS_HEAD_SHA=""
+  # `_CS_READ_DIR` STARTS AT THE UNSET SENTINEL, NOT AT `$REPO_ROOT` (#3757). The old initialiser
+  # made THE LIVE CHECKOUT the value every consumer would see if the scratch assignment were ever
+  # skipped, so "this pre-flight reads no object in the live repository" held only because every
+  # earlier failure `return 0`s before that assignment — an ORDERING property nothing checked.
+  # Job 314 rejected the same reasoning in this same function ("relying on 'the parent happens to
+  # go first'... is made explicit instead"). There is no reachable route to it today; this is
+  # HARDENING, and it is made real by three things rather than by tracing: the sentinel (a
+  # non-existent path, so an unguarded consumer fails CLOSED instead of reading live — see its
+  # measurement above), the named runtime refusal at the peel
+  # (`_cs_read_dir_isolated_or_refuse`), and a structural assert over this function's own body in
+  # scripts/tests/test_agent_gate_component_set.sh (`3757-read-dir-shape`).
+  _CS_READ_DIR="$_CS_READ_DIR_UNSET"; _CS_READ_ENV=(); _CS_HEAD_SHA=""
   _CS_KIND=""; _CS_SHA="-"; _CS_MISSING=""; _CS_EXTRA=""; _CS_UNCOMMITTED=""
   _CS_ANCESTOR=unknown; _CS_BASE_N=0; _CS_DETAIL=""
   _CS_HEAD_SET=""; _CS_HEAD_ERR=""; _CS_BASE_SRC=""; _CS_HEAD_SRC=""; _CS_BASE_OBJ=""

--- a/scripts/tests/test_agent_gate_component_set.sh
+++ b/scripts/tests/test_agent_gate_component_set.sh
@@ -24,11 +24,12 @@
 #   4d. a SHALLOW clone where rc 1 is ambiguous                          -> INDETERMINATE, never BEHIND
 #   5d. a concurrent fetch clobbering FETCH_HEAD                         -> baseline unaffected
 #   3757. HEAD is resolved UNPEELED in the live repository and PEELED in the isolated scratch
-#      (#3757): the region's LIVE git calls equal a DECLARED ALLOWLIST of exact argument shapes
-#      (structural, with FOUR planted evasion routes — a deny pattern over rev syntax never
-#      closes), the scratch peel is bounded and three-valued (structural, with a control),
-#      `$_CS_READ_DIR` never names the live checkout (structural x3 + a behavioural refusal), a
-#      FIFO at HEAD's own object is refused BY NAME, and an unpeelable HEAD stays INDETERMINATE
+#      (#3757): the region's CODE lines mentioning `_cs_live_git` or `$REPO_ROOT` are pinned as
+#      WHOLE LINES, both directions (structural, with TEN planted routes; no parser — see the pin
+#      block for why the tokeniser was deleted), the scratch peel is bounded and three-valued
+#      (structural, with a control), `$_CS_READ_DIR` never names the live checkout (structural +
+#      two behavioural cases, one of which measures that NO live read happened), a FIFO at HEAD's
+#      own object is refused BY NAME, and an unpeelable HEAD stays INDETERMINATE
 #   5. no skew                                                          -> affirmative PASS + baseline sha
 #   6. --lite with a real skew                                          -> line present, run NOT failed
 #   7. the REAL full-gate emit path                                     -> FAIL block + exit 1, no cargo
@@ -912,255 +913,133 @@ fi
 #     BEHIND).
 # ---------------------------------------------------------------------------
 
-# cs_live_call_findings <gate-path>: print one FINDING line per DEVIATION from the DECLARED set of
-# LIVE-repository git invocations in the pre-flight region. Empty output = the region's live calls
-# are exactly the declared ones.
+# ---- THE TWO WHOLE-LINE PINS (#3757, roborev job 347 / option A) -----------------------------
 #
-# WHY AN ALLOWLIST AND NOT A DENY PATTERN (roborev job 325, blocker 1). The first version of this
-# guard scanned for the single literal `^{` on `_cs_live_git`/`-C "$REPO_ROOT"` lines, and it had
-# FOUR silent false PASSes, each a live OBJECT read:
-#   (a) a dereferencing rev that contains no `^{` — `HEAD~1`, `HEAD^`, `HEAD^0`, `HEAD@{1}`,
-#       `HEAD:path`, or a bare tag/branch name (a tag is a TAG object, so resolving it peels);
-#   (b) the rev held in a VARIABLE assigned on a different line (`local rev="HEAD^{commit}"`);
-#   (c) the call split over a `\` continuation, so the peel-bearing physical line matches nothing;
-#   (d) a live call spelled other than `-C "$REPO_ROOT"` — `--git-dir="$REPO_ROOT/.git"`, a
-#       `GIT_DIR=` assignment, or `cd "$REPO_ROOT"` plus a bare `git`.
-# And the count assert did not backstop it: a NEWLY ADDED live call using `HEAD~1` leaves the
-# count of unpeeled HEAD resolutions at one. A deny-list over rev syntax the author chooses never
-# closes — the standing ruling against picking a rarer delimiter — and a guard with documented
-# false PASSes is worse than none (#3229), especially here, where the call-site comment TELLS the
-# reader this guard enforces the bare-ref contract.
+# WHAT THIS ASSERTS, and it is the whole of it: the pre-flight region's CODE lines that mention
+# `_cs_live_git` or `$REPO_ROOT` are EXACTLY the lines pinned below, compared as WHOLE STRINGS,
+# in BOTH directions. An unpinned line is a FINDING; a pinned line that no longer appears is a
+# stale-pin FINDING. Nothing is parsed.
 #
-# So the question is asked affirmatively, which is also what makes a PASS mean something: the SET
-# of live invocations must EQUAL `CS_DECLARED_LIVE_CALLS`, in BOTH directions. An unrecognised
-# shape is a FINDING whatever it contains, so (a)–(d) are all rejected by one rule; and a declared
-# entry that no longer appears is a FINDING too, because a stale entry PRE-AUTHORISES its own
-# re-introduction (section 9b's rule for git operations, applied to argv).
+# WHY THERE IS NO TOKENISER ANY MORE. Three review rounds each closed the previously-found
+# spelling of ONE unbounded question — "does this author-chosen bash line reach a command in the
+# live repository?" — and the false-PASS count went 1 -> 1 -> 4, with each round's defects living
+# inside the previous round's fix. The last one was
+# `local sha=$(… git -C "$REPO_ROOT" rev-parse --verify --quiet "HEAD^{commit}")`, which the
+# word-class scan excused because the command word was `local`. Parsing author-controlled bash to
+# decide data-versus-control IS the shared channel #3312 says to REMOVE rather than delimit more
+# finely, and #3229's ruling is that a guard with documented false PASSes is worse than none. So
+# the recogniser (`R2`, `cs_first_word`, `CS_DECLARED_REPO_ROOT_HARMLESS`, the word-class direct-
+# `git` test and the fragment splitter) is DELETED, not narrowed, and the property is re-expressed
+# with the one mechanism that cannot be evaded by rewriting a line: literal equality of the line.
 #
-# WHAT IT COVERS, AND WHAT IT DOES NOT — stated because the first version of this comment claimed
-# the rule also rejected "the next spelling nobody has thought of", AND THAT WAS FALSE (roborev
-# job 339): the shape test recognised only a command word literally spelled `git` or exactly
-# `_cs_live_git `, so a call through a variable, an `eval`, a `\git` or A SECOND WRAPPER FUNCTION
-# was classified as NOTHING — demonstrated, `_cs_live_git_quiet` routing a peel produced zero
-# findings from this guard AND from 9b. A false rationale in a guard is worse than none, because it
-# is what stops the next person looking. Rule R2 in `cs_live_call_findings` closes those spellings
-# by keying on the live repository's NAME (`$REPO_ROOT`) rather than on the command word, and its
-# own residual is stated at that rule: a live call that names the live checkout neither by that
-# token nor on that line (a CWD-relative call through an unrecognised command word) is still not
-# seen here.
+# ACCEPTED COST, stated so nobody "improves" it back into a parser: the pin is BRITTLE to
+# reformatting. Any legitimate edit to a pinned line — including rewording a diagnostic string —
+# must update the pin, and the both-directions leg turns a forgotten update into a loud finding
+# rather than a silent hole. That is the same cost the live-call pin has always carried.
 #
-# GRANULARITY, and why it differs from 9b deliberately: 9b keys on the SUBCOMMAND because a
-# flag-level key would red on a reordering of correct code. Here the ARGV IS the property — `HEAD`
-# versus `HEAD^{commit}` is one token — so this guard keys on the exact argument text and is
-# scoped to the SIX live calls, where an exact list is maintainable. It is also REGION-SCOPED, not
-# file-wide: `scripts/agent-gate.sh` legitimately peels in the live repository OUTSIDE this region
-# (the `--delta` anchor resolution runs `rev-parse --verify -q "${anchor}^{commit}"` with no
-# `-C`), and a file-wide rule would red on correct code — the guard agents learn to waive.
+# WHAT IT DOES NOT CLAIM. It does not understand bash, and it cannot see a live read that names
+# the repository some OTHER way: a path copied into a variable outside this region, a `cd` plus a
+# bare `git` with no `$REPO_ROOT` token, or a `GIT_DIR=` built from an expression that does not
+# spell `$REPO_ROOT`. Those are real residuals, not covered here, and the runtime
+# `_cs_read_dir_isolated_or_refuse` refusal plus the `/nonexistent/` sentinel are what bound them.
 #
-# WHAT IT CANNOT CLAIM: that a declared call is network-free. That judgement is recorded per site
-# in the enumeration comment at the head of the region, which is where a reviewer checks it. What
-# it guarantees is that no live call arrives UNDECLARED.
-CS_DECLARED_LIVE_CALLS=(
-  # HEAD's REF, resolved UNPEELED (#3757). The whole subject of this guard: a peel here is an
-  # object read, and in a promisor clone a missing object is fetched under the LIVE repository's
-  # own config, where an `insteadOf` rewrite invokes a remote helper.
-  '--no-replace-objects -C "$REPO_ROOT" rev-parse --verify --quiet HEAD'
-  # Repository STATE and CONFIG reads. None resolves a rev, so none can peel.
-  '-C "$REPO_ROOT" rev-parse --git-dir'
-  '-C "$REPO_ROOT" remote get-url origin'
-  '-C "$REPO_ROOT" rev-parse --git-path objects'
-  '-C "$REPO_ROOT" rev-parse --is-shallow-repository'
-  '-C "$REPO_ROOT" rev-parse --git-path shallow'
+# THE PARTITION IS A SUBSTRING TEST, so the two pins never disagree about a line: a line
+# mentioning `_cs_live_git` is judged by the live-call pin (that is what makes a SECOND wrapper
+# such as `_cs_live_git_quiet` a finding rather than an unpinned stranger); every other
+# `$REPO_ROOT` line is judged by the second pin.
+#
+# Both blocks are QUOTED HEREDOCS, so `"`, `$`, `\` and `'` inside the pinned lines need no
+# escaping and cannot drift from the gate's own text through a quoting mistake.
+CS_PINNED_LIVE_CALL_LINES=$(cat <<'CS_PIN_LIVE_EOF'
+  _cs_live_git -C "$REPO_ROOT" rev-parse --is-shallow-repository
+  _cs_live_git -C "$REPO_ROOT" rev-parse --git-path shallow
+_cs_live_git() {
+  _cs_live_git -C "$REPO_ROOT" rev-parse --git-dir
+  _cs_live_git -C "$REPO_ROOT" remote get-url origin
+  _cs_live_git -C "$REPO_ROOT" rev-parse --git-path objects
+  _cs_live_git --no-replace-objects -C "$REPO_ROOT" rev-parse --verify --quiet HEAD
+CS_PIN_LIVE_EOF
 )
-# The DIRECT `git` lines in the region that are NOT repository operations on a named repository,
-# each classified here rather than pattern-excused. A direct git line matching none of these, and
-# not carrying an isolated `-C`, is a FINDING — that is route (d)'s closure.
-#   <line-payload substring>|<why it is not a live repository read>
-CS_DECLARED_DIRECT_GIT=(
-  'git "$@" 2>/dev/null|the _cs_live_git WRAPPER itself: the one live invocation point, whose argv comes from the call sites this guard checks'
-  'command -v git|a capability probe (is git on PATH), not an invocation'
-  '"$uinfo" != git|a string comparison against the literal userinfo git, not an invocation'
-  'git init -q "$csdir/repo"|creates the ISOLATED scratch at a named target path; reads no repository'
+# Every other region CODE line that names the live repository. The six `_cs_live_git` call lines
+# also mention `$REPO_ROOT` and are deliberately NOT repeated here (see the partition above).
+CS_PINNED_REPO_ROOT_LINES=$(cat <<'CS_PIN_RR_EOF'
+  local f="$REPO_ROOT/$_CS_MANIFEST_REL" rc only_gate="" only_man="" c padded_man padded_gate
+    _CS_DETAIL="the component manifest $_CS_MANIFEST_REL is missing or unreadable in $REPO_ROOT; it is COMMITTED SOURCE and the baseline comparison is derived from it, so its absence is not an excusable state — remedy: regenerate it from this gate's own --list"
+      _CS_DETAIL="reading $1 from $REPO_ROOT EXCEEDED its ${_CS_BOUND_HINT}s bound — the read never returned. Every git command reads the repository config, and a \`include.path\` there naming a FIFO or other blocking file hangs it; on this fleet that config is SHARED by every lane on the box. Inspect it with \`git config --show-origin --get-all include.path\`"
+      _CS_DETAIL="no bounded-run mechanism available (no timeout, no gtimeout, no sleep for the bash watchdog, or no capture file) — refusing to run an UNBOUNDED read of $1 from $REPO_ROOT, which could hang the gate outright; a missing capability must not inherit the permissive branch"
+    "$REPO_ROOT")              why="the LIVE checkout ($_CS_READ_DIR)" ;;
+    _CS_KIND=no-git; _CS_DETAIL="$REPO_ROOT is not a git worktree"; return 0
+    _CS_DETAIL="no 'origin' remote is configured in $REPO_ROOT, so the baseline is unobtainable"
+    ?*) lane_objects="$REPO_ROOT/$lane_objects" ;;
+           _CS_DETAIL="deciding whether $REPO_ROOT is a SHALLOW clone required reading its repository state, and that read EXCEEDED its ${_CS_BOUND_HINT}s bound — the read never returned. Every git command reads the repository config, and an \`include.path\` there naming a FIFO or other blocking file hangs it; on this fleet that config is SHARED by every lane on the box. Inspect it with \`git config --show-origin --get-all include.path\`"
+CS_PIN_RR_EOF
 )
-CS_ISOLATED_SELECTORS=('-C "$_CS_READ_DIR"' '-C "$csdir/repo"')
-# CS_DECLARED_REPO_ROOT_HARMLESS: the command words a `$REPO_ROOT`-MENTIONING line may begin with
-# and still not be an invocation of anything that can read a repository. Everything else on such a
-# line is a FINDING (see rule R2 in `cs_live_call_findings`), which is what makes the rule
-# affirmative: a live call spelled through a VARIABLE (`$GIT`), an `eval`, a `\git`, or A SECOND
-# WRAPPER FUNCTION lands here rather than being invisible.
-CS_DECLARED_REPO_ROOT_HARMLESS=(
-  'local'   # `local f="$REPO_ROOT/…"` — declares a path for SHELL reads of committed source
-  'return'  # `_CS_KIND=…; _CS_DETAIL="… $REPO_ROOT …"; return 0`
-  ':'       # an explicit no-op
-)
-# cs_first_word <text>: the COMMAND WORD of a shell fragment, or empty when the fragment invokes
-# nothing (a bare assignment, a case-arm pattern, a keyword). Quoted spans must already be
-# removed by the caller. The stripping mirrors 9b's audit — leading keywords, `!`, `VAR=value`
-# assignments — plus a leading case-arm PATTERN, because `*) git …` is an invocation and `?*)
-# lane_objects="…"` is not, and only stripping the pattern tells them apart.
-cs_first_word() {
-  local t="$1" w
-  t="${t#"${t%%[![:space:]]*}"}"
-  while :; do
-    case "$t" in
-      '!'*)            t="${t#!}"; t="${t#"${t%%[![:space:]]*}"}"; continue ;;
-      if\ *|while\ *|until\ *|then\ *|else\ *|elif\ *|do\ *|not\ *)
-                       t="${t#* }"; t="${t#"${t%%[![:space:]]*}"}"; continue ;;
-      *')'*)
-        # A case-arm pattern only when the `)` precedes any whitespace, i.e. the fragment STARTS
-        # with `<pattern>)`. `$(…)` cannot appear here: the caller removed quoted spans and a
-        # substitution at command position is itself reported by the word test below.
-        case "${t%%')'*}" in
-          *[[:space:]]*) break ;;
-          *) t="${t#*')'}"; t="${t#"${t%%[![:space:]]*}"}"; continue ;;
-        esac ;;
-      [A-Za-z_]*=*)
-        case "${t%%=*}" in
-          *[!A-Za-z0-9_]*) break ;;
-          *) t="${t#*=}"; t="${t#"${t%%[[:space:]]*}"}"; t="${t#"${t%%[![:space:]]*}"}"; continue ;;
-        esac ;;
-    esac
-    break
-  done
-  w="${t%%[[:space:]]*}"
-  printf '%s' "$w"
-}
-cs_live_call_findings() {
-  local gate="$1" line num raw argv dq entry i hit frag w rest
-  local -a seen=()
-  for i in "${!CS_DECLARED_LIVE_CALLS[@]}"; do seen[$i]=0; done
+cs_pin_live_n=$(printf '%s\n' "$CS_PINNED_LIVE_CALL_LINES" | grep -c .)
+cs_pin_rr_n=$(printf '%s\n' "$CS_PINNED_REPO_ROOT_LINES" | grep -c .)
+
+# cs_pinned_line_findings <gate-path>: one FINDING per deviation from either pin. Empty = both
+# pins hold. `grep -Fxq` is WHOLE-LINE fixed-string membership, and the needle is always a SINGLE
+# line read by `IFS= read -r`, so the multi-line-needle trap (where a needle's first line "proves"
+# its presence) cannot apply here.
+cs_pinned_line_findings() {
+  local g="$1" code line num raw pin
+  code=$(cs_region_code "$g" | sed 's/^[0-9][0-9]*://')
   while IFS= read -r line; do
     [ -n "$line" ] || continue
     num="${line%%:*}"; raw="${line#*:}"
-    # ROUTE (c): a LIVE call split over a `\` continuation cannot be judged as a line, so it is
-    # rejected rather than judged from the fragment — a continuation is how an argument list hides
-    # from a per-line scan. SCOPED TO `_cs_live_git` LINES, because an `&&`-chained ISOLATED read
-    # legitimately continues (the fast path's presence probe does, and an unscoped rule RED on it
-    # — measured, first run: a guard that reds on correct input is the guard agents learn to
-    # waive). The TAIL of such a call needs no rule of its own: a tail that names the live
-    # repository mentions `$REPO_ROOT` and is caught by R2 below, which is also why the separate
-    # tail rule this replaces is GONE — it fired for EVERY line ending in `\`, so wrapping a long
-    # `_CS_DETAIL="… from $REPO_ROOT …"` over two lines emitted a spurious finding (roborev job
-    # 339, item 4).
     case "$raw" in
-      *_cs_live_git*'\')
-        printf 'FINDING: %s: a LIVE git call is split over a line CONTINUATION, so its argument list cannot be judged as one line — write it on one line: %s\n' "$num" "$raw"
+      *_cs_live_git*)
+        grep -Fxq -- "$raw" <<<"$CS_PINNED_LIVE_CALL_LINES" \
+          || printf 'FINDING[live-call]: %s: this line mentions _cs_live_git and is NOT one of the %s PINNED live-call lines (whole-line equality; the line is not read, only compared): %s\n' "$num" "$cs_pin_live_n" "$raw"
         continue ;;
     esac
-    case "$raw" in
-      *_cs_live_git\ *)
-        argv="${raw#*_cs_live_git }"
-        # Trailing whitespace only; anything else (a `)`, a redirection, a `;`) is part of the
-        # shape and must be DECLARED, because it changes what runs.
-        argv="${argv%"${argv##*[![:space:]]}"}"
-        hit=""
-        for i in "${!CS_DECLARED_LIVE_CALLS[@]}"; do
-          if [ "$argv" = "${CS_DECLARED_LIVE_CALLS[$i]}" ]; then hit=1; seen[$i]=1; break; fi
-        done
-        if [ -z "$hit" ]; then
-          printf 'FINDING: %s: UNDECLARED live-repository git call: %s\n' "$num" "$argv"
-        fi
-        continue ;;
-    esac
-    dq=$(printf '%s' "$raw" | sed 's/"[^"]*"//g')
-    # ---- R2: A LINE THAT NAMES THE LIVE REPOSITORY MUST NOT INVOKE ANYTHING (roborev job 339).
-    # `$REPO_ROOT` is the ONLY in-region name for the live checkout, so any line that reaches a
-    # command while mentioning it is either a declared live call (handled above, by exact argv) or
-    # a finding. This one rule closes TWO holes the previous per-selector classifier had:
-    #   * THE SAME-LINE OVERRIDE. `git -C "$_CS_READ_DIR" -C "$REPO_ROOT" rev-parse "$sha^{commit}"`
-    #     was EXCUSED, because `CS_ISOLATED_SELECTORS` matched as a bare substring and the line was
-    #     never asked whether it ALSO named the live repository — and git honours the LAST `-C`. A
-    #     PASS over a live object read, with all six declared entries still observed.
-    #   * THE UNRECOGNISED COMMAND WORD. The direct-`git` test below only recognises the literal
-    #     word `git`, so `$GIT`, `eval`, `\git` or A SECOND WRAPPER (`_cs_live_git_quiet …`) was
-    #     classified as nothing at all, and 9b cannot backstop it (its EXT census excuses every
-    #     function defined in the gate, and its GAP half looks only through
-    #     `env`/`_component_set_bounded`/`_cs_live_git`).
-    # RESIDUAL, stated because the previous comment overclaimed ("the next spelling nobody has
-    # thought of") and a false rationale in a guard is worse than none: this rule sees a live call
-    # only if the live repository is named ON THAT LINE by the token `$REPO_ROOT`. A call that
-    # reaches the live repository by CWD with an unrecognised command word (`$GIT rev-parse …`, no
-    # `-C`), or through a variable copied from `$REPO_ROOT` in a way that hides the token, is NOT
-    # caught here — the copy's ASSIGNMENT line is caught (it mentions `$REPO_ROOT`), which is why
-    # the residual is narrow rather than absent.
     case "$raw" in
       *'$REPO_ROOT'*)
-        hit=""
-        rest="$dq"
-        while [ -n "$rest" ]; do
-          case "$rest" in
-            *'&&'*) frag="${rest%%&&*}"; rest="${rest#*&&}" ;;
-            *'||'*) frag="${rest%%\|\|*}"; rest="${rest#*\|\|}" ;;
-            *';'*)  frag="${rest%%;*}";  rest="${rest#*;}" ;;
-            *)      frag="$rest"; rest="" ;;
-          esac
-          w=$(cs_first_word "$frag")
-          [ -n "$w" ] || continue
-          for entry in "${CS_DECLARED_REPO_ROOT_HARMLESS[@]}"; do
-            [ "$w" = "$entry" ] && { w=""; break; }
-          done
-          [ -n "$w" ] || continue
-          hit="$w"
-          break
-        done
-        if [ -n "$hit" ]; then
-          printf 'FINDING: %s: a line naming the LIVE repository ($REPO_ROOT) invokes `%s`, and it is not one of the %s declared live calls — git honours the LAST -C, so an isolated selector on the same line excuses nothing: %s\n' \
-            "$num" "$hit" "${#CS_DECLARED_LIVE_CALLS[@]}" "$raw"
-          continue
-        fi
-        # No invocation on this line: the mention is a diagnostic, a path for a shell read, or a
-        # case-arm pattern. Nothing to check.
-        continue ;;
+        grep -Fxq -- "$raw" <<<"$CS_PINNED_REPO_ROOT_LINES" \
+          || printf 'FINDING[repo-root]: %s: this line names the LIVE repository ($REPO_ROOT) and is NOT one of the %s PINNED lines (whole-line equality; the line is not read, only compared): %s\n' "$num" "$cs_pin_rr_n" "$raw" ;;
     esac
-    # A DIRECT `git` at command position, on a line that does NOT name the live repository. Quoted
-    # spans were removed above so a diagnostic string (`_CS_DETAIL="git fetch … exited $rc"`,
-    # `hint="… git rebase …"`) is not read as an invocation — 9b's measured lesson. The word class
-    # excludes `--git-path`/`_cs_live_git`, where `git` is part of a longer word.
-    case "$dq" in
-      git\ *|*[[:space:]\;\&\|\(]git\ *) : ;;
-      *) continue ;;
-    esac
-    # THE LIVE-REPO TEST RUNS BEFORE THE ISOLATED EXCUSAL (roborev job 339). R2 above already
-    # rejects `$REPO_ROOT`; these two spellings name a repository without that token, so they are
-    # refused here rather than being excused by an isolated `-C` earlier on the same line.
-    case "$raw" in
-      *--git-dir*|*GIT_DIR=*)
-        printf 'FINDING: %s: a git invocation selects its repository with --git-dir/GIT_DIR, which no declared call uses and which OVERRIDES an isolated -C on the same line: %s\n' "$num" "$raw"
-        continue ;;
-    esac
-    hit=""
-    for entry in "${CS_ISOLATED_SELECTORS[@]}"; do
-      case "$raw" in *"$entry"*) hit=isolated; break ;; esac
-    done
-    [ -n "$hit" ] && continue
-    for entry in "${CS_DECLARED_DIRECT_GIT[@]}"; do
-      case "$raw" in *"${entry%%|*}"*) hit=declared; break ;; esac
-    done
-    [ -n "$hit" ] && continue
-    printf 'FINDING: %s: a DIRECT git invocation names no ISOLATED repository and is not declared — it may run in the LIVE checkout (route d): %s\n' "$num" "$raw"
-  done < <(cs_region_code "$gate")
-  # BOTH DIRECTIONS: a declared shape that no longer appears is a stale entry, and a stale entry
-  # pre-authorises its own re-introduction.
-  for i in "${!CS_DECLARED_LIVE_CALLS[@]}"; do
-    [ "${seen[$i]}" = 1 ] || printf 'FINDING: declared live call NOT OBSERVED in the region (stale entry, or the shape changed): %s\n' "${CS_DECLARED_LIVE_CALLS[$i]}"
-  done
+  done < <(cs_region_code "$g")
+  while IFS= read -r pin; do
+    [ -n "$pin" ] || continue
+    grep -Fxq -- "$pin" <<<"$code" \
+      || printf 'FINDING[live-call]: a PINNED live-call line no longer appears in the region (stale pin, or the line changed): %s\n' "$pin"
+  done <<<"$CS_PINNED_LIVE_CALL_LINES"
+  while IFS= read -r pin; do
+    [ -n "$pin" ] || continue
+    grep -Fxq -- "$pin" <<<"$code" \
+      || printf 'FINDING[repo-root]: a PINNED $REPO_ROOT line no longer appears in the region (stale pin, or the line changed): %s\n' "$pin"
+  done <<<"$CS_PINNED_REPO_ROOT_LINES"
 }
 
-live_findings=$(cs_live_call_findings "$GATE")
-if [ -z "$live_findings" ]; then
-  ok "3757-live-call-allowlist: the pre-flight region's LIVE-repository git calls are EXACTLY the ${#CS_DECLARED_LIVE_CALLS[@]} declared shapes (both directions), and HEAD's is the UNPEELED bare ref"
+pin_findings=$(cs_pinned_line_findings "$GATE")
+pin_live_bad=$(grep -F 'FINDING[live-call]' <<<"$pin_findings" || true)
+pin_rr_bad=$(grep -F 'FINDING[repo-root]' <<<"$pin_findings" || true)
+if [ -z "$pin_live_bad" ]; then
+  ok "3757-live-call-allowlist: every region CODE line mentioning _cs_live_git is one of the $cs_pin_live_n PINNED lines, whole-line, both directions — so HEAD's live call is the UNPEELED bare ref and nothing shares its line"
 else
-  bad "3757-live-call-allowlist: the region's live git calls do not match the declared set:"
-  printf '%s\n' "$live_findings"
+  bad "3757-live-call-allowlist: the live-call pin does not hold:"
+  printf '%s\n' "$pin_live_bad"
+fi
+if [ -z "$pin_rr_bad" ]; then
+  ok "3757-repo-root-line-pin: every OTHER region CODE line naming \$REPO_ROOT is one of the $cs_pin_rr_n PINNED lines, whole-line, both directions — no new line names the live repository"
+else
+  bad "3757-repo-root-line-pin: the \$REPO_ROOT line pin does not hold:"
+  printf '%s\n' "$pin_rr_bad"
 fi
 
-# THE FOUR EVASION ROUTES, EACH PLANTED IN ITS OWN THROWAWAY COPY (roborev job 325, blocker 1).
-# A control that plants only the shape the OLD deny pattern already caught proves nothing about
-# the three it missed, so each route is a SEPARATE mutation of the ARTIFACT (never a seam in the
-# gate) and each must be REPORTED, NAMED, and shown to have been substituted at all — a sed that
-# matched nothing would "pass" this by proving nothing.
+# TEN PLANTED ROUTES, EACH IN ITS OWN THROWAWAY COPY. Every route found across roborev jobs 325,
+# 339 and 347 is planted here, because a control that plants only the shape a previous guard caught
+# proves nothing about the ones it missed. Each mutation is verified to have been SUBSTITUTED at
+# all — a sed that matched nothing would "pass" by proving nothing — and each must produce a
+# finding NAMING what was planted.
+#
+# NOTE WHAT THE ASSERTION IS NOW: most of these are rejected because the mutated line is not
+# LITERALLY one of the pinned lines, not because anything recognised their syntax. The finding text
+# says exactly that ("is NOT one of the N PINNED lines"), and the needles below are the planted
+# TEXT, which the finding prints verbatim — so a route is proved reported without the guard
+# pretending to have understood it.
 lc_dir="$tmp/3757-live-call-controls"; mkdir -p "$lc_dir"
-lc_ids=(a b c d e f g h)
+lc_ids=(a b c d e f g h i j)
 lc_whats=(
   'a dereferencing rev that contains no ^{ (HEAD~1)'
   'the rev held in a VARIABLE, so no rev token appears on the call line'
@@ -1170,6 +1049,8 @@ lc_whats=(
   'a --git-dir="$REPO_ROOT/.git" appended to an isolated read'
   'a live call routed through a SECOND WRAPPER function'
   'a live call whose command word is a VARIABLE, not the literal git'
+  'a live peel inside a COMMAND SUBSTITUTION on a local declaration (the round-3 High)'
+  'an UNDECLARED read SMUGGLED IN FRONT of an allowed live call (roborev 347 item 2)'
 )
 lc_progs=(
   's|^\(  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet \)HEAD$|\1HEAD~1|'
@@ -1180,6 +1061,8 @@ lc_progs=(
   's|-C "\$_CS_READ_DIR" merge-base --is-ancestor|-C "$_CS_READ_DIR" --git-dir="$REPO_ROOT/.git" merge-base --is-ancestor|'
   's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  _cs_live_git_quiet --no-replace-objects -C "$REPO_ROOT" rev-parse --verify --quiet "HEAD^{commit}"|'
   's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  $CS_PLANTED_GIT_BIN --no-replace-objects -C "$REPO_ROOT" rev-parse --verify --quiet "HEAD^{commit}"|'
+  's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  local _cs_planted_sha=$(env -i "${_CS_GIT_ENV[@]}" git -C "$REPO_ROOT" rev-parse --verify --quiet "HEAD^{commit}")\n\&|'
+  's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  _cs_planted_undeclared_read; _cs_live_git --no-replace-objects -C "$REPO_ROOT" rev-parse --verify --quiet HEAD|'
 )
 lc_tooks=(
   'rev-parse --verify --quiet HEAD~1$'
@@ -1190,24 +1073,31 @@ lc_tooks=(
   '\-C "\$_CS_READ_DIR" --git-dir="\$REPO_ROOT/\.git"'
   '_cs_live_git_quiet --no-replace-objects'
   '\$CS_PLANTED_GIT_BIN --no-replace-objects'
+  'local _cs_planted_sha=\$(env'
+  '_cs_planted_undeclared_read; _cs_live_git'
 )
 lc_needles=(
-  'HEAD~1' '_cs_planted_rev' 'line CONTINUATION' '--git-dir='
+  'HEAD~1'
+  '_cs_planted_rev'
+  '-C "$REPO_ROOT" \'
+  '--git-dir="$REPO_ROOT/.git"'
   '-C "$_CS_READ_DIR" -C "$REPO_ROOT"'
   '--git-dir="$REPO_ROOT/.git"'
   '_cs_live_git_quiet'
   '$CS_PLANTED_GIT_BIN'
+  '_cs_planted_sha'
+  '_cs_planted_undeclared_read'
 )
 for lc_i in "${!lc_ids[@]}"; do
   lc_id="${lc_ids[$lc_i]}"
   lc_copy="$lc_dir/route-$lc_id.sh"
   sed "${lc_progs[$lc_i]}" "$GATE" >"$lc_copy"
   lc_n=$(grep -c "${lc_tooks[$lc_i]}" "$lc_copy" 2>/dev/null || true)
-  lc_out=$(cs_live_call_findings "$lc_copy")
+  lc_out=$(cs_pinned_line_findings "$lc_copy")
   if [ "$lc_n" != 1 ]; then
     bad "3757-evasion-route[$lc_id]: the mutation did not take (matched $lc_n times, expected 1) — this route is NOT under test, so a clean scan on the real gate is not evidence for it. Route: ${lc_whats[$lc_i]}"
   elif grep -qF -- "${lc_needles[$lc_i]}" <<<"$lc_out"; then
-    ok "3757-evasion-route[$lc_id]: ${lc_whats[$lc_i]} is REPORTED and NAMED (needle '${lc_needles[$lc_i]}') — the affirmative allowlist rejects it, and the old ^{ deny pattern did not"
+    ok "3757-evasion-route[$lc_id]: ${lc_whats[$lc_i]} is REPORTED and NAMED (needle '${lc_needles[$lc_i]}') — rejected by whole-line inequality against the pin, with no attempt to parse it"
   else
     bad "3757-evasion-route[$lc_id]: planting ${lc_whats[$lc_i]} produced no finding naming '${lc_needles[$lc_i]}' — a silent false PASS. Findings: $lc_out"
   fi
@@ -5558,7 +5448,11 @@ fi
 # 128 -> 130 with roborev job 347's two: read-dir control vi (the assertion moved back down to the
 # peel) and the behavioural `3757-read-dir-dominates` (no live read HAPPENS, measured from the
 # gate's own progress fields against a control with the assertion deleted). Both unconditional.
-CASE_FLOOR=130
+# 130 -> 133 with option A (roborev job 347): the syntax-recognising half was DELETED and the
+# property re-expressed as two whole-line pins, so the route set grew from EIGHT to TEN (+2: the
+# round-3 `local sha=$( … )` High and 347's prefix-smuggling item 2) and the second pin brought its
+# own clean case (+1). Net +3; nothing was removed from the case set, only from the mechanism.
+CASE_FLOOR=133
 if [ "$PASS" -lt "$CASE_FLOOR" ] && [ "$FAIL" -eq 0 ]; then
   printf 'FAIL - 3544-case-floor: %d cases ran but this suite declares a floor of %d — cases were REMOVED (or are skipping) without the floor being lowered deliberately. A green tally over a shrunken suite is the exact defect #3544 is about.\n' "$PASS" "$CASE_FLOOR"
   FAIL=$((FAIL + 1))

--- a/scripts/tests/test_agent_gate_component_set.sh
+++ b/scripts/tests/test_agent_gate_component_set.sh
@@ -937,38 +937,65 @@ fi
 # must update the pin, and the both-directions leg turns a forgotten update into a loud finding
 # rather than a silent hole. That is the same cost the live-call pin has always carried.
 #
-# WHAT IT DOES CLAIM, AND WHAT IT DOES NOT. COVERED: a line naming the live repository by DIRECT
-# expansion, in EITHER spelling — `$REPO_ROOT` or `${REPO_ROOT}`. That pair is closed by bash's
-# grammar (see the partition note below), so a direct-expansion read cannot escape the pins by
-# re-spelling itself.
+# WHAT IT DOES CLAIM, AND WHAT IT DOES NOT — AND THE SCOPE IS DELIBERATELY NARROW.
+# COVERED: a line naming the live repository by DIRECT EXPANSION OF THE NAME `REPO_ROOT`, either
+# unbraced (`$REPO_ROOT`) or braced in ANY form — `${REPO_ROOT}`, `${REPO_ROOT%/}`,
+# `${REPO_ROOT:-.}`, `${REPO_ROOT##*/}`, `${REPO_ROOT:0:5}`, `${REPO_ROOT[0]}`, and so on. That is
+# the WHOLE claim. It rests on the required-prefix property stated at the partition below, NOT on
+# any enumeration of bash's operators, and NOT on a claim that this guard sees every way a line
+# could reach the live repository.
 #
 # NOT COVERED, and these are genuinely open-ended: a live read that names the repository some
 # OTHER way — a path copied into another variable outside this region, an INDIRECT expansion
 # (`${!ref}`), a `cd` plus a bare `git` with no repo-root token, or a `GIT_DIR=` built from an
 # expression that never spells the name at all. Those are real residuals, not covered here, and
 # the runtime `_cs_read_dir_isolated_or_refuse` refusal plus the `/dev/null/` sentinel are what
-# bound them. This paragraph previously excused only "an expression that does not spell
-# `$REPO_ROOT`", which read as covering the braced form while the code did not — a false
-# rationale in a guard is worse than none, because it is what stops the next reader looking.
+# bound them.
+#
+# TWO PRIOR VERSIONS OF THIS PARAGRAPH WERE FALSE, IN THE SAME DIRECTION, AND THAT IS THE POINT
+# OF WRITING IT THIS WAY. The first excused only "an expression that does not spell `$REPO_ROOT`",
+# which READ as covering the braced form while the code did not (roborev job 376). The second
+# asserted the covered set was "closed by bash's grammar" because bash has "exactly two direct
+# expansions of a name" — which is simply untrue, since `${NAME<operator>…}` spans a large
+# operator family, and a read spelled `${REPO_ROOT%/}` walked straight through (roborev job 378).
+# Both times the CODE was narrower than the SENTENCE above it. A false rationale in a guard is
+# worse than none, because it is what stops the next reader looking — so this text now asserts
+# one mechanical property and names what is out of scope, rather than claiming completeness.
 #
 # THE PARTITION IS A SUBSTRING TEST, so the two pins never disagree about a line: a line
 # mentioning `_cs_live_git` is judged by the live-call pin (that is what makes a SECOND wrapper
 # such as `_cs_live_git_quiet` a finding rather than an unpinned stranger); every other
 # repo-root line is judged by the second pin.
 #
-# AND THE PARTITION MATCHES BOTH DIRECT EXPANSIONS, `$REPO_ROOT` AND `${REPO_ROOT}` (roborev job
-# 376). The COMPARISON escaped the tokeniser's disease; the SELECTION step had not. Matching only
-# the unbraced spelling meant `git -C "${REPO_ROOT}" cat-file -e "HEAD^{commit}"` contained
-# neither `_cs_live_git` nor the literal `$REPO_ROOT`, fell through BOTH arms, was never compared
-# against either pin, and so reintroduced a live-repository object read — and its promisor
-# lazy-fetch route — with the suite green. One character's distance, reachable by an ordinary
-# refactor rather than by construction, which is what made it a defect and not a residual.
+# THE SELECTION STEP HAD THE TOKENISER'S DISEASE TWICE, AND THE PREFIX TEST IS WHAT CURES IT.
+# The COMPARISON escaped it (whole-line equality cannot be evaded by rewriting a line), but the
+# SELECTION — which lines are subject to a pin AT ALL — was still a substring guess, and it was
+# wrong twice in the same place:
+#   job 376: matching only `$REPO_ROOT`, so `git -C "${REPO_ROOT}" cat-file -e "HEAD^{commit}"`
+#            matched NEITHER arm (in `${REPO_ROOT}` the `$` is followed by `{`) and was never
+#            compared against either pin — a live object read with the suite green.
+#   job 378: matching `${REPO_ROOT}` with the closing brace, so `${REPO_ROOT%/}`,
+#            `${REPO_ROOT:-.}` and `${REPO_ROOT##*/}` walked through the same hole.
+# Each fix added one more member to an ENUMERATION of spellings, which is exactly the open-ended
+# question the deleted recogniser died of.
 #
-# THIS IS A CLOSED SET, AND THAT IS WHY IT IS NOT THE TOKENISER COMING BACK. Bash has exactly TWO
-# direct expansions of a name — `$NAME` and `${NAME}` — so this enumeration is closed by the
-# LANGUAGE GRAMMAR, not by our imagination about what an author might write. That is the precise
-# difference from the deleted recogniser, which had to enumerate an open-ended space of ways a
-# line could REACH the live repository. Indirect naming stays a declared residual below.
+# SO THE BRACED ARM IS A REQUIRED-PREFIX TEST — `${REPO_ROOT` with NO closing brace — and the
+# argument for it is a property of the SYNTAX, not a list of operators: in a braced expansion
+# bash requires the NAME immediately after `{`, and every operator comes AFTER the name. So any
+# braced expansion that yields this variable's value MUST textually begin `${REPO_ROOT`, whatever
+# follows. New bash operators cannot escape it, because they can only appear after the name.
+#
+# THE ERRORS RUN ONE WAY ONLY, WHICH IS WHY A PREFIX IS ACCEPTABLE HERE. `${REPO_ROOTX}` also
+# matches and so also gets pinned: a line that must be listed in the pin table but arguably need
+# not be — a false FAIL, loud, fixable by pinning it, and NEVER a false PASS. That is the same
+# conservatism the unbraced arm has always carried against `$REPO_ROOT_FOO`.
+#
+# TWO BRACED FORMS DO NOT BEGIN WITH THAT PREFIX, AND NEITHER IS A ROUTE — named so a reader does
+# not read them as missed. `${#REPO_ROOT}` yields the LENGTH of the value (a number: measured `6`
+# for a 6-character root), so it cannot name a repository to `git -C`; `${!REPO_ROOT}` is INDIRECT
+# — it treats the VALUE as a variable name and yields that other variable — so it is part of the
+# indirect residual declared above, not of direct expansion. This guard claims direct expansion of
+# THIS NAME, and nothing more.
 #
 # Both blocks are QUOTED HEREDOCS, so `"`, `$`, `\` and `'` inside the pinned lines need no
 # escaping and cannot drift from the gate's own text through a quoting mistake.
@@ -1016,9 +1043,9 @@ cs_pinned_line_findings() {
         continue ;;
     esac
     case "$raw" in
-      *'$REPO_ROOT'*|*'${REPO_ROOT}'*)
+      *'$REPO_ROOT'*|*'${REPO_ROOT'*)
         grep -Fxq -- "$raw" <<<"$CS_PINNED_REPO_ROOT_LINES" \
-          || printf 'FINDING[repo-root]: %s: this line names the LIVE repository ($REPO_ROOT or ${REPO_ROOT}) and is NOT one of the %s PINNED lines (whole-line equality; the line is not read, only compared): %s\n' "$num" "$cs_pin_rr_n" "$raw" ;;
+          || printf 'FINDING[repo-root]: %s: this line names the LIVE repository (direct expansion of REPO_ROOT, braced or not) and is NOT one of the %s PINNED lines (whole-line equality; the line is not read, only compared): %s\n' "$num" "$cs_pin_rr_n" "$raw" ;;
     esac
   done < <(cs_region_code "$g")
   while IFS= read -r pin; do
@@ -1061,7 +1088,7 @@ fi
 # TEXT, which the finding prints verbatim — so a route is proved reported without the guard
 # pretending to have understood it.
 lc_dir="$tmp/3757-live-call-controls"; mkdir -p "$lc_dir"
-lc_ids=(a b c d e f g h i j k)
+lc_ids=(a b c d e f g h i j k l m n)
 lc_whats=(
   'a dereferencing rev that contains no ^{ (HEAD~1)'
   'the rev held in a VARIABLE, so no rev token appears on the call line'
@@ -1074,6 +1101,9 @@ lc_whats=(
   'a live peel inside a COMMAND SUBSTITUTION on a local declaration (the round-3 High)'
   'an UNDECLARED read SMUGGLED IN FRONT of an allowed live call (roborev 347 item 2)'
   'a live read naming the repo through the BRACED expansion ${REPO_ROOT} (roborev job 376)'
+  'a live read through the braced SUFFIX-STRIP form ${REPO_ROOT%/} (roborev job 378)'
+  'a live read through the braced DEFAULT-VALUE form ${REPO_ROOT:-.} (roborev job 378)'
+  'a live read through the braced GREEDY-PREFIX-STRIP form ${REPO_ROOT##*/} (roborev job 378)'
 )
 # PORTABILITY (roborev job 366): a newline in a sed REPLACEMENT is written as a backslash
 # followed by a LITERAL newline, which POSIX mandates for splitting a line. A GNU-style `\n`
@@ -1093,6 +1123,9 @@ lc_progs=(
 \&|'
   's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  _cs_planted_undeclared_read; _cs_live_git --no-replace-objects -C "$REPO_ROOT" rev-parse --verify --quiet HEAD|'
   's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  _component_set_bounded "$_CS_BOUND_SECS" env -i "${_CS_GIT_ENV[@]}" git -C "${REPO_ROOT}" cat-file -e "HEAD^{commit}"|'
+  's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  _component_set_bounded "$_CS_BOUND_SECS" env -i "${_CS_GIT_ENV[@]}" git -C "${REPO_ROOT%/}" cat-file -e "HEAD^{commit}"|'
+  's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  _component_set_bounded "$_CS_BOUND_SECS" env -i "${_CS_GIT_ENV[@]}" git -C "${REPO_ROOT:-.}" cat-file -e "HEAD^{commit}"|'
+  's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  _component_set_bounded "$_CS_BOUND_SECS" env -i "${_CS_GIT_ENV[@]}" git -C "${REPO_ROOT##*/}" cat-file -e "HEAD^{commit}"|'
 )
 lc_tooks=(
   'rev-parse --verify --quiet HEAD~1$'
@@ -1106,6 +1139,9 @@ lc_tooks=(
   'local _cs_planted_sha=\$(env'
   '_cs_planted_undeclared_read; _cs_live_git'
   'git -C "\${REPO_ROOT}" cat-file'
+  'git -C "\${REPO_ROOT%/}" cat-file'
+  'git -C "\${REPO_ROOT:-\.}" cat-file'
+  'git -C "\${REPO_ROOT##\*/}" cat-file'
 )
 lc_needles=(
   'HEAD~1'
@@ -1119,6 +1155,9 @@ lc_needles=(
   '_cs_planted_sha'
   '_cs_planted_undeclared_read'
   '-C "${REPO_ROOT}" cat-file'
+  '-C "${REPO_ROOT%/}" cat-file'
+  '-C "${REPO_ROOT:-.}" cat-file'
+  '-C "${REPO_ROOT##*/}" cat-file'
 )
 for lc_i in "${!lc_ids[@]}"; do
   lc_id="${lc_ids[$lc_i]}"
@@ -5496,7 +5535,7 @@ fi
 # property re-expressed as two whole-line pins, so the route set grew from EIGHT to TEN (+2: the
 # round-3 `local sha=$( … )` High and 347's prefix-smuggling item 2) and the second pin brought its
 # own clean case (+1). Net +3; nothing was removed from the case set, only from the mechanism.
-CASE_FLOOR=133
+CASE_FLOOR=136
 if [ "$PASS" -lt "$CASE_FLOOR" ] && [ "$FAIL" -eq 0 ]; then
   printf 'FAIL - 3544-case-floor: %d cases ran but this suite declares a floor of %d — cases were REMOVED (or are skipping) without the floor being lowered deliberately. A green tally over a shrunken suite is the exact defect #3544 is about.\n' "$PASS" "$CASE_FLOOR"
   FAIL=$((FAIL + 1))

--- a/scripts/tests/test_agent_gate_component_set.sh
+++ b/scripts/tests/test_agent_gate_component_set.sh
@@ -1285,7 +1285,7 @@ fi
 #       (iii) the peel calls the runtime refusal before handing the value to git.
 # ---------------------------------------------------------------------------
 cs_read_dir_findings() {
-  local g="$1" init sentinel_decl assign assign_ln body_lo body_hi consumers ln peel_ln guard_ln refuse_body glob_init
+  local g="$1" init sentinel_decl assign assign_ln body_lo body_hi consumers ln guard_ln guard_n refuse_body glob_init
   init=$(cs_region_code "$g" | grep -F '_CS_READ_DIR=' | grep -F '_CS_READ_ENV=(); _CS_HEAD_SHA=' | head -1)
   if [ -z "$init" ]; then
     printf 'FINDING: could not locate the probe initialiser line that sets _CS_READ_DIR — the shape changed or the scan broke (fail-closed)\n'
@@ -1367,15 +1367,42 @@ cs_read_dir_findings() {
   elif ! grep -qF '[ "$_CS_READ_DIR" = "$_CS_SCRATCH_DIR/repo" ]' <<<"$refuse_body"; then
     printf 'FINDING: the refusal is not AFFIRMATIVE — it does not require _CS_READ_DIR to BE the scratch this run created ($_CS_SCRATCH_DIR/repo), so an unlisted bad value passes silently\n'
   fi
-  peel_ln=$(cs_region_code "$g" | grep -F 'rev-parse --verify --quiet "${head_unpeeled}^{commit}"' | head -1)
-  guard_ln=$(cs_region_code "$g" | grep -F '_cs_read_dir_isolated_or_refuse "peel HEAD' | head -1)
-  if [ -z "$peel_ln" ]; then
-    printf 'FINDING: could not locate the scratch peel (fail-closed)\n'
-  elif [ -z "$guard_ln" ]; then
-    printf 'FINDING: the peel does not call _cs_read_dir_isolated_or_refuse — an unisolated value would be handed to git instead of refused by name\n'
-  elif [ "${guard_ln%%:*}" -ge "${peel_ln%%:*}" ]; then
-    printf 'FINDING: the _cs_read_dir_isolated_or_refuse call (line %s) is not BEFORE the peel (line %s) — a check placed after the harmful effect can only report it\n' "${guard_ln%%:*}" "${peel_ln%%:*}"
+  # THE GUARD MUST DOMINATE EVERY CONSUMER, NOT MERELY PRECEDE THE PEEL (roborev job 347). The
+  # first version asserted only "the call is before the peel", and that is the standing error this
+  # repo keeps ruling on: FOUR object reads run before the peel (the fast path's `cat-file -e` and
+  # `rev-list`, and the manifest `ls-tree`/`show` through `_component_set_set_at_rev`), so a check
+  # there could only REPORT a prohibited live read that had already happened. Two consumer kinds,
+  # so two comparisons: the direct `-C "$_CS_READ_DIR"` sites in the probe body, and the probe
+  # body's CALLS to the helpers whose own bodies are lexically earlier.
+  guard_ln=$(cs_region_code "$g" | grep -F '_cs_read_dir_isolated_or_refuse "' | head -1)
+  guard_n=$(cs_region_code "$g" | grep -cF '_cs_read_dir_isolated_or_refuse "' || true)
+  if [ -z "$guard_ln" ]; then
+    printf 'FINDING: nothing calls _cs_read_dir_isolated_or_refuse — an unisolated value would be handed to git instead of refused by name\n'
+    return 0
   fi
+  if [ "$guard_n" != 1 ]; then
+    printf 'FINDING: %s calls to _cs_read_dir_isolated_or_refuse; ONE placement that dominates every consumer is the contract, and N scattered asserts is the drift this region removes\n' "$guard_n"
+  fi
+  guard_ln="${guard_ln%%:*}"
+  if [ "$guard_ln" -le "$assign_ln" ]; then
+    printf 'FINDING: the _cs_read_dir_isolated_or_refuse call (line %s) does not follow the scratch assignment (line %s), so it cannot be asserting what that assignment produced\n' "$guard_ln" "$assign_ln"
+  fi
+  while IFS= read -r ln; do
+    [ -n "$ln" ] || continue
+    [ "${ln%%:*}" -ge "$body_lo" ] || continue
+    [ "${ln%%:*}" -le "$body_hi" ] || continue
+    if [ "${ln%%:*}" -lt "$guard_ln" ]; then
+      printf 'FINDING: %s: an object read through $_CS_READ_DIR runs BEFORE the isolation assertion at line %s — the assertion does not dominate it, so a prohibited LIVE read happens and is only then reported: %s\n' "${ln%%:*}" "$guard_ln" "${ln#*:}"
+    fi
+  done <<<"$consumers"
+  while IFS= read -r ln; do
+    [ -n "$ln" ] || continue
+    [ "${ln%%:*}" -ge "$body_lo" ] || continue
+    [ "${ln%%:*}" -le "$body_hi" ] || continue
+    if [ "${ln%%:*}" -lt "$guard_ln" ]; then
+      printf 'FINDING: %s: the probe CALLS a helper that reads through $_CS_READ_DIR before the isolation assertion at line %s — lexically the helper body is elsewhere, but this call site runs first: %s\n' "${ln%%:*}" "$guard_ln" "${ln#*:}"
+    fi
+  done <<<"$(cs_region_code "$g" | grep -E '^[0-9]+:[[:space:]]*(if )?_component_set_set_at_rev ')"
   return 0
 }
 rd_findings=$(cs_read_dir_findings "$GATE")
@@ -1386,39 +1413,43 @@ else
   printf '%s\n' "$rd_findings"
 fi
 
-# FIVE PLANTED CONTROLS over the three properties (roborev job 339, item 3: this said "THREE
+# SIX PLANTED CONTROLS over the three properties (roborev job 339, item 3: this said "THREE
 # PLANTED CONTROLS, one per property" over four entries, and neither half was true — i and ii both
 # target the INITIALISER). Each mutates a COPY and must be REPORTED and NAMED.
 rd_dir="$tmp/3757-read-dir-controls"; mkdir -p "$rd_dir"
-rd_ids=(i ii iii iv v)
+rd_ids=(i ii iii iv v vi)
 rd_whats=(
   'the initialiser set back to the LIVE checkout'
   'the initialiser left EMPTY, which git reads as the CURRENT directory'
   'a -C "$_CS_READ_DIR" consumer planted BEFORE the scratch assignment, in the probe body'
-  'the runtime refusal call removed from the peel'
+  'the runtime refusal call removed entirely'
   'the refusal reverted to a DENY-LIST of bad states instead of an affirmative test'
+  'the refusal moved back DOWN to the peel, behind four object reads (the job-347 regression)'
 )
 rd_progs=(
   's|^  _CS_READ_DIR="\$_CS_READ_DIR_UNSET"; _CS_READ_ENV=(); _CS_HEAD_SHA=""$|  _CS_READ_DIR="$REPO_ROOT"; _CS_READ_ENV=(); _CS_HEAD_SHA=""|'
   's|^  _CS_READ_DIR="\$_CS_READ_DIR_UNSET"; _CS_READ_ENV=(); _CS_HEAD_SHA=""$|  _CS_READ_DIR=""; _CS_READ_ENV=(); _CS_HEAD_SHA=""|'
   's|^  _CS_READ_DIR="\$csdir/repo"$|  : "$(git --no-replace-objects -C "$_CS_READ_DIR" cat-file -e planted-by-the-selftest 2>/dev/null)"\n  _CS_READ_DIR="$csdir/repo"|'
-  '/_cs_read_dir_isolated_or_refuse "peel HEAD/d'
+  '/_cs_read_dir_isolated_or_refuse "/d'
   's|if \[ -n "\$_CS_SCRATCH_DIR" \] && \[ "\$_CS_READ_DIR" = "\$_CS_SCRATCH_DIR/repo" \]; then|if [ "$_CS_READ_DIR" != "$REPO_ROOT" ]; then|'
+  '/_cs_read_dir_isolated_or_refuse "/d; s|^\(    \)_CS_HEAD_SHA=\$(_component_set_bounded|\1if _cs_read_dir_isolated_or_refuse "peel HEAD"; then return 0; fi\n\1_CS_HEAD_SHA=$(_component_set_bounded|'
 )
 rd_tooks=(
   '^  _CS_READ_DIR="\$REPO_ROOT"; _CS_READ_ENV'
   '^  _CS_READ_DIR=""; _CS_READ_ENV'
   'cat-file -e planted-by-the-selftest'
-  '_cs_read_dir_isolated_or_refuse "peel HEAD'
+  '_cs_read_dir_isolated_or_refuse "'
   'if \[ "\$_CS_READ_DIR" != "\$REPO_ROOT" \]; then'
+  '_cs_read_dir_isolated_or_refuse "peel HEAD"'
 )
-rd_expect_n=(1 1 1 0 1)
+rd_expect_n=(1 1 1 0 1 1)
 rd_needles=(
   'THE LIVE CHECKOUT'
   'reads -C "" as the CURRENT directory'
   'BEFORE the scratch assignment'
-  'does not call _cs_read_dir_isolated_or_refuse'
+  'nothing calls _cs_read_dir_isolated_or_refuse'
   'not AFFIRMATIVE'
+  'the assertion does not dominate it'
 )
 for rd_i in "${!rd_ids[@]}"; do
   rd_id="${rd_ids[$rd_i]}"
@@ -1434,6 +1465,51 @@ for rd_i in "${!rd_ids[@]}"; do
     bad "3757-read-dir-control[$rd_id]: planting '${rd_whats[$rd_i]}' produced no finding naming '${rd_needles[$rd_i]}' — a silent false PASS. Findings: $rd_out"
   fi
 done
+
+# ---------------------------------------------------------------------------
+# 3757c-bis. BEHAVIOURAL: THE REFUSAL PREVENTS THE LIVE READS, IT DOES NOT MERELY REPORT THEM
+#     (roborev job 347, item 1). The structural case above pins WHERE the assertion sits; this one
+#     measures that no prohibited read HAPPENED, which is what the finding actually asked for.
+#
+#     HOW THE ABSENCE OF A READ IS OBSERVED, without inventing an oracle: the gate records its own
+#     progress in fields the self-test hook already prints. `BASELINE_OBJECTS` is set by the FAST
+#     PATH'S FIRST OBJECT READ (`cat-file -e <sha>^{commit}` + `rev-list`), and `BASELINE_SRC` by
+#     the manifest read (`ls-tree`/`show`). Both run through `$_CS_READ_DIR`, so with the scratch
+#     assignment rewritten to the LIVE checkout they are LIVE reads — and if the assertion
+#     dominates them, BOTH fields must still read `<none>` while the KIND is `read-dir-unisolated`.
+#     `<none>` here is not an absence of evidence: it is the gate reporting that the step which
+#     would have set the field never ran.
+#
+#     THE CONTROL IS WHAT MAKES THAT MEAN ANYTHING: the same fixture with the assertion DELETED
+#     must show those fields POPULATED, i.e. the live reads really are on this path and really do
+#     happen when nothing stops them. Without it, `<none>` could just as well mean the fixture
+#     never got that far for some unrelated reason.
+# ---------------------------------------------------------------------------
+dom_base=$(mkbaseline base-readdir-dom - )
+dom_live_sed='s|^  _CS_READ_DIR="\$csdir/repo"$|  _CS_READ_DIR="$REPO_ROOT"|'
+dom_fx=$(mkbranch readdir-dom "$dom_base" "$dom_live_sed" --from-origin)
+dom_ctl_fx=$(mkbranch readdir-dom-noassert "$dom_base" "$dom_live_sed"'; /_cs_read_dir_isolated_or_refuse "/d' --from-origin)
+dom_took=$(grep -c '^  _CS_READ_DIR="\$REPO_ROOT"$' "$dom_fx/scripts/agent-gate.sh" 2>/dev/null || true)
+dom_ctl_took=$(grep -c '_cs_read_dir_isolated_or_refuse "' "$dom_ctl_fx/scripts/agent-gate.sh" 2>/dev/null || true)
+dom_out=$(hook "$dom_fx")
+dom_ctl=$(hook "$dom_ctl_fx")
+dom_kind=$(field KIND "$dom_out")
+dom_obj=$(field BASELINE_OBJECTS "$dom_out")
+dom_src=$(field BASELINE_SRC "$dom_out")
+dom_ctl_obj=$(field BASELINE_OBJECTS "$dom_ctl")
+dom_ctl_src=$(field BASELINE_SRC "$dom_ctl")
+if [ "$dom_took" != 1 ]; then
+  bad "3757-read-dir-dominates: the fixture mutation did not take (matched $dom_took, expected 1) — nothing is under test"
+elif [ "$dom_ctl_took" != 0 ]; then
+  bad "3757-read-dir-dominates: the CONTROL still calls the assertion ($dom_ctl_took occurrence(s)) — it cannot show what happens without it"
+elif [ "$dom_ctl_obj" = "<none>" ] && [ "$dom_ctl_src" = "<none>" ]; then
+  bad "3757-read-dir-dominates: the CONTROL (assertion deleted) read NOTHING either (objects='$dom_ctl_obj' src='$dom_ctl_src'), so the live reads are not on this path and a '<none>' in the subject would prove nothing"
+elif [ "$dom_kind" = read-dir-unisolated ] && [ "$dom_obj" = "<none>" ] && [ "$dom_src" = "<none>" ]; then
+  ok "3757-read-dir-dominates: with the read repository left at the LIVE checkout the run refuses (read-dir-unisolated) having performed NO object read and NO manifest read (BASELINE_OBJECTS/BASELINE_SRC both <none>), while the same fixture without the assertion records both (objects='$dom_ctl_obj' src='$dom_ctl_src') — the assertion PREVENTS the reads, it does not report them afterwards"
+else
+  bad "3757-read-dir-dominates: expected read-dir-unisolated with NO read recorded (got kind='$dom_kind' objects='$dom_obj' src='$dom_src'; control objects='$dom_ctl_obj' src='$dom_ctl_src')"
+  printf '%s\n' "$dom_out"
+fi
 
 # ---------------------------------------------------------------------------
 # 3757d. BEHAVIOURAL: an unisolated read repository is REFUSED BY NAME, not read live.
@@ -5479,7 +5555,10 @@ fi
 # 123 -> 128 with roborev job 339's five: evasion routes e-h (the same-line -C override, the
 # --git-dir override, a second wrapper, a variable command word) and read-dir control v (the
 # refusal reverted to a deny-list). All five unconditional.
-CASE_FLOOR=128
+# 128 -> 130 with roborev job 347's two: read-dir control vi (the assertion moved back down to the
+# peel) and the behavioural `3757-read-dir-dominates` (no live read HAPPENS, measured from the
+# gate's own progress fields against a control with the assertion deleted). Both unconditional.
+CASE_FLOOR=130
 if [ "$PASS" -lt "$CASE_FLOOR" ] && [ "$FAIL" -eq 0 ]; then
   printf 'FAIL - 3544-case-floor: %d cases ran but this suite declares a floor of %d — cases were REMOVED (or are skipping) without the floor being lowered deliberately. A green tally over a shrunken suite is the exact defect #3544 is about.\n' "$PASS" "$CASE_FLOOR"
   FAIL=$((FAIL + 1))

--- a/scripts/tests/test_agent_gate_component_set.sh
+++ b/scripts/tests/test_agent_gate_component_set.sh
@@ -955,21 +955,35 @@ CS_DECLARED_DIRECT_GIT=(
 )
 CS_ISOLATED_SELECTORS=('-C "$_CS_READ_DIR"' '-C "$csdir/repo"')
 cs_live_call_findings() {
-  local gate="$1" line num raw argv dq entry i hit
+  local gate="$1" line num raw argv dq entry i hit prev_cont=0
   local -a seen=()
   for i in "${!CS_DECLARED_LIVE_CALLS[@]}"; do seen[$i]=0; done
   while IFS= read -r line; do
     [ -n "$line" ] || continue
     num="${line%%:*}"; raw="${line#*:}"
-    # ROUTE (c): a continued line cannot be judged as a line. Reject it rather than judge the
-    # fragment — a `\` continuation is how an argument list hides from a per-line scan.
+    # ROUTE (c): a LIVE call split over a `\` continuation cannot be judged as a line, so it is
+    # rejected rather than judged from the fragment — a continuation is how an argument list hides
+    # from a per-line scan. SCOPED TO `_cs_live_git` LINES, because an `&&`-chained ISOLATED read
+    # legitimately continues (the fast path's presence probe does, and an unscoped rule RED on it
+    # — measured, first run: a guard that reds on correct input is the guard agents learn to
+    # waive).
     case "$raw" in
-      *'\') case "$raw" in
-              *_cs_live_git*|*' git '*|*'	git '*)
-                printf 'FINDING: %s: a git call is split over a line CONTINUATION, so its argument list cannot be judged as one line — write it on one line (or declare it): %s\n' "$num" "$raw"
-                continue ;;
-            esac ;;
+      *_cs_live_git*'\')
+        printf 'FINDING: %s: a LIVE git call is split over a line CONTINUATION, so its argument list cannot be judged as one line — write it on one line: %s\n' "$num" "$raw"
+        prev_cont=1; continue ;;
     esac
+    # THE TAIL OF A CONTINUED CALL IS ALSO A PLACE A LIVE REPOSITORY CAN BE NAMED. `git` takes the
+    # LAST `-C`, so an isolated first line followed by a tail naming `$REPO_ROOT` (or a
+    # `--git-dir=`/`GIT_DIR=`) would run live while the first line classified as isolated. Nothing
+    # in the region does this today; the rule is what keeps it that way, and the set it forbids is
+    # EMPTY rather than declared, so there is nothing to keep in step.
+    if [ "$prev_cont" = 1 ]; then
+      case "$raw" in
+        *'$REPO_ROOT'*|*--git-dir*|*GIT_DIR=*)
+          printf 'FINDING: %s: the CONTINUATION TAIL of a git call names the live repository (git honours the LAST -C, so this can redirect an isolated call): %s\n' "$num" "$raw" ;;
+      esac
+    fi
+    case "$raw" in *'\') prev_cont=1 ;; *) prev_cont=0 ;; esac
     case "$raw" in
       *_cs_live_git\ *)
         argv="${raw#*_cs_live_git }"
@@ -983,7 +997,7 @@ cs_live_call_findings() {
         if [ -z "$hit" ]; then
           printf 'FINDING: %s: UNDECLARED live-repository git call: %s\n' "$num" "$argv"
         fi
-        continue ;;
+        prev_cont=0; continue ;;
     esac
     # A DIRECT `git` at command position. Quoted spans are removed FIRST so a diagnostic string
     # (`_CS_DETAIL="git fetch … exited $rc"`, `hint="… git rebase …"`) is not read as an
@@ -1098,7 +1112,8 @@ cs_scratch_peel_findings() {
   return 0
 }
 sp_findings=$(cs_scratch_peel_findings "$GATE")
-sp_ctl="$peel_ctl_dir/unbounded-gate.sh"
+sp_dir="$tmp/3757-scratch-peel-control"; mkdir -p "$sp_dir"
+sp_ctl="$sp_dir/unbounded-gate.sh"
 sed 's|\(_CS_HEAD_SHA=\$(\)_component_set_bounded "\$_CS_BOUND_SECS" \(env -i\)|\1\2|' "$GATE" >"$sp_ctl"
 sp_ctl_took=$(grep -c '_CS_HEAD_SHA=\$(env -i' "$sp_ctl")
 sp_ctl_findings=$(cs_scratch_peel_findings "$sp_ctl")
@@ -1132,7 +1147,7 @@ fi
 #       (iii) the peel calls the runtime refusal before handing the value to git.
 # ---------------------------------------------------------------------------
 cs_read_dir_findings() {
-  local g="$1" init assign assign_ln consumers ln peel_ln guard_ln
+  local g="$1" init sentinel_decl assign assign_ln body_lo body_hi consumers ln peel_ln guard_ln
   init=$(cs_region_code "$g" | grep -F '_CS_READ_DIR=' | grep -F '_CS_READ_ENV=(); _CS_HEAD_SHA=' | head -1)
   if [ -z "$init" ]; then
     printf 'FINDING: could not locate the probe initialiser line that sets _CS_READ_DIR — the shape changed or the scan broke (fail-closed)\n'
@@ -1140,9 +1155,22 @@ cs_read_dir_findings() {
     case "$init" in
       *'_CS_READ_DIR="$REPO_ROOT"'*)
         printf 'FINDING: %s: the initialiser makes THE LIVE CHECKOUT the default read repository, so any consumer reached before the scratch assignment reads objects live: %s\n' "${init%%:*}" "${init#*:}" ;;
-      *'_CS_READ_DIR=""'*) : ;;
-      *) printf 'FINDING: %s: the initialiser sets _CS_READ_DIR to an unrecognised value; only the empty sentinel is declared: %s\n' "${init%%:*}" "${init#*:}" ;;
+      *'_CS_READ_DIR=""'*)
+        printf 'FINDING: %s: the initialiser leaves the read repository EMPTY, and git reads -C "" as the CURRENT directory (measured: rc 0, and cat-file -e HEAD^{commit} succeeds), so an unguarded consumer reads the LIVE repository: %s\n' "${init%%:*}" "${init#*:}" ;;
+      *'_CS_READ_DIR="$_CS_READ_DIR_UNSET"'*) : ;;
+      *) printf 'FINDING: %s: the initialiser sets _CS_READ_DIR to an unrecognised value; only the declared UNSET sentinel is allowed: %s\n' "${init%%:*}" "${init#*:}" ;;
     esac
+  fi
+  # THE SENTINEL MUST BE A PATH THAT CANNOT EXIST — that is what makes an unguarded consumer fail
+  # CLOSED rather than read live, and it is the half no source scan could otherwise supply.
+  # CAPTURED, NOT PIPED INTO `grep -q`. This suite runs under `pipefail`, and a successful
+  # `grep -q` EXITS EARLY, which SIGPIPEs the upstream producer — so the PIPELINE status is 141
+  # even though the pattern was found, and `if ! …` then fires on a correct tree. Measured here on
+  # the first run: this exact predicate reported the sentinel "not declared" while a standalone
+  # `grep -c` on the same input answered 1.
+  sentinel_decl=$(cs_region_code "$g" | grep "^[0-9][0-9]*:_CS_READ_DIR_UNSET='/nonexistent/" || true)
+  if [ -z "$sentinel_decl" ]; then
+    printf 'FINDING: the UNSET sentinel is not declared as a literal /nonexistent/... path — a sentinel git can resolve is a live read waiting to happen\n'
   fi
   assign=$(cs_region_code "$g" | grep -F '_CS_READ_DIR="$csdir/repo"' | head -1)
   if [ -z "$assign" ]; then
@@ -1150,14 +1178,35 @@ cs_read_dir_findings() {
     return 0
   fi
   assign_ln="${assign%%:*}"
+  # ORDERING, SCOPED TO `_component_set_probe_inner`'s OWN BODY — and the scope is the honest part.
+  # LEXICAL POSITION IS NOT EXECUTION ORDER FOR A FUNCTION BODY: three `-C "$_CS_READ_DIR"`
+  # consumers live in helper functions DEFINED hundreds of lines EARLIER than the assignment and
+  # CALLED after it, so a region-wide rule reported all three as "before the assignment" — a false
+  # FAIL on correct code, measured on the first run. Inside one function body the two orders DO
+  # coincide, so that is where the rule applies. DECLARED RESIDUAL: consumers in helper bodies are
+  # NOT covered by this rule; they are covered by the UNSET sentinel above (an unguarded read fails
+  # closed) and, for the peel, by the runtime refusal below.
+  body_lo=$(cs_region_stream "$g" | grep '^[0-9][0-9]*:_component_set_probe_inner() {$' | head -1)
+  body_lo="${body_lo%%:*}"
+  if [ -z "$body_lo" ]; then
+    printf 'FINDING: could not locate _component_set_probe_inner in the region (fail-closed)\n'
+    return 0
+  fi
+  body_hi=$(cs_region_stream "$g" | awk -F: -v lo="$body_lo" '$1+0 > lo+0 && $0 ~ /^[0-9]+:}$/ { print $1; exit }')
+  if [ -z "$body_hi" ]; then
+    printf 'FINDING: could not locate the end of _component_set_probe_inner (fail-closed)\n'
+    return 0
+  fi
   consumers=$(cs_region_code "$g" | grep -F -- '-C "$_CS_READ_DIR"')
   if [ -z "$consumers" ]; then
     printf 'FINDING: no -C "$_CS_READ_DIR" consumer found in the region — the guard has no subject (fail-closed)\n'
   fi
   while IFS= read -r ln; do
     [ -n "$ln" ] || continue
+    [ "${ln%%:*}" -ge "$body_lo" ] || continue
+    [ "${ln%%:*}" -le "$body_hi" ] || continue
     if [ "${ln%%:*}" -lt "$assign_ln" ]; then
-      printf 'FINDING: %s: a -C "$_CS_READ_DIR" consumer runs BEFORE the scratch assignment at line %s, so it would read in whatever the initialiser left: %s\n' "${ln%%:*}" "$assign_ln" "${ln#*:}"
+      printf 'FINDING: %s: a -C "$_CS_READ_DIR" consumer runs BEFORE the scratch assignment at line %s, in the probe body where lexical order IS execution order: %s\n' "${ln%%:*}" "$assign_ln" "${ln#*:}"
     fi
   done <<<"$consumers"
   peel_ln=$(cs_region_code "$g" | grep -F 'rev-parse --verify --quiet "${head_unpeeled}^{commit}"' | head -1)
@@ -1173,7 +1222,7 @@ cs_read_dir_findings() {
 }
 rd_findings=$(cs_read_dir_findings "$GATE")
 if [ -z "$rd_findings" ]; then
-  ok "3757-read-dir-shape: the read repository is an empty sentinel until the scratch exists, every -C \$_CS_READ_DIR consumer runs after the scratch assignment, and the peel refuses an unisolated value before calling git"
+  ok "3757-read-dir-shape: the read repository is a NON-EXISTENT-path sentinel until the scratch exists (so an unguarded consumer fails closed, not live), no consumer in the probe body precedes the scratch assignment, and the peel refuses an unisolated value before calling git"
 else
   bad "3757-read-dir-shape: the read-repository invariants are not met:"
   printf '%s\n' "$rd_findings"
@@ -1181,24 +1230,27 @@ fi
 
 # THREE PLANTED CONTROLS, one per property. Each mutates a COPY and must be REPORTED and NAMED.
 rd_dir="$tmp/3757-read-dir-controls"; mkdir -p "$rd_dir"
-rd_ids=(i ii iii)
+rd_ids=(i ii iii iv)
 rd_whats=(
   'the initialiser set back to the LIVE checkout'
-  'a -C "$_CS_READ_DIR" consumer planted BEFORE the scratch assignment'
+  'the initialiser left EMPTY, which git reads as the CURRENT directory'
+  'a -C "$_CS_READ_DIR" consumer planted BEFORE the scratch assignment, in the probe body'
   'the runtime refusal call removed from the peel'
 )
 rd_progs=(
-  's|^  _CS_READ_DIR=""; _CS_READ_ENV=(); _CS_HEAD_SHA=""$|  _CS_READ_DIR="$REPO_ROOT"; _CS_READ_ENV=(); _CS_HEAD_SHA=""|'
+  's|^  _CS_READ_DIR="\$_CS_READ_DIR_UNSET"; _CS_READ_ENV=(); _CS_HEAD_SHA=""$|  _CS_READ_DIR="$REPO_ROOT"; _CS_READ_ENV=(); _CS_HEAD_SHA=""|'
+  's|^  _CS_READ_DIR="\$_CS_READ_DIR_UNSET"; _CS_READ_ENV=(); _CS_HEAD_SHA=""$|  _CS_READ_DIR=""; _CS_READ_ENV=(); _CS_HEAD_SHA=""|'
   's|^  _CS_READ_DIR="\$csdir/repo"$|  : "$(git --no-replace-objects -C "$_CS_READ_DIR" cat-file -e planted-by-the-selftest 2>/dev/null)"\n  _CS_READ_DIR="$csdir/repo"|'
   '/_cs_read_dir_isolated_or_refuse "peel HEAD/d'
 )
 rd_tooks=(
   '^  _CS_READ_DIR="\$REPO_ROOT"; _CS_READ_ENV'
+  '^  _CS_READ_DIR=""; _CS_READ_ENV'
   'cat-file -e planted-by-the-selftest'
   '_cs_read_dir_isolated_or_refuse "peel HEAD'
 )
-rd_expect_n=(1 1 0)
-rd_needles=('THE LIVE CHECKOUT' 'BEFORE the scratch assignment' 'does not call _cs_read_dir_isolated_or_refuse')
+rd_expect_n=(1 1 1 0)
+rd_needles=('THE LIVE CHECKOUT' 'reads -C "" as the CURRENT directory' 'BEFORE the scratch assignment' 'does not call _cs_read_dir_isolated_or_refuse')
 for rd_i in "${!rd_ids[@]}"; do
   rd_id="${rd_ids[$rd_i]}"
   rd_copy="$rd_dir/prop-$rd_id.sh"
@@ -5239,9 +5291,12 @@ fi
 # legitimately `skip` when the fixture's HEAD object is packed rather than loose (the same
 # conditional `3544-ancestry-bounded` carries), and a floor that counts a skippable case would red
 # on correct input.
-# 113 -> 123 with roborev job 325's ten further #3757 cases, all unconditional: the allowlist
-# clean case + its FOUR planted evasion routes (which replaced one deny-pattern case), the
-# read-dir shape case + its THREE planted controls, and the behavioural read-dir refusal.
+# 113 -> 123 with roborev job 325's #3757 work: ELEVEN cases ADDED — the allowlist clean case + its
+# FOUR planted evasion routes, the read-dir shape case + its FOUR planted controls, and the
+# behavioural read-dir refusal — and ONE REMOVED (the deny-pattern `3757-no-live-peel` case the
+# allowlist replaces), so the net is TEN and the floor is raised by exactly ten. All eleven are
+# unconditional; the one skippable case in this family remains `3757-head-object-fifo`, which the
+# floor does not count.
 CASE_FLOOR=123
 if [ "$PASS" -lt "$CASE_FLOOR" ] && [ "$FAIL" -eq 0 ]; then
   printf 'FAIL - 3544-case-floor: %d cases ran but this suite declares a floor of %d — cases were REMOVED (or are skipping) without the floor being lowered deliberately. A green tally over a shrunken suite is the exact defect #3544 is about.\n' "$PASS" "$CASE_FLOOR"

--- a/scripts/tests/test_agent_gate_component_set.sh
+++ b/scripts/tests/test_agent_gate_component_set.sh
@@ -1052,16 +1052,22 @@ lc_whats=(
   'a live peel inside a COMMAND SUBSTITUTION on a local declaration (the round-3 High)'
   'an UNDECLARED read SMUGGLED IN FRONT of an allowed live call (roborev 347 item 2)'
 )
+# PORTABILITY (roborev job 366): a newline in a sed REPLACEMENT is written as a backslash
+# followed by a LITERAL newline, which POSIX mandates for splitting a line. A GNU-style `\n`
+# escape here emits a literal `n` under BSD/macOS sed, which silently MALFORMS the plant --
+# the mutation then fails its `_tooks` assertion and reds this suite on a correct tree.
 lc_progs=(
   's|^\(  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet \)HEAD$|\1HEAD~1|'
   's|^\(  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet \)HEAD$|\1"$_cs_planted_rev"|'
-  's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  _cs_live_git --no-replace-objects -C "$REPO_ROOT" \\\n    rev-parse --verify --quiet "HEAD^{commit}"|'
+  's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  _cs_live_git --no-replace-objects -C "$REPO_ROOT" \\\
+    rev-parse --verify --quiet "HEAD^{commit}"|'
   's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  _component_set_bounded "$_CS_BOUND_SECS" env -i "${_CS_GIT_ENV[@]}" git --git-dir="$REPO_ROOT/.git" rev-parse --verify --quiet "HEAD^{commit}"|'
   's|-C "\$_CS_READ_DIR" rev-parse --verify --quiet "\${head_unpeeled}|-C "$_CS_READ_DIR" -C "$REPO_ROOT" rev-parse --verify --quiet "${head_unpeeled}|'
   's|-C "\$_CS_READ_DIR" merge-base --is-ancestor|-C "$_CS_READ_DIR" --git-dir="$REPO_ROOT/.git" merge-base --is-ancestor|'
   's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  _cs_live_git_quiet --no-replace-objects -C "$REPO_ROOT" rev-parse --verify --quiet "HEAD^{commit}"|'
   's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  $CS_PLANTED_GIT_BIN --no-replace-objects -C "$REPO_ROOT" rev-parse --verify --quiet "HEAD^{commit}"|'
-  's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  local _cs_planted_sha=$(env -i "${_CS_GIT_ENV[@]}" git -C "$REPO_ROOT" rev-parse --verify --quiet "HEAD^{commit}")\n\&|'
+  's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  local _cs_planted_sha=$(env -i "${_CS_GIT_ENV[@]}" git -C "$REPO_ROOT" rev-parse --verify --quiet "HEAD^{commit}")\
+\&|'
   's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  _cs_planted_undeclared_read; _cs_live_git --no-replace-objects -C "$REPO_ROOT" rev-parse --verify --quiet HEAD|'
 )
 lc_tooks=(
@@ -1316,13 +1322,19 @@ rd_whats=(
   'the refusal reverted to a DENY-LIST of bad states instead of an affirmative test'
   'the refusal moved back DOWN to the peel, behind four object reads (the job-347 regression)'
 )
+# PORTABILITY (roborev job 366): a newline in a sed REPLACEMENT is written as a backslash
+# followed by a LITERAL newline, which POSIX mandates for splitting a line. A GNU-style `\n`
+# escape here emits a literal `n` under BSD/macOS sed, which silently MALFORMS the plant --
+# the mutation then fails its `_tooks` assertion and reds this suite on a correct tree.
 rd_progs=(
   's|^  _CS_READ_DIR="\$_CS_READ_DIR_UNSET"; _CS_READ_ENV=(); _CS_HEAD_SHA=""$|  _CS_READ_DIR="$REPO_ROOT"; _CS_READ_ENV=(); _CS_HEAD_SHA=""|'
   's|^  _CS_READ_DIR="\$_CS_READ_DIR_UNSET"; _CS_READ_ENV=(); _CS_HEAD_SHA=""$|  _CS_READ_DIR=""; _CS_READ_ENV=(); _CS_HEAD_SHA=""|'
-  's|^  _CS_READ_DIR="\$csdir/repo"$|  : "$(git --no-replace-objects -C "$_CS_READ_DIR" cat-file -e planted-by-the-selftest 2>/dev/null)"\n  _CS_READ_DIR="$csdir/repo"|'
+  's|^  _CS_READ_DIR="\$csdir/repo"$|  : "$(git --no-replace-objects -C "$_CS_READ_DIR" cat-file -e planted-by-the-selftest 2>/dev/null)"\
+  _CS_READ_DIR="$csdir/repo"|'
   '/_cs_read_dir_isolated_or_refuse "/d'
   's|if \[ -n "\$_CS_SCRATCH_DIR" \] && \[ "\$_CS_READ_DIR" = "\$_CS_SCRATCH_DIR/repo" \]; then|if [ "$_CS_READ_DIR" != "$REPO_ROOT" ]; then|'
-  '/_cs_read_dir_isolated_or_refuse "/d; s|^\(    \)_CS_HEAD_SHA=\$(_component_set_bounded|\1if _cs_read_dir_isolated_or_refuse "peel HEAD"; then return 0; fi\n\1_CS_HEAD_SHA=$(_component_set_bounded|'
+  '/_cs_read_dir_isolated_or_refuse "/d; s|^\(    \)_CS_HEAD_SHA=\$(_component_set_bounded|\1if _cs_read_dir_isolated_or_refuse "peel HEAD"; then return 0; fi\
+\1_CS_HEAD_SHA=$(_component_set_bounded|'
 )
 rd_tooks=(
   '^  _CS_READ_DIR="\$REPO_ROOT"; _CS_READ_ENV'

--- a/scripts/tests/test_agent_gate_component_set.sh
+++ b/scripts/tests/test_agent_gate_component_set.sh
@@ -937,16 +937,38 @@ fi
 # must update the pin, and the both-directions leg turns a forgotten update into a loud finding
 # rather than a silent hole. That is the same cost the live-call pin has always carried.
 #
-# WHAT IT DOES NOT CLAIM. It does not understand bash, and it cannot see a live read that names
-# the repository some OTHER way: a path copied into a variable outside this region, a `cd` plus a
-# bare `git` with no `$REPO_ROOT` token, or a `GIT_DIR=` built from an expression that does not
-# spell `$REPO_ROOT`. Those are real residuals, not covered here, and the runtime
-# `_cs_read_dir_isolated_or_refuse` refusal plus the `/dev/null/` sentinel are what bound them.
+# WHAT IT DOES CLAIM, AND WHAT IT DOES NOT. COVERED: a line naming the live repository by DIRECT
+# expansion, in EITHER spelling — `$REPO_ROOT` or `${REPO_ROOT}`. That pair is closed by bash's
+# grammar (see the partition note below), so a direct-expansion read cannot escape the pins by
+# re-spelling itself.
+#
+# NOT COVERED, and these are genuinely open-ended: a live read that names the repository some
+# OTHER way — a path copied into another variable outside this region, an INDIRECT expansion
+# (`${!ref}`), a `cd` plus a bare `git` with no repo-root token, or a `GIT_DIR=` built from an
+# expression that never spells the name at all. Those are real residuals, not covered here, and
+# the runtime `_cs_read_dir_isolated_or_refuse` refusal plus the `/dev/null/` sentinel are what
+# bound them. This paragraph previously excused only "an expression that does not spell
+# `$REPO_ROOT`", which read as covering the braced form while the code did not — a false
+# rationale in a guard is worse than none, because it is what stops the next reader looking.
 #
 # THE PARTITION IS A SUBSTRING TEST, so the two pins never disagree about a line: a line
 # mentioning `_cs_live_git` is judged by the live-call pin (that is what makes a SECOND wrapper
 # such as `_cs_live_git_quiet` a finding rather than an unpinned stranger); every other
-# `$REPO_ROOT` line is judged by the second pin.
+# repo-root line is judged by the second pin.
+#
+# AND THE PARTITION MATCHES BOTH DIRECT EXPANSIONS, `$REPO_ROOT` AND `${REPO_ROOT}` (roborev job
+# 376). The COMPARISON escaped the tokeniser's disease; the SELECTION step had not. Matching only
+# the unbraced spelling meant `git -C "${REPO_ROOT}" cat-file -e "HEAD^{commit}"` contained
+# neither `_cs_live_git` nor the literal `$REPO_ROOT`, fell through BOTH arms, was never compared
+# against either pin, and so reintroduced a live-repository object read — and its promisor
+# lazy-fetch route — with the suite green. One character's distance, reachable by an ordinary
+# refactor rather than by construction, which is what made it a defect and not a residual.
+#
+# THIS IS A CLOSED SET, AND THAT IS WHY IT IS NOT THE TOKENISER COMING BACK. Bash has exactly TWO
+# direct expansions of a name — `$NAME` and `${NAME}` — so this enumeration is closed by the
+# LANGUAGE GRAMMAR, not by our imagination about what an author might write. That is the precise
+# difference from the deleted recogniser, which had to enumerate an open-ended space of ways a
+# line could REACH the live repository. Indirect naming stays a declared residual below.
 #
 # Both blocks are QUOTED HEREDOCS, so `"`, `$`, `\` and `'` inside the pinned lines need no
 # escaping and cannot drift from the gate's own text through a quoting mistake.
@@ -994,9 +1016,9 @@ cs_pinned_line_findings() {
         continue ;;
     esac
     case "$raw" in
-      *'$REPO_ROOT'*)
+      *'$REPO_ROOT'*|*'${REPO_ROOT}'*)
         grep -Fxq -- "$raw" <<<"$CS_PINNED_REPO_ROOT_LINES" \
-          || printf 'FINDING[repo-root]: %s: this line names the LIVE repository ($REPO_ROOT) and is NOT one of the %s PINNED lines (whole-line equality; the line is not read, only compared): %s\n' "$num" "$cs_pin_rr_n" "$raw" ;;
+          || printf 'FINDING[repo-root]: %s: this line names the LIVE repository ($REPO_ROOT or ${REPO_ROOT}) and is NOT one of the %s PINNED lines (whole-line equality; the line is not read, only compared): %s\n' "$num" "$cs_pin_rr_n" "$raw" ;;
     esac
   done < <(cs_region_code "$g")
   while IFS= read -r pin; do
@@ -1039,7 +1061,7 @@ fi
 # TEXT, which the finding prints verbatim — so a route is proved reported without the guard
 # pretending to have understood it.
 lc_dir="$tmp/3757-live-call-controls"; mkdir -p "$lc_dir"
-lc_ids=(a b c d e f g h i j)
+lc_ids=(a b c d e f g h i j k)
 lc_whats=(
   'a dereferencing rev that contains no ^{ (HEAD~1)'
   'the rev held in a VARIABLE, so no rev token appears on the call line'
@@ -1051,6 +1073,7 @@ lc_whats=(
   'a live call whose command word is a VARIABLE, not the literal git'
   'a live peel inside a COMMAND SUBSTITUTION on a local declaration (the round-3 High)'
   'an UNDECLARED read SMUGGLED IN FRONT of an allowed live call (roborev 347 item 2)'
+  'a live read naming the repo through the BRACED expansion ${REPO_ROOT} (roborev job 376)'
 )
 # PORTABILITY (roborev job 366): a newline in a sed REPLACEMENT is written as a backslash
 # followed by a LITERAL newline, which POSIX mandates for splitting a line. A GNU-style `\n`
@@ -1069,6 +1092,7 @@ lc_progs=(
   's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  local _cs_planted_sha=$(env -i "${_CS_GIT_ENV[@]}" git -C "$REPO_ROOT" rev-parse --verify --quiet "HEAD^{commit}")\
 \&|'
   's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  _cs_planted_undeclared_read; _cs_live_git --no-replace-objects -C "$REPO_ROOT" rev-parse --verify --quiet HEAD|'
+  's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  _component_set_bounded "$_CS_BOUND_SECS" env -i "${_CS_GIT_ENV[@]}" git -C "${REPO_ROOT}" cat-file -e "HEAD^{commit}"|'
 )
 lc_tooks=(
   'rev-parse --verify --quiet HEAD~1$'
@@ -1081,6 +1105,7 @@ lc_tooks=(
   '\$CS_PLANTED_GIT_BIN --no-replace-objects'
   'local _cs_planted_sha=\$(env'
   '_cs_planted_undeclared_read; _cs_live_git'
+  'git -C "\${REPO_ROOT}" cat-file'
 )
 lc_needles=(
   'HEAD~1'
@@ -1093,6 +1118,7 @@ lc_needles=(
   '$CS_PLANTED_GIT_BIN'
   '_cs_planted_sha'
   '_cs_planted_undeclared_read'
+  '-C "${REPO_ROOT}" cat-file'
 )
 for lc_i in "${!lc_ids[@]}"; do
   lc_id="${lc_ids[$lc_i]}"

--- a/scripts/tests/test_agent_gate_component_set.sh
+++ b/scripts/tests/test_agent_gate_component_set.sh
@@ -915,10 +915,21 @@ fi
 #
 # So the question is asked affirmatively, which is also what makes a PASS mean something: the SET
 # of live invocations must EQUAL `CS_DECLARED_LIVE_CALLS`, in BOTH directions. An unrecognised
-# shape is a FINDING whatever it contains, so (a)–(d) are all rejected by the same rule and so is
-# the next spelling nobody has thought of; and a declared entry that no longer appears is a
-# FINDING too, because a stale entry PRE-AUTHORISES its own re-introduction (section 9b's rule for
-# git operations, applied to argv).
+# shape is a FINDING whatever it contains, so (a)–(d) are all rejected by one rule; and a declared
+# entry that no longer appears is a FINDING too, because a stale entry PRE-AUTHORISES its own
+# re-introduction (section 9b's rule for git operations, applied to argv).
+#
+# WHAT IT COVERS, AND WHAT IT DOES NOT — stated because the first version of this comment claimed
+# the rule also rejected "the next spelling nobody has thought of", AND THAT WAS FALSE (roborev
+# job 339): the shape test recognised only a command word literally spelled `git` or exactly
+# `_cs_live_git `, so a call through a variable, an `eval`, a `\git` or A SECOND WRAPPER FUNCTION
+# was classified as NOTHING — demonstrated, `_cs_live_git_quiet` routing a peel produced zero
+# findings from this guard AND from 9b. A false rationale in a guard is worse than none, because it
+# is what stops the next person looking. Rule R2 in `cs_live_call_findings` closes those spellings
+# by keying on the live repository's NAME (`$REPO_ROOT`) rather than on the command word, and its
+# own residual is stated at that rule: a live call that names the live checkout neither by that
+# token nor on that line (a CWD-relative call through an unrecognised command word) is still not
+# seen here.
 #
 # GRANULARITY, and why it differs from 9b deliberately: 9b keys on the SUBCOMMAND because a
 # flag-level key would red on a reordering of correct code. Here the ARGV IS the property — `HEAD`
@@ -954,8 +965,50 @@ CS_DECLARED_DIRECT_GIT=(
   'git init -q "$csdir/repo"|creates the ISOLATED scratch at a named target path; reads no repository'
 )
 CS_ISOLATED_SELECTORS=('-C "$_CS_READ_DIR"' '-C "$csdir/repo"')
+# CS_DECLARED_REPO_ROOT_HARMLESS: the command words a `$REPO_ROOT`-MENTIONING line may begin with
+# and still not be an invocation of anything that can read a repository. Everything else on such a
+# line is a FINDING (see rule R2 in `cs_live_call_findings`), which is what makes the rule
+# affirmative: a live call spelled through a VARIABLE (`$GIT`), an `eval`, a `\git`, or A SECOND
+# WRAPPER FUNCTION lands here rather than being invisible.
+CS_DECLARED_REPO_ROOT_HARMLESS=(
+  'local'   # `local f="$REPO_ROOT/…"` — declares a path for SHELL reads of committed source
+  'return'  # `_CS_KIND=…; _CS_DETAIL="… $REPO_ROOT …"; return 0`
+  ':'       # an explicit no-op
+)
+# cs_first_word <text>: the COMMAND WORD of a shell fragment, or empty when the fragment invokes
+# nothing (a bare assignment, a case-arm pattern, a keyword). Quoted spans must already be
+# removed by the caller. The stripping mirrors 9b's audit — leading keywords, `!`, `VAR=value`
+# assignments — plus a leading case-arm PATTERN, because `*) git …` is an invocation and `?*)
+# lane_objects="…"` is not, and only stripping the pattern tells them apart.
+cs_first_word() {
+  local t="$1" w
+  t="${t#"${t%%[![:space:]]*}"}"
+  while :; do
+    case "$t" in
+      '!'*)            t="${t#!}"; t="${t#"${t%%[![:space:]]*}"}"; continue ;;
+      if\ *|while\ *|until\ *|then\ *|else\ *|elif\ *|do\ *|not\ *)
+                       t="${t#* }"; t="${t#"${t%%[![:space:]]*}"}"; continue ;;
+      *')'*)
+        # A case-arm pattern only when the `)` precedes any whitespace, i.e. the fragment STARTS
+        # with `<pattern>)`. `$(…)` cannot appear here: the caller removed quoted spans and a
+        # substitution at command position is itself reported by the word test below.
+        case "${t%%')'*}" in
+          *[[:space:]]*) break ;;
+          *) t="${t#*')'}"; t="${t#"${t%%[![:space:]]*}"}"; continue ;;
+        esac ;;
+      [A-Za-z_]*=*)
+        case "${t%%=*}" in
+          *[!A-Za-z0-9_]*) break ;;
+          *) t="${t#*=}"; t="${t#"${t%%[[:space:]]*}"}"; t="${t#"${t%%[![:space:]]*}"}"; continue ;;
+        esac ;;
+    esac
+    break
+  done
+  w="${t%%[[:space:]]*}"
+  printf '%s' "$w"
+}
 cs_live_call_findings() {
-  local gate="$1" line num raw argv dq entry i hit prev_cont=0
+  local gate="$1" line num raw argv dq entry i hit frag w rest
   local -a seen=()
   for i in "${!CS_DECLARED_LIVE_CALLS[@]}"; do seen[$i]=0; done
   while IFS= read -r line; do
@@ -966,24 +1019,16 @@ cs_live_call_findings() {
     # from a per-line scan. SCOPED TO `_cs_live_git` LINES, because an `&&`-chained ISOLATED read
     # legitimately continues (the fast path's presence probe does, and an unscoped rule RED on it
     # — measured, first run: a guard that reds on correct input is the guard agents learn to
-    # waive).
+    # waive). The TAIL of such a call needs no rule of its own: a tail that names the live
+    # repository mentions `$REPO_ROOT` and is caught by R2 below, which is also why the separate
+    # tail rule this replaces is GONE — it fired for EVERY line ending in `\`, so wrapping a long
+    # `_CS_DETAIL="… from $REPO_ROOT …"` over two lines emitted a spurious finding (roborev job
+    # 339, item 4).
     case "$raw" in
       *_cs_live_git*'\')
         printf 'FINDING: %s: a LIVE git call is split over a line CONTINUATION, so its argument list cannot be judged as one line — write it on one line: %s\n' "$num" "$raw"
-        prev_cont=1; continue ;;
+        continue ;;
     esac
-    # THE TAIL OF A CONTINUED CALL IS ALSO A PLACE A LIVE REPOSITORY CAN BE NAMED. `git` takes the
-    # LAST `-C`, so an isolated first line followed by a tail naming `$REPO_ROOT` (or a
-    # `--git-dir=`/`GIT_DIR=`) would run live while the first line classified as isolated. Nothing
-    # in the region does this today; the rule is what keeps it that way, and the set it forbids is
-    # EMPTY rather than declared, so there is nothing to keep in step.
-    if [ "$prev_cont" = 1 ]; then
-      case "$raw" in
-        *'$REPO_ROOT'*|*--git-dir*|*GIT_DIR=*)
-          printf 'FINDING: %s: the CONTINUATION TAIL of a git call names the live repository (git honours the LAST -C, so this can redirect an isolated call): %s\n' "$num" "$raw" ;;
-      esac
-    fi
-    case "$raw" in *'\') prev_cont=1 ;; *) prev_cont=0 ;; esac
     case "$raw" in
       *_cs_live_git\ *)
         argv="${raw#*_cs_live_git }"
@@ -997,16 +1042,73 @@ cs_live_call_findings() {
         if [ -z "$hit" ]; then
           printf 'FINDING: %s: UNDECLARED live-repository git call: %s\n' "$num" "$argv"
         fi
-        prev_cont=0; continue ;;
+        continue ;;
     esac
-    # A DIRECT `git` at command position. Quoted spans are removed FIRST so a diagnostic string
-    # (`_CS_DETAIL="git fetch … exited $rc"`, `hint="… git rebase …"`) is not read as an
-    # invocation — 9b's measured lesson. The word class excludes `--git-path`/`_cs_live_git`,
-    # where `git` is part of a longer word.
     dq=$(printf '%s' "$raw" | sed 's/"[^"]*"//g')
+    # ---- R2: A LINE THAT NAMES THE LIVE REPOSITORY MUST NOT INVOKE ANYTHING (roborev job 339).
+    # `$REPO_ROOT` is the ONLY in-region name for the live checkout, so any line that reaches a
+    # command while mentioning it is either a declared live call (handled above, by exact argv) or
+    # a finding. This one rule closes TWO holes the previous per-selector classifier had:
+    #   * THE SAME-LINE OVERRIDE. `git -C "$_CS_READ_DIR" -C "$REPO_ROOT" rev-parse "$sha^{commit}"`
+    #     was EXCUSED, because `CS_ISOLATED_SELECTORS` matched as a bare substring and the line was
+    #     never asked whether it ALSO named the live repository — and git honours the LAST `-C`. A
+    #     PASS over a live object read, with all six declared entries still observed.
+    #   * THE UNRECOGNISED COMMAND WORD. The direct-`git` test below only recognises the literal
+    #     word `git`, so `$GIT`, `eval`, `\git` or A SECOND WRAPPER (`_cs_live_git_quiet …`) was
+    #     classified as nothing at all, and 9b cannot backstop it (its EXT census excuses every
+    #     function defined in the gate, and its GAP half looks only through
+    #     `env`/`_component_set_bounded`/`_cs_live_git`).
+    # RESIDUAL, stated because the previous comment overclaimed ("the next spelling nobody has
+    # thought of") and a false rationale in a guard is worse than none: this rule sees a live call
+    # only if the live repository is named ON THAT LINE by the token `$REPO_ROOT`. A call that
+    # reaches the live repository by CWD with an unrecognised command word (`$GIT rev-parse …`, no
+    # `-C`), or through a variable copied from `$REPO_ROOT` in a way that hides the token, is NOT
+    # caught here — the copy's ASSIGNMENT line is caught (it mentions `$REPO_ROOT`), which is why
+    # the residual is narrow rather than absent.
+    case "$raw" in
+      *'$REPO_ROOT'*)
+        hit=""
+        rest="$dq"
+        while [ -n "$rest" ]; do
+          case "$rest" in
+            *'&&'*) frag="${rest%%&&*}"; rest="${rest#*&&}" ;;
+            *'||'*) frag="${rest%%\|\|*}"; rest="${rest#*\|\|}" ;;
+            *';'*)  frag="${rest%%;*}";  rest="${rest#*;}" ;;
+            *)      frag="$rest"; rest="" ;;
+          esac
+          w=$(cs_first_word "$frag")
+          [ -n "$w" ] || continue
+          for entry in "${CS_DECLARED_REPO_ROOT_HARMLESS[@]}"; do
+            [ "$w" = "$entry" ] && { w=""; break; }
+          done
+          [ -n "$w" ] || continue
+          hit="$w"
+          break
+        done
+        if [ -n "$hit" ]; then
+          printf 'FINDING: %s: a line naming the LIVE repository ($REPO_ROOT) invokes `%s`, and it is not one of the %s declared live calls — git honours the LAST -C, so an isolated selector on the same line excuses nothing: %s\n' \
+            "$num" "$hit" "${#CS_DECLARED_LIVE_CALLS[@]}" "$raw"
+          continue
+        fi
+        # No invocation on this line: the mention is a diagnostic, a path for a shell read, or a
+        # case-arm pattern. Nothing to check.
+        continue ;;
+    esac
+    # A DIRECT `git` at command position, on a line that does NOT name the live repository. Quoted
+    # spans were removed above so a diagnostic string (`_CS_DETAIL="git fetch … exited $rc"`,
+    # `hint="… git rebase …"`) is not read as an invocation — 9b's measured lesson. The word class
+    # excludes `--git-path`/`_cs_live_git`, where `git` is part of a longer word.
     case "$dq" in
       git\ *|*[[:space:]\;\&\|\(]git\ *) : ;;
       *) continue ;;
+    esac
+    # THE LIVE-REPO TEST RUNS BEFORE THE ISOLATED EXCUSAL (roborev job 339). R2 above already
+    # rejects `$REPO_ROOT`; these two spellings name a repository without that token, so they are
+    # refused here rather than being excused by an isolated `-C` earlier on the same line.
+    case "$raw" in
+      *--git-dir*|*GIT_DIR=*)
+        printf 'FINDING: %s: a git invocation selects its repository with --git-dir/GIT_DIR, which no declared call uses and which OVERRIDES an isolated -C on the same line: %s\n' "$num" "$raw"
+        continue ;;
     esac
     hit=""
     for entry in "${CS_ISOLATED_SELECTORS[@]}"; do
@@ -1040,26 +1142,44 @@ fi
 # gate) and each must be REPORTED, NAMED, and shown to have been substituted at all — a sed that
 # matched nothing would "pass" this by proving nothing.
 lc_dir="$tmp/3757-live-call-controls"; mkdir -p "$lc_dir"
-lc_ids=(a b c d)
+lc_ids=(a b c d e f g h)
 lc_whats=(
   'a dereferencing rev that contains no ^{ (HEAD~1)'
   'the rev held in a VARIABLE, so no rev token appears on the call line'
   'the call split over a \ line CONTINUATION'
   'a live call spelled --git-dir= instead of -C "$REPO_ROOT"'
+  'a SAME-LINE -C OVERRIDE on an isolated read (git honours the LAST -C)'
+  'a --git-dir="$REPO_ROOT/.git" appended to an isolated read'
+  'a live call routed through a SECOND WRAPPER function'
+  'a live call whose command word is a VARIABLE, not the literal git'
 )
 lc_progs=(
   's|^\(  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet \)HEAD$|\1HEAD~1|'
   's|^\(  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet \)HEAD$|\1"$_cs_planted_rev"|'
   's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  _cs_live_git --no-replace-objects -C "$REPO_ROOT" \\\n    rev-parse --verify --quiet "HEAD^{commit}"|'
   's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  _component_set_bounded "$_CS_BOUND_SECS" env -i "${_CS_GIT_ENV[@]}" git --git-dir="$REPO_ROOT/.git" rev-parse --verify --quiet "HEAD^{commit}"|'
+  's|-C "\$_CS_READ_DIR" rev-parse --verify --quiet "\${head_unpeeled}|-C "$_CS_READ_DIR" -C "$REPO_ROOT" rev-parse --verify --quiet "${head_unpeeled}|'
+  's|-C "\$_CS_READ_DIR" merge-base --is-ancestor|-C "$_CS_READ_DIR" --git-dir="$REPO_ROOT/.git" merge-base --is-ancestor|'
+  's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  _cs_live_git_quiet --no-replace-objects -C "$REPO_ROOT" rev-parse --verify --quiet "HEAD^{commit}"|'
+  's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  $CS_PLANTED_GIT_BIN --no-replace-objects -C "$REPO_ROOT" rev-parse --verify --quiet "HEAD^{commit}"|'
 )
 lc_tooks=(
   'rev-parse --verify --quiet HEAD~1$'
   'rev-parse --verify --quiet "\$_cs_planted_rev"$'
   '_cs_live_git .*\\$'
   'git --git-dir="\$REPO_ROOT/\.git"'
+  '\-C "\$_CS_READ_DIR" -C "\$REPO_ROOT"'
+  '\-C "\$_CS_READ_DIR" --git-dir="\$REPO_ROOT/\.git"'
+  '_cs_live_git_quiet --no-replace-objects'
+  '\$CS_PLANTED_GIT_BIN --no-replace-objects'
 )
-lc_needles=('HEAD~1' '_cs_planted_rev' 'line CONTINUATION' '--git-dir=')
+lc_needles=(
+  'HEAD~1' '_cs_planted_rev' 'line CONTINUATION' '--git-dir='
+  '-C "$_CS_READ_DIR" -C "$REPO_ROOT"'
+  '--git-dir="$REPO_ROOT/.git"'
+  '_cs_live_git_quiet'
+  '$CS_PLANTED_GIT_BIN'
+)
 for lc_i in "${!lc_ids[@]}"; do
   lc_id="${lc_ids[$lc_i]}"
   lc_copy="$lc_dir/route-$lc_id.sh"
@@ -1147,7 +1267,7 @@ fi
 #       (iii) the peel calls the runtime refusal before handing the value to git.
 # ---------------------------------------------------------------------------
 cs_read_dir_findings() {
-  local g="$1" init sentinel_decl assign assign_ln body_lo body_hi consumers ln peel_ln guard_ln
+  local g="$1" init sentinel_decl assign assign_ln body_lo body_hi consumers ln peel_ln guard_ln refuse_body glob_init
   init=$(cs_region_code "$g" | grep -F '_CS_READ_DIR=' | grep -F '_CS_READ_ENV=(); _CS_HEAD_SHA=' | head -1)
   if [ -z "$init" ]; then
     printf 'FINDING: could not locate the probe initialiser line that sets _CS_READ_DIR — the shape changed or the scan broke (fail-closed)\n'
@@ -1161,6 +1281,16 @@ cs_read_dir_findings() {
       *) printf 'FINDING: %s: the initialiser sets _CS_READ_DIR to an unrecognised value; only the declared UNSET sentinel is allowed: %s\n' "${init%%:*}" "${init#*:}" ;;
     esac
   fi
+  # THE GLOBAL INITIALISER IS PINNED TOO (roborev job 339, item 1). It sat at `""` — the value this
+  # file's own control and finding text call unsafe — one line below the sentinel introduced to
+  # replace it, because the check covered only the PROBE initialiser. Two initialisers, one
+  # property; pin both.
+  glob_init=$(cs_region_code "$g" | grep '^[0-9][0-9]*:_CS_READ_DIR=' | head -1)
+  case "$glob_init" in
+    *'_CS_READ_DIR="$_CS_READ_DIR_UNSET"'*) : ;;
+    '') printf 'FINDING: could not locate the GLOBAL _CS_READ_DIR initialiser (fail-closed)\n' ;;
+    *)  printf 'FINDING: %s: the GLOBAL initialiser does not use the UNSET sentinel: %s\n' "${glob_init%%:*}" "${glob_init#*:}" ;;
+  esac
   # THE SENTINEL MUST BE A PATH THAT CANNOT EXIST — that is what makes an unguarded consumer fail
   # CLOSED rather than read live, and it is the half no source scan could otherwise supply.
   # CAPTURED, NOT PIPED INTO `grep -q`. This suite runs under `pipefail`, and a successful
@@ -1209,6 +1339,16 @@ cs_read_dir_findings() {
       printf 'FINDING: %s: a -C "$_CS_READ_DIR" consumer runs BEFORE the scratch assignment at line %s, in the probe body where lexical order IS execution order: %s\n' "${ln%%:*}" "$assign_ln" "${ln#*:}"
     fi
   done <<<"$consumers"
+  # THE REFUSAL MUST ASK AN AFFIRMATIVE QUESTION (roborev job 339, item 5). A list of bad states is
+  # sound only for the assignment sites that exist today, and nothing pins that number: a future
+  # fourth `_CS_READ_DIR=<live-ish path>` would pass a `*)` arm silently. The value must BE the
+  # scratch this run created.
+  refuse_body=$(awk '/^_cs_read_dir_isolated_or_refuse\(\) \{$/,/^\}$/' "$g")
+  if [ -z "$refuse_body" ]; then
+    printf 'FINDING: could not locate _cs_read_dir_isolated_or_refuse (fail-closed)\n'
+  elif ! grep -qF '[ "$_CS_READ_DIR" = "$_CS_SCRATCH_DIR/repo" ]' <<<"$refuse_body"; then
+    printf 'FINDING: the refusal is not AFFIRMATIVE — it does not require _CS_READ_DIR to BE the scratch this run created ($_CS_SCRATCH_DIR/repo), so an unlisted bad value passes silently\n'
+  fi
   peel_ln=$(cs_region_code "$g" | grep -F 'rev-parse --verify --quiet "${head_unpeeled}^{commit}"' | head -1)
   guard_ln=$(cs_region_code "$g" | grep -F '_cs_read_dir_isolated_or_refuse "peel HEAD' | head -1)
   if [ -z "$peel_ln" ]; then
@@ -1228,29 +1368,40 @@ else
   printf '%s\n' "$rd_findings"
 fi
 
-# THREE PLANTED CONTROLS, one per property. Each mutates a COPY and must be REPORTED and NAMED.
+# FIVE PLANTED CONTROLS over the three properties (roborev job 339, item 3: this said "THREE
+# PLANTED CONTROLS, one per property" over four entries, and neither half was true — i and ii both
+# target the INITIALISER). Each mutates a COPY and must be REPORTED and NAMED.
 rd_dir="$tmp/3757-read-dir-controls"; mkdir -p "$rd_dir"
-rd_ids=(i ii iii iv)
+rd_ids=(i ii iii iv v)
 rd_whats=(
   'the initialiser set back to the LIVE checkout'
   'the initialiser left EMPTY, which git reads as the CURRENT directory'
   'a -C "$_CS_READ_DIR" consumer planted BEFORE the scratch assignment, in the probe body'
   'the runtime refusal call removed from the peel'
+  'the refusal reverted to a DENY-LIST of bad states instead of an affirmative test'
 )
 rd_progs=(
   's|^  _CS_READ_DIR="\$_CS_READ_DIR_UNSET"; _CS_READ_ENV=(); _CS_HEAD_SHA=""$|  _CS_READ_DIR="$REPO_ROOT"; _CS_READ_ENV=(); _CS_HEAD_SHA=""|'
   's|^  _CS_READ_DIR="\$_CS_READ_DIR_UNSET"; _CS_READ_ENV=(); _CS_HEAD_SHA=""$|  _CS_READ_DIR=""; _CS_READ_ENV=(); _CS_HEAD_SHA=""|'
   's|^  _CS_READ_DIR="\$csdir/repo"$|  : "$(git --no-replace-objects -C "$_CS_READ_DIR" cat-file -e planted-by-the-selftest 2>/dev/null)"\n  _CS_READ_DIR="$csdir/repo"|'
   '/_cs_read_dir_isolated_or_refuse "peel HEAD/d'
+  's|if \[ -n "\$_CS_SCRATCH_DIR" \] && \[ "\$_CS_READ_DIR" = "\$_CS_SCRATCH_DIR/repo" \]; then|if [ "$_CS_READ_DIR" != "$REPO_ROOT" ]; then|'
 )
 rd_tooks=(
   '^  _CS_READ_DIR="\$REPO_ROOT"; _CS_READ_ENV'
   '^  _CS_READ_DIR=""; _CS_READ_ENV'
   'cat-file -e planted-by-the-selftest'
   '_cs_read_dir_isolated_or_refuse "peel HEAD'
+  'if \[ "\$_CS_READ_DIR" != "\$REPO_ROOT" \]; then'
 )
-rd_expect_n=(1 1 1 0)
-rd_needles=('THE LIVE CHECKOUT' 'reads -C "" as the CURRENT directory' 'BEFORE the scratch assignment' 'does not call _cs_read_dir_isolated_or_refuse')
+rd_expect_n=(1 1 1 0 1)
+rd_needles=(
+  'THE LIVE CHECKOUT'
+  'reads -C "" as the CURRENT directory'
+  'BEFORE the scratch assignment'
+  'does not call _cs_read_dir_isolated_or_refuse'
+  'not AFFIRMATIVE'
+)
 for rd_i in "${!rd_ids[@]}"; do
   rd_id="${rd_ids[$rd_i]}"
   rd_copy="$rd_dir/prop-$rd_id.sh"
@@ -5297,7 +5448,10 @@ fi
 # allowlist replaces), so the net is TEN and the floor is raised by exactly ten. All eleven are
 # unconditional; the one skippable case in this family remains `3757-head-object-fifo`, which the
 # floor does not count.
-CASE_FLOOR=123
+# 123 -> 128 with roborev job 339's five: evasion routes e-h (the same-line -C override, the
+# --git-dir override, a second wrapper, a variable command word) and read-dir control v (the
+# refusal reverted to a deny-list). All five unconditional.
+CASE_FLOOR=128
 if [ "$PASS" -lt "$CASE_FLOOR" ] && [ "$FAIL" -eq 0 ]; then
   printf 'FAIL - 3544-case-floor: %d cases ran but this suite declares a floor of %d — cases were REMOVED (or are skipping) without the floor being lowered deliberately. A green tally over a shrunken suite is the exact defect #3544 is about.\n' "$PASS" "$CASE_FLOOR"
   FAIL=$((FAIL + 1))

--- a/scripts/tests/test_agent_gate_component_set.sh
+++ b/scripts/tests/test_agent_gate_component_set.sh
@@ -23,6 +23,10 @@
 #   4b. removal that is only an UNCOMMITTED working-tree edit            -> FAIL naming it
 #   4d. a SHALLOW clone where rc 1 is ambiguous                          -> INDETERMINATE, never BEHIND
 #   5d. a concurrent fetch clobbering FETCH_HEAD                         -> baseline unaffected
+#   3757. HEAD is resolved UNPEELED in the live repository and PEELED in the isolated scratch
+#      (#3757): no live git call peels an object (structural, with a positive control), the
+#      scratch peel is bounded and three-valued (structural, with a positive control), a FIFO at
+#      HEAD's own object is refused BY NAME, and an unpeelable HEAD stays INDETERMINATE
 #   5. no skew                                                          -> affirmative PASS + baseline sha
 #   6. --lite with a real skew                                          -> line present, run NOT failed
 #   7. the REAL full-gate emit path                                     -> FAIL block + exit 1, no cargo
@@ -759,8 +763,9 @@ fi
 #     walk rather than of an earlier read. Verified standalone before writing it:
 #       parent object = real file :  rev-parse --verify HEAD^{commit} 2ms   merge-base 2ms
 #       parent object = FIFO      :  rev-parse --verify HEAD^{commit} 2ms   merge-base BLOCKED
-#     FIFOing HEAD's OWN object would block `rev-parse --verify HEAD^{commit}` instead and report
-#     `repo-read-blocked` from that site, passing this case for the wrong reason.
+#     FIFOing HEAD's OWN object would block the PEEL of HEAD instead (which since #3757 runs in
+#     the scratch, not in the live repository) and report `repo-read-blocked` from that site,
+#     passing this case for the wrong reason. `3757-head-object-fifo` below is that other case.
 #
 #     LITE BOUND (15s) not strict (120s): the property is "this read is bounded at all".
 # ---------------------------------------------------------------------------
@@ -773,8 +778,10 @@ case "$anc_objdir" in /*) : ;; *) anc_objdir="$anc_fx/$anc_objdir" ;; esac
 # than depend on a builder's history depth (which is not this case's subject and can change), add
 # an empty commit: HEAD~1 is then the fixture's original branch commit, which is LOOSE in the
 # fixture's own store and — the property that makes this a test of the WALK — is read by nothing
-# earlier. HEAD's own object is resolved by `rev-parse --verify HEAD^{commit}`; the baseline's
-# objects are read in the scratch; only `merge-base` has to traverse HEAD~1.
+# earlier. HEAD's own object is peeled IN THE SCRATCH through the alternate (#3757 moved that
+# peel out of the live repository; the case below plants a FIFO on HEAD's own object and asserts
+# THAT site by name); the baseline's objects are read in the scratch; only `merge-base` has to
+# traverse HEAD~1.
 ( fx "$anc_fx" && git "${GIT_ID[@]}" commit -q --allow-empty -m anc-parent ) >/dev/null 2>&1 || true
 anc_parent=$(git -C "$anc_fx" rev-parse --verify --quiet 'HEAD~1^{commit}' 2>/dev/null || true)
 # BLAST-RADIUS GUARD, AND IT MATTERS MORE HERE THAN FOR THE CONFIG CASE. A WORKTREE's object
@@ -815,6 +822,216 @@ else
       bad "3544-ancestry-bounded: expected KIND repo-read-blocked well inside the bound (got '$anc_kind' in ${anc_el}s)"
       printf '%s\n' "$anc_out"
     fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 3757. THE LIVE REPOSITORY IS ASKED FOR HEAD'S REF, NEVER FOR HEAD'S OBJECT (issue #3757).
+#
+#     THE DEFECT. The ancestry probe resolved HEAD with `rev-parse --verify --quiet
+#     "HEAD^{commit}"` IN THE LIVE REPOSITORY. A peel is an OBJECT read, and in a promisor clone
+#     a missing object is answered by a LAZY FETCH under that repository's OWN local config —
+#     where a `url.*.insteadOf` rewrite invokes a remote HELPER. That is the route jobs 268/299
+#     removed from every other read in this pre-flight, left open at one call site because the
+#     comment above it argued the read was "genuinely local" on the grounds that no partial-clone
+#     filter omits COMMITS. True, and the wrong question: the hazard is the object being absent
+#     for any OTHER reason (a pruned or corrupted store, a hand-written ref, a peer lane editing
+#     the SHARED `.git`).
+#
+#     MEASURED before the fix was written, with a discriminating control (git 2.43.0). Promisor
+#     clones of a local bare origin at `--filter=blob:none` AND `--filter=tree:0`
+#     (`uploadpack.allowfilter=true`), HEAD pointed at a commit present on the remote and ABSENT
+#     locally (absence confirmed with `GIT_NO_LAZY_FETCH=1 cat-file -e`), the promisor URL
+#     replaced by an `ext::` recorder that logs every invocation:
+#       rev-parse --verify --quiet HEAD             rc=0    4ms   helper invocations: 0
+#       rev-parse --verify --quiet 'HEAD^{commit}'  rc=1   10ms   helper invocations: 2
+#     and, separating the OBJECT READ from the network with a FIFO at HEAD's LOOSE object path:
+#       rev-parse --verify --quiet HEAD             rc=0    3ms   (sha printed)
+#       rev-parse --verify --quiet 'HEAD^{commit}'  BLOCKED       (bound fired at 3s)
+#
+#     FOUR CASES: the shape is pinned STRUCTURALLY in both directions (no live peel; the peel is
+#     in the scratch AND bounded AND three-valued), and the two consequences that a structural
+#     scan cannot see are driven BEHAVIOURALLY (a FIFO at HEAD's own object is refused by name
+#     rather than hanging; an UNPEELABLE HEAD stays INDETERMINATE and never becomes a false
+#     BEHIND).
+# ---------------------------------------------------------------------------
+
+# cs_live_peel_findings <gate-path>: print one FINDING line per LIVE-repository git call that
+# PEELS an object. Reads CODE, never prose about code: the doctrine comments in that file
+# necessarily contain `HEAD^{commit}` (this very case's rationale does), so a whole-file grep
+# would red a correct tree — the same defect `3544-canonical-literal` records from the other
+# side. Comment lines are dropped while ORIGINAL line numbers are kept, so a finding can name
+# the line an author has to open.
+cs_live_peel_findings() {
+  local g="$1" l
+  # Both spellings of a live call: through the `_cs_live_git` wrapper, and any direct `git`
+  # invocation naming the live checkout. The second is what a FUTURE author would add.
+  while IFS= read -r l; do
+    [ -n "$l" ] || continue
+    case "$l" in
+      *'^{'*) printf 'FINDING: %s\n' "$l" ;;
+    esac
+  done < <( { grep -n '_cs_live_git ' "$g"; grep -n -- '-C "\$REPO_ROOT"' "$g"; } \
+              | grep -v ':[[:space:]]*#' | sort -u )
+}
+
+# cs_live_head_calls <gate-path>: the UNPEELED live HEAD resolutions, as code lines.
+cs_live_head_calls() {
+  grep -n '_cs_live_git .*rev-parse --verify --quiet HEAD$' "$1" | grep -v ':[[:space:]]*#'
+}
+
+peel_findings=$(cs_live_peel_findings "$GATE")
+peel_head=$(cs_live_head_calls "$GATE")
+peel_head_n=$(printf '%s\n' "$peel_head" | grep -c . )
+# THE CONTROL SUBSTITUTES THE ARTIFACT, in a throwaway copy — never a settable seam in the
+# gate (the rule `3544-canonical-literal`'s helper is built on). And the substitution is
+# VERIFIED to have taken: a sed that matched nothing would make the control "pass" by proving
+# nothing, which is the vacuous green this whole file exists to refuse.
+peel_ctl_dir="$tmp/3757-peel-control"; mkdir -p "$peel_ctl_dir"
+peel_ctl="$peel_ctl_dir/agent-gate.sh"
+sed 's|\(_cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet \)HEAD$|\1"HEAD^{commit}"|' "$GATE" >"$peel_ctl"
+peel_ctl_took=$(grep -c '_cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet "HEAD\^{commit}"' "$peel_ctl")
+peel_ctl_findings=$(cs_live_peel_findings "$peel_ctl")
+# THE PROPERTY IS JUDGED FIRST, THE CONTROL'S INTEGRITY ONLY GATES THE `ok`. Ordered the other
+# way round (control first), a gate that HAS the live peel red with "the control could not
+# reintroduce the peel" — a true sentence that sends the reader to the test instead of to the
+# defect, and AC2 requires the red to NAME the offending construct.
+if [ -n "$peel_findings" ]; then
+  bad "3757-no-live-peel: a live-repository git call PEELS an object (a lazy fetch route in a promisor clone):"
+  printf '%s\n' "$peel_findings"
+elif [ "$peel_head_n" -ne 1 ]; then
+  bad "3757-no-live-peel: expected exactly ONE unpeeled live HEAD resolution, found $peel_head_n — the shape changed or the scan broke (fail-closed: this is not a clean result). Lines: $peel_head"
+elif [ "$peel_ctl_took" -ne 1 ]; then
+  bad "3757-no-live-peel: the POSITIVE CONTROL could not reintroduce the peel (substitution took $peel_ctl_took times) — the scan cannot be shown to discriminate, so a clean result on the real gate is not evidence"
+elif ! grep -q 'FINDING:' <<<"$peel_ctl_findings" \
+     || ! grep -q 'HEAD\^{commit}' <<<"$peel_ctl_findings"; then
+  bad "3757-no-live-peel: the control's reintroduced peel was NOT reported (or was reported without NAMING the construct) — a bare red is not evidence. Control findings: $peel_ctl_findings"
+else
+  ok "3757-no-live-peel: no live-repository git call peels an object (HEAD is resolved UNPEELED, exactly once), and reintroducing the peel in a scratch copy is REPORTED and NAMED"
+fi
+
+# ---------------------------------------------------------------------------
+# 3757b. THE PEEL MOVED TO THE ISOLATED SCRATCH, AND IT IS BOUNDED AND THREE-VALUED THERE.
+#     Removing the peel from the live repository is only half the fix: the peel still reads a
+#     commit object, now out of the LANE's SHARED store through the alternate, where a LOOSE
+#     object is read as a stream and a FIFO planted by a PEER LANE blocks it (job 315's finding,
+#     one call site over). So the scratch read must be BOUNDED and must map
+#     124/137/`$_CS_UNBOUNDABLE_RC` onto the EXISTING `repo-read-blocked` refusal — a missing
+#     capability must never inherit the permissive branch.
+# ---------------------------------------------------------------------------
+cs_scratch_peel_findings() {
+  local g="$1" site n body
+  site=$(grep -n 'rev-parse --verify --quiet "\${head_unpeeled}\^{commit}"' "$g" | grep -v ':[[:space:]]*#')
+  n=$(printf '%s\n' "$site" | grep -c . )
+  if [ "$n" -ne 1 ]; then
+    printf 'FINDING: expected exactly ONE scratch peel of HEAD, found %s\n' "$n"
+    return 0
+  fi
+  grep -q '_component_set_bounded "\$_CS_BOUND_SECS"' <<<"$site" \
+    || printf 'FINDING: the scratch peel is NOT bounded: %s\n' "$site"
+  grep -q -- '-C "\$_CS_READ_DIR"' <<<"$site" \
+    || printf 'FINDING: the scratch peel does not run in $_CS_READ_DIR: %s\n' "$site"
+  grep -q '_CS_READ_ENV' <<<"$site" \
+    || printf 'FINDING: the scratch peel does not carry $_CS_READ_ENV (the alternate): %s\n' "$site"
+  # The rc mapping lives in the ten lines after the read; read it as CODE.
+  body=$(awk -v s="${site%%:*}" 'NR>s+0 && NR<=s+10' "$g" | grep -v '^[[:space:]]*#')
+  grep -q 'peel_rc" -eq 124' <<<"$body" || printf 'FINDING: 124 (bound fired) is not mapped after the scratch peel\n'
+  grep -q 'peel_rc" -eq 137' <<<"$body" || printf 'FINDING: 137 (KILLed) is not mapped after the scratch peel\n'
+  grep -q 'peel_rc" -eq "\$_CS_UNBOUNDABLE_RC"' <<<"$body" || printf 'FINDING: $_CS_UNBOUNDABLE_RC (no bounding mechanism) is not mapped after the scratch peel\n'
+  grep -q '_CS_KIND=repo-read-blocked' <<<"$body" || printf 'FINDING: the blocked/unboundable peel does not take the existing repo-read-blocked kind\n'
+  return 0
+}
+sp_findings=$(cs_scratch_peel_findings "$GATE")
+sp_ctl="$peel_ctl_dir/unbounded-gate.sh"
+sed 's|\(_CS_HEAD_SHA=\$(\)_component_set_bounded "\$_CS_BOUND_SECS" \(env -i\)|\1\2|' "$GATE" >"$sp_ctl"
+sp_ctl_took=$(grep -c '_CS_HEAD_SHA=\$(env -i' "$sp_ctl")
+sp_ctl_findings=$(cs_scratch_peel_findings "$sp_ctl")
+# Property first, control-integrity second — same reasoning as the case above.
+if [ -n "$sp_findings" ]; then
+  bad "3757-scratch-peel-bounded: the scratch peel does not have the required shape:"
+  printf '%s\n' "$sp_findings"
+elif [ "$sp_ctl_took" -ne 1 ]; then
+  bad "3757-scratch-peel-bounded: the POSITIVE CONTROL could not unbound the scratch peel (substitution took $sp_ctl_took times) — the scan cannot be shown to discriminate"
+elif ! grep -q 'NOT bounded' <<<"$sp_ctl_findings"; then
+  bad "3757-scratch-peel-bounded: unbounding the peel in a scratch copy was NOT reported — a bare pass is not evidence. Control findings: $sp_ctl_findings"
+else
+  ok "3757-scratch-peel-bounded: HEAD's peel runs in \$_CS_READ_DIR with the alternate, BOUNDED, and maps 124/137/UNBOUNDABLE onto repo-read-blocked; unbounding it in a scratch copy is REPORTED"
+fi
+
+# ---------------------------------------------------------------------------
+# 3757c. BEHAVIOURAL: a FIFO at HEAD's OWN loose object is REFUSED BY NAME, not hung.
+#     The plant targets HEAD's own commit object — the object the SCRATCH peel now reads
+#     through the alternate — and the assertion is on the DETAIL text, because
+#     `repo-read-blocked` alone is produced by three other sites (the config include, the
+#     shallowness probe, the ancestry walk) and could not tell this read from those.
+#     Same blast-radius guard as `3544-ancestry-bounded`, and for the same reason: on this
+#     fleet a WORKTREE's object dir is the SHARED store, so a FIFO planted without resolving
+#     and checking that path would hang every lane on the box.
+# ---------------------------------------------------------------------------
+hp_fx=$(mkbranch head-obj-fifo "$(mkbaseline base-headobj - )" - )
+hp_ctl=$(hook "$hp_fx")
+hp_objdir=$(git -C "$hp_fx" rev-parse --git-path objects 2>/dev/null)
+case "$hp_objdir" in /*) : ;; *) hp_objdir="$hp_fx/$hp_objdir" ;; esac
+hp_head=$(git -C "$hp_fx" rev-parse --verify --quiet 'HEAD^{commit}' 2>/dev/null || true)
+if [ -z "$hp_objdir" ] || case "$hp_objdir" in "$tmp"/?*) false ;; *) true ;; esac; then
+  bad "3757-head-object-fifo: refusing to plant a blocking object: resolved objects dir '$hp_objdir' is not strictly under \$tmp ('$tmp') — a FIFO in a SHARED object store would hang every lane on this box"
+elif [ -z "$hp_head" ]; then
+  bad "3757-head-object-fifo: the fixture's HEAD does not resolve to a commit, so the plant has no subject"
+elif [ "$(field KIND "$hp_ctl")" != ok ]; then
+  bad "3757-head-object-fifo: the POSITIVE CONTROL (same fixture, no FIFO) did not reach KIND ok (got '$(field KIND "$hp_ctl")') — the case cannot discriminate"
+else
+  hp_obj="$hp_objdir/${hp_head:0:2}/${hp_head:2}"
+  if [ ! -f "$hp_obj" ]; then
+    echo "skip - 3757-head-object-fifo: HEAD's object is packed, not loose ('$hp_obj' absent) — the loose-object path is not plantable in this fixture"
+  else
+    cp "$hp_obj" "$tmp/3757-head-backup" && rm -f "$hp_obj" && mkfifo "$hp_obj"
+    hp_t0=$(date +%s)
+    hp_out=$( fx "$hp_fx" && bash "$hp_fx/scripts/agent-gate.sh" --component-set-line lite 2>/dev/null )
+    hp_el=$(( $(date +%s) - hp_t0 ))
+    # CLEANUP FIRST AND WITHOUT GIT (the include.path case's lesson: a `git config --unset`
+    # cleanup once blocked for 10m43s on the very FIFO it had planted, and `|| true` cannot
+    # rescue a hang).
+    rm -f "$hp_obj" && cp "$tmp/3757-head-backup" "$hp_obj"
+    hp_kind=$(field KIND "$hp_out")
+    hp_line=$(field COMPONENT_SET_LINE "$hp_out")
+    if [ "$hp_kind" = repo-read-blocked ] && [ "$hp_el" -lt 80 ] \
+       && grep -q 'peeling HEAD' <<<"$hp_line" && grep -q 'SHARED object store' <<<"$hp_line"; then
+      ok "3757-head-object-fifo: a FIFO at HEAD's OWN loose object is BOUNDED and refused by name (repo-read-blocked in ${hp_el}s), and the detail names the PEEL and the shared object store"
+    else
+      bad "3757-head-object-fifo: expected KIND repo-read-blocked naming the peel, well inside the bound (got '$hp_kind' in ${hp_el}s)"
+      printf '%s\n' "$hp_out"
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 3757d. BEHAVIOURAL: an UNPEELABLE HEAD is INDETERMINATE, never a false BEHIND.
+#     The live call resolves the REF and does not check the object exists — measured, and this
+#     case is what pins it end to end: HEAD is pointed at a well-formed sha naming NO object, so
+#     the live read succeeds, the SCRATCH peel fails, and the rc=128 semantics carry it to
+#     `_CS_ANCESTOR=unknown`. The control is the SAME fixture untouched, which is genuinely
+#     BEHIND — so the pair discriminates INDETERMINATE from the verdict it must not become.
+#     Nothing is fetched to satisfy the peel: a missing HEAD object is a broken checkout, not a
+#     reason for this pre-flight to reach the network.
+# ---------------------------------------------------------------------------
+up_fx=$(mkbranch head-unpeelable "$(mkbaseline base-unpeelable "$ADD_SENTINEL" )" - )
+up_ctl=$(hook "$up_fx")
+up_branch=$(git -C "$up_fx" symbolic-ref --short HEAD 2>/dev/null || true)
+up_bogus=0123456789012345678901234567890123456789
+if [ "$(field VERDICT "$up_ctl")" != BEHIND ]; then
+  bad "3757-unpeelable-head: the POSITIVE CONTROL (same fixture, real HEAD) is not BEHIND (got '$(field VERDICT "$up_ctl")') — the case cannot show INDETERMINATE is not the default"
+elif [ -z "$up_branch" ] || [ ! -f "$up_fx/.git/refs/heads/$up_branch" ]; then
+  bad "3757-unpeelable-head: could not locate the fixture's HEAD ref file (branch='$up_branch') — the plant has no subject"
+else
+  printf '%s\n' "$up_bogus" >"$up_fx/.git/refs/heads/$up_branch"
+  up_live=$(git -C "$up_fx" rev-parse --verify --quiet HEAD 2>/dev/null || true)
+  up_out=$(hook "$up_fx" lite)
+  up_v=$(field VERDICT "$up_out"); up_a=$(field ANCESTOR "$up_out")
+  if [ "$up_live" = "$up_bogus" ] && [ "$up_v" = INDETERMINATE ] && [ "$up_a" = unknown ]; then
+    ok "3757-unpeelable-head: the live read resolves HEAD's ref WITHOUT checking the object exists, and a HEAD that cannot be peeled to a commit is INDETERMINATE (ancestor unknown) — never a false BEHIND"
+  else
+    bad "3757-unpeelable-head: expected the live read to return the bogus sha and the verdict to be INDETERMINATE/unknown (live='$up_live' verdict='$up_v' ancestor='$up_a')"
+    printf '%s\n' "$up_out"
   fi
 fi
 
@@ -4725,7 +4942,11 @@ fi
 # and `unrelated` arms of `3544-preflight-in-window`). Lowered by EXACTLY the four removed, so the
 # floor keeps the same slack it was written with: it still catches a DELETION without being an
 # equality nobody can add a case past.
-CASE_FLOOR=110
+# 110 -> 113 with #3757's four cases, RAISED BY THREE and not four: `3757-head-object-fifo` can
+# legitimately `skip` when the fixture's HEAD object is packed rather than loose (the same
+# conditional `3544-ancestry-bounded` carries), and a floor that counts a skippable case would red
+# on correct input.
+CASE_FLOOR=113
 if [ "$PASS" -lt "$CASE_FLOOR" ] && [ "$FAIL" -eq 0 ]; then
   printf 'FAIL - 3544-case-floor: %d cases ran but this suite declares a floor of %d — cases were REMOVED (or are skipping) without the floor being lowered deliberately. A green tally over a shrunken suite is the exact defect #3544 is about.\n' "$PASS" "$CASE_FLOOR"
   FAIL=$((FAIL + 1))

--- a/scripts/tests/test_agent_gate_component_set.sh
+++ b/scripts/tests/test_agent_gate_component_set.sh
@@ -941,7 +941,7 @@ fi
 # the repository some OTHER way: a path copied into a variable outside this region, a `cd` plus a
 # bare `git` with no `$REPO_ROOT` token, or a `GIT_DIR=` built from an expression that does not
 # spell `$REPO_ROOT`. Those are real residuals, not covered here, and the runtime
-# `_cs_read_dir_isolated_or_refuse` refusal plus the `/nonexistent/` sentinel are what bound them.
+# `_cs_read_dir_isolated_or_refuse` refusal plus the `/dev/null/` sentinel are what bound them.
 #
 # THE PARTITION IS A SUBSTRING TEST, so the two pins never disagree about a line: a line
 # mentioning `_cs_live_git` is judged by the live-call pin (that is what makes a SECOND wrapper
@@ -1212,9 +1212,15 @@ cs_read_dir_findings() {
   # even though the pattern was found, and `if ! …` then fires on a correct tree. Measured here on
   # the first run: this exact predicate reported the sentinel "not declared" while a standalone
   # `grep -c` on the same input answered 1.
-  sentinel_decl=$(cs_region_code "$g" | grep "^[0-9][0-9]*:_CS_READ_DIR_UNSET='/nonexistent/" || true)
+  # PINNED TO `/dev/null/` SPECIFICALLY, not to "some absent path" (roborev job 372). A merely
+  # absent path is absent only until someone creates it, and `/nonexistent/` is not reserved;
+  # `/dev/null` is a character device, so every path under it is ENOTDIR for everyone including
+  # root and cannot be made to resolve. This pin is deliberately a SINGLE accepted spelling
+  # rather than an alternation over "absent-looking" prefixes: an alternation would re-admit the
+  # createable form it exists to exclude.
+  sentinel_decl=$(cs_region_code "$g" | grep "^[0-9][0-9]*:_CS_READ_DIR_UNSET='/dev/null/" || true)
   if [ -z "$sentinel_decl" ]; then
-    printf 'FINDING: the UNSET sentinel is not declared as a literal /nonexistent/... path — a sentinel git can resolve is a live read waiting to happen\n'
+    printf 'FINDING: the UNSET sentinel is not declared as a literal /dev/null/... path — a sentinel that any user (or root) can create is a live read waiting to happen\n'
   fi
   assign=$(cs_region_code "$g" | grep -F '_CS_READ_DIR="$csdir/repo"' | head -1)
   if [ -z "$assign" ]; then
@@ -1303,7 +1309,7 @@ cs_read_dir_findings() {
 }
 rd_findings=$(cs_read_dir_findings "$GATE")
 if [ -z "$rd_findings" ]; then
-  ok "3757-read-dir-shape: the read repository is a NON-EXISTENT-path sentinel until the scratch exists (so an unguarded consumer fails closed, not live), no consumer in the probe body precedes the scratch assignment, and the peel refuses an unisolated value before calling git"
+  ok "3757-read-dir-shape: the read repository is a NON-TRAVERSABLE `/dev/null/` sentinel until the scratch exists (so an unguarded consumer fails closed, not live), no consumer in the probe body precedes the scratch assignment, and the peel refuses an unisolated value before calling git"
 else
   bad "3757-read-dir-shape: the read-repository invariants are not met:"
   printf '%s\n' "$rd_findings"

--- a/scripts/tests/test_agent_gate_component_set.sh
+++ b/scripts/tests/test_agent_gate_component_set.sh
@@ -397,6 +397,24 @@ cs_region_stream() {
     inr { if (m == "plain") print $0; else printf "%d:%s\n", NR, $0 }' "$gate"
 }
 
+# cs_hook_watchdog <repo> <mode> <secs>: the `--component-set-line` hook run under an INDEPENDENT
+# OUTER WATCHDOG. Stdout is the hook's; the exit status is `timeout`'s, so 124/137 means the
+# watchdog fired.
+#
+# WHY (roborev job 347, item 2): the FIFO cases exist to prove that a blocking read is BOUNDED. If
+# that bounding regresses, the plain `$( … )` form HANGS FOREVER — the case never reaches its
+# elapsed-time assertion, never restores the object it replaced, and the suite stops with no
+# verdict. A test for a hang that itself hangs on failure is not a test. Expiration is a NAMED
+# FAILURE at the call site, never a skip: it is the exact regression the case is for.
+#
+# `timeout` is the suite's own dependency elsewhere, but its absence is reported by the caller as a
+# skipped PRECONDITION rather than assumed — an unbounded run is what this helper exists to avoid,
+# so it must not silently fall back to one.
+cs_hook_watchdog() {
+  local repo="$1" mode="$2" secs="$3"
+  ( fx "$repo" && timeout -k 5 "$secs" bash "$repo/scripts/agent-gate.sh" --component-set-line "$mode" 2>/dev/null )
+}
+
 # cs_region_code <gate>: the region's CODE lines only, numbered. The comment strip is ANCHORED at
 # the start of the payload (`^<digits>:<space>*#`) — an UNANCHORED `:[[:space:]]*#` also matches a
 # `#` anywhere later on the line, so a real call line carrying a trailing `# note: …` was dropped
@@ -1468,6 +1486,10 @@ elif [ -z "$hp_head" ]; then
   bad "3757-head-object-fifo: the fixture's HEAD does not resolve to a commit, so the plant has no subject"
 elif [ "$(field KIND "$hp_ctl")" != ok ]; then
   bad "3757-head-object-fifo: the POSITIVE CONTROL (same fixture, no FIFO) did not reach KIND ok (got '$(field KIND "$hp_ctl")') — the case cannot discriminate"
+elif ! command -v timeout >/dev/null 2>&1; then
+  # A PRECONDITION, NOT A VERDICT: without `timeout` the run cannot be given the independent
+  # watchdog below, and running it unbounded is the hang this case must not risk.
+  echo "skip - 3757-head-object-fifo: no timeout(1) on PATH, so the planted read cannot be run under an independent outer watchdog"
 else
   hp_obj="$hp_objdir/${hp_head:0:2}/${hp_head:2}"
   if [ ! -f "$hp_obj" ]; then
@@ -1475,19 +1497,25 @@ else
   else
     cp "$hp_obj" "$tmp/3757-head-backup" && rm -f "$hp_obj" && mkfifo "$hp_obj"
     hp_t0=$(date +%s)
-    hp_out=$( fx "$hp_fx" && bash "$hp_fx/scripts/agent-gate.sh" --component-set-line lite 2>/dev/null )
+    # UNDER AN INDEPENDENT WATCHDOG (roborev job 347, item 2). Without it, a regression in the
+    # bounding this case tests would hang the SUITE here — no verdict, and the planted FIFO left in
+    # place. 90s is well above the observed 15-16s and well below forever.
+    hp_out=$(cs_hook_watchdog "$hp_fx" lite 90); hp_rc=$?
     hp_el=$(( $(date +%s) - hp_t0 ))
-    # CLEANUP FIRST AND WITHOUT GIT (the include.path case's lesson: a `git config --unset`
-    # cleanup once blocked for 10m43s on the very FIFO it had planted, and `|| true` cannot
-    # rescue a hang).
+    # CLEANUP FIRST AND WITHOUT GIT, AND ON EVERY PATH INCLUDING THE WATCHDOG'S (the include.path
+    # case's lesson: a `git config --unset` cleanup once blocked for 10m43s on the very FIFO it had
+    # planted, and `|| true` cannot rescue a hang). It runs here, before any assertion, so no
+    # branch below can skip it.
     rm -f "$hp_obj" && cp "$tmp/3757-head-backup" "$hp_obj"
     hp_kind=$(field KIND "$hp_out")
     hp_line=$(field COMPONENT_SET_LINE "$hp_out")
-    if [ "$hp_kind" = repo-read-blocked ] && [ "$hp_el" -lt 80 ] \
+    if [ "$hp_rc" -eq 124 ] || [ "$hp_rc" -eq 137 ]; then
+      bad "3757-head-object-fifo: the OUTER WATCHDOG fired after 90s — the read this case plants was NOT bounded by the gate, which is precisely the regression this case exists to catch (rc=$hp_rc)"
+    elif [ "$hp_kind" = repo-read-blocked ] && [ "$hp_el" -lt 80 ] \
        && grep -q 'peeling HEAD' <<<"$hp_line" && grep -q 'SHARED object store' <<<"$hp_line"; then
       ok "3757-head-object-fifo: a FIFO at HEAD's OWN loose object is BOUNDED and refused by name (repo-read-blocked in ${hp_el}s), and the detail names the PEEL and the shared object store"
     else
-      bad "3757-head-object-fifo: expected KIND repo-read-blocked naming the peel, well inside the bound (got '$hp_kind' in ${hp_el}s)"
+      bad "3757-head-object-fifo: expected KIND repo-read-blocked naming the peel, well inside the bound (got '$hp_kind' in ${hp_el}s, rc=$hp_rc)"
       printf '%s\n' "$hp_out"
     fi
   fi

--- a/scripts/tests/test_agent_gate_component_set.sh
+++ b/scripts/tests/test_agent_gate_component_set.sh
@@ -24,28 +24,38 @@
 #   4d. a SHALLOW clone where rc 1 is ambiguous                          -> INDETERMINATE, never BEHIND
 #   5d. a concurrent fetch clobbering FETCH_HEAD                         -> baseline unaffected
 #   3757. HEAD is resolved UNPEELED in the live repository and PEELED in the isolated scratch
-#      (#3757): no live git call peels an object (structural, with a positive control), the
-#      scratch peel is bounded and three-valued (structural, with a positive control), a FIFO at
-#      HEAD's own object is refused BY NAME, and an unpeelable HEAD stays INDETERMINATE
+#      (#3757): the region's LIVE git calls equal a DECLARED ALLOWLIST of exact argument shapes
+#      (structural, with FOUR planted evasion routes — a deny pattern over rev syntax never
+#      closes), the scratch peel is bounded and three-valued (structural, with a control),
+#      `$_CS_READ_DIR` never names the live checkout (structural x3 + a behavioural refusal), a
+#      FIFO at HEAD's own object is refused BY NAME, and an unpeelable HEAD stays INDETERMINATE
 #   5. no skew                                                          -> affirmative PASS + baseline sha
 #   6. --lite with a real skew                                          -> line present, run NOT failed
 #   7. the REAL full-gate emit path                                     -> FAIL block + exit 1, no cargo
 #
 # CENSUS, stated so a later reader can tell "covered" from "forgotten" (a silent gap is
-# the shape this whole issue is about). The pre-flight has FOUR verdicts and TEN non-`ok`
-# probe kinds, and EVERY one is exercised below:
+# the shape this whole issue is about). The pre-flight has SIX verdicts and one non-`ok` probe
+# kind per row below, and EVERY one is exercised here.
+#
+# THE KIND COUNT IS NOT REPEATED IN THIS PROSE, AND THAT IS THE FIX (roborev job 325, nit 5). It
+# was written as three different numbers at once — "TEN", "(17)" and "NINETEEN" — over an
+# enumeration that listed a fourth, while the file's own rule is that a census which miscounts its
+# own list is worse than none: a reader who trusts the number and counts the entries concludes
+# some kinds are uncovered extras. The count now lives in EXACTLY ONE place, `DECLARED_KIND_COUNT`
+# near the end of this file, which is ASSERTED against the gate's own derived set at run time
+# (`3544-kind-census`), so a new kind cannot arrive unannounced and prose cannot drift from it.
 #   verdicts (6) — PASS (case 5), DECLARED (4), UNCOMMITTED (4b), BEHIND (1),
 #                  INDETERMINATE (4c), UNMEASURED (2, 3a–3g, 4b-ii).
-#   kinds   (17) — fetch-failed, no-remote (case 2); baseline-decl-unrecognised (3a),
+#   kinds        — fetch-failed, no-remote (case 2); baseline-decl-unrecognised (3a),
 #                  baseline-set-empty (3b), baseline-set-garbage (3c/3c-ii),
 #                  baseline-unreadable (3d); manifest-missing, manifest-garbage,
 #                  manifest-stale (3e2); no-git, baseline-workspace, no-tool (3f);
 #                  unboundable (3g);
 #                  baseline-probe-unmeasured (3a-iv); baseline-ref-unparsable (3a-v);
 #                  head-set-unmeasured (4b-ii); remote-not-canonical,
-#                  remote-unreadable (10).
-# NINETEEN is the count of DISTINCT non-`ok` values assigned to `_CS_KIND` (`fetch-failed` is set
-# from several places, and `ok` is the twentieth value). THE SET CHANGED SHAPE with #3544
+#                  remote-unreadable (10); repo-read-blocked (3a-iv-ter/quater,
+#                  3757-head-object-fifo); read-dir-unisolated (3757-read-dir-unisolated).
+# THE SET CHANGED SHAPE with #3544
 # REQ-3544-01, which stopped deriving the baseline by EXECUTING a fetched script: the three
 # `baseline-list-*` kinds and `baseline-missing` were RENAMED to what a DATA read can actually
 # fail at (`baseline-unreadable`, `baseline-set-garbage`, `baseline-set-empty`,
@@ -365,6 +375,34 @@ hook() {
 }
 field() { # field <name> <hook-output>
   printf '%s\n' "$2" | grep "^$1: " | sed "s/^$1: //"
+}
+
+# THE PRE-FLIGHT REGION, EXTRACTED ONCE (#3757). Section 9b's unbounded-operation audit and
+# #3757's live-call allowlist must not disagree about where the region starts and ends: two
+# copies of the marker pair is the drift this file keeps finding elsewhere, and here a
+# disagreement would silently move a call in or out of a guard's subject.
+#
+#   cs_region_stream <gate> [numbered|plain]   (default: numbered)
+#
+# `numbered` prefixes each line with its ORIGINAL line number and a colon — the `grep -n` shape —
+# so a finding can name a line an author has to open. `plain` reproduces the region byte for byte,
+# which is what an awk program run OVER the region needs.
+CS_REGION_BEGIN='^# ---- issue #3544: component-set skew pre-flight'
+CS_REGION_END='^# ---- issue #2081:'
+cs_region_stream() {
+  local gate="$1" mode="${2:-numbered}"
+  awk -v b="$CS_REGION_BEGIN" -v e="$CS_REGION_END" -v m="$mode" '
+    $0 ~ b { inr = 1 }
+    $0 ~ e { inr = 0 }
+    inr { if (m == "plain") print $0; else printf "%d:%s\n", NR, $0 }' "$gate"
+}
+
+# cs_region_code <gate>: the region's CODE lines only, numbered. The comment strip is ANCHORED at
+# the start of the payload (`^<digits>:<space>*#`) — an UNANCHORED `:[[:space:]]*#` also matches a
+# `#` anywhere later on the line, so a real call line carrying a trailing `# note: …` was dropped
+# from the scan, which is a silent false PASS in every guard built on it (roborev job 325, nit 3).
+cs_region_code() {
+  cs_region_stream "$1" numbered | grep -v '^[0-9][0-9]*:[[:space:]]*#'
 }
 
 # ---------------------------------------------------------------------------
@@ -856,59 +894,172 @@ fi
 #     BEHIND).
 # ---------------------------------------------------------------------------
 
-# cs_live_peel_findings <gate-path>: print one FINDING line per LIVE-repository git call that
-# PEELS an object. Reads CODE, never prose about code: the doctrine comments in that file
-# necessarily contain `HEAD^{commit}` (this very case's rationale does), so a whole-file grep
-# would red a correct tree — the same defect `3544-canonical-literal` records from the other
-# side. Comment lines are dropped while ORIGINAL line numbers are kept, so a finding can name
-# the line an author has to open.
-cs_live_peel_findings() {
-  local g="$1" l
-  # Both spellings of a live call: through the `_cs_live_git` wrapper, and any direct `git`
-  # invocation naming the live checkout. The second is what a FUTURE author would add.
-  while IFS= read -r l; do
-    [ -n "$l" ] || continue
-    case "$l" in
-      *'^{'*) printf 'FINDING: %s\n' "$l" ;;
+# cs_live_call_findings <gate-path>: print one FINDING line per DEVIATION from the DECLARED set of
+# LIVE-repository git invocations in the pre-flight region. Empty output = the region's live calls
+# are exactly the declared ones.
+#
+# WHY AN ALLOWLIST AND NOT A DENY PATTERN (roborev job 325, blocker 1). The first version of this
+# guard scanned for the single literal `^{` on `_cs_live_git`/`-C "$REPO_ROOT"` lines, and it had
+# FOUR silent false PASSes, each a live OBJECT read:
+#   (a) a dereferencing rev that contains no `^{` — `HEAD~1`, `HEAD^`, `HEAD^0`, `HEAD@{1}`,
+#       `HEAD:path`, or a bare tag/branch name (a tag is a TAG object, so resolving it peels);
+#   (b) the rev held in a VARIABLE assigned on a different line (`local rev="HEAD^{commit}"`);
+#   (c) the call split over a `\` continuation, so the peel-bearing physical line matches nothing;
+#   (d) a live call spelled other than `-C "$REPO_ROOT"` — `--git-dir="$REPO_ROOT/.git"`, a
+#       `GIT_DIR=` assignment, or `cd "$REPO_ROOT"` plus a bare `git`.
+# And the count assert did not backstop it: a NEWLY ADDED live call using `HEAD~1` leaves the
+# count of unpeeled HEAD resolutions at one. A deny-list over rev syntax the author chooses never
+# closes — the standing ruling against picking a rarer delimiter — and a guard with documented
+# false PASSes is worse than none (#3229), especially here, where the call-site comment TELLS the
+# reader this guard enforces the bare-ref contract.
+#
+# So the question is asked affirmatively, which is also what makes a PASS mean something: the SET
+# of live invocations must EQUAL `CS_DECLARED_LIVE_CALLS`, in BOTH directions. An unrecognised
+# shape is a FINDING whatever it contains, so (a)–(d) are all rejected by the same rule and so is
+# the next spelling nobody has thought of; and a declared entry that no longer appears is a
+# FINDING too, because a stale entry PRE-AUTHORISES its own re-introduction (section 9b's rule for
+# git operations, applied to argv).
+#
+# GRANULARITY, and why it differs from 9b deliberately: 9b keys on the SUBCOMMAND because a
+# flag-level key would red on a reordering of correct code. Here the ARGV IS the property — `HEAD`
+# versus `HEAD^{commit}` is one token — so this guard keys on the exact argument text and is
+# scoped to the SIX live calls, where an exact list is maintainable. It is also REGION-SCOPED, not
+# file-wide: `scripts/agent-gate.sh` legitimately peels in the live repository OUTSIDE this region
+# (the `--delta` anchor resolution runs `rev-parse --verify -q "${anchor}^{commit}"` with no
+# `-C`), and a file-wide rule would red on correct code — the guard agents learn to waive.
+#
+# WHAT IT CANNOT CLAIM: that a declared call is network-free. That judgement is recorded per site
+# in the enumeration comment at the head of the region, which is where a reviewer checks it. What
+# it guarantees is that no live call arrives UNDECLARED.
+CS_DECLARED_LIVE_CALLS=(
+  # HEAD's REF, resolved UNPEELED (#3757). The whole subject of this guard: a peel here is an
+  # object read, and in a promisor clone a missing object is fetched under the LIVE repository's
+  # own config, where an `insteadOf` rewrite invokes a remote helper.
+  '--no-replace-objects -C "$REPO_ROOT" rev-parse --verify --quiet HEAD'
+  # Repository STATE and CONFIG reads. None resolves a rev, so none can peel.
+  '-C "$REPO_ROOT" rev-parse --git-dir'
+  '-C "$REPO_ROOT" remote get-url origin'
+  '-C "$REPO_ROOT" rev-parse --git-path objects'
+  '-C "$REPO_ROOT" rev-parse --is-shallow-repository'
+  '-C "$REPO_ROOT" rev-parse --git-path shallow'
+)
+# The DIRECT `git` lines in the region that are NOT repository operations on a named repository,
+# each classified here rather than pattern-excused. A direct git line matching none of these, and
+# not carrying an isolated `-C`, is a FINDING — that is route (d)'s closure.
+#   <line-payload substring>|<why it is not a live repository read>
+CS_DECLARED_DIRECT_GIT=(
+  'git "$@" 2>/dev/null|the _cs_live_git WRAPPER itself: the one live invocation point, whose argv comes from the call sites this guard checks'
+  'command -v git|a capability probe (is git on PATH), not an invocation'
+  '"$uinfo" != git|a string comparison against the literal userinfo git, not an invocation'
+  'git init -q "$csdir/repo"|creates the ISOLATED scratch at a named target path; reads no repository'
+)
+CS_ISOLATED_SELECTORS=('-C "$_CS_READ_DIR"' '-C "$csdir/repo"')
+cs_live_call_findings() {
+  local gate="$1" line num raw argv dq entry i hit
+  local -a seen=()
+  for i in "${!CS_DECLARED_LIVE_CALLS[@]}"; do seen[$i]=0; done
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    num="${line%%:*}"; raw="${line#*:}"
+    # ROUTE (c): a continued line cannot be judged as a line. Reject it rather than judge the
+    # fragment — a `\` continuation is how an argument list hides from a per-line scan.
+    case "$raw" in
+      *'\') case "$raw" in
+              *_cs_live_git*|*' git '*|*'	git '*)
+                printf 'FINDING: %s: a git call is split over a line CONTINUATION, so its argument list cannot be judged as one line — write it on one line (or declare it): %s\n' "$num" "$raw"
+                continue ;;
+            esac ;;
     esac
-  done < <( { grep -n '_cs_live_git ' "$g"; grep -n -- '-C "\$REPO_ROOT"' "$g"; } \
-              | grep -v ':[[:space:]]*#' | sort -u )
+    case "$raw" in
+      *_cs_live_git\ *)
+        argv="${raw#*_cs_live_git }"
+        # Trailing whitespace only; anything else (a `)`, a redirection, a `;`) is part of the
+        # shape and must be DECLARED, because it changes what runs.
+        argv="${argv%"${argv##*[![:space:]]}"}"
+        hit=""
+        for i in "${!CS_DECLARED_LIVE_CALLS[@]}"; do
+          if [ "$argv" = "${CS_DECLARED_LIVE_CALLS[$i]}" ]; then hit=1; seen[$i]=1; break; fi
+        done
+        if [ -z "$hit" ]; then
+          printf 'FINDING: %s: UNDECLARED live-repository git call: %s\n' "$num" "$argv"
+        fi
+        continue ;;
+    esac
+    # A DIRECT `git` at command position. Quoted spans are removed FIRST so a diagnostic string
+    # (`_CS_DETAIL="git fetch … exited $rc"`, `hint="… git rebase …"`) is not read as an
+    # invocation — 9b's measured lesson. The word class excludes `--git-path`/`_cs_live_git`,
+    # where `git` is part of a longer word.
+    dq=$(printf '%s' "$raw" | sed 's/"[^"]*"//g')
+    case "$dq" in
+      git\ *|*[[:space:]\;\&\|\(]git\ *) : ;;
+      *) continue ;;
+    esac
+    hit=""
+    for entry in "${CS_ISOLATED_SELECTORS[@]}"; do
+      case "$raw" in *"$entry"*) hit=isolated; break ;; esac
+    done
+    [ -n "$hit" ] && continue
+    for entry in "${CS_DECLARED_DIRECT_GIT[@]}"; do
+      case "$raw" in *"${entry%%|*}"*) hit=declared; break ;; esac
+    done
+    [ -n "$hit" ] && continue
+    printf 'FINDING: %s: a DIRECT git invocation names no ISOLATED repository and is not declared — it may run in the LIVE checkout (route d): %s\n' "$num" "$raw"
+  done < <(cs_region_code "$gate")
+  # BOTH DIRECTIONS: a declared shape that no longer appears is a stale entry, and a stale entry
+  # pre-authorises its own re-introduction.
+  for i in "${!CS_DECLARED_LIVE_CALLS[@]}"; do
+    [ "${seen[$i]}" = 1 ] || printf 'FINDING: declared live call NOT OBSERVED in the region (stale entry, or the shape changed): %s\n' "${CS_DECLARED_LIVE_CALLS[$i]}"
+  done
 }
 
-# cs_live_head_calls <gate-path>: the UNPEELED live HEAD resolutions, as code lines.
-cs_live_head_calls() {
-  grep -n '_cs_live_git .*rev-parse --verify --quiet HEAD$' "$1" | grep -v ':[[:space:]]*#'
-}
-
-peel_findings=$(cs_live_peel_findings "$GATE")
-peel_head=$(cs_live_head_calls "$GATE")
-peel_head_n=$(printf '%s\n' "$peel_head" | grep -c . )
-# THE CONTROL SUBSTITUTES THE ARTIFACT, in a throwaway copy — never a settable seam in the
-# gate (the rule `3544-canonical-literal`'s helper is built on). And the substitution is
-# VERIFIED to have taken: a sed that matched nothing would make the control "pass" by proving
-# nothing, which is the vacuous green this whole file exists to refuse.
-peel_ctl_dir="$tmp/3757-peel-control"; mkdir -p "$peel_ctl_dir"
-peel_ctl="$peel_ctl_dir/agent-gate.sh"
-sed 's|\(_cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet \)HEAD$|\1"HEAD^{commit}"|' "$GATE" >"$peel_ctl"
-peel_ctl_took=$(grep -c '_cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet "HEAD\^{commit}"' "$peel_ctl")
-peel_ctl_findings=$(cs_live_peel_findings "$peel_ctl")
-# THE PROPERTY IS JUDGED FIRST, THE CONTROL'S INTEGRITY ONLY GATES THE `ok`. Ordered the other
-# way round (control first), a gate that HAS the live peel red with "the control could not
-# reintroduce the peel" — a true sentence that sends the reader to the test instead of to the
-# defect, and AC2 requires the red to NAME the offending construct.
-if [ -n "$peel_findings" ]; then
-  bad "3757-no-live-peel: a live-repository git call PEELS an object (a lazy fetch route in a promisor clone):"
-  printf '%s\n' "$peel_findings"
-elif [ "$peel_head_n" -ne 1 ]; then
-  bad "3757-no-live-peel: expected exactly ONE unpeeled live HEAD resolution, found $peel_head_n — the shape changed or the scan broke (fail-closed: this is not a clean result). Lines: $peel_head"
-elif [ "$peel_ctl_took" -ne 1 ]; then
-  bad "3757-no-live-peel: the POSITIVE CONTROL could not reintroduce the peel (substitution took $peel_ctl_took times) — the scan cannot be shown to discriminate, so a clean result on the real gate is not evidence"
-elif ! grep -q 'FINDING:' <<<"$peel_ctl_findings" \
-     || ! grep -q 'HEAD\^{commit}' <<<"$peel_ctl_findings"; then
-  bad "3757-no-live-peel: the control's reintroduced peel was NOT reported (or was reported without NAMING the construct) — a bare red is not evidence. Control findings: $peel_ctl_findings"
+live_findings=$(cs_live_call_findings "$GATE")
+if [ -z "$live_findings" ]; then
+  ok "3757-live-call-allowlist: the pre-flight region's LIVE-repository git calls are EXACTLY the ${#CS_DECLARED_LIVE_CALLS[@]} declared shapes (both directions), and HEAD's is the UNPEELED bare ref"
 else
-  ok "3757-no-live-peel: no live-repository git call peels an object (HEAD is resolved UNPEELED, exactly once), and reintroducing the peel in a scratch copy is REPORTED and NAMED"
+  bad "3757-live-call-allowlist: the region's live git calls do not match the declared set:"
+  printf '%s\n' "$live_findings"
 fi
+
+# THE FOUR EVASION ROUTES, EACH PLANTED IN ITS OWN THROWAWAY COPY (roborev job 325, blocker 1).
+# A control that plants only the shape the OLD deny pattern already caught proves nothing about
+# the three it missed, so each route is a SEPARATE mutation of the ARTIFACT (never a seam in the
+# gate) and each must be REPORTED, NAMED, and shown to have been substituted at all — a sed that
+# matched nothing would "pass" this by proving nothing.
+lc_dir="$tmp/3757-live-call-controls"; mkdir -p "$lc_dir"
+lc_ids=(a b c d)
+lc_whats=(
+  'a dereferencing rev that contains no ^{ (HEAD~1)'
+  'the rev held in a VARIABLE, so no rev token appears on the call line'
+  'the call split over a \ line CONTINUATION'
+  'a live call spelled --git-dir= instead of -C "$REPO_ROOT"'
+)
+lc_progs=(
+  's|^\(  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet \)HEAD$|\1HEAD~1|'
+  's|^\(  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet \)HEAD$|\1"$_cs_planted_rev"|'
+  's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  _cs_live_git --no-replace-objects -C "$REPO_ROOT" \\\n    rev-parse --verify --quiet "HEAD^{commit}"|'
+  's|^  _cs_live_git --no-replace-objects -C "\$REPO_ROOT" rev-parse --verify --quiet HEAD$|  _component_set_bounded "$_CS_BOUND_SECS" env -i "${_CS_GIT_ENV[@]}" git --git-dir="$REPO_ROOT/.git" rev-parse --verify --quiet "HEAD^{commit}"|'
+)
+lc_tooks=(
+  'rev-parse --verify --quiet HEAD~1$'
+  'rev-parse --verify --quiet "\$_cs_planted_rev"$'
+  '_cs_live_git .*\\$'
+  'git --git-dir="\$REPO_ROOT/\.git"'
+)
+lc_needles=('HEAD~1' '_cs_planted_rev' 'line CONTINUATION' '--git-dir=')
+for lc_i in "${!lc_ids[@]}"; do
+  lc_id="${lc_ids[$lc_i]}"
+  lc_copy="$lc_dir/route-$lc_id.sh"
+  sed "${lc_progs[$lc_i]}" "$GATE" >"$lc_copy"
+  lc_n=$(grep -c "${lc_tooks[$lc_i]}" "$lc_copy" 2>/dev/null || true)
+  lc_out=$(cs_live_call_findings "$lc_copy")
+  if [ "$lc_n" != 1 ]; then
+    bad "3757-evasion-route[$lc_id]: the mutation did not take (matched $lc_n times, expected 1) — this route is NOT under test, so a clean scan on the real gate is not evidence for it. Route: ${lc_whats[$lc_i]}"
+  elif grep -qF -- "${lc_needles[$lc_i]}" <<<"$lc_out"; then
+    ok "3757-evasion-route[$lc_id]: ${lc_whats[$lc_i]} is REPORTED and NAMED (needle '${lc_needles[$lc_i]}') — the affirmative allowlist rejects it, and the old ^{ deny pattern did not"
+  else
+    bad "3757-evasion-route[$lc_id]: planting ${lc_whats[$lc_i]} produced no finding naming '${lc_needles[$lc_i]}' — a silent false PASS. Findings: $lc_out"
+  fi
+done
 
 # ---------------------------------------------------------------------------
 # 3757b. THE PEEL MOVED TO THE ISOLATED SCRATCH, AND IT IS BOUNDED AND THREE-VALUED THERE.
@@ -921,7 +1072,9 @@ fi
 # ---------------------------------------------------------------------------
 cs_scratch_peel_findings() {
   local g="$1" site n body
-  site=$(grep -n 'rev-parse --verify --quiet "\${head_unpeeled}\^{commit}"' "$g" | grep -v ':[[:space:]]*#')
+  # ANCHORED comment strip (roborev job 325, nit 3): an unanchored `:[[:space:]]*#` also matches a
+  # `#` LATER on the line, so a real call line carrying a trailing `# note: …` was dropped.
+  site=$(grep -n 'rev-parse --verify --quiet "\${head_unpeeled}\^{commit}"' "$g" | grep -v '^[0-9][0-9]*:[[:space:]]*#')
   n=$(printf '%s\n' "$site" | grep -c . )
   if [ "$n" -ne 1 ]; then
     printf 'FINDING: expected exactly ONE scratch peel of HEAD, found %s\n' "$n"
@@ -933,8 +1086,11 @@ cs_scratch_peel_findings() {
     || printf 'FINDING: the scratch peel does not run in $_CS_READ_DIR: %s\n' "$site"
   grep -q '_CS_READ_ENV' <<<"$site" \
     || printf 'FINDING: the scratch peel does not carry $_CS_READ_ENV (the alternate): %s\n' "$site"
-  # The rc mapping lives in the ten lines after the read; read it as CODE.
-  body=$(awk -v s="${site%%:*}" 'NR>s+0 && NR<=s+10' "$g" | grep -v '^[[:space:]]*#')
+  # The rc mapping lives in the lines just after the read; read it as CODE. The window is 20 raw
+  # lines, not 10, because it is counted BEFORE comments are stripped and the mapping arms carry
+  # doctrine comments — a window sized to the code would shrink every time a rationale is added,
+  # and the guard would report a mapping "missing" that is simply further down.
+  body=$(awk -v s="${site%%:*}" 'NR>s+0 && NR<=s+20' "$g" | grep -v '^[[:space:]]*#')
   grep -q 'peel_rc" -eq 124' <<<"$body" || printf 'FINDING: 124 (bound fired) is not mapped after the scratch peel\n'
   grep -q 'peel_rc" -eq 137' <<<"$body" || printf 'FINDING: 137 (KILLed) is not mapped after the scratch peel\n'
   grep -q 'peel_rc" -eq "\$_CS_UNBOUNDABLE_RC"' <<<"$body" || printf 'FINDING: $_CS_UNBOUNDABLE_RC (no bounding mechanism) is not mapped after the scratch peel\n'
@@ -956,6 +1112,136 @@ elif ! grep -q 'NOT bounded' <<<"$sp_ctl_findings"; then
   bad "3757-scratch-peel-bounded: unbounding the peel in a scratch copy was NOT reported — a bare pass is not evidence. Control findings: $sp_ctl_findings"
 else
   ok "3757-scratch-peel-bounded: HEAD's peel runs in \$_CS_READ_DIR with the alternate, BOUNDED, and maps 124/137/UNBOUNDABLE onto repo-read-blocked; unbounding it in a scratch copy is REPORTED"
+fi
+
+# ---------------------------------------------------------------------------
+# 3757c. `$_CS_READ_DIR` NEVER NAMES THE LIVE CHECKOUT — asserted, not assumed (roborev job 325,
+#     blocker 2). The claim this diff adds to the region's execution-route enumeration ("since
+#     #3757 it reads NO object in the live repository") used to hold only because every earlier
+#     failure `return 0`s before the scratch assignment, while the initialiser was `$REPO_ROOT` —
+#     an ORDERING property nothing checked, which is the reasoning job 314 rejected in this same
+#     function. There is no reachable route to it today, so this is HARDENING; the point of these
+#     cases is that the property is now MECHANICAL rather than traced by hand.
+#
+#     AND AN EMPTY SENTINEL IS NOT SELF-PROTECTING: `git -C ""` leaves the working directory
+#     UNCHANGED, i.e. it MEANS the live checkout, so the initialiser alone fixes nothing. Three
+#     properties, each with its own planted control:
+#       (i)   the initialiser is not the live checkout;
+#       (ii)  every `-C "$_CS_READ_DIR"` consumer in the region appears AFTER the scratch
+#             assignment (the ordering, made explicit);
+#       (iii) the peel calls the runtime refusal before handing the value to git.
+# ---------------------------------------------------------------------------
+cs_read_dir_findings() {
+  local g="$1" init assign assign_ln consumers ln peel_ln guard_ln
+  init=$(cs_region_code "$g" | grep -F '_CS_READ_DIR=' | grep -F '_CS_READ_ENV=(); _CS_HEAD_SHA=' | head -1)
+  if [ -z "$init" ]; then
+    printf 'FINDING: could not locate the probe initialiser line that sets _CS_READ_DIR — the shape changed or the scan broke (fail-closed)\n'
+  else
+    case "$init" in
+      *'_CS_READ_DIR="$REPO_ROOT"'*)
+        printf 'FINDING: %s: the initialiser makes THE LIVE CHECKOUT the default read repository, so any consumer reached before the scratch assignment reads objects live: %s\n' "${init%%:*}" "${init#*:}" ;;
+      *'_CS_READ_DIR=""'*) : ;;
+      *) printf 'FINDING: %s: the initialiser sets _CS_READ_DIR to an unrecognised value; only the empty sentinel is declared: %s\n' "${init%%:*}" "${init#*:}" ;;
+    esac
+  fi
+  assign=$(cs_region_code "$g" | grep -F '_CS_READ_DIR="$csdir/repo"' | head -1)
+  if [ -z "$assign" ]; then
+    printf 'FINDING: could not locate the scratch assignment _CS_READ_DIR="$csdir/repo" — the shape changed or the scan broke (fail-closed)\n'
+    return 0
+  fi
+  assign_ln="${assign%%:*}"
+  consumers=$(cs_region_code "$g" | grep -F -- '-C "$_CS_READ_DIR"')
+  if [ -z "$consumers" ]; then
+    printf 'FINDING: no -C "$_CS_READ_DIR" consumer found in the region — the guard has no subject (fail-closed)\n'
+  fi
+  while IFS= read -r ln; do
+    [ -n "$ln" ] || continue
+    if [ "${ln%%:*}" -lt "$assign_ln" ]; then
+      printf 'FINDING: %s: a -C "$_CS_READ_DIR" consumer runs BEFORE the scratch assignment at line %s, so it would read in whatever the initialiser left: %s\n' "${ln%%:*}" "$assign_ln" "${ln#*:}"
+    fi
+  done <<<"$consumers"
+  peel_ln=$(cs_region_code "$g" | grep -F 'rev-parse --verify --quiet "${head_unpeeled}^{commit}"' | head -1)
+  guard_ln=$(cs_region_code "$g" | grep -F '_cs_read_dir_isolated_or_refuse "peel HEAD' | head -1)
+  if [ -z "$peel_ln" ]; then
+    printf 'FINDING: could not locate the scratch peel (fail-closed)\n'
+  elif [ -z "$guard_ln" ]; then
+    printf 'FINDING: the peel does not call _cs_read_dir_isolated_or_refuse — an unisolated value would be handed to git instead of refused by name\n'
+  elif [ "${guard_ln%%:*}" -ge "${peel_ln%%:*}" ]; then
+    printf 'FINDING: the _cs_read_dir_isolated_or_refuse call (line %s) is not BEFORE the peel (line %s) — a check placed after the harmful effect can only report it\n' "${guard_ln%%:*}" "${peel_ln%%:*}"
+  fi
+  return 0
+}
+rd_findings=$(cs_read_dir_findings "$GATE")
+if [ -z "$rd_findings" ]; then
+  ok "3757-read-dir-shape: the read repository is an empty sentinel until the scratch exists, every -C \$_CS_READ_DIR consumer runs after the scratch assignment, and the peel refuses an unisolated value before calling git"
+else
+  bad "3757-read-dir-shape: the read-repository invariants are not met:"
+  printf '%s\n' "$rd_findings"
+fi
+
+# THREE PLANTED CONTROLS, one per property. Each mutates a COPY and must be REPORTED and NAMED.
+rd_dir="$tmp/3757-read-dir-controls"; mkdir -p "$rd_dir"
+rd_ids=(i ii iii)
+rd_whats=(
+  'the initialiser set back to the LIVE checkout'
+  'a -C "$_CS_READ_DIR" consumer planted BEFORE the scratch assignment'
+  'the runtime refusal call removed from the peel'
+)
+rd_progs=(
+  's|^  _CS_READ_DIR=""; _CS_READ_ENV=(); _CS_HEAD_SHA=""$|  _CS_READ_DIR="$REPO_ROOT"; _CS_READ_ENV=(); _CS_HEAD_SHA=""|'
+  's|^  _CS_READ_DIR="\$csdir/repo"$|  : "$(git --no-replace-objects -C "$_CS_READ_DIR" cat-file -e planted-by-the-selftest 2>/dev/null)"\n  _CS_READ_DIR="$csdir/repo"|'
+  '/_cs_read_dir_isolated_or_refuse "peel HEAD/d'
+)
+rd_tooks=(
+  '^  _CS_READ_DIR="\$REPO_ROOT"; _CS_READ_ENV'
+  'cat-file -e planted-by-the-selftest'
+  '_cs_read_dir_isolated_or_refuse "peel HEAD'
+)
+rd_expect_n=(1 1 0)
+rd_needles=('THE LIVE CHECKOUT' 'BEFORE the scratch assignment' 'does not call _cs_read_dir_isolated_or_refuse')
+for rd_i in "${!rd_ids[@]}"; do
+  rd_id="${rd_ids[$rd_i]}"
+  rd_copy="$rd_dir/prop-$rd_id.sh"
+  sed "${rd_progs[$rd_i]}" "$GATE" >"$rd_copy"
+  rd_n=$(grep -c "${rd_tooks[$rd_i]}" "$rd_copy" 2>/dev/null || true)
+  rd_out=$(cs_read_dir_findings "$rd_copy")
+  if [ "$rd_n" != "${rd_expect_n[$rd_i]}" ]; then
+    bad "3757-read-dir-control[$rd_id]: the mutation did not take (matched $rd_n, expected ${rd_expect_n[$rd_i]}) — this property is NOT under test. Property: ${rd_whats[$rd_i]}"
+  elif grep -qF -- "${rd_needles[$rd_i]}" <<<"$rd_out"; then
+    ok "3757-read-dir-control[$rd_id]: ${rd_whats[$rd_i]} is REPORTED and NAMED (needle '${rd_needles[$rd_i]}')"
+  else
+    bad "3757-read-dir-control[$rd_id]: planting '${rd_whats[$rd_i]}' produced no finding naming '${rd_needles[$rd_i]}' — a silent false PASS. Findings: $rd_out"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# 3757d. BEHAVIOURAL: an unisolated read repository is REFUSED BY NAME, not read live.
+#     The structural cases above pin the SHAPE; this one drives the runtime refusal, because a
+#     guard that exists in source and is never reached is not a guard. The fixture's own gate copy
+#     has the scratch assignment rewritten to the LIVE checkout — the exact state the initialiser
+#     used to leave — and the fixture is cloned FROM its origin so the baseline read still
+#     succeeds and execution actually reaches the peel. Control: the same fixture unmutated, which
+#     must reach KIND ok, so the case cannot pass because the fixture is simply broken.
+# ---------------------------------------------------------------------------
+rdu_base=$(mkbaseline base-readdir - )
+rdu_ctl_fx=$(mkbranch readdir-ok "$rdu_base" - --from-origin)
+rdu_fx=$(mkbranch readdir-live "$rdu_base" 's|^  _CS_READ_DIR="\$csdir/repo"$|  _CS_READ_DIR="$REPO_ROOT"|' --from-origin)
+rdu_took=$(grep -c '^  _CS_READ_DIR="\$REPO_ROOT"$' "$rdu_fx/scripts/agent-gate.sh" 2>/dev/null || true)
+rdu_ctl=$(hook "$rdu_ctl_fx")
+rdu_out=$(hook "$rdu_fx")
+rdu_kind=$(field KIND "$rdu_out")
+rdu_line=$(field COMPONENT_SET_LINE "$rdu_out")
+if [ "$rdu_took" != 1 ]; then
+  bad "3757-read-dir-unisolated: the fixture mutation did not take (matched $rdu_took, expected 1) — the refusal is not under test"
+elif [ "$(field KIND "$rdu_ctl")" != ok ]; then
+  bad "3757-read-dir-unisolated: the POSITIVE CONTROL (same fixture, unmutated) did not reach KIND ok (got '$(field KIND "$rdu_ctl")') — the case cannot discriminate"
+elif [ "$rdu_kind" = read-dir-unisolated ] \
+     && grep -q 'isolated read repository was never established' <<<"$rdu_line" \
+     && [ "$(field VERDICT "$rdu_out")" = UNMEASURED ]; then
+  ok "3757-read-dir-unisolated: a read repository left at the LIVE checkout is REFUSED by name (read-dir-unisolated, verdict UNMEASURED) instead of peeling HEAD there"
+else
+  bad "3757-read-dir-unisolated: expected KIND read-dir-unisolated naming the unestablished scratch (got '$rdu_kind', verdict '$(field VERDICT "$rdu_out")')"
+  printf '%s\n' "$rdu_out"
 fi
 
 # ---------------------------------------------------------------------------
@@ -3404,7 +3690,13 @@ fi
 # ---------------------------------------------------------------------------
 # The ONE declared constant. Bump it in the SAME change that adds/removes a `_CS_KIND`
 # value, and extend the census above and a case below at the same time.
-DECLARED_KIND_COUNT=19   # 18 -> 19: +repo-read-blocked (roborev job 312 — a live-repository read
+DECLARED_KIND_COUNT=20   # 19 -> 20: +read-dir-unisolated (#3757 — `$_CS_READ_DIR` still naming
+                         # the LIVE checkout, or left at the empty sentinel that `git -C ""`
+                         # reads AS the live checkout, at the point an object read would be
+                         # handed to git. Hardening: no reachable route today, and the refusal is
+                         # what makes "this pre-flight reads no object in the live repository" a
+                         # CHECKED claim rather than an ordering nobody verified.)
+                         # 18 -> 19: +repo-read-blocked (roborev job 312 — a live-repository read
                          # that EXCEEDED its bound, which a config `include.path` naming a FIFO
                          # causes). The step before was 20 -> 18 (-gate-script-changed,
                          # -gate-script-unverifiable, both
@@ -3471,9 +3763,10 @@ fi
 #     diff, which is what would have caught `git show`.
 # ---------------------------------------------------------------------------
 region="$tmp/preflight-region.sh"
-awk '/^# ---- issue #3544: component-set skew pre-flight/ { inr = 1 }
-     /^# ---- issue #2081:/ { inr = 0 }
-     inr { print }' "$GATE" >"$region"
+# ONE marker pair, shared with #3757's live-call allowlist (see `cs_region_stream`): a guard that
+# disagreed with this one about the region boundary would move calls in and out of its subject
+# silently.
+cs_region_stream "$GATE" plain >"$region"
 region_lines=$(wc -l <"$region" | tr -d ' ')
 
 # ONE audit program, written once and used for BOTH the region and its positive controls.
@@ -4946,7 +5239,10 @@ fi
 # legitimately `skip` when the fixture's HEAD object is packed rather than loose (the same
 # conditional `3544-ancestry-bounded` carries), and a floor that counts a skippable case would red
 # on correct input.
-CASE_FLOOR=113
+# 113 -> 123 with roborev job 325's ten further #3757 cases, all unconditional: the allowlist
+# clean case + its FOUR planted evasion routes (which replaced one deny-pattern case), the
+# read-dir shape case + its THREE planted controls, and the behavioural read-dir refusal.
+CASE_FLOOR=123
 if [ "$PASS" -lt "$CASE_FLOOR" ] && [ "$FAIL" -eq 0 ]; then
   printf 'FAIL - 3544-case-floor: %d cases ran but this suite declares a floor of %d — cases were REMOVED (or are skipping) without the floor being lowered deliberately. A green tally over a shrunken suite is the exact defect #3544 is about.\n' "$PASS" "$CASE_FLOOR"
   FAIL=$((FAIL + 1))


### PR DESCRIPTION
Closes #3757.

## What this fixes

`scripts/agent-gate.sh`'s component-set pre-flight resolved HEAD with `rev-parse --verify --quiet "HEAD^{commit}"` **in the live repository**. A peel is an object read, and in a partial/promisor clone a missing object is lazily fetched using the live repository's *shared local config*, where an `insteadOf` rewrite can invoke a remote helper. `GIT_NO_LAZY_FETCH=1` is carried in `_CS_GIT_ENV` only as a belt (git >= 2.36, and an unset variable does nothing silently).

HEAD is now resolved **unpeeled** in the live repository; the peel and commit-validation happen inside the isolated scratch repository, where no promisor configuration is reachable.

(The issue cites `:5078`; line numbers had drifted — the site was `:5155`.)

## Measured, not argued

Real promisor clones of a local bare origin (`uploadpack.allowfilter=true`), HEAD pointed at a commit **absent locally** (absence confirmed with `GIT_NO_LAZY_FETCH=1 cat-file -e`), promisor URL replaced by an `ext::` recorder, git 2.43.0:

| form | rc | remote-helper invocations |
|---|---|---|
| `rev-parse --verify --quiet HEAD` (unpeeled) | 0 | **0** |
| `rev-parse --verify --quiet 'HEAD^{commit}'` | 1 | **2** (lazy fetch) |
| `cat-file -t <sha>` | — | 1 |

Both `--filter=blob:none` and `--filter=tree:0`. Second control, FIFO planted at HEAD's loose object in a plain repo: unpeeled returns the sha in 3 ms, **peeled BLOCKS**. So the unpeeled form reads the ref, not the object.

A related measurement that changed the design: **`git -C "" rev-parse --git-dir` returns rc 0 and resolves the LIVE git dir**, so an empty-string sentinel for `_CS_READ_DIR` would have failed *open*. The sentinel is a `/nonexistent/...` path instead.

## Acceptance criteria

- **AC1** — HEAD resolved unpeeled in the live repo; peel + validation inside the isolated scratch. Both fast and slow paths reach it with the scratch and the alternate established.
- **AC2** — a **source-derived** structural assertion that the live call performs no peel, with positive controls. Implemented as two **whole-line literal pins** (`grep -Fxq`, both directions) over the pre-flight region's `_cs_live_git` lines and its other `$REPO_ROOT` lines. **Ten** planted routes each red and name what they planted.
- **AC3** — `_cs_live_git`'s bound and three-valued outcome (`ok`/`blocked`/`unboundable`) and the `_cs_live_refuse` mapping preserved; the new scratch peel is bounded and maps 124/137/`$_CS_UNBOUNDABLE_RC` onto the existing kinds; an unresolvable or unpeelable HEAD stays **INDETERMINATE**, never a false `BEHIND`.
- **AC4** — no live peel survives; the bare-ref contract and the reason are recorded at the call site.

## Hardening the reviews surfaced

- `_CS_READ_DIR` starts at a non-existent-path sentinel, and `_cs_read_dir_isolated_or_refuse` is an **affirmative** match against the scratch (new kind `read-dir-unisolated`, `DECLARED_KIND_COUNT` 19 -> 20).
- That assertion sits at the point that **dominates every consumer** (immediately after the scratch assignment; the old late call removed, not duplicated) — because a check placed after the harm can only report it. Evidence is affirmative and discriminating: the mutated fixture refuses with `BASELINE_OBJECTS: <none>` **and** `BASELINE_SRC: <none>` (the gate's own record that neither the fast-path `cat-file`/`rev-list` nor the manifest `ls-tree`/`show` ran), while the same fixture with the assertion deleted records `objects='reused' src='manifest'`. **This was hardening, not a live defect** — on the unmodified gate the only value a consumer can see is the scratch.
- The FIFO case runs under an independent outer watchdog; expiry is a **named failure**, not a skip, and cleanup runs before the assertions so the watchdog path also cleans up.

## AC2's guard was DESCOPED mid-PR — read this before reviewing it

Three review rounds produced blockers **inside the previous round's fix** of this guard, with the false-PASS count rising **1 -> 1 -> 4**. The last straw: `local sha=$(… git -C "$REPO_ROOT" rev-parse --verify --quiet "HEAD^{commit}")` produced **zero findings from both guards**, because the guard's hand-rolled `cs_first_word` returned `local`, which was on a "harmless" list.

Per #3229 (*a guard with known documented false-PASSes is worse than no guard*) and #3312 (*remove the shared channel, do not pick a rarer delimiter*), the **syntax-recognising half was deleted**: `R2`, `cs_first_word`, `CS_DECLARED_REPO_ROOT_HARMLESS`, the word-class direct-`git` test and the fragment splitter — a second partial bash parser in this file, and both of that round's false PASSes lived in it. Parsing author-controlled bash to decide data-vs-control *is* the shared channel.

Kept: everything parser-free that produced zero findings across three rounds. Rebuilt: whole-line literal equality, decidable without tokenising anything, which rejects every route from rounds 2 and 3. **Net −106 lines** in that commit. AC2 remains met — the assertion is still derived from source, not from a comment.

Declared residual, written at the pin: it is brittle to reformatting (the both-directions leg makes a stale pin loud rather than silent), it does **not** understand bash, and it cannot see a live read that names the repository some other way (a variable copied outside the region, `cd` + bare `git`, `GIT_DIR=` without the token).

Escalated to the lead as `REQ-3757-01` and taken on the announced default after 51 minutes and four re-checks; reasoning and reversibility are on the issue thread.

## Verification

`scripts/tests/test_agent_gate_component_set.sh`: **143 passed / 0 failed (floor 133)**, no skips, 24 `3757-*` cases — reproduced independently five times across five rounds, matching the implementer's reported count every time.

Gate of record + final roborev: recorded below by `flow-closer`.

## Not in scope — filed as follow-ups

- **#3906** — `${_CS_HEAD_SHA:+…}${_CS_HEAD_SHA:-…}` prints the sha twice when set, and `${_CS_HEAD_SHA:-HEAD}` would resolve `HEAD` inside the scratch (unborn) if reachable. Both pre-existing and unreachable.
- **#3907** — `scripts/agent-gate.sh:17468`: `git rev-parse --verify -q "${anchor}^{commit}"` is a real **live-repository peel** on the `--delta` anchor path, outside this pre-flight's scope. Same mechanism as this issue, different call site.
