### PR TITLE
fix(#3759): report waiver/deferral MISPLACED for a marker on the linked issue thread

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1516,9 +1516,25 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   files are not (a workflow injecting a variable). "Theoretically redundant" never justifies leaving a hole
   a non-invoker or an accident can walk through.
   **TWO RESIDUALS INSIDE THE MODEL, named rather than implied:** the marker is read from **top-level PR
-  comments only**, so one posted inside a review body or a review-thread reply is silently not applied (the
-  run reports `waiver: NONE` and the FAIL stands — fail-closed, but it reads as "my waiver was ignored");
-  and **an authorized human can authorize carelessly** — pre-authorizing a job id, or waiving without
+  comments only**, and **THE MOST PROBABLE MISPLACEMENT IS THE PR'S LINKED ISSUE THREAD (#3759)** — that is
+  where lane/lead coordination lives — followed by a review body and a review-thread reply. None of the
+  three is read, so a marker posted there is silently not applied (the run reports `waiver: NONE` and the
+  FAIL stands — fail-closed, but it reads as "my waiver was ignored"). **Measured on PR #3710:** the lead
+  granted BOTH markers, field-perfect and sole-content, from an allowlisted author — on **issue #3544**;
+  both keys read `NONE`, which is textually identical to "the lead refused", and position 1 of a six-PR
+  serial queue idled ~8 hours and blocked five lanes. **SINCE #3759 THE LINKED-ISSUE CASE IS DIAGNOSED,
+  NOT GRANTED:** when the PR-side scan returns `none`, the PR's linked issue(s) — resolved from the
+  structured `closingIssuesReferences` relation, NEVER from the mutable PR body — are scanned with the
+  SAME scanner and the SAME base/head/job/allowlist, and a marker there that WOULD have been accepted by
+  the channel is reported `waiver: MISPLACED (found on linked issue #N …)` naming the issue and the
+  remedy. **`MISPLACED` GRANTS NOTHING — not partially, not with a notice — and the FAIL STANDS**: only a
+  marker on the PULL REQUEST grants, and moving it there is a HUMAN act by the authorizer, never
+  something the tool does. A `NONE` now also DECLARES whether that probe ran (checked / bounded /
+  no linked issue / could-not-check), so "checked and it is not there either" and "never checked" can no
+  longer read alike. **LEAD-SIDE PROCEDURE, the other half of the fix: after posting either marker,
+  verify with `gh pr view <PR> --json comments` that the line is ON THE PR — a grant is only granted once
+  it is readable by the scanner that reads it.**
+  And **an authorized human can authorize carelessly** — pre-authorizing a job id, or waiving without
   checking the token accounting. Nothing mechanical detects either; the control is the permanent,
   attributable comment, which is why a substantive reason is required and recorded verbatim.
   **AND A SECOND, EQUALLY TRANSFERABLE RULE FROM THE SAME ISSUE: THE CONSTRAINED PARTY MUST NOT CHOOSE ITS
@@ -1626,7 +1642,20 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   explicitly — never by copy, because a second implementation of a channel rule is a second place for it
   to diverge and a divergence there is an authorization bypass. **There is deliberately NO flag, NO file
   in the worktree and NO env var**, each of which would hand the constrained party the power to satisfy
-  its own constraint (#3312's corollary). **The match is AFFIRMATIVE, which is what makes this a match
+  its own constraint (#3312's corollary). **AND IT INHERITS THE MISPLACEMENT RESIDUAL BY CALL TOO
+  (#3759)**: the deferral marker is read from **top-level PR comments only**, and the **MOST PROBABLE
+  MISPLACEMENT IS THE PR'S LINKED ISSUE THREAD**, ahead of a review body and a review-thread reply —
+  measured on PR #3710, where both markers were granted field-perfect on issue #3544 and both keys
+  read `NONE`. Since #3759 that case is DIAGNOSED, not granted: a would-have-been-accepted marker on a
+  linked issue reports `deferral: MISPLACED (found on linked issue #N …)` with the remedy, while
+  `findings:` stays exactly as measured — **never `DEFERRED`** (that would be the grant) and **never
+  `NONE`** (that would read as a clean review) — and `RESULT` stays `FAIL`. **`MISPLACED` GRANTS
+  NOTHING**; only a marker on the PULL REQUEST grants. The rendering claims the marker *would have
+  been accepted by the channel*, NOT that it *would have granted*: the network **issue-disposition
+  legs are deliberately not run issue-side** and still apply once the marker is on the PR, because a
+  diagnostic that overstates what it measured is what stops the next person looking. As with the
+  waiver, **verify with `gh pr view <PR> --json comments` that the line is on the PR after posting
+  it.** **The match is AFFIRMATIVE, which is what makes this a match
   and not a mute button**: `count=` must EQUAL the observed findings count and `issues=` must be
   non-empty, so a PRE-AUTHORIZATION written before the findings were read fails on a mismatch, and **any
   new finding at the same head raises the observed count and fails** — that is how the UNDEFERRED set is

--- a/openspec/changes/roborev-waiver-misplaced/design.md
+++ b/openspec/changes/roborev-waiver-misplaced/design.md
@@ -1,0 +1,246 @@
+# Design — roborev-waiver-misplaced (issue #3759)
+
+## The one thing that must not happen, stated first
+
+Every previous round in this subsystem that went wrong went wrong in **one** direction: an
+authorization path was made easier to satisfy. So the design constraint that dominates every choice
+below is not "make misplacement visible" — that part is easy — it is **make misplacement visible
+WITHOUT creating a second granting surface.**
+
+The naive implementation of this issue is a bypass. "Also look at the linked issue's comments" is one
+`if` away from "…and grant if you find one there", and the difference between the two is exactly the
+property #3312 spent five High-severity rounds defending: **only a marker on the PR grants.** An
+issue thread has a different audience, a different retention, and — decisively — a **different
+relationship to the review**: the PR is the artifact under gate, and the marker's whole purpose is to
+be a permanent, attributable statement *about that gate*.
+
+Hence the shape: **the probe answers a question whose answer is printed and thrown away.** It sets a
+state that no granting branch reads.
+
+## Chosen mechanism
+
+```
+PR-side scan (unchanged) ──► granted / unauthorized / stale / malformed / count-mismatch / unavailable
+                          │        (all six: report as today, probe NOT run)
+                          └──► none
+                                 │
+                                 ├─ resolve linked issues: gh pr view --json closingIssuesReferences
+                                 ├─ for each, in GitHub's order, bounded:
+                                 │     gh issue view <N> --json comments | <SAME scanner> <SAME kind> <SAME base/head/job/allowlist>
+                                 ├─ scanner says `granted` ⇒ state := misplaced, naming #N   (GRANTS NOTHING)
+                                 └─ otherwise            ⇒ state stays none, rendering DECLARES what was checked
+```
+
+Four properties make this cheap and safe, and each is a deliberate reuse rather than a new mechanism:
+
+**1. The scanner is already thread-agnostic, so there is exactly one enforcer.** It reads
+`{"comments":[{"author":{"login":…},"body":…}]}` from stdin and has no concept of a pull request;
+`gh issue view --json comments` returns that same shape. So the sole-nonblank-content rule, the
+column-zero anchor, the structured author association, the allowlist, the field grammar, the
+placeholder refusal and the base/head/job binding are all inherited **by call, with the same
+arguments** — not re-derived, not copied. #3626's rule applies verbatim: *a second implementation of a
+channel rule is a second place for it to diverge, and a divergence in an authorization rule is a
+bypass.* **The scanner needs no change at all**, which is the strongest available evidence that the
+channel rules are not being loosened: there is nothing to loosen them in.
+
+**2. The scanner must never EMIT `misplaced`, and the state is therefore set by the shell caller.**
+The scanner cannot know which thread its stdin came from — thread identity is the *caller's*
+knowledge. Making the scanner report `misplaced` would require telling it where the comments came
+from, i.e. adding a provenance argument to an authorization decision, which is a new input to the one
+component whose inputs we most want fixed. Keeping the assignment in `roborev-review-oracles.sh` keeps
+the scanner's contract exactly as it is: *given these comments, does an authorization for this review
+exist in them?*
+
+**3. `waiver:` and `deferral:` are INFORMATIONAL keys.** They are outside the closed verdict grammar
+and outside the affirmation loop (`roborev-review.sh:163`, `:896`), so a new value there **cannot make
+anything pass by itself** — no grammar entry is needed and none is added. The actual granting gates are
+two token-exact equalities, `[ "$ROBOREV_WAIVER_STATE" = "granted" ]` and
+`[ "$ROBOREV_DEFERRAL_STATE" = "granted" ]`. `misplaced` is not `granted`. That is the whole of R2's
+mechanism, and it is a *structural* argument rather than a behavioural one — which is why the test for
+it is structural **and** behavioural.
+
+**4. `misplaced` joins the recognised-state case lists as a BELT, not as a route.** Both lookup
+functions validate the scanner's returned state against a closed list and rewrite anything
+unrecognised to `unavailable`. The probe assigns `misplaced` *after* that validation, so no list change
+is strictly required today — and the list is amended anyway, because a future refactor that routes the
+probe result through the validation would otherwise silently rewrite an accurate diagnostic into a
+generic `unavailable`, i.e. re-collapse exactly the state this change exists to split out. The list is
+a **recognition** list, not a granting list; adding a value to it confers nothing.
+
+## Escalation is only from `none`, and only from a would-have-granted marker
+
+Both halves are the same rule: **`MISPLACED` must mean ONE unambiguous operator action** — *re-post the
+identical marker as a top-level comment on the PR.*
+
+**Only from `none`.** A PR-side `stale` says "your marker names a different review"; `malformed` says
+"a field is wrong"; `unauthorized` says "this login may not grant"; `count-mismatch` says "re-triage,
+the counts differ"; `unavailable` says "the oracle could not be consulted". Each is already specific,
+already actionable, and **already correct**. Overwriting any of them with `MISPLACED` would replace a
+precise diagnosis with a less precise one and send the operator to move a comment that would still not
+grant. There is one and only one state that carries no information — `none` — and that is the one the
+probe is allowed to refine.
+
+**Only from an issue-side `granted`.** An issue-side marker that is itself stale, malformed or
+unauthorized is **not** a misplacement — it is a *different* defect that happens to be on a different
+thread, and re-posting it on the PR would not help. Reporting `MISPLACED` for it would be actively
+misleading: the operator moves the comment, the run still FAILs, and the diagnostic that told them to
+move it has now spent its credibility. So the escalation condition is exactly *"this marker WOULD have
+been ACCEPTED BY THE CHANNEL had it been on the PR"*, and anything else leaves the state at `none`.
+
+**What "accepted by the channel" excludes, declared rather than glossed.** The probe asks the
+**scanner's** verdict — every property decidable from the comment itself: shape, sole content,
+column-zero anchor, author allowlist, field grammar, reason substance, the base/head/job binding, and
+for a deferral the `count=` match against the observed count. It does **not** run the deferral's
+**network disposition leg** (`roborev_issue_retrievability` over each `issues=` number) issue-side.
+Three reasons, in order of weight:
+
+1. **It cannot produce a false grant.** `MISPLACED` grants nothing, so the worst case is advice that
+   is one step short, never a pass.
+2. **The remedy is identical either way.** A deferral naming a closed issue, posted on the wrong
+   thread, has *two* problems; the first thing to do about it is still to put it on the PR, where the
+   disposition leg then runs and reports its own precise `ISSUE-CLOSED` / `ISSUE-ABSENT` /
+   `ISSUE-UNVERIFIABLE` state. Two specific steps beat one vague one.
+3. **Cost.** Running disposition issue-side adds one `gh issue view` per declared issue per probed
+   thread, on a path whose entire output is a diagnostic.
+
+The rendering therefore says what was measured — *"would have been accepted by the channel"* — and
+**not** *"would have granted"*, and it names that the disposition legs still apply once re-posted. A
+diagnostic that overstates what it measured is the same defect class as a gate log's false rationale:
+it is what stops the next person looking.
+
+## The linked issue is resolved STRUCTURALLY, never from the PR body
+
+`gh pr view --json closingIssuesReferences` — the structured GitHub relation. **Not** a scan of the PR
+body for `#N`.
+
+This is not a preference. #3626 **deleted** a PR-body link requirement, and the ruling is on the
+record: *a PR body is editable at any time by anyone with write access, with NO per-edit attribution,
+while a top-level comment is permanent and attributable* — so the body was the **weaker artifact**,
+and it would stay weaker **even if Markdown parsed trivially**. Its Markdown recognisers leaked in two
+successive rounds (0 → 11 Markdown-handling references in one predicate, with a multi-backtick span
+and an explicit `[#N](url)` link accepted at the end), and #3312's rule closes the question: *remove
+the shared channel, do not pick a rarer delimiter.* Reinstating a body scan here — for any purpose —
+is reinstating a deleted generation.
+
+**The honest caveat, stated because it is the one place this design touches a mutable artifact.**
+`closingIssuesReferences` is itself derived from the PR body's closing keywords, so it is
+*mutable-derived*: someone with write access can change which issues are linked. That is acceptable
+**here and only here**, and the reason is precise: **the result grants nothing.** It selects *which
+thread to print a diagnostic about*. The worst an attacker (or an accident) achieves by re-pointing it
+is a diagnostic naming the wrong issue, or none — and the run FAILs either way. The moment anything
+downstream of this relation could grant, this argument evaporates and the relation must go with it.
+That boundary is written at the call site as well as here, because a future edit that adds a granting
+consumer will read the code before it reads this file.
+
+**Several linked issues:** probe each, **in the order GitHub returns them**, bounded, and report the
+**first** carrying a matching marker. The order is GitHub's rather than a sort, because any sort is a
+policy nobody asked for; the bound exists because the probe is a diagnostic and must not become an
+unbounded fan-out of network calls on a failing run. When the declared set exceeds the bound, the
+rendering **says so** — see the next section.
+
+## The probe declares its own non-exhaustiveness
+
+The probe is **best-effort**: no `gh`, no linked issue, an API error, an unparseable payload, or a
+thread whose comments cannot be read all leave the state at `none`. It can never make anything pass,
+and it can never make anything fail.
+
+**But "best-effort" must not mean "silent".** This repository's standing rule is that *a lane that
+omits coverage silently is indistinguishable from one that covers it*, and its house idioms are the
+gate's `0 RECOGNISED` (never a bare `0`) and its `DECLARED GAP` lines. A `NONE` that might or might not
+have checked the most likely misplacement location is exactly the two-slot collapse this issue is
+about, one level down. So the `none` report carries a **closed set of renderings**:
+
+| rendering | meaning |
+|---|---|
+| `… (linked issue #N checked: no matching marker there either)` | the probe RAN and read every thread it probed |
+| `… (linked issues #A,#B checked — 2 of 5 declared, probe bounded at 2: no matching marker)` | the probe ran, and part of the declared set was NOT reached |
+| `… (no linked issue is declared on this PR, so no linked-issue thread was checked)` | there was no subject |
+| `… (the linked-issue thread could NOT be checked: <cause>)` | the probe was attempted and did not complete |
+
+**The first rendering is emitted only when EVERY probed thread was read successfully.** A mixed
+outcome — issue #A read, issue #B's comments unavailable — takes the could-not-check rendering and
+names both halves. This is the same rule as the gate's *"a bare zero in a log reads as a verified
+all-clear from a scan that is documented as incomplete"*: a partial scan reported as a complete one is
+worse than an admitted failure, because it is the version nobody re-checks.
+
+## Emit-boundary safety
+
+The new detail strings interpolate two externally-sourced values: a **runtime issue number** (from
+GitHub's structured payload) and a **`gh` diagnostic** (arbitrary remote text). Both go through the
+**existing single emit boundary** — `roborev_safe_line` in the wrapper, `safe_value` in the scanner —
+never a per-site escape. That is #3626 round 4's ruling and its generalisation: *the rule is over
+EVERY emitted value, not over one field; each process neutralises the keywords at its ONE emit
+boundary, never per interpolation site, because a per-site escape is a list to keep complete.*
+
+Concretely: **no emitted diagnostic may carry any part of either marker stem** (`roborev-waive`,
+`roborev-defer`), and the new cases are run through the existing `assert_no_marker_form` helper —
+attached to *every* diagnostic-emitting case, because *a property asserted only where it cannot fail
+is not asserted* (that helper exists because the MALFORMED detail leaked the whole marker form for a
+whole release while a nearby comment denied it). The issue number is additionally validated as digits
+before use: an affirmative shape test on a value from a remote payload, not a hope.
+
+## Alternatives rejected
+
+| Alternative | Why not |
+|---|---|
+| Let a marker on the linked issue GRANT | The entire security property of the channel is *only a marker on the PR grants*. This is the issue's own explicit scope note. |
+| Grant on the issue thread "with a warning" | A warning nobody must act on is a grant. There is no half-granting state, and inventing one is how the next five rounds get spent. |
+| Report `MISPLACED` for a stale/malformed issue-side marker | `MISPLACED` would stop meaning one operator action; the operator moves the comment, the run still FAILs, and the diagnostic has spent its credibility. |
+| Overwrite a PR-side `STALE`/`MALFORMED` with `MISPLACED` | Replaces a precise diagnosis with a vaguer one. The only state carrying no information is `none`. |
+| Resolve the linked issue by scanning the PR body for `#N` | #3626 deleted exactly this: a mutable, unattributed artifact, with a Markdown-recogniser class that provably does not close (0 → 11 references, two bypasses accepted at deletion time). |
+| Teach the scanner a `--thread-kind` argument and let it emit `misplaced` | Adds a provenance input to the one component whose inputs must stay fixed; the scanner's thread-agnosticism is what makes there be exactly one enforcer. |
+| Copy the channel rules into a new issue-side scanner | A second implementation of a channel rule is a second place for it to diverge, and a divergence in an authorization rule is a bypass. |
+| Scan *every* issue and PR the marker's author has commented on | Unbounded, and it makes "which thread" meaningless — the diagnostic's value is that it names ONE place to move a comment from. |
+| Run the deferral's disposition leg issue-side too | N extra network calls on a diagnostic path, for advice that is the same either way; and the disposition state is reported precisely once the marker is on the PR. Declared as a scoping, not hidden. |
+| Fail the run when the probe cannot be performed | The probe is a diagnostic. Failing on it would make an unreachable GitHub API a merge blocker for a reason unrelated to the review, and would red on correct input — the guard agents learn to waive. |
+| Fix it in doctrine only | Doctrine item 1 is done here too and is worth doing, but a residual paragraph is what was already there and did not name the linked issue. The eight-hour stall happened *with* a documented residual. |
+| Have the lead's tooling verify placement at post time | Adopted as procedure (issue item 3, `gh pr view <PR> --json comments` after posting) and recorded in doctrine — but a procedure is not a diagnostic. The wrapper must still be able to say what it found. |
+
+## Threat model
+
+Inherited verbatim from #3312/#3626, because the adversary is identical, and **this change does not
+move the boundary**:
+
+- **A hostile invoker is OUT OF SCOPE by construction.** Whoever runs the wrapper can edit it, shadow
+  `gh` on `PATH`, or hand-write a summary block. No check inside a process defends against the party
+  that controls the process.
+- **What is defended:** (1) parties who do not control the invocation — this is a public repository and
+  a failing block prints base/head/job; (2) accident and drift, the larger category, of which *this
+  issue is a textbook instance* — nobody attacked anything, a lead posted in the wrong thread.
+- **Triage rule:** *"the INVOKER can bypass this"* ⇒ out of model, record it; *"a NON-INVOKER can
+  bypass this"* or *"this can be bypassed BY ACCIDENT"* ⇒ defect.
+
+**Applied to the new surface:** the only new inputs are `closingIssuesReferences` (mutable-derived,
+grants nothing — see above) and a linked issue's comment list (public, anyone can post there). A
+stranger commenting a perfect marker on the linked issue achieves exactly one thing: the run prints
+`MISPLACED` naming their comment, and still FAILs. That is not a bypass; it is at worst noise, and it
+is noise an allowlisted-author check already filters, since the probe runs the same allowlist.
+
+**Residuals, named rather than left to be rediscovered:**
+
+- The marker is still read for GRANTING purposes from **top-level PR comments only**. A marker inside
+  a **review body** or a **review-thread reply** remains silently not applied — the probe does not read
+  those either (`gh pr view --json comments` returns top-level comments), so those two locations stay
+  `NONE`. They are named in doctrine beside the linked issue, which is now named as the **most
+  probable** of the three.
+- A marker on an issue that is **not linked** to the PR is not found. The relation is what makes the
+  probe bounded and attributable; scanning arbitrary threads is the rejected alternative above.
+- More linked issues than the bound leaves part of the declared set unprobed — **declared in the
+  rendering**, never silent.
+- An authorized human can still authorize carelessly. Nothing mechanical detects that; the control is
+  the permanent attributable comment.
+
+## Demonstration, and why it is post-merge
+
+A PR whose subject is how the wrapper reads authorizations **cannot certify itself**: the review of
+this branch is performed by the wrapper as it exists on the branch, and the new probe path cannot be
+demonstrated by the same run it is meant to inform. Coverage splits the way #3626's did:
+
+- **Pre-merge, hermetic:** `scripts/tests/test_roborev_review_guard.sh` (already executed by the
+  gate's `tooling-tests` component) gains a case for the grant-shaped issue-side marker for **both**
+  kinds, for each `none` rendering, for the two non-escalation rules, for the probe failure path, for
+  the no-granting-path positive control, and for marker-form absence — each planting artifacts in its
+  **own scratch copy of the tree**, never a path variable, because a test-only seam is one more thing a
+  real invoker can set.
+- **Post-merge, live:** a recorded probe on a real PR with a real linked issue, following the existing
+  "recorded live probe" precedents. Stated in the PR body.

--- a/openspec/changes/roborev-waiver-misplaced/design.md
+++ b/openspec/changes/roborev-waiver-misplaced/design.md
@@ -33,15 +33,31 @@ PR-side scan (unchanged) ──► granted / unauthorized / stale / malformed / 
 
 Four properties make this cheap and safe, and each is a deliberate reuse rather than a new mechanism:
 
-**1. The scanner is already thread-agnostic, so there is exactly one enforcer.** It reads
-`{"comments":[{"author":{"login":…},"body":…}]}` from stdin and has no concept of a pull request;
-`gh issue view --json comments` returns that same shape. So the sole-nonblank-content rule, the
-column-zero anchor, the structured author association, the allowlist, the field grammar, the
-placeholder refusal and the base/head/job binding are all inherited **by call, with the same
-arguments** — not re-derived, not copied. #3626's rule applies verbatim: *a second implementation of a
-channel rule is a second place for it to diverge, and a divergence in an authorization rule is a
-bypass.* **The scanner needs no change at all**, which is the strongest available evidence that the
-channel rules are not being loosened: there is nothing to loosen them in.
+**1. The scanner is already thread-agnostic, so there is exactly one enforcer — MEASURED, not
+predicted.** It reads `{"comments":[{"author":{"login":…},"body":…}]}` from stdin and has no concept of
+a pull request. **Measured live on issue #3626: `gh issue view <N> --json comments` emits
+`{"comments":[{"author":{"login":…},"body":…}]}`, BYTE-IDENTICAL IN SHAPE to what
+`gh pr view --json comments` emits.** So the sole-nonblank-content rule, the column-zero anchor, the
+structured author association, the allowlist, the field grammar, the placeholder refusal and the
+base/head/job binding are all inherited **by call, with the same arguments** — not re-derived, not
+copied.
+
+**The scanner is therefore reused UNMODIFIED, and that is a decision rather than a convenience.**
+#3626's *reuse, do not reinvent* ruling applies verbatim: **a second implementation of the marker
+grammar would be a second place for it to diverge, and a divergence in an AUTHORIZATION grammar is a
+bypass.** Even a "small" issue-side variant — one that only had to recognise a marker well enough to
+print a diagnostic — would be a second grammar whose agreement with the first is knowable only by
+testing it, never by care, and whose drift is invisible until it grants (or refuses) differently. That
+the scanner needs **no change at all** is also the strongest available evidence that the channel rules
+are not being loosened by this change: there is nothing in the diff to loosen them in, and the guard
+suite asserts the file is untouched.
+
+**The measurement is what licenses the reuse.** Had the two payloads differed in shape, the honest
+options would have been a translation layer (a new component in an authorization path, needing its own
+review) or a second scanner (the rejected alternative above) — not an assumption. The shape is recorded
+here so a future `gh` release that changes it fails against a written expectation rather than silently
+producing an empty comments array, which reads as *"no marker there"* and would resurrect exactly the
+indistinguishable `NONE` this change removes.
 
 **2. The scanner must never EMIT `misplaced`, and the state is therefore set by the shell caller.**
 The scanner cannot know which thread its stdin came from — thread identity is the *caller's*
@@ -66,6 +82,30 @@ is strictly required today — and the list is amended anyway, because a future 
 probe result through the validation would otherwise silently rewrite an accurate diagnostic into a
 generic `unavailable`, i.e. re-collapse exactly the state this change exists to split out. The list is
 a **recognition** list, not a granting list; adding a value to it confers nothing.
+
+**5. THE GRANTING PATH'S PAYLOAD DOES NOT CHANGE SHAPE, AND THE TWO `gh` CALLS STAY SEPARATE.** It is
+tempting to fetch `gh pr view --json comments,closingIssuesReferences` in the existing single call and
+restructure the call sites around the richer payload. **Do not.** Two reasons, and the first is the one
+that matters:
+
+- **The granting path's payload must not change shape as a side effect of adding a diagnostic.** The
+  existing single `--json comments` call is the input to an authorization decision. Widening it means
+  every consumer of that payload — the scanner's stdin included — now receives a document with an extra
+  top-level key, and the reason the scanner is safe to reuse is precisely that its input shape is
+  *fixed and measured*. A diagnostic feature has no business editing the document an authorization is
+  decided from, and a refactor of the granting call sites "while we are here" is how a review round
+  that was about a diagnostic ends up being about the grant.
+- **The probe must be reachable ONLY from a branch that has already failed to grant.** Fetching the
+  relation up front makes the resolver's data available on *every* path, including the granted one, and
+  reachability then rests on where an `if` happens to sit rather than on where the data exists. A
+  separate, LATER, best-effort call on the `none` branch alone makes the ordering structural: on any
+  other state the call is not merely ignored, it is **not made** — which is also what the `gh`
+  invocation-log assert in the test suite can actually measure.
+
+So: the existing `--json comments` call is **unchanged, byte for byte**; the resolver is a second,
+independent, best-effort call issued only after the PR-side scan has returned `none`. The extra
+round-trip on a failing run is the price, and it is the correct trade — the path it sits on has already
+decided the run FAILs.
 
 ## Escalation is only from `none`, and only from a would-have-granted marker
 
@@ -112,6 +152,22 @@ it is what stops the next person looking.
 
 `gh pr view --json closingIssuesReferences` — the structured GitHub relation. **Not** a scan of the PR
 body for `#N`.
+
+**VALIDATED AGAINST THE ACTUAL INCIDENT, not against a constructed example.** Measured live:
+
+```
+$ gh pr view 3710 --json closingIssuesReferences
+[{"number":3544, …}]
+```
+
+That is exactly the misplacement #3759 reports — the markers were on **issue #3544** and **PR #3710
+carried zero** — so the proposed resolver **would have found them on the real case**, with no
+inference, no prose scan and one call. A design validated on the instance that produced the issue is
+worth more than one validated on a fixture someone wrote afterwards, and it also settles the question
+the resolver choice actually turns on: *does the relation point at the thread where coordination
+happens?* On the one case we have, it does — because the lane's coordination thread and the issue the
+PR closes were **the same thread**, which is precisely why the misplacement was the path of least
+resistance.
 
 This is not a preference. #3626 **deleted** a PR-body link requirement, and the ruling is on the
 record: *a PR body is editable at any time by anyone with write access, with NO per-edit attribution,
@@ -190,6 +246,8 @@ before use: an affirmative shape test on a value from a remote payload, not a ho
 | Resolve the linked issue by scanning the PR body for `#N` | #3626 deleted exactly this: a mutable, unattributed artifact, with a Markdown-recogniser class that provably does not close (0 → 11 references, two bypasses accepted at deletion time). |
 | Teach the scanner a `--thread-kind` argument and let it emit `misplaced` | Adds a provenance input to the one component whose inputs must stay fixed; the scanner's thread-agnosticism is what makes there be exactly one enforcer. |
 | Copy the channel rules into a new issue-side scanner | A second implementation of a channel rule is a second place for it to diverge, and a divergence in an authorization rule is a bypass. |
+| Fetch `--json comments,closingIssuesReferences` in the existing single call | Changes the shape of the payload an AUTHORIZATION is decided from, as a side effect of adding a diagnostic — and makes the relation available on the granted path, so reachability rests on an `if` rather than on the data not existing. The existing call stays unchanged; the resolver is separate, later, and only on `none`. |
+| Restructure the existing `gh` call sites "while we are here" | A diagnostic change that refactors the granting path turns a review of a diagnostic into a review of the grant. Out of scope by construction. |
 | Scan *every* issue and PR the marker's author has commented on | Unbounded, and it makes "which thread" meaningless — the diagnostic's value is that it names ONE place to move a comment from. |
 | Run the deferral's disposition leg issue-side too | N extra network calls on a diagnostic path, for advice that is the same either way; and the disposition state is reported precisely once the marker is on the PR. Declared as a scoping, not hidden. |
 | Fail the run when the probe cannot be performed | The probe is a diagnostic. Failing on it would make an unreachable GitHub API a merge blocker for a reason unrelated to the review, and would red on correct input — the guard agents learn to waive. |

--- a/openspec/changes/roborev-waiver-misplaced/proposal.md
+++ b/openspec/changes/roborev-waiver-misplaced/proposal.md
@@ -1,0 +1,97 @@
+# roborev-waiver-misplaced — issue #3759
+
+## Why
+
+**A correct authorization posted one thread over is indistinguishable from a refusal**, and that cost
+PR #3710 — position 1 of a six-PR serial queue — roughly **eight hours of idle time**, blocking five
+lanes behind it.
+
+The coordination lead granted **both** markers for PR #3710 — field-perfect, verified base/head/job,
+each as the sole nonblank content of its own comment, from an allowlisted author — on **issue
+#3544**, the thread where that lane's coordination happens all day. The scanner reads top-level **PR**
+comments only (`roborev-review-oracles.sh:1128` states it; the call itself is at `:1260`). Measured on
+the record while the PR sat unarmed:
+
+```
+PR #3710 comments:  roborev-waive: 0   roborev-defer: 0
+issue #3544:        both markers present, correct in every field
+```
+
+So `--recheck-job 317` would have reported `waiver: NONE` / `deferral: NONE`, the `prompt-content`
+FAIL would have stood, and **the lane's natural reading of `NONE` is "the lead refused"** rather than
+"the comment landed on the wrong thread".
+
+Two lanes found it independently, and both behaved correctly: `lane-3544` validated the markers
+field-by-field, confirmed 0 on the PR / 2 on the issue, and **declined to copy them across itself** —
+on a shared login it could have made its own merge gate pass, and correctly identified that as the
+exact bypass the channel exists to prevent. `lane-3650` reached the same conclusion from outside while
+diagnosing why position 1 had not moved, verifying the read path from source rather than from memory.
+Nothing in the tooling misbehaved. **The tooling was silent about the one fact that would have ended
+the stall in a minute.**
+
+**The doctrine gap is the same fact.** CLAUDE.md's recorded residual names two misplacement locations
+— *"inside a review body or a review-thread reply"* — and **does not name the linked ISSUE thread**,
+which is the **most probable** of the three, because that is where lane/lead coordination lives. A
+lead working an issue thread all day posts there by default. This is not an exotic mistake; it is the
+path of least resistance.
+
+**The class is a familiar one.** `NONE` today covers "never granted", "granted and misplaced" and
+"granted for a different scope", and the **operator action differs for each**. That is a multi-state
+reality collapsed onto two slots where **the discarded value is the diagnostic one** — the shape the
+three-valued findings on #3229 collected repeatedly, and the shape `dead-lanes`, `roborev_issue_retrievability`
+and the gate's `0 RECOGNISED` idiom all exist to avoid. Splitting out the one misplacement that is
+**mechanically detectable** costs a second `gh` call.
+
+## What changes
+
+A new, **distinct, NON-GRANTING** state — **`MISPLACED`** — for **both** authorization kinds.
+
+When (and only when) the PR-side scan for a kind returns `none`, the wrapper additionally scans the
+**top-level comments of the PR's linked issue(s)** with the **same scanner, the same kind and the same
+base/head/job/allowlist arguments**. If that scan returns `granted`, the state becomes `misplaced`,
+reported as `waiver: MISPLACED (…)` / `deferral: MISPLACED (…)`, naming **the issue number it was
+found on** and the remedy: **re-post the identical marker as a top-level comment on the PR**.
+Otherwise the state stays `none` — and the `none` report now **says whether the probe ran**, so
+`NONE` is never silently ambiguous about it.
+
+**This is a diagnosability change, not a loosening.** `MISPLACED` grants nothing, anywhere. The
+`prompt-content:` / `findings:` FAIL stands unchanged, and the author allowlist, the
+sole-nonblank-content rule, the column-zero anchor and the base+head+job binding are all untouched.
+The security property — **only a marker on the PR grants** — is preserved exactly; what is removed is
+the failure mode where a correct authorization reads as a denial.
+
+## Scope fences (owner "Proposed" section, issue #3759; lead brief 2026-09-01)
+
+- **Subject is `scripts/flow/roborev-review-oracles.sh`** (the two lookup functions and their two
+  RESIDUALS comment blocks), **`scripts/flow/roborev-review-checks.sh`** (the two report arms),
+  `scripts/flow/roborev-review.sh` (`--help` and the key documentation), and
+  `scripts/tests/test_roborev_review_guard.sh`.
+- **`scripts/flow/roborev-waiver-scan.py` needs no change, and that is a design result, not luck.**
+  The scanner is already **thread-agnostic**: it consumes `{"comments":[{"author":{"login":…},"body":…}]}`
+  on stdin and knows nothing about pull requests. `gh issue view --json comments` returns that same
+  shape. So the channel rules are inherited **by call** — one enforcer, one grammar, one allowlist —
+  which is #3626's rule verbatim: *a second implementation of a channel rule is a second place for it
+  to diverge, and a divergence in an authorization rule is a bypass.*
+- **`scripts/agent-gate.sh` is NOT touched.**
+- **The design is fixed by the owner's numbered "Proposed" section.** This change specs it; it does
+  not redesign it.
+- **The wrapper cannot certify itself.** A PR whose subject is how the wrapper reads authorizations
+  cannot demonstrate that reading on its own review — the same shape as roborev reading
+  `exclude_patterns` from the root checkout, and as `required` reading its registry from the base ref.
+  The live demonstration is planned **post-merge** and is stated as such in the PR body.
+
+## Non-goals
+
+- **No route by which an issue-thread marker grants anything.** Not partially, not with a warning,
+  not "for the waiver but not the deferral". `MISPLACED` is a diagnostic.
+- **No PR-body parsing.** #3626 **deleted** a PR-body link check because a PR body is editable at any
+  time by anyone with write access with no per-edit attribution, while a comment is permanent and
+  attributable. Reinstating a body scan is reinstating a deleted generation.
+- **No escalation from a specific PR-side state.** `stale` / `malformed` / `unauthorized` /
+  `count-mismatch` / `unavailable` are already specific and actionable and are never overwritten.
+- **No new channel, flag, file or env var** — the constrained party must not choose its own enforcer.
+- **No change to the closed verdict grammar.** `waiver:` and `deferral:` are **informational** keys,
+  outside the verdict scan and outside the affirmation loop, so a new value there cannot make anything
+  pass by itself. The change adds a cause, not a verdict.
+- **No probe that can fail a run.** A missing `gh`, no linked issue, an API error or an unparseable
+  payload leaves the state exactly where it was.

--- a/openspec/changes/roborev-waiver-misplaced/proposal.md
+++ b/openspec/changes/roborev-waiver-misplaced/proposal.md
@@ -54,6 +54,18 @@ found on** and the remedy: **re-post the identical marker as a top-level comment
 Otherwise the state stays `none` — and the `none` report now **says whether the probe ran**, so
 `NONE` is never silently ambiguous about it.
 
+**The resolver is validated against the actual incident.** Measured live, on the PR that stalled:
+
+```
+$ gh pr view 3710 --json closingIssuesReferences
+[{"number":3544, …}]
+```
+
+The markers were on **issue #3544**; **PR #3710 carried zero**. So the proposed
+`closingIssuesReferences` resolver **would have found them on the real case** — one structured call, no
+prose scan, no inference. That is the whole eight-hour stall, resolvable by a diagnostic that names
+issue #3544 and says "re-post it on the PR".
+
 **This is a diagnosability change, not a loosening.** `MISPLACED` grants nothing, anywhere. The
 `prompt-content:` / `findings:` FAIL stands unchanged, and the author allowlist, the
 sole-nonblank-content rule, the column-zero anchor and the base+head+job binding are all untouched.
@@ -66,12 +78,20 @@ the failure mode where a correct authorization reads as a denial.
   RESIDUALS comment blocks), **`scripts/flow/roborev-review-checks.sh`** (the two report arms),
   `scripts/flow/roborev-review.sh` (`--help` and the key documentation), and
   `scripts/tests/test_roborev_review_guard.sh`.
-- **`scripts/flow/roborev-waiver-scan.py` needs no change, and that is a design result, not luck.**
-  The scanner is already **thread-agnostic**: it consumes `{"comments":[{"author":{"login":…},"body":…}]}`
-  on stdin and knows nothing about pull requests. `gh issue view --json comments` returns that same
-  shape. So the channel rules are inherited **by call** — one enforcer, one grammar, one allowlist —
-  which is #3626's rule verbatim: *a second implementation of a channel rule is a second place for it
-  to diverge, and a divergence in an authorization rule is a bypass.*
+- **`scripts/flow/roborev-waiver-scan.py` is reused UNMODIFIED, and that is a measured design result,
+  not luck.** The scanner is already **thread-agnostic**: it consumes
+  `{"comments":[{"author":{"login":…},"body":…}]}` on stdin and knows nothing about pull requests.
+  **Measured live on issue #3626, `gh issue view <N> --json comments` emits that same document,
+  byte-identical in shape to `gh pr view --json comments`.** So the channel rules are inherited **by
+  call** — one enforcer, one grammar, one allowlist — which is #3626's *reuse, do not reinvent* ruling
+  verbatim: *a second implementation of the marker grammar is a second place for it to diverge, and a
+  divergence in an authorization grammar is a bypass.* The scanner file ends this change untouched, and
+  the guard suite asserts it.
+- **The existing `gh pr view --json comments` call is UNCHANGED and the two calls stay separate.** The
+  resolver is a second, later, best-effort call made **only** on the `none` branch — never a combined
+  `--json comments,closingIssuesReferences` fetch, and no restructuring of the existing call sites. The
+  payload an *authorization* is decided from must not change shape as a side effect of adding a
+  *diagnostic*, and the probe must be reachable only from a branch that has already failed to grant.
 - **`scripts/agent-gate.sh` is NOT touched.**
 - **The design is fixed by the owner's numbered "Proposed" section.** This change specs it; it does
   not redesign it.

--- a/openspec/changes/roborev-waiver-misplaced/specs/roborev-review-guard/spec.md
+++ b/openspec/changes/roborev-waiver-misplaced/specs/roborev-review-guard/spec.md
@@ -373,6 +373,24 @@ gaps in one value — what could not be read, **and** how many declared referenc
 Reporting only the first is the same defect as rendering 4's own reason for existing: a value claiming
 more completeness than the probe achieved.
 
+**EVERY INPUT ON THE PROBE PATH SHALL BE VALIDATED AFFIRMATIVELY, AND A ZERO EXIT SHALL NOT BE READ
+AS A SUCCESSFUL READ.** This is the requirement's governing invariant, stated once rather than per
+input, because three successive reviews found the same collapse at a different input each time. The
+probe's inputs are the **current-repository identity**, the **relation payload**, each reference's
+**classification**, each thread's **comments payload**, the scanner's **exit status** and the
+scanner's returned **`state=`**; each SHALL have an affirmative test, and a new input on this path
+SHALL acquire one.
+
+Two consequences that are **not** obvious and SHALL be honoured explicitly. (1) The reused scanner
+coerces a valid-JSON but malformed payload — `{}`, `{"comments": null}`, `{"comments": {}}` — to an
+**empty comment list** and exits **0**. That is correct for the scanner's own contract and the scanner
+SHALL NOT be changed for it; the **caller** SHALL validate the payload as a JSON **object** carrying a
+`comments` **list** before drawing any conclusion, and every other shape SHALL make that thread a
+could-not-check, never a successfully read one. (2) The scanner's returned `state=` SHALL be matched
+against its **closed** recognition set before it is trusted; an **empty**, absent or never-judged state
+SHALL make that thread a could-not-check. The permissive branch SHALL be keyed on **affirmative
+membership**, never on `!= granted`.
+
 **AN UNREADABLE RELATION PAYLOAD IS NOT AN EMPTY RELATION.** Rendering 3 — *"no linked issue is
 declared on this PR"* — is an **affirmative claim about the pull request**, and it SHALL be reachable
 **only** from a payload that was affirmatively read as a JSON **object** carrying a
@@ -403,6 +421,18 @@ means before it can be printed.
 #### Scenario: An unreadable relation payload is not reported as an empty relation
 - **WHEN** the relation payload is unparseable, is not a JSON object, omits the `closingIssuesReferences` key, carries an explicit `null`, or carries a non-list value
 - **THEN** each shape takes the *could not check* rendering naming the broken payload, and none of them reports *"no linked issue is declared on this PR"*
+
+#### Scenario: A valid-JSON but malformed comments payload is not a read thread
+- **WHEN** a probed thread's comments payload parses but is not an object carrying a `comments` list — `{}`, `{"comments": null}`, `{"comments": {}}`, or a non-list value — so the scanner reduces it to zero comments and exits 0
+- **THEN** that thread takes the *could not check* rendering naming the payload, is never reported as checked, and the scanner file is unchanged
+
+#### Scenario: An unrecognised or empty scanner state is not a read thread
+- **WHEN** the scanner returns an empty `state=`, no `state=` line, or a state outside its recognition set
+- **THEN** that thread takes the *could not check* rendering naming the unrecognised state, and is never counted as successfully checked
+
+#### Scenario: The current repository identity is a single owner/name pair
+- **WHEN** the repository resolution answers with something that is not exactly one `owner/name` pair — `x/`, `/x`, `a/b/c`, or a value carrying whitespace
+- **THEN** the outcome is a could-not-check, and in particular the references are **not** reported as a cross-repository declared skip, which would be an answer about the pull request derived from an identity nobody established
 
 #### Scenario: One thread read, another unavailable
 - **WHEN** two linked issues are declared, the first is read with no match, and the second's comments cannot be retrieved

--- a/openspec/changes/roborev-waiver-misplaced/specs/roborev-review-guard/spec.md
+++ b/openspec/changes/roborev-waiver-misplaced/specs/roborev-review-guard/spec.md
@@ -1,0 +1,444 @@
+# roborev-review-guard — delta for roborev-waiver-misplaced (issue #3759)
+
+**Architecture note (read this first).** `scripts/flow/roborev-review.sh` is the only sanctioned
+roborev invocation, and its `==== ROBOREV REVIEW SUMMARY ====` block is the verdict a merge rests on.
+Two human authorizations can excuse one of its keys, each on the same tightly-constrained channel: the
+**absence waiver** (`roborev-waive: prompt-content-absent`, #3312) and the **findings deferral**
+(`roborev-defer: findings`, #3626). Both are read from **top-level pull-request comments only**. A
+marker posted anywhere else is silently not applied, and the resulting `NONE` is **textually
+indistinguishable from a refused or never-posted authorization**.
+
+Measured: for PR #3710 the coordination lead granted **both** markers — field-perfect, verified
+base/head/job, each the sole nonblank content of its own comment, from an allowlisted author — on
+**issue #3544**, the thread where that lane's coordination happened all day. `PR #3710 comments:
+roborev-waive: 0, roborev-defer: 0` / `issue #3544: both markers present, correct in every field`. So
+`--recheck-job 317` would have reported `waiver: NONE` / `deferral: NONE`, the `prompt-content` FAIL
+would have stood, and the lane's natural reading of `NONE` is *"the lead refused"*. **Position 1 of a
+six-PR serial queue idled ~8 hours and blocked five lanes.** Two lanes diagnosed it independently, and
+`lane-3544` explicitly **declined to copy the markers onto the PR itself** — on a shared login it could
+have made its own merge gate pass, and correctly identified that as the exact bypass the channel exists
+to prevent.
+
+CLAUDE.md's recorded residual names two misplacement locations — *"inside a review body or a
+review-thread reply"* — and **does not name the linked ISSUE thread**, which is the **most probable**
+of the three, because that is where lane/lead coordination lives.
+
+This delta adds a **distinct, NON-GRANTING** state, `MISPLACED`, for **both** kinds. `NONE` today
+covers "never granted", "granted and misplaced" and "granted for a different scope", and the operator
+action differs for each: a multi-state reality collapsed onto two slots where **the discarded value is
+the diagnostic one**. It is a **diagnosability** change and not a loosening — nothing here permits a
+marker on an issue thread to grant anything, and the author allowlist, the sole-nonblank-content rule,
+the column-zero anchor and the base+head+job binding are all untouched.
+
+The new state is **additive to two existing requirements' cause sets** (`waiver:` under *The reviewer
+must demonstrably have received the census's own code files*, and *The deferral state is reported under
+its own key, including when nothing was granted*) and changes no existing behaviour, so this delta is
+stated entirely as ADDED requirements, as #3626's was. It needs **no change to the closed verdict
+grammar**: `waiver:` and `deferral:` are informational keys, outside the verdict scan and outside the
+affirmation loop, so a new value there cannot make anything pass by itself.
+
+**Acceptance-criterion → requirement map** (issue #3759 body "Proposed" items 1–3 + "Scope note", lead
+brief 2026-09-01 items R1–R8):
+
+| AC / ruling item | Requirement(s) |
+|---|---|
+| Proposed 2 — a distinct diagnosable state, `waiver: MISPLACED (found on linked issue #N, not the PR)` (R1) | ADDED *A misplaced authorization is reported under a distinct, non-granting MISPLACED state, for both kinds* |
+| Proposed 2 / Scope note — `MISPLACED` must NOT grant; fail-closed either way (R2) | ADDED *MISPLACED grants nothing, and no channel rule is loosened to produce it* |
+| R3 — escalation only from `none`, and only from an issue-side marker that would have granted | ADDED *The escalation is only from `none`, and only from a marker the channel would have accepted* |
+| R4 — the linked issue is resolved structurally, never by parsing the PR body | ADDED *The linked issue is resolved from the structured GitHub relation, never from the pull-request body* |
+| R5 — the probe declares its own non-exhaustiveness; never fails the run; never looks complete | ADDED *The probe is best-effort, cannot change any verdict, and declares what it did and did not check* |
+| R6 — emit-boundary safety unchanged and re-asserted | ADDED *Every new diagnostic rides the existing single emit boundary and carries no part of either marker* |
+| Proposed 1 + 3 — doctrine names the linked issue as the most probable misplacement; lead-side verification procedure (R7) | ADDED *Doctrine and the in-source residuals name the linked-issue thread and the new state* |
+| R8 — behavioural coverage in the gate-executed guard suite | ADDED *Every MISPLACED and NONE rendering is pinned hermetically, and the live path is demonstrated post-merge* |
+
+## ADDED Requirements
+
+### Requirement: A misplaced authorization is reported under a distinct, non-granting MISPLACED state, for both kinds
+
+The wrapper SHALL recognise a new state, **`misplaced`**, for **both** authorization kinds — the
+absence waiver and the findings deferral — and SHALL report it as `waiver: MISPLACED (…)` /
+`deferral: MISPLACED (…)`.
+
+**When it is looked for.** When, and **only** when, the pull-request-side scan for a kind returns state
+`none`, the wrapper SHALL additionally scan the **top-level comments of the pull request's linked
+issue(s)**, using **the same scanner**, **the same marker kind**, and **the same** `base`, `head`,
+`job` and author-allowlist arguments (and, for the deferral, the same observed findings count). If that
+scan returns `granted`, the state SHALL become `misplaced`; otherwise it SHALL remain `none`.
+
+**One enforcer, inherited by call.** The scanner SHALL NOT be duplicated, forked or given a
+thread-specific variant. It is already **thread-agnostic** — it consumes
+`{"comments":[{"author":{"login":…},"body":…}]}` on standard input and knows nothing about pull
+requests — and `gh issue view --json comments` returns that same shape, so the sole-nonblank-content
+rule, the column-zero anchor, the structured author association, the allowlist, the field grammar, the
+placeholder refusal and the scope binding are all inherited **by call**. *A second implementation of a
+channel rule is a second place for it to diverge, and a divergence in an authorization rule is a
+bypass.* `scripts/flow/roborev-waiver-scan.py` SHALL be unmodified by this change.
+
+**The scanner SHALL NOT emit `misplaced`.** Thread identity is the **caller's** knowledge: the scanner
+cannot know which thread its input came from, and telling it would mean adding a provenance argument to
+the one component whose inputs must stay fixed. The state SHALL therefore be assigned by the shell
+caller in `roborev-review-oracles.sh`, leaving the scanner's contract exactly as it is — *given these
+comments, does an authorization for this review exist in them?*
+
+**What the report SHALL contain.** The `MISPLACED` value SHALL name (1) the **issue number** the
+marker was found on, (2) that it **grants nothing and the failing verdict stands**, and (3) the
+**remedy**: re-post the **identical marker** as a **top-level comment on the pull request**. Each of
+the two report arms SHALL be **dedicated**, not a fall-through: the generic arm that uppercases an
+unhandled state would render a syntactically correct `MISPLACED (…)` and no remedy, and this state's
+entire value is its remedy.
+
+**`misplaced` SHALL be added to both lookup functions' recognised-state lists** — as a **belt**, not as
+a route. The probe assigns after that validation today, so no list change is strictly required; the
+entry exists so that a future refactor routing the probe result through the validation cannot rewrite
+an accurate diagnostic into a generic `unavailable`, re-collapsing the very state this change splits
+out. Those lists are **recognition** lists, not granting lists, and membership SHALL confer nothing.
+
+#### Scenario: A would-have-granted waiver marker sits on the linked issue and nothing is on the PR
+- **WHEN** a run whose `prompt-content` census paths are absent finds no `roborev-waive:` marker on the PR, and the PR's linked issue #N carries one that is well-formed, sole content of a top-level comment, from an allowlisted author, naming this base, head and job
+- **THEN** the run reports `waiver: MISPLACED (…)` naming issue #N and the remedy of re-posting it as a top-level PR comment, `prompt-content:` still reads `FAIL`, and `RESULT: FAIL`
+
+#### Scenario: A would-have-granted deferral marker sits on the linked issue
+- **WHEN** a `--recheck-job` over an affirmatively measured `findings: PRESENT (n)` finds no `roborev-defer:` marker on the PR, and the PR's linked issue #N carries one naming this base, head, job and count from an allowlisted author
+- **THEN** the run reports `deferral: MISPLACED (…)` naming issue #N and the remedy, `findings:` still reads `PRESENT (n)` — never `DEFERRED` and never `NONE` — and `RESULT: FAIL`
+
+#### Scenario: The scanner is not duplicated and does not learn about threads
+- **WHEN** this change is applied
+- **THEN** `scripts/flow/roborev-waiver-scan.py` is unmodified, no second scanner exists, the scanner emits no `misplaced` state, and the issue-side call passes the same kind, base, head, job and allowlist as the PR-side call
+
+#### Scenario: The report arm is dedicated rather than a fall-through
+- **WHEN** the state is `misplaced` for either kind
+- **THEN** the emitted value carries the issue number, the non-granting statement and the remedy, rather than the generic uppercased state with only a raw detail
+
+### Requirement: MISPLACED grants nothing, and no channel rule is loosened to produce it
+
+`MISPLACED` SHALL be a **diagnostic state only**. It SHALL NOT grant, SHALL NOT partially grant, and
+SHALL NOT grant with a notice. The `prompt-content:` FAIL and the `findings:` FAIL SHALL stand exactly
+as they stand today, and the terminal `RESULT` SHALL be unchanged by the presence of a misplaced
+marker.
+
+**Nothing about the channel SHALL be loosened**: not the author allowlist, not the
+sole-nonblank-content rule, not the column-zero anchor, not the structured `gh --json` author
+association, not the placeholder-reason refusal, and not the `base` + `head` + `job` binding (nor the
+deferral's `count=` match and issue-disposition legs). The security property **only a marker on the
+pull request grants** SHALL be preserved exactly.
+
+**The granting gates SHALL remain the two token-exact equalities** —
+`[ "$ROBOREV_WAIVER_STATE" = "granted" ]` and `[ "$ROBOREV_DEFERRAL_STATE" = "granted" ]` — and no
+branch anywhere SHALL treat `misplaced` as granting. Because `waiver:` and `deferral:` are
+**informational** keys, outside the closed verdict grammar and outside the affirmation loop, the new
+value additionally **cannot** make anything pass by itself; **no grammar entry is required and none
+SHALL be added**, since adding one would be the first step toward a value with verdict weight.
+
+**A structural test SHALL assert that no granting path is reachable from `misplaced`**, alongside the
+behavioural cases. Both are required and neither substitutes for the other: a behavioural case covers
+only the fixtures someone thought of, and a structural assert cannot see a granting path built some
+other way.
+
+#### Scenario: A misplaced waiver does not waive
+- **WHEN** the waiver state is `misplaced`
+- **THEN** `prompt-content:` never reads `WAIVED`, the absence FAIL stands, and `RESULT: FAIL`
+
+#### Scenario: A misplaced deferral does not defer
+- **WHEN** the deferral state is `misplaced`
+- **THEN** `findings:` never reads `DEFERRED`, the findings FAIL stands, and `RESULT: FAIL`
+
+#### Scenario: No granting path is reachable from the new state
+- **WHEN** `scripts/tests/test_roborev_review_guard.sh` runs
+- **THEN** it asserts structurally that the only granting gates are the two token-exact `= "granted"` comparisons and that `misplaced` appears in no granting branch, and it fails if either becomes false
+
+#### Scenario: The closed verdict grammar is unchanged
+- **WHEN** this change is applied
+- **THEN** no value is added to the verdict grammar's recognised set and no key that carries a verdict can report `MISPLACED`
+
+### Requirement: The escalation is only from `none`, and only from a marker the channel would have accepted
+
+**`MISPLACED` SHALL mean exactly one operator action** — *re-post the identical marker as a top-level
+comment on the pull request.* Both halves of this requirement exist to keep that true.
+
+**Only from `none`.** A pull-request-side `stale`, `malformed`, `unauthorized`, `count-mismatch` or
+`unavailable` SHALL NEVER be overwritten. Each is already specific, already actionable and already
+correct — *"your marker names a different review"*, *"a field is wrong"*, *"this login may not grant"*,
+*"re-triage, the counts differ"*, *"the oracle could not be consulted"* — and replacing one with
+`MISPLACED` would substitute a vaguer diagnosis for a precise one and send the operator to move a
+comment that still would not grant. `none` is the only state carrying no information, and it is the
+only state the probe may refine. The probe SHALL NOT EVEN BE PERFORMED for the other states: a network
+call whose result is discarded is latency plus a future footgun.
+
+**Only from an issue-side `granted`.** An issue-side marker that is itself stale, malformed or
+unauthorized SHALL NOT produce `MISPLACED`; the state SHALL stay `none`. Such a marker is a
+**different** defect that happens to be on a different thread, and re-posting it would not help —
+reporting `MISPLACED` for it makes the run FAIL after the operator followed the remedy, which spends
+the diagnostic's credibility. The escalation condition SHALL therefore be exactly *"this marker WOULD
+have been accepted by the channel had it been on the pull request"*.
+
+**What "accepted by the channel" means SHALL be stated in the rendering, not glossed.** The probe asks
+the **scanner's** verdict — every property decidable from the comment itself: shape, sole content,
+column-zero anchor, author allowlist, field grammar, reason substance, the base/head/job binding, and
+for a deferral the `count=` match against the observed count. It SHALL NOT run the deferral's
+**network disposition leg** (each `issues=` number's four-valued open-issue check) issue-side. That is
+a **declared scoping**, sound because (1) `MISPLACED` grants nothing, so the worst case is advice one
+step short of complete rather than a pass; (2) the remedy is identical either way — a deferral naming a
+closed issue on the wrong thread must still be moved to the pull request, where the disposition leg
+then runs and reports its own precise `ISSUE-CLOSED` / `ISSUE-ABSENT` / `ISSUE-UNVERIFIABLE`; and (3) it
+would add one network call per declared issue per probed thread on a purely diagnostic path. The
+rendering SHALL therefore claim *"would have been accepted by the channel"* and **not** *"would have
+granted"*, and SHALL name that the disposition legs still apply once the marker is on the pull request.
+**A diagnostic that overstates what it measured is what stops the next person looking.**
+
+#### Scenario: A PR-side STALE marker is not overwritten by a perfect issue-side marker
+- **WHEN** the PR carries a well-formed marker naming a different job, and the linked issue carries one naming THIS review exactly
+- **THEN** the state remains `STALE` with its own cause, is never reported `MISPLACED`, and — measured against the `gh` invocation log — no linked-issue probe call was made
+
+#### Scenario: A stale issue-side marker leaves the state at NONE
+- **WHEN** nothing is on the PR and the linked issue carries a marker naming a different base, head or job
+- **THEN** the state stays `NONE` with the probe's *checked* declaration, and `MISPLACED` is not reported
+
+#### Scenario: A malformed issue-side marker leaves the state at NONE
+- **WHEN** nothing is on the PR and the linked issue carries a marker with a missing field, an abbreviated sha or a placeholder reason
+- **THEN** the state stays `NONE` with the probe's *checked* declaration
+
+#### Scenario: An unauthorized issue-side author leaves the state at NONE
+- **WHEN** nothing is on the PR and the linked issue carries a field-perfect marker from an author outside `ROBOREV_WAIVER_AUTHORS`
+- **THEN** the state stays `NONE` — the allowlist applies identically on both threads, and a stranger's comment on a public issue thread cannot even produce a diagnostic that names it as an authorization
+
+#### Scenario: The rendering does not claim more than the probe measured
+- **WHEN** a deferral is reported `MISPLACED`
+- **THEN** the value states that the marker would have been accepted by the channel and that the issue-disposition legs still apply once it is re-posted on the PR, rather than asserting it would have granted
+
+### Requirement: The linked issue is resolved from the structured GitHub relation, never from the pull-request body
+
+The linked issue(s) SHALL be resolved from `gh pr view --json closingIssuesReferences` — the structured
+GitHub relation. The pull-request **body** SHALL NOT be read, scanned, or consulted for this or any
+other purpose.
+
+**This is a standing ruling, not a preference.** #3626 **deleted** a PR-body link requirement because
+*a pull-request body is editable at any time by anyone with write access, with no per-edit attribution,
+while a top-level comment is permanent and attributable* — so the body was the **weaker artifact**, and
+would stay weaker **even if Markdown parsed trivially**. Its recogniser class provably did not close
+(Markdown-handling references in one predicate went 0 → 11 across two rounds, with a multi-backtick
+span and an explicit `[#N](url)` link accepted at deletion time). Per #3312, *remove the shared channel,
+do not pick a rarer delimiter.* Reinstating a body scan **for any purpose** is reinstating a deleted
+generation, and this requirement SHALL be read as forbidding it.
+
+**The mutable-derived caveat SHALL be declared at the call site, not only in design notes.**
+`closingIssuesReferences` is derived from the body's closing keywords and is therefore itself mutable by
+anyone with write access. That is acceptable **here and only here**, for one precise reason: **the
+result grants nothing** — it selects *which thread to print a diagnostic about*. The worst outcome from
+a re-pointed relation is a diagnostic naming the wrong issue, or none, and the run FAILs either way.
+**The moment any consumer downstream of this relation could grant, the argument evaporates and the
+relation must go with it**; that boundary SHALL be written in the source beside the call, because a
+future edit adding a granting consumer reads the code before it reads a design document.
+
+Each issue number returned SHALL be validated **affirmatively as digits** before it is used or emitted;
+a value that is not a number SHALL be a could-not-check cause and SHALL NOT be interpolated raw.
+
+**Several linked issues** SHALL each be probed, **in the order GitHub returns them** (not a sort — any
+sort is a policy nobody asked for), **bounded** by a named constant, reporting the **first** thread
+carrying a matching marker. The bound exists because the probe is a diagnostic and must not become an
+unbounded fan-out of network calls on a failing run; when the declared set exceeds it, the rendering
+SHALL say so.
+
+#### Scenario: The relation is the only source of the linked issue
+- **WHEN** the probe resolves which issue to check
+- **THEN** it uses `gh pr view --json closingIssuesReferences`, and no `#N` scan of the PR body and no `--json body` read exists anywhere in the wrapper or its sourced files
+
+#### Scenario: A PR body mentioning an issue that is not linked
+- **WHEN** the PR body mentions `#N` as prose with no closing keyword, so GitHub declares no linked issue, and issue #N carries a field-perfect marker
+- **THEN** no thread is probed, the state stays `NONE` with the declared *no linked issue* rendering, and the marker on #N is not found — the relation, not the prose, is what bounds and attributes the probe
+
+#### Scenario: Several linked issues, the first match reported
+- **WHEN** the PR declares two linked issues and the second carries the matching marker
+- **THEN** both are probed in GitHub's order and the state is `MISPLACED` naming the second
+
+#### Scenario: A non-numeric value in the relation payload
+- **WHEN** the relation payload carries a value that is not a number
+- **THEN** it is not used and not interpolated raw, and the outcome is a could-not-check cause
+
+### Requirement: The probe is best-effort, cannot change any verdict, and declares what it did and did not check
+
+The probe SHALL be **best-effort**. A missing `gh`, an unusable scanner, no linked issue, an API error,
+an unparseable payload, or a thread whose comments cannot be read SHALL each leave the state exactly
+where the pull-request-side scan left it — at `none`. The probe SHALL NEVER make a run pass and SHALL
+NEVER make a run fail on its own, and its helper SHALL NEVER return non-zero or exit: a two-valued
+return would re-import the very collapse this change exists to remove, so every failure SHALL be a
+**state with a cause**.
+
+**BUT `NONE` SHALL NEVER BE SILENTLY AMBIGUOUS ABOUT WHETHER THE PROBE RAN.** *A lane that omits
+coverage silently is indistinguishable from one that covers it* — the reason the gate prints
+`0 RECOGNISED` rather than a bare `0` and declares its gaps rather than implying completeness. The
+`none` report SHALL therefore carry the probe's declaration, from a **closed set of renderings**:
+
+1. **checked** — *"linked issue #N checked: no matching marker there either"*. Emitted **only when
+   every probed thread was read successfully**.
+2. **partially checked** — *"linked issues #A,#B checked — N of M declared, probe bounded at N: no
+   matching marker"*. The unprobed remainder is named, never implied.
+3. **no subject** — *"no linked issue is declared on this PR, so no linked-issue thread was checked"*.
+4. **could not check** — *"the linked-issue thread could NOT be checked: `<cause>`"*, naming the cause.
+
+A **mixed outcome** — one thread read, another unavailable — SHALL take rendering 4 and name **both**
+halves; it SHALL NOT take rendering 1. *A partial scan reported as a complete one is worse than an
+admitted failure, because it is the version nobody re-checks.*
+
+The existing `NONE` teaching text — that the marker must be the **sole nonblank content** of a
+**top-level** comment — SHALL be **retained**; the declaration is additional, not a replacement. An
+unrecognised rendering SHALL NOT exist: the set is closed, and a new outcome requires deciding what it
+means before it can be printed.
+
+#### Scenario: The probe ran and found nothing
+- **WHEN** no marker is on the PR and the single linked issue's comments were read and carry none
+- **THEN** the state is `NONE` and its value names the *checked* rendering identifying that issue, so a reader can tell the most probable misplacement was ruled out
+
+#### Scenario: No linked issue is declared
+- **WHEN** no marker is on the PR and the PR declares no linked issue
+- **THEN** the state is `NONE` and its value names the *no linked issue* rendering, so the absence of a check is stated rather than looking like a completed one
+
+#### Scenario: The probe could not be performed
+- **WHEN** no marker is on the PR and the linked-issue comment read fails (no `gh`, an API error, or an unparseable payload)
+- **THEN** the state is `NONE`, its value names the *could not check* rendering with the cause, the run still FAILs on the underlying key, and the probe failure itself neither fails nor rescues anything
+
+#### Scenario: One thread read, another unavailable
+- **WHEN** two linked issues are declared, the first is read with no match, and the second's comments cannot be retrieved
+- **THEN** the value takes the *could not check* rendering naming both what was read and what was not, and never the *checked* rendering
+
+#### Scenario: More linked issues than the bound
+- **WHEN** the declared linked-issue set exceeds the probe bound and no match is found in the probed prefix
+- **THEN** the value names how many were declared, how many were probed and the bound, so the unprobed remainder is visible
+
+### Requirement: Every new diagnostic rides the existing single emit boundary and carries no part of either marker
+
+The new detail strings interpolate externally-sourced values — a **runtime issue number** from
+GitHub's structured payload and a **`gh` diagnostic** which is arbitrary remote text. Every one of them
+SHALL pass through the **existing single emit boundary** for its process — `roborev_safe_line` in the
+wrapper, `safe_value` in the scanner — and SHALL NOT be escaped, redacted or sanitised per
+interpolation site. *A per-site escape is a list to keep complete*, and the class was fixed once
+already by moving the neutralisation to the one boundary rather than to the field that happened to
+carry it.
+
+**No emitted diagnostic SHALL carry any part of either marker stem** (`roborev-waive`,
+`roborev-defer`), nor a fillable field skeleton, because summary blocks are pasted into pull-request
+comments as a matter of course in this repository and an artifact that describes the escape hatch must
+not become it. The exact form SHALL remain in `--help` only. The new cases SHALL be run through the
+existing `assert_no_marker_form` helper, which is attached to **every** diagnostic-emitting case —
+*a property asserted only where it cannot fail is not asserted*, which is exactly how the MALFORMED
+detail leaked the whole marker form for a whole release while a nearby comment denied it.
+
+Values SHALL remain one line per value: a control character in a remote diagnostic SHALL be rendered as
+a **visible escape** at the boundary, so no value can span lines and the block SHALL still carry
+exactly one `RESULT:` line.
+
+#### Scenario: A misplaced diagnostic is pasted back into the PR as a comment
+- **WHEN** a run reporting `waiver: MISPLACED` or `deferral: MISPLACED` has its block posted as a PR comment
+- **THEN** it contains no part of either marker stem and no field skeleton, so it authorizes nothing on any later run
+
+#### Scenario: A gh diagnostic on the probe path carries a marker keyword
+- **WHEN** the linked-issue comment read fails with a diagnostic containing `roborev-waive` or `roborev-defer`
+- **THEN** the *could not check* cause still quotes the diagnostic, with the keyword redacted by the wrapper's own emit boundary and no marker form emitted
+
+#### Scenario: A remote diagnostic containing a control character
+- **WHEN** the probe's cause text carries a newline or other control character
+- **THEN** it is rendered as a visible escape, the value occupies one line, and the block carries exactly one `RESULT:` line
+
+#### Scenario: Every new diagnostic-emitting case is asserted
+- **WHEN** `scripts/tests/test_roborev_review_guard.sh` runs
+- **THEN** `assert_no_marker_form` is applied to both `MISPLACED` arms and to all four `NONE` renderings, not only to the case where the property holds trivially
+
+### Requirement: Doctrine and the in-source residuals name the linked-issue thread and the new state
+
+`CLAUDE.md` SHALL be updated **in this change**, in **both** places that record the residual — the
+absence waiver's and the findings deferral's, which carry the same sentence — to state that the
+**linked ISSUE thread** is the **MOST PROBABLE** misplacement, because that is where lane/lead
+coordination lives, and to record the new **`MISPLACED`** state: that it names the issue the marker was
+found on, that it **grants nothing**, and that the FAIL stands. *A residual corrected in one of two
+places is a residual that reads as correct in the other.*
+
+The **same two "RESIDUALS" comment blocks in `scripts/flow/roborev-review-oracles.sh`** SHALL receive
+the same correction, and `--help` SHALL be corrected where it states the residual (its
+*"THE COMMENT MUST BE TOP-LEVEL"* bullet names only a review body and a review-thread reply). These are
+the artifacts an implementer actually reads; leaving them stale is how the doctrine gap regenerates.
+`MISPLACED (…)` SHALL be added to the documented value sets of both the `waiver` and `deferral` keys,
+marked non-granting and informational.
+
+Doctrine SHALL also record the **lead-side procedure** (issue item 3): after posting either marker,
+verify with `gh pr view <PR> --json comments` that the marker line is on the **pull request** — *a
+grant is only granted once it is readable by the scanner that reads it.*
+
+The two locations that remain unread for granting purposes — a **review body** and a
+**review-thread reply** — SHALL still be named, since the probe does not read those either; the linked
+issue is added to the list as the most probable, not substituted for them.
+
+The website `agents-developing/roborev-findings/` page SHALL carry the same content. **Publication
+verification is POST-MERGE and cannot be performed in this change**: the site is served from `main`, so
+grepping the served page for a distinctive new phrase before this branch merges could only ever report
+`0`, which is precisely the false signal the *"never by HTTP 200"* rule exists to prevent. The phrase to
+grep SHALL be recorded in the pull-request body.
+
+#### Scenario: An agent reads the residual after this change
+- **WHEN** an agent or lead reads the waiver or deferral residual in `CLAUDE.md`
+- **THEN** it names the linked-issue thread as the most probable misplacement alongside a review body and a review-thread reply, and records that a misplaced marker is reported `MISPLACED` and grants nothing
+
+#### Scenario: The in-source residuals match the doctrine
+- **WHEN** an implementer reads the two RESIDUALS comment blocks in `roborev-review-oracles.sh` and the `--help` output
+- **THEN** all three name the linked-issue thread and the `MISPLACED` state, so no artifact still states the superseded two-location residual
+
+#### Scenario: The lead-side verification step is recorded
+- **WHEN** a lead posts either marker
+- **THEN** doctrine directs them to verify with `gh pr view <PR> --json comments` that the line is on the PR
+
+### Requirement: Every MISPLACED and NONE rendering is pinned hermetically, and the live path is demonstrated post-merge
+
+`scripts/tests/test_roborev_review_guard.sh` — already executed by the agent gate's `tooling-tests`
+component — SHALL gain behavioural cases covering, at minimum:
+
+- a would-have-granted **waiver** marker on the linked issue with nothing on the PR ⇒
+  `waiver: MISPLACED` naming that issue, with the run still FAILing;
+- the same for **`roborev-defer:`** ⇒ `deferral: MISPLACED`, with `findings:` unchanged and the FAIL
+  standing;
+- a **stale**, a **malformed** and an **unauthorized** issue-side marker ⇒ state stays `NONE`;
+- a **PR-side `stale`** with a perfect issue-side marker ⇒ stays `STALE`, is not overwritten, **and no
+  probe call was made** (asserted against the `gh` invocation log, not assumed);
+- **no linked issue** ⇒ `NONE` with the declared *no linked issue* rendering;
+- the probe **unable to run** ⇒ `NONE` with the declared *could not check* rendering and its cause, the
+  run still FAILing; plus the **partial-read** case ⇒ *could not check* naming both halves;
+- **more linked issues than the bound** ⇒ the rendering declares declared/probed/bound;
+- a **positive control** that `MISPLACED` reaches **no granting path**, for both kinds, paired with the
+  **structural** assert of R2;
+- `assert_no_marker_form` on **every** new diagnostic-emitting case, plus a keyword-bearing `gh`
+  diagnostic on the probe path.
+
+The `gh` test double SHALL be extended for the two new calls —
+`pr view --json closingIssuesReferences` and `issue view <N> --json comments` — with the linked-issue
+list **defaulting to EMPTY**, so a case that wants a probe has to **say so**. That is the fail-closed
+direction and it stops a case passing because the double happened to be permissive about a question the
+wrapper asks.
+
+Every case SHALL plant its artifacts in its **own scratch copy of the tree**, **never** a path variable
+or an environment seam: *a test-only seam is one more thing a real invoker can set*, and the harness
+already asserts that none has been reintroduced. The suite SHALL additionally assert **structurally**
+that `roborev-waiver-scan.py` is unmodified, that no consumer of `closingIssuesReferences` feeds a
+granting branch, that no pull-request **body** read was reintroduced, and that `scripts/agent-gate.sh`
+is unmodified.
+
+Each case whose subject is the **escalation rule** SHALL carry a **planted-mutant contrast** — the
+naive form (probe on every state, or escalate on any issue-side marker) applied to a scratch copy,
+producing the outcome the real code refuses — because a case that passes against both the real code and
+its naive form measures nothing.
+
+Because a pull request whose subject is how the wrapper reads authorizations **cannot certify itself**,
+the live demonstration SHALL be planned and recorded **post-merge**, and the pull-request body SHALL
+say so. A hermetic pass SHALL NOT be recorded as evidence that the live probe path works.
+
+#### Scenario: The escalation rule regresses
+- **WHEN** the escalation is loosened to fire from a state other than `none`, or from an issue-side marker the channel would not have accepted
+- **THEN** `scripts/tests/test_roborev_review_guard.sh` fails, and with it the gate's `tooling-tests` component
+
+#### Scenario: The linked-issue fixture defaults to absent
+- **WHEN** a case does not declare a linked issue
+- **THEN** the test double reports none, so no case can pass because the double was permissive about a question the wrapper asks
+
+#### Scenario: A case is planted rather than seamed
+- **WHEN** a case needs a different scanner, wrapper or oracle behaviour
+- **THEN** it substitutes the artifact in its own scratch copy of the tree, and the harness fails if a test-only path variable or environment seam is reintroduced
+
+#### Scenario: The self-certification boundary is stated
+- **WHEN** the pull request is opened
+- **THEN** its body states that the wrapper cannot certify itself, that the live probe demonstration is post-merge, and that `MISPLACED` grants nothing

--- a/openspec/changes/roborev-waiver-misplaced/specs/roborev-review-guard/spec.md
+++ b/openspec/changes/roborev-waiver-misplaced/specs/roborev-review-guard/spec.md
@@ -264,6 +264,29 @@ that the run FAILs.
 Each issue number returned SHALL be validated **affirmatively as digits** before it is used or emitted;
 a value that is not a number SHALL be a could-not-check cause and SHALL NOT be interpolated raw.
 
+**A CLOSING REFERENCE'S NUMBER IS SCOPED TO ITS OWN REPOSITORY, AND ONLY A SAME-REPOSITORY REFERENCE
+SHALL BE PROBED.** `gh issue view <N>` resolves a number in the **current** repository, so following a
+**cross-repository** reference would read a different issue that merely shares that number — which can
+produce a **false `MISPLACED` naming a thread that never carried a marker**, worse than reporting
+nothing, or miss the real one. The probe SHALL therefore establish which repository `gh` resolves here
+(by asking `gh`, not by deriving it) and SHALL probe a reference **only** when that reference's own
+repository, read from the relation payload, **equals** it — compared case-insensitively, because
+GitHub owner and repository names are case-insensitive and a case-sensitive compare would skip a
+same-repository reference.
+
+A cross-repository reference SHALL be an **explicit, DECLARED skip**, counted and named in the
+rendering, never a silent one. Following it by URL is deliberately **not** done: the reference derives
+from the mutable pull-request body, so honouring it would widen what this call can be pointed at on a
+path whose entire justification is that it grants nothing and only selects a thread to name; the
+incident this mechanism exists for is a same-repository coordination thread; and skipping is the
+fail-closed direction, whose worst case is a `NONE` that declares the skip.
+
+**"In another repository" and "cannot tell which repository" are different facts and SHALL NOT render
+alike.** A reference whose repository cannot be read from the payload, and a current repository that
+could not be established at all, SHALL each be a **could-not-check** cause — never a declared skip
+(which would assert something nobody established) and never a probe (which is the false-`MISPLACED`
+route).
+
 **Several linked issues** SHALL each be probed, **in the order GitHub returns them** (not a sort — any
 sort is a policy nobody asked for), **bounded** by a named constant, reporting the **first** thread
 carrying a matching marker. The bound exists because the probe is a diagnostic and must not become an
@@ -281,6 +304,26 @@ SHALL say so.
 #### Scenario: Several linked issues, the first match reported
 - **WHEN** the PR declares two linked issues and the second carries the matching marker
 - **THEN** both are probed in GitHub's order and the state is `MISPLACED` naming the second
+
+#### Scenario: A cross-repository closing reference is not probed, and the skip is declared
+- **WHEN** the only declared closing reference is `other-owner/other-repo#N`, and issue `#N` **in this repository** carries a marker that would have been accepted
+- **THEN** no thread is probed for it, `MISPLACED` is not reported, and the value declares how many cross-repository references were deliberately not probed and why
+
+#### Scenario: The same number in this repository is probed
+- **WHEN** the identical number is declared as a **same-repository** closing reference
+- **THEN** it is probed and reported `MISPLACED`, so the skip above is shown to turn on the reference's repository and not on the probe having stopped working
+
+#### Scenario: Owner and repository names are compared case-insensitively
+- **WHEN** the current repository and the reference's repository differ only in letter case
+- **THEN** they are one repository, the reference is probed, and no skip is declared
+
+#### Scenario: A reference whose repository cannot be established
+- **WHEN** a relation entry carries a usable number but no readable repository
+- **THEN** the outcome is a could-not-check naming an unestablished repository, it is not counted as a cross-repository skip, and it is not probed
+
+#### Scenario: The current repository cannot be established
+- **WHEN** the call resolving the current repository fails, or answers with something that is not an owner/name pair
+- **THEN** the outcome is a could-not-check naming that resolution, and no reference is probed
 
 #### Scenario: A non-numeric value in the relation payload
 - **WHEN** the relation payload carries a value that is not a number

--- a/openspec/changes/roborev-waiver-misplaced/specs/roborev-review-guard/spec.md
+++ b/openspec/changes/roborev-waiver-misplaced/specs/roborev-review-guard/spec.md
@@ -379,6 +379,16 @@ coverage silently is indistinguishable from one that covers it* — the reason t
 3. **no subject** — *"no linked issue is declared on this PR, so no linked-issue thread was checked"*.
 4. **could not check** — *"the linked-issue thread could NOT be checked: `<cause>`"*, naming the cause.
 
+**A RENDERING THAT READ NOTHING SHALL NEVER CLAIM ANYTHING ABOUT CONTENT.** Whether any thread was
+read SHALL be decided **independently of** whether the bound cut references off. When no thread was
+read the outcome SHALL say so, and SHALL carry **neither** the *no matching marker* clause — a claim
+about content nobody looked at — **nor** the declared read limit, which states what a *read*
+establishes and therefore presupposes one. Two forms: if references remain **unexamined** the outcome
+is **could not check**, naming that no thread was read and how much was never looked at (it is not
+*no subject*, which would assert that none is declared, and emphatically not *checked*); if nothing was
+cut off, every declared reference was a declared skip and the outcome is the *no subject* rendering
+naming that reason.
+
 A **mixed outcome** — one thread read, another unavailable — SHALL take rendering 4 and name **both**
 halves; it SHALL NOT take rendering 1. *A partial scan reported as a complete one is worse than an
 admitted failure, because it is the version nobody re-checks.*
@@ -481,6 +491,10 @@ means before it can be printed.
 #### Scenario: Every read on the path goes through the one validated helper
 - **WHEN** `scripts/tests/test_roborev_review_guard.sh` runs
 - **THEN** it asserts structurally that every scanner invocation and every `state=` extraction lies inside the validated-read helper, that every payload-shape predicate lies inside the one shape validator, that both granting lookups and the probe route through them, and it fails if any call site reads a payload or the scanner directly
+
+#### Scenario: The bound is exhausted by skips before any thread is read
+- **WHEN** cross-repository references exhaust the probe bound before a declared **same-repository** reference is reached, so no thread is read at all
+- **THEN** the outcome is *could not check* stating that no thread was read and naming both the unexamined remainder and the skips — and it carries neither a *no matching marker* claim, nor a *checked* rendering over an empty read list, nor the declared read limit, nor the *no linked issue* rendering, since one **is** declared and merely unexamined
 
 #### Scenario: A read thread declares what "read" does not establish
 - **WHEN** a probed thread's payload is a well-formed comments **list** whose **elements** are malformed — not objects, or with non-string bodies — so the scanner skips them and reports no authorization

--- a/openspec/changes/roborev-waiver-misplaced/specs/roborev-review-guard/spec.md
+++ b/openspec/changes/roborev-waiver-misplaced/specs/roborev-review-guard/spec.md
@@ -66,13 +66,24 @@ issue(s)**, using **the same scanner**, **the same marker kind**, and **the same
 scan returns `granted`, the state SHALL become `misplaced`; otherwise it SHALL remain `none`.
 
 **One enforcer, inherited by call.** The scanner SHALL NOT be duplicated, forked or given a
-thread-specific variant. It is already **thread-agnostic** — it consumes
+thread-specific variant, and `scripts/flow/roborev-waiver-scan.py` SHALL be **unmodified** by this
+change. It is already **thread-agnostic** — it consumes
 `{"comments":[{"author":{"login":…},"body":…}]}` on standard input and knows nothing about pull
-requests — and `gh issue view --json comments` returns that same shape, so the sole-nonblank-content
+requests — and this is **measured, not assumed**: on issue #3626,
+`gh issue view <N> --json comments` emits `{"comments":[{"author":{"login":…},"body":…}]}`,
+**byte-identical in shape** to what `gh pr view --json comments` emits. So the sole-nonblank-content
 rule, the column-zero anchor, the structured author association, the allowlist, the field grammar, the
-placeholder refusal and the scope binding are all inherited **by call**. *A second implementation of a
-channel rule is a second place for it to diverge, and a divergence in an authorization rule is a
-bypass.* `scripts/flow/roborev-waiver-scan.py` SHALL be unmodified by this change.
+placeholder refusal and the scope binding are all inherited **by call**.
+
+*A second implementation of the marker grammar would be a second place for it to diverge, and a
+divergence in an AUTHORIZATION grammar is a bypass* (#3626's *reuse, do not reinvent* ruling). This
+SHALL hold even for a variant that only had to recognise a marker well enough to print a diagnostic: a
+second grammar's agreement with the first is knowable only by testing it, never by care. **The
+measurement is what licenses the reuse** — had the payloads differed in shape, the options would have
+been a translation layer (a new component in an authorization path, needing its own review) or a second
+scanner (forbidden above), never an assumption — so the shape is recorded here, and a `gh` release that
+changes it SHALL fail against a written expectation rather than silently yield an empty comments array,
+which would read as *"no marker there"* and resurrect the indistinguishable `NONE` this change removes.
 
 **The scanner SHALL NOT emit `misplaced`.** Thread identity is the **caller's** knowledge: the scanner
 cannot know which thread its input came from, and telling it would mean adding a provenance argument to
@@ -229,6 +240,27 @@ a re-pointed relation is a diagnostic naming the wrong issue, or none, and the r
 relation must go with it**; that boundary SHALL be written in the source beside the call, because a
 future edit adding a granting consumer reads the code before it reads a design document.
 
+**THE RESOLVER SHALL BE A SEPARATE, LATER CALL, AND THE GRANTING PATH'S PAYLOAD SHALL NOT CHANGE
+SHAPE.** The existing single `gh pr view --json comments` call SHALL remain **exactly as it is**. The
+relation SHALL NOT be folded into it as
+`gh pr view --json comments,closingIssuesReferences`, and the existing call sites SHALL NOT be
+restructured around a richer payload. Two reasons, the first decisive:
+
+1. **The payload an AUTHORIZATION is decided from must not change shape as a side effect of adding a
+   DIAGNOSTIC.** That document is the scanner's input, and the reason the scanner is safe to reuse
+   unmodified is precisely that its input shape is fixed and measured. Widening it hands every consumer
+   a document with an extra top-level key for a feature that grants nothing — and a refactor of the
+   granting call sites turns a review of a diagnostic into a review of the grant.
+2. **The probe SHALL be reachable only from a branch that has already failed to grant.** Fetching the
+   relation up front makes its data available on every path including the granted one, so reachability
+   would rest on where an `if` sits rather than on the data not existing. Issued as a separate, later
+   call on the `none` branch alone, the ordering is structural: on any other state the call is **not
+   made**, not merely ignored — which is also the only version a `gh` invocation-log assert can
+   measure.
+
+The extra round-trip on a failing run is the accepted cost; the path it sits on has already determined
+that the run FAILs.
+
 Each issue number returned SHALL be validated **affirmatively as digits** before it is used or emitted;
 a value that is not a number SHALL be a could-not-check cause and SHALL NOT be interpolated raw.
 
@@ -253,6 +285,18 @@ SHALL say so.
 #### Scenario: A non-numeric value in the relation payload
 - **WHEN** the relation payload carries a value that is not a number
 - **THEN** it is not used and not interpolated raw, and the outcome is a could-not-check cause
+
+#### Scenario: The granting call is unchanged and the resolver is a separate call
+- **WHEN** this change is applied
+- **THEN** the existing `gh pr view --json comments` invocation is unchanged, no invocation requests `comments,closingIssuesReferences` together, and the relation is fetched by its own later call
+
+#### Scenario: The relation is never fetched on a state that already granted or already diagnosed
+- **WHEN** the PR-side scan returns `granted`, `unauthorized`, `stale`, `malformed`, `count-mismatch` or `unavailable`
+- **THEN** the `gh` invocation log shows no `closingIssuesReferences` call and no linked-issue comment call for that run
+
+#### Scenario: The relation resolves the incident's own linked issue
+- **WHEN** the resolver runs against a pull request whose declared closing reference is the coordination issue the marker was posted on, as measured on PR #3710 → issue #3544
+- **THEN** that issue is the thread probed, so the misplacement that produced this change is detectable by the mechanism this change specifies
 
 ### Requirement: The probe is best-effort, cannot change any verdict, and declares what it did and did not check
 
@@ -415,8 +459,9 @@ Every case SHALL plant its artifacts in its **own scratch copy of the tree**, **
 or an environment seam: *a test-only seam is one more thing a real invoker can set*, and the harness
 already asserts that none has been reintroduced. The suite SHALL additionally assert **structurally**
 that `roborev-waiver-scan.py` is unmodified, that no consumer of `closingIssuesReferences` feeds a
-granting branch, that no pull-request **body** read was reintroduced, and that `scripts/agent-gate.sh`
-is unmodified.
+granting branch, that **no invocation requests `comments` and `closingIssuesReferences` in one call**
+and the pre-existing `--json comments` invocation is unchanged, that no pull-request **body** read was
+reintroduced, and that `scripts/agent-gate.sh` is unmodified.
 
 Each case whose subject is the **escalation rule** SHALL carry a **planted-mutant contrast** — the
 naive form (probe on every state, or escalate on any issue-side marker) applied to a scratch copy,

--- a/openspec/changes/roborev-waiver-misplaced/specs/roborev-review-guard/spec.md
+++ b/openspec/changes/roborev-waiver-misplaced/specs/roborev-review-guard/spec.md
@@ -330,6 +330,10 @@ SHALL say so.
 - **WHEN** a reference's repository object carries an owner login or a name that does not satisfy the shared owner/name grammar
 - **THEN** the reference is could-not-check, not a declared cross-repository skip, and the grammar it was judged against is the same one, defined once, that the current-repository identity is judged against
 
+#### Scenario: A newline-bearing identity fails the grammar
+- **WHEN** a reference's repository name or owner login ends with a newline
+- **THEN** it fails the shared grammar and is could-not-check — never a cross-repository declared skip, which is what an anchor admitting a trailing newline produced, since the surviving newline made a same-repository reference compare unequal to everything
+
 #### Scenario: A reference whose repository cannot be established
 - **WHEN** a relation entry carries a usable number but no readable repository
 - **THEN** the outcome is a could-not-check naming an unestablished repository, it is not counted as a cross-repository skip, and it is not probed
@@ -404,9 +408,29 @@ No caller on this path SHALL read a payload, invoke the scanner, or extract the 
 other way, and a **structural** test SHALL assert that — because what four rounds of site fixes failed
 to achieve is making the **next** input structurally unable to join the unvalidated set.
 
+**AND WHAT THE VALIDATED READ ESTABLISHES SHALL BE STATED WITH ITS LIMIT, NOT IMPLIED.** An `ok`
+establishes the **container** — a top-level object whose named field is a list — the **exit status**,
+and the **closed-grammar state**. It does **NOT** distinguish a malformed **element** inside an
+otherwise well-formed list: a comment entry that is not an object, or whose `body` is not a string, is
+**skipped by the scanner**, so a list of such entries reads as a thread carrying no authorization.
+
+**That limit SHALL be DECLARED and SHALL NOT be closed here.** The scanner is reused **unmodified** by
+design and its element-skipping is correct for its own contract; a caller that re-validated every
+element and its field types would be **re-implementing the scanner parse** — a second implementation
+of the marker path, whose correctness is knowable only by differential testing against the first, and
+the precise hazard this design rejected at the outset. Closing it would trade a bounded, stated
+limitation for an unbounded one. The limit SHALL therefore be stated **in the rendering of every
+thread reported as read**, not only in a comment: an affirmative declared limit beats a silent one,
+which is this requirement's whole point. It SHALL NOT be attached to a rendering that claims no read.
+The harm ceiling is a diagnostic one step less precise than it sounds; it can never be a wrongly
+granted authorization, because nothing on this path can grant.
+
 **THE TWO GRANTING LOOKUPS SHALL USE THE SAME READ.** This is not confined to the probe: the
 pull-request payload that decides an **authorization** SHALL be validated by the same helper. A
-malformed pull-request payload SHALL make the lookup state **`unavailable`** — the value that says the
+**An EMPTY payload — `gh` exiting zero with nothing on standard output — is an unreadable payload and
+SHALL take the same path as every other**: no caller SHALL short-circuit on it, because that reports
+"there is no authorization" over comments nobody read. A
+malformed or empty pull-request payload SHALL make the lookup state **`unavailable`** — the value that says the
 oracle could not be consulted — and, because the probe runs only from `none`, SHALL therefore not be
 probed at all. *(Recorded honestly: the missing validation on that granting read predates this change
 — on `main` a malformed payload already yields `none` rather than `unavailable`. This change did not
@@ -457,6 +481,18 @@ means before it can be printed.
 #### Scenario: Every read on the path goes through the one validated helper
 - **WHEN** `scripts/tests/test_roborev_review_guard.sh` runs
 - **THEN** it asserts structurally that every scanner invocation and every `state=` extraction lies inside the validated-read helper, that every payload-shape predicate lies inside the one shape validator, that both granting lookups and the probe route through them, and it fails if any call site reads a payload or the scanner directly
+
+#### Scenario: A read thread declares what "read" does not establish
+- **WHEN** a probed thread's payload is a well-formed comments **list** whose **elements** are malformed — not objects, or with non-string bodies — so the scanner skips them and reports no authorization
+- **THEN** the thread is reported as read, and the value declares its own non-exhaustiveness: that a thread counts as read when its payload was a comments list the scanner accepted, and that a malformed entry inside an otherwise well-formed list is skipped by the scanner and is not distinguished here
+
+#### Scenario: The declared limit is absent where no read is claimed
+- **WHEN** a rendering claims no thread was read at all
+- **THEN** it carries no read limit, so the declaration cannot itself imply a read
+
+#### Scenario: An empty payload from a successful gh is unavailable, not none
+- **WHEN** `gh` exits zero with nothing on standard output, for either kind
+- **THEN** the lookup state is `unavailable` naming the empty payload, never `none`, and no linked-issue probe is performed
 
 #### Scenario: A malformed pull-request payload does not grant and is not probed
 - **WHEN** the pull-request comments payload parses but is not an object carrying a `comments` list

--- a/openspec/changes/roborev-waiver-misplaced/specs/roborev-review-guard/spec.md
+++ b/openspec/changes/roborev-waiver-misplaced/specs/roborev-review-guard/spec.md
@@ -281,6 +281,15 @@ path whose entire justification is that it grants nothing and only selects a thr
 incident this mechanism exists for is a same-repository coordination thread; and skipping is the
 fail-closed direction, whose worst case is a `NONE` that declares the skip.
 
+**BOTH COMPONENTS OF A REFERENCE'S IDENTITY SHALL BE HELD TO THE SAME CONSTRAINT AS THE CURRENT
+REPOSITORY, FROM ONE SHARED GRAMMAR.** The owner login and the repository name SHALL each satisfy the
+same character grammar the current-repository identity satisfies, and that grammar SHALL be defined
+**exactly once** and consumed by both checks. Two parallel validators of one grammar drift, and the
+drift here is not benign: an identity that passes a weaker check but matches nothing compares unequal
+to every reference, which renders as a **confident cross-repository declared skip** derived from an
+identity nobody established. An identity failing this grammar SHALL be **could-not-check**, never a
+declared skip.
+
 **"In another repository" and "cannot tell which repository" are different facts and SHALL NOT render
 alike.** A reference whose repository cannot be read from the payload, and a current repository that
 could not be established at all, SHALL each be a **could-not-check** cause — never a declared skip
@@ -316,6 +325,10 @@ SHALL say so.
 #### Scenario: Owner and repository names are compared case-insensitively
 - **WHEN** the current repository and the reference's repository differ only in letter case
 - **THEN** they are one repository, the reference is probed, and no skip is declared
+
+#### Scenario: A reference identity that fails the name grammar is not a cross-repository skip
+- **WHEN** a reference's repository object carries an owner login or a name that does not satisfy the shared owner/name grammar
+- **THEN** the reference is could-not-check, not a declared cross-repository skip, and the grammar it was judged against is the same one, defined once, that the current-repository identity is judged against
 
 #### Scenario: A reference whose repository cannot be established
 - **WHEN** a relation entry carries a usable number but no readable repository
@@ -374,14 +387,33 @@ Reporting only the first is the same defect as rendering 4's own reason for exis
 more completeness than the probe achieved.
 
 **EVERY INPUT ON THE PROBE PATH SHALL BE VALIDATED AFFIRMATIVELY, AND A ZERO EXIT SHALL NOT BE READ
-AS A SUCCESSFUL READ.** This is the requirement's governing invariant, stated once rather than per
-input, because three successive reviews found the same collapse at a different input each time. The
-probe's inputs are the **current-repository identity**, the **relation payload**, each reference's
-**classification**, each thread's **comments payload**, the scanner's **exit status** and the
-scanner's returned **`state=`**; each SHALL have an affirmative test, and a new input on this path
-SHALL acquire one.
+AS A SUCCESSFUL READ — ENFORCED BY A SINGLE VALIDATED READ, NOT BY A CHECK AT EACH CALL SITE.** Three
+successive reviews found this same collapse at a different input each time (3, then 1, then 2
+findings), and the third round's second finding was inside code that round had just **added while
+fixing the class**. Per this repository's standing ruling for that shape — defects landing inside the
+preceding fix rounds, several rounds inside one mechanism — the response SHALL be to **restructure**,
+not to validate one more site.
 
-Two consequences that are **not** obvious and SHALL be honoured explicitly. (1) The reused scanner
+Therefore: every payload read and every authorization scan on this path SHALL go through **one**
+validated-read helper, which returns a **three-valued** result — `ok`, `could-not-check(<cause>)`,
+`refused(<cause>)` — and which is the **only** place that judges (a) that a payload is a top-level
+JSON **object**, (b) that the field it needs is a **list**, (c) that the scanner's exit status was
+zero, and (d) that the scanner's returned `state=` is in its **closed** recognition set. `ok` is the
+only outcome from which any conclusion may be drawn; the other two are non-granting and carry a cause.
+No caller on this path SHALL read a payload, invoke the scanner, or extract the scanner's `state=` any
+other way, and a **structural** test SHALL assert that — because what four rounds of site fixes failed
+to achieve is making the **next** input structurally unable to join the unvalidated set.
+
+**THE TWO GRANTING LOOKUPS SHALL USE THE SAME READ.** This is not confined to the probe: the
+pull-request payload that decides an **authorization** SHALL be validated by the same helper. A
+malformed pull-request payload SHALL make the lookup state **`unavailable`** — the value that says the
+oracle could not be consulted — and, because the probe runs only from `none`, SHALL therefore not be
+probed at all. *(Recorded honestly: the missing validation on that granting read predates this change
+— on `main` a malformed payload already yields `none` rather than `unavailable`. This change did not
+introduce it; it added a new consequence to it, and repairs it.)*
+
+Two consequences that are **not** obvious and SHALL be honoured explicitly, and both now live inside
+that one helper. (1) The reused scanner
 coerces a valid-JSON but malformed payload — `{}`, `{"comments": null}`, `{"comments": {}}` — to an
 **empty comment list** and exits **0**. That is correct for the scanner's own contract and the scanner
 SHALL NOT be changed for it; the **caller** SHALL validate the payload as a JSON **object** carrying a
@@ -421,6 +453,14 @@ means before it can be printed.
 #### Scenario: An unreadable relation payload is not reported as an empty relation
 - **WHEN** the relation payload is unparseable, is not a JSON object, omits the `closingIssuesReferences` key, carries an explicit `null`, or carries a non-list value
 - **THEN** each shape takes the *could not check* rendering naming the broken payload, and none of them reports *"no linked issue is declared on this PR"*
+
+#### Scenario: Every read on the path goes through the one validated helper
+- **WHEN** `scripts/tests/test_roborev_review_guard.sh` runs
+- **THEN** it asserts structurally that every scanner invocation and every `state=` extraction lies inside the validated-read helper, that every payload-shape predicate lies inside the one shape validator, that both granting lookups and the probe route through them, and it fails if any call site reads a payload or the scanner directly
+
+#### Scenario: A malformed pull-request payload does not grant and is not probed
+- **WHEN** the pull-request comments payload parses but is not an object carrying a `comments` list
+- **THEN** the lookup state is `unavailable` naming the cause — never `none`, which would assert that no authorization exists over comments nobody read — and no linked-issue probe is performed
 
 #### Scenario: A valid-JSON but malformed comments payload is not a read thread
 - **WHEN** a probed thread's comments payload parses but is not an object carrying a `comments` list — `{}`, `{"comments": null}`, `{"comments": {}}`, or a non-list value — so the scanner reduces it to zero comments and exits 0

--- a/openspec/changes/roborev-waiver-misplaced/specs/roborev-review-guard/spec.md
+++ b/openspec/changes/roborev-waiver-misplaced/specs/roborev-review-guard/spec.md
@@ -281,6 +281,23 @@ path whose entire justification is that it grants nothing and only selects a thr
 incident this mechanism exists for is a same-repository coordination thread; and skipping is the
 fail-closed direction, whose worst case is a `NONE` that declares the skip.
 
+**AND "DEFINED ONCE" SHALL MEAN "INTERPRETED IDENTICALLY", WHICH IS A TESTED PROPERTY AND NOT A
+CONSEQUENCE OF SHARING A STRING.** The grammar is consumed by two engines — a POSIX bracket expression
+in the shell and Python's `re` — and a **range** inside a bracket expression is resolved by the
+**locale's collation** in the first and by **codepoint** in the second. Measured: under
+`LC_ALL=en_US.utf8` the shell matches `é`, `ǅ`, `İ` and `ß` against `^[A-Za-z0-9._-]+$` while Python
+refuses all four. A malformed current-repository identity could therefore pass the shell check and
+fail the reference check, and a **same-repository** reference would be reported as a cross-repository
+declared skip — the probe silently declining to examine the one thread that matters.
+
+The grammar SHALL therefore be **enumerated rather than ranged**, so no collation is consulted by
+either consumer, and a test SHALL assert **both** that it contains no range **and** that the two
+consumers agree on a corpus including non-ASCII inputs, in every locale the host provides, declaring
+its own non-exhaustiveness where the host offers no locale that could expose a divergence. *A second
+implementation is correct only insofar as it is differentially tested against the first, and sharing
+one definition does not exempt it — which is what this finding proved. A documented invariant that is
+untrue is worse than one that was never claimed.*
+
 **BOTH COMPONENTS OF A REFERENCE'S IDENTITY SHALL BE HELD TO THE SAME CONSTRAINT AS THE CURRENT
 REPOSITORY, FROM ONE SHARED GRAMMAR.** The owner login and the repository name SHALL each satisfy the
 same character grammar the current-repository identity satisfies, and that grammar SHALL be defined
@@ -329,6 +346,10 @@ SHALL say so.
 #### Scenario: A reference identity that fails the name grammar is not a cross-repository skip
 - **WHEN** a reference's repository object carries an owner login or a name that does not satisfy the shared owner/name grammar
 - **THEN** the reference is could-not-check, not a declared cross-repository skip, and the grammar it was judged against is the same one, defined once, that the current-repository identity is judged against
+
+#### Scenario: The one name grammar means the same thing to both of its consumers
+- **WHEN** the shared owner/name grammar is evaluated by the shell and by Python over the same corpus of ASCII-valid, ASCII-invalid and non-ASCII inputs, in every locale the host provides
+- **THEN** the two agree on every input, and the grammar contains no character range — a ranged class is resolved by locale collation in one engine and by codepoint in the other, which lets a same-repository reference be misreported as a cross-repository skip
 
 #### Scenario: A newline-bearing identity fails the grammar
 - **WHEN** a reference's repository name or owner login ends with a newline

--- a/openspec/changes/roborev-waiver-misplaced/specs/roborev-review-guard/spec.md
+++ b/openspec/changes/roborev-waiver-misplaced/specs/roborev-review-guard/spec.md
@@ -314,14 +314,21 @@ coverage silently is indistinguishable from one that covers it* — the reason t
 
 1. **checked** — *"linked issue #N checked: no matching marker there either"*. Emitted **only when
    every probed thread was read successfully**.
-2. **partially checked** — *"linked issues #A,#B checked — N of M declared, probe bounded at N: no
-   matching marker"*. The unprobed remainder is named, never implied.
+2. **partially checked** — *"linked issues #A,#B checked — N of M declared examined, probe bounded at
+   N, R never looked at"*. The unprobed remainder is named, never implied.
 3. **no subject** — *"no linked issue is declared on this PR, so no linked-issue thread was checked"*.
 4. **could not check** — *"the linked-issue thread could NOT be checked: `<cause>`"*, naming the cause.
 
 A **mixed outcome** — one thread read, another unavailable — SHALL take rendering 4 and name **both**
 halves; it SHALL NOT take rendering 1. *A partial scan reported as a complete one is worse than an
 admitted failure, because it is the version nobody re-checks.*
+
+**THE UNEXAMINED REMAINDER SHALL BE NAMED WHEREVER IT EXISTS, NOT ONLY ON RENDERING 1's SIBLING.**
+The bound clause SHALL be appended to **whichever** rendering fires, including rendering 4. A read
+that fails inside the bounded prefix while declared references remain unexamined SHALL report **both**
+gaps in one value — what could not be read, **and** how many declared references were never looked at.
+Reporting only the first is the same defect as rendering 4's own reason for existing: a value claiming
+more completeness than the probe achieved.
 
 **AN UNREADABLE RELATION PAYLOAD IS NOT AN EMPTY RELATION.** Rendering 3 — *"no linked issue is
 declared on this PR"* — is an **affirmative claim about the pull request**, and it SHALL be reachable
@@ -357,6 +364,10 @@ means before it can be printed.
 #### Scenario: One thread read, another unavailable
 - **WHEN** two linked issues are declared, the first is read with no match, and the second's comments cannot be retrieved
 - **THEN** the value takes the *could not check* rendering naming both what was read and what was not, and never the *checked* rendering
+
+#### Scenario: A thread is unreadable inside the bound while declared references remain unexamined
+- **WHEN** the declared set exceeds the bound and one thread inside the probed prefix cannot be read
+- **THEN** the *could not check* rendering names **both** the unreadable thread and how many declared references were never examined, in one value
 
 #### Scenario: More linked issues than the bound
 - **WHEN** the declared linked-issue set exceeds the probe bound and no match is found in the probed prefix

--- a/openspec/changes/roborev-waiver-misplaced/specs/roborev-review-guard/spec.md
+++ b/openspec/changes/roborev-waiver-misplaced/specs/roborev-review-guard/spec.md
@@ -323,6 +323,16 @@ A **mixed outcome** — one thread read, another unavailable — SHALL take rend
 halves; it SHALL NOT take rendering 1. *A partial scan reported as a complete one is worse than an
 admitted failure, because it is the version nobody re-checks.*
 
+**AN UNREADABLE RELATION PAYLOAD IS NOT AN EMPTY RELATION.** Rendering 3 — *"no linked issue is
+declared on this PR"* — is an **affirmative claim about the pull request**, and it SHALL be reachable
+**only** from a payload that was affirmatively read as a JSON **object** carrying a
+`closingIssuesReferences` **list**. An unparseable payload, a non-object top level, a **missing**
+`closingIssuesReferences` key, an explicit `null`, and a non-list value SHALL each take rendering 4.
+`gh pr view --json closingIssuesReferences` always returns the key it was asked for, so its absence is
+a broken payload; coercing any of these to zero declared references would derive an ANSWER from
+something nobody could read, which is the permissive-branch-inherits-the-unknown-state shape this
+whole mechanism is written against.
+
 The existing `NONE` teaching text — that the marker must be the **sole nonblank content** of a
 **top-level** comment — SHALL be **retained**; the declaration is additional, not a replacement. An
 unrecognised rendering SHALL NOT exist: the set is closed, and a new outcome requires deciding what it
@@ -339,6 +349,10 @@ means before it can be printed.
 #### Scenario: The probe could not be performed
 - **WHEN** no marker is on the PR and the linked-issue comment read fails (no `gh`, an API error, or an unparseable payload)
 - **THEN** the state is `NONE`, its value names the *could not check* rendering with the cause, the run still FAILs on the underlying key, and the probe failure itself neither fails nor rescues anything
+
+#### Scenario: An unreadable relation payload is not reported as an empty relation
+- **WHEN** the relation payload is unparseable, is not a JSON object, omits the `closingIssuesReferences` key, carries an explicit `null`, or carries a non-list value
+- **THEN** each shape takes the *could not check* rendering naming the broken payload, and none of them reports *"no linked issue is declared on this PR"*
 
 #### Scenario: One thread read, another unavailable
 - **WHEN** two linked issues are declared, the first is read with no match, and the second's comments cannot be retrieved

--- a/openspec/changes/roborev-waiver-misplaced/specs/roborev-review-guard/spec.md
+++ b/openspec/changes/roborev-waiver-misplaced/specs/roborev-review-guard/spec.md
@@ -240,6 +240,15 @@ a re-pointed relation is a diagnostic naming the wrong issue, or none, and the r
 relation must go with it**; that boundary SHALL be written in the source beside the call, because a
 future edit adding a granting consumer reads the code before it reads a design document.
 
+**THE RELATION SHALL BE READ BEFORE THE REPOSITORY IS RESOLVED, AND AN EMPTY RELATION SHALL BE
+ANSWERED WITHOUT RESOLVING IT AT ALL.** The repository identity exists only to classify references, so
+a pull request declaring **none** SHALL reach the definitive *no linked issue* outcome without that
+call being made — not merely without its result being used. Resolving first made a **failure of a call
+the answer never needed** report *"could not be checked"* where a definitive answer existed: a
+could-not-tell reported **where an answer exists**, which is the inverse of the collapse this path is
+built against and equally wrong, because it hides a completed check behind an apparent infrastructure
+fault.
+
 **THE RESOLVER SHALL BE A SEPARATE, LATER CALL, AND THE GRANTING PATH'S PAYLOAD SHALL NOT CHANGE
 SHAPE.** The existing single `gh pr view --json comments` call SHALL remain **exactly as it is**. The
 relation SHALL NOT be folded into it as
@@ -370,6 +379,14 @@ SHALL say so.
 #### Scenario: The granting call is unchanged and the resolver is a separate call
 - **WHEN** this change is applied
 - **THEN** the existing `gh pr view --json comments` invocation is unchanged, no invocation requests `comments,closingIssuesReferences` together, and the relation is fetched by its own later call
+
+#### Scenario: No linked issue, and the repository resolution fails
+- **WHEN** a pull request declares no closing reference and the call that resolves the current repository would fail
+- **THEN** the outcome is the definitive *no linked issue is declared* result, not a could-not-check, and the repository resolution is not performed at all
+
+#### Scenario: With references to classify, a failed repository resolution is reported
+- **WHEN** a pull request declares a closing reference and the repository resolution fails
+- **THEN** the outcome is a could-not-check naming that resolution, so the ordering above is shown to be conditional rather than the resolution having been removed
 
 #### Scenario: The relation is never fetched on a state that already granted or already diagnosed
 - **WHEN** the PR-side scan returns `granted`, `unauthorized`, `stale`, `malformed`, `count-mismatch` or `unavailable`
@@ -628,6 +645,10 @@ grep SHALL be recorded in the pull-request body.
 #### Scenario: An agent reads the residual after this change
 - **WHEN** an agent or lead reads the waiver or deferral residual in `CLAUDE.md`
 - **THEN** it names the linked-issue thread as the most probable misplacement alongside a review body and a review-thread reply, and records that a misplaced marker is reported `MISPLACED` and grants nothing
+
+#### Scenario: The documented output-state contracts are complete
+- **WHEN** either lookup's header comment enumerates the states it can emit
+- **THEN** every state the function can actually assign is listed — `misplaced` included — and the test reads the contract's own value lines rather than the surrounding prose, so a paragraph mentioning a state cannot satisfy a check about the contract
 
 #### Scenario: The in-source residuals match the doctrine
 - **WHEN** an implementer reads the two RESIDUALS comment blocks in `roborev-review-oracles.sh` and the `--help` output

--- a/openspec/changes/roborev-waiver-misplaced/tasks.md
+++ b/openspec/changes/roborev-waiver-misplaced/tasks.md
@@ -20,28 +20,28 @@ adapt if one is false: the design rests on them.
 - [x] 0.2b `gh pr view 3710 --json closingIssuesReferences` → `[{"number":3544, …}]`. **Measured live:
       the resolver would have found the markers on the actual incident**, where PR #3710 carried zero
       and issue #3544 carried both. Quoted in `proposal.md` as the validating measurement.
-- [ ] 0.3 Verify that `waiver:` and `deferral:` are **informational** keys — absent from the closed
+- [x] 0.3 Verify that `waiver:` and `deferral:` are **informational** keys — absent from the closed
       verdict grammar scan and from the affirmation loop (`roborev-review.sh` ~`:163`, ~`:896`) — so a
       new value there cannot make anything pass by itself. This is R2's structural argument; if it is
       false, the grammar work has to be designed, not assumed.
-- [ ] 0.4 Confirm `scripts/agent-gate.sh` is out of scope and will end the change unmodified.
+- [x] 0.4 Confirm `scripts/agent-gate.sh` is out of scope and will end the change unmodified.
 
 ## 1. The linked-issue probe (the only new mechanism)
 
-- [ ] 1.1 Add ONE helper to `scripts/flow/roborev-review-oracles.sh` — e.g.
+- [x] 1.1 Add ONE helper to `scripts/flow/roborev-review-oracles.sh` — e.g.
       `roborev_linked_issue_marker_probe <kind> <base> <head> <job> [<observed-count>]` — serving BOTH
       kinds. Two copies of a probe over an authorization channel is two places for it to diverge.
-- [ ] 1.2 Resolve the linked issues **structurally**: `gh pr view --json closingIssuesReferences`.
+- [x] 1.2 Resolve the linked issues **structurally**: `gh pr view --json closingIssuesReferences`.
       **Never** scan the PR body — #3626 deleted that check because a PR body is editable by anyone
       with write access with no per-edit attribution. Write the *mutable-derived, grants-nothing*
       boundary as a comment AT THE CALL SITE (not only in `design.md`), because the next edit that adds
       a granting consumer will read the code first.
-- [ ] 1.3 Validate each returned issue number **affirmatively** as digits before it is used or
+- [x] 1.3 Validate each returned issue number **affirmatively** as digits before it is used or
       emitted; a value that is not a number is a could-not-check cause, never interpolated raw.
-- [ ] 1.4 Probe each issue in **GitHub's returned order**, **bounded** (a named constant, with the
+- [x] 1.4 Probe each issue in **GitHub's returned order**, **bounded** (a named constant, with the
       bound stated in the rendering when the declared set exceeds it). Report the **first** thread
       carrying a matching marker; stop there.
-- [ ] 1.2b **The existing `gh pr view --json comments` call stays EXACTLY as it is.** Do NOT fetch
+- [x] 1.2b **The existing `gh pr view --json comments` call stays EXACTLY as it is.** Do NOT fetch
       `--json comments,closingIssuesReferences` in one call and do NOT restructure the existing call
       sites: the payload an AUTHORIZATION is decided from must not change shape as a side effect of
       adding a DIAGNOSTIC (it is the scanner's input, and the fixed measured shape is what licenses
@@ -50,92 +50,92 @@ adapt if one is false: the design rests on them.
       the `none` branch — so on every other state the call is **not made**, not merely ignored, which
       is the only version the `gh` invocation-log assert can measure. The extra round-trip on a failing
       run is the accepted cost.
-- [ ] 1.5 For each probed thread: `gh issue view <N> --json comments`, piped to **the same
+- [x] 1.5 For each probed thread: `gh issue view <N> --json comments`, piped to **the same
       `$WAIVER_SCAN_TOOL`**, with **the same kind** and **the same** `base`/`head`/`job`/
       `$ROBOREV_WAIVER_AUTHORS` (and `observed` for the deferral). No new arguments, no new grammar, no
       second scanner. The scanner file must end this change **unmodified**.
-- [ ] 1.6 Set the probe's outcome three ways and no more: `misplaced` + the issue number (the scanner
+- [x] 1.6 Set the probe's outcome three ways and no more: `misplaced` + the issue number (the scanner
       returned `granted`); `checked` (every probed thread read, no match); `no-subject` (no linked
       issue declared); `could-not-check` + a cause. A partial read — one thread read, another
       unavailable — is `could-not-check` naming BOTH halves, never `checked`.
-- [ ] 1.7 The helper NEVER returns non-zero and NEVER exits: a two-valued return would re-import the
+- [x] 1.7 The helper NEVER returns non-zero and NEVER exits: a two-valued return would re-import the
       collapse this change exists to remove. Every failure is a state with a cause.
-- [ ] 1.8 Do NOT run the deferral's `roborev_issue_retrievability` disposition leg issue-side. Record
+- [x] 1.8 Do NOT run the deferral's `roborev_issue_retrievability` disposition leg issue-side. Record
       the scoping in a comment: the rendering claims *"would have been accepted by the channel"*, not
       *"would have granted"*, and the disposition legs run once the marker is on the PR.
 
 ## 2. Wire it into the two lookup functions
 
-- [ ] 2.1 In `roborev_absence_waiver_lookup()`, after the recognised-state validation, call the probe
+- [x] 2.1 In `roborev_absence_waiver_lookup()`, after the recognised-state validation, call the probe
       **only** when `ROBOREV_WAIVER_STATE = none`. On a probe `misplaced`, set
       `ROBOREV_WAIVER_STATE="misplaced"` and put the issue number + remedy in
       `ROBOREV_WAIVER_DETAIL`; otherwise leave the state at `none` and record the probe's declaration
       in the detail.
-- [ ] 2.2 Same in `roborev_findings_deferral_lookup()`, for `ROBOREV_DEFERRAL_STATE` /
+- [x] 2.2 Same in `roborev_findings_deferral_lookup()`, for `ROBOREV_DEFERRAL_STATE` /
       `ROBOREV_DEFERRAL_DETAIL`, passing the observed count through unchanged.
-- [ ] 2.3 Add `misplaced` to BOTH recognised-state `case` lists, with a comment saying it is a
+- [x] 2.3 Add `misplaced` to BOTH recognised-state `case` lists, with a comment saying it is a
       **belt**: the probe assigns after the validation today, and the entry exists so a future refactor
       that routes through it cannot rewrite an accurate diagnostic to a generic `unavailable`. State
       that the list is a **recognition** list, not a granting list.
-- [ ] 2.4 Leave both granting gates exactly as they are —
+- [x] 2.4 Leave both granting gates exactly as they are —
       `[ "$ROBOREV_WAIVER_STATE" = "granted" ]` / `[ "$ROBOREV_DEFERRAL_STATE" = "granted" ]`,
       token-exact equality — and add no branch that treats `misplaced` as granting, partially granting,
       or grant-with-a-notice.
-- [ ] 2.5 Confirm no probe call is made on `granted`, `unauthorized`, `stale`, `malformed`,
+- [x] 2.5 Confirm no probe call is made on `granted`, `unauthorized`, `stale`, `malformed`,
       `count-mismatch` or `unavailable` — not merely that the state is not overwritten, but that the
       network call is not made. A probe that runs and is ignored is latency and a future footgun.
 
 ## 3. The two report arms (`scripts/flow/roborev-review-checks.sh`)
 
-- [ ] 3.1 Add a **dedicated** `misplaced)` arm to the `WAIVER_REPORT` case (~`:185-235`), before the
+- [x] 3.1 Add a **dedicated** `misplaced)` arm to the `WAIVER_REPORT` case (~`:185-235`), before the
       generic `*)`. The generic arm would render `MISPLACED (detail)` automatically — that is not
       enough: this state's whole value is its **remedy text**, and a remedy is not something to leave
       to a fall-through.
-- [ ] 3.2 Add the same dedicated `misplaced)` arm to the `DEFERRAL_REPORT` case (~`:565-655`).
-- [ ] 3.3 Both arms name: the issue number the marker was found on; that it **grants nothing and the
+- [x] 3.2 Add the same dedicated `misplaced)` arm to the `DEFERRAL_REPORT` case (~`:565-655`).
+- [x] 3.3 Both arms name: the issue number the marker was found on; that it **grants nothing and the
       FAIL stands**; the remedy — **re-post the identical marker as a TOP-LEVEL COMMENT ON THE PR**;
       and that only a marker on the PR grants. No part of either marker stem, and no fillable field
       skeleton — point at `--help`.
-- [ ] 3.4 Extend both `none)` arms to carry the probe's declaration, from the closed rendering set:
+- [x] 3.4 Extend both `none)` arms to carry the probe's declaration, from the closed rendering set:
       `linked issue #N checked: no matching marker there either` /
       `linked issues #A,#B checked — N of M declared, probe bounded at N: no matching marker` /
       `no linked issue is declared on this PR, so no linked-issue thread was checked` /
       `the linked-issue thread could NOT be checked: <cause>`. Keep the existing sole-content and
       top-level teaching text; the declaration is additional, not a replacement.
-- [ ] 3.5 Verify every new interpolation passes through the ONE emit boundary
+- [x] 3.5 Verify every new interpolation passes through the ONE emit boundary
       (`roborev_safe_line` / `safe_value`) — no per-site escape. Sweep the `gh` diagnostic and the
       issue number specifically.
-- [ ] 3.6 Verify the block still carries exactly one `RESULT:` line and that no new value spans lines
+- [x] 3.6 Verify the block still carries exactly one `RESULT:` line and that no new value spans lines
       (control characters rendered as visible escapes at the boundary).
 
 ## 4. Key documentation and `--help`
 
-- [ ] 4.1 `scripts/flow/roborev-review.sh` header key documentation: add `MISPLACED (...)` to the
+- [x] 4.1 `scripts/flow/roborev-review.sh` header key documentation: add `MISPLACED (...)` to the
       documented value sets of BOTH `waiver` and `deferral`, saying it is **non-granting** and
       **informational**.
-- [ ] 4.2 `--help` (~`:487-489`): the *"THE COMMENT MUST BE TOP-LEVEL"* bullet currently names only a
+- [x] 4.2 `--help` (~`:487-489`): the *"THE COMMENT MUST BE TOP-LEVEL"* bullet currently names only a
       review body and a review-thread reply. Add the **linked issue thread** as the **most probable**
       misplacement, and name the new `MISPLACED` state and the lead-side verification step.
-- [ ] 4.3 Confirm no emitted `--help` or diagnostic text became newly pasteable as an authorization
+- [x] 4.3 Confirm no emitted `--help` or diagnostic text became newly pasteable as an authorization
       (the form stays in `--help` only, which is already the one sanctioned location).
 
 ## 5. Doctrine, in the same change (issue item 1 + item 3)
 
-- [ ] 5.1 `CLAUDE.md`, the **waiver** residual (*"the marker is read from top-level PR comments only,
+- [x] 5.1 `CLAUDE.md`, the **waiver** residual (*"the marker is read from top-level PR comments only,
       so one posted inside a review body or a review-thread reply is silently not applied…"*): add the
       **linked ISSUE thread** as the **most probable** of the three misplacements — that is where
       lane/lead coordination lives — and record the new `MISPLACED` state, that it grants nothing, and
       that the FAIL stands.
-- [ ] 5.2 `CLAUDE.md`, the **deferral** residual carrying the same sentence: the same correction. Both,
+- [x] 5.2 `CLAUDE.md`, the **deferral** residual carrying the same sentence: the same correction. Both,
       not one — a residual corrected in one of two places is a residual that reads as correct in the
       other.
-- [ ] 5.3 Record issue item 3, the **lead-side procedure**: after posting either marker, verify with
+- [x] 5.3 Record issue item 3, the **lead-side procedure**: after posting either marker, verify with
       `gh pr view <PR> --json comments` that the marker line is **on the PR**. *A grant is only granted
       once it is readable by the scanner that reads it.*
-- [ ] 5.4 `scripts/flow/roborev-review-oracles.sh`: the SAME correction in BOTH "RESIDUALS" comment
+- [x] 5.4 `scripts/flow/roborev-review-oracles.sh`: the SAME correction in BOTH "RESIDUALS" comment
       blocks (the waiver's ~`:1128` and the deferral's ~`:1345`). These are the artifacts an
       implementer actually reads; leaving them stale is how the doctrine gap regenerates.
-- [ ] 5.5 Website `agents-developing/roborev-findings/` — same content. **Publication verification is
+- [x] 5.5 Website `agents-developing/roborev-findings/` — same content. **Publication verification is
       POST-MERGE and cannot be done here**: the site is served from `main`, so grepping the served page
       for a new phrase before this branch merges could only ever report `0`, which is the false signal
       the "never by HTTP 200" rule exists to prevent. Record the phrase to grep in the PR body.
@@ -148,46 +148,46 @@ Read the existing suite first and reuse its idioms: the `gh` stub (`STUB_GH_COMM
 path variable** (see the `WAIVER_SCAN_TOOL` comment: a test-only seam is one more thing a real invoker
 can set).
 
-- [ ] 6.1 Extend the `gh` stub for the two new calls: `pr view --json closingIssuesReferences` (a
+- [x] 6.1 Extend the `gh` stub for the two new calls: `pr view --json closingIssuesReferences` (a
       fixturable linked-issue list, **defaulting to EMPTY** so a case that wants a probe has to SAY so
       — the fail-closed direction, and it stops a case passing because the double was permissive) and
       `issue view <N> --json comments` (per-issue comment fixtures, independently failable so a
       partial-read case is expressible).
-- [ ] 6.2 **(a)** A would-have-granted `roborev-waive:` marker on the linked issue, nothing on the PR
+- [x] 6.2 **(a)** A would-have-granted `roborev-waive:` marker on the linked issue, nothing on the PR
       ⇒ `waiver: MISPLACED` naming that issue, `prompt-content:` still FAIL, `RESULT: FAIL`.
-- [ ] 6.3 **(b)** The same for `roborev-defer:` ⇒ `deferral: MISPLACED` naming the issue,
+- [x] 6.3 **(b)** The same for `roborev-defer:` ⇒ `deferral: MISPLACED` naming the issue,
       `findings: PRESENT (n)` unchanged (never `DEFERRED`, never `NONE`), `RESULT: FAIL`.
-- [ ] 6.4 **(c)** A **stale** and a **malformed** issue-side marker ⇒ state stays `NONE` with the
+- [x] 6.4 **(c)** A **stale** and a **malformed** issue-side marker ⇒ state stays `NONE` with the
       probe's `checked` rendering (R3: escalation only from a would-have-granted marker). Include an
       **unauthorized-author** issue-side marker in the same group.
-- [ ] 6.5 **(d)** A PR-side `stale` marker WITH a perfect issue-side marker ⇒ stays `STALE`, is not
+- [x] 6.5 **(d)** A PR-side `stale` marker WITH a perfect issue-side marker ⇒ stays `STALE`, is not
       overwritten, and — measured, not assumed — **no probe call was made** (assert against the stub's
       invocation log).
-- [ ] 6.6 **(e)** No linked issue ⇒ `NONE` carrying the declared *"no linked issue is declared on this
+- [x] 6.6 **(e)** No linked issue ⇒ `NONE` carrying the declared *"no linked issue is declared on this
       PR"* rendering.
-- [ ] 6.7 **(f)** Probe unable to run — `gh issue view` fails / the payload is unparseable / the
+- [x] 6.7 **(f)** Probe unable to run — `gh issue view` fails / the payload is unparseable / the
       relation call fails ⇒ `NONE` carrying the declared *could-not-check* rendering with its cause,
       and the run still FAILs. Plus the **partial-read** case: one thread read, another unavailable ⇒
       `could-not-check` naming both halves, never `checked`.
-- [ ] 6.8 **(g)** Positive control that `MISPLACED` reaches **no** granting path: `prompt-content:`
+- [x] 6.8 **(g)** Positive control that `MISPLACED` reaches **no** granting path: `prompt-content:`
       never reads `WAIVED` and `findings:` never reads `DEFERRED` under a `misplaced` state, in either
       kind — paired with a **structural** assert that the only granting gates remain the two token-exact
       `= "granted"` comparisons and that `misplaced` appears in no granting branch. Behavioural alone is
       not enough here (it covers the fixtures someone thought of); structural alone is not enough either
       (it cannot see a granting path built some other way).
-- [ ] 6.9 **(h)** `assert_no_marker_form` on **every** new diagnostic-emitting case — the MISPLACED
+- [x] 6.9 **(h)** `assert_no_marker_form` on **every** new diagnostic-emitting case — the MISPLACED
       arms and all four `NONE` renderings — plus a keyword-bearing `gh` diagnostic and a
       keyword-bearing author login on the issue-side path, proving the new values ride the existing
       emit boundary rather than a new one.
-- [ ] 6.10 A **more-linked-issues-than-the-bound** case: the rendering declares `N of M declared,
+- [x] 6.10 A **more-linked-issues-than-the-bound** case: the rendering declares `N of M declared,
       probe bounded at N`, and the unprobed remainder is visible rather than silent.
-- [ ] 6.11 Structural assert that `scripts/flow/roborev-waiver-scan.py` is **unmodified** by this
+- [x] 6.11 Structural assert that `scripts/flow/roborev-waiver-scan.py` is **unmodified** by this
       change (`git diff --name-only`), that no `closingIssuesReferences` consumer feeds a granting
       branch, that **no invocation requests `comments` and `closingIssuesReferences` in one call** and
       the pre-existing `--json comments` invocation is unchanged (task 1.2b), and that no PR-**body**
       read was reintroduced anywhere (`--json body`, a `#N` scan).
-- [ ] 6.12 Assert `scripts/agent-gate.sh` is unmodified.
-- [ ] 6.13 Run the suite and record the assertion-count delta; then plant the naive mutant for the
+- [x] 6.12 Assert `scripts/agent-gate.sh` is unmodified.
+- [x] 6.13 Run the suite and record the assertion-count delta; then plant the naive mutant for the
       escalation rule (probe on every state / escalate on any issue-side marker) in a scratch copy and
       confirm it REDS — a case that passes against both the real code and its naive form measures
       nothing.

--- a/openspec/changes/roborev-waiver-misplaced/tasks.md
+++ b/openspec/changes/roborev-waiver-misplaced/tasks.md
@@ -3,16 +3,23 @@
 Ordered. Each numbered group is independently reviewable; group 1 is the only new mechanism, groups
 2–4 wire it, group 5 is doctrine, group 6 is coverage.
 
-## 0. Confirm the premise before writing anything
+## 0. The premise, ALREADY VERIFIED — re-confirm, do not re-derive
 
-- [ ] 0.1 Verify from source (not memory) that `scripts/flow/roborev-waiver-scan.py` is
-      **thread-agnostic**: `main()` reads `{"comments":[…]}` from stdin and nothing in `scan()`,
-      `judge_waive_line()` or `judge_defer_line()` refers to a pull request. If that is false, STOP —
-      the whole design rests on one enforcer serving both threads.
-- [ ] 0.2 Verify that `gh issue view <N> --json comments` returns the **same shape** as
-      `gh pr view --json comments` (`{"comments":[{"author":{"login":…},"body":…}]}`). Record the
-      measurement. A shape difference means a translation layer, and a translation layer in an
-      authorization path needs its own review.
+Two of these were measured live by the lead on 2026-09-01 and are recorded as facts in `design.md`.
+Re-confirm them on the box you implement on (a `gh` upgrade can move either), and STOP rather than
+adapt if one is false: the design rests on them.
+
+- [x] 0.1 `scripts/flow/roborev-waiver-scan.py` is **thread-agnostic** — `main()` reads
+      `{"comments":[…]}` from stdin and nothing in `scan()`, `judge_waive_line()` or
+      `judge_defer_line()` refers to a pull request. **Verified from source.** If it ever becomes
+      false, STOP: the whole design rests on one enforcer serving both threads.
+- [x] 0.2 `gh issue view <N> --json comments` emits `{"comments":[{"author":{"login":…},"body":…}]}`,
+      **byte-identical in shape** to `gh pr view --json comments`. **Measured live on issue #3626.**
+      A shape difference would mean a translation layer — a new component in an authorization path,
+      needing its own review — or a second scanner, which is forbidden; never an assumption.
+- [x] 0.2b `gh pr view 3710 --json closingIssuesReferences` → `[{"number":3544, …}]`. **Measured live:
+      the resolver would have found the markers on the actual incident**, where PR #3710 carried zero
+      and issue #3544 carried both. Quoted in `proposal.md` as the validating measurement.
 - [ ] 0.3 Verify that `waiver:` and `deferral:` are **informational** keys — absent from the closed
       verdict grammar scan and from the affirmation loop (`roborev-review.sh` ~`:163`, ~`:896`) — so a
       new value there cannot make anything pass by itself. This is R2's structural argument; if it is
@@ -34,6 +41,15 @@ Ordered. Each numbered group is independently reviewable; group 1 is the only ne
 - [ ] 1.4 Probe each issue in **GitHub's returned order**, **bounded** (a named constant, with the
       bound stated in the rendering when the declared set exceeds it). Report the **first** thread
       carrying a matching marker; stop there.
+- [ ] 1.2b **The existing `gh pr view --json comments` call stays EXACTLY as it is.** Do NOT fetch
+      `--json comments,closingIssuesReferences` in one call and do NOT restructure the existing call
+      sites: the payload an AUTHORIZATION is decided from must not change shape as a side effect of
+      adding a DIAGNOSTIC (it is the scanner's input, and the fixed measured shape is what licenses
+      reusing the scanner unmodified), and the probe must be reachable only from a branch that has
+      already failed to grant. The resolver is a **separate, later, best-effort** call issued only on
+      the `none` branch — so on every other state the call is **not made**, not merely ignored, which
+      is the only version the `gh` invocation-log assert can measure. The extra round-trip on a failing
+      run is the accepted cost.
 - [ ] 1.5 For each probed thread: `gh issue view <N> --json comments`, piped to **the same
       `$WAIVER_SCAN_TOOL`**, with **the same kind** and **the same** `base`/`head`/`job`/
       `$ROBOREV_WAIVER_AUTHORS` (and `observed` for the deferral). No new arguments, no new grammar, no
@@ -167,7 +183,9 @@ can set).
       probe bounded at N`, and the unprobed remainder is visible rather than silent.
 - [ ] 6.11 Structural assert that `scripts/flow/roborev-waiver-scan.py` is **unmodified** by this
       change (`git diff --name-only`), that no `closingIssuesReferences` consumer feeds a granting
-      branch, and that no PR-**body** read was reintroduced anywhere (`--json body`, a `#N` scan).
+      branch, that **no invocation requests `comments` and `closingIssuesReferences` in one call** and
+      the pre-existing `--json comments` invocation is unchanged (task 1.2b), and that no PR-**body**
+      read was reintroduced anywhere (`--json body`, a `#N` scan).
 - [ ] 6.12 Assert `scripts/agent-gate.sh` is unmodified.
 - [ ] 6.13 Run the suite and record the assertion-count delta; then plant the naive mutant for the
       escalation rule (probe on every state / escalate on any issue-side marker) in a scratch copy and

--- a/openspec/changes/roborev-waiver-misplaced/tasks.md
+++ b/openspec/changes/roborev-waiver-misplaced/tasks.md
@@ -1,0 +1,181 @@
+# Tasks — roborev-waiver-misplaced (issue #3759)
+
+Ordered. Each numbered group is independently reviewable; group 1 is the only new mechanism, groups
+2–4 wire it, group 5 is doctrine, group 6 is coverage.
+
+## 0. Confirm the premise before writing anything
+
+- [ ] 0.1 Verify from source (not memory) that `scripts/flow/roborev-waiver-scan.py` is
+      **thread-agnostic**: `main()` reads `{"comments":[…]}` from stdin and nothing in `scan()`,
+      `judge_waive_line()` or `judge_defer_line()` refers to a pull request. If that is false, STOP —
+      the whole design rests on one enforcer serving both threads.
+- [ ] 0.2 Verify that `gh issue view <N> --json comments` returns the **same shape** as
+      `gh pr view --json comments` (`{"comments":[{"author":{"login":…},"body":…}]}`). Record the
+      measurement. A shape difference means a translation layer, and a translation layer in an
+      authorization path needs its own review.
+- [ ] 0.3 Verify that `waiver:` and `deferral:` are **informational** keys — absent from the closed
+      verdict grammar scan and from the affirmation loop (`roborev-review.sh` ~`:163`, ~`:896`) — so a
+      new value there cannot make anything pass by itself. This is R2's structural argument; if it is
+      false, the grammar work has to be designed, not assumed.
+- [ ] 0.4 Confirm `scripts/agent-gate.sh` is out of scope and will end the change unmodified.
+
+## 1. The linked-issue probe (the only new mechanism)
+
+- [ ] 1.1 Add ONE helper to `scripts/flow/roborev-review-oracles.sh` — e.g.
+      `roborev_linked_issue_marker_probe <kind> <base> <head> <job> [<observed-count>]` — serving BOTH
+      kinds. Two copies of a probe over an authorization channel is two places for it to diverge.
+- [ ] 1.2 Resolve the linked issues **structurally**: `gh pr view --json closingIssuesReferences`.
+      **Never** scan the PR body — #3626 deleted that check because a PR body is editable by anyone
+      with write access with no per-edit attribution. Write the *mutable-derived, grants-nothing*
+      boundary as a comment AT THE CALL SITE (not only in `design.md`), because the next edit that adds
+      a granting consumer will read the code first.
+- [ ] 1.3 Validate each returned issue number **affirmatively** as digits before it is used or
+      emitted; a value that is not a number is a could-not-check cause, never interpolated raw.
+- [ ] 1.4 Probe each issue in **GitHub's returned order**, **bounded** (a named constant, with the
+      bound stated in the rendering when the declared set exceeds it). Report the **first** thread
+      carrying a matching marker; stop there.
+- [ ] 1.5 For each probed thread: `gh issue view <N> --json comments`, piped to **the same
+      `$WAIVER_SCAN_TOOL`**, with **the same kind** and **the same** `base`/`head`/`job`/
+      `$ROBOREV_WAIVER_AUTHORS` (and `observed` for the deferral). No new arguments, no new grammar, no
+      second scanner. The scanner file must end this change **unmodified**.
+- [ ] 1.6 Set the probe's outcome three ways and no more: `misplaced` + the issue number (the scanner
+      returned `granted`); `checked` (every probed thread read, no match); `no-subject` (no linked
+      issue declared); `could-not-check` + a cause. A partial read — one thread read, another
+      unavailable — is `could-not-check` naming BOTH halves, never `checked`.
+- [ ] 1.7 The helper NEVER returns non-zero and NEVER exits: a two-valued return would re-import the
+      collapse this change exists to remove. Every failure is a state with a cause.
+- [ ] 1.8 Do NOT run the deferral's `roborev_issue_retrievability` disposition leg issue-side. Record
+      the scoping in a comment: the rendering claims *"would have been accepted by the channel"*, not
+      *"would have granted"*, and the disposition legs run once the marker is on the PR.
+
+## 2. Wire it into the two lookup functions
+
+- [ ] 2.1 In `roborev_absence_waiver_lookup()`, after the recognised-state validation, call the probe
+      **only** when `ROBOREV_WAIVER_STATE = none`. On a probe `misplaced`, set
+      `ROBOREV_WAIVER_STATE="misplaced"` and put the issue number + remedy in
+      `ROBOREV_WAIVER_DETAIL`; otherwise leave the state at `none` and record the probe's declaration
+      in the detail.
+- [ ] 2.2 Same in `roborev_findings_deferral_lookup()`, for `ROBOREV_DEFERRAL_STATE` /
+      `ROBOREV_DEFERRAL_DETAIL`, passing the observed count through unchanged.
+- [ ] 2.3 Add `misplaced` to BOTH recognised-state `case` lists, with a comment saying it is a
+      **belt**: the probe assigns after the validation today, and the entry exists so a future refactor
+      that routes through it cannot rewrite an accurate diagnostic to a generic `unavailable`. State
+      that the list is a **recognition** list, not a granting list.
+- [ ] 2.4 Leave both granting gates exactly as they are —
+      `[ "$ROBOREV_WAIVER_STATE" = "granted" ]` / `[ "$ROBOREV_DEFERRAL_STATE" = "granted" ]`,
+      token-exact equality — and add no branch that treats `misplaced` as granting, partially granting,
+      or grant-with-a-notice.
+- [ ] 2.5 Confirm no probe call is made on `granted`, `unauthorized`, `stale`, `malformed`,
+      `count-mismatch` or `unavailable` — not merely that the state is not overwritten, but that the
+      network call is not made. A probe that runs and is ignored is latency and a future footgun.
+
+## 3. The two report arms (`scripts/flow/roborev-review-checks.sh`)
+
+- [ ] 3.1 Add a **dedicated** `misplaced)` arm to the `WAIVER_REPORT` case (~`:185-235`), before the
+      generic `*)`. The generic arm would render `MISPLACED (detail)` automatically — that is not
+      enough: this state's whole value is its **remedy text**, and a remedy is not something to leave
+      to a fall-through.
+- [ ] 3.2 Add the same dedicated `misplaced)` arm to the `DEFERRAL_REPORT` case (~`:565-655`).
+- [ ] 3.3 Both arms name: the issue number the marker was found on; that it **grants nothing and the
+      FAIL stands**; the remedy — **re-post the identical marker as a TOP-LEVEL COMMENT ON THE PR**;
+      and that only a marker on the PR grants. No part of either marker stem, and no fillable field
+      skeleton — point at `--help`.
+- [ ] 3.4 Extend both `none)` arms to carry the probe's declaration, from the closed rendering set:
+      `linked issue #N checked: no matching marker there either` /
+      `linked issues #A,#B checked — N of M declared, probe bounded at N: no matching marker` /
+      `no linked issue is declared on this PR, so no linked-issue thread was checked` /
+      `the linked-issue thread could NOT be checked: <cause>`. Keep the existing sole-content and
+      top-level teaching text; the declaration is additional, not a replacement.
+- [ ] 3.5 Verify every new interpolation passes through the ONE emit boundary
+      (`roborev_safe_line` / `safe_value`) — no per-site escape. Sweep the `gh` diagnostic and the
+      issue number specifically.
+- [ ] 3.6 Verify the block still carries exactly one `RESULT:` line and that no new value spans lines
+      (control characters rendered as visible escapes at the boundary).
+
+## 4. Key documentation and `--help`
+
+- [ ] 4.1 `scripts/flow/roborev-review.sh` header key documentation: add `MISPLACED (...)` to the
+      documented value sets of BOTH `waiver` and `deferral`, saying it is **non-granting** and
+      **informational**.
+- [ ] 4.2 `--help` (~`:487-489`): the *"THE COMMENT MUST BE TOP-LEVEL"* bullet currently names only a
+      review body and a review-thread reply. Add the **linked issue thread** as the **most probable**
+      misplacement, and name the new `MISPLACED` state and the lead-side verification step.
+- [ ] 4.3 Confirm no emitted `--help` or diagnostic text became newly pasteable as an authorization
+      (the form stays in `--help` only, which is already the one sanctioned location).
+
+## 5. Doctrine, in the same change (issue item 1 + item 3)
+
+- [ ] 5.1 `CLAUDE.md`, the **waiver** residual (*"the marker is read from top-level PR comments only,
+      so one posted inside a review body or a review-thread reply is silently not applied…"*): add the
+      **linked ISSUE thread** as the **most probable** of the three misplacements — that is where
+      lane/lead coordination lives — and record the new `MISPLACED` state, that it grants nothing, and
+      that the FAIL stands.
+- [ ] 5.2 `CLAUDE.md`, the **deferral** residual carrying the same sentence: the same correction. Both,
+      not one — a residual corrected in one of two places is a residual that reads as correct in the
+      other.
+- [ ] 5.3 Record issue item 3, the **lead-side procedure**: after posting either marker, verify with
+      `gh pr view <PR> --json comments` that the marker line is **on the PR**. *A grant is only granted
+      once it is readable by the scanner that reads it.*
+- [ ] 5.4 `scripts/flow/roborev-review-oracles.sh`: the SAME correction in BOTH "RESIDUALS" comment
+      blocks (the waiver's ~`:1128` and the deferral's ~`:1345`). These are the artifacts an
+      implementer actually reads; leaving them stale is how the doctrine gap regenerates.
+- [ ] 5.5 Website `agents-developing/roborev-findings/` — same content. **Publication verification is
+      POST-MERGE and cannot be done here**: the site is served from `main`, so grepping the served page
+      for a new phrase before this branch merges could only ever report `0`, which is the false signal
+      the "never by HTTP 200" rule exists to prevent. Record the phrase to grep in the PR body.
+
+## 6. Hermetic coverage (`scripts/tests/test_roborev_review_guard.sh`, gate `tooling-tests`)
+
+Read the existing suite first and reuse its idioms: the `gh` stub (`STUB_GH_COMMENTS`,
+`STUB_GH_COMMENTS_JSON`, `STUB_GH_RC`, `STUB_GH_ISSUES`, `STUB_GH_ISSUE_ERR`), `assert_no_marker_form`,
+`assert_one_result_line`, and **artifact substitution in a per-case scratch copy of the tree — never a
+path variable** (see the `WAIVER_SCAN_TOOL` comment: a test-only seam is one more thing a real invoker
+can set).
+
+- [ ] 6.1 Extend the `gh` stub for the two new calls: `pr view --json closingIssuesReferences` (a
+      fixturable linked-issue list, **defaulting to EMPTY** so a case that wants a probe has to SAY so
+      — the fail-closed direction, and it stops a case passing because the double was permissive) and
+      `issue view <N> --json comments` (per-issue comment fixtures, independently failable so a
+      partial-read case is expressible).
+- [ ] 6.2 **(a)** A would-have-granted `roborev-waive:` marker on the linked issue, nothing on the PR
+      ⇒ `waiver: MISPLACED` naming that issue, `prompt-content:` still FAIL, `RESULT: FAIL`.
+- [ ] 6.3 **(b)** The same for `roborev-defer:` ⇒ `deferral: MISPLACED` naming the issue,
+      `findings: PRESENT (n)` unchanged (never `DEFERRED`, never `NONE`), `RESULT: FAIL`.
+- [ ] 6.4 **(c)** A **stale** and a **malformed** issue-side marker ⇒ state stays `NONE` with the
+      probe's `checked` rendering (R3: escalation only from a would-have-granted marker). Include an
+      **unauthorized-author** issue-side marker in the same group.
+- [ ] 6.5 **(d)** A PR-side `stale` marker WITH a perfect issue-side marker ⇒ stays `STALE`, is not
+      overwritten, and — measured, not assumed — **no probe call was made** (assert against the stub's
+      invocation log).
+- [ ] 6.6 **(e)** No linked issue ⇒ `NONE` carrying the declared *"no linked issue is declared on this
+      PR"* rendering.
+- [ ] 6.7 **(f)** Probe unable to run — `gh issue view` fails / the payload is unparseable / the
+      relation call fails ⇒ `NONE` carrying the declared *could-not-check* rendering with its cause,
+      and the run still FAILs. Plus the **partial-read** case: one thread read, another unavailable ⇒
+      `could-not-check` naming both halves, never `checked`.
+- [ ] 6.8 **(g)** Positive control that `MISPLACED` reaches **no** granting path: `prompt-content:`
+      never reads `WAIVED` and `findings:` never reads `DEFERRED` under a `misplaced` state, in either
+      kind — paired with a **structural** assert that the only granting gates remain the two token-exact
+      `= "granted"` comparisons and that `misplaced` appears in no granting branch. Behavioural alone is
+      not enough here (it covers the fixtures someone thought of); structural alone is not enough either
+      (it cannot see a granting path built some other way).
+- [ ] 6.9 **(h)** `assert_no_marker_form` on **every** new diagnostic-emitting case — the MISPLACED
+      arms and all four `NONE` renderings — plus a keyword-bearing `gh` diagnostic and a
+      keyword-bearing author login on the issue-side path, proving the new values ride the existing
+      emit boundary rather than a new one.
+- [ ] 6.10 A **more-linked-issues-than-the-bound** case: the rendering declares `N of M declared,
+      probe bounded at N`, and the unprobed remainder is visible rather than silent.
+- [ ] 6.11 Structural assert that `scripts/flow/roborev-waiver-scan.py` is **unmodified** by this
+      change (`git diff --name-only`), that no `closingIssuesReferences` consumer feeds a granting
+      branch, and that no PR-**body** read was reintroduced anywhere (`--json body`, a `#N` scan).
+- [ ] 6.12 Assert `scripts/agent-gate.sh` is unmodified.
+- [ ] 6.13 Run the suite and record the assertion-count delta; then plant the naive mutant for the
+      escalation rule (probe on every state / escalate on any issue-side marker) in a scratch copy and
+      confirm it REDS — a case that passes against both the real code and its naive form measures
+      nothing.
+
+## 7. PR body (for whoever opens the PR — not the implementer's to tick)
+
+- [ ] 7.1 State that the **wrapper cannot certify itself**, that the **live demonstration is
+      post-merge**, and that `MISPLACED` is a **diagnosability** change that grants nothing.
+- [ ] 7.2 Record the website phrase to grep post-merge (task 5.5).

--- a/scripts/flow/roborev-review-checks.sh
+++ b/scripts/flow/roborev-review-checks.sh
@@ -216,7 +216,24 @@ roborev_check_prompt_content() {
           # merely "no waiver line exists" re-checks their SYNTAX — not the shape of the comment or the
           # channel — and concludes the mechanism is broken. Both rules are load-bearing and both are
           # invisible from a syntactically perfect marker, so the diagnostic states them.
-          none) WAIVER_REPORT="NONE (no waiver comment for this review: the marker must be the SOLE NONBLANK CONTENT of a TOP-LEVEL PR comment — a marker inside prose, a code fence, a quote or a review body is not read)" ;;
+          # THE `none` CAUSE ALSO DECLARES WHETHER THE LINKED-ISSUE THREAD WAS CHECKED (#3759).
+          # `NONE` used to be silent about it, so "checked and the marker is not there either" and
+          # "never checked" read identically — the same shape as a lane that omits coverage
+          # silently being indistinguishable from one that covers it. The declaration comes from
+          # the probe's CLOSED rendering set; the `:-` fallback is itself a could-not-check
+          # rendering, so a path that reached `none` without running the probe says so rather than
+          # implying a completed check.
+          none) WAIVER_REPORT="NONE (no waiver comment for this review: the marker must be the SOLE NONBLANK CONTENT of a TOP-LEVEL PR comment — a marker inside prose, a code fence, a quote or a review body is not read; ${ROBOREV_WAIVER_DETAIL:-the linked-issue thread could NOT be checked: the probe was not reached on this path})" ;;
+          # ===== A DEDICATED ARM, NOT A FALL-THROUGH (#3759) =====
+          # The generic `*)` arm below would render a syntactically correct `MISPLACED (<detail>)`
+          # and NO REMEDY — and this state's entire value IS its remedy. A remedy is not something
+          # to leave to a fall-through, so the arm is written out. It names (1) the issue the
+          # marker was found on (carried in the detail the probe built), (2) that it GRANTS NOTHING
+          # and the FAIL STANDS, and (3) the one operator action that fixes it. No part of either
+          # marker stem and no fillable field skeleton appears here — the exact form lives in
+          # `--help` only, because summary blocks get pasted into PR comments as a matter of course
+          # and an artifact that DESCRIBED the escape hatch became it once already (#3312 job 23).
+          misplaced) WAIVER_REPORT="MISPLACED (${ROBOREV_WAIVER_DETAIL:-an authorization for this review was found on a linked issue thread rather than on the pull request}. IT GRANTS NOTHING AND THIS FAIL STANDS — only an authorization on the PULL REQUEST is read. REMEDY: the authorizer re-posts the IDENTICAL line as a TOP-LEVEL COMMENT ON THE PR, as the sole nonblank content of that comment, then verifies with 'gh pr view <PR> --json comments' that it is there; run 'bash scripts/flow/roborev-review.sh --help' for the exact form, which is deliberately not printed here)" ;;
           *) WAIVER_REPORT="$(printf '%s' "$ROBOREV_WAIVER_STATE" | tr '[:lower:]' '[:upper:]') (${ROBOREV_WAIVER_DETAIL:-cause not established})" ;;
         esac
         # ===== LAYER 3 (roborev job 23): THIS DIAGNOSTIC MUST NOT BE A CREDENTIAL =====
@@ -635,7 +652,15 @@ roborev_check_findings_deferral() {
       # "no authorization exists" re-checks their SYNTAX — not the shape of the comment or the channel
       # — and concludes the mechanism is broken. Both rules are load-bearing and both are invisible
       # from a syntactically perfect marker, so the diagnostic states them.
-      none) DEFERRAL_REPORT="NONE (no findings-deferral comment for this review: the authorization must be the SOLE NONBLANK CONTENT of a TOP-LEVEL PR comment — one inside prose, a code fence, a quote or a review body is not read)" ;;
+      # AND IT DECLARES WHETHER THE LINKED-ISSUE THREAD WAS CHECKED (#3759) — see the waiver's
+      # `none` arm for why a silent `NONE` is the defect. Same closed rendering set, same
+      # could-not-check fallback.
+      none) DEFERRAL_REPORT="NONE (no findings-deferral comment for this review: the authorization must be the SOLE NONBLANK CONTENT of a TOP-LEVEL PR comment — one inside prose, a code fence, a quote or a review body is not read; ${ROBOREV_DEFERRAL_DETAIL:-the linked-issue thread could NOT be checked: the probe was not reached on this path})" ;;
+      # ===== A DEDICATED ARM, NOT A FALL-THROUGH (#3759) — see the waiver's arm for the reason ====
+      # The detail additionally records that the issue-disposition legs are NOT run issue-side and
+      # still apply once the marker is on the PR, so the rendering claims "would have been ACCEPTED
+      # BY THE CHANNEL" and never "would have granted".
+      misplaced) DEFERRAL_REPORT="MISPLACED (${ROBOREV_DEFERRAL_DETAIL:-an authorization for this review was found on a linked issue thread rather than on the pull request}. IT GRANTS NOTHING AND THIS FAIL STANDS — only an authorization on the PULL REQUEST is read. REMEDY: the authorizer re-posts the IDENTICAL line as a TOP-LEVEL COMMENT ON THE PR, as the sole nonblank content of that comment, then verifies with 'gh pr view <PR> --json comments' that it is there; run 'bash scripts/flow/roborev-review.sh --help' for the exact form, which is deliberately not printed here)" ;;
       *) DEFERRAL_REPORT="$(printf '%s' "$ROBOREV_DEFERRAL_STATE" | tr '[:lower:]' '[:upper:]') (${ROBOREV_DEFERRAL_DETAIL:-cause not established})" ;;
     esac
     # THE EXACT MARKER FORM IS NOT PRINTED HERE, and not even its prefix — summary blocks are pasted

--- a/scripts/flow/roborev-review-oracles.sh
+++ b/scripts/flow/roborev-review-oracles.sh
@@ -1240,9 +1240,10 @@ ROBOREV_LINKED_ISSUE_PROBE_MAX=3
 
 roborev_linked_issue_marker_probe() { # <kind> <base> <head> <job> [<observed-findings-count>]
   local kind="$1" base="$2" head="$3" job="$4" observed="${5:-}"
-  local rel_errfile rel_json rel_errtext numbers declared probed=0
+  local rel_errfile rel_json rel_errtext numbers declared probed=0 skipped_cross=0
   local issue read_ok=() unread=() comments result state scan_rc
-  local issue_errfile issue_errtext read_list unread_list bound_clause
+  local issue_errfile issue_errtext read_list unread_list bound_clause cross_clause suffix
+  local repo_nwo repo_errfile repo_errtext
   ROBOREV_PROBE_OUTCOME="could-not-check"
   # THE STRUCTURED VALUE, KEPT BESIDE THE RENDERED ONE ON PURPOSE. `_DETAIL` is prose for a human;
   # `_ISSUE` is the number as data, so a later consumer (or a test) never has to parse the number back
@@ -1261,6 +1262,54 @@ roborev_linked_issue_marker_probe() { # <kind> <base> <head> <job> [<observed-fi
     ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: no temporary file could be created to capture the 'gh' diagnostic"
     return 0
   fi
+  # ===== WHICH REPOSITORY WILL `gh issue view <N>` RESOLVE AGAINST? ASK, DO NOT ASSUME (#3759 r1) =====
+  # A closing reference carries a REPOSITORY-SCOPED number, and `gh issue view "$issue"` resolves that
+  # number in the CURRENT repository. So a CROSS-REPOSITORY closing reference — which a PR body can
+  # declare, and a PR body is editable by anyone with write access — used to send the probe at a
+  # DIFFERENT issue that merely shares a number. Two bad outcomes, and the first is worse than having
+  # no probe at all: a false `MISPLACED` naming a thread that never carried a marker, which sends the
+  # operator somewhere pointless and spends the diagnostic's credibility; or the real thread missed.
+  #
+  # THE RESOLUTION IS THE SKIP, NOT A URL. The relation also carries the full identity (`repository`,
+  # `url`), so the probe COULD follow a cross-repo reference by URL. It deliberately does not:
+  #   * the reference is derived from the MUTABLE PR body, and handing an arbitrary, attacker-choosable
+  #     repository URL to `gh` widens what this call can be pointed at — on a path whose entire
+  #     justification is "it grants nothing, it only selects which thread to NAME";
+  #   * the incident this mechanism exists for is a SAME-REPOSITORY coordination thread (PR #3710 ->
+  #     issue #3544 in this repository), which is where lane/lead coordination lives; and
+  #   * skipping is the fail-closed direction — the worst case is a `NONE` that DECLARES the skip,
+  #     never a MISPLACED naming the wrong thread.
+  # SO IT IS AN EXPLICIT, DECLARED SKIP (R5), counted and named in the rendering, NEVER a silent one:
+  # a probe that omits coverage silently is indistinguishable from one that covers it.
+  #
+  # `gh repo view --json nameWithOwner` is the RIGHT oracle rather than a convenient one: it answers
+  # exactly the question asked — which repository does `gh` resolve HERE — using the same base-repo
+  # resolution `gh issue view <N>` uses. Deriving it by parsing the PR's own URL would be a second,
+  # weaker implementation of that resolution. A failure is a could-not-check: with the current
+  # repository unknown, "same repository" cannot be established AFFIRMATIVELY for any reference, and
+  # an unestablished identity must never inherit the probing branch.
+  if ! repo_errfile="$(mktemp 2>/dev/null)"; then
+    rm -f "$rel_errfile"
+    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: no temporary file could be created to capture the 'gh' diagnostic"
+    return 0
+  fi
+  if ! repo_nwo="$(cd "$REPO" && gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>"$repo_errfile")"; then
+    repo_errtext="$(tr -d '\r' <"$repo_errfile" | tr '\n' ' ')"
+    rm -f "$repo_errfile" "$rel_errfile"
+    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: 'gh repo view --json nameWithOwner' failed (${repo_errtext:-no diagnostic was produced}), so which repository a closing reference points at could not be established"
+    return 0
+  fi
+  rm -f "$repo_errfile"
+  # AFFIRMATIVE SHAPE TEST on the identity itself, for the same reason each issue number gets one: it
+  # is remote text, and it is the value every same-repository decision below is compared against.
+  case "$repo_nwo" in
+    */*) ;;
+    *)
+      rm -f "$rel_errfile"
+      ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: 'gh repo view --json nameWithOwner' did not answer with an owner/name pair, so which repository a closing reference points at could not be established"
+      return 0
+      ;;
+  esac
   # ===== THE LINKED ISSUE COMES FROM THE STRUCTURED RELATION, NEVER FROM THE PR BODY (#3626) =====
   # #3626 DELETED a PR-body link requirement, and not because Markdown is hard to parse: A PULL-REQUEST
   # BODY IS EDITABLE AT ANY TIME BY ANYONE WITH WRITE ACCESS, WITH NO PER-EDIT ATTRIBUTION, while a
@@ -1301,8 +1350,12 @@ roborev_linked_issue_marker_probe() { # <kind> <base> <head> <job> [<observed-fi
   # for digits itself. Two affirmative tests rather than one because the shell is what interpolates
   # into an emitted diagnostic, and a value that reaches a renderer must have been judged by the
   # process that renders it.
-  if ! numbers="$(printf '%s' "$rel_json" | python3 -c '
-import json, sys
+  if ! numbers="$(printf '%s' "$rel_json" | PROBE_REPO_NWO="$repo_nwo" python3 -c '
+import json, os, sys
+# The current repository, as `gh` itself resolves it. Compared CASE-INSENSITIVELY because GitHub
+# owner and repository names are case-insensitive, so `PMcFadin/CQLite` and `pmcfadin/cqlite` are one
+# repository and treating them as two would produce a declared skip for a same-repository reference.
+want_repo = " ".join(os.environ.get("PROBE_REPO_NWO", "").split()).lower()
 try:
     data = json.load(sys.stdin)
 except ValueError:
@@ -1323,17 +1376,50 @@ if "closingIssuesReferences" not in data:
 refs = data["closingIssuesReferences"]
 if not isinstance(refs, list):
     sys.exit(1)
+
+def ref_repo(ref):
+    """owner/name for a reference, lowercased, or None when it cannot be established.
+
+    THREE-VALUED BY CONSTRUCTION: the caller must be able to tell "another repository" from "could
+    not tell which repository", because they are different verdicts — the first is a declared skip
+    and the second is a could-not-check. Collapsing them would put an unestablished identity on the
+    permissive side of a comparison.
+    """
+    repo = ref.get("repository")
+    if not isinstance(repo, dict):
+        return None
+    name = repo.get("name")
+    owner = repo.get("owner")
+    login = owner.get("login") if isinstance(owner, dict) else None
+    if not isinstance(name, str) or not isinstance(login, str) or not name or not login:
+        return None
+    return ("%s/%s" % (login, name)).lower()
+
+
 for ref in refs:
     n = ref.get("number") if isinstance(ref, dict) else None
     if isinstance(n, bool):
         n = None
     if isinstance(n, int):
-        sys.stdout.write("%d\n" % n)
-    elif isinstance(n, str) and n.isdigit() and n:
-        sys.stdout.write("%s\n" % n)
-    else:
+        n = "%d" % n
+    elif not (isinstance(n, str) and n and n.isdigit()):
+        n = None
+    if n is None:
         # NEVER the raw value: an unrecognised entry is reported as a KIND, not as text.
         sys.stdout.write("NON-NUMERIC\n")
+        continue
+    # ===== THE NUMBER IS ONLY USABLE IF IT NAMES *THIS* REPOSITORY (#3759 round 1, finding 1) =====
+    # A closing reference number is REPOSITORY-SCOPED and `gh issue view <N>` resolves it in the
+    # current repository, so a number from another repository would probe a DIFFERENT issue that
+    # merely shares it. Keyed on the AFFIRMATIVE match: only a reference whose repository was read
+    # and EQUALS this one yields a probeable number.
+    have_repo = ref_repo(ref)
+    if have_repo is None or not want_repo:
+        sys.stdout.write("REPO-UNVERIFIED\n")
+    elif have_repo == want_repo:
+        sys.stdout.write("%s\n" % n)
+    else:
+        sys.stdout.write("CROSS-REPO\n")
 ' 2>/dev/null)"; then
     ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: the closingIssuesReferences payload was not readable as a JSON object carrying a closingIssuesReferences LIST (it was unparseable, a non-object, missing that key, or null) — that is a broken payload, NOT an empty relation, and the two must never render alike"
     return 0
@@ -1349,7 +1435,24 @@ for ref in refs:
   # order GitHub returns is the only one attributable to something outside this code.
   for issue in $numbers; do
     [ "$probed" -lt "$ROBOREV_LINKED_ISSUE_PROBE_MAX" ] || break
+    # THE TOKEN SET IS CLOSED, AND EACH NON-NUMERIC TOKEN HAS ITS OWN DISPOSITION. `CROSS-REPO` is a
+    # DECLARED SKIP (a reference we affirmatively established points elsewhere, and deliberately do
+    # not follow — see the header above the resolver call); `REPO-UNVERIFIED` is a COULD-NOT-CHECK
+    # (we could not establish where it points, which is not the same fact and must not read alike);
+    # anything else is a malformed entry. All three consume a bound slot, because the bound is on
+    # references EXAMINED and each of these was examined. The final `*[!0-9]*` arm is the fail-closed
+    # catch: a token this code has never judged is a could-not-check, never a probeable number.
     case "$issue" in
+      CROSS-REPO)
+        probed=$(( probed + 1 ))
+        skipped_cross=$(( skipped_cross + 1 ))
+        continue
+        ;;
+      REPO-UNVERIFIED)
+        probed=$(( probed + 1 ))
+        unread+=("an entry whose repository could not be established, so whether its number names an issue in THIS repository is unknown")
+        continue
+        ;;
       ''|*[!0-9]*)
         probed=$(( probed + 1 ))
         unread+=("an entry that is not an issue number")
@@ -1433,19 +1536,34 @@ for ref in refs:
   if [ "$probed" -lt "$declared" ]; then
     bound_clause=" — $probed of $declared declared examined, probe bounded at $ROBOREV_LINKED_ISSUE_PROBE_MAX, $(( declared - probed )) never looked at"
   fi
+  # THE DECLARED CROSS-REPOSITORY SKIP IS NAMED ON EVERY RENDERING IT APPLIES TO, for the same reason
+  # the bound clause is: a skip nobody is told about is indistinguishable from coverage.
+  cross_clause=""
+  if [ "$skipped_cross" -gt 0 ]; then
+    cross_clause=" — $skipped_cross cross-repository closing reference(s) declared and deliberately NOT probed (a reference's number is scoped to ITS repository, so following one here could only name the wrong thread)"
+  fi
+  suffix="$bound_clause$cross_clause"
   # ===== A PARTIAL READ IS `could-not-check` NAMING BOTH HALVES, NEVER `checked` =====
   if [ -n "$unread_list" ]; then
     ROBOREV_PROBE_OUTCOME="could-not-check"
-    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: read with no matching marker: ${read_list:-none}; NOT read: $unread_list$bound_clause"
+    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: read with no matching marker: ${read_list:-none}; NOT read: $unread_list$suffix"
     return 0
   fi
-  if [ -n "$bound_clause" ]; then
-    ROBOREV_PROBE_OUTCOME="checked"
-    ROBOREV_PROBE_DETAIL="linked issues $read_list checked$bound_clause: no matching marker"
+  if [ -z "$read_list" ] && [ -z "$bound_clause" ]; then
+    # NOTHING WAS READ AND NOTHING WAS CUT OFF, so every declared reference was a declared skip. This
+    # is rendering 3's slot — no thread was checked — with the reason named, NOT a fifth outcome and
+    # NOT the bare "no linked issue is declared", which would be false: references ARE declared, they
+    # just do not point here.
+    ROBOREV_PROBE_OUTCOME="no-subject"
+    ROBOREV_PROBE_DETAIL="no linked issue IN THIS REPOSITORY is declared on this PR, so no linked-issue thread was checked$cross_clause"
     return 0
   fi
   ROBOREV_PROBE_OUTCOME="checked"
-  if [ "$declared" -eq 1 ]; then
+  if [ -n "$suffix" ]; then
+    ROBOREV_PROBE_DETAIL="linked issues ${read_list:-none} checked$suffix: no matching marker"
+    return 0
+  fi
+  if [ "${#read_ok[@]}" -eq 1 ]; then
     ROBOREV_PROBE_DETAIL="linked issue $read_list checked: no matching marker there either"
   else
     ROBOREV_PROBE_DETAIL="linked issues $read_list checked: no matching marker there either"

--- a/scripts/flow/roborev-review-oracles.sh
+++ b/scripts/flow/roborev-review-oracles.sh
@@ -1730,18 +1730,40 @@ for ref in refs:
     ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: read with no matching marker: ${read_list:-none}; NOT read: $unread_list$suffix$read_limit"
     return 0
   fi
-  if [ -z "$read_list" ] && [ -z "$bound_clause" ]; then
-    # NOTHING WAS READ AND NOTHING WAS CUT OFF, so every declared reference was a declared skip. This
-    # is rendering 3's slot — no thread was checked — with the reason named, NOT a fifth outcome and
-    # NOT the bare "no linked issue is declared", which would be false: references ARE declared, they
-    # just do not point here.
-    ROBOREV_PROBE_OUTCOME="no-subject"
-    ROBOREV_PROBE_DETAIL="no linked issue IN THIS REPOSITORY is declared on this PR, so no linked-issue thread was checked$cross_clause"
+  # ===== NOTHING READ IS NEVER `checked`, WHATEVER ELSE HAPPENED (#3759 round 5) =====
+  # THE DEFECT THIS CLOSES: this branch used to be guarded by
+  # `[ -z "$read_list" ] && [ -z "$bound_clause" ]`, so an empty `read_list` with a NON-empty bound
+  # clause — the probe bound exhausted by cross-repository skips BEFORE it reached any
+  # same-repository reference — fell through to the `checked` rendering and printed
+  # `linked issues none checked … no matching marker`: a confident NEGATIVE derived from ZERO reads.
+  # That is the same false confidence the identity grammar and the validated read were each built to
+  # remove, arriving through the RENDERING rather than the VALIDATION. So the empty-`read_list` case
+  # is now decided FIRST and INDEPENDENTLY of the bound, and neither of its forms may carry the
+  # "no matching marker" clause — a claim about content nobody looked at — nor the read limit, which
+  # declares what a READ does not establish and therefore presupposes one.
+  if [ -z "$read_list" ]; then
+    if [ -n "$bound_clause" ]; then
+      # REFERENCES REMAIN UNEXAMINED, so a subject may well exist and we simply never reached it.
+      # That is not `no-subject`, which would assert that none is declared, and it is emphatically not
+      # `checked`. The probe did not check, and the bound clause names how much it did not look at.
+      ROBOREV_PROBE_OUTCOME="could-not-check"
+      ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: no thread was read$suffix"
+    else
+      # NOTHING WAS READ AND NOTHING WAS CUT OFF, so every declared reference was a declared skip.
+      # This is rendering 3's slot — no thread was checked — with the reason named, NOT a fifth
+      # outcome and NOT the bare "no linked issue is declared", which would be false: references ARE
+      # declared, they just do not point here.
+      ROBOREV_PROBE_OUTCOME="no-subject"
+      ROBOREV_PROBE_DETAIL="no linked issue IN THIS REPOSITORY is declared on this PR, so no linked-issue thread was checked$cross_clause"
+    fi
     return 0
   fi
+  # Past this point at least one thread WAS read, so the renderings below may speak about content.
+  # `$read_list` is interpolated with NO `:-none` fallback, deliberately: such a fallback is exactly
+  # what let "none" be reported as checked.
   ROBOREV_PROBE_OUTCOME="checked"
   if [ -n "$suffix" ]; then
-    ROBOREV_PROBE_DETAIL="linked issues ${read_list:-none} checked$suffix: no matching marker$read_limit"
+    ROBOREV_PROBE_DETAIL="linked issues $read_list checked$suffix: no matching marker$read_limit"
     return 0
   fi
   if [ "${#read_ok[@]}" -eq 1 ]; then

--- a/scripts/flow/roborev-review-oracles.sh
+++ b/scripts/flow/roborev-review-oracles.sh
@@ -1307,9 +1307,20 @@ try:
     data = json.load(sys.stdin)
 except ValueError:
     sys.exit(1)
-refs = data.get("closingIssuesReferences") if isinstance(data, dict) else None
-if refs is None:
-    refs = []
+# ===== THE SHAPE IS TESTED AFFIRMATIVELY; NOTHING UNREADABLE BECOMES AN ANSWER (#3759 round 1) =====
+# This used to read `data.get(...) if isinstance(data, dict) else None` and then coerce a `None` to
+# `[]`, so FOUR different unreadable payloads — a non-object top level, a MISSING
+# `closingIssuesReferences` key, an explicit `null`, and a non-list value — all arrived at the
+# shell as ZERO declared references and rendered "no linked issue is declared on this PR". That is
+# an ANSWER derived from a payload that could not be read: the permissive-branch-inherits-the-
+# unknown-state shape this whole file is written against. `gh pr view --json closingIssuesReferences`
+# ALWAYS returns the key it was asked for, so its absence is a broken payload and never an empty
+# relation. Each of these is now a NON-ZERO exit, which the caller renders as could-not-check.
+if not isinstance(data, dict):
+    sys.exit(1)
+if "closingIssuesReferences" not in data:
+    sys.exit(1)
+refs = data["closingIssuesReferences"]
 if not isinstance(refs, list):
     sys.exit(1)
 for ref in refs:
@@ -1324,7 +1335,7 @@ for ref in refs:
         # NEVER the raw value: an unrecognised entry is reported as a KIND, not as text.
         sys.stdout.write("NON-NUMERIC\n")
 ' 2>/dev/null)"; then
-    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: the closingIssuesReferences payload could not be parsed"
+    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: the closingIssuesReferences payload was not readable as a JSON object carrying a closingIssuesReferences LIST (it was unparseable, a non-object, missing that key, or null) — that is a broken payload, NOT an empty relation, and the two must never render alike"
     return 0
   fi
   declared=0

--- a/scripts/flow/roborev-review-oracles.sh
+++ b/scripts/flow/roborev-review-oracles.sh
@@ -1242,8 +1242,11 @@ roborev_linked_issue_marker_probe() { # <kind> <base> <head> <job> [<observed-fi
   local kind="$1" base="$2" head="$3" job="$4" observed="${5:-}"
   local rel_errfile rel_json rel_errtext numbers declared probed=0
   local issue read_ok=() unread=() comments result state scan_rc
-  local issue_errfile issue_errtext
+  local issue_errfile issue_errtext read_list unread_list
   ROBOREV_PROBE_OUTCOME="could-not-check"
+  # THE STRUCTURED VALUE, KEPT BESIDE THE RENDERED ONE ON PURPOSE. `_DETAIL` is prose for a human;
+  # `_ISSUE` is the number as data, so a later consumer (or a test) never has to parse the number back
+  # out of a diagnostic string — re-parsing a rendered value is the shape this file exists to refuse.
   ROBOREV_PROBE_ISSUE=""
   ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: the probe was never asked"
   if ! command -v gh >/dev/null 2>&1; then
@@ -1400,10 +1403,16 @@ for ref in refs:
       return 0
     fi
   done
+  # Joined explicitly rather than through `${arr[*]}` + IFS: the separator is part of the rendering a
+  # human reads, and a trailing one (what `printf '%s; '` leaves) reads as a truncated list.
+  read_list=""
+  for issue in ${read_ok[@]+"${read_ok[@]}"}; do read_list="${read_list:+$read_list,}$issue"; done
+  unread_list=""
+  for issue in ${unread[@]+"${unread[@]}"}; do unread_list="${unread_list:+$unread_list; }$issue"; done
   # ===== A PARTIAL READ IS `could-not-check` NAMING BOTH HALVES, NEVER `checked` =====
-  if [ "${#unread[@]}" -gt 0 ]; then
+  if [ -n "$unread_list" ]; then
     ROBOREV_PROBE_OUTCOME="could-not-check"
-    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: read with no matching marker: ${read_ok[*]:-none}; NOT read: $(printf '%s; ' "${unread[@]}")"
+    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: read with no matching marker: ${read_list:-none}; NOT read: $unread_list"
     return 0
   fi
   if [ "$probed" -lt "$declared" ]; then
@@ -1411,14 +1420,14 @@ for ref in refs:
     # `0 RECOGNISED` rather than a bare `0`. A lane that omits coverage silently is
     # indistinguishable from one that covers it.
     ROBOREV_PROBE_OUTCOME="checked"
-    ROBOREV_PROBE_DETAIL="linked issues ${read_ok[*]} checked — $probed of $declared declared, probe bounded at $ROBOREV_LINKED_ISSUE_PROBE_MAX: no matching marker"
+    ROBOREV_PROBE_DETAIL="linked issues $read_list checked — $probed of $declared declared, probe bounded at $ROBOREV_LINKED_ISSUE_PROBE_MAX: no matching marker"
     return 0
   fi
   ROBOREV_PROBE_OUTCOME="checked"
   if [ "$declared" -eq 1 ]; then
-    ROBOREV_PROBE_DETAIL="linked issue ${read_ok[*]} checked: no matching marker there either"
+    ROBOREV_PROBE_DETAIL="linked issue $read_list checked: no matching marker there either"
   else
-    ROBOREV_PROBE_DETAIL="linked issues ${read_ok[*]} checked: no matching marker there either"
+    ROBOREV_PROBE_DETAIL="linked issues $read_list checked: no matching marker there either"
   fi
   return 0
 }

--- a/scripts/flow/roborev-review-oracles.sh
+++ b/scripts/flow/roborev-review-oracles.sh
@@ -1242,7 +1242,7 @@ roborev_linked_issue_marker_probe() { # <kind> <base> <head> <job> [<observed-fi
   local kind="$1" base="$2" head="$3" job="$4" observed="${5:-}"
   local rel_errfile rel_json rel_errtext numbers declared probed=0
   local issue read_ok=() unread=() comments result state scan_rc
-  local issue_errfile issue_errtext read_list unread_list
+  local issue_errfile issue_errtext read_list unread_list bound_clause
   ROBOREV_PROBE_OUTCOME="could-not-check"
   # THE STRUCTURED VALUE, KEPT BESIDE THE RENDERED ONE ON PURPOSE. `_DETAIL` is prose for a human;
   # `_ISSUE` is the number as data, so a later consumer (or a test) never has to parse the number back
@@ -1420,18 +1420,28 @@ for ref in refs:
   for issue in ${read_ok[@]+"${read_ok[@]}"}; do read_list="${read_list:+$read_list,}$issue"; done
   unread_list=""
   for issue in ${unread[@]+"${unread[@]}"}; do unread_list="${unread_list:+$unread_list; }$issue"; done
+  # ===== THE BOUND CLAUSE IS COMPUTED ONCE AND APPENDED TO WHICHEVER RENDERING FIRES =====
+  # (#3759 round 1, finding 3.) The remainder used to be named on the `checked` rendering ALONE, so a
+  # read that FAILED inside the bounded prefix returned through the could-not-check branch and the
+  # diagnostic never said that part of the declared set had also never been looked at. That is the
+  # same family as finding 2 one step along: a rendering claiming more completeness than the probe
+  # achieved. THE UNPROBED REMAINDER IS NAMED WHEREVER IT EXISTS, never implied — the same reason the
+  # gate prints `0 RECOGNISED` rather than a bare `0`, and the reason a partial read may not take the
+  # `checked` rendering. `probed` counts references EXAMINED (a read attempt, a declared skip or a
+  # malformed entry all consume one), so `declared - probed` is exactly what the bound cut off.
+  bound_clause=""
+  if [ "$probed" -lt "$declared" ]; then
+    bound_clause=" — $probed of $declared declared examined, probe bounded at $ROBOREV_LINKED_ISSUE_PROBE_MAX, $(( declared - probed )) never looked at"
+  fi
   # ===== A PARTIAL READ IS `could-not-check` NAMING BOTH HALVES, NEVER `checked` =====
   if [ -n "$unread_list" ]; then
     ROBOREV_PROBE_OUTCOME="could-not-check"
-    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: read with no matching marker: ${read_list:-none}; NOT read: $unread_list"
+    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: read with no matching marker: ${read_list:-none}; NOT read: $unread_list$bound_clause"
     return 0
   fi
-  if [ "$probed" -lt "$declared" ]; then
-    # THE UNPROBED REMAINDER IS NAMED, NEVER IMPLIED — the same reason the gate prints
-    # `0 RECOGNISED` rather than a bare `0`. A lane that omits coverage silently is
-    # indistinguishable from one that covers it.
+  if [ -n "$bound_clause" ]; then
     ROBOREV_PROBE_OUTCOME="checked"
-    ROBOREV_PROBE_DETAIL="linked issues $read_list checked — $probed of $declared declared, probe bounded at $ROBOREV_LINKED_ISSUE_PROBE_MAX: no matching marker"
+    ROBOREV_PROBE_DETAIL="linked issues $read_list checked$bound_clause: no matching marker"
     return 0
   fi
   ROBOREV_PROBE_OUTCOME="checked"

--- a/scripts/flow/roborev-review-oracles.sh
+++ b/scripts/flow/roborev-review-oracles.sh
@@ -1209,7 +1209,29 @@ WAIVER_SCAN_TOOL="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/roborev-waiver-s
 # one grammar drift, and a drift here produces a CONFIDENT declared skip from an unvalidated identity,
 # which is the false confidence this whole feature exists to remove. So the pattern is written here
 # and is the only one either side uses: the shell interpolates it, and the python leg receives it.
-ROBOREV_GH_NAME_RE='[A-Za-z0-9._-]+'
+#
+# ===== AND "DEFINED ONCE" IS NOT "INTERPRETED IDENTICALLY" (#3759 round 6) =====
+# THE FALSIFICATION OF THE INVARIANT ABOVE, which is why this is a fix and not an edge case bolted on.
+# The class used to be `[A-Za-z0-9._-]+`, i.e. RANGES — and a range inside a bracket expression is
+# resolved by the LOCALE's collation in POSIX regex, while Python's `re` resolves it by CODEPOINT.
+# MEASURED ON THIS FLEET, not theorised: under `LC_ALL=en_US.utf8`, bash matches `é`, `ǅ`, `İ` and `ß`
+# against `^[A-Za-z0-9._-]+$`; Python refuses all four. So a malformed current-repository identity
+# could pass the shell check and then fail `ref_repo()`, and a SAME-repository reference would be
+# reported as a cross-repository DECLARED SKIP — the feature silently declining to probe the one
+# thread that matters. One definition with two meanings is precisely the second-implementation hazard
+# this hoist was supposed to remove, and a documented invariant that is untrue is worse than one never
+# claimed.
+#
+# THE CLASS IS THEREFORE ENUMERATED, NOT RANGED: with no range there is no collation to consult, so
+# both consumers read exactly these bytes in every locale.
+#
+# WHY NOT `LC_ALL=C` INSTEAD, which would also fix it: it fixes the shell side by changing the
+# ENVIRONMENT rather than the DATA, and this function runs `gh` and `python3` as children. A locale
+# forced for a regex would have to be scoped so it cannot reach them — `gh`'s and the scanner's output
+# and diagnostics are consumed here — and a scoping that must not leak is a thing to get wrong later,
+# for a benefit an enumerated class delivers with no environment at all. Verbosity is the whole cost.
+# `-` is LAST so it is a literal in both grammars, and `.` is literal inside a bracket in both.
+ROBOREV_GH_NAME_RE='[ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-]+'
 
 # roborev_json_list_field <json> <field>: is this payload a top-level JSON OBJECT whose <field> is a
 # LIST? Sets, and never returns non-zero:

--- a/scripts/flow/roborev-review-oracles.sh
+++ b/scripts/flow/roborev-review-oracles.sh
@@ -1302,14 +1302,18 @@ roborev_linked_issue_marker_probe() { # <kind> <base> <head> <job> [<observed-fi
   rm -f "$repo_errfile"
   # AFFIRMATIVE SHAPE TEST on the identity itself, for the same reason each issue number gets one: it
   # is remote text, and it is the value every same-repository decision below is compared against.
-  case "$repo_nwo" in
-    */*) ;;
-    *)
-      rm -f "$rel_errfile"
-      ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: 'gh repo view --json nameWithOwner' did not answer with an owner/name pair, so which repository a closing reference points at could not be established"
-      return 0
-      ;;
-  esac
+  # A BARE `*/*` IS TOO LOOSE, AND ITS FAILURE MODE IS THE WORST ONE ON THIS PATH (#3759 r2, found
+  # while fixing the class): `x/`, `/x`, `a/b/c` and a whitespace- or newline-bearing answer all match
+  # it, and an identity that matches nothing then makes EVERY reference compare unequal — so the probe
+  # renders a confident "these references point at another repository" DECLARED SKIP, an answer about
+  # the pull request derived from an identity nobody established. The pattern is therefore exactly one
+  # `owner/name` pair over GitHub's own character set, so anything else takes the could-not-check
+  # branch with the rest of the class.
+  if [[ ! "$repo_nwo" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+    rm -f "$rel_errfile"
+    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: 'gh repo view --json nameWithOwner' did not answer with a single owner/name pair, so which repository a closing reference points at could not be established"
+    return 0
+  fi
   # ===== THE LINKED ISSUE COMES FROM THE STRUCTURED RELATION, NEVER FROM THE PR BODY (#3626) =====
   # #3626 DELETED a PR-body link requirement, and not because Markdown is hard to parse: A PULL-REQUEST
   # BODY IS EDITABLE AT ANY TIME BY ANYONE WITH WRITE ACCESS, WITH NO PER-EDIT ATTRIBUTION, while a
@@ -1471,6 +1475,39 @@ for ref in refs:
       continue
     fi
     rm -f "$issue_errfile"
+    # ===== THE PAYLOAD IS VALIDATED AFFIRMATIVELY BEFORE ANY CONCLUSION IS DRAWN FROM IT (#3759 r2) =
+    # A ZERO EXIT FROM THE SCANNER IS NOT "THE THREAD WAS READ". The scanner coerces a valid-JSON but
+    # malformed payload — `{}`, `{"comments": null}`, `{"comments": {}}` — to an EMPTY comment list
+    # and exits 0, which is CORRECT for its own contract (*given these comments, is there an
+    # authorization in them?* — over no comments, the answer is no). It is this CALLER that then drew
+    # the unwarranted conclusion, rendering "checked: no matching marker" over a thread nothing was
+    # ever read from. The scanner is reused UNMODIFIED by design, so the validation belongs here.
+    #
+    # AND THIS IS THE INVARIANT, NOT THE SITE. Round 1 fixed the same collapse on the RELATION payload
+    # and left the sibling input on the same path with it. The rule for this whole probe is: EVERY
+    # INPUT IS VALIDATED AFFIRMATIVELY, AND "COULD NOT TELL" NEVER COLLAPSES ONTO AN ANSWER. The
+    # inputs are the current-repository identity, the relation payload, each reference's
+    # classification token, this comments payload, the scanner's exit status and the scanner's
+    # `state=` — all six now have an affirmative test, and a new input on this path needs one too.
+    if ! printf '%s' "$comments" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except ValueError:
+    sys.exit(1)
+# The object form is what `gh issue view --json comments` emits, measured; a bare top-level list is
+# refused even though the scanner would accept one, because a shape `gh` does not produce is a shape
+# nobody established, and a false could-not-check is the fail-closed direction.
+if not isinstance(data, dict):
+    sys.exit(1)
+if "comments" not in data:
+    sys.exit(1)
+if not isinstance(data["comments"], list):
+    sys.exit(1)
+' 2>/dev/null; then
+      unread+=("#$issue (its comments payload was not a JSON object carrying a comments LIST, so nothing was actually read from that thread — the scanner would have reduced it to zero comments and exited 0, which is NOT a check)")
+      continue
+    fi
     # THE SAME SCANNER, THE SAME KIND, THE SAME SCOPE, THE SAME ALLOWLIST. No new argument, no new
     # grammar, no thread parameter — see the header. The deferral additionally passes the SAME
     # observed count, so `count=` is matched identically on both threads.
@@ -1480,10 +1517,31 @@ for ref in refs:
       result="$(printf '%s' "$comments" | python3 "$WAIVER_SCAN_TOOL" "$kind" "$base" "$head" "$job" "$ROBOREV_WAIVER_AUTHORS" 2>/dev/null)" && scan_rc=0 || scan_rc=1
     fi
     if [ "$scan_rc" -ne 0 ]; then
-      unread+=("#$issue (its comments payload could not be parsed)")
+      # REACHED ONLY FOR A NON-ZERO EXIT THE VALIDATION ABOVE DID NOT ALREADY EXPLAIN: the payload was
+      # affirmatively a JSON object carrying a comments list, so an unparseable payload is no longer
+      # this branch's cause and the text no longer claims it is. Kept as a defensive branch — a
+      # scanner that dies for any other reason must still be a could-not-check and never a check.
+      unread+=("#$issue (the scanner exited non-zero for that thread although its payload was well-formed, so what it found there was never established)")
       continue
     fi
     state="$(printf '%s\n' "$result" | sed -n 's/^state=//p' | head -1)"
+    # ===== THE RETURNED STATE IS A CLOSED GRAMMAR, CHECKED BEFORE IT IS TRUSTED (#3759 r2) =====
+    # An EMPTY or ABSENT `state=` line, or one this code has never judged, used to count as a
+    # successfully checked thread — a verdict derived from a value nobody validated, and the same
+    # collapse as the payload above. The permissive branch is keyed on the AFFIRMATIVE membership,
+    # never on `!= granted`, which is the rule the wrapper already applies to its own verdict keys.
+    #
+    # THE UNION OF THE TWO LOOKUPS' RECOGNITION LISTS, deliberately not narrowed per kind: this is a
+    # RECOGNITION list, not a granting list, every member of it is non-granting except `granted`, and
+    # the escalation below keys on `granted` alone — so per-kind precision here would buy nothing and
+    # would add a second place for those lists to drift.
+    case "$state" in
+      granted|unauthorized|stale|malformed|none|count-mismatch|unavailable) ;;
+      *)
+        unread+=("#$issue (the scanner returned the unrecognised state '${state:-<none>}' for that thread, so what it found there was never established)")
+        continue
+        ;;
+    esac
     read_ok+=("#$issue")
     # ===== ESCALATION ONLY FROM AN ISSUE-SIDE `granted`, KEYED ON THE AFFIRMATIVE VALUE =====
     # An issue-side marker that is itself stale, malformed or unauthorized is a DIFFERENT defect that

--- a/scripts/flow/roborev-review-oracles.sh
+++ b/scripts/flow/roborev-review-oracles.sh
@@ -1237,19 +1237,26 @@ ROBOREV_GH_NAME_RE='[ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456
 # LIST? Sets, and never returns non-zero:
 #   ROBOREV_JSONF_OK     1 (affirmatively yes) | 0 (anything else)
 #   ROBOREV_JSONF_CAUSE  the reason, when 0
+#   ROBOREV_JSONF_LEN    the LIST's length, when 1 — reported here because this function has already
+#                        parsed the payload, so a caller needing the count gets it without a SECOND
+#                        parse site, which is what the chokepoint exists to prevent. Affirmatively
+#                        validated as digits before it is published: an unreadable count is not a
+#                        count, and a caller must not be handed one it cannot trust.
 #
 # THE ONLY PLACE A PAYLOAD SHAPE IS JUDGED on this path. A missing key, an explicit `null`, a non-list
 # value, a non-object top level and an unparseable body are ONE answer here — none of them is the
 # shape we require — but they are never the PERMISSIVE answer, which is the whole point: `gh` always
 # returns the field it was asked for, so any of these is a broken payload and never an empty result.
 roborev_json_list_field() { # <json> <field>
+  local _jsonf_out
   ROBOREV_JSONF_OK=0
   ROBOREV_JSONF_CAUSE="the payload was never examined"
+  ROBOREV_JSONF_LEN=""
   if ! command -v python3 >/dev/null 2>&1; then
     ROBOREV_JSONF_CAUSE="python3 is not on PATH, so the payload's shape could not be established"
     return 0
   fi
-  if printf '%s' "$1" | ROBOREV_JSONF_FIELD="$2" python3 -c '
+  if _jsonf_out="$(printf '%s' "$1" | ROBOREV_JSONF_FIELD="$2" python3 -c '
 import json, os, sys
 field = os.environ.get("ROBOREV_JSONF_FIELD", "")
 try:
@@ -1265,9 +1272,19 @@ if field not in data:
     sys.exit(1)
 if not isinstance(data[field], list):
     sys.exit(1)
-' 2>/dev/null; then
+sys.stdout.write("%d" % len(data[field]))
+' 2>/dev/null)"; then
+    case "$_jsonf_out" in
+      ''|*[!0-9]*)
+        # The shape passed but the count did not arrive as digits, so the payload was parsed and its
+        # size was not established. Keyed on the AFFIRMATIVE value, like every other test here.
+        ROBOREV_JSONF_CAUSE="the payload was a JSON object carrying a $2 LIST, but its length could not be established"
+        return 0
+        ;;
+    esac
     ROBOREV_JSONF_OK=1
     ROBOREV_JSONF_CAUSE=""
+    ROBOREV_JSONF_LEN="$_jsonf_out"
     return 0
   fi
   ROBOREV_JSONF_CAUSE="the payload was not a JSON object carrying a $2 LIST (it was empty, unparseable, a non-object, missing that key, or null)"
@@ -1420,7 +1437,7 @@ roborev_linked_issue_marker_probe() { # <kind> <base> <head> <job> [<observed-fi
   local rel_errfile rel_json rel_errtext numbers declared probed=0 skipped_cross=0
   local issue read_ok=() unread=() comments state
   local issue_errfile issue_errtext read_list unread_list bound_clause cross_clause suffix read_limit
-  local repo_nwo repo_errfile repo_errtext
+  local repo_nwo repo_errfile repo_errtext _probe_tokens
   ROBOREV_PROBE_OUTCOME="could-not-check"
   # THE STRUCTURED VALUE, KEPT BESIDE THE RENDERED ONE ON PURPOSE. `_DETAIL` is prose for a human;
   # `_ISSUE` is the number as data, so a later consumer (or a test) never has to parse the number back
@@ -1455,38 +1472,8 @@ roborev_linked_issue_marker_probe() { # <kind> <base> <head> <job> [<observed-fi
   # SO IT IS AN EXPLICIT, DECLARED SKIP (R5), counted and named in the rendering, NEVER a silent one:
   # a probe that omits coverage silently is indistinguishable from one that covers it.
   #
-  # `gh repo view --json nameWithOwner` is the RIGHT oracle rather than a convenient one: it answers
-  # exactly the question asked — which repository does `gh` resolve HERE — using the same base-repo
-  # resolution `gh issue view <N>` uses. Deriving it by parsing the PR's own URL would be a second,
-  # weaker implementation of that resolution. A failure is a could-not-check: with the current
-  # repository unknown, "same repository" cannot be established AFFIRMATIVELY for any reference, and
-  # an unestablished identity must never inherit the probing branch.
-  if ! repo_errfile="$(mktemp 2>/dev/null)"; then
-    rm -f "$rel_errfile"
-    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: no temporary file could be created to capture the 'gh' diagnostic"
-    return 0
-  fi
-  if ! repo_nwo="$(cd "$REPO" && gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>"$repo_errfile")"; then
-    repo_errtext="$(tr -d '\r' <"$repo_errfile" | tr '\n' ' ')"
-    rm -f "$repo_errfile" "$rel_errfile"
-    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: 'gh repo view --json nameWithOwner' failed (${repo_errtext:-no diagnostic was produced}), so which repository a closing reference points at could not be established"
-    return 0
-  fi
-  rm -f "$repo_errfile"
-  # AFFIRMATIVE SHAPE TEST on the identity itself, for the same reason each issue number gets one: it
-  # is remote text, and it is the value every same-repository decision below is compared against.
-  # A BARE `*/*` IS TOO LOOSE, AND ITS FAILURE MODE IS THE WORST ONE ON THIS PATH (#3759 r2, found
-  # while fixing the class): `x/`, `/x`, `a/b/c` and a whitespace- or newline-bearing answer all match
-  # it, and an identity that matches nothing then makes EVERY reference compare unequal — so the probe
-  # renders a confident "these references point at another repository" DECLARED SKIP, an answer about
-  # the pull request derived from an identity nobody established. The pattern is therefore exactly one
-  # `owner/name` pair over GitHub's own character set, so anything else takes the could-not-check
-  # branch with the rest of the class.
-  if [[ ! "$repo_nwo" =~ ^${ROBOREV_GH_NAME_RE}/${ROBOREV_GH_NAME_RE}$ ]]; then
-    rm -f "$rel_errfile"
-    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: 'gh repo view --json nameWithOwner' did not answer with a single owner/name pair, so which repository a closing reference points at could not be established"
-    return 0
-  fi
+  # THE REPOSITORY IS RESOLVED FURTHER DOWN, only once the relation has produced references that
+  # actually need classifying (#3759 round 7) — see the block after the empty-relation answer.
   # ===== THE LINKED ISSUE COMES FROM THE STRUCTURED RELATION, NEVER FROM THE PR BODY (#3626) =====
   # #3626 DELETED a PR-body link requirement, and not because Markdown is hard to parse: A PULL-REQUEST
   # BODY IS EDITABLE AT ANY TIME BY ANYONE WITH WRITE ACCESS, WITH NO PER-EDIT ATTRIBUTION, while a
@@ -1533,6 +1520,52 @@ roborev_linked_issue_marker_probe() { # <kind> <base> <head> <job> [<observed-fi
   roborev_json_list_field "$rel_json" closingIssuesReferences
   if [ "$ROBOREV_JSONF_OK" -ne 1 ]; then
     ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: $ROBOREV_JSONF_CAUSE — that is a broken payload, NOT an empty relation, and the two must never render alike"
+    return 0
+  fi
+  declared="$ROBOREV_JSONF_LEN"
+  # ===== NO REFERENCES ⇒ THE ANSWER IS DEFINITIVE, AND NOTHING ELSE NEED BE ASKED (#3759 round 7) ====
+  # THE ORDERING DEFECT THIS CLOSES, and it cost CORRECTNESS and not merely a call: the current
+  # repository used to be resolved BEFORE the relation was read, so a pull request with NO linked
+  # issues at all still depended on `gh repo view` — and if that call failed while the relation was
+  # perfectly readable, the probe reported "could NOT be checked" where the truthful answer was the
+  # definitive `no-subject`. That is a could-not-tell reported WHERE AN ANSWER EXISTS: the exact
+  # inverse of the collapse this path is built against, and just as wrong. The relation is read FIRST,
+  # an empty one is answered immediately, and the repository is resolved ONLY when there are
+  # references to classify — so on a PR with no links that call is NOT MADE, not merely ignored, which
+  # is the only version an invocation-log assert can measure.
+  if [ "$declared" -eq 0 ]; then
+    ROBOREV_PROBE_OUTCOME="no-subject"
+    ROBOREV_PROBE_DETAIL="no linked issue is declared on this PR, so no linked-issue thread was checked"
+    return 0
+  fi
+  # `gh repo view --json nameWithOwner` is the RIGHT oracle rather than a convenient one: it answers
+  # exactly the question asked — which repository does `gh` resolve HERE — using the same base-repo
+  # resolution `gh issue view <N>` uses. Deriving it by parsing the PR's own URL would be a second,
+  # weaker implementation of that resolution. A failure is a could-not-check: with the current
+  # repository unknown, "same repository" cannot be established AFFIRMATIVELY for any reference, and
+  # an unestablished identity must never inherit the probing branch.
+  if ! repo_errfile="$(mktemp 2>/dev/null)"; then
+    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: no temporary file could be created to capture the 'gh' diagnostic"
+    return 0
+  fi
+  if ! repo_nwo="$(cd "$REPO" && gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>"$repo_errfile")"; then
+    repo_errtext="$(tr -d '\r' <"$repo_errfile" | tr '\n' ' ')"
+    rm -f "$repo_errfile"
+    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: 'gh repo view --json nameWithOwner' failed (${repo_errtext:-no diagnostic was produced}), so which repository a closing reference points at could not be established"
+    return 0
+  fi
+  rm -f "$repo_errfile"
+  # AFFIRMATIVE SHAPE TEST on the identity itself, for the same reason each issue number gets one: it
+  # is remote text, and it is the value every same-repository decision below is compared against.
+  # A BARE `*/*` IS TOO LOOSE, AND ITS FAILURE MODE IS THE WORST ONE ON THIS PATH (#3759 r2, found
+  # while fixing the class): `x/`, `/x`, `a/b/c` and a whitespace- or newline-bearing answer all match
+  # it, and an identity that matches nothing then makes EVERY reference compare unequal — so the probe
+  # renders a confident "these references point at another repository" DECLARED SKIP, an answer about
+  # the pull request derived from an identity nobody established. The pattern is therefore exactly one
+  # `owner/name` pair over GitHub's own character set, so anything else takes the could-not-check
+  # branch with the rest of the class.
+  if [[ ! "$repo_nwo" =~ ^${ROBOREV_GH_NAME_RE}/${ROBOREV_GH_NAME_RE}$ ]]; then
+    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: 'gh repo view --json nameWithOwner' did not answer with a single owner/name pair, so which repository a closing reference points at could not be established"
     return 0
   fi
   if ! numbers="$(printf '%s' "$rel_json" | PROBE_REPO_NWO="$repo_nwo" PROBE_NAME_RE="$ROBOREV_GH_NAME_RE" python3 -c '
@@ -1617,11 +1650,14 @@ for ref in refs:
     ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: the closingIssuesReferences payload was not readable as a JSON object carrying a closingIssuesReferences LIST (it was unparseable, a non-object, missing that key, or null) — that is a broken payload, NOT an empty relation, and the two must never render alike"
     return 0
   fi
-  declared=0
-  for issue in $numbers; do declared=$(( declared + 1 )); done
-  if [ "$declared" -eq 0 ]; then
-    ROBOREV_PROBE_OUTCOME="no-subject"
-    ROBOREV_PROBE_DETAIL="no linked issue is declared on this PR, so no linked-issue thread was checked"
+  # `declared` came from the validated read, so the classification must have produced exactly one
+  # token per reference. ASSERTED rather than recomputed: the count the bound arithmetic uses and the
+  # count the payload actually carried must not silently be two different numbers, and a mismatch is a
+  # could-not-check rather than a quietly smaller set.
+  _probe_tokens=0
+  for issue in $numbers; do _probe_tokens=$(( _probe_tokens + 1 )); done
+  if [ "$_probe_tokens" -ne "$declared" ]; then
+    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: the relation declared $declared reference(s) but their classification produced $_probe_tokens, so the declared set was never established"
     return 0
   fi
   # PROBED IN GITHUB'S RETURNED ORDER — not sorted. Any sort is a policy nobody asked for, and the
@@ -1798,7 +1834,12 @@ for ref in refs:
 
 # roborev_absence_waiver_lookup <base-sha> <head-sha> <job-id>: does the PR for this branch carry a
 # waiver for THIS REVIEW? Sets, and never returns non-zero:
-#   ROBOREV_WAIVER_STATE   granted | stale | malformed | none | unavailable
+#   ROBOREV_WAIVER_STATE   granted | unauthorized | stale | malformed | none | misplaced |
+#                          unavailable
+#     (`unauthorized` predates #3759 and was missing from this list; `misplaced` is #3759's
+#      non-granting linked-issue diagnostic. A CLOSED state list that is missing states is worse than
+#      no list, because a caller trusts it — and a comment naming a mechanism is a claim about code
+#      that decays exactly like any other, which is why these are corrected rather than left.)
 #   ROBOREV_WAIVER_AUTHOR / _SCOPE / _REASON / _DETAIL
 #
 # THE MARKER — a DEDICATED LINE of a PR comment, anchored at column zero, all four fields required:
@@ -2112,8 +2153,11 @@ roborev_issue_retrievability() {
 # roborev_findings_deferral_lookup <base-sha> <head-sha> <job-id> <observed-findings-count>:
 # does the PR for this branch carry a findings deferral for THIS REVIEW, covering exactly this many
 # findings, with every named issue an OPEN issue GitHub confirms? Sets, and never returns non-zero:
-#   ROBOREV_DEFERRAL_STATE   granted | unauthorized | stale | malformed | none | count-mismatch |
-#                            issue-absent | issue-closed | issue-unverifiable | unavailable
+#   ROBOREV_DEFERRAL_STATE   granted | unauthorized | stale | malformed | none | misplaced |
+#                            count-mismatch | issue-absent | issue-closed | issue-unverifiable |
+#                            unavailable
+#     (`misplaced` is #3759's non-granting linked-issue diagnostic; see the waiver's copy of this
+#      note for why an incomplete closed list is worse than none.)
 #   ROBOREV_DEFERRAL_AUTHOR / _SCOPE / _REASON / _DETAIL / _ISSUES / _COUNT
 #
 # FAIL-CLOSED EVERYWHERE: no `gh`, no PR, a `gh` error, an unusable scanner, a marker for another

--- a/scripts/flow/roborev-review-oracles.sh
+++ b/scripts/flow/roborev-review-oracles.sh
@@ -1125,10 +1125,23 @@ roborev_diff_header_has_path() {
 # reason to leave a hole that a non-invoker or an accident can walk through.
 #
 # TWO RESIDUALS INSIDE THE MODEL, named rather than implied:
-#   * THE MARKER IS READ FROM TOP-LEVEL PR COMMENTS ONLY (`gh pr view --json comments`). A marker posted
-#     inside a REVIEW body or as a review-thread reply is NOT read, so it silently does not apply — the
-#     run reports `waiver: NONE` and the FAIL stands. That direction is fail-CLOSED, but it will read as
-#     "my waiver was ignored", so the form documents the channel.
+#   * THE MARKER IS READ FROM TOP-LEVEL PR COMMENTS ONLY (`gh pr view --json comments`), AND THE MOST
+#     PROBABLE MISPLACEMENT IS THE LINKED ISSUE THREAD (#3759). Three locations are not read: a marker
+#     posted on the PR's LINKED ISSUE — the likeliest, because that is where lane/lead coordination
+#     lives — inside a REVIEW body, or as a review-thread reply. None of them applies, and the FAIL
+#     stands. MEASURED: for PR #3710 both authorizations were granted, field-perfect, on issue #3544,
+#     and the run reported `waiver: NONE` / `deferral: NONE` — textually identical to "the lead
+#     refused" and to "nobody posted one". Position 1 of a six-PR queue idled ~8 hours.
+#     SINCE #3759 THE LINKED-ISSUE CASE IS DIAGNOSED, NOT GRANTED: when the PR-side scan returns
+#     `none`, the PR's linked issue(s) are scanned with the SAME scanner and the SAME scope, and a
+#     marker there that WOULD have been accepted by the channel is reported `waiver: MISPLACED (found
+#     on linked issue #N …)` naming the issue and the remedy. `MISPLACED` GRANTS NOTHING — not
+#     partially, not with a notice — and the FAIL stands; only a marker on the PULL REQUEST grants,
+#     and moving it there is a HUMAN act by the authorizer. A `none` verdict now also DECLARES whether
+#     the probe ran, so "checked and not there" and "never checked" can never read alike.
+#     LEAD-SIDE PROCEDURE, the other half of the fix: after posting either marker, verify with
+#     `gh pr view <PR> --json comments` that the line is ON THE PR. A grant is only granted once it is
+#     readable by the scanner that reads it.
 #   * AN AUTHORIZED HUMAN CAN AUTHORIZE CARELESSLY — pre-authorizing a job id, or waiving without checking
 #     the token accounting. Nothing here can detect that; the control is the permanent, attributable
 #     comment, which is why the reason is required and recorded verbatim.
@@ -1175,6 +1188,240 @@ WAIVER_SCAN_TOOL="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/roborev-waiver-s
 # edit calling it instead of the scanner would reintroduce a SECOND, shell-side authorization path, and
 # two implementations of an authorization rule drift, and a drift in an authorization rule is a bypass.
 # The allowlist is still expressed once, above, and consumed only by the scanner it is passed to.
+
+
+# ============ THE LINKED-ISSUE MISPLACEMENT PROBE (issue #3759) ============
+# WHY IT EXISTS, measured rather than imagined. For PR #3710 the coordination lead granted BOTH
+# authorizations — field-perfect, correct base/head/job, each the sole nonblank content of its own
+# top-level comment, from an allowlisted author — on ISSUE #3544, the thread where that lane's
+# coordination had happened all day. The wrapper reads PR comments only, so it reported
+# `waiver: NONE` / `deferral: NONE`, which is TEXTUALLY IDENTICAL to "the lead refused" and to
+# "nobody ever posted one". Position 1 of a six-PR serial queue idled ~8 hours and blocked five
+# lanes. The channel behaved exactly as designed; the DIAGNOSTIC could not tell the operator which
+# of three very different situations they were in.
+#
+# WHAT THIS ADDS, AND WHAT IT DELIBERATELY DOES NOT. It adds one DIAGNOSTIC state, `misplaced`. It
+# GRANTS NOTHING — not partially, not with a notice — and no channel rule is loosened to produce
+# it: the allowlist, the sole-nonblank-content rule, the column-zero anchor, the structured author
+# association, the placeholder refusal and the base+head+job binding are all untouched, and the
+# security property ONLY A MARKER ON THE PULL REQUEST GRANTS is preserved exactly. Copying a marker
+# from an issue onto the PR is a HUMAN act by the authorizer; this code only tells them to do it.
+#
+# ONE ENFORCER, INHERITED BY CALL. `roborev-waiver-scan.py` is unmodified and is passed the SAME
+# kind, base, head, job, allowlist (and observed count) as the PR-side call. It is already
+# thread-agnostic — it consumes `{"comments":[{"author":{"login":…},"body":…}]}` on stdin and knows
+# nothing about pull requests — and `gh issue view <N> --json comments` emits that shape
+# BYTE-IDENTICALLY to `gh pr view --json comments` (measured live on issue #3626, 2026-09-01). That
+# measurement is what LICENSES the reuse: had the shapes differed, the options would have been a
+# translation layer (a new component inside an authorization path) or a second scanner — and a
+# second implementation of a marker grammar is a second place for it to diverge, which in an
+# AUTHORIZATION grammar is a bypass (#3626's "reuse, do not reinvent" ruling). The scanner is never
+# told which thread its input came from: thread identity is the CALLER's knowledge, so the
+# `misplaced` state is assigned HERE and the scanner's contract stays exactly "given these
+# comments, does an authorization for this review exist in them?".
+#
+# NEVER RETURNS NON-ZERO AND NEVER EXITS. A two-valued return would re-import the very collapse
+# this change exists to remove, so every failure is a STATE WITH A CAUSE, from a CLOSED set of four
+# outcomes: `misplaced` / `checked` / `no-subject` / `could-not-check`. A partial read — one thread
+# read, another unavailable — is `could-not-check` naming BOTH halves and is NEVER `checked`: a
+# partial scan reported as a complete one is worse than an admitted failure, because it is the
+# version nobody re-checks.
+#
+# Sets, and never returns non-zero:
+#   ROBOREV_PROBE_OUTCOME  misplaced | checked | no-subject | could-not-check
+#   ROBOREV_PROBE_ISSUE    the issue number, on `misplaced` only
+#   ROBOREV_PROBE_DETAIL   the rendering for this outcome, from the closed set above
+
+# THE BOUND. The probe is a DIAGNOSTIC on a path that has already determined the run FAILs, so it
+# must not become an unbounded fan-out of network calls; when the declared set exceeds this, the
+# rendering says so rather than leaving the unprobed remainder silent. Named, not inline, because
+# the number appears in the rendering the operator reads.
+ROBOREV_LINKED_ISSUE_PROBE_MAX=3
+
+roborev_linked_issue_marker_probe() { # <kind> <base> <head> <job> [<observed-findings-count>]
+  local kind="$1" base="$2" head="$3" job="$4" observed="${5:-}"
+  local rel_errfile rel_json rel_errtext numbers declared probed=0
+  local issue read_ok=() unread=() comments result state scan_rc
+  local issue_errfile issue_errtext
+  ROBOREV_PROBE_OUTCOME="could-not-check"
+  ROBOREV_PROBE_ISSUE=""
+  ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: the probe was never asked"
+  if ! command -v gh >/dev/null 2>&1; then
+    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: 'gh' is not on PATH"
+    return 0
+  fi
+  if ! command -v python3 >/dev/null 2>&1 || [ ! -f "$WAIVER_SCAN_TOOL" ]; then
+    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: the structured authorization scanner is unusable, and a marker is NEVER recognised from a flattened text stream — not even to print a diagnostic, because a second recogniser is a second place for the grammar to diverge"
+    return 0
+  fi
+  if ! rel_errfile="$(mktemp 2>/dev/null)"; then
+    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: no temporary file could be created to capture the 'gh' diagnostic"
+    return 0
+  fi
+  # ===== THE LINKED ISSUE COMES FROM THE STRUCTURED RELATION, NEVER FROM THE PR BODY (#3626) =====
+  # #3626 DELETED a PR-body link requirement, and not because Markdown is hard to parse: A PULL-REQUEST
+  # BODY IS EDITABLE AT ANY TIME BY ANYONE WITH WRITE ACCESS, WITH NO PER-EDIT ATTRIBUTION, while a
+  # top-level comment is permanent and attributable — so the body was the WEAKER ARTIFACT and would
+  # stay weaker even if Markdown parsed trivially. Reinstating a body scan FOR ANY PURPOSE would be
+  # reinstating a deleted generation, so this reads the relation and the guard suite asserts that no
+  # `--json body` read and no `#N` prose scan came back.
+  #
+  # ===== THE MUTABLE-DERIVED BOUNDARY, WRITTEN HERE BECAUSE THE NEXT EDIT READS THE CODE FIRST =====
+  # `closingIssuesReferences` is itself derived from the body's closing keywords, so it is ALSO
+  # mutable by anyone with write access. That is acceptable HERE AND ONLY HERE for one precise
+  # reason: THE RESULT GRANTS NOTHING. It selects WHICH THREAD TO PRINT A DIAGNOSTIC ABOUT. The worst
+  # outcome from a re-pointed relation is a diagnostic naming the wrong issue, or naming none, and the
+  # run FAILs either way. THE MOMENT ANY CONSUMER DOWNSTREAM OF THIS RELATION COULD GRANT, THIS
+  # ARGUMENT EVAPORATES AND THE RELATION MUST GO WITH IT.
+  #
+  # ===== A SEPARATE, LATER CALL — THE GRANTING PAYLOAD DOES NOT CHANGE SHAPE (#3759 R4) =====
+  # This is deliberately NOT folded into the caller's `gh pr view --json comments` as
+  # `--json comments,closingIssuesReferences`. Two reasons, the first decisive. (1) THE PAYLOAD AN
+  # AUTHORIZATION IS DECIDED FROM MUST NOT CHANGE SHAPE AS A SIDE EFFECT OF ADDING A DIAGNOSTIC: that
+  # document is the scanner's input, and the fixed, measured shape is exactly what licenses reusing
+  # the scanner unmodified. (2) THE PROBE MUST BE REACHABLE ONLY FROM A BRANCH THAT HAS ALREADY
+  # FAILED TO GRANT: fetching the relation up front would make its data available on every path
+  # including the granted one, so reachability would rest on where an `if` sits rather than on the
+  # data not existing. Issued as its own later call, the ordering is STRUCTURAL — on any other state
+  # the call is NOT MADE, not merely ignored, which is also the only version an invocation-log assert
+  # can measure. The extra round-trip on a failing run is the accepted cost.
+  if ! rel_json="$(cd "$REPO" && gh pr view --json closingIssuesReferences 2>"$rel_errfile")"; then
+    rel_errtext="$(tr -d '\r' <"$rel_errfile" | tr '\n' ' ')"
+    rm -f "$rel_errfile"
+    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: 'gh pr view --json closingIssuesReferences' failed (${rel_errtext:-no diagnostic was produced})"
+    return 0
+  fi
+  rm -f "$rel_errfile"
+  # ===== EVERY NUMBER IS VALIDATED AFFIRMATIVELY, AND A NON-NUMBER IS NEVER INTERPOLATED RAW =====
+  # The payload is remote text. The python leg reduces each entry to DIGITS or to the fixed token
+  # `NON-NUMERIC` — it never echoes an unrecognised value — and the shell then re-tests each token
+  # for digits itself. Two affirmative tests rather than one because the shell is what interpolates
+  # into an emitted diagnostic, and a value that reaches a renderer must have been judged by the
+  # process that renders it.
+  if ! numbers="$(printf '%s' "$rel_json" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except ValueError:
+    sys.exit(1)
+refs = data.get("closingIssuesReferences") if isinstance(data, dict) else None
+if refs is None:
+    refs = []
+if not isinstance(refs, list):
+    sys.exit(1)
+for ref in refs:
+    n = ref.get("number") if isinstance(ref, dict) else None
+    if isinstance(n, bool):
+        n = None
+    if isinstance(n, int):
+        sys.stdout.write("%d\n" % n)
+    elif isinstance(n, str) and n.isdigit() and n:
+        sys.stdout.write("%s\n" % n)
+    else:
+        # NEVER the raw value: an unrecognised entry is reported as a KIND, not as text.
+        sys.stdout.write("NON-NUMERIC\n")
+' 2>/dev/null)"; then
+    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: the closingIssuesReferences payload could not be parsed"
+    return 0
+  fi
+  declared=0
+  for issue in $numbers; do declared=$(( declared + 1 )); done
+  if [ "$declared" -eq 0 ]; then
+    ROBOREV_PROBE_OUTCOME="no-subject"
+    ROBOREV_PROBE_DETAIL="no linked issue is declared on this PR, so no linked-issue thread was checked"
+    return 0
+  fi
+  # PROBED IN GITHUB'S RETURNED ORDER — not sorted. Any sort is a policy nobody asked for, and the
+  # order GitHub returns is the only one attributable to something outside this code.
+  for issue in $numbers; do
+    [ "$probed" -lt "$ROBOREV_LINKED_ISSUE_PROBE_MAX" ] || break
+    case "$issue" in
+      ''|*[!0-9]*)
+        probed=$(( probed + 1 ))
+        unread+=("an entry that is not an issue number")
+        continue
+        ;;
+    esac
+    probed=$(( probed + 1 ))
+    if ! issue_errfile="$(mktemp 2>/dev/null)"; then
+      unread+=("#$issue (no temporary file could be created to capture the 'gh' diagnostic)")
+      continue
+    fi
+    if ! comments="$(cd "$REPO" && gh issue view "$issue" --json comments 2>"$issue_errfile")"; then
+      issue_errtext="$(tr -d '\r' <"$issue_errfile" | tr '\n' ' ')"
+      rm -f "$issue_errfile"
+      unread+=("#$issue (${issue_errtext:-no diagnostic was produced})")
+      continue
+    fi
+    rm -f "$issue_errfile"
+    # THE SAME SCANNER, THE SAME KIND, THE SAME SCOPE, THE SAME ALLOWLIST. No new argument, no new
+    # grammar, no thread parameter — see the header. The deferral additionally passes the SAME
+    # observed count, so `count=` is matched identically on both threads.
+    if [ -n "$observed" ]; then
+      result="$(printf '%s' "$comments" | python3 "$WAIVER_SCAN_TOOL" "$kind" "$base" "$head" "$job" "$ROBOREV_WAIVER_AUTHORS" "$observed" 2>/dev/null)" && scan_rc=0 || scan_rc=1
+    else
+      result="$(printf '%s' "$comments" | python3 "$WAIVER_SCAN_TOOL" "$kind" "$base" "$head" "$job" "$ROBOREV_WAIVER_AUTHORS" 2>/dev/null)" && scan_rc=0 || scan_rc=1
+    fi
+    if [ "$scan_rc" -ne 0 ]; then
+      unread+=("#$issue (its comments payload could not be parsed)")
+      continue
+    fi
+    state="$(printf '%s\n' "$result" | sed -n 's/^state=//p' | head -1)"
+    read_ok+=("#$issue")
+    # ===== ESCALATION ONLY FROM AN ISSUE-SIDE `granted`, KEYED ON THE AFFIRMATIVE VALUE =====
+    # An issue-side marker that is itself stale, malformed or unauthorized is a DIFFERENT defect that
+    # happens to be on a different thread, and re-posting it would not help — reporting MISPLACED for
+    # it would make the run FAIL after the operator followed the remedy, which spends the
+    # diagnostic's credibility. `MISPLACED` must mean EXACTLY ONE operator action: re-post the
+    # identical marker as a top-level PR comment. So the condition is exactly "this marker WOULD have
+    # been accepted by the channel had it been on the pull request", and every other state — including
+    # one this code has never judged — leaves the outcome alone rather than inheriting an escalating
+    # branch.
+    if [ "$state" = "granted" ]; then
+      ROBOREV_PROBE_OUTCOME="misplaced"
+      ROBOREV_PROBE_ISSUE="$issue"
+      # ===== THE RENDERING CLAIMS WHAT THE PROBE MEASURED, AND NOT ONE STEP MORE (#3759 R3) =====
+      # "would have been ACCEPTED BY THE CHANNEL", never "would have GRANTED". The probe asks the
+      # SCANNER's verdict — every property decidable from the comment itself: shape, sole content,
+      # column-zero anchor, allowlist, field grammar, reason substance, the base/head/job binding, and
+      # for a deferral the `count=` match. It deliberately does NOT run the deferral's NETWORK
+      # DISPOSITION LEG (each `issues=` number's four-valued open-issue check) issue-side. That
+      # scoping is sound because (1) MISPLACED grants nothing, so the worst case is advice one step
+      # short of complete rather than a pass; (2) the remedy is identical either way — a deferral
+      # naming a closed issue on the wrong thread must STILL be moved to the PR, where the disposition
+      # leg then runs and reports its own precise ISSUE-CLOSED / ISSUE-ABSENT / ISSUE-UNVERIFIABLE;
+      # and (3) it would add one network call per declared issue per probed thread on a purely
+      # diagnostic path. A DIAGNOSTIC THAT OVERSTATES WHAT IT MEASURED IS WHAT STOPS THE NEXT PERSON
+      # LOOKING, so the claim is stated at its true strength and the remaining legs are named.
+      ROBOREV_PROBE_DETAIL="an authorization for THIS review (this base, head and job) is on LINKED ISSUE #$issue, not on the pull request — it would have been ACCEPTED BY THE CHANNEL there (shape, sole nonblank content, top-level, allowlisted author, fields and scope all check out)"
+      if [ -n "$observed" ]; then
+        ROBOREV_PROBE_DETAIL="$ROBOREV_PROBE_DETAIL, and its count= matches the $observed observed finding(s); the issue-disposition legs (every issues= number must be an OPEN issue GitHub confirms) are NOT run issue-side and still apply once it is on the PR"
+      fi
+      return 0
+    fi
+  done
+  # ===== A PARTIAL READ IS `could-not-check` NAMING BOTH HALVES, NEVER `checked` =====
+  if [ "${#unread[@]}" -gt 0 ]; then
+    ROBOREV_PROBE_OUTCOME="could-not-check"
+    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: read with no matching marker: ${read_ok[*]:-none}; NOT read: $(printf '%s; ' "${unread[@]}")"
+    return 0
+  fi
+  if [ "$probed" -lt "$declared" ]; then
+    # THE UNPROBED REMAINDER IS NAMED, NEVER IMPLIED — the same reason the gate prints
+    # `0 RECOGNISED` rather than a bare `0`. A lane that omits coverage silently is
+    # indistinguishable from one that covers it.
+    ROBOREV_PROBE_OUTCOME="checked"
+    ROBOREV_PROBE_DETAIL="linked issues ${read_ok[*]} checked — $probed of $declared declared, probe bounded at $ROBOREV_LINKED_ISSUE_PROBE_MAX: no matching marker"
+    return 0
+  fi
+  ROBOREV_PROBE_OUTCOME="checked"
+  if [ "$declared" -eq 1 ]; then
+    ROBOREV_PROBE_DETAIL="linked issue ${read_ok[*]} checked: no matching marker there either"
+  else
+    ROBOREV_PROBE_DETAIL="linked issues ${read_ok[*]} checked: no matching marker there either"
+  fi
+  return 0
+}
 
 # roborev_absence_waiver_lookup <base-sha> <head-sha> <job-id>: does the PR for this branch carry a
 # waiver for THIS REVIEW? Sets, and never returns non-zero:
@@ -1284,12 +1531,39 @@ roborev_absence_waiver_lookup() {
   # A STATE THIS CODE HAS NEVER JUDGED IS NOT A PASS: an unrecognised (or empty) verdict from the
   # scanner fails closed instead of inheriting the permissive path.
   case "$ROBOREV_WAIVER_STATE" in
-    granted|unauthorized|stale|malformed|none) ;;
+    # `misplaced` IS IN THIS LIST AS A BELT, NOT AS A ROUTE (#3759). The scanner never emits it —
+    # thread identity is the caller's knowledge — and the probe below assigns it AFTER this
+    # validation, so no list entry is strictly required today. It is here so that a future refactor
+    # routing the probe's result through this validation cannot rewrite an accurate diagnostic into a
+    # generic `unavailable`, re-collapsing the very state this change splits out. THIS IS A
+    # RECOGNITION LIST, NOT A GRANTING LIST: membership confers nothing, and the only granting gate
+    # anywhere is the token-exact `[ "$ROBOREV_WAIVER_STATE" = "granted" ]` in the checks file.
+    granted|unauthorized|stale|malformed|none|misplaced) ;;
     *)
       ROBOREV_WAIVER_DETAIL="the waiver scanner returned the unrecognised state '$ROBOREV_WAIVER_STATE'; failing closed"
       ROBOREV_WAIVER_STATE="unavailable"
       ;;
   esac
+  # ===== THE LINKED-ISSUE PROBE: ONLY FROM `none`, AND IT GRANTS NOTHING (#3759) =====
+  # ONLY FROM `none`, and the probe is NOT EVEN PERFORMED for the other states. A PR-side `stale`,
+  # `malformed`, `unauthorized` or `unavailable` is already specific, already actionable and already
+  # correct — "your marker names a different review", "a field is wrong", "this login may not grant",
+  # "the oracle could not be consulted" — and replacing one with MISPLACED would substitute a vaguer
+  # diagnosis for a precise one and send the operator to move a comment that still would not grant.
+  # `none` is the only state carrying no information, so it is the only one the probe may refine.
+  # Not calling it (rather than calling and discarding) is what makes the reachability STRUCTURAL and
+  # measurable from an invocation log; a network call whose result is discarded is latency plus a
+  # future footgun.
+  if [ "$ROBOREV_WAIVER_STATE" = "none" ]; then
+    roborev_linked_issue_marker_probe prompt-content-absent "$base" "$head" "$job"
+    if [ "$ROBOREV_PROBE_OUTCOME" = "misplaced" ]; then
+      # KEYED ON THE AFFIRMATIVE VALUE: only the one outcome that means "a marker the channel would
+      # have accepted is on the wrong thread" changes the state. Every other outcome — including one
+      # this code has never judged — leaves it at `none` and merely records what the probe did.
+      ROBOREV_WAIVER_STATE="misplaced"
+    fi
+    ROBOREV_WAIVER_DETAIL="$ROBOREV_PROBE_DETAIL"
+  fi
   return 0
 }
 
@@ -1341,10 +1615,19 @@ roborev_absence_waiver_lookup() {
 # larger category. "The invoker can bypass this" => record it, do not patch it. "A non-invoker can
 # bypass this", or "this can be bypassed BY ACCIDENT" => defect.
 #
-# RESIDUALS, named rather than implied: the marker is read from TOP-LEVEL PR COMMENTS ONLY, so one
-# posted inside a review body or a review-thread reply is silently not applied (the run reports
-# `deferral: NONE` and the FAIL stands — fail-closed, but it reads as "my authorization was ignored");
-# and an authorized human can authorize carelessly — pre-authorizing a job, or deferring without
+# RESIDUALS, named rather than implied: the marker is read from TOP-LEVEL PR COMMENTS ONLY, AND THE
+# MOST PROBABLE MISPLACEMENT IS THE PR'S LINKED ISSUE THREAD (#3759) — that is where lane/lead
+# coordination lives — followed by a review body and a review-thread reply. None of the three is read,
+# so a marker there is silently not applied (the run reports `deferral: NONE` and the FAIL stands —
+# fail-closed, but it reads as "my authorization was ignored"). MEASURED on PR #3710, where both
+# authorizations were granted field-perfect on issue #3544 and neither applied. SINCE #3759 THE
+# LINKED-ISSUE CASE IS DIAGNOSED, NOT GRANTED: on a `none`, the PR's linked issue(s) are scanned with
+# the SAME scanner and scope, and a marker there that WOULD have been accepted by the channel reports
+# `deferral: MISPLACED (found on linked issue #N …)` with the remedy. MISPLACED GRANTS NOTHING and the
+# FAIL stands — only a marker on the PULL REQUEST grants — and a `none` now DECLARES whether the probe
+# ran. LEAD-SIDE PROCEDURE: after posting the marker, verify with `gh pr view <PR> --json comments`
+# that the line is ON THE PR; a grant is only granted once it is readable by the scanner that reads it.
+# And an authorized human can authorize carelessly — pre-authorizing a job, or deferring without
 # checking that the findings really are the tracked ones. Nothing mechanical detects either; the
 # control is the permanent, attributable comment, which is why a substantive reason is required and
 # recorded verbatim.
@@ -1519,13 +1802,33 @@ roborev_findings_deferral_lookup() {
     # of being rewritten to a generic "unrecognised state", which is the diagnostic-quality failure
     # this case exists to avoid; nothing becomes permissive either way, because `unavailable` is
     # non-granting on both paths. `pr-unlinked` is GONE with the check that produced it.
-    granted|unauthorized|stale|malformed|none|count-mismatch|unavailable) ;;
+    # `misplaced` IS A BELT HERE FOR THE SAME REASON AS ON THE WAIVER (#3759): the scanner never
+    # emits it, the probe below assigns it after this validation, and the entry exists so a future
+    # refactor routing the probe through this validation cannot rewrite an accurate diagnostic into a
+    # generic `unavailable`. A RECOGNITION LIST, NOT A GRANTING LIST — the only granting gate is the
+    # token-exact `= "granted"` comparison on the line after this `case`.
+    granted|unauthorized|stale|malformed|none|count-mismatch|unavailable|misplaced) ;;
     *)
       ROBOREV_DEFERRAL_DETAIL="the deferral scanner returned the unrecognised state '$ROBOREV_DEFERRAL_STATE'; failing closed"
       ROBOREV_DEFERRAL_STATE="unavailable"
       return 0
       ;;
   esac
+  # ===== THE LINKED-ISSUE PROBE: ONLY FROM `none`, AND IT GRANTS NOTHING (#3759) =====
+  # Identical rule and identical reasoning to the waiver's (see the block in
+  # `roborev_absence_waiver_lookup`), served by the SAME helper — two copies of a probe over an
+  # authorization channel would be two places for it to diverge. The observed findings count is
+  # passed through UNCHANGED, so `count=` is matched issue-side exactly as it is PR-side; what is
+  # deliberately NOT run issue-side is the network disposition leg, and the rendering says so.
+  if [ "$ROBOREV_DEFERRAL_STATE" = "none" ]; then
+    roborev_linked_issue_marker_probe findings-deferral "$base" "$head" "$job" "$observed"
+    if [ "$ROBOREV_PROBE_OUTCOME" = "misplaced" ]; then
+      ROBOREV_DEFERRAL_STATE="misplaced"
+    fi
+    ROBOREV_DEFERRAL_DETAIL="$ROBOREV_PROBE_DETAIL"
+  fi
+  # The disposition legs below are unreachable from `none`/`misplaced` — this comparison is the one
+  # granting gate, and it is left EXACTLY as it was: nothing about the probe widens it.
   [ "$ROBOREV_DEFERRAL_STATE" = "granted" ] || return 0
   # ===== DISPOSITION: EACH DEFERRED ISSUE MUST BE AN OPEN, FILED ISSUE — AND THAT IS THE WHOLE OF IT =
   # This is the ONE leg that enforces NOT-DROPPED, since the PR-body scan was removed (#3626). It needs

--- a/scripts/flow/roborev-review-oracles.sh
+++ b/scripts/flow/roborev-review-oracles.sh
@@ -1248,7 +1248,7 @@ if not isinstance(data[field], list):
     ROBOREV_JSONF_CAUSE=""
     return 0
   fi
-  ROBOREV_JSONF_CAUSE="the payload was not a JSON object carrying a $2 LIST (it was unparseable, a non-object, missing that key, or null)"
+  ROBOREV_JSONF_CAUSE="the payload was not a JSON object carrying a $2 LIST (it was empty, unparseable, a non-object, missing that key, or null)"
   return 0
 }
 
@@ -1266,6 +1266,27 @@ if not isinstance(data[field], list):
 # that is not an object carrying a comments list; a `state=` outside the closed set) — fix or report
 # the payload. Neither is ever permissive, and a two-valued return would re-import the collapse this
 # whole restructure exists to remove.
+#
+# ===== WHAT `ok` ESTABLISHES, AND WHAT IT DELIBERATELY DOES NOT (#3759 round 4) =====
+# IT ESTABLISHES: the payload is a top-level JSON OBJECT; the field it needs is a LIST; the scanner
+# exited zero; and the returned `state=` is in the closed recognition set. IT DOES NOT DISTINGUISH A
+# MALFORMED ELEMENT INSIDE AN OTHERWISE WELL-FORMED LIST — a comment entry that is not an object, or
+# whose `body` is not a string, is SKIPPED by the scanner, so a list of such entries reads here as a
+# thread with no authorization in it.
+#
+# THAT IS A DECLARED LIMIT, NOT AN OVERSIGHT, AND IT IS DELIBERATELY NOT CLOSED HERE. The scanner is
+# reused UNMODIFIED by design and its element-skipping is CORRECT for its own contract. A caller that
+# re-validated every element and its field types would be re-implementing the scanner parse — a SECOND
+# implementation of the marker path, which is the hazard this design rejected at the outset and which
+# this repository rules on repeatedly: a second implementation is correct only insofar as it is
+# differentially tested against the first, never by care. Closing it would trade a bounded, stated
+# limitation for an unbounded one.
+#
+# SO IT IS STATED WHERE IT IS RELIED ON: the probe repeats this boundary in the rendering of every
+# thread it reports as READ, because an affirmative declared limit beats a silent one — that is the
+# same rule the probe follows for its bound and its cross-repository skips. The harm ceiling is a
+# diagnostic that is one step less precise than it sounds; it is NEVER a wrongly granted
+# authorization, because nothing here can grant.
 #
 # A ZERO EXIT FROM THE SCANNER IS NOT A SUCCESSFUL READ. The scanner reduces `{}`,
 # `{"comments": null}` and `{"comments": {}}` to an EMPTY comment list and exits 0 — CORRECT for its
@@ -1376,7 +1397,7 @@ roborev_linked_issue_marker_probe() { # <kind> <base> <head> <job> [<observed-fi
   local kind="$1" base="$2" head="$3" job="$4" observed="${5:-}"
   local rel_errfile rel_json rel_errtext numbers declared probed=0 skipped_cross=0
   local issue read_ok=() unread=() comments state
-  local issue_errfile issue_errtext read_list unread_list bound_clause cross_clause suffix
+  local issue_errfile issue_errtext read_list unread_list bound_clause cross_clause suffix read_limit
   local repo_nwo repo_errfile repo_errtext
   ROBOREV_PROBE_OUTCOME="could-not-check"
   # THE STRUCTURED VALUE, KEPT BESIDE THE RENDERED ONE ON PURPOSE. `_DETAIL` is prose for a human;
@@ -1500,7 +1521,14 @@ import json, os, re, sys
 # ONE grammar for a GitHub owner or repository name, received from the shell so that the current
 # repository and every reference are held to the SAME constraint. Two parallel validators of one
 # grammar drift, and a drift here yields a CONFIDENT declared skip from an unvalidated identity.
-NAME_RE = re.compile("^" + os.environ.get("PROBE_NAME_RE", "(?!)") + "$")
+# ANCHORED WITH fullmatch, NOT WITH a trailing dollar (#3759 round 4). In Python that anchor matches
+# BEFORE a final newline, so a name ending in a newline satisfied it — and the newline then survived
+# into the joined identity, which compares unequal to everything, so a SAME-repository reference was
+# reported as a confident CROSS-REPO declared skip instead of REPO-UNVERIFIED. fullmatch has no such
+# exception. The shell copy of this check is unaffected: the bash =~ operator anchors at end of
+# string, and command substitution strips trailing newlines before it ever runs.
+# NO APOSTROPHES IN THIS BLOCK: it lives inside a single-quoted shell string, so one would end it.
+NAME_RE = re.compile(os.environ.get("PROBE_NAME_RE", "(?!)"))
 want_repo = " ".join(os.environ.get("PROBE_REPO_NWO", "").split()).lower()
 # The shape was judged by `roborev_json_list_field` before this ran, so this leg PARSES and never
 # DECIDES. A parse failure here would mean the payload changed between the two reads, which cannot
@@ -1534,7 +1562,7 @@ def ref_repo(ref):
     # produced a joined identity that compares unequal to everything, and an identity that matches
     # nothing renders as a CONFIDENT cross-repository DECLARED SKIP. An identity that fails this is
     # REPO-UNVERIFIED — "cannot tell which repository" — and never CROSS-REPO.
-    if not NAME_RE.match(name) or not NAME_RE.match(login):
+    if not NAME_RE.fullmatch(name) or not NAME_RE.fullmatch(login):
         return None
     return ("%s/%s" % (login, name)).lower()
 
@@ -1684,11 +1712,22 @@ for ref in refs:
   if [ "$skipped_cross" -gt 0 ]; then
     cross_clause=" — $skipped_cross cross-repository closing reference(s) declared and deliberately NOT probed (a reference's number is scoped to ITS repository, so following one here could only name the wrong thread)"
   fi
+  # THE DECLARED LIMIT OF A "READ" THREAD, carried by every rendering that claims one (#3759 round 4).
+  # A thread counts as read when its payload was a comments LIST the scanner accepted; a malformed
+  # ENTRY inside an otherwise well-formed list is skipped by the scanner and is NOT distinguished
+  # here. Declared rather than closed: closing it would mean re-implementing the scanner parse in the
+  # caller, which is the second-implementation hazard the whole design rejects. Not appended to the
+  # MISPLACED rendering, where a marker WAS found and the limit cannot affect the claim, nor to the
+  # no-subject rendering, which claims no read at all.
+  read_limit=""
+  if [ -n "$read_list" ]; then
+    read_limit=" (NON-EXHAUSTIVE: a thread counts as read when its payload was a comments LIST the scanner accepted; a malformed ENTRY inside an otherwise well-formed list is skipped by the scanner and is not distinguished here)"
+  fi
   suffix="$bound_clause$cross_clause"
   # ===== A PARTIAL READ IS `could-not-check` NAMING BOTH HALVES, NEVER `checked` =====
   if [ -n "$unread_list" ]; then
     ROBOREV_PROBE_OUTCOME="could-not-check"
-    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: read with no matching marker: ${read_list:-none}; NOT read: $unread_list$suffix"
+    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: read with no matching marker: ${read_list:-none}; NOT read: $unread_list$suffix$read_limit"
     return 0
   fi
   if [ -z "$read_list" ] && [ -z "$bound_clause" ]; then
@@ -1702,13 +1741,13 @@ for ref in refs:
   fi
   ROBOREV_PROBE_OUTCOME="checked"
   if [ -n "$suffix" ]; then
-    ROBOREV_PROBE_DETAIL="linked issues ${read_list:-none} checked$suffix: no matching marker"
+    ROBOREV_PROBE_DETAIL="linked issues ${read_list:-none} checked$suffix: no matching marker$read_limit"
     return 0
   fi
   if [ "${#read_ok[@]}" -eq 1 ]; then
-    ROBOREV_PROBE_DETAIL="linked issue $read_list checked: no matching marker there either"
+    ROBOREV_PROBE_DETAIL="linked issue $read_list checked: no matching marker there either$read_limit"
   else
-    ROBOREV_PROBE_DETAIL="linked issues $read_list checked: no matching marker there either"
+    ROBOREV_PROBE_DETAIL="linked issues $read_list checked: no matching marker there either$read_limit"
   fi
   return 0
 }
@@ -1794,7 +1833,14 @@ roborev_absence_waiver_lookup() {
     ROBOREV_WAIVER_DETAIL="'gh pr view --json comments' failed (no PR for this branch, no auth, or an API error), so no waiver could be read"
     return 0
   fi
-  [ -n "$json" ] || return 0
+  # ===== AN EMPTY PAYLOAD IS AN UNREADABLE PAYLOAD, NOT AN ABSENT AUTHORIZATION (#3759 round 4) =====
+  # There used to be a `[ -n "$json" ] || return 0` here, which BYPASSED the validated read on the one
+  # input shape most likely to arrive from a healthy-looking `gh`: exit 0 with nothing on stdout. The
+  # early return left the state at its `none` default, so the block reported "there is no
+  # authorization" over comments NOBODY READ — the same false claim as every other unvalidated payload,
+  # on the GRANTING path, and (like the missing shape check this helper replaced) it predates the
+  # misplacement probe. Empty output now falls into `roborev_json_list_field` with every other shape
+  # and comes back `unavailable`, which is the value that says the oracle could not be consulted.
   # ===== THE ONE VALIDATED READ (#3759 round 3) =====
   # The scanner owns the WHOLE authorization decision — shape, scope, reason and authorization — so
   # this shell never associates an author with a body. Its output is `key=value` lines with
@@ -2073,7 +2119,14 @@ roborev_findings_deferral_lookup() {
     ROBOREV_DEFERRAL_DETAIL="'gh pr view --json comments' failed (no PR for this branch, no auth, or an API error), so no deferral could be read"
     return 0
   fi
-  [ -n "$json" ] || return 0
+  # ===== AN EMPTY PAYLOAD IS AN UNREADABLE PAYLOAD, NOT AN ABSENT AUTHORIZATION (#3759 round 4) =====
+  # There used to be a `[ -n "$json" ] || return 0` here, which BYPASSED the validated read on the one
+  # input shape most likely to arrive from a healthy-looking `gh`: exit 0 with nothing on stdout. The
+  # early return left the state at its `none` default, so the block reported "there is no
+  # authorization" over comments NOBODY READ — the same false claim as every other unvalidated payload,
+  # on the GRANTING path, and (like the missing shape check this helper replaced) it predates the
+  # misplacement probe. Empty output now falls into `roborev_json_list_field` with every other shape
+  # and comes back `unavailable`, which is the value that says the oracle could not be consulted.
   # THE ONE VALIDATED READ (#3759 round 3) — see the waiver's copy of this comment for what routing it
   # through the helper repairs on the GRANTING path, which is a pre-existing defect and not the
   # probe's. A malformed payload is `unavailable`, and the probe therefore never runs over it.

--- a/scripts/flow/roborev-review-oracles.sh
+++ b/scripts/flow/roborev-review-oracles.sh
@@ -1190,6 +1190,140 @@ WAIVER_SCAN_TOOL="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/roborev-waiver-s
 # The allowlist is still expressed once, above, and consumed only by the scanner it is passed to.
 
 
+# ============ THE ONE VALIDATED READ ON THIS PATH (issue #3759, round 3) ============
+# WHY THIS EXISTS AS A CHOKEPOINT AND NOT AS THREE MORE CHECKS. Three review rounds produced 3, then
+# 1, then 2 findings, and EVERY ONE was the same class: an input reaching a conclusion without an
+# affirmative validation, so "could not tell" collapsed onto an answer. Round 3's second finding was
+# inside `ref_repo()` — code round 3 ADDED while fixing that very class. This repository's standing
+# ruling for that shape (#3229: defects landing inside the preceding fix rounds; #3544: five rounds in
+# one mechanism) is to RESTRUCTURE, not to carve the same place a fourth time. So the validation is
+# removed from the call sites and expressed ONCE, and the guard suite asserts structurally that no
+# payload read and no scanner invocation on this path exists outside these two helpers. That is this
+# repo's own "remove the shared channel rather than pick a rarer delimiter", applied to validation:
+# it makes the NEXT input structurally unable to join the unvalidated set, which four rounds of site
+# fixes did not achieve.
+#
+# THE CHARACTER CONSTRAINT FOR A GITHUB OWNER OR REPOSITORY NAME, DEFINED EXACTLY ONCE. Round 3's
+# second finding was two PARALLEL identity validations — the shell's on the current repository and
+# `ref_repo()`'s on each reference's — where only one of them constrained anything. Two validators of
+# one grammar drift, and a drift here produces a CONFIDENT declared skip from an unvalidated identity,
+# which is the false confidence this whole feature exists to remove. So the pattern is written here
+# and is the only one either side uses: the shell interpolates it, and the python leg receives it.
+ROBOREV_GH_NAME_RE='[A-Za-z0-9._-]+'
+
+# roborev_json_list_field <json> <field>: is this payload a top-level JSON OBJECT whose <field> is a
+# LIST? Sets, and never returns non-zero:
+#   ROBOREV_JSONF_OK     1 (affirmatively yes) | 0 (anything else)
+#   ROBOREV_JSONF_CAUSE  the reason, when 0
+#
+# THE ONLY PLACE A PAYLOAD SHAPE IS JUDGED on this path. A missing key, an explicit `null`, a non-list
+# value, a non-object top level and an unparseable body are ONE answer here — none of them is the
+# shape we require — but they are never the PERMISSIVE answer, which is the whole point: `gh` always
+# returns the field it was asked for, so any of these is a broken payload and never an empty result.
+roborev_json_list_field() { # <json> <field>
+  ROBOREV_JSONF_OK=0
+  ROBOREV_JSONF_CAUSE="the payload was never examined"
+  if ! command -v python3 >/dev/null 2>&1; then
+    ROBOREV_JSONF_CAUSE="python3 is not on PATH, so the payload's shape could not be established"
+    return 0
+  fi
+  if printf '%s' "$1" | ROBOREV_JSONF_FIELD="$2" python3 -c '
+import json, os, sys
+field = os.environ.get("ROBOREV_JSONF_FIELD", "")
+try:
+    data = json.load(sys.stdin)
+except ValueError:
+    sys.exit(1)
+# The OBJECT form is what every `gh ... --json <field>` call emits, measured. A bare top-level list is
+# refused even where a downstream consumer would accept one: a shape `gh` does not produce is a shape
+# nobody established, and a false could-not-check is the fail-closed direction.
+if not isinstance(data, dict):
+    sys.exit(1)
+if field not in data:
+    sys.exit(1)
+if not isinstance(data[field], list):
+    sys.exit(1)
+' 2>/dev/null; then
+    ROBOREV_JSONF_OK=1
+    ROBOREV_JSONF_CAUSE=""
+    return 0
+  fi
+  ROBOREV_JSONF_CAUSE="the payload was not a JSON object carrying a $2 LIST (it was unparseable, a non-object, missing that key, or null)"
+  return 0
+}
+
+# roborev_validated_authorization_scan <kind> <base> <head> <job> <observed-or-empty> <json>:
+# the ONE way an authorization scan is performed anywhere in this file. Sets, and never returns
+# non-zero:
+#   ROBOREV_VSCAN_OUTCOME  ok | could-not-check | refused
+#   ROBOREV_VSCAN_CAUSE    the reason, on the two non-ok outcomes
+#   ROBOREV_VSCAN_RESULT   the scanner's raw key=value lines, on `ok` only
+#   ROBOREV_VSCAN_STATE    the scanner's state, VALIDATED, on `ok` only
+#
+# THREE-VALUED ON PURPOSE, because the two failures are different operator actions. `could-not-check`
+# is "this box could not perform the read" (no python3, no scanner file, the scanner died) — fix the
+# box. `refused` is "we DID look and what came back is not a shape or a verdict we accept" (a payload
+# that is not an object carrying a comments list; a `state=` outside the closed set) — fix or report
+# the payload. Neither is ever permissive, and a two-valued return would re-import the collapse this
+# whole restructure exists to remove.
+#
+# A ZERO EXIT FROM THE SCANNER IS NOT A SUCCESSFUL READ. The scanner reduces `{}`,
+# `{"comments": null}` and `{"comments": {}}` to an EMPTY comment list and exits 0 — CORRECT for its
+# own contract (*given these comments, is there an authorization in them?* over no comments is "no"),
+# and it is reused UNMODIFIED by design, so the shape check belongs to the CALLER that draws a
+# conclusion. That caller is now this one function rather than three separate ones.
+roborev_validated_authorization_scan() { # <kind> <base> <head> <job> <observed-or-empty> <json>
+  local kind="$1" base="$2" head="$3" job="$4" observed="$5" json="$6" rc
+  ROBOREV_VSCAN_OUTCOME="could-not-check"
+  ROBOREV_VSCAN_CAUSE="the scan was never performed"
+  ROBOREV_VSCAN_RESULT=""
+  ROBOREV_VSCAN_STATE=""
+  if ! command -v python3 >/dev/null 2>&1 || [ ! -f "$WAIVER_SCAN_TOOL" ]; then
+    ROBOREV_VSCAN_CAUSE="the structured authorization scanner is unusable (python3 present: $(command -v python3 >/dev/null 2>&1 && printf yes || printf no); tool: $WAIVER_SCAN_TOOL) — an authorization is NEVER decided from a flattened text stream, so this fails closed rather than falling back to line parsing"
+    return 0
+  fi
+  roborev_json_list_field "$json" comments
+  if [ "$ROBOREV_JSONF_OK" -ne 1 ]; then
+    ROBOREV_VSCAN_OUTCOME="refused"
+    ROBOREV_VSCAN_CAUSE="$ROBOREV_JSONF_CAUSE, so nothing was actually read from it — the scanner would have reduced it to zero comments and exited 0, which is NOT a check"
+    return 0
+  fi
+  # THE ONE SCANNER INVOCATION IN THIS FILE. The kind is always named explicitly by the caller and
+  # there is no default, so no call can ever read a marker its caller did not ask for; the deferral
+  # additionally passes its observed count, so `count=` is matched identically wherever it is asked.
+  if [ -n "$observed" ]; then
+    ROBOREV_VSCAN_RESULT="$(printf '%s' "$json" | python3 "$WAIVER_SCAN_TOOL" "$kind" "$base" "$head" "$job" "$ROBOREV_WAIVER_AUTHORS" "$observed" 2>/dev/null)" && rc=0 || rc=1
+  else
+    ROBOREV_VSCAN_RESULT="$(printf '%s' "$json" | python3 "$WAIVER_SCAN_TOOL" "$kind" "$base" "$head" "$job" "$ROBOREV_WAIVER_AUTHORS" 2>/dev/null)" && rc=0 || rc=1
+  fi
+  if [ "$rc" -ne 0 ]; then
+    ROBOREV_VSCAN_RESULT=""
+    ROBOREV_VSCAN_OUTCOME="could-not-check"
+    ROBOREV_VSCAN_CAUSE="the scanner exited non-zero although the payload was well-formed, so what it found was never established"
+    return 0
+  fi
+  ROBOREV_VSCAN_STATE="$(printf '%s\n' "$ROBOREV_VSCAN_RESULT" | sed -n 's/^state=//p' | head -1)"
+  # ===== THE RETURNED STATE IS A CLOSED GRAMMAR, CHECKED BEFORE IT IS TRUSTED =====
+  # An EMPTY or ABSENT `state=` line, or one nothing here has ever judged, is not a verdict. The
+  # permissive branch is keyed on AFFIRMATIVE membership, never on `!= granted` — the same rule the
+  # wrapper applies to its own verdict keys. This is the set the SCANNER may return; it is NOT the
+  # lookups' own recognition lists, which additionally carry `misplaced` (a state the scanner cannot
+  # emit, because thread identity is the caller's knowledge).
+  case "$ROBOREV_VSCAN_STATE" in
+    granted|unauthorized|stale|malformed|none|count-mismatch|unavailable) ;;
+    *)
+      ROBOREV_VSCAN_OUTCOME="refused"
+      ROBOREV_VSCAN_CAUSE="the scanner returned the unrecognised state '${ROBOREV_VSCAN_STATE:-<none>}', so what it found was never established"
+      ROBOREV_VSCAN_RESULT=""
+      ROBOREV_VSCAN_STATE=""
+      return 0
+      ;;
+  esac
+  ROBOREV_VSCAN_OUTCOME="ok"
+  ROBOREV_VSCAN_CAUSE=""
+  return 0
+}
+
 # ============ THE LINKED-ISSUE MISPLACEMENT PROBE (issue #3759) ============
 # WHY IT EXISTS, measured rather than imagined. For PR #3710 the coordination lead granted BOTH
 # authorizations — field-perfect, correct base/head/job, each the sole nonblank content of its own
@@ -1241,7 +1375,7 @@ ROBOREV_LINKED_ISSUE_PROBE_MAX=3
 roborev_linked_issue_marker_probe() { # <kind> <base> <head> <job> [<observed-findings-count>]
   local kind="$1" base="$2" head="$3" job="$4" observed="${5:-}"
   local rel_errfile rel_json rel_errtext numbers declared probed=0 skipped_cross=0
-  local issue read_ok=() unread=() comments result state scan_rc
+  local issue read_ok=() unread=() comments state
   local issue_errfile issue_errtext read_list unread_list bound_clause cross_clause suffix
   local repo_nwo repo_errfile repo_errtext
   ROBOREV_PROBE_OUTCOME="could-not-check"
@@ -1252,10 +1386,6 @@ roborev_linked_issue_marker_probe() { # <kind> <base> <head> <job> [<observed-fi
   ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: the probe was never asked"
   if ! command -v gh >/dev/null 2>&1; then
     ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: 'gh' is not on PATH"
-    return 0
-  fi
-  if ! command -v python3 >/dev/null 2>&1 || [ ! -f "$WAIVER_SCAN_TOOL" ]; then
-    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: the structured authorization scanner is unusable, and a marker is NEVER recognised from a flattened text stream — not even to print a diagnostic, because a second recogniser is a second place for the grammar to diverge"
     return 0
   fi
   if ! rel_errfile="$(mktemp 2>/dev/null)"; then
@@ -1309,7 +1439,7 @@ roborev_linked_issue_marker_probe() { # <kind> <base> <head> <job> [<observed-fi
   # the pull request derived from an identity nobody established. The pattern is therefore exactly one
   # `owner/name` pair over GitHub's own character set, so anything else takes the could-not-check
   # branch with the rest of the class.
-  if [[ ! "$repo_nwo" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+  if [[ ! "$repo_nwo" =~ ^${ROBOREV_GH_NAME_RE}/${ROBOREV_GH_NAME_RE}$ ]]; then
     rm -f "$rel_errfile"
     ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: 'gh repo view --json nameWithOwner' did not answer with a single owner/name pair, so which repository a closing reference points at could not be established"
     return 0
@@ -1354,32 +1484,34 @@ roborev_linked_issue_marker_probe() { # <kind> <base> <head> <job> [<observed-fi
   # for digits itself. Two affirmative tests rather than one because the shell is what interpolates
   # into an emitted diagnostic, and a value that reaches a renderer must have been judged by the
   # process that renders it.
-  if ! numbers="$(printf '%s' "$rel_json" | PROBE_REPO_NWO="$repo_nwo" python3 -c '
-import json, os, sys
+  # THE RELATION PAYLOAD'S SHAPE IS JUDGED BY THE ONE VALIDATOR, not by this extractor. The extractor
+  # below therefore PARSES and never DECIDES: by the time it runs, the payload is affirmatively an
+  # object whose `closingIssuesReferences` is a list.
+  roborev_json_list_field "$rel_json" closingIssuesReferences
+  if [ "$ROBOREV_JSONF_OK" -ne 1 ]; then
+    ROBOREV_PROBE_DETAIL="the linked-issue thread could NOT be checked: $ROBOREV_JSONF_CAUSE — that is a broken payload, NOT an empty relation, and the two must never render alike"
+    return 0
+  fi
+  if ! numbers="$(printf '%s' "$rel_json" | PROBE_REPO_NWO="$repo_nwo" PROBE_NAME_RE="$ROBOREV_GH_NAME_RE" python3 -c '
+import json, os, re, sys
 # The current repository, as `gh` itself resolves it. Compared CASE-INSENSITIVELY because GitHub
 # owner and repository names are case-insensitive, so `PMcFadin/CQLite` and `pmcfadin/cqlite` are one
 # repository and treating them as two would produce a declared skip for a same-repository reference.
+# ONE grammar for a GitHub owner or repository name, received from the shell so that the current
+# repository and every reference are held to the SAME constraint. Two parallel validators of one
+# grammar drift, and a drift here yields a CONFIDENT declared skip from an unvalidated identity.
+NAME_RE = re.compile("^" + os.environ.get("PROBE_NAME_RE", "(?!)") + "$")
 want_repo = " ".join(os.environ.get("PROBE_REPO_NWO", "").split()).lower()
+# The shape was judged by `roborev_json_list_field` before this ran, so this leg PARSES and never
+# DECIDES. A parse failure here would mean the payload changed between the two reads, which cannot
+# happen (it is one shell variable), so it stays a non-zero exit rather than a silent empty set.
 try:
     data = json.load(sys.stdin)
 except ValueError:
     sys.exit(1)
-# ===== THE SHAPE IS TESTED AFFIRMATIVELY; NOTHING UNREADABLE BECOMES AN ANSWER (#3759 round 1) =====
-# This used to read `data.get(...) if isinstance(data, dict) else None` and then coerce a `None` to
-# `[]`, so FOUR different unreadable payloads — a non-object top level, a MISSING
-# `closingIssuesReferences` key, an explicit `null`, and a non-list value — all arrived at the
-# shell as ZERO declared references and rendered "no linked issue is declared on this PR". That is
-# an ANSWER derived from a payload that could not be read: the permissive-branch-inherits-the-
-# unknown-state shape this whole file is written against. `gh pr view --json closingIssuesReferences`
-# ALWAYS returns the key it was asked for, so its absence is a broken payload and never an empty
-# relation. Each of these is now a NON-ZERO exit, which the caller renders as could-not-check.
-if not isinstance(data, dict):
-    sys.exit(1)
-if "closingIssuesReferences" not in data:
+if not isinstance(data, dict) or not isinstance(data.get("closingIssuesReferences"), list):
     sys.exit(1)
 refs = data["closingIssuesReferences"]
-if not isinstance(refs, list):
-    sys.exit(1)
 
 def ref_repo(ref):
     """owner/name for a reference, lowercased, or None when it cannot be established.
@@ -1395,7 +1527,14 @@ def ref_repo(ref):
     name = repo.get("name")
     owner = repo.get("owner")
     login = owner.get("login") if isinstance(owner, dict) else None
-    if not isinstance(name, str) or not isinstance(login, str) or not name or not login:
+    if not isinstance(name, str) or not isinstance(login, str):
+        return None
+    # BOTH COMPONENTS ARE HELD TO THE SAME CONSTRAINT AS THE CURRENT REPOSITORY (#3759 round 3). A
+    # non-empty check is not a validation: `"a b"`, `"x/y"` or a newline-bearing value would have
+    # produced a joined identity that compares unequal to everything, and an identity that matches
+    # nothing renders as a CONFIDENT cross-repository DECLARED SKIP. An identity that fails this is
+    # REPO-UNVERIFIED — "cannot tell which repository" — and never CROSS-REPO.
+    if not NAME_RE.match(name) or not NAME_RE.match(login):
         return None
     return ("%s/%s" % (login, name)).lower()
 
@@ -1475,73 +1614,18 @@ for ref in refs:
       continue
     fi
     rm -f "$issue_errfile"
-    # ===== THE PAYLOAD IS VALIDATED AFFIRMATIVELY BEFORE ANY CONCLUSION IS DRAWN FROM IT (#3759 r2) =
-    # A ZERO EXIT FROM THE SCANNER IS NOT "THE THREAD WAS READ". The scanner coerces a valid-JSON but
-    # malformed payload — `{}`, `{"comments": null}`, `{"comments": {}}` — to an EMPTY comment list
-    # and exits 0, which is CORRECT for its own contract (*given these comments, is there an
-    # authorization in them?* — over no comments, the answer is no). It is this CALLER that then drew
-    # the unwarranted conclusion, rendering "checked: no matching marker" over a thread nothing was
-    # ever read from. The scanner is reused UNMODIFIED by design, so the validation belongs here.
-    #
-    # AND THIS IS THE INVARIANT, NOT THE SITE. Round 1 fixed the same collapse on the RELATION payload
-    # and left the sibling input on the same path with it. The rule for this whole probe is: EVERY
-    # INPUT IS VALIDATED AFFIRMATIVELY, AND "COULD NOT TELL" NEVER COLLAPSES ONTO AN ANSWER. The
-    # inputs are the current-repository identity, the relation payload, each reference's
-    # classification token, this comments payload, the scanner's exit status and the scanner's
-    # `state=` — all six now have an affirmative test, and a new input on this path needs one too.
-    if ! printf '%s' "$comments" | python3 -c '
-import json, sys
-try:
-    data = json.load(sys.stdin)
-except ValueError:
-    sys.exit(1)
-# The object form is what `gh issue view --json comments` emits, measured; a bare top-level list is
-# refused even though the scanner would accept one, because a shape `gh` does not produce is a shape
-# nobody established, and a false could-not-check is the fail-closed direction.
-if not isinstance(data, dict):
-    sys.exit(1)
-if "comments" not in data:
-    sys.exit(1)
-if not isinstance(data["comments"], list):
-    sys.exit(1)
-' 2>/dev/null; then
-      unread+=("#$issue (its comments payload was not a JSON object carrying a comments LIST, so nothing was actually read from that thread — the scanner would have reduced it to zero comments and exited 0, which is NOT a check)")
+    # ===== ONE VALIDATED READ, THE SAME ONE THE GRANTING LOOKUPS USE (#3759 round 3) =====
+    # The payload shape, the scanner invocation, the scanner's exit status and its returned `state=`
+    # are all judged inside `roborev_validated_authorization_scan` — the same kind, base, head, job,
+    # allowlist and observed count as the pull-request-side call, with no new argument, no new grammar
+    # and no thread parameter. Anything other than `ok` makes this thread UNREAD, never checked: a
+    # thread whose read we could not validate was not looked at, whatever the scanner's exit code said.
+    roborev_validated_authorization_scan "$kind" "$base" "$head" "$job" "$observed" "$comments"
+    if [ "$ROBOREV_VSCAN_OUTCOME" != "ok" ]; then
+      unread+=("#$issue ($ROBOREV_VSCAN_OUTCOME: $ROBOREV_VSCAN_CAUSE)")
       continue
     fi
-    # THE SAME SCANNER, THE SAME KIND, THE SAME SCOPE, THE SAME ALLOWLIST. No new argument, no new
-    # grammar, no thread parameter — see the header. The deferral additionally passes the SAME
-    # observed count, so `count=` is matched identically on both threads.
-    if [ -n "$observed" ]; then
-      result="$(printf '%s' "$comments" | python3 "$WAIVER_SCAN_TOOL" "$kind" "$base" "$head" "$job" "$ROBOREV_WAIVER_AUTHORS" "$observed" 2>/dev/null)" && scan_rc=0 || scan_rc=1
-    else
-      result="$(printf '%s' "$comments" | python3 "$WAIVER_SCAN_TOOL" "$kind" "$base" "$head" "$job" "$ROBOREV_WAIVER_AUTHORS" 2>/dev/null)" && scan_rc=0 || scan_rc=1
-    fi
-    if [ "$scan_rc" -ne 0 ]; then
-      # REACHED ONLY FOR A NON-ZERO EXIT THE VALIDATION ABOVE DID NOT ALREADY EXPLAIN: the payload was
-      # affirmatively a JSON object carrying a comments list, so an unparseable payload is no longer
-      # this branch's cause and the text no longer claims it is. Kept as a defensive branch — a
-      # scanner that dies for any other reason must still be a could-not-check and never a check.
-      unread+=("#$issue (the scanner exited non-zero for that thread although its payload was well-formed, so what it found there was never established)")
-      continue
-    fi
-    state="$(printf '%s\n' "$result" | sed -n 's/^state=//p' | head -1)"
-    # ===== THE RETURNED STATE IS A CLOSED GRAMMAR, CHECKED BEFORE IT IS TRUSTED (#3759 r2) =====
-    # An EMPTY or ABSENT `state=` line, or one this code has never judged, used to count as a
-    # successfully checked thread — a verdict derived from a value nobody validated, and the same
-    # collapse as the payload above. The permissive branch is keyed on the AFFIRMATIVE membership,
-    # never on `!= granted`, which is the rule the wrapper already applies to its own verdict keys.
-    #
-    # THE UNION OF THE TWO LOOKUPS' RECOGNITION LISTS, deliberately not narrowed per kind: this is a
-    # RECOGNITION list, not a granting list, every member of it is non-granting except `granted`, and
-    # the escalation below keys on `granted` alone — so per-kind precision here would buy nothing and
-    # would add a second place for those lists to drift.
-    case "$state" in
-      granted|unauthorized|stale|malformed|none|count-mismatch|unavailable) ;;
-      *)
-        unread+=("#$issue (the scanner returned the unrecognised state '${state:-<none>}' for that thread, so what it found there was never established)")
-        continue
-        ;;
-    esac
+    state="$ROBOREV_VSCAN_STATE"
     read_ok+=("#$issue")
     # ===== ESCALATION ONLY FROM AN ISSUE-SIDE `granted`, KEYED ON THE AFFIRMATIVE VALUE =====
     # An issue-side marker that is itself stale, malformed or unauthorized is a DIFFERENT defect that
@@ -1694,11 +1778,6 @@ roborev_absence_waiver_lookup() {
     ROBOREV_WAIVER_DETAIL="'gh' is not on PATH, so no PR comment could be read"
     return 0
   fi
-  if ! command -v python3 >/dev/null 2>&1 || [ ! -f "$WAIVER_SCAN_TOOL" ]; then
-    ROBOREV_WAIVER_STATE="unavailable"
-    ROBOREV_WAIVER_DETAIL="the structured waiver scanner is unusable (python3 present: $(command -v python3 >/dev/null 2>&1 && printf yes || printf no); tool: $WAIVER_SCAN_TOOL) — a waiver is NEVER decided from a flattened text stream, so this fails closed rather than falling back to line parsing"
-    return 0
-  fi
   # ===== ONE `gh` CALL, RAW JSON, DECIDED STRUCTURALLY (#3312 job 26) =====
   # `--json comments` WITHOUT `--jq`: the author and the body must stay SEPARATE FIELDS of the same
   # object all the way to the decision. The previous form asked `jq` to flatten them into one text
@@ -1716,26 +1795,39 @@ roborev_absence_waiver_lookup() {
     return 0
   fi
   [ -n "$json" ] || return 0
-  # The scanner owns the WHOLE decision — shape, scope, reason and authorization — so this shell never
-  # associates an author with a body. Its output is `key=value` lines with whitespace-collapsed values,
-  # the same shape `roborev-job-facts.py` emits, so a free-text reason cannot introduce a second channel.
-  # THE MARKER KIND IS NAMED EXPLICITLY (#3626). The scanner now decides TWO authorizations — the
-  # absence waiver and the findings deferral — and each call selects exactly one, so neither can ever
-  # read the other's marker: an absence waiver confers no authority over `findings:` and a findings
-  # deferral confers none over `prompt-content:`. There is no default kind, deliberately: a default
-  # would be the one thing that could make a call read a marker its caller did not ask for.
-  if ! result=$(printf '%s' "$json" | python3 "$WAIVER_SCAN_TOOL" prompt-content-absent "$base" "$head" "$job" "$ROBOREV_WAIVER_AUTHORS" 2>/dev/null); then
+  # ===== THE ONE VALIDATED READ (#3759 round 3) =====
+  # The scanner owns the WHOLE authorization decision — shape, scope, reason and authorization — so
+  # this shell never associates an author with a body. Its output is `key=value` lines with
+  # whitespace-collapsed values, the same shape `roborev-job-facts.py` emits, so a free-text reason
+  # cannot introduce a second channel. THE MARKER KIND IS NAMED EXPLICITLY (#3626): the scanner
+  # decides TWO authorizations and each call selects exactly one, with no default — a default would
+  # be the one thing that could make a call read a marker its caller did not ask for.
+  #
+  # WHAT ROUTING THIS THROUGH THE HELPER REPAIRS, AND IT IS NOT ONLY THE PROBE: this call previously
+  # handed the PR payload to the scanner with NO SHAPE VALIDATION, so a valid-JSON but malformed
+  # payload (`{}`, `{"comments": null}`, `{"comments": {}}`) was reduced to zero comments and reported
+  # `waiver: NONE` — "there is no authorization" — when the comments were never read. That is a
+  # PRE-EXISTING defect on the GRANTING path, older than the misplacement probe; the probe merely
+  # added a new consequence to it. A malformed payload is now `unavailable` (the state that says the
+  # oracle could not be consulted), and because the probe runs ONLY from `none`, it is not run at all.
+  roborev_validated_authorization_scan prompt-content-absent "$base" "$head" "$job" "" "$json"
+  if [ "$ROBOREV_VSCAN_OUTCOME" != "ok" ]; then
     ROBOREV_WAIVER_STATE="unavailable"
-    ROBOREV_WAIVER_DETAIL="the PR comments could not be parsed as JSON, so no waiver could be established"
+    # THE HELPER'S CAUSE IS PASSED THROUGH VERBATIM, not wrapped. It is already a self-contained
+    # sentence, and one of them names the SCANNER'S OWN PATH, which an operator has to read to fix a
+    # fail-closed UNAVAILABLE — a wrapper sentence in front of it buys nothing and costs the reader.
+    ROBOREV_WAIVER_DETAIL="$ROBOREV_VSCAN_CAUSE"
     return 0
   fi
-  ROBOREV_WAIVER_STATE=$(printf '%s\n' "$result" | sed -n 's/^state=//p' | head -1)
+  result="$ROBOREV_VSCAN_RESULT"
+  ROBOREV_WAIVER_STATE="$ROBOREV_VSCAN_STATE"
   ROBOREV_WAIVER_AUTHOR=$(printf '%s\n' "$result" | sed -n 's/^author=//p' | head -1)
   ROBOREV_WAIVER_SCOPE=$(printf '%s\n' "$result" | sed -n 's/^scope=//p' | head -1)
   ROBOREV_WAIVER_REASON=$(printf '%s\n' "$result" | sed -n 's/^reason=//p' | head -1)
   ROBOREV_WAIVER_DETAIL=$(printf '%s\n' "$result" | sed -n 's/^detail=//p' | head -1)
-  # A STATE THIS CODE HAS NEVER JUDGED IS NOT A PASS: an unrecognised (or empty) verdict from the
-  # scanner fails closed instead of inheriting the permissive path.
+  # A STATE THIS CODE HAS NEVER JUDGED IS NOT A PASS. The scanner's own state was already validated
+  # against its closed set inside the helper, so this `case` is now a BELT over THIS function's state
+  # variable — which is a different subject, because the probe below can additionally set `misplaced`.
   case "$ROBOREV_WAIVER_STATE" in
     # `misplaced` IS IN THIS LIST AS A BELT, NOT AS A ROUTE (#3759). The scanner never emits it —
     # thread identity is the caller's knowledge — and the probe below assigns it AFTER this
@@ -1969,11 +2061,6 @@ roborev_findings_deferral_lookup() {
     ROBOREV_DEFERRAL_DETAIL="'gh' is not on PATH, so no PR comment could be read"
     return 0
   fi
-  if ! command -v python3 >/dev/null 2>&1 || [ ! -f "$WAIVER_SCAN_TOOL" ]; then
-    ROBOREV_DEFERRAL_STATE="unavailable"
-    ROBOREV_DEFERRAL_DETAIL="the structured authorization scanner is unusable (python3 present: $(command -v python3 >/dev/null 2>&1 && printf yes || printf no); tool: $WAIVER_SCAN_TOOL) — an authorization is NEVER decided from a flattened text stream, so this fails closed rather than falling back to line parsing"
-    return 0
-  fi
   # ONE `gh` CALL, RAW JSON, DECIDED STRUCTURALLY — AND `comments` IS THE WHOLE PAYLOAD (#3626).
   # `body` was fetched here for a PR-body link check that has been DELETED rather than patched: a PR
   # body is editable at any time by anyone with write access with NO per-edit attribution, while a
@@ -1987,12 +2074,17 @@ roborev_findings_deferral_lookup() {
     return 0
   fi
   [ -n "$json" ] || return 0
-  if ! result=$(printf '%s' "$json" | python3 "$WAIVER_SCAN_TOOL" findings-deferral "$base" "$head" "$job" "$ROBOREV_WAIVER_AUTHORS" "$observed" 2>/dev/null); then
+  # THE ONE VALIDATED READ (#3759 round 3) — see the waiver's copy of this comment for what routing it
+  # through the helper repairs on the GRANTING path, which is a pre-existing defect and not the
+  # probe's. A malformed payload is `unavailable`, and the probe therefore never runs over it.
+  roborev_validated_authorization_scan findings-deferral "$base" "$head" "$job" "$observed" "$json"
+  if [ "$ROBOREV_VSCAN_OUTCOME" != "ok" ]; then
     ROBOREV_DEFERRAL_STATE="unavailable"
-    ROBOREV_DEFERRAL_DETAIL="the PR payload could not be parsed as JSON, so no deferral could be established"
+    ROBOREV_DEFERRAL_DETAIL="$ROBOREV_VSCAN_CAUSE"
     return 0
   fi
-  ROBOREV_DEFERRAL_STATE=$(printf '%s\n' "$result" | sed -n 's/^state=//p' | head -1)
+  result="$ROBOREV_VSCAN_RESULT"
+  ROBOREV_DEFERRAL_STATE="$ROBOREV_VSCAN_STATE"
   ROBOREV_DEFERRAL_AUTHOR=$(printf '%s\n' "$result" | sed -n 's/^author=//p' | head -1)
   ROBOREV_DEFERRAL_SCOPE=$(printf '%s\n' "$result" | sed -n 's/^scope=//p' | head -1)
   ROBOREV_DEFERRAL_REASON=$(printf '%s\n' "$result" | sed -n 's/^reason=//p' | head -1)

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -121,7 +121,15 @@
 #                     snapshot-delivered diff and a vacuous review that received nothing are IDENTICAL
 #                     to the machine. A human plus the review's token accounting distinguishes them.
 #   waiver            GRANTED (author=@<login> sha=<40-hex> reason=<why>) | NONE (...) | STALE (...) |
-#                     MALFORMED (...) | UNAVAILABLE (...)
+#                     MALFORMED (...) | UNAUTHORIZED (...) | MISPLACED (...) | UNAVAILABLE (...)
+#                     MISPLACED (#3759) is NON-GRANTING and purely INFORMATIONAL: when no marker is
+#                     on the PR, the PR's LINKED ISSUE(s) are scanned with the SAME scanner and the
+#                     SAME scope, and one there that WOULD have been accepted by the channel is
+#                     reported `MISPLACED (found on linked issue #N …)` with the remedy — re-post it
+#                     as a TOP-LEVEL PR COMMENT. It GRANTS NOTHING and the absence FAIL stands;
+#                     only a marker on the PULL REQUEST grants. A `NONE` additionally DECLARES
+#                     whether that probe ran, so "checked and it is not there either" and "never
+#                     checked" can never read alike.
 #                     PRESENT ONLY WHEN THE ABSENCE BRANCH RAN, so it is absent rather than
 #                     placeholdered on a run that had nothing to waive. INFORMATIONAL: it is not in the
 #                     verdict scan and cannot make anything pass by itself. The waiver is a DEDICATED,
@@ -156,7 +164,12 @@
 #                     head=<…> job=<id> reason=<why>) | NONE (...) | STALE (...) |
 #                     MALFORMED (...) | UNAUTHORIZED (...) | COUNT-MISMATCH (...) |
 #                     ISSUE-ABSENT (...) | ISSUE-CLOSED (...) | ISSUE-UNVERIFIABLE (...) |
-#                     UNAVAILABLE (...)
+#                     MISPLACED (...) | UNAVAILABLE (...)
+#                     MISPLACED (#3759) is NON-GRANTING and purely INFORMATIONAL, exactly as on
+#                     `waiver:` and served by the same probe: an authorization on the PR's LINKED
+#                     ISSUE that would have been accepted by the channel is NAMED, with the remedy,
+#                     while `findings:` stays exactly as measured — never DEFERRED, never NONE. A
+#                     `NONE` here declares whether the probe ran, too.
 #                     PRESENT ONLY WHEN THE FINDINGS BRANCH HAD A DEFERRAL TO LOOK FOR (a
 #                     `--recheck-job` over an affirmatively measured `PRESENT (n)`), so it is
 #                     absent rather than placeholdered otherwise. INFORMATIONAL, exactly like
@@ -484,8 +497,21 @@ SHAPE AND CHANNEL, both load-bearing:
     fence skipping, fence-state tracking): deciding "data or control?" inside a grammar
     the author controls is unbounded, and no quoting construct can be the ONLY thing in
     a comment, so quoting cannot grant.
-  * THE COMMENT MUST BE TOP-LEVEL. Markers inside a review body or a review-thread
-    reply are not read (fail-closed, but it looks like the waiver was ignored).
+  * THE COMMENT MUST BE TOP-LEVEL, AND ON THE PULL REQUEST. Three locations are not
+    read: the PR's LINKED ISSUE thread — THE MOST PROBABLE MISPLACEMENT, because that
+    is where lane/lead coordination lives — a review body, and a review-thread reply.
+    None of them applies (fail-closed, but it looks like the authorization was
+    ignored). MEASURED: for PR #3710 both markers were granted, field-perfect, on
+    issue #3544, and the run reported NONE for both; a six-PR queue idled ~8 hours.
+    SINCE #3759 THE LINKED-ISSUE CASE IS DIAGNOSED: on a 'none', the PR's linked
+    issue(s) are scanned with the SAME scanner and scope, and a marker there that
+    would have been accepted is reported 'waiver: MISPLACED (...)' /
+    'deferral: MISPLACED (...)' naming the issue. It GRANTS NOTHING and the FAIL
+    stands — only a marker on the PULL REQUEST grants, and moving it there is the
+    authorizer's own act.
+  * AFTER POSTING EITHER MARKER, VERIFY IT IS ON THE PR, with
+    'gh pr view <the-PR-number> --json comments'. A grant is only granted once it is
+    readable by the scanner that reads it.
 
 THE AUTHOR MUST BE ON AN EXPLICIT ALLOWLIST (see ROBOREV_WAIVER_AUTHORS in
 roborev-review-oracles.sh). This is a PUBLIC repository and a failing block PRINTS the

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -6649,6 +6649,53 @@ assert_says 'case (mp20b) and the declared read limit, because a read is claimed
 assert_lacks 'case (mp20b) and it is not a could-not-check' 'no thread was read'
 reset_stub
 
+printf '== (mp21) #3759 r7: NO linked issues + a FAILING repository resolution is still no-subject ==\n'
+# ROUND-7 FINDING 1, AND IT COST CORRECTNESS RATHER THAN A CALL. The current repository used to be
+# resolved BEFORE the relation was read, so a PR with NO linked issues at all still depended on
+# `gh repo view` — and when that call failed while the relation was perfectly readable, the probe
+# reported "could NOT be checked" where the truthful answer was the definitive `no-subject`. A
+# could-not-tell reported WHERE AN ANSWER EXISTS is the exact inverse of the collapse this path is
+# built against, and just as wrong: it hides a finished check behind an apparent infrastructure fault.
+reset_stub
+mp_waiver_fixture
+STUB_GH_REPO_RC=1
+run_wrapper "$w_work"
+assert_verdict 'case (mp21)' FAIL 1
+assert_no_marker_form 'case (mp21)'
+assert_says 'case (mp21) the definitive answer survives an unrelated resolution failure' \
+  'no linked issue is declared on this PR, so no linked-issue thread was checked'
+assert_lacks 'case (mp21) and it is NOT reported as a could-not-check' 'could NOT be checked'
+assert_lacks 'case (mp21) nor does it name a resolution the answer never needed' \
+  'gh repo view --json nameWithOwner'
+# MEASURED, NOT INFERRED: the call is NOT MADE, not merely ignored — which is the only version an
+# invocation log can distinguish, and the same standard the probe's own reachability is held to.
+if grep -qE 'gh repo view' "$INVOKED"; then
+  bad 'case (mp21): the repository was resolved for a PR with no linked references at all — the answer does not depend on it, so the call must not be made'
+else
+  ok 'case (mp21): no repository resolution was performed (checked against the stub invocation record)'
+fi
+reset_stub
+
+printf '== (mp21b) #3759 r7: WITH references, the resolution IS required and its failure IS reported ==\n'
+# The control: one variable changes — a reference now exists — and the same failing resolution becomes
+# load-bearing, so it must be reported rather than swallowed. Without this, (mp21) would pass
+# identically if the repository resolution had simply been deleted.
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_ISSUES='3544'
+STUB_GH_REPO_RC=1
+run_wrapper "$w_work"
+assert_verdict 'case (mp21b)' FAIL 1
+assert_says 'case (mp21b) with references to classify, the failed resolution is the cause' \
+  "the linked-issue thread could NOT be checked: 'gh repo view --json nameWithOwner' failed"
+assert_lacks 'case (mp21b) and it is not misreported as no-subject' 'no linked issue is declared on this PR'
+if grep -qE 'gh repo view' "$INVOKED"; then
+  ok 'case (mp21b): the repository WAS resolved once a reference needed classifying (the ordering is conditional, not removed)'
+else
+  bad 'case (mp21b): the repository was never resolved even with a reference to classify, so (mp21) proves nothing about ordering'
+fi
+reset_stub
+
 printf '== (mp12) #3759 MUTANT: probing on EVERY state reds — the escalation is only from none ==\n'
 # A CASE THAT PASSES AGAINST BOTH THE REAL CODE AND ITS NAIVE FORM MEASURES NOTHING. The naive form
 # here is "probe whatever the PR-side state was", which overwrites a precise STALE with a vaguer
@@ -8181,6 +8228,42 @@ fi
 # "simplification" would quietly undo. Neither substitutes for the other — a structural assert cannot
 # see a granting path built some other way, and a behavioural case cannot see a granting path nobody
 # fixtured.
+printf '== structural (#3759 r7): the documented output-state contracts list every state ==\n'
+# A COMMENT NAMING A MECHANISM IS A CLAIM ABOUT CODE and decays exactly like any other. These two
+# headers enumerate what their function can emit, and a CLOSED list missing states is worse than no
+# list, because a caller trusts it — the waiver's omitted `unauthorized` predates #3759 and had gone
+# unnoticed for exactly that reason. Asserted against the states the code can actually assign.
+# EXTRACTED TO FILES, NEVER PIPED INTO `grep -q` (#3387). The polarity here is fail-CLOSED in the
+# noisy direction — `grep -q` exits at its first match, SIGPIPEs the upstream `sed`, this file's
+# `pipefail` takes the 141, and a state that IS documented reads as missing. Caught in review of this
+# very block: two consecutive runs reported DIFFERENT states missing, which is the race and not the
+# contract. A guard that reds at random is one agents learn to ignore, so it is removed rather than
+# tolerated.
+_sc_bad=""
+_sc_wh="$tmp/state-contract-waiver.txt"
+_sc_dh="$tmp/state-contract-deferral.txt"
+# THE VALUE LINES ONLY, NOT THE HEADER PARAGRAPH AROUND THEM. Caught by this block's own mutant: with
+# the whole header extracted, the PROSE explaining which states had been missing named those states,
+# so deleting them from the CONTRACT still read as clean — a check about code satisfied by a comment,
+# which is the shape this repository already lints for elsewhere. The extraction now runs from the
+# state key to the next key and stops.
+awk '/^#   ROBOREV_WAIVER_STATE/{f=1} f&&/^#   ROBOREV_WAIVER_AUTHOR/{exit} f' "$ORACLES" >"$_sc_wh" || true
+awk '/^#   ROBOREV_DEFERRAL_STATE/{f=1} f&&/^#   ROBOREV_DEFERRAL_AUTHOR/{exit} f' "$ORACLES" >"$_sc_dh" || true
+[ -s "$_sc_wh" ] || _sc_bad="$_sc_bad waiver-header-not-found"
+[ -s "$_sc_dh" ] || _sc_bad="$_sc_bad deferral-header-not-found"
+for _sc_state in granted unauthorized stale malformed none misplaced unavailable; do
+  grep -qF -- "$_sc_state" "$_sc_wh" || _sc_bad="$_sc_bad waiver-header-missing:$_sc_state"
+done
+for _sc_state in granted unauthorized stale malformed none misplaced count-mismatch \
+                 issue-absent issue-closed issue-unverifiable unavailable; do
+  grep -qF -- "$_sc_state" "$_sc_dh" || _sc_bad="$_sc_bad deferral-header-missing:$_sc_state"
+done
+if [ -z "$_sc_bad" ]; then
+  ok 'structural (#3759): both lookup headers enumerate every state their function can emit, misplaced included'
+else
+  bad "structural (#3759): a documented output-state contract is incomplete —$_sc_bad. An inaccurate contract on a security-relevant function is what stops the next reader looking, and a closed list missing a state is worse than no list because a caller trusts it"
+fi
+
 printf '== structural (#3759 r6): the ONE name grammar means the SAME THING to both consumers ==\n'
 # ROUND-6 FINDING, AND IT FALSIFIED A STATED INVARIANT rather than adding an edge case. Hoisting the
 # grammar into one definition was supposed to deliver ONE GRAMMAR WITH ONE MEANING; it delivered one

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -425,14 +425,44 @@ if [ "${1:-}" = "pr" ] && [ "${2:-}" = "view" ]; then
         printf '%s\n' "$STUB_GH_LINKED_JSON"
         exit 0
       fi
+      # EVERY REFERENCE CARRIES ITS REPOSITORY, as the real payload does (#3759 round 1): a closing
+      # reference's number is scoped to ITS repository, so a double that omitted the repository
+      # would make every case exercise a code path the real payload never takes.
+      # STUB_GH_LINKED_ISSUES declares SAME-repository references (the stub's own
+      # STUB_GH_REPO_NWO); STUB_GH_LINKED_CROSS declares references in another repository, so a
+      # declared skip is expressible; STUB_GH_LINKED_NOREPO declares references whose repository
+      # object is absent, so a could-not-establish is expressible and cannot be confused with either.
       _stub_refs=""
+      _stub_owner="${STUB_GH_REPO_NWO%%/*}"
+      _stub_name="${STUB_GH_REPO_NWO#*/}"
       for _stub_n in ${STUB_GH_LINKED_ISSUES:-}; do
+        _stub_refs="${_stub_refs:+$_stub_refs,}{\"number\":$_stub_n,\"repository\":{\"name\":\"$_stub_name\",\"owner\":{\"login\":\"$_stub_owner\"}}}"
+      done
+      for _stub_n in ${STUB_GH_LINKED_CROSS:-}; do
+        _stub_refs="${_stub_refs:+$_stub_refs,}{\"number\":$_stub_n,\"repository\":{\"name\":\"other-repo\",\"owner\":{\"login\":\"other-owner\"}}}"
+      done
+      for _stub_n in ${STUB_GH_LINKED_NOREPO:-}; do
         _stub_refs="${_stub_refs:+$_stub_refs,}{\"number\":$_stub_n}"
       done
       printf '{"closingIssuesReferences":[%s]}\n' "$_stub_refs"
       exit 0
       ;;
   esac
+fi
+# ===== `repo view --json nameWithOwner`: WHICH REPOSITORY `gh issue view <N>` RESOLVES AGAINST =====
+# The probe asks `gh` rather than deriving it, so the double answers as `gh` does. Independently
+# failable (STUB_GH_REPO_RC) and independently malformable (STUB_GH_REPO_NWO without a slash),
+# because "the repository could not be established" is its own could-not-check cause.
+if [ "${1:-}" = "repo" ] && [ "${2:-}" = "view" ]; then
+  if [ "${STUB_GH_REPO_RC:-0}" -ne 0 ]; then
+    printf '%s\n' "${STUB_GH_REPO_ERR:-gh: simulated repo view failure}" >&2
+    exit "${STUB_GH_REPO_RC}"
+  fi
+  case " $* " in
+    *" --jq "*) printf '%s\n' "${STUB_GH_REPO_NWO:-}" ;;
+    *) printf '{"nameWithOwner":"%s"}\n' "${STUB_GH_REPO_NWO:-}" ;;
+  esac
+  exit 0
 fi
 if [ "${1:-}" = "issue" ] && [ "${2:-}" = "view" ]; then
   # ===== `issue view <N> --json comments`: THE PROBED THREAD (#3759) =====
@@ -1286,9 +1316,18 @@ export STUB_GH_ISSUE_ERR=''
 # _FAIL/_GARBAGE/_ERR knobs make an individual thread independently unreadable so a PARTIAL read is
 # expressible. Nothing here is a seam in the wrapper: the whole `gh` binary is a substituted artifact.
 export STUB_GH_LINKED_ISSUES=''
+export STUB_GH_LINKED_CROSS=''
+export STUB_GH_LINKED_NOREPO=''
 export STUB_GH_LINKED_JSON=''
 export STUB_GH_LINKED_RC=0
 export STUB_GH_LINKED_ERR=''
+# The current repository as `gh` resolves it. This one DEFAULTS TO A VALUE rather than to empty,
+# because it is the ordinary state of every real invocation and an empty default would make every
+# case take the could-not-establish path — the mirror of the fail-closed argument for the knobs
+# above, where the ordinary state is "no linked issue" and a permissive default would hide a gap.
+export STUB_GH_REPO_NWO='pmcfadin/cqlite'
+export STUB_GH_REPO_RC=0
+export STUB_GH_REPO_ERR=''
 export STUB_GH_ISSUE_COMMENTS=''
 export STUB_GH_ISSUE_COMMENTS_FAIL=''
 export STUB_GH_ISSUE_COMMENTS_GARBAGE=''
@@ -1321,9 +1360,14 @@ reset_stub() {
   STUB_GH_ISSUES_CLOSED=''
   STUB_GH_ISSUE_ERR=''
   STUB_GH_LINKED_ISSUES=''
+  STUB_GH_LINKED_CROSS=''
+  STUB_GH_LINKED_NOREPO=''
   STUB_GH_LINKED_JSON=''
   STUB_GH_LINKED_RC=0
   STUB_GH_LINKED_ERR=''
+  STUB_GH_REPO_NWO='pmcfadin/cqlite'
+  STUB_GH_REPO_RC=0
+  STUB_GH_REPO_ERR=''
   STUB_GH_ISSUE_COMMENTS=''
   STUB_GH_ISSUE_COMMENTS_FAIL=''
   STUB_GH_ISSUE_COMMENTS_GARBAGE=''
@@ -6209,6 +6253,128 @@ assert_verdict 'case (mp11)' FAIL 1
 assert_one_result_line 'case (mp11)'
 assert_no_marker_form 'case (mp11)'
 assert_says 'case (mp11) no probe value can introduce a second RESULT line' '^RESULT: FAIL$'
+reset_stub
+
+printf '== (mp14) #3759 r1: a CROSS-REPOSITORY closing reference is skipped, and the skip is DECLARED ==\n'
+# ROUND-1 FINDING 1. A closing reference number is scoped to ITS repository, and `gh issue view <N>`
+# resolves it in the CURRENT one — so following a cross-repo reference probes a DIFFERENT issue that
+# merely shares a number. THE FALSE `MISPLACED` IS THE DANGEROUS DIRECTION: it names a thread that
+# never carried a marker and sends the operator somewhere pointless. The fixture makes that concrete:
+# issue #3544 in THIS repository DOES carry a would-have-granted marker, and the only declared
+# reference is `other-owner/other-repo#3544`. The probe must not report MISPLACED, and must say why.
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_CROSS='3544'
+STUB_GH_ISSUE_COMMENTS="\002#3544\n\001pmcfadin\n$mp_waive_grant\n"
+run_wrapper "$w_work"
+assert_verdict 'case (mp14)' FAIL 1
+assert_no_marker_form 'case (mp14)'
+assert_lacks 'case (mp14) a cross-repository reference NEVER yields a MISPLACED naming a same-number thread' \
+  '^waiver: MISPLACED'
+assert_says 'case (mp14) the skip is DECLARED, with its count and its reason' \
+  '1 cross-repository closing reference\(s\) declared and deliberately NOT probed'
+assert_says 'case (mp14) and the value does not claim that no reference is declared at all' \
+  'no linked issue IN THIS REPOSITORY is declared on this PR'
+# MEASURED, NOT ASSUMED: the same-number issue in THIS repository was never read.
+if grep -qE 'gh issue view 3544 --json comments' "$INVOKED"; then
+  bad 'case (mp14): the probe READ a same-number issue in this repository for a reference that points at another one — that is the false-MISPLACED route the skip exists to close'
+else
+  ok 'case (mp14): no same-number thread was read (checked against the stub invocation record)'
+fi
+reset_stub
+
+printf '== (mp14b) #3759 r1: the SAME reference in THIS repository IS probed (the control) ==\n'
+# THE CONTROL FOR (mp14), and it is not optional: without it, (mp14) would pass identically if the
+# probe had simply stopped working. Same number, same fixture, same marker — only the reference's
+# repository differs, and that one variable flips the outcome to MISPLACED.
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_ISSUES='3544'
+STUB_GH_ISSUE_COMMENTS="\002#3544\n\001pmcfadin\n$mp_waive_grant\n"
+run_wrapper "$w_work"
+assert_verdict 'case (mp14b)' FAIL 1
+assert_says 'case (mp14b) a SAME-repository reference with the identical number IS probed and reported' \
+  '^waiver: MISPLACED \(an authorization for THIS review \(this base, head and job\) is on LINKED ISSUE #3544'
+assert_lacks 'case (mp14b) and no skip is declared for it' 'cross-repository closing reference'
+reset_stub
+
+printf '== (mp14c) #3759 r1: owner/name are matched CASE-INSENSITIVELY ==\n'
+# GitHub owner and repository names are case-insensitive, so `PMcFadin/CQLite` and `pmcfadin/cqlite`
+# are ONE repository. A case-sensitive compare would declare a skip for a same-repository reference —
+# a false negative that silently loses the very thread this mechanism exists to find.
+reset_stub
+mp_waiver_fixture
+STUB_GH_REPO_NWO='PMcFadin/CQLite'
+STUB_GH_LINKED_JSON='{"closingIssuesReferences":[{"number":3544,"repository":{"name":"cqlite","owner":{"login":"pmcfadin"}}}]}'
+STUB_GH_ISSUE_COMMENTS="\002#3544\n\001pmcfadin\n$mp_waive_grant\n"
+run_wrapper "$w_work"
+assert_verdict 'case (mp14c)' FAIL 1
+assert_says 'case (mp14c) a differently-cased spelling of the same repository is the same repository' \
+  '^waiver: MISPLACED \(an authorization for THIS review'
+assert_lacks 'case (mp14c) and is not declared as a cross-repository skip' 'cross-repository closing reference'
+reset_stub
+
+printf '== (mp14d) #3759 r1: a reference whose REPOSITORY cannot be established is could-not-check ==\n'
+# "IN ANOTHER REPOSITORY" AND "CANNOT TELL WHICH REPOSITORY" ARE DIFFERENT FACTS, and only one of
+# them is an answer. A payload entry with no repository object must not be filed under the declared
+# skip — that would assert something nobody established — nor probed, which is the false-MISPLACED
+# route. It is a could-not-check, with its own cause.
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_NOREPO='3544'
+STUB_GH_ISSUE_COMMENTS="\002#3544\n\001pmcfadin\n$mp_waive_grant\n"
+run_wrapper "$w_work"
+assert_verdict 'case (mp14d)' FAIL 1
+assert_no_marker_form 'case (mp14d)'
+assert_says 'case (mp14d) the cause names an unestablished repository, not a cross-repository skip' \
+  'NOT read: an entry whose repository could not be established'
+assert_lacks 'case (mp14d) it is NOT filed as a declared cross-repository skip' 'cross-repository closing reference'
+assert_lacks 'case (mp14d) and it is never probed' '^waiver: MISPLACED'
+reset_stub
+
+printf '== (mp14e) #3759 r1: an unresolvable CURRENT repository is could-not-check, not a skip ==\n'
+# With the current repository unknown, "same repository" cannot be established AFFIRMATIVELY for ANY
+# reference — so the whole probe is a could-not-check rather than a set of skips or, worse, a set of
+# probes against numbers nobody could place. Both failure shapes are covered: the call failing, and
+# the call succeeding with an answer that is not an owner/name pair.
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_ISSUES='3544'
+STUB_GH_REPO_RC=1
+run_wrapper "$w_work"
+assert_verdict 'case (mp14e/failed)' FAIL 1
+assert_no_marker_form 'case (mp14e/failed)'
+assert_says 'case (mp14e/failed) the cause names the resolution that failed' \
+  "'gh repo view --json nameWithOwner' failed"
+reset_stub
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_ISSUES='3544'
+STUB_GH_REPO_NWO='not-an-owner-name-pair'
+run_wrapper "$w_work"
+assert_verdict 'case (mp14e/malformed)' FAIL 1
+assert_says 'case (mp14e/malformed) an answer that is not an owner/name pair is not an identity' \
+  'did not answer with an owner/name pair'
+assert_lacks 'case (mp14e/malformed) and nothing is probed on an unestablished identity' '^waiver: MISPLACED'
+reset_stub
+
+printf '== (mp14f) #3759 r1: a MIXED set — same-repo probed, cross-repo declared, both reported ==\n'
+# The realistic shape, and the one a per-fact case cannot reach: the same-repository thread IS read
+# and carries no marker, while a cross-repository reference is skipped. Both facts must appear in one
+# value, because a rendering that reported only the first would claim the whole declared set was
+# examined.
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_ISSUES='3626'
+STUB_GH_LINKED_CROSS='3544'
+STUB_GH_ISSUE_COMMENTS="\002#3626\n\001pmcfadin\nnothing here\n"
+run_wrapper "$w_work"
+assert_verdict 'case (mp14f)' FAIL 1
+assert_no_marker_form 'case (mp14f)'
+assert_says 'case (mp14f) the same-repository thread is reported as checked' \
+  'linked issues #3626 checked'
+assert_says 'case (mp14f) and the cross-repository skip is declared in the SAME value' \
+  '1 cross-repository closing reference\(s\) declared and deliberately NOT probed'
 reset_stub
 
 printf '== (mp12) #3759 MUTANT: probing on EVERY state reds — the escalation is only from none ==\n'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -6952,6 +6952,18 @@ done
 grep -qF 'the INVOKER can bypass this' "$ORACLES" || _tm_missing="$_tm_missing oracles-triage-rule"
 grep -qF 'top-level PR comments only' "$ORACLES" \
   || grep -qF 'TOP-LEVEL PR COMMENTS ONLY' "$ORACLES" || _tm_missing="$_tm_missing comment-channel-residual"
+# ===== AND THE RESIDUAL NAMES THE LINKED-ISSUE THREAD, IN BOTH BLOCKS (#3759) =====
+# STRENGTHENED, NOT MERELY REWORDED. The residual used to name two misplacement locations — a review
+# body and a review-thread reply — and NOT the PR's LINKED ISSUE, which is the MOST PROBABLE of the
+# three because that is where lane/lead coordination lives. That omission is what the #3710 incident
+# cost 8 hours to. The two RESIDUALS blocks in the oracles (the waiver's and the deferral's) are the
+# artifacts an implementer actually reads, so BOTH must carry the correction: a residual corrected in
+# one of two places is a residual that reads as correct in the other. Counted rather than merely
+# found, for exactly that reason.
+if [ "$(grep -ciF 'PROBABLE MISPLACEMENT IS THE' "$ORACLES")" -lt 2 ]; then
+  _tm_missing="$_tm_missing linked-issue-residual-in-both-blocks"
+fi
+grep -qF 'MISPLACED' "$ORACLES" || _tm_missing="$_tm_missing misplaced-state-not-recorded-in-residual"
 if [ -z "$_tm_missing" ]; then
   ok 'structural: the waiver threat model, its triage rule and the comment-channel residual are stated in code'
 else
@@ -7677,6 +7689,122 @@ if [ -f "$SCRIPT_DIR/../../docs/reports/3229-artifacts/live-probe-procedure.md" 
   done
 else
   bad 'structural: docs/reports/3229-artifacts/live-probe-procedure.md is missing — the AC2 requirement was dropped rather than rescheduled'
+fi
+
+# =============================================================================================
+# structural (#3759): THE MISPLACED STATE IS DIAGNOSTIC-ONLY, AND THE PROBE REUSES ONE ENFORCER
+# =============================================================================================
+# Behavioural cases cover the fixtures someone thought of; these cover the properties a later
+# "simplification" would quietly undo. Neither substitutes for the other — a structural assert cannot
+# see a granting path built some other way, and a behavioural case cannot see a granting path nobody
+# fixtured.
+printf '== structural (#3759): MISPLACED grants nothing, and the probe reuses the one scanner ==\n'
+# (1) THE GRANTING GATES ARE STILL THE TWO TOKEN-EXACT `= "granted"` COMPARISONS, and `misplaced`
+# appears in NO granting branch. A `MISPLACED*` prefix test, a `!= none` test or a second granting
+# comparison would each be an authorization change wearing a diagnostic's clothes.
+_mps_ok=1
+_mps_why=""
+grep -qF '[ "$ROBOREV_WAIVER_STATE" = "granted" ]' "$CHECKS_FILE" || { _mps_ok=0; _mps_why="$_mps_why waiver-gate-not-token-exact;"; }
+grep -qF '[ "$ROBOREV_DEFERRAL_STATE" = "granted" ]' "$CHECKS_FILE" \
+  || grep -qF '[ "$ROBOREV_DEFERRAL_STATE" = "granted" ] || return 0' "$ORACLES" \
+  || { _mps_ok=0; _mps_why="$_mps_why deferral-gate-not-token-exact;"; }
+# EXTRACTED TO A FILE, NEVER PIPED INTO A NEGATED `grep -q` (#3387): the polarity here is the
+# fail-open one — a SIGPIPE-141 would read as "no granting use of misplaced found" exactly when one
+# exists. Every `misplaced` mention in the three shell files must be a RECOGNITION or a REPORT: the
+# two case-list entries, the two probe assignments, the two report arms, the probe's own outcome
+# handling, and comments. What must never appear is `misplaced` beside a grant.
+_mps_sites="$tmp/mps-misplaced-sites.txt"
+{ grep -nF 'misplaced' "$ORACLES" || true; grep -nF 'misplaced' "$CHECKS_FILE" || true; } >"$_mps_sites"
+if [ ! -s "$_mps_sites" ]; then
+  _mps_ok=0; _mps_why="$_mps_why no-misplaced-state-at-all;"
+fi
+# GRANT-SHAPED TOKENS beside the state: the verdicts a grant produces (`WAIVED`, `DEFERRED`) and the
+# admission variable. None of them may appear on a line that also mentions `misplaced`.
+if grep -nE 'misplaced' "$_mps_sites" | grep -qE 'WAIVED|DEFERRED \(|deferral_admits|= "granted"'; then
+  _mps_ok=0; _mps_why="$_mps_why misplaced-on-a-granting-line;"
+fi
+if [ "$_mps_ok" -eq 1 ]; then
+  ok 'structural (#3759): the only granting gates are the two token-exact = "granted" comparisons, and misplaced reaches none of them'
+else
+  bad "structural (#3759): the MISPLACED state has reached a granting path, or a granting gate is no longer token-exact —$_mps_why. MISPLACED is a DIAGNOSTIC state: only a marker on the PULL REQUEST grants, and moving one there is a human act by the authorizer"
+fi
+# (2) THE SCANNER IS UNMODIFIED BY THIS CHANGE, AND THERE IS NO SECOND ONE. A second implementation
+# of a marker grammar is a second place for it to diverge, and a divergence in an AUTHORIZATION
+# grammar is a bypass — which is why the issue-side call passes the SAME kind, base, head, job and
+# allowlist and the scanner is never told which thread its input came from.
+if grep -qF 'python3 "$WAIVER_SCAN_TOOL" "$kind" "$base" "$head" "$job" "$ROBOREV_WAIVER_AUTHORS"' "$ORACLES"; then
+  ok 'structural (#3759): the linked-issue probe calls the SAME scanner with the same kind, scope and allowlist'
+else
+  bad 'structural (#3759): the linked-issue probe no longer delegates to the one scanner with the caller-supplied kind/scope/allowlist — a second recogniser over an authorization grammar is a bypass (#3626 reuse-do-not-reinvent)'
+fi
+if grep -qE 'misplaced' "$SCAN_TOOL"; then
+  bad 'structural (#3759): the SCANNER emits or knows about the misplaced state — thread identity is the CALLER-side knowledge, and telling the scanner would mean adding a provenance argument to the one component whose inputs must stay fixed'
+else
+  ok 'structural (#3759): the scanner knows nothing about threads — misplaced is assigned by the shell caller'
+fi
+# (3) THE GRANTING PAYLOAD DID NOT CHANGE SHAPE, AND THE RESOLVER IS A SEPARATE, LATER CALL. The
+# payload an AUTHORIZATION is decided from must not change shape as a side effect of adding a
+# DIAGNOSTIC — its fixed, measured shape is exactly what licenses reusing the scanner unmodified —
+# and a combined fetch would make the relation available on paths that never run the probe, so
+# reachability would rest on where an `if` sits rather than on the data not existing.
+# EXECUTABLE LINES ONLY, for the reason the #3229 sole-content guard states: the oracles' comment
+# block RECORDS the rejected combined form by name (`--json comments,closingIssuesReferences`) and
+# says why it was rejected, and that record is the durable artifact. Scanning prose would make
+# WRITING THE REASONING DOWN a violation — the same mistake as the job-18 census assert.
+_mpj_exec="$tmp/mpj-oracles-exec.txt"
+grep -v '^[[:space:]]*#' "$ORACLES" >"$_mpj_exec" || true
+_mpj_ok=1
+[ "$(grep -cF 'gh pr view --json comments 2>/dev/null' "$_mpj_exec")" -eq 2 ] || _mpj_ok=0
+grep -qE 'json comments,closingIssuesReferences|json closingIssuesReferences,comments' "$_mpj_exec" && _mpj_ok=0
+grep -qF 'gh pr view --json closingIssuesReferences' "$_mpj_exec" || _mpj_ok=0
+if [ "$_mpj_ok" -eq 1 ]; then
+  ok 'structural (#3759): the two granting --json comments calls are unchanged and the relation is fetched by its own later call'
+else
+  bad 'structural (#3759): the granting call was restructured, or comments and closingIssuesReferences are requested together — the payload an authorization is decided from must not change shape as a side effect of adding a diagnostic (#3759 R4)'
+fi
+# (4) NO PULL-REQUEST BODY READ CAME BACK, IN ANY FORM. #3626 deleted the PR-body link requirement
+# because a body is EDITABLE AT ANY TIME BY ANYONE WITH WRITE ACCESS WITH NO PER-EDIT ATTRIBUTION,
+# while a top-level comment is permanent and attributable — the recogniser problem was a SYMPTOM, not
+# the reason. Reinstating a body scan FOR ANY PURPOSE, including choosing which thread to name in a
+# diagnostic, would be reinstating a deleted generation.
+_mpb_exec="$tmp/mpb-exec.txt"
+{ grep -v '^[[:space:]]*#' "$ORACLES" || true; grep -v '^[[:space:]]*#' "$CHECKS_FILE" || true; } >"$_mpb_exec"
+if grep -qE -- '--json[ ,]*body|json body|PR_BODY|pr view --json [a-zA-Z,]*\bbody\b' "$_mpb_exec"; then
+  bad 'structural (#3759): a pull-request BODY read was reintroduced — the body is the weaker artifact (mutable by anyone with write access, no per-edit attribution) and #3626 deleted it deliberately'
+else
+  ok 'structural (#3759): no pull-request body read exists — the linked issue comes from the structured relation alone'
+fi
+# (5) THE MUTABLE-DERIVED BOUNDARY IS WRITTEN AT THE CALL SITE, not only in a design document,
+# because the next edit that adds a granting consumer reads the code before it reads a design note.
+if grep -qF 'THE MOMENT ANY CONSUMER DOWNSTREAM OF THIS RELATION COULD GRANT' "$ORACLES"; then
+  ok 'structural (#3759): the mutable-derived boundary for closingIssuesReferences is stated beside the call'
+else
+  bad 'structural (#3759): the closingIssuesReferences call no longer states WHY a mutable-derived relation is acceptable here (it grants nothing; it only selects which thread to name) — an unstated boundary is how a granting consumer gets added'
+fi
+# (6) THE PROBE NEVER RETURNS NON-ZERO AND ITS OUTCOME SET IS CLOSED. A two-valued return would
+# re-import the collapse this change exists to remove.
+_mpo_ok=1
+grep -qF 'ROBOREV_PROBE_OUTCOME  misplaced | checked | no-subject | could-not-check' "$ORACLES" || _mpo_ok=0
+grep -qF 'NEVER RETURNS NON-ZERO AND NEVER EXITS' "$ORACLES" || _mpo_ok=0
+_mpp_body="$tmp/mpp-body.txt"
+awk '/^roborev_linked_issue_marker_probe\(\) \{/,/^\}$/' "$ORACLES" >"$_mpp_body"
+[ -s "$_mpp_body" ] || _mpo_ok=0
+grep -qE '^[[:space:]]*return [1-9]' "$_mpp_body" && _mpo_ok=0
+grep -qE '^[[:space:]]*exit ' "$_mpp_body" && _mpo_ok=0
+if [ "$_mpo_ok" -eq 1 ]; then
+  ok 'structural (#3759): the probe has a closed four-outcome set and can neither return non-zero nor exit'
+else
+  bad 'structural (#3759): the probe can fail two-valued (a non-zero return or an exit), or its outcome set is no longer the declared closed four — every failure must be a STATE WITH A CAUSE, or "could not check" collapses onto "checked" again'
+fi
+# (7) THE GATE OF RECORD IS UNMODIFIED BY THIS CHANGE. `scripts/agent-gate.sh` is out of scope, and
+# no gate component may learn to read a misplacement diagnostic.
+_mpg_gate="$SCRIPT_DIR/../agent-gate.sh"
+if [ ! -f "$_mpg_gate" ]; then
+  bad "structural (#3759): the agent gate is not at $_mpg_gate, so the out-of-scope claim could not be checked"
+elif grep -qE 'closingIssuesReferences|ROBOREV_PROBE_|MISPLACED' "$_mpg_gate"; then
+  bad 'structural (#3759): the agent gate reads the misplacement probe or its state — this change is confined to the roborev wrapper diagnostic and agent-gate.sh must end it unmodified'
+else
+  ok 'structural (#3759): the agent gate is untouched by the misplacement probe'
 fi
 
 printf '== hermeticity: the wrapper never reaches a real roborev ==\n'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -495,6 +495,14 @@ if [ "${1:-}" = "issue" ] && [ "${2:-}" = "view" ]; then
           exit 0
         fi
       done
+      # A VERBATIM payload for every thread, so a VALID-JSON-BUT-MALFORMED shape is expressible
+      # (#3759 round 2). `{}`, `{"comments":null}` and `{"comments":{}}` all parse, and the reused
+      # scanner reduces each to zero comments and exits 0 — which is why the CALLER has to validate
+      # the shape, and why the double has to be able to produce it.
+      if [ -n "${STUB_GH_ISSUE_COMMENTS_JSON:-}" ]; then
+        printf '%s\n' "$STUB_GH_ISSUE_COMMENTS_JSON"
+        exit 0
+      fi
       printf '%b' "${STUB_GH_ISSUE_COMMENTS:-}" | STUB_WANT_ISSUE="${3:-}" python3 -c '
 import json, os, sys
 want = os.environ.get("STUB_WANT_ISSUE", "")
@@ -1329,6 +1337,7 @@ export STUB_GH_REPO_NWO='pmcfadin/cqlite'
 export STUB_GH_REPO_RC=0
 export STUB_GH_REPO_ERR=''
 export STUB_GH_ISSUE_COMMENTS=''
+export STUB_GH_ISSUE_COMMENTS_JSON=''
 export STUB_GH_ISSUE_COMMENTS_FAIL=''
 export STUB_GH_ISSUE_COMMENTS_GARBAGE=''
 export STUB_GH_ISSUE_COMMENTS_ERR=''
@@ -1369,6 +1378,7 @@ reset_stub() {
   STUB_GH_REPO_RC=0
   STUB_GH_REPO_ERR=''
   STUB_GH_ISSUE_COMMENTS=''
+  STUB_GH_ISSUE_COMMENTS_JSON=''
   STUB_GH_ISSUE_COMMENTS_FAIL=''
   STUB_GH_ISSUE_COMMENTS_GARBAGE=''
   STUB_GH_ISSUE_COMMENTS_ERR=''
@@ -6117,7 +6127,7 @@ STUB_GH_ISSUE_COMMENTS_GARBAGE='3544'
 run_wrapper "$w_work"
 assert_verdict 'case (mp6/unparseable)' FAIL 1
 assert_says 'case (mp6/unparseable) an unparseable comments payload is its own could-not-check cause' \
-  'NOT read: #3544 \(its comments payload could not be parsed\)'
+  'NOT read: #3544 \(its comments payload was not a JSON object carrying a comments LIST'
 reset_stub
 reset_stub
 mp_waiver_fixture
@@ -6354,7 +6364,7 @@ STUB_GH_REPO_NWO='not-an-owner-name-pair'
 run_wrapper "$w_work"
 assert_verdict 'case (mp14e/malformed)' FAIL 1
 assert_says 'case (mp14e/malformed) an answer that is not an owner/name pair is not an identity' \
-  'did not answer with an owner/name pair'
+  'did not answer with a single owner/name pair'
 assert_lacks 'case (mp14e/malformed) and nothing is probed on an unestablished identity' '^waiver: MISPLACED'
 reset_stub
 
@@ -6376,6 +6386,93 @@ assert_says 'case (mp14f) the same-repository thread is reported as checked' \
 assert_says 'case (mp14f) and the cross-repository skip is declared in the SAME value' \
   '1 cross-repository closing reference\(s\) declared and deliberately NOT probed'
 reset_stub
+
+printf '== (mp15) #3759 r2: a valid-JSON but MALFORMED comments payload is could-not-check ==\n'
+# ROUND-2 BLOCKER, AND THE THIRD APPEARANCE OF ONE SHAPE. The reused scanner reduces `{}`,
+# `{"comments":null}` and `{"comments":{}}` to an EMPTY comment list and exits 0 — correct for its own
+# contract (*given these comments, is there an authorization in them?* over no comments is "no"), and
+# the scanner is reused UNMODIFIED by design. It was this CALLER that turned a zero exit into "the
+# thread was read", rendering "checked: no matching marker" over a thread nothing was read from.
+# THE FIXTURE MAKES THE FALSE CLAIM CONCRETE: a real, would-have-granted marker exists on #3544, and a
+# malformed payload must never let the probe say it looked and found nothing.
+for _mp15_shape in \
+  'empty-object:{}' \
+  'null-comments:{"comments":null}' \
+  'object-comments:{"comments":{"author":{"login":"pmcfadin"}}}' \
+  'string-comments:{"comments":"none"}' ; do
+  reset_stub
+  mp_waiver_fixture
+  STUB_GH_LINKED_ISSUES='3544'
+  STUB_GH_ISSUE_COMMENTS_JSON="${_mp15_shape#*:}"
+  run_wrapper "$w_work"
+  assert_verdict "case (mp15/${_mp15_shape%%:*})" FAIL 1
+  assert_no_marker_form "case (mp15/${_mp15_shape%%:*})"
+  assert_says "case (mp15/${_mp15_shape%%:*}) the thread is could-not-check, naming what was not a comments LIST" \
+    'NOT read: #3544 \(its comments payload was not a JSON object carrying a comments LIST'
+  assert_lacks "case (mp15/${_mp15_shape%%:*}) and the probe NEVER claims it checked that thread" \
+    'checked: no matching marker there either'
+  assert_lacks "case (mp15/${_mp15_shape%%:*}) nor does a zero exit from the scanner become a grant" \
+    '^prompt-content: WAIVED'
+  reset_stub
+done
+
+printf '== (mp15b) #3759 r2: the WELL-FORMED payload is read (the control) ==\n'
+# Without this, (mp15) would pass identically if the probe had simply stopped reading anything. Same
+# fixture, same thread, same marker — only the payload SHAPE differs, and that one variable flips the
+# outcome from could-not-check to MISPLACED.
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_ISSUES='3544'
+STUB_GH_ISSUE_COMMENTS_JSON="{\"comments\":[{\"author\":{\"login\":\"pmcfadin\"},\"body\":\"$mp_waive_grant\"}]}"
+run_wrapper "$w_work"
+assert_verdict 'case (mp15b)' FAIL 1
+assert_says 'case (mp15b) a well-formed payload IS read and its marker IS found' \
+  '^waiver: MISPLACED \(an authorization for THIS review \(this base, head and job\) is on LINKED ISSUE #3544'
+assert_lacks 'case (mp15b) and it is not reported as unreadable' 'was not a JSON object carrying a comments LIST'
+reset_stub
+
+printf '== (mp16) #3759 r2: an UNRECOGNISED or EMPTY scanner state is could-not-check, not checked ==\n'
+# THE SECOND HALF OF THE SAME INVARIANT. The `state=` line is an INPUT to this probe like any other,
+# so it is validated against the closed recognition grammar before a conclusion is drawn from it — the
+# permissive branch keyed on AFFIRMATIVE membership, never on `!= granted`. An empty, absent or
+# never-judged state used to count as a successfully checked thread.
+#
+# THE FIXTURE SUBSTITUTES THE ARTIFACT, NOT A PATH (job 27): a scratch copy of `scripts/flow/` whose
+# scanner is replaced. There is deliberately no way to point the wrapper at another enforcer — that
+# override WAS the hole — so a case needing different scanner behaviour replaces the file, which is a
+# state a real checkout can be in. The replacement answers `none` for an EMPTY comment list (so the
+# PR-side scan still reaches the probe) and the state under test for a non-empty one.
+for _mp16_state in 'unrecognised:totally-unknown-state' 'empty:' ; do
+  reset_stub
+  _mp16_dir="$tmp/scanner-state-${_mp16_state%%:*}"
+  mkdir -p "$_mp16_dir"
+  cp "$WRAPPER_REAL" "$ORACLES_SRC" "$CHECKS_SRC" "$_mp16_dir/"
+  if [ -f "$SCRIPT_DIR/../flow/roborev-job-facts.py" ]; then
+    cp "$SCRIPT_DIR/../flow/roborev-job-facts.py" "$_mp16_dir/"
+  fi
+  cat >"$_mp16_dir/roborev-waiver-scan.py" <<MP16SCAN
+#!/usr/bin/env python3
+import json, os, sys
+data = json.load(sys.stdin)
+n = len(data.get("comments") or [])
+sys.stdout.write("state=%s\n" % ("none" if n == 0 else os.environ.get("MP16_STATE", "")))
+for _k in ("author", "scope", "reason", "detail", "issues", "count"):
+    sys.stdout.write("%s=\n" % _k)
+MP16SCAN
+  chmod +x "$_mp16_dir/roborev-waiver-scan.py"
+  mp_waiver_fixture
+  STUB_GH_LINKED_ISSUES='3544'
+  STUB_GH_ISSUE_COMMENTS="\002#3544\n\001pmcfadin\n$mp_waive_grant\n"
+  MP16_STATE="${_mp16_state#*:}" run_wrapper --wrapper "$_mp16_dir/roborev-review.sh" "$w_work"
+  assert_verdict "case (mp16/${_mp16_state%%:*})" FAIL 1
+  assert_no_marker_form "case (mp16/${_mp16_state%%:*})"
+  assert_says "case (mp16/${_mp16_state%%:*}) an unvalidated state does not make a thread checked" \
+    'NOT read: #3544 \(the scanner returned the unrecognised state'
+  assert_lacks "case (mp16/${_mp16_state%%:*}) and the probe never claims it checked that thread" \
+    'checked: no matching marker there either'
+  assert_lacks "case (mp16/${_mp16_state%%:*}) nor does an unrecognised state escalate" '^waiver: MISPLACED'
+  reset_stub
+done
 
 printf '== (mp12) #3759 MUTANT: probing on EVERY state reds — the escalation is only from none ==\n'
 # A CASE THAT PASSES AGAINST BOTH THE REAL CODE AND ITS NAIVE FORM MEASURES NOTHING. The naive form

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -6136,8 +6136,8 @@ STUB_GH_ISSUE_COMMENTS="\002#3544\n\001pmcfadin\nnothing\n\002#3626\n\001pmcfadi
 run_wrapper "$w_work"
 assert_verdict 'case (mp8)' FAIL 1
 assert_no_marker_form 'case (mp8)'
-assert_says 'case (mp8) the rendering declares declared / probed / bound' \
-  'linked issues #3544,#3626,#3312 checked — 3 of 4 declared, probe bounded at 3: no matching marker'
+assert_says 'case (mp8) the rendering declares declared / probed / bound / remainder' \
+  'linked issues #3544,#3626,#3312 checked — 3 of 4 declared examined, probe bounded at 3, 1 never looked at: no matching marker'
 assert_lacks 'case (mp8) the unprobed remainder is not silently claimed as checked' \
   'checked: no matching marker there either'
 if grep -qE 'gh issue view 3710 --json comments' "$INVOKED"; then
@@ -6145,6 +6145,27 @@ if grep -qE 'gh issue view 3710 --json comments' "$INVOKED"; then
 else
   ok 'case (mp8): the bound was honoured (the fourth declared thread was not read)'
 fi
+reset_stub
+
+printf '== (mp8b) #3759: UNREADABLE inside the bound AND over-bound — BOTH gaps are declared ==\n'
+# (#3759 round 1, finding 3.) The case neither (mp7) nor (mp8) reaches: a read FAILS inside the
+# bounded prefix while declared references remain unexamined. The could-not-check rendering used to
+# return without ever saying that part of the declared set was never looked at, so a diagnostic that
+# had examined 3 of 5 and failed on one of them read exactly like one that had examined everything.
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_ISSUES='3544 3626 3312 3710 3572'
+STUB_GH_ISSUE_COMMENTS="\002#3544\n\001pmcfadin\nnothing\n\002#3312\n\001pmcfadin\nnothing\n"
+STUB_GH_ISSUE_COMMENTS_FAIL='3626'
+run_wrapper "$w_work"
+assert_verdict 'case (mp8b)' FAIL 1
+assert_no_marker_form 'case (mp8b)'
+assert_says 'case (mp8b) the unreadable half is named' \
+  'the linked-issue thread could NOT be checked: read with no matching marker: #3544,#3312; NOT read: #3626 \('
+assert_says 'case (mp8b) AND the unexamined remainder is named in the SAME rendering' \
+  '3 of 5 declared examined, probe bounded at 3, 2 never looked at'
+assert_lacks 'case (mp8b) a could-not-check with an unexamined remainder never reads as checked' \
+  'checked: no matching marker there either'
 reset_stub
 
 printf '== (mp9) #3759: several linked issues, the FIRST MATCH is reported, in GitHub order ==\n'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -8181,6 +8181,64 @@ fi
 # "simplification" would quietly undo. Neither substitutes for the other — a structural assert cannot
 # see a granting path built some other way, and a behavioural case cannot see a granting path nobody
 # fixtured.
+printf '== structural (#3759 r6): the ONE name grammar means the SAME THING to both consumers ==\n'
+# ROUND-6 FINDING, AND IT FALSIFIED A STATED INVARIANT rather than adding an edge case. Hoisting the
+# grammar into one definition was supposed to deliver ONE GRAMMAR WITH ONE MEANING; it delivered one
+# STRING with two meanings, because a RANGE inside a bracket expression is resolved by the LOCALE's
+# collation in POSIX regex and by CODEPOINT in Python. A malformed current-repository identity could
+# then pass the shell check and fail `ref_repo()`, and a SAME-repository reference would be reported
+# as a cross-repository DECLARED SKIP — the feature silently declining to probe the one thread that
+# matters. A documented invariant that is untrue is worse than one never claimed, so it is tested
+# rather than asserted in prose.
+#
+# THE GRAMMAR IS EXTRACTED FROM THE SHIPPED FILE, never re-typed here: a test that re-types its
+# subject tests its own copy of it, which is the second-implementation hazard one directory over.
+_gr_re=$(sed -n "s/^ROBOREV_GH_NAME_RE='\(.*\)'\$/\1/p" "$ORACLES" | head -1)
+if [ -z "$_gr_re" ]; then
+  bad 'structural (#3759): the shared name grammar could not be extracted from the oracles, so neither its shape nor its agreement was measured — a failure to measure, not a measurement'
+else
+  # (a) NO RANGES. Deterministic on every host, and it is the property that makes (b) hold everywhere
+  #     rather than only where this box happens to have a locale that exposes the divergence.
+  if printf '%s' "$_gr_re" | grep -qE '[A-Za-z0-9]-[A-Za-z0-9]'; then
+    bad 'structural (#3759): the shared name grammar contains a RANGE, which POSIX regex resolves by locale collation and Python resolves by codepoint — so its two consumers can disagree and a same-repository reference can be misreported as a cross-repository skip. Enumerate the class (#3759 round 6)'
+  else
+    ok 'structural (#3759): the shared name grammar is enumerated, so no locale collation can give its two consumers different meanings'
+  fi
+  # (b) THE DIFFERENTIAL, which is the invariant itself: bash and python must AGREE on every probe in
+  #     every locale this host has. A second implementation is correct only insofar as it is
+  #     differentially tested against the first — this repository's standing ruling — and "one
+  #     definition" does not exempt it, which is exactly what round 6 proved.
+  _gr_locales="C"
+  for _gr_l in $(locale -a 2>/dev/null | grep -iE 'utf-?8$' | head -4); do
+    _gr_locales="$_gr_locales $_gr_l"
+  done
+  # The corpus deliberately mixes ASCII-valid, ASCII-invalid and NON-ASCII: the divergence lives only
+  # in the third group (measured on this fleet: under en_US.utf8 bash matched é, ǅ, İ and ß against
+  # the old ranged class while Python refused all four), so a corpus without it would agree vacuously.
+  _gr_bad=""
+  _gr_pairs=0
+  for _gr_l in $_gr_locales; do
+    for _gr_s in 'cqlite' 'pmcfadin' 'a.b_c-d' '0' 'a b' 'a/b' 'a:b' 'é' 'ǅ' 'İ' 'ß' 'Ω' 'cqlite␤'; do
+      _gr_s=${_gr_s/␤/$'\n'}
+      _gr_b=$(LC_ALL="$_gr_l" bash -c 'RE=$1; [[ $2 =~ ^${RE}$ ]] && echo M || echo n' _ "$_gr_re" "$_gr_s" 2>/dev/null)
+      _gr_p=$(LC_ALL="$_gr_l" python3 -c 'import re,sys; print("M" if re.compile(sys.argv[1]).fullmatch(sys.argv[2]) else "n")' "$_gr_re" "$_gr_s" 2>/dev/null)
+      _gr_pairs=$((_gr_pairs + 1))
+      [ "$_gr_b" = "$_gr_p" ] || _gr_bad="$_gr_bad ${_gr_l}:$(printf '%s' "$_gr_s" | tr -d '\n')(bash=$_gr_b,py=$_gr_p)"
+    done
+  done
+  if [ -z "$_gr_bad" ]; then
+    ok "structural (#3759): the shell and python consumers of the one name grammar AGREE on every probe, across $_gr_pairs locale/input pairs"
+  else
+    bad "structural (#3759): the two consumers of the ONE name grammar DISAGREE —$_gr_bad. 'Defined once' is not 'interpreted identically', and a divergence here misreports a same-repository reference as a cross-repository skip (#3759 round 6)"
+  fi
+  # DECLARED NON-EXHAUSTIVENESS, because the differential can only exercise locales this host HAS. On
+  # a box with no non-C UTF-8 locale the loop above agrees vacuously, so the range check (a) is what
+  # carries the property there — stated rather than left to be assumed from a green line.
+  if [ "$_gr_locales" = "C" ]; then
+    printf 'NOTICE - structural (#3759): only the C locale is installed here, so the differential could not exercise a collation that exposes a ranged class; clause (a) is what holds the property on this host\n'
+  fi
+fi
+
 printf '== structural (#3759 r3): EVERY payload read on the probe path goes through ONE helper ==\n'
 # WHY THIS ASSERT EXISTS RATHER THAN A FOURTH SITE FIX. Three review rounds produced 3, then 1, then 2
 # findings, and EVERY one was the same class — an input reaching a conclusion without an affirmative
@@ -8246,9 +8304,15 @@ done
 #     identity validations where only one constrained anything, so the character class is defined once
 #     and BOTH the shell's check and the python leg's `ref_repo` consume that one definition. A literal
 #     class re-appearing in the executable text is the drift this forbids.
-grep -qF "ROBOREV_GH_NAME_RE='[A-Za-z0-9._-]+'" "$_chk_exec" || _chk_bad="$_chk_bad name-grammar-not-defined-once"
+grep -qE "^ROBOREV_GH_NAME_RE='\[[A-Za-z0-9._-]+\]\+'$" "$_chk_exec" || _chk_bad="$_chk_bad name-grammar-not-defined-once"
 grep -qF 'PROBE_NAME_RE="$ROBOREV_GH_NAME_RE"' "$_chk_exec" || _chk_bad="$_chk_bad name-grammar-not-passed-to-the-python-leg"
-if [ "$(grep -cF '[A-Za-z0-9._-]+' "$_chk_exec" || true)" != "1" ]; then
+# ONE SPELLING, matched against the value the file actually defines rather than a literal repeated
+# here — a hard-coded copy would have to be edited in lockstep with the grammar, which is the drift
+# this clause exists to forbid.
+_chk_re_val=$(sed -n "s/^ROBOREV_GH_NAME_RE='\(.*\)'$/\1/p" "$ORACLES" | head -1)
+if [ -z "$_chk_re_val" ]; then
+  _chk_bad="$_chk_bad name-grammar-value-unreadable"
+elif [ "$(grep -cF -- "$_chk_re_val" "$_chk_exec" || true)" != "1" ]; then
   _chk_bad="$_chk_bad name-grammar-spelled-more-than-once"
 fi
 

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -403,7 +403,91 @@ fi
 # STUB_GH_ISSUE_ERR overrides the diagnostic (and forces exit 1) so a COULD-NOT-ASK can be fixtured
 # without also disabling `gh pr view`, which STUB_GH_RC would do — the deferral would then never reach
 # the retrievability leg at all and the case would pass for the wrong reason.
+# ===== `pr view --json closingIssuesReferences`: THE LINKED-ISSUE RELATION (#3759) =====
+# The misplacement probe resolves which thread to look at from the STRUCTURED GitHub relation, never
+# from the PR body. Modelled as its OWN call because the wrapper issues it as its own call: folding
+# it into `--json comments` would change the shape of the payload an AUTHORIZATION is decided from,
+# and would make the probe's data available on paths that never run it.
+#
+# `STUB_GH_LINKED_ISSUES` DEFAULTS TO EMPTY, so a case that wants a probe has to SAY so. That is the
+# fail-closed direction and it stops a case passing because the double happened to be permissive
+# about a question the wrapper asks. `STUB_GH_LINKED_JSON` passes a payload through verbatim (a
+# non-numeric entry, or garbage), and `STUB_GH_LINKED_RC` fails the call — each a distinct
+# could-not-check cause the wrapper must report separately.
+if [ "${1:-}" = "pr" ] && [ "${2:-}" = "view" ]; then
+  case " $* " in
+    *closingIssuesReferences*)
+      if [ "${STUB_GH_LINKED_RC:-0}" -ne 0 ]; then
+        printf '%s\n' "${STUB_GH_LINKED_ERR:-gh: simulated closingIssuesReferences failure}" >&2
+        exit "${STUB_GH_LINKED_RC}"
+      fi
+      if [ -n "${STUB_GH_LINKED_JSON:-}" ]; then
+        printf '%s\n' "$STUB_GH_LINKED_JSON"
+        exit 0
+      fi
+      _stub_refs=""
+      for _stub_n in ${STUB_GH_LINKED_ISSUES:-}; do
+        _stub_refs="${_stub_refs:+$_stub_refs,}{\"number\":$_stub_n}"
+      done
+      printf '{"closingIssuesReferences":[%s]}\n' "$_stub_refs"
+      exit 0
+      ;;
+  esac
+fi
 if [ "${1:-}" = "issue" ] && [ "${2:-}" = "view" ]; then
+  # ===== `issue view <N> --json comments`: THE PROBED THREAD (#3759) =====
+  # Handled BEFORE the retrievability branch below, and driven by its OWN knobs, so a case that
+  # fixtures a disposition failure (STUB_GH_ISSUE_ERR) does not silently also break the probe read —
+  # two independent questions must be independently failable or a case measures the wrong one.
+  #
+  # The comment fixture is one multi-record string: a `\002<issue-number>` line opens a record, and
+  # the usual `\001<login>` + body lines follow, so the SAME converter produces the SAME
+  # `{"comments":[{"author":{"login":…},"body":…}]}` shape the PR call produces — which is the
+  # measured fact that licenses the wrapper reusing one scanner for both threads.
+  case " $* " in
+    *" comments"*|*",comments"*|*"comments,"*)
+      for _stub_fail in ${STUB_GH_ISSUE_COMMENTS_FAIL:-}; do
+        if [ "$_stub_fail" = "${3:-}" ]; then
+          printf '%s\n' "${STUB_GH_ISSUE_COMMENTS_ERR:-HTTP 502: Bad gateway (https://api.github.com/graphql)}" >&2
+          exit 1
+        fi
+      done
+      for _stub_garbage in ${STUB_GH_ISSUE_COMMENTS_GARBAGE:-}; do
+        if [ "$_stub_garbage" = "${3:-}" ]; then
+          printf 'not json at all\n'
+          exit 0
+        fi
+      done
+      printf '%b' "${STUB_GH_ISSUE_COMMENTS:-}" | STUB_WANT_ISSUE="${3:-}" python3 -c '
+import json, os, sys
+want = os.environ.get("STUB_WANT_ISSUE", "")
+raw = sys.stdin.read()
+current = None
+records = {}
+author = None
+body = []
+def flush():
+    if current is not None and author is not None:
+        records.setdefault(current, []).append(
+            {"author": {"login": author}, "body": "\n".join(body)})
+for line in raw.split("\n"):
+    if line.startswith("\u0002"):
+        flush()
+        current = line[1:].strip()
+        author = None
+        body = []
+    elif line.startswith("\u0001"):
+        flush()
+        author = line[1:]
+        body = []
+    elif author is not None:
+        body.append(line)
+flush()
+json.dump({"comments": records.get(want, [])}, sys.stdout)
+'
+      exit 0
+      ;;
+  esac
   if [ -n "${STUB_GH_ISSUE_ERR:-}" ]; then
     printf '%s\n' "$STUB_GH_ISSUE_ERR" >&2
     exit 1
@@ -1189,6 +1273,19 @@ export STUB_GH_RC=0
 export STUB_GH_ISSUES=''
 export STUB_GH_ISSUES_CLOSED=''
 export STUB_GH_ISSUE_ERR=''
+# #3759: the LINKED-ISSUE MISPLACEMENT PROBE knobs. STUB_GH_LINKED_ISSUES is the closingIssuesReferences
+# relation and DEFAULTS TO EMPTY — a case that wants a probe has to say so, which is the fail-closed
+# direction; STUB_GH_ISSUE_COMMENTS carries per-issue comment fixtures (\002<n> opens a record), and the
+# _FAIL/_GARBAGE/_ERR knobs make an individual thread independently unreadable so a PARTIAL read is
+# expressible. Nothing here is a seam in the wrapper: the whole `gh` binary is a substituted artifact.
+export STUB_GH_LINKED_ISSUES=''
+export STUB_GH_LINKED_JSON=''
+export STUB_GH_LINKED_RC=0
+export STUB_GH_LINKED_ERR=''
+export STUB_GH_ISSUE_COMMENTS=''
+export STUB_GH_ISSUE_COMMENTS_FAIL=''
+export STUB_GH_ISSUE_COMMENTS_GARBAGE=''
+export STUB_GH_ISSUE_COMMENTS_ERR=''
 export STUB_ON_REVIEW=''
 reset_stub() {
   STUB_JOB=4656
@@ -1216,6 +1313,14 @@ reset_stub() {
   STUB_GH_ISSUES=''
   STUB_GH_ISSUES_CLOSED=''
   STUB_GH_ISSUE_ERR=''
+  STUB_GH_LINKED_ISSUES=''
+  STUB_GH_LINKED_JSON=''
+  STUB_GH_LINKED_RC=0
+  STUB_GH_LINKED_ERR=''
+  STUB_GH_ISSUE_COMMENTS=''
+  STUB_GH_ISSUE_COMMENTS_FAIL=''
+  STUB_GH_ISSUE_COMMENTS_GARBAGE=''
+  STUB_GH_ISSUE_COMMENTS_ERR=''
   STUB_ON_REVIEW=''
 }
 
@@ -3744,7 +3849,7 @@ assert_says 'case (wv1) the NONE cause names the SHAPE requirement (job 29)' \
 assert_says 'case (wv1) and it names the contexts that do not count' \
   'a marker inside prose, a code fence, a quote or a review body is not read'
 assert_says 'case (wv1) the waiver state is reported as NONE' \
-  '^waiver: NONE \(no waiver comment for this review: the marker must be the SOLE NONBLANK CONTENT of a TOP-LEVEL PR comment — a marker inside prose, a code fence, a quote or a review body is not read\)$'
+  '^waiver: NONE \(no waiver comment for this review: the marker must be the SOLE NONBLANK CONTENT of a TOP-LEVEL PR comment — a marker inside prose, a code fence, a quote or a review body is not read; no linked issue is declared on this PR, so no linked-issue thread was checked\)$'
 assert_lacks 'case (wv1) no NOTICE verdict exists for this key any more' '^prompt-content: NOTICE'
 assert_lacks 'case (wv1) and no snapshot keys are emitted' '^snapshot-'
 reset_stub
@@ -3929,7 +4034,7 @@ assert_verdict 'case (wv11)' FAIL 1
 assert_says 'case (wv11) reposting the diagnostic does not waive anything' \
   '^prompt-content: FAIL \(2/2 code census paths absent from the prompt\)$'
 assert_says 'case (wv11) and no waiver is found in it' \
-  '^waiver: NONE \(no waiver comment for this review: the marker must be the SOLE NONBLANK CONTENT of a TOP-LEVEL PR comment — a marker inside prose, a code fence, a quote or a review body is not read\)$'
+  '^waiver: NONE \(no waiver comment for this review: the marker must be the SOLE NONBLANK CONTENT of a TOP-LEVEL PR comment — a marker inside prose, a code fence, a quote or a review body is not read; no linked issue is declared on this PR, so no linked-issue thread was checked\)$'
 assert_lacks 'case (wv11) the reposted block never grants' '^prompt-content: WAIVED'
 reset_stub
 
@@ -3944,7 +4049,7 @@ STUB_GH_COMMENTS="\001pmcfadin\n> roborev-waive: prompt-content-absent base=$w_b
 run_wrapper "$w_work"
 assert_verdict 'case (wv12)' FAIL 1
 assert_says 'case (wv12) no quoted or indented copy is honoured' \
-  '^waiver: NONE \(no waiver comment for this review: the marker must be the SOLE NONBLANK CONTENT of a TOP-LEVEL PR comment — a marker inside prose, a code fence, a quote or a review body is not read\)$'
+  '^waiver: NONE \(no waiver comment for this review: the marker must be the SOLE NONBLANK CONTENT of a TOP-LEVEL PR comment — a marker inside prose, a code fence, a quote or a review body is not read; no linked issue is declared on this PR, so no linked-issue thread was checked\)$'
 assert_lacks 'case (wv12) and none of them grants' '^prompt-content: WAIVED'
 reset_stub
 
@@ -4763,7 +4868,7 @@ assert_verdict 'case (df2)' FAIL 1
 assert_no_marker_form 'case (df2)'
 assert_says 'case (df2) the findings stand as PRESENT' '^findings: PRESENT \(2\)$'
 assert_says 'case (df2) the NONE cause teaches the sole-content and top-level rules' \
-  '^deferral: NONE \(no findings-deferral comment for this review: the authorization must be the SOLE NONBLANK CONTENT of a TOP-LEVEL PR comment — one inside prose, a code fence, a quote or a review body is not read\)$'
+  '^deferral: NONE \(no findings-deferral comment for this review: the authorization must be the SOLE NONBLANK CONTENT of a TOP-LEVEL PR comment — one inside prose, a code fence, a quote or a review body is not read; no linked issue is declared on this PR, so no linked-issue thread was checked\)$'
 assert_lacks 'case (df2) nothing is deferred' '^findings: DEFERRED'
 # LAYER 3 (#3312 job 23): no emitted diagnostic carries ANY part of the marker, because a summary
 # block pasted into a PR comment would otherwise authorize the next run.

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -7737,6 +7737,18 @@ if grep -qF 'python3 "$WAIVER_SCAN_TOOL" "$kind" "$base" "$head" "$job" "$ROBORE
 else
   bad 'structural (#3759): the linked-issue probe no longer delegates to the one scanner with the caller-supplied kind/scope/allowlist — a second recogniser over an authorization grammar is a bypass (#3626 reuse-do-not-reinvent)'
 fi
+# AND THERE IS EXACTLY ONE SCANNER FILE. "The scanner is unmodified by this change" is a property of
+# a diff and cannot be asserted durably here (a `git diff origin/main` assert goes stale the moment
+# this merges, and a stale assert is one that reds on correct input); what IS durable is that no
+# SECOND scanner was added beside it, which is the thing the reuse ruling actually forbids.
+# The count is required to be EXACTLY 1, so a find that FAILED (yielding 0) reds rather than passing
+# — the fail-closed direction for the three-valued-signal trap this repo lints for (1699-find-tristate).
+_mps_scanners=$(find "$SCRIPT_DIR/../flow" -maxdepth 1 \( -name '*waiver*scan*.py' -o -name '*marker*scan*.py' \) 2>/dev/null | wc -l | tr -d '[:space:]')
+if [ "$_mps_scanners" = "1" ]; then
+  ok 'structural (#3759): exactly one authorization scanner exists — the probe forked no thread-specific variant'
+else
+  bad "structural (#3759): $_mps_scanners authorization scanner files exist in scripts/flow (want exactly 1) — a second implementation of a marker grammar is a second place for it to diverge, and a divergence in an AUTHORIZATION grammar is a bypass"
+fi
 if grep -qE 'misplaced' "$SCAN_TOOL"; then
   bad 'structural (#3759): the SCANNER emits or knows about the misplaced state — thread identity is the CALLER-side knowledge, and telling the scanner would mean adding a provenance argument to the one component whose inputs must stay fixed'
 else

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -6084,14 +6084,30 @@ assert_says 'case (mp6/non-numeric) a non-numeric relation entry is a could-not-
   'NOT read: an entry that is not an issue number'
 assert_lacks 'case (mp6/non-numeric) and the raw value is NEVER interpolated' 'not-a-number'
 reset_stub
-reset_stub
-mp_waiver_fixture
-STUB_GH_LINKED_JSON='this is not json'
-run_wrapper "$w_work"
-assert_verdict 'case (mp6/unparseable-relation)' FAIL 1
-assert_says 'case (mp6/unparseable-relation) an unparseable relation payload names itself' \
-  'the closingIssuesReferences payload could not be parsed'
-reset_stub
+# ===== FOUR UNREADABLE PAYLOAD SHAPES, EACH A COULD-NOT-CHECK AND NEVER "NONE DECLARED" =====
+# (#3759 round 1, finding 2.) The coercion these replace turned an unparseable payload, a non-object
+# top level, a MISSING key and an explicit `null` all into ZERO declared references, which rendered
+# as the affirmative "no linked issue is declared on this PR" — an ANSWER derived from a payload
+# nobody could read. Asserted PER SHAPE: one standing for the family is exactly how three of these
+# stayed invisible behind the fourth.
+for _mp6_shape in \
+  'unparseable:this is not json' \
+  'non-object:[1, 2, 3]' \
+  'missing-key:{"someOtherField":[]}' \
+  'explicit-null:{"closingIssuesReferences":null}' \
+  'non-list:{"closingIssuesReferences":{"number":3544}}' ; do
+  reset_stub
+  mp_waiver_fixture
+  STUB_GH_LINKED_JSON="${_mp6_shape#*:}"
+  run_wrapper "$w_work"
+  assert_verdict "case (mp6/relation-shape/${_mp6_shape%%:*})" FAIL 1
+  assert_no_marker_form "case (mp6/relation-shape/${_mp6_shape%%:*})"
+  assert_says "case (mp6/relation-shape/${_mp6_shape%%:*}) is a could-not-check naming the broken payload" \
+    'the closingIssuesReferences payload was not readable as a JSON object carrying a closingIssuesReferences LIST'
+  assert_lacks "case (mp6/relation-shape/${_mp6_shape%%:*}) and NEVER claims that no linked issue is declared" \
+    'no linked issue is declared on this PR'
+  reset_stub
+done
 
 printf '== (mp7) #3759: a PARTIAL read is could-not-check naming BOTH halves, never checked ==\n'
 # A PARTIAL SCAN REPORTED AS A COMPLETE ONE IS WORSE THAN AN ADMITTED FAILURE, because it is the

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -562,6 +562,12 @@ json.dump({"comments": records.get(want, [])}, sys.stdout)
   printf 'GraphQL: Could not resolve to an issue or pull request with the number of %s. (repository.issue)\n' "${3:-}" >&2
   exit 1
 fi
+# EXIT 0 WITH NOTHING ON STDOUT — its own knob, because it cannot be spelled with any other (#3759
+# round 4). It is a plausible real-world `gh` result and it is the shape that used to BYPASS the
+# validated read entirely, so it has to be expressible or the case measures nothing.
+if [ -n "${STUB_GH_PR_EMPTY_STDOUT:-}" ]; then
+  exit 0
+fi
 if [ -n "${STUB_GH_COMMENTS_JSON:-}" ]; then
   printf '%s\n' "$STUB_GH_COMMENTS_JSON"
   exit 0
@@ -1310,6 +1316,7 @@ export STUB_RECORD_OUTPUT_FIELD=''
 export STUB_GH_COMMENTS=''
 export STUB_GH_COMMENTS_JSON=''
 export STUB_GH_COMMENTS_FILE=''
+export STUB_GH_PR_EMPTY_STDOUT=''
 export STUB_GH_RC=0
 # #3626: the FINDINGS-DEFERRAL knobs. STUB_GH_ISSUES is the set of issue numbers that EXIST, so
 # retrievability is a fixture decision and not a stub default; STUB_GH_ISSUE_ERR fixtures a
@@ -1364,6 +1371,7 @@ reset_stub() {
   STUB_GH_COMMENTS=''
   STUB_GH_COMMENTS_JSON=''
   STUB_GH_COMMENTS_FILE=''
+  STUB_GH_PR_EMPTY_STDOUT=''
   STUB_GH_RC=0
   STUB_GH_ISSUES=''
   STUB_GH_ISSUES_CLOSED=''
@@ -6023,7 +6031,7 @@ for _mp3 in \
   assert_verdict "case (mp3/$_mp3_kind)" FAIL 1
   assert_no_marker_form "case (mp3/$_mp3_kind)"
   assert_says "case (mp3/$_mp3_kind) the state stays NONE with the probe's checked declaration" \
-    '^waiver: NONE \(no waiver comment for this review:.*; linked issue #3544 checked: no matching marker there either\)$'
+    '^waiver: NONE \(no waiver comment for this review:.*; linked issue #3544 checked: no matching marker there either \(NON-EXHAUSTIVE: a thread counts as read when its payload was a comments LIST the scanner accepted; a malformed ENTRY inside an otherwise well-formed list is skipped by the scanner and is not distinguished here\)\)$'
   assert_lacks "case (mp3/$_mp3_kind) MISPLACED is not reported for a marker that would not have been accepted" \
     '^waiver: MISPLACED'
   assert_lacks "case (mp3/$_mp3_kind) and nothing is waived" '^prompt-content: WAIVED'
@@ -6475,6 +6483,106 @@ MP16SCAN
   assert_lacks "case (mp16/${_mp16_state%%:*}) nor does an unrecognised state escalate" '^waiver: MISPLACED'
   reset_stub
 done
+
+printf '== (mp17) #3759 r4: `gh` exiting 0 with EMPTY output is UNAVAILABLE, never NONE ==\n'
+# ROUND-4 FINDING 1, SECOND HALF, AND IT IS ON THE GRANTING PATH. Both PR-side callers had an
+# `[ -n "$json" ] || return 0` that BYPASSED the validated read on the one input shape a healthy-
+# looking `gh` most plausibly produces: exit 0, nothing on stdout. The early return left the state at
+# its `none` default, so the block asserted "there is no authorization" over comments NOBODY READ.
+# Like the missing shape check before it, this predates the misplacement probe.
+# THE FIXTURE MAKES THE FALSE CLAIM CONCRETE: a would-have-granted marker exists on the linked issue,
+# so a `none` here would additionally have run the probe and reported MISPLACED off an unread PR.
+reset_stub
+mp_waiver_fixture
+STUB_GH_PR_EMPTY_STDOUT=1
+STUB_GH_LINKED_ISSUES='3544'
+STUB_GH_ISSUE_COMMENTS="\002#3544\n\001pmcfadin\n$mp_waive_grant\n"
+run_wrapper "$w_work"
+assert_verdict 'case (mp17)' FAIL 1
+assert_no_marker_form 'case (mp17)'
+assert_says 'case (mp17) an empty payload is the state that says the oracle could not be consulted' \
+  '^waiver: UNAVAILABLE \(the payload was not a JSON object carrying a comments LIST \(it was empty'
+assert_lacks 'case (mp17) it NEVER asserts that no authorization exists over comments nobody read' '^waiver: NONE'
+assert_lacks 'case (mp17) and nothing is waived' '^prompt-content: WAIVED'
+# AND THE PROBE IS NOT RUN AT ALL: it runs only from `none`, so an unreadable PR payload can no longer
+# produce a MISPLACED derived from a pull request that was never read.
+assert_lacks 'case (mp17) an unread PR payload can never yield a MISPLACED' '^waiver: MISPLACED'
+if grep -qF 'closingIssuesReferences' "$INVOKED"; then
+  bad 'case (mp17): the probe RAN over a PR payload that was never read'
+else
+  ok 'case (mp17): no probe was performed (checked against the stub invocation record)'
+fi
+reset_stub
+
+printf '== (mp17b) #3759 r4: the same on the DEFERRAL side ==\n'
+# The deferral carried the identical bypass, and a residual corrected in one of two places reads as
+# correct in the other.
+reset_stub
+df_grant_fixture
+STUB_GH_PR_EMPTY_STDOUT=1
+run_wrapper "$w_work" --recheck-job 4656
+assert_verdict 'case (mp17b)' FAIL 1
+assert_no_marker_form 'case (mp17b)'
+assert_says 'case (mp17b) an empty payload is UNAVAILABLE on the deferral side too' \
+  '^deferral: UNAVAILABLE \(the payload was not a JSON object carrying a comments LIST \(it was empty'
+assert_lacks 'case (mp17b) never NONE' '^deferral: NONE'
+assert_says 'case (mp17b) and the findings stand exactly as measured' '^findings: PRESENT \(2\)$'
+reset_stub
+
+printf '== (mp18) #3759 r4: a NEWLINE-BEARING identity is REPO-UNVERIFIED, not CROSS-REPO ==\n'
+# ROUND-4 FINDING 2. A trailing-dollar anchor in Python matches BEFORE a final newline, so a login or
+# repository name ending in a newline VALIDATED — and the newline then survived into the joined
+# identity, which compares unequal to everything. A SAME-repository reference therefore came out as a
+# CONFIDENT cross-repository DECLARED SKIP: the exact false confidence the identity validation exists
+# to remove, produced by the validation itself. `fullmatch` has no such exception.
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_JSON='{"closingIssuesReferences":[{"number":3544,"repository":{"name":"cqlite\n","owner":{"login":"pmcfadin"}}}]}'
+STUB_GH_ISSUE_COMMENTS="\002#3544\n\001pmcfadin\n$mp_waive_grant\n"
+run_wrapper "$w_work"
+assert_verdict 'case (mp18)' FAIL 1
+assert_no_marker_form 'case (mp18)'
+assert_says 'case (mp18) an identity that fails the grammar is a could-not-check' \
+  'NOT read: an entry whose repository could not be established'
+assert_lacks 'case (mp18) and is NEVER a confident cross-repository declared skip' \
+  'cross-repository closing reference'
+assert_lacks 'case (mp18) nor is it probed' '^waiver: MISPLACED'
+reset_stub
+
+printf '== (mp19) #3759 r4: a READ thread DECLARES what "read" does not establish ==\n'
+# R5 APPLIED TO THIS FEATURE'S OWN LIMIT. The validated read establishes the CONTAINER (a top-level
+# object whose field is a list), the exit status and the closed-grammar state — it does NOT
+# distinguish a malformed ELEMENT inside an otherwise well-formed list, because the scanner skips such
+# an entry and the scanner is reused UNMODIFIED by design. Re-validating each element in the caller
+# would be a SECOND implementation of the marker path, whose correctness is knowable only by
+# differential testing against the first. So the limit is DECLARED rather than closed — and it is
+# declared IN THE RENDERING, where the claim is made, not only in a comment nobody opens.
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_ISSUES='3544'
+STUB_GH_ISSUE_COMMENTS_JSON='{"comments":[{"author":"not-an-object"},{"body":42},"a bare string"]}'
+run_wrapper "$w_work"
+assert_verdict 'case (mp19)' FAIL 1
+assert_no_marker_form 'case (mp19)'
+# The container IS well-formed, so the thread genuinely counts as read — and the value says exactly
+# what that does and does not mean rather than implying an element-level check nobody performed.
+assert_says 'case (mp19) the thread is reported as read' 'linked issue #3544 checked: no matching marker there either'
+assert_says 'case (mp19) and the rendering declares its own non-exhaustiveness' \
+  'NON-EXHAUSTIVE: a thread counts as read when its payload was a comments LIST the scanner accepted'
+assert_says 'case (mp19) naming precisely what is not distinguished' \
+  'a malformed ENTRY inside an otherwise well-formed list is skipped by the scanner and is not distinguished here'
+reset_stub
+
+printf '== (mp19b) #3759 r4: the declared limit is absent where no read is claimed ==\n'
+# A limit printed where nothing was read would be noise, and worse, would imply a read. The no-subject
+# rendering claims no read at all, so it carries no such clause.
+reset_stub
+mp_waiver_fixture
+run_wrapper "$w_work"
+assert_says 'case (mp19b) no linked issue means no read is claimed' \
+  'no linked issue is declared on this PR, so no linked-issue thread was checked'
+assert_lacks 'case (mp19b) so the read limit is not declared here' 'NON-EXHAUSTIVE: a thread counts as read'
+reset_stub
 
 printf '== (mp12) #3759 MUTANT: probing on EVERY state reds — the escalation is only from none ==\n'
 # A CASE THAT PASSES AGAINST BOTH THE REAL CODE AND ITS NAIVE FORM MEASURES NOTHING. The naive form

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -6121,7 +6121,7 @@ run_wrapper "$w_work"
 assert_verdict 'case (mp8)' FAIL 1
 assert_no_marker_form 'case (mp8)'
 assert_says 'case (mp8) the rendering declares declared / probed / bound' \
-  'linked issues #3544 #3626 #3312 checked — 3 of 4 declared, probe bounded at 3: no matching marker'
+  'linked issues #3544,#3626,#3312 checked — 3 of 4 declared, probe bounded at 3: no matching marker'
 assert_lacks 'case (mp8) the unprobed remainder is not silently claimed as checked' \
   'checked: no matching marker there either'
 if grep -qE 'gh issue view 3710 --json comments' "$INVOKED"; then

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -6584,6 +6584,71 @@ assert_says 'case (mp19b) no linked issue means no read is claimed' \
 assert_lacks 'case (mp19b) so the read limit is not declared here' 'NON-EXHAUSTIVE: a thread counts as read'
 reset_stub
 
+printf '== (mp20) #3759 r5: the bound exhausted by SKIPS reads nothing — and never says "checked" ==\n'
+# ROUND-5 FINDING. Three cross-repository references exhaust the probe bound before it reaches the
+# same-repository one, so NOTHING is read — and the rendering used to be guarded on the bound clause
+# being EMPTY, so this fell through to `checked` and printed `linked issues none checked … no matching
+# marker`: a confident NEGATIVE derived from ZERO reads. Same false confidence as the defects the
+# identity grammar and the validated read each closed, arriving this time through the RENDERING.
+# THE FIXTURE PUTS A REAL MARKER ON THE UNEXAMINED THREAD, so "no matching marker" would be false in
+# fact and not merely unwarranted in form. Ordered explicitly via the payload, because the outcome
+# turns on the cross-repository references coming FIRST.
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_JSON='{"closingIssuesReferences":[
+  {"number":3544,"repository":{"name":"other-repo","owner":{"login":"other-owner"}}},
+  {"number":3626,"repository":{"name":"other-repo","owner":{"login":"other-owner"}}},
+  {"number":3312,"repository":{"name":"other-repo","owner":{"login":"other-owner"}}},
+  {"number":3710,"repository":{"name":"cqlite","owner":{"login":"pmcfadin"}}}]}'
+STUB_GH_ISSUE_COMMENTS="\002#3710\n\001pmcfadin\n$mp_waive_grant\n"
+run_wrapper "$w_work"
+assert_verdict 'case (mp20)' FAIL 1
+assert_no_marker_form 'case (mp20)'
+assert_says 'case (mp20) the outcome says plainly that no thread was read' \
+  'the linked-issue thread could NOT be checked: no thread was read'
+assert_says 'case (mp20) and names how much of the declared set it never looked at' \
+  '3 of 4 declared examined, probe bounded at 3, 1 never looked at'
+assert_says 'case (mp20) and why the three it examined were not read' \
+  '3 cross-repository closing reference\(s\) declared and deliberately NOT probed'
+# THE THREE FALSE CLAIMS THAT MUST NOT APPEAR. "no matching marker" is a statement about CONTENT, and
+# no content was read; "none checked" is the literal shape of the defect; and the read limit declares
+# what a READ does not establish, so it presupposes a read.
+assert_lacks 'case (mp20) it NEVER claims anything about a marker it did not look for' 'no matching marker'
+assert_lacks 'case (mp20) and never renders an empty read list as checked' 'linked issues none checked'
+assert_lacks 'case (mp20) nor carries the read limit, which presupposes a read' 'NON-EXHAUSTIVE: a thread counts as read'
+# AND IT IS NOT MISFILED AS "no linked issue": one IS declared in this repository, unexamined.
+assert_lacks 'case (mp20) a declared-but-unexamined reference is not "no linked issue"' \
+  'no linked issue IN THIS REPOSITORY is declared'
+# MEASURED: the same-repository thread really was never read, so the case is about the bound and not
+# about a read that silently failed.
+if grep -qE 'gh issue view 3710 --json comments' "$INVOKED"; then
+  bad 'case (mp20): the bound was not exhausted — the same-repository thread WAS read, so this case is not exercising the empty-read_list rendering at all'
+else
+  ok 'case (mp20): the same-repository thread was never reached (checked against the stub invocation record)'
+fi
+reset_stub
+
+printf '== (mp20b) #3759 r5: one thread read past the same skips DOES speak about content (control) ==\n'
+# Without this, (mp20) would pass identically if the probe had stopped rendering content claims
+# altogether. Two cross-repository skips instead of three, so the bound reaches the same-repository
+# reference: one variable, and the outcome flips back to a content claim with its declared limit.
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_JSON='{"closingIssuesReferences":[
+  {"number":3544,"repository":{"name":"other-repo","owner":{"login":"other-owner"}}},
+  {"number":3626,"repository":{"name":"other-repo","owner":{"login":"other-owner"}}},
+  {"number":3710,"repository":{"name":"cqlite","owner":{"login":"pmcfadin"}}}]}'
+STUB_GH_ISSUE_COMMENTS="\002#3710\n\001pmcfadin\nnothing here\n"
+run_wrapper "$w_work"
+assert_verdict 'case (mp20b)' FAIL 1
+assert_says 'case (mp20b) a thread that WAS read is reported as checked, naming it' \
+  'linked issues #3710 checked'
+assert_says 'case (mp20b) with a content claim, because content was read' 'no matching marker'
+assert_says 'case (mp20b) and the declared read limit, because a read is claimed' \
+  'NON-EXHAUSTIVE: a thread counts as read'
+assert_lacks 'case (mp20b) and it is not a could-not-check' 'no thread was read'
+reset_stub
+
 printf '== (mp12) #3759 MUTANT: probing on EVERY state reds — the escalation is only from none ==\n'
 # A CASE THAT PASSES AGAINST BOTH THE REAL CODE AND ITS NAIVE FORM MEASURES NOTHING. The naive form
 # here is "probe whatever the PR-side state was", which overwrites a precise STALE with a vaguer

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -440,10 +440,17 @@ if [ "${1:-}" = "issue" ] && [ "${2:-}" = "view" ]; then
   # fixtures a disposition failure (STUB_GH_ISSUE_ERR) does not silently also break the probe read —
   # two independent questions must be independently failable or a case measures the wrong one.
   #
-  # The comment fixture is one multi-record string: a `\002<issue-number>` line opens a record, and
+  # The comment fixture is one multi-record string: a `\002#<issue-number>` line opens a record, and
   # the usual `\001<login>` + body lines follow, so the SAME converter produces the SAME
   # `{"comments":[{"author":{"login":…},"body":…}]}` shape the PR call produces — which is the
   # measured fact that licenses the wrapper reusing one scanner for both threads.
+  #
+  # THE `#` IS LOAD-BEARING, NOT DECORATION. `printf %b` reads `\0nnn` as up to THREE octal digits
+  # after the `\0`, so an opener written WITHOUT the `#` would read its first digit as part of the
+  # escape (a four-character `\0` + `023` = 0x13) and the rest as text — a silently WRONG record
+  # opener, and the fixture then declares a thread nobody can select. The existing `\001<login>`
+  # form is safe only because a login never starts with a digit. `#` is not an octal digit, so the
+  # escape terminates deterministically; the converter strips it.
   case " $* " in
     *" comments"*|*",comments"*|*"comments,"*)
       for _stub_fail in ${STUB_GH_ISSUE_COMMENTS_FAIL:-}; do
@@ -473,7 +480,7 @@ def flush():
 for line in raw.split("\n"):
     if line.startswith("\u0002"):
         flush()
-        current = line[1:].strip()
+        current = line[1:].strip().lstrip("#")
         author = None
         body = []
     elif line.startswith("\u0001"):
@@ -5841,6 +5848,390 @@ if sed_inplace_verified "$_dfk_dir/roborev-review-checks.sh" \
   assert_lacks 'case (df18) one authorization can never excuse a check nobody authorized' '^RESULT: PASS$'
 else
   bad 'case (df18): could not patch the copied checks file, so the misplaced-DEFERRED path was never exercised (a green run here would be a probe failing in the direction that looks like success)'
+fi
+reset_stub
+
+# =============================================================================================
+# (mp*) #3759: A MISPLACED AUTHORIZATION IS DIAGNOSED — AND GRANTS NOTHING
+# =============================================================================================
+# THE INCIDENT, measured. For PR #3710 the coordination lead granted BOTH authorizations —
+# field-perfect base/head/job, each the sole nonblank content of its own top-level comment, from an
+# allowlisted author — on ISSUE #3544, the thread where that lane's coordination had happened all
+# day. The wrapper reads PR comments only, so `--recheck-job 317` reported `waiver: NONE` /
+# `deferral: NONE`, which is TEXTUALLY IDENTICAL to "the lead refused" and to "nobody posted one".
+# Position 1 of a six-PR serial queue idled ~8 hours and blocked five lanes. `gh pr view 3710 --json
+# closingIssuesReferences` returns `[{"number":3544}]`, so the probe specified here WOULD have named
+# the right thread on the actual incident.
+#
+# WHAT THIS FAMILY PINS, in both directions:
+#   * an issue-side marker the channel WOULD have accepted ⇒ `MISPLACED` naming the issue and the
+#     remedy, with the underlying FAIL untouched and `RESULT: FAIL` — for BOTH kinds;
+#   * MISPLACED reaches NO granting path: `prompt-content:` never reads WAIVED, `findings:` never
+#     reads DEFERRED, and the structural asserts below pin that the granting gates are still the two
+#     token-exact `= "granted"` comparisons;
+#   * the escalation fires ONLY from `none` and ONLY from an issue-side `granted` — a PR-side STALE
+#     is not overwritten AND (measured against the stub's invocation log) is not even probed;
+#   * every `NONE` DECLARES what the probe did, from the closed rendering set, so "checked and it is
+#     not there either" and "never checked" can never read alike;
+#   * the linked issue comes from the STRUCTURED relation and nothing reads the PR body.
+mp_waive_grant="roborev-waive: prompt-content-absent base=$w_base head=$w_head job=4656 reason=snapshot-delivered; 541812 in / 472576 cached"
+mp_defer_grant="roborev-defer: findings issues=$d_issues count=2 base=$w_base head=$w_head job=4656 reason=$d_reason"
+# The fixture EVERY waiver-side case needs: the census paths absent from the prompt, so the absence
+# branch runs and there is a waiver to look for, and NOTHING on the PR.
+mp_waiver_fixture() {
+  STUB_ANNOUNCE_SHA="$w_head"
+  STUB_PROMPT="$PROMPT_WITHOUT_PATHS"
+}
+
+printf '== (mp1) #3759: a would-have-granted WAIVER on the linked issue ⇒ MISPLACED, FAIL ==\n'
+# THE ACCEPTANCE CASE FOR THE WAIVER HALF, and the incident reproduced hermetically.
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_ISSUES='3544'
+STUB_GH_ISSUE_COMMENTS="\002#3544\n\001pmcfadin\n$mp_waive_grant\n"
+run_wrapper "$w_work"
+assert_verdict 'case (mp1)' FAIL 1
+assert_no_marker_form 'case (mp1)'
+assert_one_result_line 'case (mp1)'
+assert_says 'case (mp1) the waiver key reports MISPLACED, naming the linked issue it was found on' \
+  '^waiver: MISPLACED \(an authorization for THIS review \(this base, head and job\) is on LINKED ISSUE #3544, not on the pull request'
+assert_says 'case (mp1) it claims only what the probe measured — accepted by the CHANNEL' \
+  'would have been ACCEPTED BY THE CHANNEL there'
+assert_says 'case (mp1) it states that it grants nothing and the FAIL stands' \
+  'IT GRANTS NOTHING AND THIS FAIL STANDS'
+assert_says 'case (mp1) and it carries the one operator action that fixes it' \
+  'REMEDY: the authorizer re-posts the IDENTICAL line as a TOP-LEVEL COMMENT ON THE PR'
+assert_says 'case (mp1) with the lead-side verification step named' \
+  "verifies with 'gh pr view <PR> --json comments' that it is there"
+# THE POSITIVE CONTROL FOR "GRANTS NOTHING" (R2). Behavioural, paired with the structural asserts.
+assert_says 'case (mp1) the absence FAIL is untouched' \
+  '^prompt-content: FAIL \(2/2 code census paths absent from the prompt\)$'
+assert_lacks 'case (mp1) a misplaced waiver NEVER waives' '^prompt-content: WAIVED'
+assert_lacks 'case (mp1) and never reads as a certification' '^prompt-content: PASS'
+assert_lacks 'case (mp1) nor is it reported as if no authorization existed anywhere' '^waiver: NONE'
+assert_lacks 'case (mp1) nor as GRANTED' '^waiver: GRANTED'
+reset_stub
+
+printf '== (mp2) #3759: a would-have-granted DEFERRAL on the linked issue ⇒ MISPLACED, FAIL ==\n'
+# THE ACCEPTANCE CASE FOR THE DEFERRAL HALF. `findings:` must stay exactly as the run measured it —
+# never DEFERRED (that would be the grant) and never NONE (that would read as a clean review).
+reset_stub
+df_grant_fixture
+STUB_GH_LINKED_ISSUES='3544'
+STUB_GH_ISSUE_COMMENTS="\002#3544\n\001pmcfadin\n$mp_defer_grant\n"
+run_wrapper "$w_work" --recheck-job 4656
+assert_verdict 'case (mp2)' FAIL 1
+assert_no_marker_form 'case (mp2)'
+assert_one_result_line 'case (mp2)'
+assert_says 'case (mp2) the deferral key reports MISPLACED, naming the linked issue' \
+  '^deferral: MISPLACED \(an authorization for THIS review \(this base, head and job\) is on LINKED ISSUE #3544, not on the pull request'
+assert_says 'case (mp2) the count= match IS claimed, because the scanner decided it' \
+  'its count= matches the 2 observed finding\(s\)'
+# R3: THE RENDERING DOES NOT CLAIM MORE THAN THE PROBE MEASURED. The network disposition leg is
+# deliberately not run issue-side, and the value says so instead of implying a completed check.
+assert_says 'case (mp2) but the issue-disposition legs are declared NOT run issue-side' \
+  'are NOT run issue-side and still apply once it is on the PR'
+assert_says 'case (mp2) the findings stand exactly as measured' '^findings: PRESENT \(2\)$'
+assert_lacks 'case (mp2) a misplaced deferral NEVER defers' '^findings: DEFERRED'
+assert_lacks 'case (mp2) and NEVER reads as a clean review' '^findings: NONE'
+assert_lacks 'case (mp2) nor is it reported as if no authorization existed anywhere' '^deferral: NONE'
+# MEASURED AGAINST THE INVOCATION LOG, not inferred: the disposition leg asks
+# `gh issue view <N> --json number,state`, and the probe must not have run it issue-side.
+if grep -qF -- '--json number,state' "$INVOKED"; then
+  bad 'case (mp2): the issue-disposition leg RAN on the probe path — the rendering claims it does not, and a diagnostic that overstates what it measured is what stops the next person looking'
+else
+  ok 'case (mp2): the network disposition leg was NOT run issue-side (checked against the stub invocation record)'
+fi
+reset_stub
+
+printf '== (mp3) #3759: an issue-side STALE / MALFORMED / UNAUTHORIZED marker stays NONE ==\n'
+# R3, SECOND HALF: only an issue-side marker the channel WOULD HAVE ACCEPTED escalates. Each of these
+# is a DIFFERENT defect that happens to be on a different thread, and re-posting it would not help —
+# reporting MISPLACED for it would make the run FAIL after the operator followed the remedy, which
+# spends the diagnostic's credibility. Asserted PER SHAPE, never one standing for the family.
+for _mp3 in \
+  "stale:roborev-waive: prompt-content-absent base=$w_base head=0000000000000000000000000000000000000000 job=4656 reason=names another review" \
+  "malformed:roborev-waive: prompt-content-absent base=$w_base head=$w_head job=4656 reason=<why>" \
+  "unauthorized:\001a-stranger" ; do
+  _mp3_kind="${_mp3%%:*}"
+  _mp3_body="${_mp3#*:}"
+  reset_stub
+  mp_waiver_fixture
+  STUB_GH_LINKED_ISSUES='3544'
+  if [ "$_mp3_kind" = unauthorized ]; then
+    STUB_GH_ISSUE_COMMENTS="\002#3544\n\001a-stranger\n$mp_waive_grant\n"
+  else
+    STUB_GH_ISSUE_COMMENTS="\002#3544\n\001pmcfadin\n$_mp3_body\n"
+  fi
+  run_wrapper "$w_work"
+  assert_verdict "case (mp3/$_mp3_kind)" FAIL 1
+  assert_no_marker_form "case (mp3/$_mp3_kind)"
+  assert_says "case (mp3/$_mp3_kind) the state stays NONE with the probe's checked declaration" \
+    '^waiver: NONE \(no waiver comment for this review:.*; linked issue #3544 checked: no matching marker there either\)$'
+  assert_lacks "case (mp3/$_mp3_kind) MISPLACED is not reported for a marker that would not have been accepted" \
+    '^waiver: MISPLACED'
+  assert_lacks "case (mp3/$_mp3_kind) and nothing is waived" '^prompt-content: WAIVED'
+  reset_stub
+done
+# THE ALLOWLIST APPLIES IDENTICALLY ON BOTH THREADS, which is what stops a stranger's comment on a
+# PUBLIC issue thread even producing a diagnostic that names it as an authorization.
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_ISSUES='3544'
+STUB_GH_ISSUE_COMMENTS="\002#3544\n\001a-stranger\n$mp_waive_grant\n"
+run_wrapper "$w_work"
+assert_lacks 'case (mp3/unauthorized) a stranger is never named as an authorizer' 'a-stranger'
+reset_stub
+
+printf '== (mp4) #3759: a PR-side STALE is NOT overwritten, and the probe is NOT EVEN CALLED ==\n'
+# R3, FIRST HALF, MEASURED RATHER THAN ASSUMED. `stale` is already specific and already actionable;
+# replacing it with MISPLACED would substitute a vaguer diagnosis for a precise one. And the probe is
+# NOT PERFORMED — not merely ignored — which is the only version an invocation log can measure. A
+# network call whose result is discarded is latency plus a future footgun.
+reset_stub
+mp_waiver_fixture
+STUB_GH_COMMENTS="\001pmcfadin\nroborev-waive: prompt-content-absent base=$w_base head=0000000000000000000000000000000000000000 job=4656 reason=names another review\n"
+STUB_GH_LINKED_ISSUES='3544'
+STUB_GH_ISSUE_COMMENTS="\002#3544\n\001pmcfadin\n$mp_waive_grant\n"
+run_wrapper "$w_work"
+assert_verdict 'case (mp4)' FAIL 1
+assert_no_marker_form 'case (mp4)'
+assert_says 'case (mp4) the precise PR-side cause survives' '^waiver: STALE \(the marker names a different review'
+assert_lacks 'case (mp4) a perfect issue-side marker does NOT overwrite it' '^waiver: MISPLACED'
+if grep -qF 'closingIssuesReferences' "$INVOKED"; then
+  bad 'case (mp4): the linked-issue relation WAS fetched on a state that had already diagnosed — reachability must rest on the call not being made, not on where an if sits'
+else
+  ok 'case (mp4): no closingIssuesReferences call was made (checked against the stub invocation record)'
+fi
+if grep -qE 'gh issue view [0-9]+ --json comments' "$INVOKED"; then
+  bad 'case (mp4): a linked-issue comment read WAS made on an already-diagnosed state'
+else
+  ok 'case (mp4): no linked-issue comment read was made either'
+fi
+reset_stub
+
+printf '== (mp5) #3759: NO linked issue ⇒ NONE naming the no-subject rendering ==\n'
+# The absence of a check is STATED rather than looking like a completed one — the same reason the
+# gate prints `0 RECOGNISED` rather than a bare `0`.
+reset_stub
+mp_waiver_fixture
+run_wrapper "$w_work"
+assert_verdict 'case (mp5)' FAIL 1
+assert_no_marker_form 'case (mp5)'
+assert_says 'case (mp5) the NONE value declares that no linked-issue thread was checked' \
+  '^waiver: NONE \(no waiver comment for this review:.*; no linked issue is declared on this PR, so no linked-issue thread was checked\)$'
+reset_stub
+
+printf '== (mp5b) #3759: a PR body mentioning an unlinked #N is NOT a subject (R4) ==\n'
+# THE RELATION, NOT THE PROSE, IS WHAT BOUNDS AND ATTRIBUTES THE PROBE. #3626 DELETED a PR-body link
+# check because a body is editable at any time by anyone with write access with NO per-edit
+# attribution; reinstating a body scan for ANY purpose would be reinstating a deleted generation. So
+# an issue mentioned only in prose is not probed, even though its thread carries a perfect marker.
+reset_stub
+mp_waiver_fixture
+STUB_GH_ISSUE_COMMENTS="\002#3544\n\001pmcfadin\n$mp_waive_grant\n"
+run_wrapper "$w_work"
+assert_verdict 'case (mp5b)' FAIL 1
+assert_says 'case (mp5b) an unlinked issue is not a subject, whatever the body says' \
+  'no linked issue is declared on this PR, so no linked-issue thread was checked'
+assert_lacks 'case (mp5b) and its marker is not found' '^waiver: MISPLACED'
+if grep -qE 'gh issue view [0-9]+ --json comments' "$INVOKED"; then
+  bad 'case (mp5b): a thread was probed although the structured relation declared none'
+else
+  ok 'case (mp5b): no thread was probed (checked against the stub invocation record)'
+fi
+reset_stub
+
+printf '== (mp6) #3759: the probe unable to run ⇒ NONE with the could-not-check cause ==\n'
+# EVERY FAILURE IS A STATE WITH A CAUSE — never a two-valued return, which would re-import the very
+# collapse this change exists to remove — and the run still FAILs on the underlying key: the probe
+# can neither rescue nor fail anything.
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_RC=1
+run_wrapper "$w_work"
+assert_verdict 'case (mp6/relation)' FAIL 1
+assert_no_marker_form 'case (mp6/relation)'
+assert_says 'case (mp6/relation) the relation failure is named as a could-not-check' \
+  "the linked-issue thread could NOT be checked: 'gh pr view --json closingIssuesReferences' failed"
+assert_lacks 'case (mp6/relation) and it never reads as a completed check' 'checked: no matching marker there either'
+reset_stub
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_ISSUES='3544'
+STUB_GH_ISSUE_COMMENTS_FAIL='3544'
+run_wrapper "$w_work"
+assert_verdict 'case (mp6/thread)' FAIL 1
+assert_no_marker_form 'case (mp6/thread)'
+assert_says 'case (mp6/thread) an unreadable thread is a could-not-check naming the cause' \
+  'the linked-issue thread could NOT be checked: read with no matching marker: none; NOT read: #3544 \(HTTP 502: Bad gateway'
+reset_stub
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_ISSUES='3544'
+STUB_GH_ISSUE_COMMENTS_GARBAGE='3544'
+run_wrapper "$w_work"
+assert_verdict 'case (mp6/unparseable)' FAIL 1
+assert_says 'case (mp6/unparseable) an unparseable comments payload is its own could-not-check cause' \
+  'NOT read: #3544 \(its comments payload could not be parsed\)'
+reset_stub
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_JSON='{"closingIssuesReferences":[{"number":"not-a-number"}]}'
+run_wrapper "$w_work"
+assert_verdict 'case (mp6/non-numeric)' FAIL 1
+assert_says 'case (mp6/non-numeric) a non-numeric relation entry is a could-not-check, reported as a KIND' \
+  'NOT read: an entry that is not an issue number'
+assert_lacks 'case (mp6/non-numeric) and the raw value is NEVER interpolated' 'not-a-number'
+reset_stub
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_JSON='this is not json'
+run_wrapper "$w_work"
+assert_verdict 'case (mp6/unparseable-relation)' FAIL 1
+assert_says 'case (mp6/unparseable-relation) an unparseable relation payload names itself' \
+  'the closingIssuesReferences payload could not be parsed'
+reset_stub
+
+printf '== (mp7) #3759: a PARTIAL read is could-not-check naming BOTH halves, never checked ==\n'
+# A PARTIAL SCAN REPORTED AS A COMPLETE ONE IS WORSE THAN AN ADMITTED FAILURE, because it is the
+# version nobody re-checks. One thread read with no match, one unavailable.
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_ISSUES='3544 3626'
+STUB_GH_ISSUE_COMMENTS="\002#3544\n\001pmcfadin\nnothing here\n"
+STUB_GH_ISSUE_COMMENTS_FAIL='3626'
+run_wrapper "$w_work"
+assert_verdict 'case (mp7)' FAIL 1
+assert_no_marker_form 'case (mp7)'
+assert_says 'case (mp7) both halves are named — what was read and what was not' \
+  'the linked-issue thread could NOT be checked: read with no matching marker: #3544; NOT read: #3626 \('
+assert_lacks 'case (mp7) a partial read NEVER takes the checked rendering' 'checked: no matching marker there either'
+reset_stub
+
+printf '== (mp8) #3759: MORE linked issues than the bound ⇒ the remainder is declared ==\n'
+# The probe is a diagnostic on a path that has already determined the run FAILs, so it is bounded —
+# and when the declared set exceeds the bound the rendering SAYS SO. The unprobed remainder is
+# visible rather than silent.
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_ISSUES='3544 3626 3312 3710'
+STUB_GH_ISSUE_COMMENTS="\002#3544\n\001pmcfadin\nnothing\n\002#3626\n\001pmcfadin\nnothing\n\002#3312\n\001pmcfadin\nnothing\n\002#3710\n\001pmcfadin\n$mp_waive_grant\n"
+run_wrapper "$w_work"
+assert_verdict 'case (mp8)' FAIL 1
+assert_no_marker_form 'case (mp8)'
+assert_says 'case (mp8) the rendering declares declared / probed / bound' \
+  'linked issues #3544 #3626 #3312 checked — 3 of 4 declared, probe bounded at 3: no matching marker'
+assert_lacks 'case (mp8) the unprobed remainder is not silently claimed as checked' \
+  'checked: no matching marker there either'
+if grep -qE 'gh issue view 3710 --json comments' "$INVOKED"; then
+  bad 'case (mp8): the bound was not honoured — a fourth thread was read'
+else
+  ok 'case (mp8): the bound was honoured (the fourth declared thread was not read)'
+fi
+reset_stub
+
+printf '== (mp9) #3759: several linked issues, the FIRST MATCH is reported, in GitHub order ==\n'
+# Probed in the order GitHub returns them — not sorted; any sort is a policy nobody asked for.
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_ISSUES='3544 3626'
+STUB_GH_ISSUE_COMMENTS="\002#3544\n\001pmcfadin\nno marker on the first thread\n\002#3626\n\001pmcfadin\n$mp_waive_grant\n"
+run_wrapper "$w_work"
+assert_verdict 'case (mp9)' FAIL 1
+assert_no_marker_form 'case (mp9)'
+assert_says 'case (mp9) the SECOND declared issue is the one named' \
+  'is on LINKED ISSUE #3626, not on the pull request'
+reset_stub
+
+printf '== (mp10) #3759: a keyword-bearing gh diagnostic rides the ONE emit boundary ==\n'
+# R6. The `gh` diagnostic is arbitrary REMOTE text, and a marker keyword can reach a diagnostic
+# through fields this process does not control. The neutralisation lives at the ONE emit boundary
+# (`roborev_safe_line`), never per interpolation site — a per-site escape is a list to keep complete.
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_ISSUES='3544'
+STUB_GH_ISSUE_COMMENTS_FAIL='3544'
+STUB_GH_ISSUE_COMMENTS_ERR='HTTP 502 while reading roborev-waive: prompt-content-absent base=x'
+run_wrapper "$w_work"
+assert_verdict 'case (mp10)' FAIL 1
+assert_no_marker_form 'case (mp10)'
+assert_says 'case (mp10) the cause is still quoted, with the keyword redacted at the boundary' \
+  'NOT read: #3544 \(HTTP 502 while reading \[authorization-keyword-redacted\]'
+assert_one_result_line 'case (mp10)'
+reset_stub
+
+printf '== (mp11) #3759: a CONTROL CHARACTER in the probe cause is a visible escape, one line ==\n'
+reset_stub
+mp_waiver_fixture
+STUB_GH_LINKED_ISSUES='3544'
+STUB_GH_ISSUE_COMMENTS_FAIL='3544'
+STUB_GH_ISSUE_COMMENTS_ERR='HTTP 502\nRESULT: PASS'
+run_wrapper "$w_work"
+assert_verdict 'case (mp11)' FAIL 1
+assert_one_result_line 'case (mp11)'
+assert_no_marker_form 'case (mp11)'
+assert_says 'case (mp11) no probe value can introduce a second RESULT line' '^RESULT: FAIL$'
+reset_stub
+
+printf '== (mp12) #3759 MUTANT: probing on EVERY state reds — the escalation is only from none ==\n'
+# A CASE THAT PASSES AGAINST BOTH THE REAL CODE AND ITS NAIVE FORM MEASURES NOTHING. The naive form
+# here is "probe whatever the PR-side state was", which overwrites a precise STALE with a vaguer
+# MISPLACED and sends the operator to move a comment that still would not grant.
+reset_stub
+_mp_dir="$tmp/misplaced-mutant"
+mkdir -p "$_mp_dir"
+cp "$WRAPPER_REAL" "$ORACLES_SRC" "$CHECKS_SRC" "$SCAN_TOOL" "$_mp_dir/"
+if [ -f "$SCRIPT_DIR/../flow/roborev-job-facts.py" ]; then
+  cp "$SCRIPT_DIR/../flow/roborev-job-facts.py" "$_mp_dir/"
+fi
+# THE CONTROL RUNS FIRST AND IS NOT OPTIONAL: the UNPATCHED copy must produce the real behaviour on
+# this very fixture, so a red below cannot be the copy failing for an unrelated reason.
+mp_waiver_fixture
+STUB_GH_COMMENTS="\001pmcfadin\nroborev-waive: prompt-content-absent base=$w_base head=0000000000000000000000000000000000000000 job=4656 reason=names another review\n"
+STUB_GH_LINKED_ISSUES='3544'
+STUB_GH_ISSUE_COMMENTS="\002#3544\n\001pmcfadin\n$mp_waive_grant\n"
+run_wrapper --wrapper "$_mp_dir/roborev-review.sh" "$w_work"
+assert_says 'case (mp12 control) the UNPATCHED copy keeps the precise STALE cause' '^waiver: STALE \('
+assert_lacks 'case (mp12 control) and reports no MISPLACED' '^waiver: MISPLACED'
+if sed_inplace_verified "$_mp_dir/roborev-review-oracles.sh" \
+  's/  if \[ "\$ROBOREV_WAIVER_STATE" = "none" \]; then/  if [ -n "$ROBOREV_WAIVER_STATE" ]; then/' \
+  'if [ -n "$ROBOREV_WAIVER_STATE" ]; then' 'if [ "$ROBOREV_WAIVER_STATE" = "none" ]; then'; then
+  ok 'case (mp12): the probe-on-every-state mutant was really applied to the copy'
+  run_wrapper --wrapper "$_mp_dir/roborev-review.sh" "$w_work"
+  assert_says 'case (mp12) the NAIVE form overwrites the precise STALE — which is why the real code guards it' \
+    '^waiver: MISPLACED'
+else
+  bad 'case (mp12): the probe-on-every-state mutant could not be applied, so the escalation guard was never contrasted with its naive form — a case that passes against both measures nothing'
+fi
+reset_stub
+
+printf '== (mp13) #3759 MUTANT: escalating on ANY issue-side marker reds ==\n'
+# The second naive form: "a marker is over there, say MISPLACED". It reports MISPLACED for a marker
+# that would NOT have been accepted, so the run FAILs after the operator followed the remedy.
+reset_stub
+_mp2_dir="$tmp/misplaced-mutant-2"
+mkdir -p "$_mp2_dir"
+cp "$WRAPPER_REAL" "$ORACLES_SRC" "$CHECKS_SRC" "$SCAN_TOOL" "$_mp2_dir/"
+if [ -f "$SCRIPT_DIR/../flow/roborev-job-facts.py" ]; then
+  cp "$SCRIPT_DIR/../flow/roborev-job-facts.py" "$_mp2_dir/"
+fi
+mp_waiver_fixture
+STUB_GH_LINKED_ISSUES='3544'
+STUB_GH_ISSUE_COMMENTS="\002#3544\n\001pmcfadin\nroborev-waive: prompt-content-absent base=$w_base head=0000000000000000000000000000000000000000 job=4656 reason=names another review\n"
+run_wrapper --wrapper "$_mp2_dir/roborev-review.sh" "$w_work"
+assert_says 'case (mp13 control) the UNPATCHED copy leaves a stale issue-side marker at NONE' \
+  '^waiver: NONE \(no waiver comment for this review:'
+assert_lacks 'case (mp13 control) and reports no MISPLACED' '^waiver: MISPLACED'
+if sed_inplace_verified "$_mp2_dir/roborev-review-oracles.sh" \
+  's/^    if \[ "\$state" = "granted" \]; then$/    if [ -n "$state" ] \&\& [ "$state" != "none" ]; then/' \
+  'if [ -n "$state" ] && [ "$state" != "none" ]; then' '    if [ "$state" = "granted" ]; then'; then
+  ok 'case (mp13): the escalate-on-any-marker mutant was really applied to the copy'
+  run_wrapper --wrapper "$_mp2_dir/roborev-review.sh" "$w_work"
+  assert_says 'case (mp13) the NAIVE form escalates a marker the channel would have REFUSED' \
+    '^waiver: MISPLACED'
+else
+  bad 'case (mp13): the escalate-on-any-marker mutant could not be applied, so the would-have-granted condition was never contrasted with its naive form'
 fi
 reset_stub
 

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4480,8 +4480,10 @@ STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" HOME="$FIXTURE_HOME" \
   --log "$tmp/transcript-$CASE_N.txt" >"$OUT" 2>&1
 RC=$?
 assert_verdict 'case (wv31)' FAIL 1
+# The wording is the SHARED helper's since #3759 round 3 — one validated read serves both kinds, so it
+# says "authorization" rather than "waiver". The properties asserted are unchanged.
 assert_says 'case (wv31) an unusable scanner is UNAVAILABLE and fails closed' \
-  '^waiver: UNAVAILABLE \(the structured waiver scanner is unusable'
+  '^waiver: UNAVAILABLE \(the structured authorization scanner is unusable'
 assert_says 'case (wv31) and it says a waiver is never decided from a text stream' \
   'NEVER decided from a flattened text stream'
 # THE LOAD-BEARING CONTROL FOR THE KEYWORD REDACTION'S WORD BOUNDARY (roborev job 230). This cause names
@@ -6127,7 +6129,7 @@ STUB_GH_ISSUE_COMMENTS_GARBAGE='3544'
 run_wrapper "$w_work"
 assert_verdict 'case (mp6/unparseable)' FAIL 1
 assert_says 'case (mp6/unparseable) an unparseable comments payload is its own could-not-check cause' \
-  'NOT read: #3544 \(its comments payload was not a JSON object carrying a comments LIST'
+  'NOT read: #3544 \(refused: the payload was not a JSON object carrying a comments LIST'
 reset_stub
 reset_stub
 mp_waiver_fixture
@@ -6157,7 +6159,7 @@ for _mp6_shape in \
   assert_verdict "case (mp6/relation-shape/${_mp6_shape%%:*})" FAIL 1
   assert_no_marker_form "case (mp6/relation-shape/${_mp6_shape%%:*})"
   assert_says "case (mp6/relation-shape/${_mp6_shape%%:*}) is a could-not-check naming the broken payload" \
-    'the closingIssuesReferences payload was not readable as a JSON object carrying a closingIssuesReferences LIST'
+    'the payload was not a JSON object carrying a closingIssuesReferences LIST'
   assert_lacks "case (mp6/relation-shape/${_mp6_shape%%:*}) and NEVER claims that no linked issue is declared" \
     'no linked issue is declared on this PR'
   reset_stub
@@ -6408,7 +6410,7 @@ for _mp15_shape in \
   assert_verdict "case (mp15/${_mp15_shape%%:*})" FAIL 1
   assert_no_marker_form "case (mp15/${_mp15_shape%%:*})"
   assert_says "case (mp15/${_mp15_shape%%:*}) the thread is could-not-check, naming what was not a comments LIST" \
-    'NOT read: #3544 \(its comments payload was not a JSON object carrying a comments LIST'
+    'NOT read: #3544 \(refused: the payload was not a JSON object carrying a comments LIST'
   assert_lacks "case (mp15/${_mp15_shape%%:*}) and the probe NEVER claims it checked that thread" \
     'checked: no matching marker there either'
   assert_lacks "case (mp15/${_mp15_shape%%:*}) nor does a zero exit from the scanner become a grant" \
@@ -6467,7 +6469,7 @@ MP16SCAN
   assert_verdict "case (mp16/${_mp16_state%%:*})" FAIL 1
   assert_no_marker_form "case (mp16/${_mp16_state%%:*})"
   assert_says "case (mp16/${_mp16_state%%:*}) an unvalidated state does not make a thread checked" \
-    'NOT read: #3544 \(the scanner returned the unrecognised state'
+    'NOT read: #3544 \(refused: the scanner returned the unrecognised state'
   assert_lacks "case (mp16/${_mp16_state%%:*}) and the probe never claims it checked that thread" \
     'checked: no matching marker there either'
   assert_lacks "case (mp16/${_mp16_state%%:*}) nor does an unrecognised state escalate" '^waiver: MISPLACED'
@@ -7407,8 +7409,16 @@ fi
 # divergence in a channel rule is an authorization bypass — which is exactly how the in-band author
 # channel came back once already (#3312 job 26).
 _dfe_bad=""
-grep -qF 'python3 "$WAIVER_SCAN_TOOL" findings-deferral' "$ORACLES" || _dfe_bad="$_dfe_bad deferral-does-not-call-the-one-scanner"
-grep -qF 'python3 "$WAIVER_SCAN_TOOL" prompt-content-absent' "$ORACLES" || _dfe_bad="$_dfe_bad waiver-kind-not-named-explicitly"
+# SINCE #3759 ROUND 3 THE CALL IS ONE HOP FURTHER IN, AND THE PROPERTY IS STRICTLY STRONGER. Both kinds
+# now reach the scanner through the single validated read `roborev_validated_authorization_scan`, so
+# what is asserted is that each kind is named explicitly AT ITS CALL of that one helper — an
+# unambiguous literal, exactly as the direct invocation was — rather than that each lookup spells out
+# its own `python3 "$WAIVER_SCAN_TOOL" <kind>`. The "no second enforcer" half is now enforced by the
+# #3759 chokepoint assert below, which requires EVERY scanner invocation to be inside that helper;
+# before the restructure nothing forbade a third call site anywhere in the file.
+grep -qF 'roborev_validated_authorization_scan findings-deferral' "$ORACLES" || _dfe_bad="$_dfe_bad deferral-does-not-call-the-one-scanner"
+grep -qF 'roborev_validated_authorization_scan prompt-content-absent' "$ORACLES" || _dfe_bad="$_dfe_bad waiver-kind-not-named-explicitly"
+grep -qF 'python3 "$WAIVER_SCAN_TOOL"' "$ORACLES" || _dfe_bad="$_dfe_bad one-scanner-path-not-invoked"
 grep -qF 'roborev-defer: findings' "$SCAN_TOOL" || _dfe_bad="$_dfe_bad marker-form-absent-from-the-scanner"
 # THE MARKER FORM MAY NOT LIVE IN THE SHELL. Executable lines only: the comment blocks in these files
 # describe the mechanism, and scanning prose would make writing it down a violation — the same mistake
@@ -7998,6 +8008,83 @@ fi
 # "simplification" would quietly undo. Neither substitutes for the other — a structural assert cannot
 # see a granting path built some other way, and a behavioural case cannot see a granting path nobody
 # fixtured.
+printf '== structural (#3759 r3): EVERY payload read on the probe path goes through ONE helper ==\n'
+# WHY THIS ASSERT EXISTS RATHER THAN A FOURTH SITE FIX. Three review rounds produced 3, then 1, then 2
+# findings, and EVERY one was the same class — an input reaching a conclusion without an affirmative
+# validation. Round 3's second finding was inside code round 3 had just ADDED while fixing that class.
+# Site fixes provably do not converge here, so the validation was restructured into one chokepoint and
+# this assert is what keeps it one: it makes the NEXT input STRUCTURALLY unable to join the unvalidated
+# set. That is the repo's own "remove the shared channel rather than pick a rarer delimiter", applied
+# to validation.
+#
+# EXECUTABLE LINES ONLY, and EXTRACTED TO A FILE rather than piped into `grep -q` (#3387): the comment
+# blocks in the oracles NAME the rejected shapes and the mechanism, so scanning prose would make
+# writing the reasoning down a violation; and a negated `grep -q` on a pipe reports a non-match on a
+# real match once the writer outruns the 64 KB buffer, which is fail-open for every clause here.
+_chk_bad=""
+_chk_exec="$tmp/chokepoint-oracles-exec.txt"
+grep -v '^[[:space:]]*#' "$ORACLES" >"$_chk_exec" || true
+
+# (1) THE SCANNER IS INVOKED ONLY FROM INSIDE THE ONE VALIDATED READ. Extract that function's body and
+#     require every invocation in the file to be inside it. A count-based assert would pass a second
+#     call site that happened to replace one inside the helper.
+_chk_vscan="$tmp/chokepoint-vscan-body.txt"
+awk '/^roborev_validated_authorization_scan\(\) \{/,/^\}$/' "$ORACLES" >"$_chk_vscan"
+if [ ! -s "$_chk_vscan" ]; then
+  _chk_bad="$_chk_bad validated-read-helper-not-found"
+else
+  _chk_total=$(grep -cF 'python3 "$WAIVER_SCAN_TOOL"' "$_chk_exec" || true)
+  _chk_inside=$(grep -cF 'python3 "$WAIVER_SCAN_TOOL"' "$_chk_vscan" || true)
+  [ "$_chk_total" -gt 0 ] || _chk_bad="$_chk_bad no-scanner-invocation-at-all"
+  [ "$_chk_total" = "$_chk_inside" ] || _chk_bad="$_chk_bad scanner-invoked-outside-the-validated-read($_chk_inside-of-$_chk_total-inside)"
+  # AND THE STATE IS READ ONLY THERE. A caller extracting `state=` itself would be re-deriving the
+  # verdict from raw scanner output, which is the exact collapse the closed-grammar check removes.
+  _chk_state_total=$(grep -cF "sed -n 's/^state=//p'" "$_chk_exec" || true)
+  _chk_state_inside=$(grep -cF "sed -n 's/^state=//p'" "$_chk_vscan" || true)
+  [ "$_chk_state_total" = "$_chk_state_inside" ] || _chk_bad="$_chk_bad scanner-state-extracted-outside-the-validated-read"
+fi
+
+# (2) THE PAYLOAD SHAPE IS JUDGED ONLY INSIDE THE ONE VALIDATOR. The predicates are named individually
+#     because a future edit is far likelier to re-add one of them at a call site than to reimplement
+#     all three.
+_chk_jsonf="$tmp/chokepoint-jsonf-body.txt"
+awk '/^roborev_json_list_field\(\) \{/,/^\}$/' "$ORACLES" >"$_chk_jsonf"
+if [ ! -s "$_chk_jsonf" ]; then
+  _chk_bad="$_chk_bad shape-validator-not-found"
+else
+  for _chk_pred in 'if not isinstance(data, dict):' 'not in data' 'if not isinstance(data[' ; do
+    _chk_pt=$(grep -cF -- "$_chk_pred" "$_chk_exec" || true)
+    _chk_pi=$(grep -cF -- "$_chk_pred" "$_chk_jsonf" || true)
+    [ "$_chk_pt" = "$_chk_pi" ] || _chk_bad="$_chk_bad shape-predicate-outside-the-validator:${_chk_pred}"
+  done
+fi
+
+# (3) BOTH GRANTING LOOKUPS AND THE PROBE GO THROUGH THE HELPER — asserted positively, because
+#     (1) and (2) only forbid a SECOND implementation and would be satisfied by a caller that
+#     validated nothing at all.
+for _chk_caller in 'roborev_validated_authorization_scan prompt-content-absent' \
+                   'roborev_validated_authorization_scan findings-deferral' \
+                   'roborev_validated_authorization_scan "$kind"' \
+                   'roborev_json_list_field "$rel_json" closingIssuesReferences' ; do
+  grep -qF -- "$_chk_caller" "$_chk_exec" || _chk_bad="$_chk_bad caller-not-routed:${_chk_caller%% *}"
+done
+
+# (4) ONE GRAMMAR FOR A GITHUB OWNER OR REPOSITORY NAME. Round 3's second finding was two PARALLEL
+#     identity validations where only one constrained anything, so the character class is defined once
+#     and BOTH the shell's check and the python leg's `ref_repo` consume that one definition. A literal
+#     class re-appearing in the executable text is the drift this forbids.
+grep -qF "ROBOREV_GH_NAME_RE='[A-Za-z0-9._-]+'" "$_chk_exec" || _chk_bad="$_chk_bad name-grammar-not-defined-once"
+grep -qF 'PROBE_NAME_RE="$ROBOREV_GH_NAME_RE"' "$_chk_exec" || _chk_bad="$_chk_bad name-grammar-not-passed-to-the-python-leg"
+if [ "$(grep -cF '[A-Za-z0-9._-]+' "$_chk_exec" || true)" != "1" ]; then
+  _chk_bad="$_chk_bad name-grammar-spelled-more-than-once"
+fi
+
+if [ -z "$_chk_bad" ]; then
+  ok 'structural (#3759): every payload read, every scanner invocation and every identity check on the probe path goes through the ONE validated read, and the name grammar is defined once'
+else
+  bad "structural (#3759): the validation chokepoint has been bypassed —$_chk_bad. Four review rounds of per-site fixes did not converge on this class; the helper is what makes a NEW input structurally unable to join the unvalidated set, so a call site that reads a payload or the scanner directly reopens it (#3229/#3544: restructure, do not carve the same place again)"
+fi
+
 printf '== structural (#3759): MISPLACED grants nothing, and the probe reuses the one scanner ==\n'
 # (1) THE GRANTING GATES ARE STILL THE TWO TOKEN-EXACT `= "granted"` COMPARISONS, and `misplaced`
 # appears in NO granting branch. A `MISPLACED*` prefix test, a `!= none` test or a second granting

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -91,6 +91,28 @@ bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
 # `rm -rf "$tmp"` on an unverified path is the same hazard, hence the ordering. Non-empty AND a
 # directory: a diagnostic printed on stdout would pass the emptiness test alone.
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/roborev-guard-test.XXXXXX") || tmp=''
+
+# ===== `<producer> | grep -q` IS FAIL-OPEN UNDER `pipefail`, SO IT IS UNAVAILABLE HERE (#3387) =====
+# `grep -q` exits at its FIRST match and closes the pipe; the producer's next write takes SIGPIPE; and
+# this file's `pipefail` hands the PIPELINE a 141. So a genuine MATCH can report a NON-match, and
+# every assert built on that shape reds or greens BY BYTE POSITION and scheduler timing.
+#
+# THIS IS NOT THEORETICAL AND IT IS NOT NEW: the pre-existing assert "the waiver is looked up EXACTLY
+# ONCE, inside the absence branch" red once in five consecutive runs on an unrelated, clean diff, and
+# a guard added earlier in this same change reported DIFFERENT states missing on consecutive runs.
+# `tooling-tests` is a component of the GATE OF RECORD, so a 1-in-5 flake there can red a certifying
+# gate on a clean tree — and a lane must not waive a red it cannot attribute.
+#
+# The shape is therefore REMOVED rather than fixed site by site: the text is materialised and the FILE
+# is grepped, so there is no pipe to break. A structural assert below forbids reintroducing the shape,
+# because a rule this mechanical is one a future edit will otherwise re-add by habit.
+STR_MATCH_FILE="$tmp/str-match-subject.txt"
+str_matches() { # str_matches <text> <grep-args...>  -> grep's own status, with no pipeline
+  local _sm_text="$1"
+  shift
+  printf '%s\n' "$_sm_text" >"$STR_MATCH_FILE" || return 2
+  grep "$@" "$STR_MATCH_FILE" >/dev/null 2>&1
+}
 if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
   printf 'FAIL - mktemp -d did not yield a usable temp directory (got: %s) — refusing to run rather than resolving every "$tmp/..." fixture path under /\n' "${tmp:-<empty>}"
   exit 1
@@ -1837,7 +1859,7 @@ assert_tracked_mode 'case (cx3h) fixture' "$cx3h_work" HEAD base-exec-head-plain
 assert_tracked_mode 'case (cx3h) fixture' "$cx3h_work" "$cx3h_base" head-exec-base-plain 100644
 assert_tracked_mode 'case (cx3h) fixture' "$cx3h_work" HEAD head-exec-base-plain 100755
 assert_tracked_mode 'case (cx3h) fixture' "$cx3h_work" "$cx3h_base" base-only-exec 100755
-if git -C "$cx3h_work" ls-tree HEAD -- ':(literal)base-only-exec' | grep -q .; then
+if [ -n "$(git -C "$cx3h_work" ls-tree HEAD -- ':(literal)base-only-exec')" ]; then
   bad 'case (cx3h): base-only-exec still exists at HEAD, so the BASE-only combination is not reproduced'
 else
   ok 'case (cx3h): base-only-exec is absent from HEAD (the BASE-only combination is reproduced)'
@@ -1958,7 +1980,7 @@ cx3j_shape() { # cx3j_shape <file> [funcname]
     inf { print }
   ' "$file" | grep -vE '^[[:space:]]*#' | grep -vE '^[[:space:]]*$')
   if [ -z "$body" ]; then printf 'NOT-FOUND\n'; return 0; fi
-  if printf '%s\n' "$body" | grep -qE '(^|[^[:alnum:]_])(break|continue)([^[:alnum:]_]|$)'; then
+  if str_matches "$body" -E '(^|[^[:alnum:]_])(break|continue)([^[:alnum:]_]|$)'; then
     printf 'HAS-BREAK-OR-CONTINUE\n'; return 0
   fi
   nret=$(printf '%s\n' "$body" | grep -cE '(^|[^[:alnum:]_])return([^[:alnum:]_]|$)' || true)
@@ -2043,7 +2065,9 @@ cx3j_pred=$(awk '
 if [ -z "$cx3j_pred" ]; then
   bad 'case (cx3j): _roborev_mode_exec_state_at was not found, so its range-blindness was not checked'
 else
-  if ! printf '%s\n' "$cx3j_pred" | grep -vE '^[[:space:]]*#' | grep -qE 'RANGE_BASE_SHA|BASE_TIP_SHA|\bHEAD\b'; then
+  _cx3j_exec="$tmp/cx3j-pred-exec.txt"
+  printf '%s\n' "$cx3j_pred" | grep -vE '^[[:space:]]*#' >"$_cx3j_exec" || true
+  if ! grep -qE 'RANGE_BASE_SHA|BASE_TIP_SHA|\bHEAD\b' "$_cx3j_exec"; then
     ok 'case (cx3j): the per-endpoint predicate names no endpoint (range-blind, so it cannot encode an ordering)'
   else
     bad 'case (cx3j): _roborev_mode_exec_state_at references a specific endpoint — it can encode a precedence again'
@@ -7021,7 +7045,7 @@ fi
 _unq_callers=$(grep -nE '(^|[^#])roborev_unquote_path ' "$ORACLES" "$CHECKS_FILE" "$WRAPPER_REAL" \
   | grep -v '^[^:]*:[0-9]*: *#' || true)
 _unq_caller_files=$(printf '%s\n' "$_unq_callers" | sed -n 's|^\([^:]*\):.*|\1|p' | sort -u | wc -l | tr -d '[:space:]')
-if [ "${_unq_caller_files:-0}" -eq 1 ] && printf '%s' "$_unq_callers" | grep -qF 'roborev-review-oracles.sh'; then
+if [ "${_unq_caller_files:-0}" -eq 1 ] && str_matches "$_unq_callers" -F 'roborev-review-oracles.sh'; then
   ok 'structural: roborev_unquote_path is called ONLY from the oracles file (one boundary)'
 else
   bad "structural: roborev_unquote_path is called from $_unq_caller_files file(s) — a second consumer normalises on its own"
@@ -7054,7 +7078,9 @@ fi
 # COMMENT LINES ARE EXEMPT: the file DOCUMENTS what was retired and why, which is the
 # record that keeps a future edit from reintroducing it. Only executable lines are checked.
 for _pat in 'diff --git a/\[\^ \]' 'promptpaths' 'grep -Fxq'; do
-  if grep -nE -- "$_pat" "$CHECKS_FILE" 2>/dev/null | grep -qv '^[0-9]*: *#'; then
+  _retired_hits="$tmp/retired-mechanism-hits.txt"
+  grep -nE -- "$_pat" "$CHECKS_FILE" >"$_retired_hits" 2>/dev/null || true
+  if grep -qv '^[0-9]*: *#' "$_retired_hits" 2>/dev/null; then
     bad "structural: roborev-review-checks.sh still EXECUTES the retired mechanism '$_pat'"
   else
     ok "structural: the retired mechanism '$_pat' is not executed by roborev-review-checks.sh"
@@ -7071,7 +7097,9 @@ fi
 #     grow a second, subtly different idea of the extended-header run. It therefore does no
 #     `diff --git` scanning of its own at all. Only a SCAN counts — the key's ERROR prose
 #     legitimately says the words "diff --git" when it explains what was looked for.
-if grep -nE '(grep|awk|sed|case)[^#]*diff --git' "$CHECKS_FILE" 2>/dev/null | grep -qv '^[0-9]*: *#'; then
+_dg_hits="$tmp/checks-diffgit-hits.txt"
+grep -nE '(grep|awk|sed|case)[^#]*diff --git' "$CHECKS_FILE" >"$_dg_hits" 2>/dev/null || true
+if grep -qv '^[0-9]*: *#' "$_dg_hits" 2>/dev/null; then
   bad 'structural: roborev-review-checks.sh EXECUTES its own diff --git scan — header-shape knowledge must stay with the matcher in the oracles file'
 else
   ok 'structural: roborev-review-checks.sh does no diff --git scanning of its own'
@@ -7241,7 +7269,7 @@ else
   _ac2_hits=$(_cls_hits "$_cls_all")
   _ac2_leaked=""
   for _ac2_tok in $_ac2_prose; do
-    printf '%s\n' "$_ac2_hits" | grep -qxF "$_ac2_tok" && _ac2_leaked="$_ac2_leaked $_ac2_tok"
+    str_matches "$_ac2_hits" -xF "$_ac2_tok" && _ac2_leaked="$_ac2_leaked $_ac2_tok"
   done
   if [ -z "$_ac2_leaked" ]; then
     ok "structural (#3367 AC2): the real wrapper's doctrine prose names$_ac2_prose and NONE of them is in the scanned token list — recording what was deleted cannot be a violation, with no heredoc exemption needed to make that true"
@@ -7377,9 +7405,9 @@ _pc_start=$(grep -nE '^roborev_check_prompt_content\(\) \{' "$CHECKS_FILE" | hea
 _pc_end=$(awk -v s="${_pc_start:-0}" 'NR>s && /^}/ {print NR; exit}' "$CHECKS_FILE")
 _pc_body=$(sed -n "${_pc_start:-1},${_pc_end:-1}p" "$CHECKS_FILE")
 _pc_exec=$(printf '%s\n' "$_pc_body" | grep -v '^[[:space:]]*#')
-if printf '%s\n' "$_pc_exec" | grep -qF 'roborev_absence_waiver_lookup "${RANGE_BASE_SHA:-}" "${HEAD_SHA:-}" "${JOB:-}"' \
+if str_matches "$_pc_exec" -F 'roborev_absence_waiver_lookup "${RANGE_BASE_SHA:-}" "${HEAD_SHA:-}" "${JOB:-}"' \
   && [ "$(printf '%s\n' "$_pc_exec" | grep -cF 'roborev_absence_waiver_lookup')" -eq 1 ] \
-  && printf '%s\n' "$_pc_body" | grep -qF 'PROMPT_CONTENT="WAIVED ('; then
+  && str_matches "$_pc_body" -F 'PROMPT_CONTENT="WAIVED ('; then
   ok 'structural: the waiver is looked up EXACTLY ONCE, inside the absence branch, so it can excuse only that verdict (constraint (c))'
 else
   bad 'structural: the absence waiver is not confined to the absence branch — a lookup anywhere else could excuse a verdict the ruling says it may never touch (#3312 ruling (4c))'
@@ -7772,10 +7800,10 @@ fi
 # test, and none of them is a fall-through. PASS requires every code census path to have been FOUND;
 # FAIL is the absence; WAIVED is the absence plus a complete human provenance. A `0/0` is still never a
 # pass, which is the one case where "nothing to measure" must not read as "measured fine".
-if printf '%s\n' "$_pc_body" | grep -qF 'PROMPT_CONTENT="PASS (${#checked_paths[@]}/$census_total code census paths present)"' \
-  && printf '%s\n' "$_pc_body" | grep -qF 'PROMPT_CONTENT="FAIL (${#missing_paths[@]}/${#checked_paths[@]} code census paths absent from the prompt)"' \
-  && printf '%s\n' "$_pc_body" | grep -qF 'a 0/0 is never a pass' \
-  && printf '%s\n' "$_pc_body" | grep -qF 'FAIL (prompt unretrievable'; then
+if str_matches "$_pc_body" -F 'PROMPT_CONTENT="PASS (${#checked_paths[@]}/$census_total code census paths present)"' \
+  && str_matches "$_pc_body" -F 'PROMPT_CONTENT="FAIL (${#missing_paths[@]}/${#checked_paths[@]} code census paths absent from the prompt)"' \
+  && str_matches "$_pc_body" -F 'a 0/0 is never a pass' \
+  && str_matches "$_pc_body" -F 'FAIL (prompt unretrievable'; then
   ok 'structural: prompt-content has exactly its three affirmative outcomes (present PASS / absent FAIL / absent+provenance WAIVED), plus the 0/0 and unretrievable-prompt refusals'
 else
   bad 'structural: prompt-content no longer reaches its outcomes affirmatively — a missing absent-FAIL, a missing 0/0 refusal or a missing unretrievable-prompt refusal each turns an unmeasured prompt into a pass (#3312 ruling (4))'
@@ -7785,17 +7813,17 @@ fi
 # a bare positional test is exactly blocker 1 reintroduced.
 if [ -n "$_matcher_start" ] && [ -n "${_matcher_end:-}" ]; then
   _m_body=$(sed -n "${_matcher_start},${_matcher_end}p" "$ORACLES")
-  if printf '%s\n' "$_m_body" | grep -qE '\[ -n "\$from_tok" \] && \[ -n "\$to_tok" \]'; then
+  if str_matches "$_m_body" -E '\[ -n "\$from_tok" \] && \[ -n "\$to_tok" \]'; then
     ok 'structural: the matcher resolves a rename/copy header from its from/to path tokens first'
   else
     bad 'structural: the matcher no longer resolves from the rename/copy from/to tokens — ambiguity would be guessed positionally again (#3229 blocker 1)'
   fi
-  if printf '%s\n' "$_m_body" | grep -qE '"a/\$want b/"\*'; then
+  if str_matches "$_m_body" -E '"a/\$want b/"\*'; then
     bad 'structural: the matcher is back to the PREFIX test `case $rest in "a/$want b/"*` — a tracked file named `foo b/x` would make the unrelated path `foo` read PRESENT (#3229 blocker 1)'
   else
     ok 'structural: the retired `"a/$want b/"*` prefix test is gone from the matcher'
   fi
-  if printf '%s\n' "$_m_body" | grep -qE 'eq_seen'; then
+  if str_matches "$_m_body" -E 'eq_seen'; then
     ok 'structural: an ambiguous non-rename header is decided by the EQUAL split, not by position'
   else
     bad 'structural: the matcher has no equal-split resolution for an ambiguous header'
@@ -7818,12 +7846,12 @@ if [ -n "$_census_start" ]; then
   else
     ok "structural: the census body bounds resolved (lines $_census_start-$_census_end)"
     _census_body=$(sed -n "${_census_start},${_census_end}p" "$ORACLES")
-    if printf '%s\n' "$_census_body" | grep -q 'roborev_unquote_path '; then
+    if str_matches "$_census_body" -e 'roborev_unquote_path '; then
       bad 'structural: the census normalises inside its own loop — it must read raw paths instead (-z)'
     else
       ok 'structural: the census classifies the RAW path (no unquoting inside the census loop)'
     fi
-    if printf '%s\n' "$_census_body" | grep -qF 'read -r -d '; then
+    if str_matches "$_census_body" -F 'read -r -d '; then
       ok 'structural: the census reads NUL-terminated records (a newline-bearing path survives)'
     else
       bad 'structural: the census does not read NUL-terminated records — a newline-bearing path would split'
@@ -7893,8 +7921,13 @@ fi
 _fin_start=$(grep -nE '^finish\(\) \{' "$WRAPPER_REAL" | head -1 | cut -d: -f1)
 _fin_end=""
 [ -z "$_fin_start" ] || _fin_end=$(awk -v s="$_fin_start" 'NR>s && /^}/ {print NR; exit}' "$WRAPPER_REAL")
+_fin_body_f="$tmp/finish-body.txt"
+: >"$_fin_body_f"
+if [ -n "$_fin_start" ] && [ -n "$_fin_end" ]; then
+  sed -n "${_fin_start},${_fin_end}p" "$WRAPPER_REAL" >"$_fin_body_f" || true
+fi
 if [ -n "$_fin_start" ] && [ -n "$_fin_end" ] \
-  && sed -n "${_fin_start},${_fin_end}p" "$WRAPPER_REAL" | grep -q 'roborev_safe_line'; then
+  && grep -q 'roborev_safe_line' "$_fin_body_f"; then
   ok "structural: finish neutralises every DETAILS line (lines $_fin_start-$_fin_end)"
 else
   bad 'structural: finish does not neutralise DETAILS lines'
@@ -7915,11 +7948,13 @@ _rl_end=""
 if [ -z "$_rl_start" ] || [ -z "$_rl_end" ]; then
   bad 'structural: could not locate roborev_safe_line() to inspect the keyword denylist — a failure to measure, not a measurement'
 else
-  sed -n "${_rl_start},${_rl_end}p" "$WRAPPER_REAL" | grep -q 'ROBOREV_MARKER_REDACTION' \
+  _rl_body_f="$tmp/safe-line-body.txt"
+  sed -n "${_rl_start},${_rl_end}p" "$WRAPPER_REAL" >"$_rl_body_f" || true
+  grep -q 'ROBOREV_MARKER_REDACTION' "$_rl_body_f" \
     || _rd_bad="$_rd_bad wrapper-boundary-does-not-redact"
   # The word boundary is part of the rule, not an optimisation: without it the scanner's own file name
   # is mangled in the `waiver: UNAVAILABLE (... tool: <path>)` cause (case wv31).
-  sed -n "${_rl_start},${_rl_end}p" "$WRAPPER_REAL" | grep -qF '[^a-zA-Z]|$' \
+  grep -qF '[^a-zA-Z]|$' "$_rl_body_f" \
     || _rd_bad="$_rd_bad wrapper-redaction-has-no-word-boundary"
   # EVERY other mention is a per-site escape — the definition line is the one exception.
   _rd_out=$(grep -n 'ROBOREV_MARKER_REDACTION' "$WRAPPER_REAL" \
@@ -7983,17 +8018,17 @@ if [ -z "$_scan_block" ] || [ -z "$_scan_keys" ] || [ -z "$_scan_case" ]; then
   bad 'structural: could not locate the wrapper verdict scan STATEMENT (for scan_keyed in … case … done) to inspect'
 else
   ok "structural: the verdict scan is a single case over the per-check keys (lines $_scan_start-$_scan_end)"
-  if printf '%s\n' "$_scan_keys" | grep -qE '; do[[:space:]]*$'; then
+  if str_matches "$_scan_keys" -E '; do[[:space:]]*$'; then
     ok 'structural: the extracted key list is the complete for-statement (terminates at "; do")'
   else
     bad 'structural: the extracted verdict-scan key list does not terminate at "; do" — the extraction is truncated, so the per-key asserts below would be unreliable'
   fi
-  if printf '%s\n' "$_scan_case" | grep -qE 'case "\$verdict_token" in FAIL\|FINDINGS\|ERROR\|INCONSISTENT\)'; then
+  if str_matches "$_scan_case" -E 'case "\$verdict_token" in FAIL\|FINDINGS\|ERROR\|INCONSISTENT\)'; then
     ok 'structural: the failing-capable set is exactly FAIL|FINDINGS|ERROR|INCONSISTENT'
   else
     bad 'structural: the failing-capable verdict set is not the expected FAIL|FINDINGS|ERROR|INCONSISTENT'
   fi
-  if printf '%s\n' "$_scan_case" | grep -q 'NOTICE'; then
+  if str_matches "$_scan_case" -e 'NOTICE'; then
     bad 'structural: NOTICE appears in the failing-capable verdict scan — an advisory vacuity-tier1 NOTICE would red RESULT:'
   else
     ok 'structural: NOTICE is absent from the failing-capable verdict scan'
@@ -8003,12 +8038,12 @@ else
   # reject unplanned values would accept any value merely BEGINNING with a planned token.
   # Pinned structurally as well as behaviourally (cases cx28b/cx28c) because a future edit
   # could restore the globs while every behavioural case but those two stayed green.
-  if printf '%s\n' "$_scan_block" | grep -qE '^[[:space:]]*verdict_token="\$\{verdict%% \*\}"'; then
+  if str_matches "$_scan_block" -E '^[[:space:]]*verdict_token="\$\{verdict%% \*\}"'; then
     ok 'structural: the scan reduces each value to its VERDICT TOKEN (up to the first space) before classifying'
   else
     bad 'structural: the verdict scan does not extract a verdict token — it is classifying the whole value, so a token followed by anything is matched by prefix (#3229 M3)'
   fi
-  if printf '%s\n' "$_scan_block" | grep -qE '(PASS|FAIL|SKIP|NOTICE|UNAVAILABLE|DEGRADED|NONE|PRESENT|UNKNOWN)\*'; then
+  if str_matches "$_scan_block" -E '(PASS|FAIL|SKIP|NOTICE|UNAVAILABLE|DEGRADED|NONE|PRESENT|UNKNOWN)\*'; then
     bad 'structural: a PREFIX GLOB (TOKEN*) survives in the verdict scan — PASSthisNeverRan would match PASS* and inherit the non-failing branch (#3229 M3)'
   else
     ok 'structural: the verdict scan carries NO prefix globs — every token is matched exactly'
@@ -8032,7 +8067,7 @@ else
   _scan_fallthrough=$(printf '%s\n' "$_scan_block" \
     | awk '/PASS\|WAIVED\|SKIP\|NOTICE/ { inb = 1 } inb { print } inb && /esac/ { exit }' \
     | grep -A 3 -E '^[[:space:]]*\*\)' || printf '')
-  if printf '%s\n' "$_scan_fallthrough" | grep -qE '^[[:space:]]*failed=1[[:space:]]*$'; then
+  if str_matches "$_scan_fallthrough" -E '^[[:space:]]*failed=1[[:space:]]*$'; then
     ok 'structural: the positive arm FAILS CLOSED on an unrecognised value (its *) sets failed=1)'
   else
     bad 'structural: the verdict scan positive arm does not fail closed — an unrecognised value would be accepted silently, which is the shape this sweep closed'
@@ -8162,7 +8197,7 @@ else
   # rather than assumed: a leftover `"$CENSUS_EXCLUSION"` in the key list would be a permanently
   # EMPTY value, which the closed grammar (correctly) FAILs — i.e. the residue of an incomplete
   # deletion would red every run, and it must be caught here rather than in the field.
-  if printf '%s\n' "$_scan_keys" | grep -qE 'CENSUS_EXCLUSION'; then
+  if str_matches "$_scan_keys" -E 'CENSUS_EXCLUSION'; then
     bad 'structural: the deleted CENSUS_EXCLUSION key is still named in the verdict-scan key list — it would hold a permanently empty value and red every run'
   else
     ok 'structural: the deleted census-exclusion key is absent from the verdict-scan key list'
@@ -8228,6 +8263,37 @@ fi
 # "simplification" would quietly undo. Neither substitutes for the other — a structural assert cannot
 # see a granting path built some other way, and a behavioural case cannot see a granting path nobody
 # fixtured.
+printf '== structural (#3387/#3759 r7): the fail-open `grep -q` PIPE SHAPE is gone from this file ==\n'
+# CLOSED AS A SHAPE, NOT AS A LINE. `grep -q` exits at its first match and closes the pipe; the
+# producer's next write takes SIGPIPE; `pipefail` hands the pipeline a 141 — so a genuine MATCH reports
+# a NON-match, and the assert built on it flips with scheduler timing and byte position. This file
+# documented the hazard in several places and still carried THIRTY instances of it, one of which — the
+# pre-existing "the waiver is looked up EXACTLY ONCE" assert — red once in five consecutive runs on a
+# clean, unrelated diff. `tooling-tests` is a component of the GATE OF RECORD, so that is a certifying
+# gate reddening spuriously, and a lane must not waive a red it cannot attribute.
+#
+# Every site now materialises its subject and greps the FILE (`str_matches` for the common
+# text-in-a-variable case). This guard stops the shape coming back by habit, which is the only way a
+# rule this mechanical survives. COMMENTS ARE EXCLUDED deliberately: the blocks above and below EXPLAIN
+# the hazard by naming it, and a guard that made writing the reasoning down a violation would be the
+# job-18 census mistake. THE NEEDLE IS SPLIT so this guard cannot match its own line — a self-matching
+# grep is a guard that can only ever be red.
+_pq_exec="$tmp/test-self-exec.txt"
+grep -v '^[[:space:]]*#' "$TEST_SELF" >"$_pq_exec" || true
+# THE NEEDLE CARRIES A LEADING SPACE, which is what separates a PIPE from a logical OR: this file has
+# legitimate `|| grep -qF … <file>` clauses (an OR into a grep OF A FILE, with no pipeline at all), and
+# a bare `| grep -q` needle matches the second bar of those too. Measured: it flagged two such lines
+# before the space was added — a guard reporting a violation that is not one, which is the same
+# false-claim shape this whole change is about.
+_pq_needle=' | grep -'"q"
+if [ ! -s "$_pq_exec" ]; then
+  bad 'structural (#3387): this suite could not be read to check for the fail-open pipe shape — a failure to measure, not a measurement'
+elif grep -qF -- "$_pq_needle" "$_pq_exec"; then
+  bad "structural (#3387): an executable line of this suite pipes into 'grep -q' again. Under pipefail that is fail-open BY BYTE POSITION: grep exits at its first match, SIGPIPEs the producer, and a real match reports as absent. Materialise the subject and grep the FILE (str_matches does this for text in a variable)"
+else
+  ok 'structural (#3387): no executable line pipes into a short-circuiting grep -q, so no assert in this gate-of-record component can flip on a SIGPIPE race'
+fi
+
 printf '== structural (#3759 r7): the documented output-state contracts list every state ==\n'
 # A COMMENT NAMING A MECHANISM IS A CLAIM ABOUT CODE and decays exactly like any other. These two
 # headers enumerate what their function can emit, and a CLOSED list missing states is worse than no
@@ -8282,7 +8348,7 @@ if [ -z "$_gr_re" ]; then
 else
   # (a) NO RANGES. Deterministic on every host, and it is the property that makes (b) hold everywhere
   #     rather than only where this box happens to have a locale that exposes the divergence.
-  if printf '%s' "$_gr_re" | grep -qE '[A-Za-z0-9]-[A-Za-z0-9]'; then
+  if str_matches "$_gr_re" -E '[A-Za-z0-9]-[A-Za-z0-9]'; then
     bad 'structural (#3759): the shared name grammar contains a RANGE, which POSIX regex resolves by locale collation and Python resolves by codepoint — so its two consumers can disagree and a same-repository reference can be misreported as a cross-repository skip. Enumerate the class (#3759 round 6)'
   else
     ok 'structural (#3759): the shared name grammar is enumerated, so no locale collation can give its two consumers different meanings'
@@ -8427,7 +8493,9 @@ if [ ! -s "$_mps_sites" ]; then
 fi
 # GRANT-SHAPED TOKENS beside the state: the verdicts a grant produces (`WAIVED`, `DEFERRED`) and the
 # admission variable. None of them may appear on a line that also mentions `misplaced`.
-if grep -nE 'misplaced' "$_mps_sites" | grep -qE 'WAIVED|DEFERRED \(|deferral_admits|= "granted"'; then
+_mps_lines="$tmp/mps-misplaced-lines.txt"
+grep -nE 'misplaced' "$_mps_sites" >"$_mps_lines" 2>/dev/null || true
+if grep -qE 'WAIVED|DEFERRED \(|deferral_admits|= "granted"' "$_mps_lines"; then
   _mps_ok=0; _mps_why="$_mps_why misplaced-on-a-granting-line;"
 fi
 if [ "$_mps_ok" -eq 1 ]; then

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -484,9 +484,25 @@ mechanism below, under *"the unwaivable rule made one merge unobtainable"*.
    files are not (a workflow injecting a variable). "Theoretically redundant" never justifies leaving a hole
    a non-invoker or an accident can walk through.
    **TWO RESIDUALS INSIDE THE MODEL, named rather than implied:** the marker is read from **top-level PR
-   comments only**, so one posted inside a review body or a review-thread reply is silently not applied (the
-   run reports `waiver: NONE` and the FAIL stands — fail-closed, but it reads as "my waiver was ignored");
-   and **an authorized human can authorize carelessly** — pre-authorizing a job id, or waiving without
+   comments only**, and **THE MOST PROBABLE MISPLACEMENT IS THE PR'S LINKED ISSUE THREAD (#3759)** — that is
+   where lane/lead coordination lives — followed by a review body and a review-thread reply. None of the
+   three is read, so a marker posted there is silently not applied (the run reports `waiver: NONE` and the
+   FAIL stands — fail-closed, but it reads as "my waiver was ignored"). **Measured on PR #3710:** the lead
+   granted BOTH markers, field-perfect and sole-content, from an allowlisted author — on **issue #3544**;
+   both keys read `NONE`, which is textually identical to "the lead refused", and position 1 of a six-PR
+   serial queue idled ~8 hours and blocked five lanes. **SINCE #3759 THE LINKED-ISSUE CASE IS DIAGNOSED,
+   NOT GRANTED:** when the PR-side scan returns `none`, the PR's linked issue(s) — resolved from the
+   structured `closingIssuesReferences` relation, NEVER from the mutable PR body — are scanned with the
+   SAME scanner and the SAME base/head/job/allowlist, and a marker there that WOULD have been accepted by
+   the channel is reported `waiver: MISPLACED (found on linked issue #N …)` naming the issue and the
+   remedy. **`MISPLACED` GRANTS NOTHING — not partially, not with a notice — and the FAIL STANDS**: only a
+   marker on the PULL REQUEST grants, and moving it there is a HUMAN act by the authorizer, never
+   something the tool does. A `NONE` now also DECLARES whether that probe ran (checked / bounded /
+   no linked issue / could-not-check), so "checked and it is not there either" and "never checked" can no
+   longer read alike. **LEAD-SIDE PROCEDURE, the other half of the fix: after posting either marker,
+   verify with `gh pr view <PR> --json comments` that the line is ON THE PR — a grant is only granted once
+   it is readable by the scanner that reads it.**
+   And **an authorized human can authorize carelessly** — pre-authorizing a job id, or waiving without
    checking the token accounting. Nothing mechanical detects either; the control is the permanent,
    attributable comment, which is why a substantive reason is required and recorded verbatim.
    **AND A SECOND, EQUALLY TRANSFERABLE RULE FROM THE SAME ISSUE: THE CONSTRAINED PARTY MUST NOT CHOOSE ITS
@@ -756,6 +772,20 @@ mechanism below, under *"the unwaivable rule made one merge unobtainable"*.
    party must not choose its own enforcer* — and a worker could then clear its own findings. That absence
    is asserted **structurally** in the guard suite, because behavioural cases only cover the channels
    someone already thought of.
+
+   **It inherits the misplacement residual by call too (issue #3759).** The deferral marker is read
+   from **top-level PR comments only**, and the **most probable misplacement is the PR's linked issue
+   thread**, ahead of a review body and a review-thread reply — measured on PR #3710, where both
+   markers were granted field-perfect on issue #3544 and both keys read `NONE`. Since #3759 that case
+   is **diagnosed, not granted**: a would-have-been-accepted marker on a linked issue reports
+   `deferral: MISPLACED (found on linked issue #N …)` with the remedy, while `findings:` stays exactly
+   as measured — **never `DEFERRED`** (that would be the grant) and **never `NONE`** (that would read
+   as a clean review) — and `RESULT` stays `FAIL`. **`MISPLACED` grants nothing**; only a marker on the
+   pull request grants. The rendering claims the marker *would have been accepted by the channel*, not
+   that it *would have granted*: the network issue-disposition legs are deliberately **not run
+   issue-side** and still apply once the marker is on the PR, because a diagnostic that overstates
+   what it measured is what stops the next person looking. As with the waiver, **verify with
+   `gh pr view <PR> --json comments` that the line is on the PR after posting it.**
 
    **The match is affirmative, which is what makes this a match and not a mute button.** `count=` must
    **equal** the observed findings count and `issues=` must be non-empty. A job is a completed review and


### PR DESCRIPTION
Closes #3759

## What this does

Adds a distinct, **non-granting** state — **`MISPLACED`** — for both roborev authorizations
(`roborev-waive:` and `roborev-defer:`). When the PR-side scan returns `none`, the wrapper also scans
the top-level comments of the PR's **linked issue(s)** with the **same scanner, same kind, same
base/head/job/allowlist**. If that scan would have granted, the state becomes `MISPLACED`, naming the
issue it was found on and the remedy: **re-post the identical marker as a top-level comment on the PR**.

**This is a diagnosability change, not a loosening.** `MISPLACED` grants nothing, anywhere. The
`prompt-content:` / `findings:` FAIL stands. The author allowlist, the sole-nonblank-content rule, the
column-zero anchor and the base+head+job binding are untouched. Only a marker on the PR grants.

The motivating incident: for PR #3710 the lead granted both markers — field-perfect, from an
allowlisted author — on **issue #3544**, and the PR carried zero. `NONE` is textually
indistinguishable from a refusal, so position 1 of a six-PR queue idled ~8 hours and blocked five
lanes. `gh pr view 3710 --json closingIssuesReferences` returns `[{"number":3544}]`, so the resolver
added here **would have found them on the real case** — that is a measurement, not a prediction.

## It also repairs two PRE-EXISTING holes on the GRANTING path

Named explicitly rather than smuggled in under a diagnostics change. Both are **older than this
feature** and both were found by roborev while reviewing it. On `origin/main`, the PR comments payload
is handed to the scanner unvalidated, so:

- a **malformed payload** (`{}`, `{"comments": null}`) is coerced to an empty comment list, exits 0,
  and yields **`waiver: NONE`** — *"there is no authorization"* asserted over comments nobody read;
- an **empty-but-successful `gh`** result does the same.

Both are now `unavailable` (fail-closed), and because the probe runs only from `none`, it does not run
at all in those states.

## Self-certification boundary — read before trusting the roborev block on this PR

**This change edits the roborev wrapper, so every roborev round on this PR RUNS the changed wrapper.**
Same property #3544 records for `agent-gate.sh`. It is circular, not impossible — but the block below
is not independent evidence of its own correctness, and the **live path is demonstrated post-merge**,
not here. The hermetic coverage is what stands in for it: every `MISPLACED` and `NONE` rendering is
pinned against planted pre-fix mutants, with fixtures substituted as artifacts rather than through any
env seam.

## Post-merge verification owed

Per the "a publish is verified by the NEW CONTENT being served, never by HTTP 200" rule, the website
change cannot be verified from this branch (the site serves from `main`, so a pre-merge grep could
only ever return `0` — the exact false signal that rule exists to prevent). After merge, and allowing
for the ~3-minute CDN staleness window:

```bash
curl -sS https://pmcfadin.github.io/cqlite/agents-developing/roborev-findings/ \
  | grep -c "THE MOST PROBABLE MISPLACEMENT IS THE PR'S LINKED ISSUE THREAD"
```

## Declared residuals (deliberate, in the spec, not discovered later)

1. **Per-element payload validation is NOT performed.** The validated read establishes the container
   (top-level object, named field is a list), the exit status and the closed-grammar state — it does
   **not** distinguish a malformed *element* inside a well-formed list. The scanner is reused
   **unmodified** by design, and its element-skipping is correct for its own contract; a caller
   re-validating each element would be a **second implementation of the marker path**, correct only
   insofar as it is differentially tested against the first. Declared in the helper comment, in the
   rendering of every thread reported as read (and deliberately absent where no read is claimed), and
   as a spec scenario. Harm ceiling: a diagnostic one step less precise than it sounds — never a
   wrongly granted authorization.
2. **Cross-repository closing references are not probed**, by choice: a reference's number is scoped
   to its own repository, so following one could only name the wrong thread. The skip is **declared**
   with its count and reason in the rendering, never silent.
3. **The locale differential declares its own non-exhaustiveness** on a host that offers only the C
   locale, since there is then no locale that could expose a divergence.

## Review history — 7 roborev rounds, and one process ruling worth recording

Findings per round: **3 → 1 → 2 → 2 → 1 → 1 → (final)**. Every finding across the first four rounds was
**one class**: an input reaching a conclusion without an affirmative validation, i.e. "cannot tell"
collapsing onto an answer.

Round 3's finding landed **inside round 3's own fix**. Per #3229 (defects landing in the preceding fix
rounds) and #3544 (*split or restructure, do not carve the same place again*), the response was a
**restructure rather than a fourth site fix**: two helpers now own all validation on this path —
`roborev_json_list_field` (the only place a payload shape is judged) and
`roborev_validated_authorization_scan` (the only authorization scan in the file, three-valued, owning
the payload shape, the single scanner invocation, its exit status and the closed-grammar state check).
A structural assert requires every caller to route through them, verified against planted bypasses.

Round 6 falsified a *stated design invariant*: `ROBOREV_GH_NAME_RE` was hoisted into one definition so
there would be one grammar with one meaning, but `[A-Z]` is **locale-sensitive in bash and ASCII in
Python**, so its two consumers could disagree and a same-repository reference could be reported as a
cross-repo skip. The class is now enumerated; `LC_ALL=C` was rejected with the reason recorded at the
definition site (it fixes the shell by changing the **environment** rather than the **data**, and this
function spawns `gh` and `python3` children whose output it consumes). The test is the differential
that *is* the invariant: both consumers must agree over an ASCII/non-ASCII corpus in every locale the
host has, with the grammar extracted from the shipped file rather than re-typed.

## Verification

- `scripts/tests/test_roborev_review_guard.sh`: **passed 1508, failed 0** (1341 before this change's
  test additions; +167 assertions). This is the real signal — the suite runs under the full gate's
  `tooling-tests` and **`--lite` covers none of this diff** (shell/python/markdown, so lite's blast
  radius falls back to `cqlite-core --lib`).
- `--lite`: PASS with `tree-integrity: PASS` on every stable-tree run.
- Rebased onto current `origin/main`; `base-staleness.sh` now reports
  `verdict NO-STALENESS-RECOGNISED` (0 behind). Before the rebase it was `STALE-RECOGNISED`, 2 of 7
  commits behind touching the blast radius.
- OpenSpec change: `openspec/changes/roborev-waiver-misplaced/` — 7 requirements, 30+ scenarios.

## Routing note

Process/tooling work routes design-driven, and the owner authored #3759 with a numbered `Proposed`
section fixing every design decision in it (the state name, that it must not grant, the scope fence).
That was treated as the Seam-1 approval rather than requesting approval of a restatement; declared on
the issue thread with an explicit invitation to `HOLD:`.


---

# Certification record

## Gate of record — `==== AGENT-GATE SUMMARY ====`

Verified at sha `beff8f42c6e5e8348c28ca4d825bd7e8273f9299`. **Read this as "gate of record verified
at that sha", NOT "certified against main"** — a squash-merge composes this diff with main's current
tip, which no gate here has executed (#3650 slice 2 is unimplemented). `premerge-assert.sh` says so
itself on its `PREMERGE: SCOPE` lines, and its base-staleness output is **advisory only and did not
affect the assert**.

```
==== AGENT-GATE SUMMARY ====
run-id: /tmp/agent-gate.rnG9Pu
commit: beff8f4 branch: issue-3759-roborev-waiver-marker-misplaced dirty: no
datasets: 144 Data.db files under /data/datasets
schemas: 8/8 canonical .cql readable under /data/lanes/lane-3759/test-data/schemas (checkout-relative)
component-set: PASS (37/37 names vs origin/main ebc48177991a67e60d03d601086a88ae0d572598; NAMES ONLY — not implementations, and no component is run here) — baseline read via the committed manifest; objects: baseline REUSED from this lane's SHARED store — store TRUSTED, not verified (#3746)
ci-pins: DATASET_TAG: datasets-v3 DATASET_ASSET: cassandra5-small-full-v3.5.tar.gz DATASET_SHA256: 414195074f6df446a7381aad051af84158e9a021a6e2cd21cbc6c3ad0be1ba16 
accelerators: sccache=on nextest=on lanes=on sccache-health=ok mold=present-unconfigured perf=ok
cpu-budget: wrapper=nice ncpu=16 max-concurrency=1(pinned) cores-per-gate=16 build-jobs=16(derived) test-threads=16
tree-start: beff8f42c6e5 dirty: no digest: cbac7772411c
tree-end: beff8f42c6e5 dirty: no digest: cbac7772411c
tree-integrity: PASS
census: 24/37 components AFFIRMED a count; 13 DECLARED-GAP (RECOGNISED); 0 NOT-MEASURED (RECOGNISED); 0 measured-ZERO (RECOGNISED); 0 not-applicable (component did not PASS); 0 no-subject (PASSed; the run had nothing to measure); 0 UNDECLARED; 0 unrecognised; 0 row(s) carry a VACUOUS status. NON-EXHAUSTIVE: the gap set is CURATED, so an unaffirmed component is UNMEASURED, never verified (#3625; the remaining gaps are tracked in #3162).
file-size:         PASS (0s)  [no-cargo]  {no census — shell/python guard prints no AGENT-GATE-CENSUS contract line yet (#3162)}
fmt:               PASS (12s)  [fmt workspace features=n/a]  {no census — cargo fmt --all --check emits no per-file tally to count}
clippy:            PASS (510s)  [clippy workspace(excl 5) --all-features | clippy cqlite-core --features 33:all-compression,arrow,bench-internals,+30 more | clippy cqlite-cli --features 10:benchmarks,ci_zero_tolerance,cli-helpers,+7 more | clippy cqlite-flight+cqlite-py+cqlite-node --features cqlite-node/write-support]  {no census — cargo clippy emits a per-crate tally only COLD; a warm run prints Finished alone}
roborev-lints:     PASS (150s)  [no-cargo]  {no census — shell/python guard prints no AGENT-GATE-CENSUS contract line yet (#3162)}
core-tests:        PASS (821s)  [nextest run cqlite-core --features cli-helpers | test cqlite-core --features cli-helpers]  {verified: 5518 tests passed (across 2 result line(s))}
tombstones-scan:   PASS (45s)  [test cqlite-core --features write-support,cli-helpers,tombstones]  {verified: 2 tests passed (across 1 result line(s))}
scan-offload-guard: PASS (163s)  [test cqlite-core --features cli-helpers,scan-offload-probe x2]  {verified: 15 tests passed (across 8 result line(s))}
work-counters-guard: PASS (87s)  [test cqlite-core --features write-support,cli-helpers,state_machine,work-counters]  {verified: 60 tests passed (across 15 result line(s))}
byte-budget-guard: PASS (13s)  [test cqlite-core --features write-support,cli-helpers,state_machine]  {verified: 21 tests passed (across 5 result line(s))}
arrow-parity-guard: PASS (73s)  [test cqlite-core --features arrow]  {verified: 4 tests passed (across 1 result line(s))}
memory-budget:     PASS (517s)  [test cqlite-core --features cli-helpers,dhat-heap,arrow x3 | test cqlite-flight --features dhat-heap]  {verified: 6 tests passed (across 4 result line(s))}
integration-tests: PASS (62s)  [test cqlite-integration-tests default-features x2]  {verified: 42 tests passed and 25 test binaries built/verified}
format-compat:     PASS (43s)  [test format-compatibility-tests default-features]  {verified: 10 tests passed (across 1 result line(s))}
write-tests:       PASS (156s)  [test cqlite-core --features write-support x3]  {verified: 3835 tests passed (across 3 result line(s))}
cli-tests:         PASS (232s)  [test cqlite-cli default-features | test cqlite-cli --features write-support]  {verified: 742 tests passed (across 47 result line(s))}
compaction-byte-parity: PASS (10s)  [test cqlite-core --features write-support x2]  {verified: 12 tests passed (across 4 result line(s))}
bti-multiclustering: PASS (5s)  [test cqlite-core --features state_machine,cli-helpers x2]  {verified: 12 tests passed (across 3 result line(s))}
query-semantics-oracle: PASS (0s)  [test cqlite-core --features state_machine,cli-helpers]  {verified: 6 tests passed (across 1 result line(s))}
flight-query-semantics-oracle: PASS (81s)  [test cqlite-flight default-features]  {verified: 4 tests passed (across 2 result line(s))}
flight-tests:      PASS (279s)  [test cqlite-flight default-features]  {verified: 392 tests passed (across 2 result line(s))}
legacy-heuristics: PASS (430s)  [build cqlite-core --features legacy-heuristics]  {verified: 3729 tests passed (across 6 result line(s))}
feature-iso-parquet: PASS (321s)  [test cqlite-core --no-default-features --features all-compression,parquet]  {verified: 1 test binaries built/verified}
feature-iso-delta-scan: PASS (156s)  [test cqlite-core --no-default-features --features all-compression,delta-scan]  {verified: 1 test binaries built/verified}
python-bindings:   PASS (834s)  [via maturin: feature set NOT observed]  {verified: 786 pytest tests passed}
node-bindings:     PASS (855s)  [via npm run build (napi): feature set NOT observed]  {verified: 594 jest tests passed}
binding-rust-tests: PASS (565s)  [test cqlite-ffi-common default-features | test cqlite-node --features write-support]  {verified: 123 tests passed (across 5 result line(s))}
delivery-telemetry: PASS (2s)  [no-cargo]  {no census — shell/python guard prints no AGENT-GATE-CENSUS contract line yet (#3162)}
oom-audit:         PASS (6s)  [build xtask default-features | run xtask default-features]  {no census — xtask/report driver prints no machine-readable subject count (#3162)}
parity-report:     PASS (74s)  [run cassandra-parity default-features]  {no census — xtask/report driver prints no machine-readable subject count (#3162)}
operator-metrics-doc: PASS (32s)  [run cqlite-core default-features]  {no census — xtask/report driver prints no machine-readable subject count (#3162)}
kit-dashboard-drift: PASS (1s)  [test cqlite-core default-features]  {verified: 6 tests passed (across 1 result line(s))}
binding-unwind-profile: PASS (1s)  [no-cargo]  {no census — shell/python guard prints no AGENT-GATE-CENSUS contract line yet (#3162)}
pub-surface:       PASS (0s)  [no-cargo]  {no census — shell/python guard prints no AGENT-GATE-CENSUS contract line yet (#3162)}
tooling-tests:     PASS (2513s)  [test ws0-corpus-gen default-features | + cargo not observable: cargo may run inside ~60 nested test scripts (child processes)]  {no census — shell/python guard prints no AGENT-GATE-CENSUS contract line yet (#3162)}
minimal-build:     PASS (82s)  [build cqlite-core --no-default-features --features all-compression | test cqlite-core --no-default-features --features all-compression]  {verified: 1 test binaries built/verified}
all-features-check: PASS (236s)  [check cqlite-core --all-features | clippy cqlite-core --all-features]  {no census — cargo check/clippy passes execute no tests; the subject is a feature set, not a count}
smoke:             PASS (129s)  [build cqlite-cli default-features]  {no census — smoke-test-all-tables.sh prints no machine-readable table count (#3162)}
node-bindings-leak-lane: RAN (#1465 exception-path/abandoned-iterator leak budgets executed inside #3522's whole-suite npm test; AFFIRMED from that run's own jest JSON report — every named budget test present and passed)
logs: /tmp/agent-gate.rnG9Pu
summary-file: /tmp/cqlite-gate-hVyZdc/summary.txt
heartbeat: on file: /tmp/cqlite-gate-hVyZdc/summary.txt.heartbeat interval: 20s
launch-nonce: 20260903T200725Z-2392580-109775510
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```

## Final roborev — `==== ROBOREV REVIEW SUMMARY ====`

Clean at the same sha, run **after** all fixes and **before** the gate, per the fleet gate-last
ordering rule. Genuine review: 438k input / 348k cached (the vacuous baseline is ~18.7k / 0).

```
```

## premerge-assert

```
PREMERGE: OK beff8f42c6e5e8348c28ca4d825bd7e8273f9299
PREMERGE: GATE-OF-RECORD commit: beff8f4 tree-start: beff8f42c6e5 tree-integrity: PASS dirty: no
```

## Verification caveats — stated, not buried

1. **The C intent audit was performed by the LEAD, not by an independent `spec-auditor`.** Two
   delegated subagents failed to deliver (the closer sat ~1 day across four messages with no gate
   and no reply; the auditor went idle twice without a verdict), and both were stopped. This is
   **weaker on independence** than a `spec-auditor` sign-off and is recorded as such. What was
   verified directly: 8 requirements / 58 scenarios in the delta spec, evidenced by 33 `mp*`
   behavioural cases and 31 `structural (#3759)` asserts; R2's load-bearing assert present and
   affirmative — *"the only granting gates are the two token-exact `= "granted"` comparisons, and
   misplaced reaches none of them"*; guard suite 1522 passed / 0 failed over repeated clean-tree runs.
2. **Completeness of input validation, stated precisely.** The chokepoint routing assert proves no
   scanner invocation, no state extraction and no shape predicate exists outside the two validation
   helpers, and those helpers validate the container, the exit status and the closed-grammar state.
   So there is **no unvalidated-and-undeclared input at that granularity**; **element** granularity
   is the one declared exception (residual 1 above). That is the whole claim — deliberately not a
   broader one.
3. **This PR changes the roborev wrapper, so the roborev block above was produced by the changed
   wrapper.** Circular, not impossible (the same property #3544 records for `agent-gate.sh`); the
   hermetic planted-mutant coverage is what stands in for independence, and the live path is
   demonstrated post-merge.
