### PR TITLE
fix(#3653): bind the Case B delta anchor to the PR's history, and correct residual 2

### DIFF
--- a/.claude/agents/flow-lead.md
+++ b/.claude/agents/flow-lead.md
@@ -52,14 +52,24 @@ back into one.
 ## Autonomy: arm `--auto`, GitHub merges on green (default, #2667)
 
 - **Default:** the moment **local certification** is met — `agent-gate.sh` PASS + **C** PASS
-  (design-driven) + roborev clean — the closer runs `bash scripts/flow/premerge-assert.sh <pr>
-  <certified-sha> <gate-summary-file>` — the third argument is REQUIRED and is the FULL gate's own
-  summary file, so a merge with NO gate of record is now mechanically refused (#3465) — re-reads for
+  (design-driven) + roborev clean — the closer runs the pre-merge assert in one of its **two call
+  shapes** — the third argument is REQUIRED and is the FULL gate's own summary file, so a merge with
+  NO gate of record is mechanically refused (#3465) — re-reads for
   a fresh `HOLD:` order, then **arms `gh pr merge --auto --squash
   --delete-branch`** and `flow-finalize`s. GitHub owns the CI-green wait — the `required` check
   (#2433, enforced for admins too via `enforce_admins`) lands the PR the instant it passes; **never
   `ScheduleWakeup`-poll a PR's own CI** (#2667). Do NOT wait for the owner. **Seam 1 (spec approval)
   is the ONLY standing human gate.**
+  ```bash
+  # CASE A — the usual shape: the full gate ran on the head being merged.
+  bash scripts/flow/premerge-assert.sh <pr> <certified-sha> /tmp/gate-<N>.txt
+  # CASE B — the #1892 post-gate-polish route: a full PASS at anchor X, then a
+  # test/docs-only diff re-certified with `--delta X` (never a repeat full gate).
+  # Arg 3 is the ANCHOR's full summary, arg 4 the delta block; the anchor must
+  # also be an ANCESTOR of <certified-sha>, checked fail-closed (#3653).
+  bash scripts/flow/premerge-assert.sh <pr> <certified-sha> /tmp/gate-<N>.txt /tmp/delta-<N>.txt
+  ```
+  (`.claude/agents/flow-closer.md` carries the full contract for both shapes.)
 - **Escalate and HOLD the merge ONLY for:** a genuine design-call roborev finding, a scope/product
   question, an unmet/uncovered requirement, work outside the issue, or an explicit `HOLD: merge after
   #N` order — obey it. Everything else merges autonomously.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1768,12 +1768,16 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM=/dev/null` plus an explicit empty `--template=`. The reads are
   also **bounded** by the runner this script already resolves for the advisory — but **only the EXTERNAL
   commands are** (every git call and `mktemp -d`), and the token says exactly that:
-  `anchor-reads: bounded-<n>s+<g>s(external:git,mktemp;UNBOUNDED:cd/test-builtins)`. `cd`/`pwd -P` and the
-  object-dir `[ -d … ]` probe are SHELL BUILTINS with no process for a runner to signal, so on a stalled
-  mount they can still hang the guard; inventing a way to bound a builtin is explicitly not the fix, and
-  one such probe was DELETED rather than bounded (redundant: a bounded `git init` failure refuses anyway).
-  A bare `bounded-…` claimed more than is true, which is the overclaim shape this issue exists to remove —
-  a check claiming nothing false beats one claiming a closure it does not deliver. And **where no `timeout`/`gtimeout`
+  `anchor-reads: bounded-<n>s+<g>s(external:git,mktemp,sh,rm;UNBOUNDED:command-v+pwd-builtins)`. **The
+  token was corrected TWICE — once for overclaiming, once for UNDERclaiming**, and an
+  **ANCHOR-PATH OPERATION AUDIT** in the script header now lists every operation with two facts, *is it
+  bounded* and *is its target validated*, in the `workspace-test-disposition.txt` idiom (a new operation
+  must join the table; it records completeness and labelling, not truth). That audit exists because seven
+  shipped-script findings on #3653 were the same two questions asked of different operations, one per
+  review round. It made canonicalisation runner-bounded (`sh -c 'cd … && pwd -P'` is external, so no
+  builtin-bounding was invented), DELETED both `[ -d … ]` builtin stats as redundant with it, and bounded
+  + target-revalidated the scratch `rm -rf`. What is left unbounded is `command -v` PATH lookups and one
+  `$(pwd)` diagnostic — builtins over local state, unreachable from the shared object store or TMPDIR. And **where no `timeout`/`gtimeout`
   supporting `--kill-after` exists the check REFUSES** (`ANCHOR-UNVERIFIABLE`, naming a one-command
   remedy). **That REVERSES the first ruling here, which said run unbounded and declare it, on the ground
   that a hang is a LIVENESS failure yielding no verdict rather than a false pass.** What that missed: **a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1766,8 +1766,14 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   sites a later change adds) — runs under `env -i` + an allowlist ADMITting only `PATH` and `TMPDIR`
   (tighter than the pre-flight's: no network here, so no `HOME`, no `SSH_*`, no proxy), with
   `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM=/dev/null` plus an explicit empty `--template=`. The reads are
-  also **bounded** by the runner this script already resolves for the advisory, with
-  `anchor-reads: bounded-<n>s+<g>s` as the affirmative record — and **where no `timeout`/`gtimeout`
+  also **bounded** by the runner this script already resolves for the advisory — but **only the EXTERNAL
+  commands are** (every git call and `mktemp -d`), and the token says exactly that:
+  `anchor-reads: bounded-<n>s+<g>s(external:git,mktemp;UNBOUNDED:cd/test-builtins)`. `cd`/`pwd -P` and the
+  object-dir `[ -d … ]` probe are SHELL BUILTINS with no process for a runner to signal, so on a stalled
+  mount they can still hang the guard; inventing a way to bound a builtin is explicitly not the fix, and
+  one such probe was DELETED rather than bounded (redundant: a bounded `git init` failure refuses anyway).
+  A bare `bounded-…` claimed more than is true, which is the overclaim shape this issue exists to remove —
+  a check claiming nothing false beats one claiming a closure it does not deliver. And **where no `timeout`/`gtimeout`
   supporting `--kill-after` exists the check REFUSES** (`ANCHOR-UNVERIFIABLE`, naming a one-command
   remedy). **That REVERSES the first ruling here, which said run unbounded and declare it, on the ground
   that a hang is a LIVENESS failure yielding no verdict rather than a false pass.** What that missed: **a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1766,10 +1766,17 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   sites a later change adds) — runs under `env -i` + an allowlist ADMITting only `PATH` and `TMPDIR`
   (tighter than the pre-flight's: no network here, so no `HOME`, no `SSH_*`, no proxy), with
   `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM=/dev/null` plus an explicit empty `--template=`. The reads are
-  also **bounded** by the runner this script already resolves for the advisory; where no
-  `timeout`/`gtimeout` exists they run UNBOUNDED and the evidence line SAYS so
-  (`anchor-reads: bounded-…` / `UNBOUNDED(…)`) rather than refusing — a hang is a LIVENESS failure that
-  yields no verdict, not a false pass, and refusing a box without `timeout` would red correct input.
+  also **bounded** by the runner this script already resolves for the advisory, with
+  `anchor-reads: bounded-<n>s+<g>s` as the affirmative record — and **where no `timeout`/`gtimeout`
+  supporting `--kill-after` exists the check REFUSES** (`ANCHOR-UNVERIFIABLE`, naming a one-command
+  remedy). **That REVERSES the first ruling here, which said run unbounded and declare it, on the ground
+  that a hang is a LIVENESS failure yielding no verdict rather than a false pass.** What that missed: **a
+  hang in this guard BLOCKS THE MERGE ANYWAY**, so the real comparison is never merge-vs-refuse but
+  *hang forever with no diagnosis* vs *refuse now with a named cause and remedy* — same outcome for the
+  merge, and the refusal strictly dominates. "It cannot produce a false pass" was true and IRRELEVANT,
+  because the alternative was never a pass. Hand-rolling a portable bounded runner is ruled OUT: that is
+  new process-lifetime code, the family that produced three defects in this issue's own test scaffolding,
+  and a fourth inside a merge guard costs more than one named install command.
   **THE COMMIT-GRAPH IS TRUSTED METADATA, SO IT IS DISABLED — AND THE MEASUREMENT IS NOT THE ONE THE
   FINDING PREDICTED** (roborev job 361). `objects/info/commit-graph` reaches the scratch through the
   alternate, is NOT content-addressed, and git trusts its parent edges. Measured on git 2.43.0 against a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1768,7 +1768,11 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM=/dev/null` plus an explicit empty `--template=`. The reads are
   also **bounded** by the runner this script already resolves for the advisory — but **only the EXTERNAL
   commands are** (every git call and `mktemp -d`), and the token says exactly that:
-  `anchor-reads: bounded-<n>s+<g>s(external:git,mktemp,sh,rm;UNBOUNDED:command-v+pwd-builtins)`. **The
+  `anchor-reads: bounded-<n>s+<g>s(external:git,mktemp,sh;UNBOUNDED:command-v+pwd-builtins)`. **The scratch
+  directory is deliberately NOT DELETED** — a delete through a peer-mutable pathname cannot be made
+  race-free in shell (no `openat`/`unlinkat`) and every lane here runs as the SAME USER, so after three
+  rounds of narrowing it was REMOVED: one object-less `git init` is left under TMPDIR per Case B merge and
+  the OS reaps it. **The
   token was corrected TWICE — once for overclaiming, once for UNDERclaiming**, and an
   **ANCHOR-PATH OPERATION AUDIT** in the script header now lists every operation with two facts, *is it
   bounded* and *is its target validated*, in the `workspace-test-disposition.txt` idiom (a new operation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1746,11 +1746,19 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   everything UNMEASURABLE — no git, not a work tree, either object absent, shallow or shallowness
   unknown, `--is-ancestor` exiting ≥ 2 — is exit 3 under its own `PREMERGE: ANCHOR-UNVERIFIABLE`
   marker, each cause carrying its own remedy, because an unmeasurable result is UNKNOWN and "fix the
-  box" is a different operator action from "your chain is wrong". The reads run against the CURRENT
-  DIRECTORY's repository with **no env override** (#3312) under `GIT_NO_LAZY_FETCH=1` +
-  `GIT_NO_REPLACE_OBJECTS=1` + `--no-replace-objects`. It proves ancestry **in the local repository
-  only** — not that the anchor is on the PR as GitHub sees it, and a manipulated local object store is
-  invoker-class and out of model.
+  box" is a different operator action from "your chain is wrong". **The walk does NOT run in the lane**
+  (roborev job 355): `$GIT_DIR/info/grafts` rewrites parentage and SURVIVES `--no-replace-objects` (the
+  job-285 measurement above, re-measured for this check: `no` → `YES` → `YES`), so a graft alone turns a
+  FOREIGN anchor into `BOUND` — and grafts live in the COMMON git dir that every lane on this fleet
+  shares, making the planter a PEER LANE as well as an accident. The ruling there was to MOVE the walk,
+  and it is applied here: the object reads and `merge-base` run in a throwaway `git init` scratch whose
+  only view of the lane is `GIT_ALTERNATE_OBJECT_DIRECTORIES` — pure object storage, no config, hence no
+  grafts, no replace refs, no promisor; a failure to build it is UNVERIFIABLE, **never** a fall-back to
+  the live repository. Two reads stay in the lane on purpose: resolving its object directory
+  (`rev-parse --git-path objects`, no object read, no network) and `--is-shallow-repository`, because a
+  fresh scratch is NEVER shallow and probing it there would answer `false` unconditionally, making the
+  shallow guard a vacuous pass. No env override anywhere (#3312); the pins stay as belt. It proves
+  ancestry **in the local object store only** — not that the anchor is on the PR as GitHub sees it.
   **What a `PREMERGE: OK` does NOT prove (#3650) — it says so itself, on a `PREMERGE: SCOPE` line.**
   It proves the diff is unchanged since certification and that a full gate PASSed on **that exact
   tree**. It does NOT prove the change was certified against the `main` it will join: a squash-merge

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1807,7 +1807,16 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   *"one axis closed, space declared done"* shape, and #3746 / job 311 already ruled on the unclosable
   version: DECLARE it in the emitted line and hand the subject to the issue that owns it. So every Case B
   success line ends with one constant — `ancestry over this box's SHARED object store: objects+metadata
-  TRUSTED, not verified (#3746)` — folded into the ONE renderer, never per-arm. What the binding proves:
+  and SCRATCH namespace: objects, metadata and scratch TRUSTED, not verified (#3746) — closes
+  accident/drift, NOT a same-UID peer` — folded into the ONE renderer, never per-arm. **THAT IS THE
+  TERMINUS OF THIS HARDENING LINE (job 390).** Every lane on this fleet runs as the same user, so a peer
+  can write the shared object store AND our scratch — it can drop `.git/info/grafts` into the scratch
+  between `git init` and the walk, reproducing the graft attack inside the thing built to prevent it — and
+  no mode or ownership can admit this process while excluding a peer. So the CLAIM is narrowed rather than
+  the hole patched, and the hazard is assigned to **#3746**, which already owns "lanes share an object
+  store". **A later same-UID-peer instance is that declared boundary, not a new defect** — which is what
+  #3653 asked for, since its own text says the hostile route is largely closed elsewhere and the defect was
+  the constraint not being stated where the guard is read. What the binding proves:
   ancestry over the objects and commit metadata this box's shared store presents, isolated (each with a
   positive control) from grafts, replace refs, an inherited `GIT_DIR`, an ambient template, and the
   commit-graph. What it does not: that the anchor is on the PR **as GitHub sees it**, and anything against

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1731,6 +1731,26 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   EXIST and the merged tree is covered — directly, or by an anchored delta re-cert on top of it. A
   block carrying `nested-under:` (#2874) is refused outright: a nested sub-gate runs at the SAME tree,
   so the sha binding provably cannot see it.
+  **AND IN CASE B THE ANCHOR MUST BE ON THE CERTIFIED SHA'S HISTORY (#3653).** Everything above proves
+  the two blocks AGREE about a sha, never that the sha is on THIS PR — Case B's anchor identity rested
+  entirely on the delta run's SELF-DECLARED `delta-anchor:` line, so any full-gate PASS plus a delta
+  naming it satisfied the chain: the #3616 cross-lane class surviving in the one path Case A's sha
+  binding does not cover. (The accident route was narrowed by `agent-gate.sh --delta`'s own
+  fail-closed diff classification, i.e. **by another script** — a real constraint stated nowhere the
+  guard is read.) So `git merge-base --is-ancestor <anchor> <certified>`, **three-valued** because
+  `--is-ancestor`'s rc 1 is itself three-valued (#3544 — in a SHALLOW clone it also means "the
+  connecting history is absent", so rc 1 is a verdict only in a repository proven complete):
+  **BOUND** (rc 0) proceeds and is RECORDED as `anchor-ancestry: BOUND` on the `PREMERGE: DELTA-RECERT`
+  line, because a silent pass is indistinguishable from a check that never ran; **NOT-ANCESTOR**
+  (rc 1, both objects present, `--is-shallow-repository` = `false`) is exit 2 naming both shas;
+  everything UNMEASURABLE — no git, not a work tree, either object absent, shallow or shallowness
+  unknown, `--is-ancestor` exiting ≥ 2 — is exit 3 under its own `PREMERGE: ANCHOR-UNVERIFIABLE`
+  marker, each cause carrying its own remedy, because an unmeasurable result is UNKNOWN and "fix the
+  box" is a different operator action from "your chain is wrong". The reads run against the CURRENT
+  DIRECTORY's repository with **no env override** (#3312) under `GIT_NO_LAZY_FETCH=1` +
+  `GIT_NO_REPLACE_OBJECTS=1` + `--no-replace-objects`. It proves ancestry **in the local repository
+  only** — not that the anchor is on the PR as GitHub sees it, and a manipulated local object store is
+  invoker-class and out of model.
   **What a `PREMERGE: OK` does NOT prove (#3650) — it says so itself, on a `PREMERGE: SCOPE` line.**
   It proves the diff is unchanged since certification and that a full gate PASSed on **that exact
   tree**. It does NOT prove the change was certified against the `main` it will join: a squash-merge

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1757,8 +1757,20 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   the live repository. Two reads stay in the lane on purpose: resolving its object directory
   (`rev-parse --git-path objects`, no object read, no network) and `--is-shallow-repository`, because a
   fresh scratch is NEVER shallow and probing it there would answer `false` unconditionally, making the
-  shallow guard a vacuous pass. No env override anywhere (#3312); the pins stay as belt. It proves
-  ancestry **in the local object store only** — not that the anchor is on the PR as GitHub sees it.
+  shallow guard a vacuous pass. **A SCRATCH'S ENVIRONMENT IS LOAD-BEARING IN A WAY A LANE READ'S IS NOT**
+  (roborev job 358): the old rationale — "these reads are addressed BY A SHA, so no environment can bend
+  them" — is right about a read in the lane and WRONG here, because an environment variable does not bend
+  the OBJECT, it bends WHICH REPOSITORY ANSWERS. Measured on git 2.43.0: `GIT_DIR` **overrides `-C`**, and
+  both `git init --template=<dir>` and `GIT_TEMPLATE_DIR` seed a planted `info/grafts` INTO the new
+  scratch. So every git call — the lane DISCOVERY reads included (job 276: the allowlist has to reach the
+  sites a later change adds) — runs under `env -i` + an allowlist ADMITting only `PATH` and `TMPDIR`
+  (tighter than the pre-flight's: no network here, so no `HOME`, no `SSH_*`, no proxy), with
+  `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM=/dev/null` plus an explicit empty `--template=`. The reads are
+  also **bounded** by the runner this script already resolves for the advisory; where no
+  `timeout`/`gtimeout` exists they run UNBOUNDED and the evidence line SAYS so
+  (`anchor-reads: bounded-…` / `UNBOUNDED(…)`) rather than refusing — a hang is a LIVENESS failure that
+  yields no verdict, not a false pass, and refusing a box without `timeout` would red correct input. It
+  proves ancestry **in the local object store only** — not that the anchor is on the PR as GitHub sees it.
   **What a `PREMERGE: OK` does NOT prove (#3650) — it says so itself, on a `PREMERGE: SCOPE` line.**
   It proves the diff is unchanged since certification and that a full gate PASSed on **that exact
   tree**. It does NOT prove the change was certified against the `main` it will join: a squash-merge

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1769,8 +1769,30 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   also **bounded** by the runner this script already resolves for the advisory; where no
   `timeout`/`gtimeout` exists they run UNBOUNDED and the evidence line SAYS so
   (`anchor-reads: bounded-…` / `UNBOUNDED(…)`) rather than refusing — a hang is a LIVENESS failure that
-  yields no verdict, not a false pass, and refusing a box without `timeout` would red correct input. It
-  proves ancestry **in the local object store only** — not that the anchor is on the PR as GitHub sees it.
+  yields no verdict, not a false pass, and refusing a box without `timeout` would red correct input.
+  **THE COMMIT-GRAPH IS TRUSTED METADATA, SO IT IS DISABLED — AND THE MEASUREMENT IS NOT THE ONE THE
+  FINDING PREDICTED** (roborev job 361). `objects/info/commit-graph` reaches the scratch through the
+  alternate, is NOT content-addressed, and git trusts its parent edges. Measured on git 2.43.0 against a
+  graph whose CDAT parent slot was patched and whose checksum recomputed: `rev-list --parents` reports the
+  FORGED parent and `-c core.commitGraph=false` the real one (so the graph IS consulted and IS trusted) —
+  but `merge-base --is-ancestor`, the call this guard makes, answered `no` **both** ways, so the exploit
+  against THIS call did not reproduce. The flag ships as defence in depth (one git version or one refactor
+  from mattering) and the test says so, pinning it STRUCTURALLY where no behavioural arm can. Measured and
+  deliberately NOT disabled: `core.multiPackIndex` (with the pack `.idx` removed the object was
+  unreadable, so no evidence it supplies lookups or edges) and reachability bitmaps (`GIT_TRACE2_PERF=1`
+  showed ZERO bitmap mentions during the call) — widening past a measurement is guessing.
+  **AND AT THAT POINT THE BOUNDARY IS DECLARED RATHER THAN ENUMERATED AGAIN.** Three review rounds found
+  three routes into one mechanism (graft → environment/template → commit-graph), which is #3544 job 264's
+  *"one axis closed, space declared done"* shape, and #3746 / job 311 already ruled on the unclosable
+  version: DECLARE it in the emitted line and hand the subject to the issue that owns it. So every Case B
+  success line ends with one constant — `ancestry over this box's SHARED object store: objects+metadata
+  TRUSTED, not verified (#3746)` — folded into the ONE renderer, never per-arm. What the binding proves:
+  ancestry over the objects and commit metadata this box's shared store presents, isolated (each with a
+  positive control) from grafts, replace refs, an inherited `GIT_DIR`, an ambient template, and the
+  commit-graph. What it does not: that the anchor is on the PR **as GitHub sees it**, and anything against
+  a peer that can WRITE that shared store. A fifth route in this family is a residual under that
+  declaration, not a false claim — a check that claims nothing false is worth more than one claiming a
+  closure it does not deliver.
   **What a `PREMERGE: OK` does NOT prove (#3650) — it says so itself, on a `PREMERGE: SCOPE` line.**
   It proves the diff is unchanged since certification and that a full gate PASSed on **that exact
   tree**. It does NOT prove the change was certified against the `main` it will join: a squash-merge

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -636,6 +636,26 @@ _anchor_run() {
   fi
 }
 
+# _anchor_refuse_timeout <anchor> <head> <what> — THE ONE timeout refusal, shared
+# by EVERY bounded call (roborev job 374). It exists so a new call site cannot
+# invent a different wording, and so a timeout can never borrow another cause's
+# REMEDY: the whole reason this script splits exit 2 from exit 3 is to hand the
+# operator the right action, and "not inside a git work tree" sends someone to
+# check their cwd when the real answer is a stalled filesystem. A misleading
+# diagnostic is worse than a vague one.
+_anchor_refuse_timeout() {
+  refuse_anchor_unverifiable "$1" "$2" \
+    "$3 timed out after ${ADVISORY_TIMEOUT_SECS}s (+${ADVISORY_KILL_GRACE}s kill grace)" \
+    "The call did not return. These reads touch the SHARED object store and the" \
+    "repository metadata beside it, where a malformed loose object (a FIFO) or a" \
+    "stalled mount stops them; a hang here would leave the merge guard with no" \
+    "verdict at all, which the bound converts into this one." \
+    "This is NOT a statement about your cwd, your TMPDIR or your object paths —" \
+    "those causes have their own wording, and a timeout no longer borrows them." \
+    "REMEDY: check the object store under this repository's objects directory and" \
+    "the mount it lives on, then re-run this assert."
+}
+
 # _anchor_timed_out <rc> — TRUE when the runner terminated the call rather than
 # git answering. Only meaningful when a runner is in use; with none, no exit code
 # means "timed out" and the test is simply never true.
@@ -676,7 +696,21 @@ trap '_anchor_cleanup; trap - HUP;  kill -HUP  $$' HUP
 # _anchor_canon <dir> — canonicalize with `cd`+`pwd -P`, EMPTY on failure. The
 # convention scripts/flow/base-staleness.sh uses (no `realpath` dependency), and
 # every caller treats empty as "could not measure", never as "outside".
-_anchor_canon() { (cd "$1" 2>/dev/null && pwd -P) || true; }
+#
+# AN EMPTY ARGUMENT IS REFUSED EXPLICITLY, AND WITHOUT THAT LINE EVERY
+# "could not be resolved" BRANCH WAS UNREACHABLE (found while RED-verifying job
+# 374). Measured: **`cd ""` SUCCEEDS in bash and leaves the shell where it is**,
+# so `(cd "" && pwd -P)` prints the CURRENT DIRECTORY. A discovery call that
+# failed or timed out therefore yielded cwd instead of an empty string, the
+# `[ -z … ]` guards never fired, and the check proceeded on a plausible-looking
+# wrong value — the RED control for job 374 exited 0 with `PREMERGE: OK`, i.e. a
+# FALSE PASS, not merely a wrong remedy. The timeout propagation above closes the
+# timeout route; this line closes the ordinary-git-failure route, which no status
+# check can, because there the value really is empty.
+_anchor_canon() {
+  [ -n "$1" ] || return 0
+  (cd "$1" 2>/dev/null && pwd -P) || true
+}
 
 # _anchor_build_scratch — on success sets ANCHOR_SCRATCH (the mktemp dir),
 # ANCHOR_SCRATCH_REPO (the git dir to run in) and ANCHOR_ALT (the value for
@@ -686,7 +720,9 @@ ANCHOR_SCRATCH_REPO=""
 ANCHOR_ALT=""
 ANCHOR_SCRATCH_ERR=""
 _anchor_build_scratch() {
+  local anchor="$1" head="$2"
   local lane_objects repo_canon common_canon tmp_req tmp_canon created_canon alt_q
+  local rc toplevel commondir
 
   # THE SCRATCH MUST BE PROVABLY OUTSIDE THE REPOSITORY, and "the repository" is
   # BOTH roots: the work tree AND the git COMMON dir (these are worktrees of one
@@ -695,8 +731,23 @@ _anchor_build_scratch() {
   # pre-check answers about the path as it resolved a moment ago, so what was
   # ACTUALLY CREATED is re-validated, because a symlink swapped in between lands
   # the real directory somewhere else.
-  repo_canon=$(_anchor_canon "$(_anchor_lane rev-parse --show-toplevel 2>/dev/null || true)")
-  common_canon=$(_anchor_canon "$(_anchor_lane rev-parse --git-common-dir 2>/dev/null || true)")
+  # SPLIT so the status is visible: the old form nested the git call inside two
+  # command substitutions with a `|| true`, which discarded a timeout entirely and
+  # reported it as an unresolvable work-tree root (job 374).
+  rc=0
+  toplevel=$(_anchor_lane rev-parse --show-toplevel 2>/dev/null) || rc=$?
+  if _anchor_timed_out "$rc"; then
+    _anchor_refuse_timeout "$anchor" "$head" "the work-tree root probe (rev-parse --show-toplevel)"
+  fi
+  rc=0
+  commondir=$(_anchor_lane rev-parse --git-common-dir 2>/dev/null) || rc=$?
+  if _anchor_timed_out "$rc"; then
+    _anchor_refuse_timeout "$anchor" "$head" "the git common-directory probe (rev-parse --git-common-dir)"
+  fi
+  # A non-timeout failure, or an empty answer, keeps its ORIGINAL cause below:
+  # those are real states (an unusable repository) with their own remedy.
+  repo_canon=$(_anchor_canon "$toplevel")
+  common_canon=$(_anchor_canon "$commondir")
   if [ -z "$repo_canon" ] || [ -z "$common_canon" ]; then
     ANCHOR_SCRATCH_ERR="the work-tree root and/or git common directory could not be resolved, so a scratch location cannot be proven outside them"
     return 1
@@ -737,7 +788,12 @@ _anchor_build_scratch() {
   # (measured here: `--git-path objects` = /…/repo/.git/objects while
   # `--git-dir` = /…/repo/.git/worktrees/<lane>). It reads no object and reaches
   # no network; a graft cannot redirect a path.
-  lane_objects=$(_anchor_lane rev-parse --git-path objects 2>/dev/null) || lane_objects=""
+  rc=0
+  lane_objects=$(_anchor_lane rev-parse --git-path objects 2>/dev/null) || rc=$?
+  if _anchor_timed_out "$rc"; then
+    _anchor_refuse_timeout "$anchor" "$head" "the object-directory probe (rev-parse --git-path objects)"
+  fi
+  [ "$rc" -eq 0 ] || lane_objects=""
   # MADE ABSOLUTE: `--git-path` answers RELATIVE TO THE WORK-TREE ROOT for a
   # plain clone (`.git/objects`) and absolute only for a worktree. A relative
   # value would be resolved against the SCRATCH, a different directory, and the
@@ -764,8 +820,12 @@ _anchor_build_scratch() {
   # refuses, removing both lets the attack land at exit 0 (see the header). Kept
   # as defence in depth, and because the flag additionally beats a config-FILE
   # `init.templateDir` that no environment can clear.
-  if ! _anchor_run init -q --template= "$ANCHOR_SCRATCH_REPO" >/dev/null 2>&1 ||
-     [ ! -d "$ANCHOR_SCRATCH_REPO/.git" ]; then
+  rc=0
+  _anchor_run init -q --template= "$ANCHOR_SCRATCH_REPO" >/dev/null 2>&1 || rc=$?
+  if _anchor_timed_out "$rc"; then
+    _anchor_refuse_timeout "$anchor" "$head" "initialising the isolated scratch repository (git init)"
+  fi
+  if [ "$rc" -ne 0 ] || [ ! -d "$ANCHOR_SCRATCH_REPO/.git" ]; then
     ANCHOR_SCRATCH_ERR="could not initialise an isolated scratch repository at $ANCHOR_SCRATCH_REPO"
     return 1
   fi
@@ -822,7 +882,16 @@ assert_anchor_on_history() {
   # Resolve the bound BEFORE the first read, so no read is ever unbounded by
   # accident rather than by the measured absence of a runner.
   _anchor_resolve_bound "$anchor" "$head"
-  if ! _anchor_lane rev-parse --git-dir >/dev/null 2>&1; then
+  # STATUS IS INSPECTED, NOT DISCARDED (job 374). An `if !` collapses "timed out"
+  # onto "not a work tree", which is the two-valued-predicate-over-a-multi-state-
+  # signal shape — except here the permissive branch is not the danger, a WRONG
+  # REMEDY is.
+  rc=0
+  _anchor_lane rev-parse --git-dir >/dev/null 2>&1 || rc=$?
+  if _anchor_timed_out "$rc"; then
+    _anchor_refuse_timeout "$anchor" "$head" "the git work-tree probe (rev-parse --git-dir)"
+  fi
+  if [ "$rc" -ne 0 ]; then
     refuse_anchor_unverifiable "$anchor" "$head" \
       "the current directory is not inside a git work tree (cwd: $(pwd))" \
       "REMEDY: run this assert from the ISSUE'S WORKTREE. The repository whose" \
@@ -832,7 +901,7 @@ assert_anchor_on_history() {
   # THE ISOLATED REPOSITORY IS BUILT BEFORE ANY OBJECT IS READ, and a failure to
   # build it is UNVERIFIABLE — never a fall-back to the live repository, which is
   # the whole hole job 355 closes.
-  if ! _anchor_build_scratch; then
+  if ! _anchor_build_scratch "$anchor" "$head"; then
     refuse_anchor_unverifiable "$anchor" "$head" \
       "the isolated scratch repository could not be built: $ANCHOR_SCRATCH_ERR" \
       "The ancestry walk deliberately does NOT run in this checkout: a graft in" \
@@ -863,14 +932,7 @@ assert_anchor_on_history() {
   rc=0
   _anchor_git cat-file -e "$anchor^{commit}" >/dev/null 2>&1 || rc=$?
   if _anchor_timed_out "$rc"; then
-    refuse_anchor_unverifiable "$anchor" "$head" \
-      "reading the ANCHOR object timed out after ${ADVISORY_TIMEOUT_SECS}s (+${ADVISORY_KILL_GRACE}s kill grace)" \
-      "The object store did not answer. A malformed loose object (a FIFO) or a" \
-      "stalled filesystem will do this, and both are reachable here: the store is" \
-      "SHARED between lanes and a stalled mount is an accident, not an attack." \
-      "A hang would give NO verdict at all, so the bound turns it into this one." \
-      "REMEDY: check the object store under this repository's objects directory" \
-      "and the mount it lives on, then re-run this assert."
+    _anchor_refuse_timeout "$anchor" "$head" "reading the ANCHOR object"
   fi
   if [ "$rc" -ne 0 ]; then
     refuse_anchor_unverifiable "$anchor" "$head" \
@@ -883,11 +945,7 @@ assert_anchor_on_history() {
   rc=0
   _anchor_git cat-file -e "$head^{commit}" >/dev/null 2>&1 || rc=$?
   if _anchor_timed_out "$rc"; then
-    refuse_anchor_unverifiable "$anchor" "$head" \
-      "reading the CERTIFIED object timed out after ${ADVISORY_TIMEOUT_SECS}s (+${ADVISORY_KILL_GRACE}s kill grace)" \
-      "See the ANCHOR timeout cause above: a shared object store that does not" \
-      "answer is UNMEASURED, never a pass." \
-      "REMEDY: check the object store and its mount, then re-run this assert."
+    _anchor_refuse_timeout "$anchor" "$head" "reading the CERTIFIED object"
   fi
   if [ "$rc" -ne 0 ]; then
     refuse_anchor_unverifiable "$anchor" "$head" \
@@ -904,12 +962,7 @@ assert_anchor_on_history() {
     return 0
   fi
   if _anchor_timed_out "$rc"; then
-    refuse_anchor_unverifiable "$anchor" "$head" \
-      "the ancestry walk timed out after ${ADVISORY_TIMEOUT_SECS}s (+${ADVISORY_KILL_GRACE}s kill grace)" \
-      "merge-base did not finish. The walk reads the SHARED object store, where a" \
-      "malformed object or a stalled mount stops it; a hang here would leave the" \
-      "merge guard with no verdict at all, which the bound converts into this one." \
-      "REMEDY: check the object store and its mount, then re-run this assert."
+    _anchor_refuse_timeout "$anchor" "$head" "the ancestry walk"
   fi
   if [ "$rc" -ne 1 ]; then
     refuse_anchor_unverifiable "$anchor" "$head" \
@@ -932,7 +985,17 @@ assert_anchor_on_history() {
   # unconditionally and turn this guard into a vacuous pass — the exact shape
   # this whole check exists to refuse. It is a STATE probe, not an object read,
   # so the graft route job 355 closed does not apply to it.
-  shallow=$(_anchor_lane rev-parse --is-shallow-repository 2>/dev/null) || shallow=""
+  rc=0
+  shallow=$(_anchor_lane rev-parse --is-shallow-repository 2>/dev/null) || rc=$?
+  if _anchor_timed_out "$rc"; then
+    # Without this a timeout HERE would be reported as "this repository is not
+    # proven complete", i.e. it would borrow the shallow cause's remedy
+    # (`git fetch --unshallow`) for a stalled mount (job 374).
+    _anchor_refuse_timeout "$anchor" "$head" "the shallowness probe (rev-parse --is-shallow-repository)"
+  fi
+  # A non-timeout failure (an old git that does not know the option) legitimately
+  # keeps the "not proven complete" cause below — that IS the unmeasured state.
+  [ "$rc" -eq 0 ] || shallow=""
   if [ "$shallow" != false ]; then
     refuse_anchor_unverifiable "$anchor" "$head" \
       "--is-ancestor said 'no', but this repository is NOT PROVEN COMPLETE (git rev-parse --is-shallow-repository = '$shallow')" \

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -388,11 +388,76 @@ refuse_tool_failure() {
 # very shape this check is about. It is a state probe, not an object read, and it
 # cannot be redirected by a graft.
 #
-# THE READS ARE DELIBERATELY **NOT** WRAPPED IN `env -i` + an allowlist, unlike
-# agent-gate.sh's pre-flight. That wrapper exists where a git call can REACH A
-# REMOTE and the answer's provenance is a fetch. Here nothing is fetched and
-# every read is BY A SHA against a config-less object source, so there is no
-# transport an environment could bend. Do not "fix" this by adding one.
+# EVERY GIT CALL RUNS UNDER `env -i` + AN ALLOWLIST — AND THE COMMENT THAT USED
+# TO SAY THE OPPOSITE WAS FALSE ONCE THE SCRATCH EXISTED (roborev job 358, High).
+# The earlier text argued that these reads need no environment control because
+# they are lane-local and addressed BY A SHA, so nothing an environment can set
+# changes which bytes a sha resolves to. That argument is CORRECT for a read in
+# the lane repository and WRONG for this design, and the difference is the whole
+# finding: **an environment variable here does not bend the OBJECT, it bends
+# WHICH REPOSITORY ANSWERS.** A scratch whose entire purpose is isolation has a
+# load-bearing environment. Two measured routes, both of which manufacture
+# `BOUND` (git 2.43.0):
+#   * `GIT_DIR` OVERRIDES `-C`. `GIT_DIR=<grafted>/.git git -C <scratch>
+#     rev-parse --git-dir` answers `<grafted>/.git`; under `env -i` it answers
+#     `.git`. So an inherited `GIT_DIR`/`GIT_COMMON_DIR` redirects the walk
+#     straight back into a grafted repository.
+#   * A TEMPLATE SEEDS `info/grafts` INTO THE SCRATCH. `git init
+#     --template=<dir>` and `GIT_TEMPLATE_DIR=<dir> git init` both copy a planted
+#     `info/grafts` into the new repo (measured: content `x` present in both);
+#     `env -i … git init --template=` produces none.
+# So the isolated hop's environment is an ALLOWLIST (CLAUDE.md job 258: allowlist
+# the safe shape, never blocklist the dangerous one — a denylist of git variables
+# recedes), and it reaches EVERY site, including the lane DISCOVERY reads (job
+# 276: the migrated reads ran under a bare `env` and the earlier hole re-opened
+# at the NEW sites). An inherited `GIT_DIR` on a discovery read would make
+# `--git-path objects`, `--git-common-dir` and `--is-shallow-repository` answer
+# about a DIFFERENT repository, poisoning the alternate and the shallowness
+# verdict alike.
+#   ADMIT  only what git needs to RUN AT ALL. There is no network here, so —
+#          unlike agent-gate.sh's pre-flight — nothing needs HOME for key or
+#          `known_hosts` discovery, nothing needs SSH_AUTH_SOCK, and no proxy
+#          variable is admitted. The list is PATH and TMPDIR.
+#   CLEAR  everything else, BY DEFAULT via `env -i`, which is what makes this
+#          closed: a git variable nobody has thought of is cleared without
+#          needing to be discovered.
+# THE CONFIG FILES ARE NOT SANITISABLE BY THE ENVIRONMENT — `/etc/gitconfig` and
+# `~/.gitconfig` are FILES, so clearing `GIT_CONFIG_*` alone does not stop an
+# `init.templateDir` set in one of them. They are neutralised by pointing
+# `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` at `/dev/null` AND by passing an
+# explicit empty `--template=` to `git init`.
+#   HOW THOSE TWO ACTUALLY RELATE, MEASURED RATHER THAN ASSERTED, because an
+#   earlier draft of this paragraph claimed "neither alone closes it" and the
+#   suite falsifies that: remove ONLY the `--template=` and the template arm
+#   still refuses (`env -i` cleared `GIT_TEMPLATE_DIR`); remove ONLY the `env -i`
+#   and it still refuses (the explicit flag beats the inherited variable); remove
+#   BOTH and the attack lands — `exit 0`, a false acceptance. So against every
+#   route this suite can construct they are REDUNDANT WITH EACH OTHER, kept as
+#   defence in depth rather than because each is separately necessary. What the
+#   flag uniquely covers is a config-FILE `init.templateDir` — which the two
+#   `/dev/null` neutralisers also cover, and which no test here constructs,
+#   because doing so would mean writing to `/etc/gitconfig`.
+# A side effect worth stating: clearing `GIT_DIR` makes this file's standing
+# claim — "the repository is the CURRENT WORKING DIRECTORY's, with no env
+# override" — true, where before a caller's `GIT_DIR` silently won.
+#
+# THE READS ARE ALSO BOUNDED (roborev job 358, Medium). They read the SHARED
+# object store, so a malformed loose object (a FIFO) or a stalled filesystem read
+# would hang the merge guard forever instead of producing the documented
+# `ANCHOR-UNVERIFIABLE`. In model on both halves: a peer lane can plant into that
+# store, and a stalled mount is the accident route. The bound is the runner this
+# script ALREADY resolves for the advisory (`resolve_advisory_timeout`, probed
+# for `--kill-after` because a TERM-only bound bounds nothing) at the same
+# `ADVISORY_TIMEOUT_SECS`/`ADVISORY_KILL_GRACE`; no second timing implementation
+# is written, and `timeout(1)` owns and reaps its own child, so job 279's rule
+# against signalling a process group you no longer own is not in play here.
+# WHERE NO RUNNER EXISTS the reads run UNBOUNDED and SAY SO on the evidence line
+# (`anchor-reads: UNBOUNDED(...)`) — they are NOT refused. This is a LIVENESS
+# property, not a correctness one: a hang produces NO verdict, where the graft
+# produced a WRONG one, and an unbounded read cannot manufacture a false pass.
+# Turning "this box has no `timeout`" into a merge refusal would be the guard
+# that reds on correct input. What must never happen is the bounded path
+# silently becoming unbounded, hence the affirmative token rather than silence.
 export GIT_NO_LAZY_FETCH=1
 export GIT_NO_REPLACE_OBJECTS=1
 
@@ -427,6 +492,73 @@ refuse_anchor_unverifiable() {
   printf '========================================================\n' >&2
   exit 3
 }
+
+# --- THE ISOLATED HOP'S ENVIRONMENT (roborev job 358) -----------------------
+# See the header for the two measured routes and the ADMIT/CLEAR line. Built
+# once, used by every git call below — lane discovery included.
+ANCHOR_GIT_ENV=()
+_anchor_build_git_env() {
+  ANCHOR_GIT_ENV=()
+  # PATH: find `git` itself, and the bounding `timeout`/`gtimeout`.
+  ANCHOR_GIT_ENV+=("PATH=${PATH:-/usr/bin:/bin}")
+  # TMPDIR: git's own temporary files. Also where the scratch is created.
+  [ -n "${TMPDIR:-}" ] && ANCHOR_GIT_ENV+=("TMPDIR=$TMPDIR")
+  # THE NEUTRALISERS, LAST so nothing above can shadow them. The two config
+  # variables are what make the FILE-based `init.templateDir` route inert; the
+  # explicit `--template=` at the init call is the other half. No prompt: an
+  # interactive credential prompt is one of the ways this could hang. Replace
+  # refs and lazy fetch off as belt — the structural control is that no object
+  # read runs in the live repository at all.
+  ANCHOR_GIT_ENV+=("GIT_CONFIG_GLOBAL=/dev/null" "GIT_CONFIG_SYSTEM=/dev/null" \
+                   "GIT_TERMINAL_PROMPT=0" "GIT_NO_REPLACE_OBJECTS=1" "GIT_NO_LAZY_FETCH=1")
+  return 0
+}
+_anchor_build_git_env
+
+# --- THE BOUND (roborev job 358) --------------------------------------------
+# Resolved ONCE, from the runner this script already has. `ANCHOR_READS` is the
+# affirmative token published on the evidence line; it is never silently empty.
+ANCHOR_BOUND_RUNNER=""
+ANCHOR_READS="UNRECORDED"
+_anchor_resolve_bound() {
+  local name
+  if name=$(resolve_advisory_timeout) && ANCHOR_BOUND_RUNNER=$(command -v "$name" 2>/dev/null) &&
+     [ -n "$ANCHOR_BOUND_RUNNER" ]; then
+    ANCHOR_READS="bounded-${ADVISORY_TIMEOUT_SECS}s+${ADVISORY_KILL_GRACE}s"
+  else
+    ANCHOR_BOUND_RUNNER=""
+    ANCHOR_READS="UNBOUNDED(no-timeout-runner-supporting--kill-after)"
+  fi
+  return 0
+}
+
+# _anchor_run <git-args...> — ONE place every git call in this check goes
+# through: `env -i` + the allowlist, bounded when a runner exists. Callers add
+# location-specific variables by exporting them in a subshell (see _anchor_git).
+# A timeout is reported through the exit code (124 from timeout(1), or 137 when
+# the SIGKILL escalation was needed) and every caller maps those to UNVERIFIABLE.
+_anchor_run() {
+  if [ -n "$ANCHOR_BOUND_RUNNER" ]; then
+    env -i "${ANCHOR_GIT_ENV[@]}" "$ANCHOR_BOUND_RUNNER" \
+      --kill-after="$ADVISORY_KILL_GRACE" "$ADVISORY_TIMEOUT_SECS" git "$@"
+  else
+    env -i "${ANCHOR_GIT_ENV[@]}" git "$@"
+  fi
+}
+
+# _anchor_timed_out <rc> — TRUE when the runner terminated the call rather than
+# git answering. Only meaningful when a runner is in use; with none, no exit code
+# means "timed out" and the test is simply never true.
+_anchor_timed_out() {
+  [ -n "$ANCHOR_BOUND_RUNNER" ] || return 1
+  [ "$1" = 124 ] || [ "$1" = 137 ]
+}
+
+# _anchor_lane <git-args...> — a DISCOVERY read of the lane repository (cwd).
+# Same isolation: an inherited GIT_DIR would make discovery answer about another
+# repository, which poisons the alternate and the shallowness verdict (job 276:
+# the allowlist has to reach the sites a later change adds).
+_anchor_lane() { _anchor_run --no-replace-objects "$@"; }
 
 # --- THE ISOLATED SCRATCH REPOSITORY (roborev job 355) ----------------------
 # CLEANUP IS REGISTERED BEFORE THE RESOURCE EXISTS. CLAUDE.md's recurring lesson
@@ -471,8 +603,8 @@ _anchor_build_scratch() {
   # pre-check answers about the path as it resolved a moment ago, so what was
   # ACTUALLY CREATED is re-validated, because a symlink swapped in between lands
   # the real directory somewhere else.
-  repo_canon=$(_anchor_canon "$(git rev-parse --show-toplevel 2>/dev/null || true)")
-  common_canon=$(_anchor_canon "$(git rev-parse --git-common-dir 2>/dev/null || true)")
+  repo_canon=$(_anchor_canon "$(_anchor_lane rev-parse --show-toplevel 2>/dev/null || true)")
+  common_canon=$(_anchor_canon "$(_anchor_lane rev-parse --git-common-dir 2>/dev/null || true)")
   if [ -z "$repo_canon" ] || [ -z "$common_canon" ]; then
     ANCHOR_SCRATCH_ERR="the work-tree root and/or git common directory could not be resolved, so a scratch location cannot be proven outside them"
     return 1
@@ -513,7 +645,7 @@ _anchor_build_scratch() {
   # (measured here: `--git-path objects` = /…/repo/.git/objects while
   # `--git-dir` = /…/repo/.git/worktrees/<lane>). It reads no object and reaches
   # no network; a graft cannot redirect a path.
-  lane_objects=$(git rev-parse --git-path objects 2>/dev/null) || lane_objects=""
+  lane_objects=$(_anchor_lane rev-parse --git-path objects 2>/dev/null) || lane_objects=""
   # MADE ABSOLUTE: `--git-path` answers RELATIVE TO THE WORK-TREE ROOT for a
   # plain clone (`.git/objects`) and absolute only for a worktree. A relative
   # value would be resolved against the SCRATCH, a different directory, and the
@@ -532,7 +664,15 @@ _anchor_build_scratch() {
   fi
 
   ANCHOR_SCRATCH_REPO="$ANCHOR_SCRATCH/repo"
-  if ! git init -q "$ANCHOR_SCRATCH_REPO" >/dev/null 2>&1 ||
+  # `--template=` (EMPTY). `git init --template=<dir>` and `GIT_TEMPLATE_DIR=<dir>
+  # git init` BOTH copy a planted `info/grafts` into the new repository
+  # (measured), which would make the scratch born grafted and the isolation
+  # worthless. This flag and the allowlist's cleared environment are REDUNDANT
+  # with each other against that route — measured: removing either alone still
+  # refuses, removing both lets the attack land at exit 0 (see the header). Kept
+  # as defence in depth, and because the flag additionally beats a config-FILE
+  # `init.templateDir` that no environment can clear.
+  if ! _anchor_run init -q --template= "$ANCHOR_SCRATCH_REPO" >/dev/null 2>&1 ||
      [ ! -d "$ANCHOR_SCRATCH_REPO/.git" ]; then
     ANCHOR_SCRATCH_ERR="could not initialise an isolated scratch repository at $ANCHOR_SCRATCH_REPO"
     return 1
@@ -564,8 +704,17 @@ _anchor_build_scratch() {
 # with the lane's objects supplied as an alternate. This is the only place the
 # ancestry reads happen; nothing here consults the lane's config.
 _anchor_git() {
-  GIT_ALTERNATE_OBJECT_DIRECTORIES="$ANCHOR_ALT" \
-    git --no-replace-objects -C "$ANCHOR_SCRATCH_REPO" "$@"
+  # The alternate is the one location-specific value layered on top of the
+  # allowlist — appended AFTER it, so it cannot be shadowed by a neutraliser and
+  # cannot smuggle anything else in.
+  if [ -n "$ANCHOR_BOUND_RUNNER" ]; then
+    env -i "${ANCHOR_GIT_ENV[@]}" "GIT_ALTERNATE_OBJECT_DIRECTORIES=$ANCHOR_ALT" \
+      "$ANCHOR_BOUND_RUNNER" --kill-after="$ADVISORY_KILL_GRACE" "$ADVISORY_TIMEOUT_SECS" \
+      git --no-replace-objects -C "$ANCHOR_SCRATCH_REPO" "$@"
+  else
+    env -i "${ANCHOR_GIT_ENV[@]}" "GIT_ALTERNATE_OBJECT_DIRECTORIES=$ANCHOR_ALT" \
+      git --no-replace-objects -C "$ANCHOR_SCRATCH_REPO" "$@"
+  fi
 }
 
 # assert_anchor_on_history <anchor-40-hex> <certified-40-hex> — the #3653
@@ -578,7 +727,10 @@ assert_anchor_on_history() {
     refuse_anchor_unverifiable "$anchor" "$head" "git is not on PATH" \
       "REMEDY: install git, or run this assert from a box that has it."
   fi
-  if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  # Resolve the bound BEFORE the first read, so no read is ever unbounded by
+  # accident rather than by the measured absence of a runner.
+  _anchor_resolve_bound
+  if ! _anchor_lane rev-parse --git-dir >/dev/null 2>&1; then
     refuse_anchor_unverifiable "$anchor" "$head" \
       "the current directory is not inside a git work tree (cwd: $(pwd))" \
       "REMEDY: run this assert from the ISSUE'S WORKTREE. The repository whose" \
@@ -616,7 +768,19 @@ assert_anchor_on_history() {
   # (or 1 in a repository this check then refuses to call complete) and the
   # verdict is UNVERIFIABLE either way. A false "present" costs a less specific
   # diagnostic, never a pass.
-  if ! _anchor_git cat-file -e "$anchor^{commit}" >/dev/null 2>&1; then
+  rc=0
+  _anchor_git cat-file -e "$anchor^{commit}" >/dev/null 2>&1 || rc=$?
+  if _anchor_timed_out "$rc"; then
+    refuse_anchor_unverifiable "$anchor" "$head" \
+      "reading the ANCHOR object timed out after ${ADVISORY_TIMEOUT_SECS}s (+${ADVISORY_KILL_GRACE}s kill grace)" \
+      "The object store did not answer. A malformed loose object (a FIFO) or a" \
+      "stalled filesystem will do this, and both are reachable here: the store is" \
+      "SHARED between lanes and a stalled mount is an accident, not an attack." \
+      "A hang would give NO verdict at all, so the bound turns it into this one." \
+      "REMEDY: check the object store under this repository's objects directory" \
+      "and the mount it lives on, then re-run this assert."
+  fi
+  if [ "$rc" -ne 0 ]; then
     refuse_anchor_unverifiable "$anchor" "$head" \
       "the ANCHOR commit is not present in this repository" \
       "An absent object cannot be shown to lie on any history, and its absence is" \
@@ -624,7 +788,16 @@ assert_anchor_on_history() {
       "REMEDY: fetch the branch that carries it (git fetch origin <branch>) and" \
       "re-run this assert."
   fi
-  if ! _anchor_git cat-file -e "$head^{commit}" >/dev/null 2>&1; then
+  rc=0
+  _anchor_git cat-file -e "$head^{commit}" >/dev/null 2>&1 || rc=$?
+  if _anchor_timed_out "$rc"; then
+    refuse_anchor_unverifiable "$anchor" "$head" \
+      "reading the CERTIFIED object timed out after ${ADVISORY_TIMEOUT_SECS}s (+${ADVISORY_KILL_GRACE}s kill grace)" \
+      "See the ANCHOR timeout cause above: a shared object store that does not" \
+      "answer is UNMEASURED, never a pass." \
+      "REMEDY: check the object store and its mount, then re-run this assert."
+  fi
+  if [ "$rc" -ne 0 ]; then
     refuse_anchor_unverifiable "$anchor" "$head" \
       "the CERTIFIED commit is not present in this repository" \
       "REMEDY: fetch the PR branch (git fetch origin <branch>) and re-run this" \
@@ -637,6 +810,14 @@ assert_anchor_on_history() {
     ANCHOR_ANCESTRY=BOUND
     _anchor_cleanup
     return 0
+  fi
+  if _anchor_timed_out "$rc"; then
+    refuse_anchor_unverifiable "$anchor" "$head" \
+      "the ancestry walk timed out after ${ADVISORY_TIMEOUT_SECS}s (+${ADVISORY_KILL_GRACE}s kill grace)" \
+      "merge-base did not finish. The walk reads the SHARED object store, where a" \
+      "malformed object or a stalled mount stops it; a hang here would leave the" \
+      "merge guard with no verdict at all, which the bound converts into this one." \
+      "REMEDY: check the object store and its mount, then re-run this assert."
   fi
   if [ "$rc" -ne 1 ]; then
     refuse_anchor_unverifiable "$anchor" "$head" \
@@ -659,7 +840,7 @@ assert_anchor_on_history() {
   # unconditionally and turn this guard into a vacuous pass — the exact shape
   # this whole check exists to refuse. It is a STATE probe, not an object read,
   # so the graft route job 355 closed does not apply to it.
-  shallow=$(git --no-replace-objects rev-parse --is-shallow-repository 2>/dev/null) || shallow=""
+  shallow=$(_anchor_lane rev-parse --is-shallow-repository 2>/dev/null) || shallow=""
   if [ "$shallow" != false ]; then
     refuse_anchor_unverifiable "$anchor" "$head" \
       "--is-ancestor said 'no', but this repository is NOT PROVEN COMPLETE (git rev-parse --is-shallow-repository = '$shallow')" \
@@ -1465,7 +1646,12 @@ if [ -n "$delta_file" ]; then
   # `anchor-ancestry:` is the AFFIRMATIVE record that the #3653 binding RAN. After
   # assert_anchor_on_history it can only ever read BOUND — which is the point: a
   # silent pass is indistinguishable from a check that was never reached.
-  printf 'PREMERGE: DELTA-RECERT anchor: %s anchor-ancestry: %s commit: %s tree-start: %s tree-integrity: PASS dirty: %s summary: %s\n' \
-    "$delta_anchor" "$ANCHOR_ANCESTRY" "$delta_commit" "$delta_ts" "$delta_dirty" "$delta_file"
+  # `anchor-reads:` is AFFIRMATIVE in both directions (job 358): `bounded-<n>s+<g>s`
+  # or `UNBOUNDED(no-timeout-runner-supporting--kill-after)`. An unbounded run is
+  # legitimate — a hang cannot manufacture a false pass, and refusing a box with
+  # no `timeout` would red correct input — but it must never be SILENT, because a
+  # bounded path degrading into an unbounded one unnoticed is the real hazard.
+  printf 'PREMERGE: DELTA-RECERT anchor: %s anchor-ancestry: %s anchor-reads: %s commit: %s tree-start: %s tree-integrity: PASS dirty: %s summary: %s\n' \
+    "$delta_anchor" "$ANCHOR_ANCESTRY" "$ANCHOR_READS" "$delta_commit" "$delta_ts" "$delta_dirty" "$delta_file"
 fi
 exit 0

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -213,7 +213,8 @@
 #       broken box — fix the box, do NOT re-run the gate), `PREMERGE: GH-FAILURE`
 #       (auth/network/no-such-PR), `PREMERGE: ANCHOR-UNVERIFIABLE` (#3653 — this
 #       box could not measure whether the anchor is on this PR's history: no git,
-#       no work tree, an absent object, or a shallow/unproven history).
+#       no work tree, an absent object, a shallow/unproven history, a read that
+#       TIMED OUT, or no `timeout`/`gtimeout` available to bound the reads at all).
 #
 # macOS bash 3.2 compatible, shellcheck-clean.
 set -euo pipefail
@@ -467,13 +468,34 @@ refuse_tool_failure() {
 # `ADVISORY_TIMEOUT_SECS`/`ADVISORY_KILL_GRACE`; no second timing implementation
 # is written, and `timeout(1)` owns and reaps its own child, so job 279's rule
 # against signalling a process group you no longer own is not in play here.
-# WHERE NO RUNNER EXISTS the reads run UNBOUNDED and SAY SO on the evidence line
-# (`anchor-reads: UNBOUNDED(...)`) — they are NOT refused. This is a LIVENESS
-# property, not a correctness one: a hang produces NO verdict, where the graft
-# produced a WRONG one, and an unbounded read cannot manufacture a false pass.
-# Turning "this box has no `timeout`" into a merge refusal would be the guard
-# that reds on correct input. What must never happen is the bounded path
-# silently becoming unbounded, hence the affirmative token rather than silence.
+# WHERE NO SUPPORTED RUNNER EXISTS THE CHECK REFUSES — `ANCHOR-UNVERIFIABLE`,
+# naming the remedy. THIS REVERSES AN EARLIER DECISION IN THIS SAME FILE, and the
+# reasoning is recorded because the earlier reasoning was persuasive and wrong.
+#
+# The earlier rule was: run unbounded, declare it on the evidence line, and do NOT
+# refuse — because a hang is a LIVENESS failure that yields no verdict rather than
+# a false pass, and refusing a box with no coreutils would be the guard that reds
+# on correct input.
+#
+# WHAT THAT MISSED: a hang in this guard BLOCKS THE MERGE ANYWAY. So the real
+# comparison was never "merge proceeds vs merge refused" — it is **hang forever
+# with no diagnosis vs refuse immediately with a named cause and remedy**. Those
+# have the SAME outcome for the merge, and the refusal strictly dominates: same
+# non-merge, plus a diagnosis. "It cannot produce a false pass" was true and
+# IRRELEVANT, because the alternative was never a pass. The second half of the old
+# argument still stands, and is why the refusal names a ONE-COMMAND remedy rather
+# than being a dead end.
+#
+# AND THE THIRD OPTION IS RULED OUT ON PURPOSE: do NOT hand-roll a portable
+# bounded runner here. That is new PROCESS-LIFETIME code, and process lifetime is
+# the family that has already produced three defects in this issue's own test
+# scaffolding (an orphaning decoy, a vacuous census, an unregistered decoy
+# cleanup). The cost of failing closed is bounded and fixed by one named command;
+# the cost of a fourth lifetime bug inside a merge guard is not.
+#
+# The `anchor-reads: bounded-<n>s+<g>s` affirmation is KEPT for the path that does
+# run, and there is deliberately NO `UNBOUNDED` spelling left to emit: a run that
+# would have needed one never reaches the evidence line.
 export GIT_NO_LAZY_FETCH=1
 export GIT_NO_REPLACE_OBJECTS=1
 
@@ -576,16 +598,27 @@ ANCHOR_READS="UNRECORDED"
 # value on purpose: there is no measurement this script can take that would make
 # it false, so a variable would only invite a future arm to omit it.
 ANCHOR_PROVENANCE="ancestry over this box's SHARED object store: objects+metadata TRUSTED, not verified (#3746)"
+# _anchor_resolve_bound <anchor> <certified> — REFUSES when there is no supported
+# runner (see the reversal in the header). The two shas are taken only so the
+# refusal can name them, exactly like every other UNVERIFIABLE cause.
 _anchor_resolve_bound() {
-  local name
+  local anchor="$1" head="$2" name
   if name=$(resolve_advisory_timeout) && ANCHOR_BOUND_RUNNER=$(command -v "$name" 2>/dev/null) &&
      [ -n "$ANCHOR_BOUND_RUNNER" ]; then
     ANCHOR_READS="bounded-${ADVISORY_TIMEOUT_SECS}s+${ADVISORY_KILL_GRACE}s"
-  else
-    ANCHOR_BOUND_RUNNER=""
-    ANCHOR_READS="UNBOUNDED(no-timeout-runner-supporting--kill-after)"
+    return 0
   fi
-  return 0
+  ANCHOR_BOUND_RUNNER=""
+  refuse_anchor_unverifiable "$anchor" "$head" \
+    "no timeout/gtimeout on PATH supporting --kill-after, so the ancestry reads cannot be BOUNDED" \
+    "These reads touch the SHARED object store, where a malformed loose object (a" \
+    "FIFO) or a stalled mount makes them never return. UNBOUNDED they would HANG" \
+    "this guard — which BLOCKS THE MERGE ANYWAY, with no diagnosis. So the choice is" \
+    "not merge-vs-refuse: it is hang-forever-silently vs refuse-now-with-a-cause," \
+    "and the refusal strictly dominates. A SIGTERM-only bound is not a bound either" \
+    "(a child can ignore TERM), which is why --kill-after is PROBED, not assumed." \
+    "REMEDY: install GNU coreutils (its timeout is gtimeout on macOS, and IS" \
+    "accepted here), then re-run this assert. No gate re-run is needed."
 }
 
 # _anchor_run <git-args...> — ONE place every git call in this check goes
@@ -788,7 +821,7 @@ assert_anchor_on_history() {
   fi
   # Resolve the bound BEFORE the first read, so no read is ever unbounded by
   # accident rather than by the measured absence of a runner.
-  _anchor_resolve_bound
+  _anchor_resolve_bound "$anchor" "$head"
   if ! _anchor_lane rev-parse --git-dir >/dev/null 2>&1; then
     refuse_anchor_unverifiable "$anchor" "$head" \
       "the current directory is not inside a git work tree (cwd: $(pwd))" \
@@ -1711,11 +1744,12 @@ if [ -n "$delta_file" ]; then
   # ONE suffix the renderer consumes — never appended per verdict arm, or the two
   # spellings would drift.
   #
-  # `anchor-reads:` is AFFIRMATIVE in both directions (job 358): `bounded-<n>s+<g>s`
-  # or `UNBOUNDED(no-timeout-runner-supporting--kill-after)`. An unbounded run is
-  # legitimate — a hang cannot manufacture a false pass, and refusing a box with
-  # no `timeout` would red correct input — but it must never be SILENT, because a
-  # bounded path degrading into an unbounded one unnoticed is the real hazard.
+  # `anchor-reads:` is the AFFIRMATIVE record that the bound was applied
+  # (`bounded-<n>s+<g>s`). Since the reversal documented in the header there is no
+  # UNBOUNDED spelling: a box with no supported runner REFUSES before reaching
+  # here, so this token can never silently mean "we gave up on bounding". Printed
+  # rather than assumed, because a bounded path degrading unnoticed is the hazard
+  # the token exists for.
   printf 'PREMERGE: DELTA-RECERT anchor: %s anchor-ancestry: %s anchor-reads: %s commit: %s tree-start: %s tree-integrity: PASS dirty: %s summary: %s | %s\n' \
     "$delta_anchor" "$ANCHOR_ANCESTRY" "$ANCHOR_READS" "$delta_commit" "$delta_ts" "$delta_dirty" \
     "$delta_file" "$ANCHOR_PROVENANCE"

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -177,15 +177,31 @@
 #           hold commits never pushed, and no `gh` call here reads the PR's commit
 #           list. The `commit:`/`tree-start:` binding plus the head compare are
 #           what tie the chain to the sha GitHub will merge.
-#       (b) anything against a PEER THAT CAN WRITE THE SHARED OBJECT STORE. Git
-#           does not rehash a packed object against the id it was asked for, and
-#           not every file in that store is content-addressed. So the ancestry
-#           verdict is derived from a store that is TRUSTED, NOT VERIFIED — which
-#           the evidence line SAYS, on every run, naming #3746. That hazard is
-#           strictly bigger than this guard: #3746's own note is that its subject
-#           may be the infrastructure decision that lanes share an object store
-#           at all. A FIFTH route in this family is therefore a residual under
-#           (b), not a defect in this check and not a false claim here.
+#       (b) ANYTHING AGAINST A HOSTILE SAME-UID PEER. This is the TERMINUS of
+#           #3653's hardening line, and it is one fact with many faces. Git does
+#           not rehash a packed object against the id it was asked for and not
+#           every file in the shared store is content-addressed; AND the SCRATCH
+#           is peer-writable too, so a peer can drop `.git/info/grafts` into it,
+#           or replace the `repo` pathname, between `git init` and the walk —
+#           reproducing the round-1 graft attack inside the thing built to prevent
+#           it. Both halves have the SAME cause: every lane on this fleet runs as
+#           the SAME USER, so no mode or ownership can admit this process and
+#           exclude a peer, and the only alternative is a helper binary, which is
+#           not this issue.
+#
+#           SO WHAT THIS GUARD CLAIMS, EXACTLY: bounded, environment-isolated, and
+#           immune to grafts, replace refs, ambient templates and a trusted
+#           commit-graph AGAINST ACCIDENT AND DRIFT — a stray graft in the lane
+#           repo, a leftover `GIT_DIR`, an inherited template, a stale
+#           commit-graph. It is explicitly NOT a boundary against a hostile
+#           same-UID peer. The evidence line says so on every run, naming #3746,
+#           which already owns "lanes share an object store".
+#
+#           A LATER SAME-UID-PEER INSTANCE IS NOT A NEW DEFECT. It is this
+#           declared boundary, and it belongs to #3746. That is also what #3653
+#           asked for: the issue text says the hostile route is largely closed
+#           elsewhere and that the DEFECT WAS THE CONSTRAINT NOT BEING STATED
+#           WHERE THE GUARD IS READ. Stating it is the fix.
 #
 # USAGE
 #   scripts/flow/premerge-assert.sh <pr-number> <certified-sha> \
@@ -603,7 +619,16 @@ refuse_anchor_unverifiable() {
 # $(pwd) in the no-work-tree diagnostic          | NONE    | n/a (diagnostic text only)
 #                                               |  (b)    |
 # trap install (EXIT/INT/TERM/HUP)               | n/a     | registered BEFORE any resource
-#                                               |         | exists; handlers re-raise
+#                                               |         | exists; handlers re-raise. They
+#                                               |         | REPORT the retained scratch and
+#                                               |         | delete nothing. (This row was
+#                                               |         | FALSE between jobs 388 and 390:
+#                                               |         | the traps had been removed as
+#                                               |         | collateral while the table still
+#                                               |         | claimed them. Reconciled.)
+# the scratch directory itself, between      | n/a     | *** NOT ISOLATED FROM A SAME-UID
+#   `git init` and the walk                     |         | PEER (e) ***. Peer-writable; see
+#                                               |         | the terminus statement.
 # env -i + allowlist (wraps every git call)      | n/a     | ADMIT list is hard-coded, not
 #                                               |         | env-derived; neutralisers last
 # GIT_ALTERNATE_OBJECT_DIRECTORIES value         | n/a     | non-empty checked; C-quoted
@@ -617,6 +642,17 @@ refuse_anchor_unverifiable() {
 #      it only runs on a path that is already refusing.
 # Neither is reachable from the SHARED object store or from TMPDIR, which are the
 # surfaces the bounds exist for. The `anchor-reads:` token names both.
+#
+# AND THE BOUNDARY THIS WHOLE GUARD STOPS AT:
+#  (e) THE SCRATCH NAMESPACE IS TRUSTED, NOT VERIFIED — exactly as the shared
+#      object store is, for the same reason and with the same owner (#3746). A
+#      same-UID peer can drop `.git/info/grafts` into OUR scratch, or replace the
+#      `repo` pathname, between `git init` and the walk — reproducing round 1's
+#      graft attack INSIDE the thing built to prevent it. There is no permission
+#      boundary available: every lane on this fleet runs as the SAME USER, so
+#      neither mode nor ownership can admit us and exclude a peer, and the only
+#      alternative is a helper binary, which is not this issue. So the CLAIM is
+#      narrowed instead of the hole patched.
 #
 # AND ONE DECLARED NON-OPERATION:
 #  (c) THE SCRATCH DIRECTORY IS NOT DELETED. A delete through a peer-mutable
@@ -718,10 +754,14 @@ ANCHOR_BOUND_RUNNER=""
 ANCHOR_READS="UNRECORDED"
 
 # THE DECLARED BOUNDARY, in ONE constant consumed by the ONE renderer (job 361,
+# WIDENED at job 390 to name the SCRATCH NAMESPACE as well — see the terminus
+# statement in the header. The two halves have the same cause and the same owner:
+# every lane runs as the same user, so a peer can write both the shared object
+# store and our scratch.
 # following #3746 / job 311's mechanics). It is a CONSTANT and not a computed
 # value on purpose: there is no measurement this script can take that would make
 # it false, so a variable would only invite a future arm to omit it.
-ANCHOR_PROVENANCE="ancestry over this box's SHARED object store: objects+metadata TRUSTED, not verified (#3746)"
+ANCHOR_PROVENANCE="ancestry over this box's SHARED object store and SCRATCH namespace: objects, metadata and scratch TRUSTED, not verified (#3746) — closes accident/drift, NOT a same-UID peer"
 # _anchor_resolve_bound <anchor> <certified> — REFUSES when there is no supported
 # runner (see the reversal in the header). The two shas are taken only so the
 # refusal can name them, exactly like every other UNVERIFIABLE cause.
@@ -818,16 +858,9 @@ _anchor_timed_out() {
 _anchor_lane() { _anchor_run "$@"; }
 
 # --- THE ISOLATED SCRATCH REPOSITORY (roborev job 355) ----------------------
-# CLEANUP IS REGISTERED BEFORE THE RESOURCE EXISTS. CLAUDE.md's recurring lesson
-# in this family (roborev job 282) is exactly that ordering, plus: a fix that
-# ADDS a resource inherits that resource's lifetime bugs. So the variable is
+# REGISTRATION PRECEDES THE RESOURCE (CLAUDE.md job 282): the variable is
 # declared and the traps installed HERE, above any `mktemp`, and the handler is
-# empty-safe (`rm -rf ""` would delete nothing but is still a bug worth not
-# writing). Signals get handlers because bash runs NO EXIT trap for a signal left
-# at its default disposition; each re-raises after cleaning up, so the process
-# still dies of the signal it was sent. This script installs no other traps (it
-# had none before this change), so there is no caller disposition to save.
-ANCHOR_SCRATCH=""
+# empty-safe. Nothing here deletes — see below — so the handler only ever REPORTS.
 # THE SCRATCH IS DELIBERATELY NOT DELETED (roborev job 388). Three consecutive
 # rounds narrowed this one recursive delete — bounded it, validated its target,
 # then closed a symlink TOCTOU — and each fix could only SHRINK the check-to-use
@@ -857,6 +890,23 @@ ANCHOR_SCRATCH=""
 # device+inode identity probe — whose own measured limits (ext4 REUSES a
 # just-freed inode, so a same-path recreate was invisible; and no portable `stat`
 # format exists) were the clearest sign this was being narrowed, not solved.
+ANCHOR_SCRATCH=""
+
+# _anchor_cleanup — REPORTS the retained scratch path. It deletes nothing (see
+# above); its whole job is to make sure an operator learns where the directory
+# went, on EVERY post-creation exit path.
+#
+# THE TRAPS WERE DOCUMENTED IN THE AUDIT TABLE AND DID NOT EXIST (roborev job 390,
+# finding 3). They were removed as collateral by a span-replacing edit when the
+# delete came out, leaving ONE call on the success path — so every refusal, and
+# every signal, retained a scratch directory with NONE of the promised notice
+# while the table still claimed the traps were installed. A false claim in a
+# declared artifact is worse than a missing one, which is this issue in one line.
+#
+# Restored NON-DELETING: registered before any resource exists (job 282), signals
+# included because bash runs no EXIT trap for a signal at its default disposition,
+# each re-raising so the process still dies of what it was sent. There is nothing
+# to race here — reporting a path cannot delete anything.
 _anchor_cleanup() {
   [ -n "$ANCHOR_SCRATCH" ] || return 0
   printf 'PREMERGE: NOTE scratch dir left in place (NOT deleted): %s\n' "$ANCHOR_SCRATCH" >&2
@@ -867,6 +917,10 @@ _anchor_cleanup() {
   ANCHOR_SCRATCH=""
   return 0
 }
+trap '_anchor_cleanup' EXIT
+trap '_anchor_cleanup; trap - INT;  kill -INT  $$' INT
+trap '_anchor_cleanup; trap - TERM; kill -TERM $$' TERM
+trap '_anchor_cleanup; trap - HUP;  kill -HUP  $$' HUP
 
 # _anchor_canon <dir> — canonicalize with `cd`+`pwd -P`, EMPTY on failure. The
 # convention scripts/flow/base-staleness.sh uses (no `realpath` dependency), and

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -332,9 +332,13 @@ refuse_tool_failure() {
 #   * `GIT_NO_LAZY_FETCH=1` — in a PARTIAL/PROMISOR clone a plain OBJECT READ
 #     fetches over the network and WRITES packfiles, so "this is an offline
 #     check" would be an intention rather than a property. A missing object then
-#     fails its git call, which routes here to UNVERIFIABLE — the correct verdict
-#     for an unmeasurable read. Honoured only from git 2.36, so like
-#     base-staleness.sh this is a DECLARED precondition, not a detected one.
+#     fails the ANCESTRY call (`merge-base`), which routes here to UNVERIFIABLE —
+#     the correct verdict for an unmeasurable read. **NOT every git call behaves
+#     that way, and `cat-file -e` measurably does not** — see the presence-probe
+#     note in assert_anchor_on_history, which is why the probe there is a
+#     diagnostic refinement and not the soundness boundary. Honoured only from
+#     git 2.36, so like base-staleness.sh this is a DECLARED precondition, not a
+#     detected one.
 #   * `GIT_NO_REPLACE_OBJECTS=1`, plus `--no-replace-objects` on every call — one
 #     local `refs/replace/*` entry rewrites the ancestry `merge-base` walks, i.e.
 #     it can make a foreign anchor LOOK like an ancestor. Honoured by every git
@@ -402,9 +406,21 @@ assert_anchor_on_history() {
       "history the anchor must lie on is the CURRENT DIRECTORY's, and there is" \
       "deliberately no env override naming a different one (#3312)."
   fi
-  # Presence is probed per object so the diagnostic can name WHICH one is absent
-  # — the two have different remedies in practice (an anchor from a rebased-away
-  # branch vs a certified head that was never fetched).
+  # THE PRESENCE PROBE IS A DIAGNOSTIC REFINEMENT, NOT THE SOUNDNESS BOUNDARY.
+  # It exists to name WHICH object is absent, because the two have different
+  # remedies in practice (an anchor from a rebased-away branch vs a certified
+  # head that was never fetched). It is NOT what makes the check sound, and it
+  # cannot be: CLAUDE.md records, as a MEASUREMENT rather than a theory (see
+  # "cat-file -e cannot even probe presence" in the #3544 job-268 paragraph),
+  # that with `GIT_NO_LAZY_FETCH=1` set `cat-file -e` answered 0 for an object
+  # whose `show` then FAILED — it answers about PROMISED objects. So in a
+  # partial/promisor clone BOTH probes below can say "present" for an object
+  # that is not there.
+  # WHAT STILL HOLDS, and why the design fails closed anyway: `merge-base` cannot
+  # SUCCEED on an object that is not really available, so it exits >= 2 (or, at
+  # worst, 1 in a repository this check then refuses to call complete) and the
+  # verdict is UNVERIFIABLE either way. A false "present" here therefore costs a
+  # less specific diagnostic, never a pass.
   if ! git --no-replace-objects cat-file -e "$anchor^{commit}" >/dev/null 2>&1; then
     refuse_anchor_unverifiable "$anchor" "$head" \
       "the ANCHOR commit is not present in this repository" \

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -623,6 +623,15 @@ refuse_anchor_unverifiable() {
 # DELETED as redundant with it rather than bounded; `rm -rf` became RUNNER-bounded
 # and target-revalidated; and the `anchor-reads:` token was corrected twice — once
 # for overclaiming, once for UNDERclaiming after these fixes.
+#
+# AND WHAT THE NEXT ROUND CHANGED, kept in the same honest register (job 387): the
+# cleanup's revalidation had a TOCTOU the audit did not see — it canonicalised
+# first and deleted the RESOLVED path, so a symlink to another `premerge-anchor.*`
+# child passed validation and redirected the recursive delete at that directory,
+# plausibly a concurrent lane's scratch. This is a REFINEMENT of a row the audit
+# correctly LISTED and had just hardened, not a row it missed. The fix deletes the
+# RECORDED path with `rm -rf --`, requires it to canonicalise TO ITSELF, and adds
+# the device+inode identity above with its measured limits.
 
 # --- THE ISOLATED HOP'S ENVIRONMENT (roborev job 358) -----------------------
 # See the header for the two measured routes and the ADMIT/CLEAR line. Built
@@ -804,6 +813,32 @@ ANCHOR_SCRATCH=""
 # make cleanup delete anything.
 ANCHOR_SCRATCH_ROOT=""
 ANCHOR_SCRATCH_PREFIX="premerge-anchor."
+# The created directory's IDENTITY (device + inode), recorded at create time and
+# re-verified immediately before the delete (roborev job 387). Empty when no
+# usable `stat` form exists on this box, which is a DECLARED conditional gap in
+# the audit table rather than a silent one.
+ANCHOR_SCRATCH_ID=""
+
+# _anchor_dir_id <dir> — "<dev> <inode>", or EMPTY when it cannot be established.
+#
+# THE PROBE VALIDATES THE OUTPUT SHAPE, NOT JUST THE EXIT CODE, and that is not
+# defensiveness — it is measured. GNU `stat -f` is a FILESYSTEM query, not BSD's
+# format flag: on GNU coreutils `stat -f '%d %i' <dir>` EXITS 0 and prints
+# multi-line filesystem information. A fallback keyed on the exit code alone would
+# accept that as an "identity", and comparing it later would be a check that
+# passes on noise. So each candidate form must produce exactly digits-and-a-space.
+_anchor_dir_id() {
+  local out
+  [ -n "$1" ] || return 0
+  for _fmt in -c -f; do
+    out=$(_anchor_bounded stat "$_fmt" '%d %i' -- "$1" 2>/dev/null) || out=""
+    case "$out" in
+      ''|*[!0-9\ ]*) continue ;;
+      *' '*) printf '%s\n' "$out"; return 0 ;;
+    esac
+  done
+  return 0
+}
 
 # _anchor_cleanup — remove the scratch dir. BOUNDED, and its TARGET REVALIDATED
 # immediately before the delete (roborev job 384; both findings were here).
@@ -836,16 +871,44 @@ _anchor_cleanup() {
       "$target" >&2
     return 0
   fi
+  # THE RECORDED PATH IS DELETED, NEVER THE RESOLVED ONE (roborev job 387). The
+  # previous version canonicalised first and deleted `$canon`, so replacing the
+  # scratch with a SYMLINK to another `premerge-anchor.*` direct child passed every
+  # validation and the recursive delete landed on THAT directory — plausibly a
+  # concurrent lane's scratch, which is the cross-lane damage class this fleet
+  # cares about most. The planter is a peer lane on the shared box.
+  #
+  # THE ASYMMETRY THAT MAKES THIS SIMPLE, measured rather than assumed:
+  #   rm -rf -- <symlink-to-dir>   removes the LINK; the target survives intact
+  #   rm -rf -- "$(canon <link>)"  removes the TARGET
+  # So the whole bug was resolving first. `--` and no trailing slash matter: a
+  # trailing slash would make `rm` follow the link.
   canon=$(_anchor_canon "$target")
-  base="${canon##*/}"
-  if [ -z "$canon" ] || [ "$canon" = "/" ] ||
-     [ "$canon" != "$root/$base" ] ||
+  base="${target##*/}"
+  # SELF-CANONICALISING: a symlink resolves ELSEWHERE and a moved directory
+  # resolves to its new place, so requiring canon == the recorded path detects
+  # both, rather than merely declining to follow them.
+  if [ -z "$canon" ] || [ "$canon" = "/" ] || [ "$canon" != "$target" ] ||
+     [ "$target" != "$root/$base" ] ||
      [ "$base" = "${base#"$ANCHOR_SCRATCH_PREFIX"}" ]; then
-    printf 'PREMERGE: NOTE scratch dir %s left in place: it is no longer a %s* direct child of %s\n' \
+    printf 'PREMERGE: NOTE scratch dir %s left in place: it no longer canonicalises to itself as a %s* direct child of %s\n' \
       "$target" "$ANCHOR_SCRATCH_PREFIX" "$root" >&2
     return 0
   fi
-  _anchor_bounded rm -rf "$canon" >/dev/null 2>&1 || true
+  # IDENTITY, so a swap is DETECTED and not merely not-followed. Only enforced when
+  # an identity was established at create time; when it was not (no usable `stat`
+  # form) the path checks above stand alone — declared in the audit table.
+  if [ -n "$ANCHOR_SCRATCH_ID" ]; then
+    if [ "$(_anchor_dir_id "$target")" != "$ANCHOR_SCRATCH_ID" ]; then
+      printf 'PREMERGE: NOTE scratch dir %s left in place: its device+inode identity changed or could not be re-read (recorded %s)\n' \
+        "$target" "$ANCHOR_SCRATCH_ID" >&2
+      return 0
+    fi
+  fi
+  # An undeleted scratch dir under TMPDIR is a LEAK; deleting the wrong directory
+  # is DAMAGE. Those are not comparable costs, which is why every branch above
+  # leaves it in place and says so.
+  _anchor_bounded rm -rf -- "$target" >/dev/null 2>&1 || true
   return 0
 }
 trap '_anchor_cleanup' EXIT
@@ -973,6 +1036,7 @@ _anchor_build_scratch() {
   # revalidates against it rather than trusting this moment.
   ANCHOR_SCRATCH="$created_canon"
   ANCHOR_SCRATCH_ROOT="$tmp_canon"
+  ANCHOR_SCRATCH_ID=$(_anchor_dir_id "$created_canon")
 
   # THE LANE'S OBJECT DIRECTORY, resolved rather than assumed — and this is the
   # ONE read that still happens in the live repository, mirroring the reference

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -542,6 +542,88 @@ refuse_anchor_unverifiable() {
   exit 3
 }
 
+# ===========================================================================
+# ANCHOR-PATH OPERATION AUDIT (roborev job 384) — A DECLARED ARTIFACT
+# ===========================================================================
+# WHY THIS EXISTS. Seven shipped-script findings on #3653 — graft, environment,
+# commit-graph, no-runner, discovery status, filesystem probes, and cleanup twice
+# — were all the SAME TWO QUESTIONS asked of a different operation: IS IT BOUNDED,
+# and IS ITS TARGET VALIDATED. Letting a reviewer enumerate those one per round
+# does not converge. So every operation in the anchor path is listed here with
+# both answers, and an operation that is deliberately unbounded or unvalidated
+# SAYS SO WITH ITS REASON.
+#
+# THIS IS A MAINTENANCE OBLIGATION, in the idiom of
+# scripts/tests/workspace-test-disposition.txt: a NEW operation added to this path
+# must join the table, and an omission is then visible in review rather than
+# discovered by a reviewer round. The table records COMPLETENESS AND LABELLING,
+# not truth — nothing mechanically enforces it, exactly as #1716 ruled for the
+# tools/ disposition list.
+#
+# LEGEND  bound:  RUNNER = through _anchor_bounded (timeout + --kill-after)
+#                 SELF   = bounded by its own construction
+#                 NONE   = unbounded, with the reason stated
+#         target: what the operation's inputs/targets are checked against
+#
+# ---------------------------------------------------------------------------
+# OPERATION                                    | BOUND   | TARGET / INPUT VALIDATION
+# ---------------------------------------------------------------------------
+# resolve_advisory_timeout: command -v          | NONE    | closed hard-coded candidate
+#   (PATH lookup for timeout/gtimeout)          |  (a)    | set {timeout,gtimeout}
+# resolve_advisory_timeout: <cand> --kill-after | SELF    | capability PROBED, not assumed;
+#   =1 1 true  (the capability probe)           | (1s)    | a rejecting cand is discarded
+# command -v git                                | NONE    | n/a (presence only); absence is
+#                                               |  (a)    | its own UNVERIFIABLE refusal
+# rev-parse --git-dir       (work-tree probe)   | RUNNER  | cwd's repo, no env override;
+#                                               |         | rc three-valued, 124/137 routed
+# rev-parse --show-toplevel                     | RUNNER  | rc inspected; empty => refuse
+# rev-parse --git-common-dir                    | RUNNER  | rc inspected; empty => refuse
+# rev-parse --git-path objects                  | RUNNER  | rc inspected; non-empty, made
+#                                               |         | absolute, canonicalised
+# rev-parse --is-shallow-repository              | RUNNER  | must equal the literal `false`;
+#                                               |         | anything else => UNVERIFIABLE
+# _anchor_canon  (sh -c 'cd -- "$1" && pwd -P') | RUNNER  | empty input refused; empty output
+#   x4: toplevel, common-dir, TMPDIR, created   |         | treated as could-not-measure
+# TMPDIR read                                    | n/a     | canonicalised, then proven
+#                                               |         | OUTSIDE work tree AND git dir
+# mktemp -d <tmp_canon>/premerge-anchor.XXXXXX   | RUNNER  | result: non-empty, canonical,
+#                                               |         | outside repo, DIRECT child of
+#                                               |         | tmp_canon, prefix-matched
+# git init -q --template=  (scratch repo)       | RUNNER  | target is the validated scratch
+#                                               |         | path; empty template forced
+# cat-file -e <anchor>^{commit}   (in scratch)  | RUNNER  | input is a validated 40-hex sha
+# cat-file -e <certified>^{commit} (in scratch) | RUNNER  | input is a validated 40-hex sha
+# merge-base --is-ancestor <a> <b> (in scratch) | RUNNER  | validated 40-hex shas; rc
+#                                               |         | three-valued (0/1/>=2)
+# rm -rf <scratch>          (_anchor_cleanup)   | RUNNER  | REVALIDATED at delete time:
+#                                               |         | canonical, not `/`, DIRECT child
+#                                               |         | of the persisted root, prefix
+#                                               |         | matched; else LEFT IN PLACE
+# $(pwd) in the no-work-tree diagnostic          | NONE    | n/a (diagnostic text only)
+#                                               |  (b)    |
+# trap install (EXIT/INT/TERM/HUP)               | n/a     | registered BEFORE any resource
+#                                               |         | exists; handlers re-raise
+# env -i + allowlist (wraps every git call)      | n/a     | ADMIT list is hard-coded, not
+#                                               |         | env-derived; neutralisers last
+# GIT_ALTERNATE_OBJECT_DIRECTORIES value         | n/a     | non-empty checked; C-quoted
+# ---------------------------------------------------------------------------
+#
+# THE TWO DECLARED GAPS, both `NONE`, both shell builtins over LOCAL state:
+#  (a) `command -v` stats PATH directories. Unboundable (a builtin), and no user
+#      or repository data reaches it — PATH comes from the invoking environment.
+#      A stalled directory ON PATH would hang it. Accepted, not fixed.
+#  (b) `$(pwd)` in one refusal message reads the shell's own cwd. Same class, and
+#      it only runs on a path that is already refusing.
+# Neither is reachable from the SHARED object store or from TMPDIR, which are the
+# surfaces the bounds exist for. The `anchor-reads:` token names both.
+#
+# WHAT THE AUDIT CHANGED, so the table is not read as a description of what was
+# already there: `_anchor_canon` became RUNNER-bounded (it was the FIRST filesystem
+# touch in the path and was unbounded); the two `[ -d … ]` builtin stats were
+# DELETED as redundant with it rather than bounded; `rm -rf` became RUNNER-bounded
+# and target-revalidated; and the `anchor-reads:` token was corrected twice — once
+# for overclaiming, once for UNDERclaiming after these fixes.
+
 # --- THE ISOLATED HOP'S ENVIRONMENT (roborev job 358) -----------------------
 # See the header for the two measured routes and the ADMIT/CLEAR line. Built
 # once, used by every git call below — lane discovery included.
@@ -616,16 +698,17 @@ _anchor_resolve_bound() {
   local anchor="$1" head="$2" name
   if name=$(resolve_advisory_timeout) && ANCHOR_BOUND_RUNNER=$(command -v "$name" 2>/dev/null) &&
      [ -n "$ANCHOR_BOUND_RUNNER" ]; then
-    # THE TOKEN NAMES EXACTLY WHAT IS BOUNDED (roborev job 382). It used to read a
-    # bare `bounded-<n>s+<g>s`, which claimed more than is true: `_anchor_canon`
-    # (`cd` + `pwd -P`) and the `[ -d "$lane_objects" ]` probe are SHELL BUILTINS,
-    # so there is no process to bound and a stalled mount can still hang them. A
-    # guard that says "bounded" while a filesystem probe can hang is the overclaim
-    # shape this issue has spent every round removing, and the standing rule is
-    # that a check claiming nothing false beats one claiming a closure it does not
-    # deliver. So the token says: the EXTERNAL commands are bounded, the builtin
-    # filesystem probes are not.
-    ANCHOR_READS="bounded-${ADVISORY_TIMEOUT_SECS}s+${ADVISORY_KILL_GRACE}s(external:git,mktemp;UNBOUNDED:cd/test-builtins)"
+    # THE TOKEN NAMES EXACTLY WHAT IS BOUNDED (job 382), AND IT WAS CORRECTED AGAIN
+    # BY THE job-384 AUDIT — in the UNDERSTATING direction this time, which is the
+    # same defect wearing modest clothes. It first read a bare `bounded-<n>s+<g>s`
+    # (an overclaim: builtin filesystem probes could hang). The audit then made
+    # those probes bounded — canonicalisation via `sh -c 'cd … && pwd -P'`, and the
+    # two `[ -d … ]` stats deleted as redundant with it — so the previous token's
+    # `UNBOUNDED:cd/test-builtins` had become FALSE in the other direction.
+    # What remains genuinely unbounded is named instead: `command -v` PATH lookups
+    # and the single `$(pwd)` in the no-work-tree diagnostic, both shell builtins
+    # over local state. Full per-operation record: the AUDIT TABLE in the header.
+    ANCHOR_READS="bounded-${ADVISORY_TIMEOUT_SECS}s+${ADVISORY_KILL_GRACE}s(external:git,mktemp,sh,rm;UNBOUNDED:command-v+pwd-builtins)"
     return 0
   fi
   ANCHOR_BOUND_RUNNER=""
@@ -714,10 +797,56 @@ _anchor_lane() { _anchor_run "$@"; }
 # still dies of the signal it was sent. This script installs no other traps (it
 # had none before this change), so there is no caller disposition to save.
 ANCHOR_SCRATCH=""
+# PERSISTED FOR CLEANUP (roborev job 384): the canonical scratch ROOT the create
+# was validated against, and the basename prefix `mktemp` was given. Cleanup
+# revalidates against BOTH immediately before the recursive delete — see
+# `_anchor_cleanup`. Empty until the create validates, so an early signal cannot
+# make cleanup delete anything.
+ANCHOR_SCRATCH_ROOT=""
+ANCHOR_SCRATCH_PREFIX="premerge-anchor."
+
+# _anchor_cleanup — remove the scratch dir. BOUNDED, and its TARGET REVALIDATED
+# immediately before the delete (roborev job 384; both findings were here).
+#
+#  1. BOUNDED. `rm -rf` on a stalled scratch filesystem would hang a SUCCESSFUL
+#     check, a timeout refusal, AND a signal handler — defeating the bounded-exit
+#     behaviour the rest of this path was built for. It runs through the resolved
+#     runner when there is one. When there is not, it runs unbounded: cleanup is
+#     the LAST thing this script does, so an unbounded delete there cannot delay a
+#     verdict that has not been emitted yet, and Case B refuses long before this
+#     point without a runner anyway.
+#  2. TARGET REVALIDATED. It used to delete whatever path `mktemp` emitted,
+#     without confirming that path is still an expected direct child of the
+#     canonical root — so a path-replacement race, or a faulty shim, redirects a
+#     RECURSIVE DELETE somewhere else. This is the one operation in this file that
+#     can damage something outside its own scratch, so it gets the care regardless
+#     of severity: the value must be canonically a DIRECT child of the persisted
+#     root AND carry the expected basename prefix, checked HERE and not merely at
+#     create time. A check at create time answers about the path as it was then.
+#
+# Anything that fails revalidation is LEFT IN PLACE and reported to stderr rather
+# than deleted: a scratch dir the OS will reap is a far smaller problem than an
+# `rm -rf` aimed at an unverified path.
 _anchor_cleanup() {
-  [ -n "$ANCHOR_SCRATCH" ] || return 0
-  rm -rf "$ANCHOR_SCRATCH" 2>/dev/null || true
+  local target="$ANCHOR_SCRATCH" root="$ANCHOR_SCRATCH_ROOT" canon base
   ANCHOR_SCRATCH=""
+  [ -n "$target" ] || return 0
+  if [ -z "$root" ]; then
+    printf 'PREMERGE: NOTE scratch dir %s left in place: no validated scratch root recorded\n' \
+      "$target" >&2
+    return 0
+  fi
+  canon=$(_anchor_canon "$target")
+  base="${canon##*/}"
+  if [ -z "$canon" ] || [ "$canon" = "/" ] ||
+     [ "$canon" != "$root/$base" ] ||
+     [ "$base" = "${base#"$ANCHOR_SCRATCH_PREFIX"}" ]; then
+    printf 'PREMERGE: NOTE scratch dir %s left in place: it is no longer a %s* direct child of %s\n' \
+      "$target" "$ANCHOR_SCRATCH_PREFIX" "$root" >&2
+    return 0
+  fi
+  _anchor_bounded rm -rf "$canon" >/dev/null 2>&1 || true
+  return 0
 }
 trap '_anchor_cleanup' EXIT
 trap '_anchor_cleanup; trap - INT;  kill -INT  $$' INT
@@ -738,9 +867,19 @@ trap '_anchor_cleanup; trap - HUP;  kill -HUP  $$' HUP
 # FALSE PASS, not merely a wrong remedy. The timeout propagation above closes the
 # timeout route; this line closes the ordinary-git-failure route, which no status
 # check can, because there the value really is empty.
+# BOUNDED SINCE THE job-384 AUDIT, and it is the operation that most needed it:
+# canonicalising `TMPDIR` is the FIRST filesystem touch in this path, before any
+# git call, so a stalled mount there hung the guard with nothing to stop it. `cd`
+# and `pwd` are builtins with no process to bound — but `sh -c 'cd … && pwd -P'`
+# is an EXTERNAL command, so it goes through the existing runner. Verified to
+# agree with the builtin form, symlinked input included.
+#
+# A timeout, a missing/unreadable path and an absent `sh` all yield EMPTY, which
+# every caller already treats as "could not measure" and refuses on. That is the
+# fail-closed direction, and it is why this does not need its own timeout arm.
 _anchor_canon() {
   [ -n "$1" ] || return 0
-  (cd "$1" 2>/dev/null && pwd -P) || true
+  _anchor_bounded sh -c 'cd -- "$1" && pwd -P' sh "$1" 2>/dev/null || true
 }
 
 # _anchor_build_scratch — on success sets ANCHOR_SCRATCH (the mktemp dir),
@@ -753,6 +892,7 @@ ANCHOR_SCRATCH_ERR=""
 _anchor_build_scratch() {
   local anchor="$1" head="$2"
   local lane_objects repo_canon common_canon tmp_req tmp_canon created_canon alt_q
+  local created_base
   local rc toplevel commondir
 
   # THE SCRATCH MUST BE PROVABLY OUTSIDE THE REPOSITORY, and "the repository" is
@@ -801,7 +941,10 @@ _anchor_build_scratch() {
   if _anchor_timed_out "$rc"; then
     _anchor_refuse_timeout "$anchor" "$head" "creating the scratch directory (mktemp -d)"
   fi
-  if [ "$rc" -ne 0 ] || [ -z "$ANCHOR_SCRATCH" ] || [ ! -d "$ANCHOR_SCRATCH" ]; then
+  # No `[ -d … ]` stat here: `_anchor_canon` below is BOUNDED and returns empty
+  # unless the path is a directory this process can `cd` into, which is a strictly
+  # stronger check than an unbounded builtin stat (job-384 audit).
+  if [ "$rc" -ne 0 ] || [ -z "$ANCHOR_SCRATCH" ]; then
     ANCHOR_SCRATCH=""
     ANCHOR_SCRATCH_ERR="could not create a scratch directory under $tmp_canon"
     return 1
@@ -816,6 +959,20 @@ _anchor_build_scratch() {
       ANCHOR_SCRATCH_ERR="the CREATED scratch directory $created_canon resolves INSIDE the repository — the root resolved into the checkout between the pre-check and the create"
       return 1 ;;
   esac
+  # THE CREATED PATH MUST BE AN EXPECTED DIRECT CHILD OF THE ROOT IT WAS VALIDATED
+  # AGAINST (job 384). `mktemp` was given `$tmp_canon/premerge-anchor.XXXXXX`, so
+  # anything else means the value did not come from that template — and cleanup
+  # would later aim a recursive delete at it.
+  created_base="${created_canon##*/}"
+  if [ "$created_canon" != "$tmp_canon/$created_base" ] ||
+     [ "$created_base" = "${created_base#"$ANCHOR_SCRATCH_PREFIX"}" ]; then
+    ANCHOR_SCRATCH_ERR="the created scratch directory $created_canon is not a ${ANCHOR_SCRATCH_PREFIX}* DIRECT child of $tmp_canon, so it did not come from the mktemp template this run asked for"
+    return 1
+  fi
+  # Recorded only now, i.e. only for a path that passed every check above. Cleanup
+  # revalidates against it rather than trusting this moment.
+  ANCHOR_SCRATCH="$created_canon"
+  ANCHOR_SCRATCH_ROOT="$tmp_canon"
 
   # THE LANE'S OBJECT DIRECTORY, resolved rather than assumed — and this is the
   # ONE read that still happens in the live repository, mirroring the reference
@@ -843,8 +1000,11 @@ _anchor_build_scratch() {
     /*) : ;;
     *)  lane_objects="$repo_canon/$lane_objects" ;;
   esac
-  if [ ! -d "$lane_objects" ]; then
-    ANCHOR_SCRATCH_ERR="this repository's object directory ($lane_objects) is not a directory"
+  # BOUNDED, and it keeps its own diagnostic (job 374's lesson: a broken object
+  # directory must not borrow the absent-object remedy). The unbounded builtin
+  # stat this replaces was the last first-touch filesystem probe in the path.
+  if [ -z "$(_anchor_canon "$lane_objects")" ]; then
+    ANCHOR_SCRATCH_ERR="this repository's object directory ($lane_objects) is not a readable directory"
     return 1
   fi
 

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -833,24 +833,45 @@ _anchor_run() {
   _anchor_bounded git "${ANCHOR_GIT_OPTS[@]}" "$@"
 }
 
-# _anchor_refuse_timeout <anchor> <head> <what> — THE ONE timeout refusal, shared
-# by EVERY bounded call (roborev job 374). It exists so a new call site cannot
-# invent a different wording, and so a timeout can never borrow another cause's
+# _anchor_refuse_timeout <anchor> <head> <what> [<subject>] — THE ONE timeout
+# refusal, shared by EVERY bounded call (roborev job 374). One wording, so a new
+# call site cannot invent its own, and so a timeout never borrows another cause's
 # REMEDY: the whole reason this script splits exit 2 from exit 3 is to hand the
-# operator the right action, and "not inside a git work tree" sends someone to
-# check their cwd when the real answer is a stalled filesystem. A misleading
-# diagnostic is worse than a vague one.
+# operator the right ACTION, and "not inside a git work tree" sends someone to
+# check their cwd when the real answer is a stalled filesystem.
+#
+# THE BODY IS NEUTRAL AND NAMES ITS SUBJECT, and that is the job-410 fix: the text
+# used to assert "this is NOT a statement about your cwd, your TMPDIR or your
+# object paths" and send the operator to the OBJECT STORE — while being the shared
+# destination for timeouts that occurred canonicalising TMPDIR, running `mktemp`,
+# or canonicalising the created scratch. So the job-395 change (route all five
+# canonicalisations here) moved the misleading-remedy defect one layer DOWN rather
+# than removing it: third instance of the class, after jobs 374 and 395.
+#
+# A NEUTRAL MESSAGE THAT NAMES THE SUBJECT beats five bespoke strings — it is less
+# to keep correct, and the "keep it correct" part is exactly what failed twice.
+# `<subject>` is the path or store the timed-out operation actually touched; when a
+# caller has none to give, the message says so rather than guessing one.
 _anchor_refuse_timeout() {
+  local subject="${4:-}"
+  # An EMPTY 4th arg must not become a blank indented line in the refusal, so the
+  # subject is passed as a possibly-empty ARRAY rather than an interpolated string.
+  # `${arr[@]+"${arr[@]}"}` is the bash 3.2-safe expansion of a possibly-empty
+  # array under `set -u`.
+  local subj_lines=()
+  [ -n "$subject" ] && subj_lines=("SUBJECT: the timed-out operation was acting on: $subject")
   refuse_anchor_unverifiable "$1" "$2" \
     "$3 timed out after ${ADVISORY_TIMEOUT_SECS}s (+${ADVISORY_KILL_GRACE}s kill grace)" \
-    "The call did not return. These reads touch the SHARED object store and the" \
-    "repository metadata beside it, where a malformed loose object (a FIFO) or a" \
-    "stalled mount stops them; a hang here would leave the merge guard with no" \
-    "verdict at all, which the bound converts into this one." \
-    "This is NOT a statement about your cwd, your TMPDIR or your object paths —" \
-    "those causes have their own wording, and a timeout no longer borrows them." \
-    "REMEDY: check the object store under this repository's objects directory and" \
-    "the mount it lives on, then re-run this assert."
+    "The call did not return. Every bounded operation here touches a filesystem —" \
+    "the SHARED object store, the repository metadata beside it, or TMPDIR where" \
+    "the scratch lives — and a stalled mount or a malformed loose object (a FIFO)" \
+    "stops any of them. A hang would leave the merge guard with NO verdict at all," \
+    "which the bound converts into this one." \
+    ${subj_lines[@]+"${subj_lines[@]}"} \
+    "REMEDY: check that subject and the filesystem it lives on, then re-run this" \
+    "assert. This says nothing about whether your chain is correct (that would be" \
+    "exit 2) and nothing about the OTHER paths this script reads — only the one" \
+    "named above timed out."
 }
 
 # _anchor_timed_out <rc> — TRUE when the runner terminated the call rather than
@@ -1005,12 +1026,14 @@ _anchor_build_scratch() {
   rc=0
   toplevel=$(_anchor_lane rev-parse --show-toplevel 2>/dev/null) || rc=$?
   if _anchor_timed_out "$rc"; then
-    _anchor_refuse_timeout "$anchor" "$head" "the work-tree root probe (rev-parse --show-toplevel)"
+    _anchor_refuse_timeout "$anchor" "$head" "the work-tree root probe (rev-parse --show-toplevel)" \
+      "this checkout (the current working directory's repository)"
   fi
   rc=0
   commondir=$(_anchor_lane rev-parse --git-common-dir 2>/dev/null) || rc=$?
   if _anchor_timed_out "$rc"; then
-    _anchor_refuse_timeout "$anchor" "$head" "the git common-directory probe (rev-parse --git-common-dir)"
+    _anchor_refuse_timeout "$anchor" "$head" "the git common-directory probe (rev-parse --git-common-dir)" \
+      "this checkout (the current working directory's repository)"
   fi
   # A non-timeout failure, or an empty answer, keeps its ORIGINAL cause below:
   # those are real states (an unusable repository) with their own remedy.
@@ -1021,12 +1044,14 @@ _anchor_build_scratch() {
   rc=0
   repo_canon=$(_anchor_canon "$toplevel") || rc=$?
   if _anchor_timed_out "$rc"; then
-    _anchor_refuse_timeout "$anchor" "$head" "canonicalising the work-tree root (cd + pwd -P)"
+    _anchor_refuse_timeout "$anchor" "$head" "canonicalising the work-tree root (cd + pwd -P)" \
+      "$toplevel"
   fi
   rc=0
   common_canon=$(_anchor_canon "$commondir") || rc=$?
   if _anchor_timed_out "$rc"; then
-    _anchor_refuse_timeout "$anchor" "$head" "canonicalising the git common directory (cd + pwd -P)"
+    _anchor_refuse_timeout "$anchor" "$head" "canonicalising the git common directory (cd + pwd -P)" \
+      "$commondir"
   fi
   if [ -z "$repo_canon" ] || [ -z "$common_canon" ]; then
     ANCHOR_SCRATCH_ERR="the work-tree root and/or git common directory could not be resolved, so a scratch location cannot be proven outside them"
@@ -1036,7 +1061,8 @@ _anchor_build_scratch() {
   rc=0
   tmp_canon=$(_anchor_canon "$tmp_req") || rc=$?
   if _anchor_timed_out "$rc"; then
-    _anchor_refuse_timeout "$anchor" "$head" "canonicalising TMPDIR (cd + pwd -P)"
+    _anchor_refuse_timeout "$anchor" "$head" "canonicalising TMPDIR (cd + pwd -P)" \
+      "$tmp_req"
   fi
   if [ -z "$tmp_canon" ]; then
     ANCHOR_SCRATCH_ERR="the scratch root TMPDIR=$tmp_req could not be resolved (absent, unreadable, or not a directory)"
@@ -1052,7 +1078,8 @@ _anchor_build_scratch() {
   rc=0
   ANCHOR_SCRATCH=$(_anchor_bounded mktemp -d "$tmp_canon/premerge-anchor.XXXXXX" 2>/dev/null) || rc=$?
   if _anchor_timed_out "$rc"; then
-    _anchor_refuse_timeout "$anchor" "$head" "creating the scratch directory (mktemp -d)"
+    _anchor_refuse_timeout "$anchor" "$head" "creating the scratch directory (mktemp -d)" \
+      "$tmp_canon"
   fi
   # No `[ -d … ]` stat here: `_anchor_canon` below is BOUNDED and returns empty
   # unless the path is a directory this process can `cd` into, which is a strictly
@@ -1065,7 +1092,8 @@ _anchor_build_scratch() {
   rc=0
   created_canon=$(_anchor_canon "$ANCHOR_SCRATCH") || rc=$?
   if _anchor_timed_out "$rc"; then
-    _anchor_refuse_timeout "$anchor" "$head" "canonicalising the created scratch directory (cd + pwd -P)"
+    _anchor_refuse_timeout "$anchor" "$head" "canonicalising the created scratch directory (cd + pwd -P)" \
+      "$ANCHOR_SCRATCH"
   fi
   if [ -z "$created_canon" ]; then
     ANCHOR_SCRATCH_ERR="the created scratch directory could not be canonicalized"
@@ -1100,7 +1128,8 @@ _anchor_build_scratch() {
   rc=0
   lane_objects=$(_anchor_lane rev-parse --git-path objects 2>/dev/null) || rc=$?
   if _anchor_timed_out "$rc"; then
-    _anchor_refuse_timeout "$anchor" "$head" "the object-directory probe (rev-parse --git-path objects)"
+    _anchor_refuse_timeout "$anchor" "$head" "the object-directory probe (rev-parse --git-path objects)" \
+      "this checkout (the current working directory's repository)"
   fi
   [ "$rc" -eq 0 ] || lane_objects=""
   # MADE ABSOLUTE: `--git-path` answers RELATIVE TO THE WORK-TREE ROOT for a
@@ -1123,7 +1152,8 @@ _anchor_build_scratch() {
   rc=0
   lane_objects_canon=$(_anchor_canon "$lane_objects") || rc=$?
   if _anchor_timed_out "$rc"; then
-    _anchor_refuse_timeout "$anchor" "$head" "canonicalising the object directory (cd + pwd -P)"
+    _anchor_refuse_timeout "$anchor" "$head" "canonicalising the object directory (cd + pwd -P)" \
+      "$lane_objects"
   fi
   if [ -z "$lane_objects_canon" ]; then
     ANCHOR_SCRATCH_ERR="this repository's object directory ($lane_objects) is not a readable directory"
@@ -1142,7 +1172,8 @@ _anchor_build_scratch() {
   rc=0
   _anchor_run init -q --template= "$ANCHOR_SCRATCH_REPO" >/dev/null 2>&1 || rc=$?
   if _anchor_timed_out "$rc"; then
-    _anchor_refuse_timeout "$anchor" "$head" "initialising the isolated scratch repository (git init)"
+    _anchor_refuse_timeout "$anchor" "$head" "initialising the isolated scratch repository (git init)" \
+      "$ANCHOR_SCRATCH_REPO"
   fi
   # THE `[ -d "$ANCHOR_SCRATCH_REPO/.git" ]` CHECK IS DELETED (job 382), not
   # bounded: it was an UNBOUNDED builtin stat, and it was redundant for
@@ -1217,7 +1248,8 @@ assert_anchor_on_history() {
   rc=0
   _anchor_lane rev-parse --git-dir >/dev/null 2>&1 || rc=$?
   if _anchor_timed_out "$rc"; then
-    _anchor_refuse_timeout "$anchor" "$head" "the git work-tree probe (rev-parse --git-dir)"
+    _anchor_refuse_timeout "$anchor" "$head" "the git work-tree probe (rev-parse --git-dir)" \
+      "this checkout (the current working directory's repository)"
   fi
   if [ "$rc" -ne 0 ]; then
     refuse_anchor_unverifiable "$anchor" "$head" \
@@ -1260,7 +1292,8 @@ assert_anchor_on_history() {
   rc=0
   _anchor_git cat-file -e "$anchor^{commit}" >/dev/null 2>&1 || rc=$?
   if _anchor_timed_out "$rc"; then
-    _anchor_refuse_timeout "$anchor" "$head" "reading the ANCHOR object"
+    _anchor_refuse_timeout "$anchor" "$head" "reading the ANCHOR object" \
+      "the SHARED object store, read through the scratch alternate"
   fi
   if [ "$rc" -ne 0 ]; then
     refuse_anchor_unverifiable "$anchor" "$head" \
@@ -1273,7 +1306,8 @@ assert_anchor_on_history() {
   rc=0
   _anchor_git cat-file -e "$head^{commit}" >/dev/null 2>&1 || rc=$?
   if _anchor_timed_out "$rc"; then
-    _anchor_refuse_timeout "$anchor" "$head" "reading the CERTIFIED object"
+    _anchor_refuse_timeout "$anchor" "$head" "reading the CERTIFIED object" \
+      "the SHARED object store, read through the scratch alternate"
   fi
   if [ "$rc" -ne 0 ]; then
     refuse_anchor_unverifiable "$anchor" "$head" \
@@ -1290,7 +1324,8 @@ assert_anchor_on_history() {
     return 0
   fi
   if _anchor_timed_out "$rc"; then
-    _anchor_refuse_timeout "$anchor" "$head" "the ancestry walk"
+    _anchor_refuse_timeout "$anchor" "$head" "the ancestry walk" \
+      "the SHARED object store, read through the scratch alternate"
   fi
   if [ "$rc" -ne 1 ]; then
     refuse_anchor_unverifiable "$anchor" "$head" \
@@ -1319,7 +1354,8 @@ assert_anchor_on_history() {
     # Without this a timeout HERE would be reported as "this repository is not
     # proven complete", i.e. it would borrow the shallow cause's remedy
     # (`git fetch --unshallow`) for a stalled mount (job 374).
-    _anchor_refuse_timeout "$anchor" "$head" "the shallowness probe (rev-parse --is-shallow-repository)"
+    _anchor_refuse_timeout "$anchor" "$head" "the shallowness probe (rev-parse --is-shallow-repository)" \
+      "this checkout (the current working directory's repository)"
   fi
   # A non-timeout failure (an old git that does not know the option) legitimately
   # keeps the "not proven complete" cause below — that IS the unmeasured state.

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -595,10 +595,11 @@ refuse_anchor_unverifiable() {
 # cat-file -e <certified>^{commit} (in scratch) | RUNNER  | input is a validated 40-hex sha
 # merge-base --is-ancestor <a> <b> (in scratch) | RUNNER  | validated 40-hex shas; rc
 #                                               |         | three-valued (0/1/>=2)
-# rm -rf <scratch>          (_anchor_cleanup)   | RUNNER  | REVALIDATED at delete time:
-#                                               |         | canonical, not `/`, DIRECT child
-#                                               |         | of the persisted root, prefix
-#                                               |         | matched; else LEFT IN PLACE
+# scratch removal          (_anchor_cleanup)    | n/a     | *** NOT PERFORMED (c) ***. The
+#                                               |         | scratch is LEFT IN PLACE and its
+#                                               |         | path reported on stderr, so there
+#                                               |         | is no delete to bound and no
+#                                               |         | delete target to validate.
 # $(pwd) in the no-work-tree diagnostic          | NONE    | n/a (diagnostic text only)
 #                                               |  (b)    |
 # trap install (EXIT/INT/TERM/HUP)               | n/a     | registered BEFORE any resource
@@ -617,6 +618,15 @@ refuse_anchor_unverifiable() {
 # Neither is reachable from the SHARED object store or from TMPDIR, which are the
 # surfaces the bounds exist for. The `anchor-reads:` token names both.
 #
+# AND ONE DECLARED NON-OPERATION:
+#  (c) THE SCRATCH DIRECTORY IS NOT DELETED. A delete through a peer-mutable
+#      pathname cannot be made race-free in shell (`openat`/`unlinkat` do not
+#      exist here), and a permission boundary cannot substitute because every lane
+#      on this fleet runs as the SAME USER. Three rounds narrowed the same delete
+#      and each only shrank the window, so it was removed. Cost: one object-less
+#      `git init` under TMPDIR per Case B merge, which the OS reaps. Benefit: no
+#      recursive delete can land on a concurrent lane's directory.
+#
 # WHAT THE AUDIT CHANGED, so the table is not read as a description of what was
 # already there: `_anchor_canon` became RUNNER-bounded (it was the FIRST filesystem
 # touch in the path and was unbounded); the two `[ -d … ]` builtin stats were
@@ -624,7 +634,19 @@ refuse_anchor_unverifiable() {
 # and target-revalidated; and the `anchor-reads:` token was corrected twice — once
 # for overclaiming, once for UNDERclaiming after these fixes.
 #
-# AND WHAT THE NEXT ROUND CHANGED, kept in the same honest register (job 387): the
+# AND WHAT THE LATEST ROUND CHANGED (job 388), a MATERIAL change to what this
+# table claims: the `rm -rf` row is now a DECLARED NON-DELETION, and the identity
+# probe plus the whole delete-time revalidation are GONE with it. The
+# `anchor-reads:` token lost `rm` from its bounded externals — its third
+# correction, and the first caused by REMOVING an operation rather than by
+# mis-describing one.
+#   HONEST NOTE ON THE PREVIOUS ROUND: job 387's intended table update never
+#   landed. The edit script that carried it aborted on a failed assertion before
+#   writing, so the code fix went in while the table kept describing the older
+#   delete, and the round's report claimed otherwise. The table state above is
+#   written from the code as it now stands, not from that report.
+#
+# AND WHAT THE ROUND BEFORE THAT CHANGED (job 387): the
 # cleanup's revalidation had a TOCTOU the audit did not see — it canonicalised
 # first and deleted the RESOLVED path, so a symlink to another `premerge-anchor.*`
 # child passed validation and redirected the recursive delete at that directory,
@@ -717,7 +739,7 @@ _anchor_resolve_bound() {
     # What remains genuinely unbounded is named instead: `command -v` PATH lookups
     # and the single `$(pwd)` in the no-work-tree diagnostic, both shell builtins
     # over local state. Full per-operation record: the AUDIT TABLE in the header.
-    ANCHOR_READS="bounded-${ADVISORY_TIMEOUT_SECS}s+${ADVISORY_KILL_GRACE}s(external:git,mktemp,sh,rm;UNBOUNDED:command-v+pwd-builtins)"
+    ANCHOR_READS="bounded-${ADVISORY_TIMEOUT_SECS}s+${ADVISORY_KILL_GRACE}s(external:git,mktemp,sh;UNBOUNDED:command-v+pwd-builtins)"
     return 0
   fi
   ANCHOR_BOUND_RUNNER=""
@@ -806,115 +828,40 @@ _anchor_lane() { _anchor_run "$@"; }
 # still dies of the signal it was sent. This script installs no other traps (it
 # had none before this change), so there is no caller disposition to save.
 ANCHOR_SCRATCH=""
-# PERSISTED FOR CLEANUP (roborev job 384): the canonical scratch ROOT the create
-# was validated against, and the basename prefix `mktemp` was given. Cleanup
-# revalidates against BOTH immediately before the recursive delete — see
-# `_anchor_cleanup`. Empty until the create validates, so an early signal cannot
-# make cleanup delete anything.
-ANCHOR_SCRATCH_ROOT=""
-ANCHOR_SCRATCH_PREFIX="premerge-anchor."
-# The created directory's IDENTITY (device + inode), recorded at create time and
-# re-verified immediately before the delete (roborev job 387). Empty when no
-# usable `stat` form exists on this box, which is a DECLARED conditional gap in
-# the audit table rather than a silent one.
-ANCHOR_SCRATCH_ID=""
-
-# _anchor_dir_id <dir> — "<dev> <inode>", or EMPTY when it cannot be established.
+# THE SCRATCH IS DELIBERATELY NOT DELETED (roborev job 388). Three consecutive
+# rounds narrowed this one recursive delete — bounded it, validated its target,
+# then closed a symlink TOCTOU — and each fix could only SHRINK the check-to-use
+# window. A peer can still replace the path with another real directory after
+# validation and have it recursively deleted.
 #
-# THE PROBE VALIDATES THE OUTPUT SHAPE, NOT JUST THE EXIT CODE, and that is not
-# defensiveness — it is measured. GNU `stat -f` is a FILESYSTEM query, not BSD's
-# format flag: on GNU coreutils `stat -f '%d %i' <dir>` EXITS 0 and prints
-# multi-line filesystem information. A fallback keyed on the exit code alone would
-# accept that as an "identity", and comparing it later would be a check that
-# passes on noise. So each candidate form must produce exactly digits-and-a-space.
-_anchor_dir_id() {
-  local out
-  [ -n "$1" ] || return 0
-  for _fmt in -c -f; do
-    out=$(_anchor_bounded stat "$_fmt" '%d %i' -- "$1" 2>/dev/null) || out=""
-    case "$out" in
-      ''|*[!0-9\ ]*) continue ;;
-      *' '*) printf '%s\n' "$out"; return 0 ;;
-    esac
-  done
-  return 0
-}
-
-# _anchor_cleanup — remove the scratch dir. BOUNDED, and its TARGET REVALIDATED
-# immediately before the delete (roborev job 384; both findings were here).
+# IT IS UNCLOSABLE IN SHELL. Descriptor-relative, no-follow deletion needs
+# `openat`/`unlinkat`; bash has neither, so every delete here goes through a
+# PEER-MUTABLE PATHNAME. A permission boundary cannot substitute either, because
+# EVERY LANE ON THIS FLEET RUNS AS THE SAME USER — there is no mode or ownership
+# that lets this process delete its own scratch while denying a peer the ability
+# to swap it. Removal or nothing, not a tuning problem.
 #
-#  1. BOUNDED. `rm -rf` on a stalled scratch filesystem would hang a SUCCESSFUL
-#     check, a timeout refusal, AND a signal handler — defeating the bounded-exit
-#     behaviour the rest of this path was built for. It runs through the resolved
-#     runner when there is one. When there is not, it runs unbounded: cleanup is
-#     the LAST thing this script does, so an unbounded delete there cannot delay a
-#     verdict that has not been emitted yet, and Case B refuses long before this
-#     point without a runner anyway.
-#  2. TARGET REVALIDATED. It used to delete whatever path `mktemp` emitted,
-#     without confirming that path is still an expected direct child of the
-#     canonical root — so a path-replacement race, or a faulty shim, redirects a
-#     RECURSIVE DELETE somewhere else. This is the one operation in this file that
-#     can damage something outside its own scratch, so it gets the care regardless
-#     of severity: the value must be canonically a DIRECT child of the persisted
-#     root AND carry the expected basename prefix, checked HERE and not merely at
-#     create time. A check at create time answers about the path as it was then.
+# THE TRADE, stated because it is a real cost and not a free win: one small
+# directory per Case B merge is left under TMPDIR — an object-less `git init` on
+# the RARE path (Case B is #1892's post-gate-polish route, not the ordinary
+# merge) — and the OS reaps TMPDIR. Against that: a recursive delete that can land
+# on a concurrent lane's directory. Not comparable, which is the same reasoning
+# that already made every refusing branch leave the directory in place.
 #
-# Anything that fails revalidation is LEFT IN PLACE and reported to stderr rather
-# than deleted: a scratch dir the OS will reap is a far smaller problem than an
-# `rm -rf` aimed at an unverified path.
+# GONE WITH IT: the persisted root, the basename-prefix revalidation, and the
+# device+inode identity probe — whose own measured limits (ext4 REUSES a
+# just-freed inode, so a same-path recreate was invisible; and no portable `stat`
+# format exists) were the clearest sign this was being narrowed, not solved.
 _anchor_cleanup() {
-  local target="$ANCHOR_SCRATCH" root="$ANCHOR_SCRATCH_ROOT" canon base
+  [ -n "$ANCHOR_SCRATCH" ] || return 0
+  printf 'PREMERGE: NOTE scratch dir left in place (NOT deleted): %s\n' "$ANCHOR_SCRATCH" >&2
+  printf 'PREMERGE: NOTE  a delete through a peer-mutable pathname cannot be made race-free in\n' >&2
+  printf 'PREMERGE: NOTE  shell (no openat/unlinkat), and every lane here runs as the same user,\n' >&2
+  printf 'PREMERGE: NOTE  so it was REMOVED rather than narrowed a fourth time (#3653). It is an\n' >&2
+  printf 'PREMERGE: NOTE  object-less git init under TMPDIR; the OS reaps it.\n' >&2
   ANCHOR_SCRATCH=""
-  [ -n "$target" ] || return 0
-  if [ -z "$root" ]; then
-    printf 'PREMERGE: NOTE scratch dir %s left in place: no validated scratch root recorded\n' \
-      "$target" >&2
-    return 0
-  fi
-  # THE RECORDED PATH IS DELETED, NEVER THE RESOLVED ONE (roborev job 387). The
-  # previous version canonicalised first and deleted `$canon`, so replacing the
-  # scratch with a SYMLINK to another `premerge-anchor.*` direct child passed every
-  # validation and the recursive delete landed on THAT directory — plausibly a
-  # concurrent lane's scratch, which is the cross-lane damage class this fleet
-  # cares about most. The planter is a peer lane on the shared box.
-  #
-  # THE ASYMMETRY THAT MAKES THIS SIMPLE, measured rather than assumed:
-  #   rm -rf -- <symlink-to-dir>   removes the LINK; the target survives intact
-  #   rm -rf -- "$(canon <link>)"  removes the TARGET
-  # So the whole bug was resolving first. `--` and no trailing slash matter: a
-  # trailing slash would make `rm` follow the link.
-  canon=$(_anchor_canon "$target")
-  base="${target##*/}"
-  # SELF-CANONICALISING: a symlink resolves ELSEWHERE and a moved directory
-  # resolves to its new place, so requiring canon == the recorded path detects
-  # both, rather than merely declining to follow them.
-  if [ -z "$canon" ] || [ "$canon" = "/" ] || [ "$canon" != "$target" ] ||
-     [ "$target" != "$root/$base" ] ||
-     [ "$base" = "${base#"$ANCHOR_SCRATCH_PREFIX"}" ]; then
-    printf 'PREMERGE: NOTE scratch dir %s left in place: it no longer canonicalises to itself as a %s* direct child of %s\n' \
-      "$target" "$ANCHOR_SCRATCH_PREFIX" "$root" >&2
-    return 0
-  fi
-  # IDENTITY, so a swap is DETECTED and not merely not-followed. Only enforced when
-  # an identity was established at create time; when it was not (no usable `stat`
-  # form) the path checks above stand alone — declared in the audit table.
-  if [ -n "$ANCHOR_SCRATCH_ID" ]; then
-    if [ "$(_anchor_dir_id "$target")" != "$ANCHOR_SCRATCH_ID" ]; then
-      printf 'PREMERGE: NOTE scratch dir %s left in place: its device+inode identity changed or could not be re-read (recorded %s)\n' \
-        "$target" "$ANCHOR_SCRATCH_ID" >&2
-      return 0
-    fi
-  fi
-  # An undeleted scratch dir under TMPDIR is a LEAK; deleting the wrong directory
-  # is DAMAGE. Those are not comparable costs, which is why every branch above
-  # leaves it in place and says so.
-  _anchor_bounded rm -rf -- "$target" >/dev/null 2>&1 || true
   return 0
 }
-trap '_anchor_cleanup' EXIT
-trap '_anchor_cleanup; trap - INT;  kill -INT  $$' INT
-trap '_anchor_cleanup; trap - TERM; kill -TERM $$' TERM
-trap '_anchor_cleanup; trap - HUP;  kill -HUP  $$' HUP
 
 # _anchor_canon <dir> — canonicalize with `cd`+`pwd -P`, EMPTY on failure. The
 # convention scripts/flow/base-staleness.sh uses (no `realpath` dependency), and
@@ -1023,20 +970,17 @@ _anchor_build_scratch() {
       return 1 ;;
   esac
   # THE CREATED PATH MUST BE AN EXPECTED DIRECT CHILD OF THE ROOT IT WAS VALIDATED
-  # AGAINST (job 384). `mktemp` was given `$tmp_canon/premerge-anchor.XXXXXX`, so
-  # anything else means the value did not come from that template — and cleanup
-  # would later aim a recursive delete at it.
+  # AGAINST. `mktemp` was given `$tmp_canon/premerge-anchor.XXXXXX`, so anything
+  # else means the value did not come from that template. This is RETAINED after
+  # the delete was removed (job 388) — it is now validating the directory this run
+  # will `git init` into and expose as an alternate, not a delete target.
   created_base="${created_canon##*/}"
   if [ "$created_canon" != "$tmp_canon/$created_base" ] ||
-     [ "$created_base" = "${created_base#"$ANCHOR_SCRATCH_PREFIX"}" ]; then
-    ANCHOR_SCRATCH_ERR="the created scratch directory $created_canon is not a ${ANCHOR_SCRATCH_PREFIX}* DIRECT child of $tmp_canon, so it did not come from the mktemp template this run asked for"
+     [ "$created_base" = "${created_base#"premerge-anchor."}" ]; then
+    ANCHOR_SCRATCH_ERR="the created scratch directory $created_canon is not a premerge-anchor.* DIRECT child of $tmp_canon, so it did not come from the mktemp template this run asked for"
     return 1
   fi
-  # Recorded only now, i.e. only for a path that passed every check above. Cleanup
-  # revalidates against it rather than trusting this moment.
   ANCHOR_SCRATCH="$created_canon"
-  ANCHOR_SCRATCH_ROOT="$tmp_canon"
-  ANCHOR_SCRATCH_ID=$(_anchor_dir_id "$created_canon")
 
   # THE LANE'S OBJECT DIRECTORY, resolved rather than assumed — and this is the
   # ONE read that still happens in the live repository, mirroring the reference

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -159,12 +159,17 @@
 #     local branch could hold commits that were never pushed, and no `gh` call
 #     here reads the PR's commit list. The `commit:`/`tree-start:` binding plus
 #     the head compare are what tie the whole chain to the sha GitHub will merge.
-#     (b) A MANIPULATED LOCAL OBJECT STORE or a `refs/replace/*` entry could make
-#     a foreign anchor look like an ancestor — INVOKER-CLASS and out of model by
-#     residual 2, and narrowed anyway by the two git pins at the check
-#     (`GIT_NO_REPLACE_OBJECTS=1` + `--no-replace-objects`), which close the
-#     replacement-ref route because it also fires BY ACCIDENT (a `git replace`
-#     left behind by an unrelated debugging session).
+#     (b) REPOSITORY STATE THAT REWRITES ANCESTRY is closed by CONSTRUCTION, not
+#     by the threat model: the walk runs in an isolated scratch repository whose
+#     only view of this lane is `GIT_ALTERNATE_OBJECT_DIRECTORIES` (roborev job
+#     355), so `$GIT_DIR/info/grafts` and `refs/replace/*` — both of which are
+#     PEER-WRITABLE here, since every lane is a worktree of one shared `.git`,
+#     and both of which also fire BY ACCIDENT as leftovers of an unrelated
+#     debugging session — cannot reach it. The two git pins stay as belt. What
+#     remains INVOKER-CLASS and out of model by residual 2 is planting forged
+#     OBJECTS in the shared store: objects are content-addressed, so that means
+#     defeating sha collision resistance or replacing the store wholesale, and
+#     the shared-store trust boundary is #3746's subject, not this check's.
 #
 # USAGE
 #   scripts/flow/premerge-assert.sh <pr-number> <certified-sha> \
@@ -343,17 +348,51 @@ refuse_tool_failure() {
 #     local `refs/replace/*` entry rewrites the ancestry `merge-base` walks, i.e.
 #     it can make a foreign anchor LOOK like an ancestor. Honoured by every git
 #     that has replacement refs at all, so it needs no version measurement.
-# Neither is settable by the caller, and the repository read is the CURRENT
-# WORKING DIRECTORY's, with no env override (#3312: the constrained party must
-# not choose its own enforcer, and "which repository decides whether my anchor is
-# on this PR" is exactly what a lane wanting to skip a re-cert would redirect).
+# Neither is settable by the caller (#3312: the constrained party must not choose
+# its own enforcer, and "which repository decides whether my anchor is on this
+# PR" is exactly what a lane wanting to skip a re-cert would redirect).
 #
-# THESE READS ARE DELIBERATELY **NOT** WRAPPED IN `env -i` + an allowlist, unlike
-# scripts/agent-gate.sh's component-set pre-flight. That wrapper exists where a
-# git call can REACH A REMOTE and the answer's provenance is a fetch. Here every
-# read is lane-local and addressed BY A SHA, and everything addressed by a sha is
-# CONTENT-ADDRESSED — so there is nothing an environment can bend that the two
-# pins above do not already cover. Do not "fix" this by adding one.
+# BUT THE PINS ARE NOT ENOUGH, AND THE WALK DOES NOT RUN IN THE LANE AT ALL
+# (roborev job 355, High — the fix mirrors scripts/agent-gate.sh's component-set
+# pre-flight rather than inventing anything). `$GIT_DIR/info/grafts` rewrites
+# parentage and **`--no-replace-objects` does NOT disable it**: CLAUDE.md records
+# the measurement under "A SYMLINK IS A BLOB, AND A GRAFT OUTLIVES
+# `--no-replace-objects`" (roborev job 285, on #3544) — `no -> YES -> YES` across
+# before-graft / plain / `--no-replace-objects`, i.e. the graft wins in all three.
+# Re-measured for THIS check on git 2.43.0 with the same result. So a graft alone
+# turns a FOREIGN anchor into `BOUND`, recreating the exact false acceptance this
+# binding exists to refuse. It is IN MODEL on BOTH halves of the triage rule:
+# every lane on this fleet is a worktree of ONE shared `.git` and grafts live in
+# the COMMON git dir, so the planter is a PEER LANE (a non-invoker route) — and a
+# leftover debugging graft is the accident route.
+#
+# When agent-gate.sh hit this in the same place — an ancestry walk reading the
+# live repository — the ruling was to MOVE THE WALK, not to flag the graft. Same
+# here: the object reads AND the `merge-base --is-ancestor` walk run inside a
+# throwaway scratch repository (`git init` under TMPDIR), with the LANE's object
+# directory exposed only through `GIT_ALTERNATE_OBJECT_DIRECTORIES`. An alternate
+# is PURE OBJECT STORAGE: it carries no config and no `$GIT_DIR`, hence no
+# grafts, no replace refs, no promisor, no `insteadOf`, and nothing a remote
+# helper could be invoked from. Objects are CONTENT-ADDRESSED, so a read BY SHA
+# there is exactly as trustworthy as one in the lane. Failing to build the
+# scratch is UNVERIFIABLE — never a fall-back to the live repository, which would
+# silently restore the hole.
+#   Measured, this fixture, git 2.43.0: with a graft making the foreign anchor a
+#   parent of the certified head, `merge-base --is-ancestor` in the lane answers
+#   0 (attack works) and the same walk in the scratch answers 1 (refused).
+#
+# ONE PROBE STILL READS THE LANE ON PURPOSE: `--is-shallow-repository`.
+# Shallowness is a property of the repository that HOLDS the history, and a fresh
+# scratch is NEVER shallow — probing it there would answer `false`
+# unconditionally and turn the shallow guard into a vacuous pass, which is the
+# very shape this check is about. It is a state probe, not an object read, and it
+# cannot be redirected by a graft.
+#
+# THE READS ARE DELIBERATELY **NOT** WRAPPED IN `env -i` + an allowlist, unlike
+# agent-gate.sh's pre-flight. That wrapper exists where a git call can REACH A
+# REMOTE and the answer's provenance is a fetch. Here nothing is fetched and
+# every read is BY A SHA against a config-less object source, so there is no
+# transport an environment could bend. Do not "fix" this by adding one.
 export GIT_NO_LAZY_FETCH=1
 export GIT_NO_REPLACE_OBJECTS=1
 
@@ -389,6 +428,146 @@ refuse_anchor_unverifiable() {
   exit 3
 }
 
+# --- THE ISOLATED SCRATCH REPOSITORY (roborev job 355) ----------------------
+# CLEANUP IS REGISTERED BEFORE THE RESOURCE EXISTS. CLAUDE.md's recurring lesson
+# in this family (roborev job 282) is exactly that ordering, plus: a fix that
+# ADDS a resource inherits that resource's lifetime bugs. So the variable is
+# declared and the traps installed HERE, above any `mktemp`, and the handler is
+# empty-safe (`rm -rf ""` would delete nothing but is still a bug worth not
+# writing). Signals get handlers because bash runs NO EXIT trap for a signal left
+# at its default disposition; each re-raises after cleaning up, so the process
+# still dies of the signal it was sent. This script installs no other traps (it
+# had none before this change), so there is no caller disposition to save.
+ANCHOR_SCRATCH=""
+_anchor_cleanup() {
+  [ -n "$ANCHOR_SCRATCH" ] || return 0
+  rm -rf "$ANCHOR_SCRATCH" 2>/dev/null || true
+  ANCHOR_SCRATCH=""
+}
+trap '_anchor_cleanup' EXIT
+trap '_anchor_cleanup; trap - INT;  kill -INT  $$' INT
+trap '_anchor_cleanup; trap - TERM; kill -TERM $$' TERM
+trap '_anchor_cleanup; trap - HUP;  kill -HUP  $$' HUP
+
+# _anchor_canon <dir> — canonicalize with `cd`+`pwd -P`, EMPTY on failure. The
+# convention scripts/flow/base-staleness.sh uses (no `realpath` dependency), and
+# every caller treats empty as "could not measure", never as "outside".
+_anchor_canon() { (cd "$1" 2>/dev/null && pwd -P) || true; }
+
+# _anchor_build_scratch — on success sets ANCHOR_SCRATCH (the mktemp dir),
+# ANCHOR_SCRATCH_REPO (the git dir to run in) and ANCHOR_ALT (the value for
+# GIT_ALTERNATE_OBJECT_DIRECTORIES). On failure returns 1 with ANCHOR_SCRATCH_ERR
+# set to a cause sentence. NEVER falls back to the live repository.
+ANCHOR_SCRATCH_REPO=""
+ANCHOR_ALT=""
+ANCHOR_SCRATCH_ERR=""
+_anchor_build_scratch() {
+  local lane_objects repo_canon common_canon tmp_req tmp_canon created_canon alt_q
+
+  # THE SCRATCH MUST BE PROVABLY OUTSIDE THE REPOSITORY, and "the repository" is
+  # BOTH roots: the work tree AND the git COMMON dir (these are worktrees of one
+  # shared `.git`, so the common dir is elsewhere entirely). Reasoning and the
+  # two-phase check are base-staleness.sh's, reused rather than reinvented: the
+  # pre-check answers about the path as it resolved a moment ago, so what was
+  # ACTUALLY CREATED is re-validated, because a symlink swapped in between lands
+  # the real directory somewhere else.
+  repo_canon=$(_anchor_canon "$(git rev-parse --show-toplevel 2>/dev/null || true)")
+  common_canon=$(_anchor_canon "$(git rev-parse --git-common-dir 2>/dev/null || true)")
+  if [ -z "$repo_canon" ] || [ -z "$common_canon" ]; then
+    ANCHOR_SCRATCH_ERR="the work-tree root and/or git common directory could not be resolved, so a scratch location cannot be proven outside them"
+    return 1
+  fi
+  tmp_req="${TMPDIR:-/tmp}"
+  tmp_canon=$(_anchor_canon "$tmp_req")
+  if [ -z "$tmp_canon" ]; then
+    ANCHOR_SCRATCH_ERR="the scratch root TMPDIR=$tmp_req could not be resolved (absent, unreadable, or not a directory)"
+    return 1
+  fi
+  case "$tmp_canon/" in
+    "$repo_canon"/* | "$common_canon"/*)
+      ANCHOR_SCRATCH_ERR="the scratch root $tmp_canon resolves INSIDE the repository (work tree $repo_canon / git dir $common_canon); NOTHING was created"
+      return 1 ;;
+  esac
+  if ! ANCHOR_SCRATCH=$(mktemp -d "$tmp_canon/premerge-anchor.XXXXXX" 2>/dev/null) ||
+     [ -z "$ANCHOR_SCRATCH" ] || [ ! -d "$ANCHOR_SCRATCH" ]; then
+    ANCHOR_SCRATCH=""
+    ANCHOR_SCRATCH_ERR="could not create a scratch directory under $tmp_canon"
+    return 1
+  fi
+  created_canon=$(_anchor_canon "$ANCHOR_SCRATCH")
+  if [ -z "$created_canon" ]; then
+    ANCHOR_SCRATCH_ERR="the created scratch directory could not be canonicalized"
+    return 1
+  fi
+  case "$created_canon/" in
+    "$repo_canon"/* | "$common_canon"/*)
+      ANCHOR_SCRATCH_ERR="the CREATED scratch directory $created_canon resolves INSIDE the repository — the root resolved into the checkout between the pre-check and the create"
+      return 1 ;;
+  esac
+
+  # THE LANE'S OBJECT DIRECTORY, resolved rather than assumed — and this is the
+  # ONE read that still happens in the live repository, mirroring the reference
+  # implementation (agent-gate.sh: `rev-parse --git-path objects`). In a
+  # `git worktree` it answers the SHARED store of the parent checkout, i.e. the
+  # objects dir under `--git-common-dir`, which is where HEAD's objects live
+  # (measured here: `--git-path objects` = /…/repo/.git/objects while
+  # `--git-dir` = /…/repo/.git/worktrees/<lane>). It reads no object and reaches
+  # no network; a graft cannot redirect a path.
+  lane_objects=$(git rev-parse --git-path objects 2>/dev/null) || lane_objects=""
+  # MADE ABSOLUTE: `--git-path` answers RELATIVE TO THE WORK-TREE ROOT for a
+  # plain clone (`.git/objects`) and absolute only for a worktree. A relative
+  # value would be resolved against the SCRATCH, a different directory, and the
+  # alternate would point at nothing. (`--path-format=absolute` is git >= 2.31,
+  # so the prefix is applied here rather than relied upon.)
+  case "$lane_objects" in
+    '')
+      ANCHOR_SCRATCH_ERR="this repository's object directory resolved to an EMPTY path, so its objects cannot be made readable to the isolated repository"
+      return 1 ;;
+    /*) : ;;
+    *)  lane_objects="$repo_canon/$lane_objects" ;;
+  esac
+  if [ ! -d "$lane_objects" ]; then
+    ANCHOR_SCRATCH_ERR="this repository's object directory ($lane_objects) is not a directory"
+    return 1
+  fi
+
+  ANCHOR_SCRATCH_REPO="$ANCHOR_SCRATCH/repo"
+  if ! git init -q "$ANCHOR_SCRATCH_REPO" >/dev/null 2>&1 ||
+     [ ! -d "$ANCHOR_SCRATCH_REPO/.git" ]; then
+    ANCHOR_SCRATCH_ERR="could not initialise an isolated scratch repository at $ANCHOR_SCRATCH_REPO"
+    return 1
+  fi
+
+  # C-QUOTED, ALWAYS. `GIT_ALTERNATE_OBJECT_DIRECTORIES` is a COLON-separated
+  # list, so a colon in the path cannot be expressed raw — but git accepts a
+  # C-quoted entry, and agent-gate.sh measured all five shapes (plain, colon,
+  # space, embedded `"`, embedded `\`) resolving correctly through it. Quoting
+  # unconditionally avoids a second code path for the common case. ORDER IS
+  # LOAD-BEARING: escape backslashes FIRST, then quotes, or the backslash pass
+  # escapes the backslashes the quote pass just added.
+  alt_q="${lane_objects//\\/\\\\}"
+  alt_q="${alt_q//\"/\\\"}"
+  ANCHOR_ALT="\"$alt_q\""
+
+  # NESTED ALTERNATES NEED NO CARRY-OVER, AND THAT IS MEASURED, NOT ASSUMED. If
+  # the lane's object store itself has `objects/info/alternates`, git FOLLOWS it
+  # transitively from an entry named in GIT_ALTERNATE_OBJECT_DIRECTORIES —
+  # measured on git 2.43.0: an object present ONLY in repo A was resolved from a
+  # scratch repository whose alternate named repo B, where B reached A solely
+  # through its own `info/alternates`. So an object reachable in the lane only
+  # through its alternates is reachable here too, and copying the list would be
+  # a second, drift-prone source for the same fact.
+  return 0
+}
+
+# _anchor_git <git-args...> — a git call INSIDE the isolated scratch repository,
+# with the lane's objects supplied as an alternate. This is the only place the
+# ancestry reads happen; nothing here consults the lane's config.
+_anchor_git() {
+  GIT_ALTERNATE_OBJECT_DIRECTORIES="$ANCHOR_ALT" \
+    git --no-replace-objects -C "$ANCHOR_SCRATCH_REPO" "$@"
+}
+
 # assert_anchor_on_history <anchor-40-hex> <certified-40-hex> — the #3653
 # binding. Sets ANCHOR_ANCESTRY=BOUND on the one passing verdict; every other
 # outcome refuses. Exit codes are captured WITHOUT tripping `set -e`.
@@ -406,22 +585,38 @@ assert_anchor_on_history() {
       "history the anchor must lie on is the CURRENT DIRECTORY's, and there is" \
       "deliberately no env override naming a different one (#3312)."
   fi
+  # THE ISOLATED REPOSITORY IS BUILT BEFORE ANY OBJECT IS READ, and a failure to
+  # build it is UNVERIFIABLE — never a fall-back to the live repository, which is
+  # the whole hole job 355 closes.
+  if ! _anchor_build_scratch; then
+    refuse_anchor_unverifiable "$anchor" "$head" \
+      "the isolated scratch repository could not be built: $ANCHOR_SCRATCH_ERR" \
+      "The ancestry walk deliberately does NOT run in this checkout: a graft in" \
+      "\$GIT_DIR/info/grafts rewrites parentage and survives --no-replace-objects" \
+      "(#3544 job 285), so a walk here could report a FOREIGN anchor as BOUND." \
+      "Falling back to the live repository would restore exactly that hole, so an" \
+      "unbuildable scratch is UNMEASURED instead." \
+      "REMEDY: give this process a usable TMPDIR outside the work tree and outside" \
+      "the git common directory, then re-run this assert."
+  fi
+
   # THE PRESENCE PROBE IS A DIAGNOSTIC REFINEMENT, NOT THE SOUNDNESS BOUNDARY.
   # It exists to name WHICH object is absent, because the two have different
   # remedies in practice (an anchor from a rebased-away branch vs a certified
-  # head that was never fetched). It is NOT what makes the check sound, and it
-  # cannot be: CLAUDE.md records, as a MEASUREMENT rather than a theory (see
-  # "cat-file -e cannot even probe presence" in the #3544 job-268 paragraph),
-  # that with `GIT_NO_LAZY_FETCH=1` set `cat-file -e` answered 0 for an object
-  # whose `show` then FAILED — it answers about PROMISED objects. So in a
-  # partial/promisor clone BOTH probes below can say "present" for an object
-  # that is not there.
-  # WHAT STILL HOLDS, and why the design fails closed anyway: `merge-base` cannot
-  # SUCCEED on an object that is not really available, so it exits >= 2 (or, at
-  # worst, 1 in a repository this check then refuses to call complete) and the
-  # verdict is UNVERIFIABLE either way. A false "present" here therefore costs a
-  # less specific diagnostic, never a pass.
-  if ! git --no-replace-objects cat-file -e "$anchor^{commit}" >/dev/null 2>&1; then
+  # head that was never fetched). Since job 355 it runs in the SCRATCH, which
+  # has no config and therefore no promisor remote — so the #3544 job-268
+  # measurement that made this probe unsound in the LANE ("cat-file -e cannot
+  # even probe presence": with `GIT_NO_LAZY_FETCH=1` set it answered 0 for an
+  # object whose `show` then FAILED, because it answers about PROMISED objects)
+  # no longer has a mechanism to fire through here: an object promised but absent
+  # in the lane is simply ABSENT to a config-less alternate.
+  # That last sentence is REASONING, not a measurement, which is why the probe
+  # is still not load-bearing. What is load-bearing, in every case: `merge-base`
+  # cannot SUCCEED on an object that is not really available, so it exits >= 2
+  # (or 1 in a repository this check then refuses to call complete) and the
+  # verdict is UNVERIFIABLE either way. A false "present" costs a less specific
+  # diagnostic, never a pass.
+  if ! _anchor_git cat-file -e "$anchor^{commit}" >/dev/null 2>&1; then
     refuse_anchor_unverifiable "$anchor" "$head" \
       "the ANCHOR commit is not present in this repository" \
       "An absent object cannot be shown to lie on any history, and its absence is" \
@@ -429,7 +624,7 @@ assert_anchor_on_history() {
       "REMEDY: fetch the branch that carries it (git fetch origin <branch>) and" \
       "re-run this assert."
   fi
-  if ! git --no-replace-objects cat-file -e "$head^{commit}" >/dev/null 2>&1; then
+  if ! _anchor_git cat-file -e "$head^{commit}" >/dev/null 2>&1; then
     refuse_anchor_unverifiable "$anchor" "$head" \
       "the CERTIFIED commit is not present in this repository" \
       "REMEDY: fetch the PR branch (git fetch origin <branch>) and re-run this" \
@@ -437,9 +632,10 @@ assert_anchor_on_history() {
   fi
 
   rc=0
-  git --no-replace-objects merge-base --is-ancestor "$anchor" "$head" >/dev/null 2>&1 || rc=$?
+  _anchor_git merge-base --is-ancestor "$anchor" "$head" >/dev/null 2>&1 || rc=$?
   if [ "$rc" -eq 0 ]; then
     ANCHOR_ANCESTRY=BOUND
+    _anchor_cleanup
     return 0
   fi
   if [ "$rc" -ne 1 ]; then
@@ -456,6 +652,13 @@ assert_anchor_on_history() {
   # An empty answer (a git too old to know the option, or a failed call) is
   # UNMEASURED and takes the same refusing branch as `true` — the permissive
   # branch is never the default for an unestablished state.
+  #
+  # PROBED IN THE **LANE**, NOT THE SCRATCH, AND THAT IS NOT AN OVERSIGHT.
+  # Shallowness is a property of the repository that HOLDS the history; a freshly
+  # `git init`-ed scratch is never shallow, so asking it would answer `false`
+  # unconditionally and turn this guard into a vacuous pass — the exact shape
+  # this whole check exists to refuse. It is a STATE probe, not an object read,
+  # so the graft route job 355 closed does not apply to it.
   shallow=$(git --no-replace-objects rev-parse --is-shallow-repository 2>/dev/null) || shallow=""
   if [ "$shallow" != false ]; then
     refuse_anchor_unverifiable "$anchor" "$head" \

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -841,8 +841,13 @@ ANCHOR_SCRATCH=""
 # that lets this process delete its own scratch while denying a peer the ability
 # to swap it. Removal or nothing, not a tuning problem.
 #
-# THE TRADE, stated because it is a real cost and not a free win: one small
-# directory per Case B merge is left under TMPDIR — an object-less `git init` on
+# THE TRADE, stated because it is a real cost and not a free win, and MEASURED
+# rather than estimated: one small directory per Case B INVOCATION is left under
+# TMPDIR. Note INVOCATION, not merge — the test suite exercises Case B dozens of
+# times per run, and 240 such directories accumulated on this box during one round
+# of development before that was noticed. A caller that invokes this repeatedly
+# should point TMPDIR at a directory it owns and removes wholesale (which is what
+# scripts/tests/test_premerge_assert.sh now does); for an actual merge it is one — an object-less `git init` on
 # the RARE path (Case B is #1892's post-gate-polish route, not the ordinary
 # merge) — and the OS reaps TMPDIR. Against that: a recursive delete that can land
 # on a concurrent lane's directory. Not comparable, which is the same reasoning

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -458,7 +458,18 @@ refuse_tool_failure() {
 # claim — "the repository is the CURRENT WORKING DIRECTORY's, with no env
 # override" — true, where before a caller's `GIT_DIR` silently won.
 #
-# THE READS ARE ALSO BOUNDED (roborev job 358, Medium). They read the SHARED
+# WHAT IS BOUNDED, AND WHAT IS NOT (roborev job 358, NARROWED by job 382). The
+# EXTERNAL commands are bounded: every git call and `mktemp -d`, through the one
+# `_anchor_bounded` runner. NOT BOUNDED, and the evidence line SAYS so rather than
+# implying otherwise: `_anchor_canon` (`cd` + `pwd -P`) and the `[ -d … ]` probe on
+# the lane object directory are SHELL BUILTINS — there is no process for a runner
+# to signal — so on a stalled mount they can still hang this guard before any git
+# read happens. Inventing a way to bound a builtin is explicitly NOT the fix; the
+# claim is narrowed to what is true instead. One unbounded builtin stat was also
+# DELETED rather than bounded (the scratch `.git` check — see its own note below),
+# because removing code beats bounding it.
+#
+# THE BOUNDED READS (job 358, Medium). They read the SHARED
 # object store, so a malformed loose object (a FIFO) or a stalled filesystem read
 # would hang the merge guard forever instead of producing the documented
 # `ANCHOR-UNVERIFIABLE`. In model on both halves: a peer lane can plant into that
@@ -605,7 +616,16 @@ _anchor_resolve_bound() {
   local anchor="$1" head="$2" name
   if name=$(resolve_advisory_timeout) && ANCHOR_BOUND_RUNNER=$(command -v "$name" 2>/dev/null) &&
      [ -n "$ANCHOR_BOUND_RUNNER" ]; then
-    ANCHOR_READS="bounded-${ADVISORY_TIMEOUT_SECS}s+${ADVISORY_KILL_GRACE}s"
+    # THE TOKEN NAMES EXACTLY WHAT IS BOUNDED (roborev job 382). It used to read a
+    # bare `bounded-<n>s+<g>s`, which claimed more than is true: `_anchor_canon`
+    # (`cd` + `pwd -P`) and the `[ -d "$lane_objects" ]` probe are SHELL BUILTINS,
+    # so there is no process to bound and a stalled mount can still hang them. A
+    # guard that says "bounded" while a filesystem probe can hang is the overclaim
+    # shape this issue has spent every round removing, and the standing rule is
+    # that a check claiming nothing false beats one claiming a closure it does not
+    # deliver. So the token says: the EXTERNAL commands are bounded, the builtin
+    # filesystem probes are not.
+    ANCHOR_READS="bounded-${ADVISORY_TIMEOUT_SECS}s+${ADVISORY_KILL_GRACE}s(external:git,mktemp;UNBOUNDED:cd/test-builtins)"
     return 0
   fi
   ANCHOR_BOUND_RUNNER=""
@@ -626,14 +646,25 @@ _anchor_resolve_bound() {
 # location-specific variables by exporting them in a subshell (see _anchor_git).
 # A timeout is reported through the exit code (124 from timeout(1), or 137 when
 # the SIGKILL escalation was needed) and every caller maps those to UNVERIFIABLE.
-_anchor_run() {
+# _anchor_bounded <external-cmd> <args...> — the ONE bounded-external runner
+# (roborev job 382). Extracted from `_anchor_run` rather than duplicated, so
+# `mktemp` and git share one bound and one env allowlist. Only EXTERNAL commands
+# can go through it; a shell builtin has no process to bound, which is why the
+# claim is narrowed rather than extended (see the header).
+_anchor_bounded() {
   if [ -n "$ANCHOR_BOUND_RUNNER" ]; then
     env -i "${ANCHOR_GIT_ENV[@]}" "$ANCHOR_BOUND_RUNNER" \
-      --kill-after="$ADVISORY_KILL_GRACE" "$ADVISORY_TIMEOUT_SECS" \
-      git "${ANCHOR_GIT_OPTS[@]}" "$@"
+      --kill-after="$ADVISORY_KILL_GRACE" "$ADVISORY_TIMEOUT_SECS" "$@"
   else
-    env -i "${ANCHOR_GIT_ENV[@]}" git "${ANCHOR_GIT_OPTS[@]}" "$@"
+    env -i "${ANCHOR_GIT_ENV[@]}" "$@"
   fi
+}
+
+# MULTI-LINE ON PURPOSE: the structural census in the test suite detects function
+# boundaries by a line that is exactly `}`, and a one-line definition left its
+# scan running into the NEXT function (job 382 — it flagged a comment there).
+_anchor_run() {
+  _anchor_bounded git "${ANCHOR_GIT_OPTS[@]}" "$@"
 }
 
 # _anchor_refuse_timeout <anchor> <head> <what> — THE ONE timeout refusal, shared
@@ -763,8 +794,14 @@ _anchor_build_scratch() {
       ANCHOR_SCRATCH_ERR="the scratch root $tmp_canon resolves INSIDE the repository (work tree $repo_canon / git dir $common_canon); NOTHING was created"
       return 1 ;;
   esac
-  if ! ANCHOR_SCRATCH=$(mktemp -d "$tmp_canon/premerge-anchor.XXXXXX" 2>/dev/null) ||
-     [ -z "$ANCHOR_SCRATCH" ] || [ ! -d "$ANCHOR_SCRATCH" ]; then
+  # BOUNDED (job 382): `mktemp` is an EXTERNAL command touching the filesystem, so
+  # a stalled TMPDIR mount would hang the guard before any git read.
+  rc=0
+  ANCHOR_SCRATCH=$(_anchor_bounded mktemp -d "$tmp_canon/premerge-anchor.XXXXXX" 2>/dev/null) || rc=$?
+  if _anchor_timed_out "$rc"; then
+    _anchor_refuse_timeout "$anchor" "$head" "creating the scratch directory (mktemp -d)"
+  fi
+  if [ "$rc" -ne 0 ] || [ -z "$ANCHOR_SCRATCH" ] || [ ! -d "$ANCHOR_SCRATCH" ]; then
     ANCHOR_SCRATCH=""
     ANCHOR_SCRATCH_ERR="could not create a scratch directory under $tmp_canon"
     return 1
@@ -825,7 +862,16 @@ _anchor_build_scratch() {
   if _anchor_timed_out "$rc"; then
     _anchor_refuse_timeout "$anchor" "$head" "initialising the isolated scratch repository (git init)"
   fi
-  if [ "$rc" -ne 0 ] || [ ! -d "$ANCHOR_SCRATCH_REPO/.git" ]; then
+  # THE `[ -d "$ANCHOR_SCRATCH_REPO/.git" ]` CHECK IS DELETED (job 382), not
+  # bounded: it was an UNBOUNDED builtin stat, and it was redundant for
+  # CORRECTNESS — a `git init` that exits 0 without creating a repository would
+  # make every bounded read below fail, so the check still refuses. Removing code
+  # beats bounding it.
+  #   THE TRADE, stated: in that (essentially impossible) case the refusal would
+  #   name "the ANCHOR commit is not present in this repository" rather than a
+  #   broken scratch — a less accurate cause for a state that requires a broken
+  #   git. An unbounded stat on a stalled mount is a real hang; that is not.
+  if [ "$rc" -ne 0 ]; then
     ANCHOR_SCRATCH_ERR="could not initialise an isolated scratch repository at $ANCHOR_SCRATCH_REPO"
     return 1
   fi

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -598,8 +598,11 @@ refuse_anchor_unverifiable() {
 #                                               |         | absolute, canonicalised
 # rev-parse --is-shallow-repository              | RUNNER  | must equal the literal `false`;
 #                                               |         | anything else => UNVERIFIABLE
-# _anchor_canon  (sh -c 'cd -- "$1" && pwd -P') | RUNNER  | empty input refused; empty output
-#   x4: toplevel, common-dir, TMPDIR, created   |         | treated as could-not-measure
+# _anchor_canon  (sh -c 'cd -- "$1" && pwd -P') | RUNNER  | empty input refused; rc now
+#   x5: toplevel, common-dir, TMPDIR, created,  |         | INSPECTED three-valued (job 395):
+#       object-dir                              |         | 124/137 -> TIMEOUT cause, rc 1 ->
+#                                               |         | unresolvable-path cause. Empty
+#                                               |         | output alone no longer decides.
 # TMPDIR read                                    | n/a     | canonicalised, then proven
 #                                               |         | OUTSIDE work tree AND git dir
 # mktemp -d <tmp_canon>/premerge-anchor.XXXXXX   | RUNNER  | result: non-empty, canonical,
@@ -670,7 +673,16 @@ refuse_anchor_unverifiable() {
 # and target-revalidated; and the `anchor-reads:` token was corrected twice — once
 # for overclaiming, once for UNDERclaiming after these fixes.
 #
-# AND WHAT THE LATEST ROUND CHANGED (job 388), a MATERIAL change to what this
+# AND WHAT THE LATEST ROUND CHANGED (job 395): `_anchor_canon` stopped
+# suppressing its exit status with `|| true`, so all FIVE canonicalisations now
+# distinguish a TIMEOUT (124/137, stalled filesystem) from an unresolvable path
+# (rc 1) instead of collapsing both onto "empty output". Its table row narrows
+# accordingly: empty output alone no longer decides the cause. This was the one
+# site job 374 did not reach, because its own `|| true` hid the status job 374
+# taught every other call to inspect — and the comment there ARGUED for the
+# suppression on safety grounds, which was true and was not the point.
+#
+# AND WHAT THE ROUND BEFORE THAT CHANGED (job 388), a MATERIAL change to what this
 # table claims: the `rm -rf` row is now a DECLARED NON-DELETION, and the identity
 # probe plus the whole delete-time revalidation are GONE with it. The
 # `anchor-reads:` token lost `rm` from its bounded externals — its third
@@ -943,12 +955,28 @@ trap '_anchor_cleanup; trap - HUP;  kill -HUP  $$' HUP
 # is an EXTERNAL command, so it goes through the existing runner. Verified to
 # agree with the builtin form, symlinked input included.
 #
-# A timeout, a missing/unreadable path and an absent `sh` all yield EMPTY, which
-# every caller already treats as "could not measure" and refuses on. That is the
-# fail-closed direction, and it is why this does not need its own timeout arm.
+# A missing/unreadable path and an absent `sh` yield EMPTY, which every caller
+# treats as "could not measure" and refuses on — the fail-closed direction. A
+# TIMEOUT is no longer in that set: since job 395 the rc is preserved and each
+# caller routes 124/137 to the TIMEOUT cause, because failing closed with the
+# WRONG REMEDY still sends an operator to the wrong place.
+# THE EXIT STATUS IS PRESERVED, NOT SUPPRESSED (roborev job 395). It used to end
+# in `|| true`, and the comment above justified that: a timeout, a missing path and
+# an absent `sh` all yield EMPTY, and every caller treats empty as
+# could-not-measure. That reasoning was right about SAFETY — it fails closed, the
+# merge stays blocked, no false pass — and wrong about DIAGNOSIS: an operator sent
+# to hunt an unreadable path when the real cause is a stalled mount. That is the
+# misleading-remedy class job 374 fixed everywhere else; this was the one site that
+# escaped it, because its `|| true` hid the status job 374 taught every other call
+# to inspect.
+#
+# The rc is naturally THREE-VALUED here, which is what makes the split possible:
+#   0        canonicalised; stdout is the path
+#   1        `cd` failed — a genuinely missing/unreadable path (its own cause)
+#   124/137  the runner terminated it — a stalled filesystem (the TIMEOUT cause)
 _anchor_canon() {
   [ -n "$1" ] || return 0
-  _anchor_bounded sh -c 'cd -- "$1" && pwd -P' sh "$1" 2>/dev/null || true
+  _anchor_bounded sh -c 'cd -- "$1" && pwd -P' sh "$1" 2>/dev/null
 }
 
 # _anchor_build_scratch — on success sets ANCHOR_SCRATCH (the mktemp dir),
@@ -962,7 +990,7 @@ _anchor_build_scratch() {
   local anchor="$1" head="$2"
   local lane_objects repo_canon common_canon tmp_req tmp_canon created_canon alt_q
   local created_base
-  local rc toplevel commondir
+  local rc toplevel commondir lane_objects_canon
 
   # THE SCRATCH MUST BE PROVABLY OUTSIDE THE REPOSITORY, and "the repository" is
   # BOTH roots: the work tree AND the git COMMON dir (these are worktrees of one
@@ -986,14 +1014,30 @@ _anchor_build_scratch() {
   fi
   # A non-timeout failure, or an empty answer, keeps its ORIGINAL cause below:
   # those are real states (an unusable repository) with their own remedy.
-  repo_canon=$(_anchor_canon "$toplevel")
-  common_canon=$(_anchor_canon "$commondir")
+  # EACH CANONICALISATION INSPECTS ITS STATUS (job 395), so a stalled mount gets
+  # the TIMEOUT cause and its remedy instead of borrowing the unresolvable-path
+  # one. The non-timeout failure keeps that original cause below — it is a real
+  # state (an unusable repository) with its own remedy.
+  rc=0
+  repo_canon=$(_anchor_canon "$toplevel") || rc=$?
+  if _anchor_timed_out "$rc"; then
+    _anchor_refuse_timeout "$anchor" "$head" "canonicalising the work-tree root (cd + pwd -P)"
+  fi
+  rc=0
+  common_canon=$(_anchor_canon "$commondir") || rc=$?
+  if _anchor_timed_out "$rc"; then
+    _anchor_refuse_timeout "$anchor" "$head" "canonicalising the git common directory (cd + pwd -P)"
+  fi
   if [ -z "$repo_canon" ] || [ -z "$common_canon" ]; then
     ANCHOR_SCRATCH_ERR="the work-tree root and/or git common directory could not be resolved, so a scratch location cannot be proven outside them"
     return 1
   fi
   tmp_req="${TMPDIR:-/tmp}"
-  tmp_canon=$(_anchor_canon "$tmp_req")
+  rc=0
+  tmp_canon=$(_anchor_canon "$tmp_req") || rc=$?
+  if _anchor_timed_out "$rc"; then
+    _anchor_refuse_timeout "$anchor" "$head" "canonicalising TMPDIR (cd + pwd -P)"
+  fi
   if [ -z "$tmp_canon" ]; then
     ANCHOR_SCRATCH_ERR="the scratch root TMPDIR=$tmp_req could not be resolved (absent, unreadable, or not a directory)"
     return 1
@@ -1018,7 +1062,11 @@ _anchor_build_scratch() {
     ANCHOR_SCRATCH_ERR="could not create a scratch directory under $tmp_canon"
     return 1
   fi
-  created_canon=$(_anchor_canon "$ANCHOR_SCRATCH")
+  rc=0
+  created_canon=$(_anchor_canon "$ANCHOR_SCRATCH") || rc=$?
+  if _anchor_timed_out "$rc"; then
+    _anchor_refuse_timeout "$anchor" "$head" "canonicalising the created scratch directory (cd + pwd -P)"
+  fi
   if [ -z "$created_canon" ]; then
     ANCHOR_SCRATCH_ERR="the created scratch directory could not be canonicalized"
     return 1
@@ -1070,7 +1118,14 @@ _anchor_build_scratch() {
   # BOUNDED, and it keeps its own diagnostic (job 374's lesson: a broken object
   # directory must not borrow the absent-object remedy). The unbounded builtin
   # stat this replaces was the last first-touch filesystem probe in the path.
-  if [ -z "$(_anchor_canon "$lane_objects")" ]; then
+  # SPLIT OUT of an `[ -z "$(...)" ]` test, which discarded the status entirely —
+  # the most thorough of the five suppressions (job 395).
+  rc=0
+  lane_objects_canon=$(_anchor_canon "$lane_objects") || rc=$?
+  if _anchor_timed_out "$rc"; then
+    _anchor_refuse_timeout "$anchor" "$head" "canonicalising the object directory (cd + pwd -P)"
+  fi
+  if [ -z "$lane_objects_canon" ]; then
     ANCHOR_SCRATCH_ERR="this repository's object directory ($lane_objects) is not a readable directory"
     return 1
   fi

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -152,24 +152,40 @@
 #     So the three `PREMERGE: SCOPE` lines are RETAINED: slice 1 does not close
 #     the gap they disclose, and removing them would be exactly the overclaim
 #     this residual exists to prevent.
-#  4. THE #3653 ANCHOR BINDING IS A LOCAL-REPOSITORY FACT (Case B only). It
-#     proves the anchor is an ancestor of the certified sha AS THIS CHECKOUT'S
-#     OBJECT STORE RECORDS IT. Two things it therefore does NOT prove. (a) It
-#     says NOTHING about whether the anchor is on the PR AS GITHUB SEES IT: the
-#     local branch could hold commits that were never pushed, and no `gh` call
-#     here reads the PR's commit list. The `commit:`/`tree-start:` binding plus
-#     the head compare are what tie the whole chain to the sha GitHub will merge.
-#     (b) REPOSITORY STATE THAT REWRITES ANCESTRY is closed by CONSTRUCTION, not
-#     by the threat model: the walk runs in an isolated scratch repository whose
-#     only view of this lane is `GIT_ALTERNATE_OBJECT_DIRECTORIES` (roborev job
-#     355), so `$GIT_DIR/info/grafts` and `refs/replace/*` — both of which are
-#     PEER-WRITABLE here, since every lane is a worktree of one shared `.git`,
-#     and both of which also fire BY ACCIDENT as leftovers of an unrelated
-#     debugging session — cannot reach it. The two git pins stay as belt. What
-#     remains INVOKER-CLASS and out of model by residual 2 is planting forged
-#     OBJECTS in the shared store: objects are content-addressed, so that means
-#     defeating sha collision resistance or replacing the store wholesale, and
-#     the shared-store trust boundary is #3746's subject, not this check's.
+#  4. THE #3653 ANCHOR BINDING — WHAT IT PROVES, AND THE BOUNDARY IT DOES NOT
+#     CROSS (Case B only). Stated as a BOUNDARY rather than as another list of
+#     closed attacks, because three review rounds found three routes into one
+#     mechanism (graft -> environment/template -> commit-graph) and the pattern
+#     predicts a fourth: that is CLAUDE.md's "one axis closed, space declared
+#     done" shape (#3544 job 264), and the repository has already ruled on the
+#     unclosable version of it (#3746 / job 311 — DECLARE the boundary in the
+#     emitted line, hand the real subject to the issue that owns it).
+#
+#     IT PROVES: the anchor is an ancestor of the certified sha over the objects
+#     and commit metadata THIS BOX'S SHARED OBJECT STORE PRESENTS, read in an
+#     isolated scratch repository that is proof against — with a positive control
+#     for each — `$GIT_DIR/info/grafts` (job 355), `refs/replace/*`, an inherited
+#     `GIT_DIR`/`GIT_COMMON_DIR` and an ambient `GIT_TEMPLATE_DIR`/config
+#     `init.templateDir` (job 358), and a trusted `commit-graph` (job 361). Each
+#     of those is PEER-WRITABLE on this fleet, because every lane is a worktree
+#     of ONE shared `.git`, and each also fires BY ACCIDENT as a leftover of an
+#     unrelated debugging session — which is why they are closed and not merely
+#     declared.
+#
+#     IT DOES NOT PROVE, and no further enumeration will change this:
+#       (a) that the anchor is on the PR AS GITHUB SEES IT. The local branch may
+#           hold commits never pushed, and no `gh` call here reads the PR's commit
+#           list. The `commit:`/`tree-start:` binding plus the head compare are
+#           what tie the chain to the sha GitHub will merge.
+#       (b) anything against a PEER THAT CAN WRITE THE SHARED OBJECT STORE. Git
+#           does not rehash a packed object against the id it was asked for, and
+#           not every file in that store is content-addressed. So the ancestry
+#           verdict is derived from a store that is TRUSTED, NOT VERIFIED — which
+#           the evidence line SAYS, on every run, naming #3746. That hazard is
+#           strictly bigger than this guard: #3746's own note is that its subject
+#           may be the infrastructure decision that lanes share an object store
+#           at all. A FIFTH route in this family is therefore a residual under
+#           (b), not a defect in this check and not a false claim here.
 #
 # USAGE
 #   scripts/flow/premerge-assert.sh <pr-number> <certified-sha> \
@@ -496,6 +512,40 @@ refuse_anchor_unverifiable() {
 # --- THE ISOLATED HOP'S ENVIRONMENT (roborev job 358) -----------------------
 # See the header for the two measured routes and the ADMIT/CLEAR line. Built
 # once, used by every git call below — lane discovery included.
+# THE PRE-COMMAND OPTIONS, IN ONE ARRAY BECAUSE THEY MUST REACH EVERY SITE
+# (roborev job 361 + job 276's rule). `-c core.commitGraph=false` is the new one:
+# `objects/info/commit-graph` (and the `objects/info/commit-graphs/` chain) is
+# reachable through the alternate, it is NOT content-addressed, and git TRUSTS its
+# recorded parent edges — so a peer-writable forged graph is a parent-edge source
+# the isolation does not otherwise remove.
+#
+# MEASURED ON THIS BOX (git 2.43.0), with a commit-graph whose CDAT parent slot was
+# patched to name a FOREIGN commit and whose trailing checksum was recomputed:
+#   rev-list --parents -1 <c2>              -> the FORGED parent   (graph trusted)
+#   -c core.commitGraph=false, same command -> the REAL parent      (flag works)
+#   rev-list <c2> | grep <foreign>          -> 1 by default, 0 with the flag
+#   merge-base --is-ancestor <foreign> <c2> -> "no" in BOTH cases
+# So the MECHANISM is real and measured, and the EXPLOIT AGAINST THIS PARTICULAR
+# CALL DID NOT REPRODUCE on this git version: `merge-base --is-ancestor` did not
+# take the forged edge, while `rev-list` did. The flag is therefore DEFENCE IN
+# DEPTH against a measured-trusted metadata source that is one git version, or one
+# refactor of this walk, away from mattering — not the fix for a reproduced
+# exploit. That distinction is stated here, and in the test, rather than implied.
+#
+# WHAT WAS MEASURED AND DELIBERATELY *NOT* DISABLED, because widening past the
+# measurement is guessing:
+#   * `core.multiPackIndex` — with the pack `.idx` removed and a multi-pack-index
+#     present, the object was NOT readable (`packfile ... index unavailable`), so
+#     no evidence it substitutes for object lookup here, and none that it supplies
+#     parent edges. Its hazard class is "which BYTES an oid resolves to", which is
+#     #3746's trusted-store boundary, not a parent-edge route.
+#   * reachability bitmaps — with a bitmap present, `GIT_TRACE2_PERF=1` during
+#     `merge-base --is-ancestor` produced ZERO bitmap mentions. No evidence of
+#     consultation. (Bitmaps serve packing and `rev-list --objects`.)
+# Both are named so a future reader knows they were measured and left alone, not
+# forgotten.
+ANCHOR_GIT_OPTS=(--no-replace-objects -c core.commitGraph=false)
+
 ANCHOR_GIT_ENV=()
 _anchor_build_git_env() {
   ANCHOR_GIT_ENV=()
@@ -520,6 +570,12 @@ _anchor_build_git_env
 # affirmative token published on the evidence line; it is never silently empty.
 ANCHOR_BOUND_RUNNER=""
 ANCHOR_READS="UNRECORDED"
+
+# THE DECLARED BOUNDARY, in ONE constant consumed by the ONE renderer (job 361,
+# following #3746 / job 311's mechanics). It is a CONSTANT and not a computed
+# value on purpose: there is no measurement this script can take that would make
+# it false, so a variable would only invite a future arm to omit it.
+ANCHOR_PROVENANCE="ancestry over this box's SHARED object store: objects+metadata TRUSTED, not verified (#3746)"
 _anchor_resolve_bound() {
   local name
   if name=$(resolve_advisory_timeout) && ANCHOR_BOUND_RUNNER=$(command -v "$name" 2>/dev/null) &&
@@ -540,9 +596,10 @@ _anchor_resolve_bound() {
 _anchor_run() {
   if [ -n "$ANCHOR_BOUND_RUNNER" ]; then
     env -i "${ANCHOR_GIT_ENV[@]}" "$ANCHOR_BOUND_RUNNER" \
-      --kill-after="$ADVISORY_KILL_GRACE" "$ADVISORY_TIMEOUT_SECS" git "$@"
+      --kill-after="$ADVISORY_KILL_GRACE" "$ADVISORY_TIMEOUT_SECS" \
+      git "${ANCHOR_GIT_OPTS[@]}" "$@"
   else
-    env -i "${ANCHOR_GIT_ENV[@]}" git "$@"
+    env -i "${ANCHOR_GIT_ENV[@]}" git "${ANCHOR_GIT_OPTS[@]}" "$@"
   fi
 }
 
@@ -558,7 +615,9 @@ _anchor_timed_out() {
 # Same isolation: an inherited GIT_DIR would make discovery answer about another
 # repository, which poisons the alternate and the shallowness verdict (job 276:
 # the allowlist has to reach the sites a later change adds).
-_anchor_lane() { _anchor_run --no-replace-objects "$@"; }
+# (The options come from ANCHOR_GIT_OPTS inside _anchor_run — ONE definition for
+# every site, so a new option cannot reach some calls and miss others.)
+_anchor_lane() { _anchor_run "$@"; }
 
 # --- THE ISOLATED SCRATCH REPOSITORY (roborev job 355) ----------------------
 # CLEANUP IS REGISTERED BEFORE THE RESOURCE EXISTS. CLAUDE.md's recurring lesson
@@ -710,10 +769,10 @@ _anchor_git() {
   if [ -n "$ANCHOR_BOUND_RUNNER" ]; then
     env -i "${ANCHOR_GIT_ENV[@]}" "GIT_ALTERNATE_OBJECT_DIRECTORIES=$ANCHOR_ALT" \
       "$ANCHOR_BOUND_RUNNER" --kill-after="$ADVISORY_KILL_GRACE" "$ADVISORY_TIMEOUT_SECS" \
-      git --no-replace-objects -C "$ANCHOR_SCRATCH_REPO" "$@"
+      git "${ANCHOR_GIT_OPTS[@]}" -C "$ANCHOR_SCRATCH_REPO" "$@"
   else
     env -i "${ANCHOR_GIT_ENV[@]}" "GIT_ALTERNATE_OBJECT_DIRECTORIES=$ANCHOR_ALT" \
-      git --no-replace-objects -C "$ANCHOR_SCRATCH_REPO" "$@"
+      git "${ANCHOR_GIT_OPTS[@]}" -C "$ANCHOR_SCRATCH_REPO" "$@"
   fi
 }
 
@@ -1646,12 +1705,19 @@ if [ -n "$delta_file" ]; then
   # `anchor-ancestry:` is the AFFIRMATIVE record that the #3653 binding RAN. After
   # assert_anchor_on_history it can only ever read BOUND — which is the point: a
   # silent pass is indistinguishable from a check that was never reached.
+  # THE BOUNDARY IS DECLARED ON THE LINE, NOT ENUMERATED FOREVER (job 361; the
+  # #3746 / job-311 precedent, applied verbatim: a check that claims nothing false
+  # is worth more than one claiming a closure it does not deliver). Folded into the
+  # ONE suffix the renderer consumes — never appended per verdict arm, or the two
+  # spellings would drift.
+  #
   # `anchor-reads:` is AFFIRMATIVE in both directions (job 358): `bounded-<n>s+<g>s`
   # or `UNBOUNDED(no-timeout-runner-supporting--kill-after)`. An unbounded run is
   # legitimate — a hang cannot manufacture a false pass, and refusing a box with
   # no `timeout` would red correct input — but it must never be SILENT, because a
   # bounded path degrading into an unbounded one unnoticed is the real hazard.
-  printf 'PREMERGE: DELTA-RECERT anchor: %s anchor-ancestry: %s anchor-reads: %s commit: %s tree-start: %s tree-integrity: PASS dirty: %s summary: %s\n' \
-    "$delta_anchor" "$ANCHOR_ANCESTRY" "$ANCHOR_READS" "$delta_commit" "$delta_ts" "$delta_dirty" "$delta_file"
+  printf 'PREMERGE: DELTA-RECERT anchor: %s anchor-ancestry: %s anchor-reads: %s commit: %s tree-start: %s tree-integrity: PASS dirty: %s summary: %s | %s\n' \
+    "$delta_anchor" "$ANCHOR_ANCESTRY" "$ANCHOR_READS" "$delta_commit" "$delta_ts" "$delta_dirty" \
+    "$delta_file" "$ANCHOR_PROVENANCE"
 fi
 exit 0

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -597,7 +597,15 @@ refuse_anchor_unverifiable() {
 # rev-parse --git-path objects                  | RUNNER  | rc inspected; non-empty, made
 #                                               |         | absolute, canonicalised
 # rev-parse --is-shallow-repository              | RUNNER  | must equal the literal `false`;
-#                                               |         | anything else => UNVERIFIABLE
+#                                               |         | anything else => UNVERIFIABLE.
+#                                               |         | `false` means NO SHALLOW MARKER,
+#                                               |         | NOT a complete history (job 412):
+#                                               |         | it no longer establishes
+#                                               |         | completeness on its own.
+# rev-list --quiet <certified>  (in scratch)     | RUNNER  | the CONNECTIVITY check that does
+#   ONLY on the rc-1 path; 0ms on success        |         | establish it: rc != 0 => the
+#                                               |         | history is INCOMPLETE =>
+#                                               |         | UNVERIFIABLE, never exit 2
 # _anchor_canon  (sh -c 'cd -- "$1" && pwd -P') | RUNNER  | empty input refused; rc now
 #   x5: toplevel, common-dir, TMPDIR, created,  |         | INSPECTED three-valued (job 395):
 #       object-dir                              |         | 124/137 -> TIMEOUT cause, rc 1 ->
@@ -673,7 +681,16 @@ refuse_anchor_unverifiable() {
 # and target-revalidated; and the `anchor-reads:` token was corrected twice — once
 # for overclaiming, once for UNDERclaiming after these fixes.
 #
-# AND WHAT THE LATEST ROUND CHANGED (job 395): `_anchor_canon` stopped
+# AND WHAT THE LATEST ROUND CHANGED (job 412), and it is the only VERDICT defect
+# found since round 12 rather than a diagnostic one: `--is-shallow-repository =
+# false` was treated as establishing a complete history, and it does not — it says
+# there is no shallow MARKER. A missing intermediate commit object in a non-shallow
+# repository yields the same rc 1 from the ancestry walk, so a VALID anchor was
+# refused at EXIT 2 as NOT-ANCESTOR ("your chain is wrong") when the truth was
+# "this box could not measure it". A connectivity walk (`rev-list --quiet
+# <certified>`, in the scratch, bounded, on the rc-1 path ONLY) now establishes
+# completeness before rc 1 is treated as a verdict, with its own textually
+# distinct cause and remedy. The shallowness rows `_anchor_canon` stopped
 # suppressing its exit status with `|| true`, so all FIVE canonicalisations now
 # distinguish a TIMEOUT (124/137, stalled filesystem) from an unresolvable path
 # (rc 1) instead of collapsing both onto "empty output". Its table row narrows
@@ -1368,6 +1385,63 @@ assert_anchor_on_history() {
       "that is not the literal 'false' — 'true', empty, or a git too old to answer" \
       "— is UNMEASURED, and an unmeasured ancestry is never read as a pass." \
       "REMEDY: git fetch --unshallow (or fetch the missing history), then re-run."
+  fi
+
+  # SHALLOWNESS IS NOT THE ONLY REASON rc 1 CAN BE NON-DEFINITIVE (roborev job
+  # 412). `--is-shallow-repository = false` says there is no SHALLOW MARKER; it
+  # does NOT say the certified commit's reachable history is COMPLETE. If an
+  # intermediate commit object is missing or corrupt in a non-shallow repository,
+  # `merge-base --is-ancestor` returns the same rc 1 — and this script then
+  # reported a VALID anchor as NOT-ANCESTOR at exit 2, telling the operator their
+  # chain is wrong when the truth is that this box could not measure it.
+  #
+  # THAT IS A FALSE DEFINITIVE VERDICT, which is why it outranks every diagnostic
+  # fix since round 12: the whole point of the exit-2/exit-3 split is that they are
+  # DIFFERENT OPERATOR ACTIONS. It is the "rc 1 is three-valued" lesson (#3544)
+  # caught one axis short — we had encoded shallowness as the only cause.
+  #
+  # MEASURED, on a non-shallow repo with one intermediate commit object removed:
+  #   merge-base --is-ancestor <a> <c>  -> rc 1     (the false NOT-ANCESTOR)
+  #   rev-list --quiet <c>              -> rc 128   (the connectivity signal)
+  #   rev-parse --is-shallow-repository -> false    (no marker; useless here)
+  #
+  # SO CONNECTIVITY IS VERIFIED BEFORE rc 1 IS TREATED AS A VERDICT. The walk is
+  # over COMMITS only, which is exactly what `--is-ancestor` traverses — trees and
+  # blobs cannot change an ancestry answer, so `--objects` would buy nothing and
+  # cost a great deal. It runs in the SCRATCH through the same `_anchor_git`
+  # wrapper, so it inherits the bound, the `env -i` allowlist and ANCHOR_GIT_OPTS
+  # (job 276: the option must reach every site) and adds NO resource and NO
+  # lifetime.
+  #
+  # COST, MEASURED RATHER THAN ESTIMATED (2539 commits, this repo, in the real
+  # scratch-over-alternate posture): 57-61ms, against 4ms for the ancestry walk
+  # itself. AND IT IS ZERO ON THE SUCCESS PATH — this branch is only reached when
+  # the walk already answered "no", so a correct Case B merge (anchor IS an
+  # ancestor, rc 0) returns above without walking anything. The cost is paid only
+  # on a refusal, where a slow correct answer beats a fast wrong one.
+  rc=0
+  _anchor_git rev-list --quiet "$head" >/dev/null 2>&1 || rc=$?
+  if _anchor_timed_out "$rc"; then
+    _anchor_refuse_timeout "$anchor" "$head" "the connectivity walk (rev-list over the certified sha's history)" \
+      "the SHARED object store, read through the scratch alternate"
+  fi
+  if [ "$rc" -ne 0 ]; then
+    # TEXTUALLY DISTINCT from the shallow cause and from the timeout cause: there
+    # are now THREE reasons rc 1 is not a verdict, and an operator must be able to
+    # tell which one fired.
+    refuse_anchor_unverifiable "$anchor" "$head" \
+      "the certified sha's reachable history is INCOMPLETE in this object store (rev-list exited $rc)" \
+      "There is no shallow marker on this repository, so the shallowness probe" \
+      "above answered 'false' — but that only means no marker, NOT that the history" \
+      "is complete. A missing or corrupt intermediate COMMIT object produces the" \
+      "same rc 1 from the ancestry walk, and treating it as a verdict would report" \
+      "a VALID anchor as 'not on this history' (exit 2) when the truth is that this" \
+      "box could not measure it." \
+      "REMEDY: repair the object store — 'git fsck' names the missing objects, and" \
+      "'git fetch' the branches that carry them — then re-run this assert. Do NOT" \
+      "re-run the gate: the chain may well be correct." \
+      "This is NOT the shallow cause (that names a shallow/unproven repository) and" \
+      "NOT a timeout (that names the operation that hung)."
   fi
 
   refuse_no_gate \

--- a/scripts/flow/premerge-assert.sh
+++ b/scripts/flow/premerge-assert.sh
@@ -61,9 +61,16 @@
 #   CASE B (4 args) — ANCHORED DELTA. The full block is the ANCHOR (its sha need
 #     NOT be the certified sha), and the fourth argument must be a `--delta`
 #     block that (i) is a PASS with an intact tree, (ii) names that exact anchor
-#     in `delta-anchor:`, and (iii) whose OWN `commit:`/`tree-start:` cover the
-#     certified sha. The chain is therefore closed end to end: full PASS at X →
-#     delta re-cert anchored at X → delta ran on Y → Y is the PR head.
+#     in `delta-anchor:`, (iii) whose OWN `commit:`/`tree-start:` cover the
+#     certified sha, and (iv) whose anchor is ON THE CERTIFIED SHA'S HISTORY
+#     (#3653 — `git merge-base --is-ancestor`, three-valued: BOUND proceeds,
+#     NOT-ANCESTOR is exit 2, and anything UNMEASURABLE is exit 3 under
+#     `PREMERGE: ANCHOR-UNVERIFIABLE`). Without (iv) the anchor's identity rested
+#     on the delta run's SELF-DECLARED `delta-anchor:` line, so ANY full-gate
+#     PASS plus a delta naming it satisfied the chain — the #3616 cross-lane
+#     class surviving in the one path Case A's sha binding does not cover.
+#     The chain is therefore closed end to end: full PASS at X, X on this PR's
+#     history → delta re-cert anchored at X → delta ran on Y → Y is the PR head.
 #
 # In BOTH cases a full-gate PASS must EXIST, and the merged tree is covered
 # either directly (A) or by an anchored delta re-cert on top of it (B). What is
@@ -79,8 +86,8 @@
 # block was recovered from a coloured CAPTURE rather than from the summary file
 # (#3400: colour survives redirection).
 #
-# TWO RESIDUALS, STATED RATHER THAN FAKED
-# ---------------------------------------
+# FOUR RESIDUALS, STATED RATHER THAN FAKED
+# ----------------------------------------
 #  1. `run-id:` CANNOT be verified here. The #2874 reader contract says a reader
 #     must confirm the summary's `run-id:` matches the run IT launched — this
 #     script did not launch the gate, so it has nothing to compare against. It
@@ -91,12 +98,22 @@
 #  2. This assert proves a summary EXISTS claiming a full-gate PASS covering this
 #     sha with an intact tree. It cannot prove that summary was produced by a
 #     genuine gate run rather than hand-written. A HOSTILE INVOKER IS OUT OF THE
-#     THREAT MODEL — whoever runs this script controls the process and could
-#     edit the script, fake the file, or skip the script entirely; no check
-#     inside a process defends against the party that controls the process. What
-#     this guard defends is ACCIDENT AND DRIFT, which is the observed failure
-#     mode: a diligent worker with no step in its path telling it the gate of
-#     record was never run.
+#     THREAT MODEL — whoever runs this script controls the process and could edit
+#     the script or fabricate the file; no check inside a process defends against
+#     the party that controls the process. What this guard defends is ACCIDENT
+#     AND DRIFT, which is the observed failure mode: a diligent worker with no
+#     step in its path telling it the gate of record was never run.
+#
+#     "SKIP THE SCRIPT ENTIRELY" IS A DIFFERENT AND LARGER GAP, AND IT IS **IN**
+#     THE MODEL (#3653). It used to be filed above, under the hostile invoker —
+#     which was not true: #3408's actual escape was ACCIDENT/DRIFT (22 `--lite`
+#     PASSes and no full gate, because nothing in the merge path ever asked for
+#     the block), and by the triage rule's own terms an accident route is a
+#     defect, not out of model. Stated honestly: THIS GUARD CANNOT MAKE ITSELF
+#     INVOKED; THE DOCUMENTS THAT ROUTE WORKERS HERE ARE THE CONTROL (CLAUDE.md's
+#     flow-closer bullet, `.claude/agents/flow-closer.md`, `.claude/agents/
+#     flow-lead.md`). A mechanism that closed it would have to live where the
+#     merge is issued, not inside the check the merge path may never call.
 #  3. THE CERTIFIED TREE IS NOT THE MERGED TREE (#3650). A squash-merge composes
 #     this diff with main's CURRENT tip, not with the base the branch was written
 #     against, so for any PR whose base is behind main the tree this script
@@ -135,6 +152,19 @@
 #     So the three `PREMERGE: SCOPE` lines are RETAINED: slice 1 does not close
 #     the gap they disclose, and removing them would be exactly the overclaim
 #     this residual exists to prevent.
+#  4. THE #3653 ANCHOR BINDING IS A LOCAL-REPOSITORY FACT (Case B only). It
+#     proves the anchor is an ancestor of the certified sha AS THIS CHECKOUT'S
+#     OBJECT STORE RECORDS IT. Two things it therefore does NOT prove. (a) It
+#     says NOTHING about whether the anchor is on the PR AS GITHUB SEES IT: the
+#     local branch could hold commits that were never pushed, and no `gh` call
+#     here reads the PR's commit list. The `commit:`/`tree-start:` binding plus
+#     the head compare are what tie the whole chain to the sha GitHub will merge.
+#     (b) A MANIPULATED LOCAL OBJECT STORE or a `refs/replace/*` entry could make
+#     a foreign anchor look like an ancestor — INVOKER-CLASS and out of model by
+#     residual 2, and narrowed anyway by the two git pins at the check
+#     (`GIT_NO_REPLACE_OBJECTS=1` + `--no-replace-objects`), which close the
+#     replacement-ref route because it also fires BY ACCIDENT (a `git replace`
+#     left behind by an unrelated debugging session).
 #
 # USAGE
 #   scripts/flow/premerge-assert.sh <pr-number> <certified-sha> \
@@ -150,14 +180,19 @@
 #         NOT proven, #3650), "PREMERGE: ADVISORY ..." (the non-blocking
 #         base-staleness report, #3650 slice 1 — it NEVER changes this exit
 #         code) and "PREMERGE: GATE-OF-RECORD ..."
-#         (plus "PREMERGE: DELTA-RECERT ..." in Case B)
-#   2   no/invalid gate of record, OR head moved (mismatch), OR PR closed/merged
-#       — LOUD multi-line refusal
-#   3   gh/network failure, a required TOOL failing, or a usage error — fail
-#       closed, never merge on uncertainty. The three are distinguished by the
-#       printed marker, NOT by the code: `PREMERGE: USAGE` (you called it wrong),
-#       `PREMERGE: TOOL-FAILURE` (a broken box — fix the box, do NOT re-run the
-#       gate), `PREMERGE: GH-FAILURE` (auth/network/no-such-PR).
+#         (plus "PREMERGE: DELTA-RECERT ... anchor-ancestry: BOUND ..." in Case B,
+#          the affirmative record that the #3653 ancestry binding RAN)
+#   2   no/invalid gate of record (INCLUDING a Case B anchor that is NOT on the
+#       certified sha's history, #3653), OR head moved (mismatch), OR PR
+#       closed/merged — LOUD multi-line refusal
+#   3   gh/network failure, a required TOOL failing, an UNMEASURABLE anchor
+#       ancestry, or a usage error — fail closed, never merge on uncertainty. The
+#       four are distinguished by the printed marker, NOT by the code:
+#       `PREMERGE: USAGE` (you called it wrong), `PREMERGE: TOOL-FAILURE` (a
+#       broken box — fix the box, do NOT re-run the gate), `PREMERGE: GH-FAILURE`
+#       (auth/network/no-such-PR), `PREMERGE: ANCHOR-UNVERIFIABLE` (#3653 — this
+#       box could not measure whether the anchor is on this PR's history: no git,
+#       no work tree, an absent object, or a shallow/unproven history).
 #
 # macOS bash 3.2 compatible, shellcheck-clean.
 set -euo pipefail
@@ -258,6 +293,176 @@ refuse_tool_failure() {
   printf '  assert — do NOT re-run the gate. Refusing to merge (fail closed).\n' >&2
   printf '========================================================\n' >&2
   exit 3
+}
+
+# ---------------------------------------------------------------------------
+# CASE B ONLY — THE DELTA ANCHOR MUST BE ON THE CERTIFIED SHA'S HISTORY (#3653)
+# ---------------------------------------------------------------------------
+# WHAT WAS MISSING. In Case B the anchor's identity rested entirely on the DELTA
+# run's SELF-DECLARED `delta-anchor:` line: the checks above prove the full block
+# and the delta block AGREE about a sha, never that the sha is on THIS PR. So any
+# full-gate PASS, plus a delta naming it, satisfied the chain — the #3616
+# cross-lane class surviving in the one path Case A's sha binding does not cover.
+# `git merge-base --is-ancestor <anchor> <certified>` closes it offline and for
+# free. (The accident path was ALSO narrowed by scripts/agent-gate.sh's own
+# fail-closed `--delta` diff classification, which refuses anything but a
+# test/docs-only diff between anchor and head — but a constraint that lives in
+# ANOTHER script is not a constraint stated where this guard is read.)
+#
+# THE VERDICT IS THREE-VALUED, because `--is-ancestor`'s rc 1 is ITSELF
+# three-valued (#3544): in a SHALLOW clone rc 1 also means "the connecting
+# history is absent", so rc 1 is definitive ONLY in a repository proven complete.
+# Reading it two-valued would refuse a correct merge in a shallow checkout — the
+# guard agents learn to waive.
+#   BOUND         rc 0 -> proceed, and RECORD it on the `PREMERGE: DELTA-RECERT`
+#                 evidence line. An affirmative record is required: a silent pass
+#                 is indistinguishable from a check that never ran.
+#   NOT-ANCESTOR  rc 1 AND both objects present AND the repository proven
+#                 complete -> exit 2 via refuse_no_gate ("your chain is wrong").
+#   UNVERIFIABLE  anything that could not be MEASURED -> exit 3 under its OWN
+#                 marker. An unmeasurable result is UNKNOWN, never ok (never
+#                 derive a pass from the ABSENCE of a bad signal), and exit 3 is
+#                 this script's home for "this box could not measure it — fix the
+#                 box, do NOT re-run the gate", a DIFFERENT operator action from
+#                 exit 2's "re-certify with a correct anchor".
+#
+# AMBIENT GIT STATE IS PINNED, the same two pins scripts/flow/base-staleness.sh
+# carries and for the same reasons — both are cheap, and each turns a silently
+# wrong answer into an ordinary git failure:
+#   * `GIT_NO_LAZY_FETCH=1` — in a PARTIAL/PROMISOR clone a plain OBJECT READ
+#     fetches over the network and WRITES packfiles, so "this is an offline
+#     check" would be an intention rather than a property. A missing object then
+#     fails its git call, which routes here to UNVERIFIABLE — the correct verdict
+#     for an unmeasurable read. Honoured only from git 2.36, so like
+#     base-staleness.sh this is a DECLARED precondition, not a detected one.
+#   * `GIT_NO_REPLACE_OBJECTS=1`, plus `--no-replace-objects` on every call — one
+#     local `refs/replace/*` entry rewrites the ancestry `merge-base` walks, i.e.
+#     it can make a foreign anchor LOOK like an ancestor. Honoured by every git
+#     that has replacement refs at all, so it needs no version measurement.
+# Neither is settable by the caller, and the repository read is the CURRENT
+# WORKING DIRECTORY's, with no env override (#3312: the constrained party must
+# not choose its own enforcer, and "which repository decides whether my anchor is
+# on this PR" is exactly what a lane wanting to skip a re-cert would redirect).
+#
+# THESE READS ARE DELIBERATELY **NOT** WRAPPED IN `env -i` + an allowlist, unlike
+# scripts/agent-gate.sh's component-set pre-flight. That wrapper exists where a
+# git call can REACH A REMOTE and the answer's provenance is a fetch. Here every
+# read is lane-local and addressed BY A SHA, and everything addressed by a sha is
+# CONTENT-ADDRESSED — so there is nothing an environment can bend that the two
+# pins above do not already cover. Do not "fix" this by adding one.
+export GIT_NO_LAZY_FETCH=1
+export GIT_NO_REPLACE_OBJECTS=1
+
+# The value published on the DELTA-RECERT evidence line. Initialised to a value
+# that would be VISIBLY wrong rather than left unset: if a future reordering ever
+# printed the line without running the check, the operator must see that, not a
+# `set -u` crash and not a plausible-looking blank.
+ANCHOR_ANCESTRY=UNRECORDED
+
+# refuse_anchor_unverifiable <anchor> <certified> <cause> <remedy-line>... —
+# exit 3 under a marker TEXTUALLY DISTINCT from `PREMERGE: NO-GATE-OF-RECORD`
+# (exit 2 — your chain is wrong) and from `PREMERGE: TOOL-FAILURE` (a broken
+# parser on this box). "This box could not measure the ancestry" is a third
+# operator action and gets its own name, for the same reason nit 8 split USAGE
+# from GH-FAILURE: the exit CODES cannot carry that distinction.
+refuse_anchor_unverifiable() {
+  local anchor="$1" head="$2" cause="$3"
+  shift 3
+  printf '========================================================\n' >&2
+  printf 'PREMERGE: ANCHOR-UNVERIFIABLE — REFUSING TO MERGE\n' >&2
+  printf '  delta anchor:  %s\n' "$anchor" >&2
+  printf '  certified sha: %s\n' "$head" >&2
+  printf '  cause: %s\n' "$cause" >&2
+  while [ "$#" -gt 0 ]; do
+    printf '  %s\n' "$1" >&2
+    shift
+  done
+  printf '  An UNMEASURABLE ancestry is UNKNOWN, never ok: a pass may not be derived\n' >&2
+  printf '  from the ABSENCE of a bad signal. This is NOT a verdict about your chain\n' >&2
+  printf '  and NOT a parser failure — it is "THIS BOX could not measure it". Fix the\n' >&2
+  printf '  checkout/box and re-run this assert; do NOT re-run the gate.\n' >&2
+  printf '========================================================\n' >&2
+  exit 3
+}
+
+# assert_anchor_on_history <anchor-40-hex> <certified-40-hex> — the #3653
+# binding. Sets ANCHOR_ANCESTRY=BOUND on the one passing verdict; every other
+# outcome refuses. Exit codes are captured WITHOUT tripping `set -e`.
+assert_anchor_on_history() {
+  local anchor="$1" head="$2" rc=0 shallow=""
+
+  if ! command -v git >/dev/null 2>&1; then
+    refuse_anchor_unverifiable "$anchor" "$head" "git is not on PATH" \
+      "REMEDY: install git, or run this assert from a box that has it."
+  fi
+  if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    refuse_anchor_unverifiable "$anchor" "$head" \
+      "the current directory is not inside a git work tree (cwd: $(pwd))" \
+      "REMEDY: run this assert from the ISSUE'S WORKTREE. The repository whose" \
+      "history the anchor must lie on is the CURRENT DIRECTORY's, and there is" \
+      "deliberately no env override naming a different one (#3312)."
+  fi
+  # Presence is probed per object so the diagnostic can name WHICH one is absent
+  # — the two have different remedies in practice (an anchor from a rebased-away
+  # branch vs a certified head that was never fetched).
+  if ! git --no-replace-objects cat-file -e "$anchor^{commit}" >/dev/null 2>&1; then
+    refuse_anchor_unverifiable "$anchor" "$head" \
+      "the ANCHOR commit is not present in this repository" \
+      "An absent object cannot be shown to lie on any history, and its absence is" \
+      "not evidence that it does not (it may simply never have been fetched)." \
+      "REMEDY: fetch the branch that carries it (git fetch origin <branch>) and" \
+      "re-run this assert."
+  fi
+  if ! git --no-replace-objects cat-file -e "$head^{commit}" >/dev/null 2>&1; then
+    refuse_anchor_unverifiable "$anchor" "$head" \
+      "the CERTIFIED commit is not present in this repository" \
+      "REMEDY: fetch the PR branch (git fetch origin <branch>) and re-run this" \
+      "assert from a checkout that holds the sha being merged."
+  fi
+
+  rc=0
+  git --no-replace-objects merge-base --is-ancestor "$anchor" "$head" >/dev/null 2>&1 || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    ANCHOR_ANCESTRY=BOUND
+    return 0
+  fi
+  if [ "$rc" -ne 1 ]; then
+    refuse_anchor_unverifiable "$anchor" "$head" \
+      "git merge-base --is-ancestor exited $rc — an ERROR, not an answer" \
+      "Only 0 (ancestor) and 1 (not, or history absent) are answers; anything else" \
+      "is git reporting that it could not decide." \
+      "REMEDY: run that command by hand to see git's own diagnostic, fix the" \
+      "checkout, then re-run this assert."
+  fi
+
+  # rc 1 is itself THREE-valued (#3544). It is a VERDICT only in a repository
+  # proven complete; `--is-shallow-repository` must answer the literal `false`.
+  # An empty answer (a git too old to know the option, or a failed call) is
+  # UNMEASURED and takes the same refusing branch as `true` — the permissive
+  # branch is never the default for an unestablished state.
+  shallow=$(git --no-replace-objects rev-parse --is-shallow-repository 2>/dev/null) || shallow=""
+  if [ "$shallow" != false ]; then
+    refuse_anchor_unverifiable "$anchor" "$head" \
+      "--is-ancestor said 'no', but this repository is NOT PROVEN COMPLETE (git rev-parse --is-shallow-repository = '$shallow')" \
+      "In a SHALLOW clone rc 1 ALSO means 'the connecting history is absent'" \
+      "(#3544), so 'no' is a verdict only where the history is complete. An answer" \
+      "that is not the literal 'false' — 'true', empty, or a git too old to answer" \
+      "— is UNMEASURED, and an unmeasured ancestry is never read as a pass." \
+      "REMEDY: git fetch --unshallow (or fetch the missing history), then re-run."
+  fi
+
+  refuse_no_gate \
+    "The delta block's 'delta-anchor:' sha is NOT on the certified sha's history." \
+    "delta anchor:  $anchor" \
+    "certified sha: $head" \
+    "git merge-base --is-ancestor <anchor> <certified> answers NO, in a repository" \
+    "proven complete: the anchor is not on THIS PR's history. Case B's anchor" \
+    "identity otherwise rests on the delta run's SELF-DECLARED 'delta-anchor:'" \
+    "line, so an unbound anchor lets ANY full-gate PASS anchor THIS merge — the" \
+    "#3616 cross-lane class (a peer lane's real, valid summary) surviving in the" \
+    "one path Case A's sha binding does not cover (#3653)." \
+    "REMEDY: re-run 'scripts/agent-gate.sh --delta <anchor>' with an anchor that IS" \
+    "on this PR's history, and pass THAT pair — never a foreign full-gate summary."
 }
 
 # ---------------------------------------------------------------------------
@@ -936,6 +1141,16 @@ fi
 assert_clean_tree "full-gate block" "$full_dirty" full "$full_ndirty" commit:
 assert_clean_tree "full-gate block" "$full_tsdirty" full "$full_ntsdirty" tree-start:
 
+# CASE B ONLY (#3653) — the anchor must be on the certified sha's history.
+# Placed LAST among the offline gate-of-record checks, and deliberately: every
+# cheaper structural refusal above reports FIRST (so the diagnostic still names
+# the first thing that is wrong), and running it after the full block's own
+# `dirty:` enforcement keeps a dirty anchor reported as dirty rather than as
+# unverifiable. It is the only check here that reads a repository.
+if [ -n "$delta_file" ]; then
+  assert_anchor_on_history "$delta_anchor" "$certified"
+fi
+
 # ---------------------------------------------------------------------------
 # THE ADVISORY IS MEASURED **BEFORE** THE HEAD CHECK (#3650, roborev job 250)
 # ---------------------------------------------------------------------------
@@ -1028,7 +1243,10 @@ fi
 printf 'PREMERGE: GATE-OF-RECORD commit: %s tree-start: %s tree-integrity: PASS dirty: %s summary: %s\n' \
   "$full_commit" "$full_ts" "$full_dirty" "$summary_file"
 if [ -n "$delta_file" ]; then
-  printf 'PREMERGE: DELTA-RECERT anchor: %s commit: %s tree-start: %s tree-integrity: PASS dirty: %s summary: %s\n' \
-    "$delta_anchor" "$delta_commit" "$delta_ts" "$delta_dirty" "$delta_file"
+  # `anchor-ancestry:` is the AFFIRMATIVE record that the #3653 binding RAN. After
+  # assert_anchor_on_history it can only ever read BOUND — which is the point: a
+  # silent pass is indistinguishable from a check that was never reached.
+  printf 'PREMERGE: DELTA-RECERT anchor: %s anchor-ancestry: %s commit: %s tree-start: %s tree-integrity: PASS dirty: %s summary: %s\n' \
+    "$delta_anchor" "$ANCHOR_ANCESTRY" "$delta_commit" "$delta_ts" "$delta_dirty" "$delta_file"
 fi
 exit 0

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -102,6 +102,20 @@ suite_cleanup() {
   rm -rf "$T"
 }
 
+# EVERY CHILD GETS $T AS ITS TMPDIR (found while measuring job 388). The shipped
+# assert creates its scratch under TMPDIR and, since the delete was removed, LEAVES
+# IT THERE. This suite exercises Case B dozens of times per run and runs in the
+# gate's tooling-tests, so with the ambient /tmp it accumulated scratch dirs
+# without bound — 240 measured on this box after a round of development, not the
+# "one per Case B merge" the removal's trade was stated against.
+#
+# Pointing TMPDIR at $T contains them WITHOUT reinstating any per-path delete in
+# the shipped script: the suite already owns $T and removes it WHOLESALE, which is
+# safe precisely because it is this run's own mktemp directory rather than a
+# peer-mutable path. Exported after $T is validated, so the suite's own mktemp
+# above still used the ambient TMPDIR.
+export TMPDIR="$T"
+
 trap 'suite_cleanup' EXIT
 trap 'suite_cleanup; trap - INT;  kill -INT  $$' INT
 trap 'suite_cleanup; trap - TERM; kill -TERM $$' TERM

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -75,72 +75,55 @@ if ! T=$(mktemp -d "${TMPDIR:-/tmp}/premerge-assert-test.XXXXXX" 2>/dev/null) ||
   printf 'FAIL - every path in this suite would resolve under / instead.\n' >&2
   exit 1
 fi
-# CLEANUP IS A FUNCTION SO IT CAN GROW, AND IT IS REGISTERED BEFORE ANY RESOURCE
-# EXISTS (CLAUDE.md job 282). The decoy of case 44(l) is a TERM-IGNORING process
-# blocked on a FIFO: if its recognition fails, or the suite is interrupted, it
-# would otherwise sit blocked forever. The trap reads DECOY_CLEANUP_PID at FIRE
-# time, so installing the handler here — before the decoy exists — is exactly the
-# ordering job 282 asks for. Signals get handlers too, because bash runs no EXIT
-# trap for a signal left at its default disposition; each re-raises so the process
-# still dies of what it was sent.
+# CLEANUP IS UNCONDITIONAL, RUN-SCOPED, AND MAKES NO VERDICT (roborev job 381,
+# firing the stop line). The leak ADJUDICATION that used to live here — deciding
+# LEAK vs RECYCLED vs GONE vs ZOMBIE vs UNMEASURABLE from a two-valued `ps` probe
+# — is DELETED. Six findings in that apparatus, three of them the same fail-open
+# read after three correct fixes, and the standing ruling applies: a guard with a
+# persistent documented false-PASS record is worse than no guard, because it
+# invites reliance it cannot support.
 #
-# ORDER IS LOAD-BEARING: the decoy is reaped BEFORE `rm -rf "$T"`, because it
-# blocks on a FIFO inside $T and removing the FIFO does NOT unblock an open() that
-# is already waiting.
-DECOY_CLEANUP_PID=""
-DECOY_CLEANUP_NEEDLE=""
+# WHAT REPLACES IT NEEDS NO ADJUDICATION AT ALL. Every process this suite spawns
+# carries `$T/` in its argv — the shim paths and the sentinel sleep alike — and
+# `$T` is a per-run `mktemp -d`, so ANYTHING wearing it IS OURS. That makes the
+# kill safe by CONSTRUCTION (job 279's argv validation, with a needle no peer can
+# produce) instead of by interpreting an exit status. Nothing here decides
+# anything, so nothing here can fail open: if `ps` cannot run, the sweep kills
+# nothing and no assertion depends on it.
+#
+# Registered BEFORE any resource exists (CLAUDE.md job 282), signals included,
+# because bash runs no EXIT trap for a signal at its default disposition; each
+# re-raises so the process still dies of what it was sent.
+#
+# ORDER IS LOAD-BEARING: the sweep runs BEFORE `rm -rf "$T"`. A shim can be
+# blocked on a FIFO inside $T, and removing the FIFO does NOT unblock a reader
+# already waiting on it.
 suite_cleanup() {
-  to_kill_decoy
+  to_sweep_run_processes
+  rm -f "$T/ps-census.txt" 2>/dev/null
   rm -rf "$T"
 }
-# to_kill_decoy — kill the registered decoy, VALIDATING ITS ARGV FIRST so a pid
-# that has been recycled into something else is never signalled (job 279:
-# ownership ends at reap, not at exit; on this fleet the inheritor of a released
-# pid is most likely a peer lane's gate). Safe to call any number of times.
-#
-# THREE THINGS THE FIRST VERSION GOT WRONG (roborev job 378):
-#
-#  1. IT CLEARED THE REGISTRATION EVEN WHEN THE PROBE COULD NOT ANSWER. `args=$(ps
-#     …) || args=""` collapses "ps FAILED" onto "the process is GONE", and the
-#     unconditional clear then DISCARDED the registration — so a failed probe
-#     silently leaked the process. That is the fail-open shape this repo names
-#     explicitly: a probe that could not answer taking the permissive branch. And
-#     it is not niche — a failing `ps` is exactly when the registration matters
-#     most. MEASURED, which is what makes the split expressible: `ps -p <gone>`
-#     exits 1 with no output (an AFFIRMATIVE "not found"), while a broken `ps`
-#     exits >= 2. So rc >= 2 KEEPS the registration for a later call; only an
-#     affirmative determination may clear it.
-#  2. IT KILLED WITHOUT REAPING. The decoy is a DIRECT CHILD, so an unreaped
-#     SIGKILL leaves a zombie holding the pid. `wait` follows the kill, and the
-#     clear follows the wait — in that order.
-#  3. It relied on `rm -rf "$T"` as a backstop, which cannot work: REMOVING THE
-#     FIFO DOES NOT UNBLOCK A READER ALREADY BLOCKED ON IT. That is why the reap
-#     runs BEFORE the directory removal in `suite_cleanup`, not after.
-#
-# An EMPTY needle is also a "cannot validate" state: it neither signals nor
-# clears, because `*""*` matches anything and would authorise a blind kill.
-to_kill_decoy() {
-  local pid="$DECOY_CLEANUP_PID" args rc=0
-  [ -n "$pid" ] || return 0
-  args=$(ps -p "$pid" -o args= 2>/dev/null) || rc=$?
-  if [ "$rc" -ge 2 ]; then
-    return 0                      # the probe FAILED: keep the registration
-  fi
-  if [ -z "$args" ]; then
-    DECOY_CLEANUP_PID=""          # affirmatively gone (ps ran, found nothing)
-    return 0
-  fi
-  [ -n "$DECOY_CLEANUP_NEEDLE" ] || return 0   # cannot validate: never blind-kill
-  case "$args" in
-    *"$DECOY_CLEANUP_NEEDLE"*)
-      kill -KILL "$pid" 2>/dev/null
-      wait "$pid" 2>/dev/null || true          # reap: it is a direct child
-      DECOY_CLEANUP_PID=""
-      ;;
-    *) : ;;                       # RECYCLED: never signalled, never cleared
-  esac
+
+# to_sweep_run_processes — kill every process whose argv names THIS RUN's scratch
+# dir. Best-effort by design: no status is inspected and no verdict is produced.
+# `wait` follows, for whatever was a direct child (it is a no-op for the rest).
+to_sweep_run_processes() {
+  local snap p a
+  snap="${TMPDIR:-/tmp}/premerge-sweep.$$"
+  ps -eo pid=,args= >"$snap" 2>/dev/null || { rm -f "$snap"; return 0; }
+  while read -r p a; do
+    case "$p" in ''|*[!0-9]*) continue ;; esac
+    case "$a" in
+      *"$T/"*)
+        kill -KILL "$p" 2>/dev/null || true
+        wait "$p" 2>/dev/null || true
+        ;;
+    esac
+  done <"$snap"
+  rm -f "$snap"
   return 0
 }
+
 trap 'suite_cleanup' EXIT
 trap 'suite_cleanup; trap - INT;  kill -INT  $$' INT
 trap 'suite_cleanup; trap - TERM; kill -TERM $$' TERM
@@ -2219,8 +2202,8 @@ fi
 # no other process on the box can produce — never a `pkill -f` pattern.
 TOFLOW="$T/flow-timeout"
 # THE SENTINEL MUST BE UNIQUE PER RUN, AND A FIXED STRING WAS A REAL BLOCKER.
-# It used to be a FIXED `sleep <constant>` argv, while `to_leaks` and the cleanup
-# census the WHOLE BOX (`ps -eo …`). Measured, both directions: a suite run
+# It used to be a FIXED `sleep <constant>` argv, while the leak census and the
+# cleanup scanned the WHOLE BOX (`ps -eo …`). Measured, both directions: a suite run
 # CONCURRENTLY with another run of itself reported `293 passed, 1 FAILED —
 # 1 stray process(es) matching the sentinel survived`, and the same suite run
 # alone immediately after reported `294 passed, 0 failed` with no strays on the
@@ -2295,134 +2278,12 @@ else
   ok "hung-read: SKIPPED (no bounding runner / fixture unbuildable — arms UNEXERCISED, declared not silent)"
 fi
 
-# to_leaks — count processes whose FULL argv is exactly the sentinel. An exact
-# whole-line match, never a `pkill -f` pattern: on this fleet a pattern-based
-# kill has already taken out a peer lane's gate.
-#
-# THIS CENSUS IS NOT SUFFICIENT ON ITS OWN, and believing it was is roborev job
-# 367: only the TERM shim ever WEARS that argv (it `exec`s into the sentinel
-# sleep). The KILL shim stays a BASH process blocked on the FIFO — measured argv
-# `bash <shimdir>/git merge-base --is-ancestor <sha> <sha>` — so a surviving
-# KILL-path process passed this assertion untouched. The assertion was vacuous
-# for precisely the arm that needs it, the one where the runner had to escalate.
-# A vacuous assertion is worse than a missing one, because it invites reliance it
-# cannot support. It is KEPT as a cheap second signal (it also catches a stray
-# sentinel from an earlier run) and is no longer the primary check.
-# THREE-VALUED SINCE roborev job 380, and it had TWO fail-open routes at once:
-#   * `ps` ran INSIDE A PIPELINE, so its exit status was DISCARDED entirely — the
-#     pipeline's status is grep's. A failing `ps` produced EMPTY input, grep
-#     counted 0, and the caller read "no leaks".
-#   * `grep -c` prints `0` AND EXITS 1 on no-match, so its status cannot be used
-#     naively either (that trap already cost this file one round).
-# So `ps` writes to a FILE, its status is inspected, and only then is the count
-# taken. Prints a NUMBER, or the literal `UNMEASURABLE` — never a silent 0. The
-# caller must FAIL on UNMEASURABLE: this suite tests a guard that is fail-closed
-# on an unmeasurable state, so its own checks being permissive there would be
-# incoherent.
-to_leaks() {
-  local psout n rc=0 grc=0
-  psout="$T/ps-census.txt"
-  ps -eo args= >"$psout" 2>/dev/null || rc=$?
-  if [ "$rc" -ne 0 ]; then
-    rm -f "$psout"
-    printf 'UNMEASURABLE\n'
-    return 0
-  fi
-  n=$(grep -c -x -F "$TOSENTINEL" "$psout" 2>/dev/null)
-  grc=$?
-  rm -f "$psout"
-  # grep -c: 0 = matches, 1 = none (still prints a count), >=2 = ERROR.
-  if [ "$grc" -ge 2 ]; then
-    printf 'UNMEASURABLE\n'
-    return 0
-  fi
-  case "$n" in
-    ''|*[!0-9]*) printf 'UNMEASURABLE\n'; return 0 ;;
-  esac
-  printf '%s\n' "$n"
-}
-
-# to_check_pid <label> <pidfile> <expected-argv-needle> — the PRIMARY leak check
-# (job 367). The shim records its OWN pid before it blocks; `exec` PRESERVES the
-# pid, so this covers the TERM arm as well as the KILL arm, uniformly.
-#
-# THREE-VALUED, and the middle value is the whole point of doing this carefully:
-#   gone                      -> no leak.
-#   present AND argv MATCHES  -> a real leak. Reported, then killed.
-#   present AND argv does NOT -> INDETERMINATE. The pid was RELEASED and RECYCLED
-#                                into another process, and on this fleet the most
-#                                likely inheritor is A PEER LANE'S GATE (this repo
-#                                has that incident). So the argv is validated
-#                                BEFORE any signal, and a mismatch is REPORTED and
-#                                NEVER SIGNALLED — job 279's "ownership ends at
-#                                REAP, not at exit".
-# A `<defunct>` entry is its own, fourth outcome: a zombie holds a pid but runs no
-# code and is reaped by init, so it is not a leak — named explicitly rather than
-# folded into either branch.
-# to_pid_verdict <pidfile> <needle> — the DECIDING half, split out so it can be
-# SELF-TESTED (see 44(l)): it prints exactly one verdict token and KILLS NOTHING.
-# A check whose only caller reports "no leak" cannot demonstrate that it would
-# ever say otherwise, which is the defect this whole round is about.
-#   NO-SUBJECT | BAD-PID | UNMEASURABLE | GONE | ZOMBIE | LEAK | RECYCLED
-#
-# `UNMEASURABLE` was added on roborev job 380: `args=$(ps …) || args=""` collapsed
-# a FAILED probe onto an EMPTY one, so a `ps` that could not run was reported as
-# `GONE` — a surviving timeout child read as successfully reaped while the suite
-# passed. Same measured split as `to_kill_decoy` uses: `ps -p <gone>` exits 1 with
-# no output (an affirmative "not found"), a broken `ps` exits >= 2.
-to_pid_verdict() {
-  local pidfile="$1" needle="$2" pid args rc=0
-  if [ ! -f "$pidfile" ]; then printf 'NO-SUBJECT\n'; return 0; fi
-  pid=$(cat "$pidfile" 2>/dev/null)
-  case "$pid" in
-    ''|*[!0-9]*) printf 'BAD-PID\n'; return 0 ;;
-  esac
-  args=$(ps -p "$pid" -o args= 2>/dev/null) || rc=$?
-  if [ "$rc" -ge 2 ]; then printf 'UNMEASURABLE\n'; return 0; fi
-  if [ -z "$args" ]; then printf 'GONE\n'; return 0; fi
-  case "$args" in
-    *"<defunct>"*) printf 'ZOMBIE\n' ;;
-    *"$needle"*)   printf 'LEAK\n' ;;
-    *)             printf 'RECYCLED\n' ;;
-  esac
-  return 0
-}
-
-# to_check_pid <label> <pidfile> <expected-argv-needle> — the REPORTING half.
-to_check_pid() {
-  local label="$1" pidfile="$2" needle="$3" pid verdict args
-  verdict=$(to_pid_verdict "$pidfile" "$needle")
-  pid=$(cat "$pidfile" 2>/dev/null || true)
-  case "$verdict" in
-    NO-SUBJECT)
-      bad "hung-read ($label): the shim never recorded a pid — it did not run, so this arm proves nothing"
-      return 1 ;;
-    BAD-PID)
-      bad "hung-read ($label): the shim recorded a non-numeric pid ('$pid') — the leak check cannot be made"
-      return 1 ;;
-    UNMEASURABLE)
-      # NOT read as "no leak": the probe could not answer, so whether the runner
-      # reaped its child is UNKNOWN, and an unknown is never a pass (job 380).
-      bad "hung-read ($label): the process probe FAILED (ps unusable), so whether pid $pid survived the bound is UNKNOWN — never read as reaped"
-      return 1 ;;
-  esac
-  ok "hung-read ($label): the shim recorded its own pid ($pid) — the leak check has a SUBJECT"
-  case "$verdict" in
-    GONE)
-      ok "hung-read ($label): the shim process is GONE — nothing leaked past the bound" ;;
-    ZOMBIE)
-      ok "hung-read ($label): the shim pid is a ZOMBIE (runs no code, reaped by init) — not a leak" ;;
-    LEAK)
-      args=$(ps -p "$pid" -o args= 2>/dev/null || true)
-      bad "hung-read ($label): the shim process $pid SURVIVED the bound (argv: $args) — the runner did not reap its child (job 279)"
-      # Signalled ONLY because the argv was VALIDATED to be OUR shim.
-      kill -KILL "$pid" 2>/dev/null ;;
-    RECYCLED)
-      args=$(ps -p "$pid" -o args= 2>/dev/null || true)
-      bad "hung-read ($label): pid $pid is alive but its argv does NOT match this shim (argv: $args) — the pid was RECYCLED, so whether the shim leaked is INDETERMINATE. NOT signalled: on this fleet the inheritor of a released pid is most likely a peer lane's gate." ;;
-  esac
-  return 0
-}
+# THE LEAK ADJUDICATION USED TO LIVE HERE (`to_leaks`, `to_pid_verdict`,
+# `to_check_pid`) AND IS DELETED — see the cleanup block at the top of this file
+# for why. What the arms below still assert is the SHIPPED behaviour rounds 4 and
+# 7 asked for: exit 3, the ANCHOR-UNVERIFIABLE marker, and a TIMEOUT cause
+# distinct from every other cause, each with a runner-exit control. What they no
+# longer assert is WHO leaked and WHY.
 
 # to_run_arm <label> <shim-dir> <expected-runner-rc>
 #
@@ -2481,30 +2342,9 @@ to_run_arm() {
       *) ok "hung-read ($label): a timeout borrows NO other cause's remedy (not work-tree, TMPDIR, absent-object, shallow or NOT-ANCESTOR)" ;;
     esac
   fi
-  # PRIMARY: the shim's OWN recorded pid (job 367). Works for BOTH arms, because
-  # the KILL shim never wears the sentinel argv.
-  to_check_pid "$label" "$pidfile" "$shimdir/git"
-  # SECONDARY: the sentinel census, kept as a cheap cross-check. It can only see
-  # the TERM arm's `exec`ed sleep — see the note on to_leaks.
-  leaks=$(to_leaks)
-  if [ "$leaks" = UNMEASURABLE ]; then
-    bad "hung-read ($label): the sentinel census could not be taken (ps unusable) — that is UNKNOWN, not 'no strays' (job 380)"
-  elif [ "$leaks" = 0 ]; then
-    ok "hung-read ($label): the sentinel census also finds no stray sleep (secondary check)"
-  else
-    bad "hung-read ($label): $leaks stray process(es) matching the sentinel survived — the runner did not reap its child (job 279)"
-    # Clean up ONLY pids whose full argv EQUALS the sentinel. WHAT MAKES THIS
-    # SAFE IS THAT THE SENTINEL IS UNIQUE TO THIS RUN (derived from `$T`), NOT
-    # that the match is exact. The previous comment claimed exactness was the
-    # safety property — "an exact whole-argv match cannot be a peer lane's gate"
-    # — which is true and buys nothing: with a shared constant the match is
-    # exactly a PEER LANE'S COPY OF THIS SUITE, and this loop SIGKILLed it. Do
-    # not weaken the derivation back to a constant; the reasoning error is easy
-    # to reproduce, which is why it is written down here.
-    ps -eo pid=,args= 2>/dev/null | while read -r _p _a; do
-      [ "$_a" = "$TOSENTINEL" ] && kill -KILL "$_p" 2>/dev/null
-    done
-  fi
+  # NO LEAK ASSERTION HERE ANY MORE (job 381). Reaping is covered by the
+  # unconditional run-scoped sweep at suite exit, which makes no claim about it.
+  # DECLARED, not buried: see the DECLARED LOSS notice printed below this arm.
 }
 
 if [ "$to_shape" -eq 1 ]; then
@@ -2648,216 +2488,23 @@ FAILSHIM
   fi
 fi
 
-# --- 44(l): THE LEAK CHECK MUST BE ABLE TO SAY "LEAK" (roborev job 367) ------
+# --- 44(l) REMOVED: the leak self-test and its decoy (roborev job 381) -------
 #
-# Round 4's leak assertion searched for the sentinel sleep argv. Only
-# the TERM shim ever wears it (it `exec`s into that sleep); the KILL shim stays a
-# BASH process blocked on the FIFO — measured argv
-# `bash <shimdir>/git merge-base --is-ancestor <sha> <sha>` — so a surviving
-# KILL-path process passed the assertion untouched. The check was VACUOUS for the
-# one arm that needs it, the arm where the runner had to escalate.
+# This case existed to prove the leak adjudication could say LEAK. The
+# adjudication is gone, so the proof has nothing to prove — and the decoy was the
+# only fixture in this suite that deliberately spawned a live process in order to
+# INSPECT it, which is where every process-lifetime defect in this apparatus
+# originated (an orphaning child, an unregistered pid, a kill without a reap).
 #
-# A vacuous assertion is worse than a missing one: it invites reliance it cannot
-# support. So the deciding half is now `to_pid_verdict`, and THIS case proves it
-# has discriminating power — the same standard the mutation arm at 44(c) is held
-# to. Three properties, over a DECOY that is deliberately alive:
-#   1. a live process whose argv MATCHES -> LEAK        (the assert can fire)
-#   2. a live process whose argv does NOT -> RECYCLED, and it is NOT SIGNALLED
-#      (job 279: ownership ends at reap, and a released pid on this fleet is most
-#      likely inherited by a peer lane's gate)
-#   3. a dead pid -> GONE                               (no false alarm)
-# The decoy's argv is built to CONTAIN a shim-like path, so property 1 exercises
-# the same needle shape the real arms use.
-DECOY_DIR="$T/leak-decoy"
-DECOY_PID="$T/leak-decoy.pid"
-DECOY_FIFO="$T/leak-decoy.fifo"
-decoy_shape=0
-# THE DECOY IS AN ORDINARY PROCESS ON PURPOSE — NO `trap '' TERM` (roborev job
-# 378). It used to ignore TERM, which was shaping carried over from the KILL-path
-# shim, where ignoring TERM IS the point. Here it bought NOTHING and cost the
-# entire cleanup problem: an unkillable-by-TERM child needs careful management,
-# and four findings in this scaffolding came from managing it.
-#   VERIFIED rather than assumed, because it is the premise of the change:
-#   `to_pid_verdict` contains ZERO `kill` — it only inspects `ps` — so none of the
-#   verdicts this arm tests (LEAK / RECYCLED / GONE / NO-SUBJECT / BAD-PID) needs
-#   the decoy to survive a signal. Nothing in this suite sends the decoy TERM
-#   either; the only TERM senders target `$$`. And on a Ctrl-C the decoy now dies
-#   with the foreground group by itself, which is strictly better.
-# So the hazardous PROPERTY is removed at its source rather than managed: a plain
-# direct child is removable with `kill` + `wait`, which reaps reliably.
-#
-# THE DECOY MUST NOT SPAWN A CHILD, and getting that wrong ONCE is why this
-# comment exists. The first version ran a bare `sleep`, so the decoy was TWO
-# processes: the bash wrapper (which carries the argv the needle matches, and is
-# the pid recorded) and its sleep CHILD. SIGKILLing the wrapper ORPHANED the
-# child, and five runs of this suite left five stray sleeps on the box —
-# precisely the "a test that leaks processes is its own hazard" failure this arm
-# exists to guard against, introduced BY the guard. So the decoy blocks the same
-# way the KILL shim does: opening a writer-less FIFO, which needs no child, so
-# one SIGKILL removes the whole thing. The arm asserts its own cleanup below.
-rm -f "$DECOY_FIFO"
-if mkdir -p "$DECOY_DIR" 2>/dev/null && mkfifo "$DECOY_FIFO" 2>/dev/null; then
-  cat >"$DECOY_DIR/git" <<DECOY
-#!/usr/bin/env bash
-read -r _ < "$DECOY_FIFO"
-DECOY
-  chmod +x "$DECOY_DIR/git"
-  bash "$DECOY_DIR/git" merge-base --is-ancestor deadbeef deadbeef >/dev/null 2>&1 &
-  decoy_pid=$!
-  # REGISTERED IMMEDIATELY, on the line after the spawn (job 282). Everything
-  # below this point — a failed recognition, a `bad`, an interrupt, a normal exit
-  # — is covered by the trap installed at the top of this file.
-  DECOY_CLEANUP_PID="$decoy_pid"
-  DECOY_CLEANUP_NEEDLE="$DECOY_DIR/git"
-  printf '%s\n' "$decoy_pid" >"$DECOY_PID"
-  # Give it a moment to appear in the process table, then CONFIRM it is really
-  # alive with the expected argv — a decoy that died makes every property below
-  # vacuous, which is the exact failure this case exists to remove.
-  sleep 1
-  if [ -n "$(ps -p "$decoy_pid" -o args= 2>/dev/null | grep -F "$DECOY_DIR/git")" ]; then
-    decoy_shape=1
-  fi
-  # THE NO-CHILD PROPERTY, ASSERTED WHILE THE DECOY IS ALIVE — this is the check
-  # that would have caught round 7's orphaning decoy, and it can only be made
-  # here, because after the parent dies its children are reparented and the link
-  # is gone. A decoy with a child means SIGKILLing the recorded pid ORPHANS that
-  # child, which is the "a leak guard that leaks" hazard.
-  if [ "$decoy_shape" -eq 1 ]; then
-    decoy_kids=$(ps -eo ppid= 2>/dev/null | awk -v p="$decoy_pid" '$1 == p { n++ } END { print n + 0 }')
-    if [ "$decoy_kids" = 0 ]; then
-      ok "leak self-test fixture: the decoy has NO child process, so killing it cannot orphan anything"
-    else
-      bad "leak self-test fixture: the decoy has $decoy_kids child process(es) — killing the recorded pid would ORPHAN them (this is the round-7 defect)"
-    fi
-  fi
-fi
-if [ "$decoy_shape" -ne 1 ]; then
-  # REAP BEFORE DECLARING THE SKIP: recognition may have failed with the decoy
-  # STILL ALIVE and blocked on its FIFO. Reporting a skip while leaving it running
-  # is the leak this arm exists to guard against (roborev job 370, finding 2). The
-  # exit trap would also get it, but a skip should not depend on that.
-  to_kill_decoy
-  printf 'ARM NOT TAKEN: leak-check self-test (job 367) — a live decoy process carrying a shim-like argv\n'
-  printf 'ARM NOT TAKEN: could not be started on this host, so the leak checks discriminating power is\n'
-  printf 'ARM NOT TAKEN: UNPROVEN on this run. Any partially-started decoy has been reaped.\n'
-  ok "leak self-test: SKIPPED (decoy unavailable — arm UNEXERCISED, declared not silent)"
-else
-  ok "leak self-test fixture: a live decoy carrying a shim-like argv really exists"
-  # (1) it can say LEAK.
-  v=$(to_pid_verdict "$DECOY_PID" "$DECOY_DIR/git")
-  if [ "$v" = LEAK ]; then
-    ok "leak self-test: a live process with a MATCHING argv is reported as LEAK — the assert can fire"
-  else
-    bad "leak self-test: a live matching process was reported '$v', not LEAK — the leak assertion is vacuous (job 367)"
-  fi
-  # (2) a NON-matching argv is RECYCLED, and the decoy must SURVIVE the check,
-  # because a mismatched pid must never be signalled.
-  v=$(to_pid_verdict "$DECOY_PID" "$T/no-such-shim-dir/git")
-  if [ "$v" = RECYCLED ]; then
-    ok "leak self-test: a live process with a NON-matching argv is reported RECYCLED, not LEAK"
-  else
-    bad "leak self-test: a non-matching argv was reported '$v', not RECYCLED — the argv is not being validated before cleanup"
-  fi
-  if [ -n "$(ps -p "$decoy_pid" -o args= 2>/dev/null)" ]; then
-    ok "leak self-test: the RECYCLED verdict did NOT signal the process (job 279)"
-  else
-    bad "leak self-test: the decoy was killed on a NON-matching argv — a recycled pid must never be signalled (job 279)"
-  fi
-  # (3) a dead pid is GONE, not a false alarm. Killed by pid AFTER validating the
-  # argv is our own decoy — the same discipline the real check follows.
-  # ONE implementation of the validated kill+reap: the arm calls the same helper
-  # the traps do, rather than duplicating it. A second copy is a second place for
-  # the ordering (kill -> wait -> clear) to be wrong.
-  to_kill_decoy
-  if [ -z "$DECOY_CLEANUP_PID" ]; then
-    ok "leak self-test: the validated kill+reap cleared the registration (job 282's second half)"
-  else
-    bad "leak self-test: the registration survived the kill — either the probe could not answer or the argv did not match, and the decoy may still be running"
-  fi
-  sleep 1
-  v=$(to_pid_verdict "$DECOY_PID" "$DECOY_DIR/git")
-  if [ "$v" = GONE ]; then
-    ok "leak self-test: once the decoy is killed the verdict is GONE — no false alarm, and it was REAPED"
-  elif [ "$v" = ZOMBIE ]; then
-    # NOT LOAD-BEARING ON THIS BASH, and said so rather than left to look pinned.
-    # MEASURED: deleting the `wait` from to_kill_decoy leaves this suite at 318/0,
-    # because bash reaps a background child asynchronously and the pid is gone from
-    # `ps` without an explicit wait. So the `wait` is defence in depth — correct,
-    # documented, and required by shells that do not auto-reap — while this arm can
-    # only catch a zombie that some other shell or a future refactor produces. A
-    # fixture that could provoke one would have to suppress bash's own SIGCHLD
-    # bookkeeping, which is not controllable from a script.
-    bad "leak self-test: the decoy is a ZOMBIE — it was killed without being reaped (job 378); it is a direct child, so \`wait\` must follow the kill"
-  else
-    bad "leak self-test: a dead decoy was reported '$v' — the check would red on a clean run"
-  fi
-  # THE FAIL-CLOSED PROBE PROPERTY, which is job 378's core finding: when `ps`
-  # CANNOT ANSWER the registration must be KEPT, never discarded. Exercised with a
-  # `ps` that exits 2 shadowed onto PATH for exactly this call — the shipped
-  # helper is unchanged, only what it can see is.
-  FAILPS="$T/bin-failing-ps"
-  mkdir -p "$FAILPS"
-  printf '#!/bin/sh\nexit 2\n' >"$FAILPS/ps"
-  chmod +x "$FAILPS/ps"
-  DECOY_CLEANUP_PID=424242
-  DECOY_CLEANUP_NEEDLE="$DECOY_DIR/git"
-  _kd_path="$PATH"
-  PATH="$FAILPS:$PATH"
-  to_kill_decoy
-  PATH="$_kd_path"
-  if [ "$DECOY_CLEANUP_PID" = 424242 ]; then
-    ok "leak self-test: a FAILED ps probe KEEPS the registration — a probe that cannot answer never takes the permissive branch (job 378)"
-  else
-    bad "leak self-test: a failed ps probe DISCARDED the registration — the process would leak silently, which is the fail-open shape this repo forbids"
-  fi
-  # ...and the affirmative counterpart: a working `ps` that finds nothing DOES
-  # clear it, or the registration would pile up forever.
-  DECOY_CLEANUP_PID=424242
-  to_kill_decoy
-  if [ -z "$DECOY_CLEANUP_PID" ]; then
-    ok "leak self-test: an AFFIRMATIVE 'not found' clears the registration (rc 1 with no output)"
-  else
-    bad "leak self-test: an affirmatively-gone pid left the registration set — it would never be released"
-  fi
-  DECOY_CLEANUP_NEEDLE=""
-  # THE SAME FAIL-CLOSED PROPERTY FOR THE TWO *LEAK CHECKS* (job 380). The arm
-  # above covers `to_kill_decoy`; these cover the PRIMARY verdict and the
-  # SECONDARY census, which had the same permissive-on-unmeasurable read. Reuses
-  # the `$FAILPS` shim built above — no new machinery.
-  _kd_path="$PATH"
-  PATH="$FAILPS:$PATH"
-  v=$(to_pid_verdict "$DECOY_PID" "$DECOY_DIR/git")
-  n=$(to_leaks)
-  PATH="$_kd_path"
-  if [ "$v" = UNMEASURABLE ]; then
-    ok "leak self-test: a FAILED ps probe makes to_pid_verdict UNMEASURABLE, never GONE (job 380)"
-  else
-    bad "leak self-test: to_pid_verdict reported '$v' with an unusable ps — a surviving process would read as successfully reaped"
-  fi
-  if [ "$n" = UNMEASURABLE ]; then
-    ok "leak self-test: a FAILED ps makes the census UNMEASURABLE, never a silent 0 (job 380)"
-  else
-    bad "leak self-test: to_leaks reported '$n' with an unusable ps — a stray would read as absent"
-  fi
-  # (the no-child property is asserted at the fixture, while the decoy is still
-  # alive — see `decoy_kids` above. A post-hoc census for a `sleep` argv, which
-  # is what stood here, became VACUOUS the moment the decoy stopped spawning one:
-  # nothing could ever wear that argv again, so the assertion could not fail.
-  # That is the same "worse than missing" class this whole round is about, one
-  # arm over.)
-  # And the absent/garbage subjects, so a silent NO-SUBJECT can never read as clean.
-  if [ "$(to_pid_verdict "$T/no-such-pidfile" "$DECOY_DIR/git")" = NO-SUBJECT ]; then
-    ok "leak self-test: a MISSING pidfile is NO-SUBJECT (the arm proves nothing), never 'no leak'"
-  else
-    bad "leak self-test: a missing pidfile must be NO-SUBJECT"
-  fi
-  printf 'x\n' >"$T/leak-decoy-garbage.pid"
-  if [ "$(to_pid_verdict "$T/leak-decoy-garbage.pid" "$DECOY_DIR/git")" = BAD-PID ]; then
-    ok "leak self-test: a non-numeric pidfile is BAD-PID, never 'no leak'"
-  else
-    bad "leak self-test: a non-numeric pidfile must be BAD-PID"
-  fi
-fi
+# DECLARED LOSS, printed at run time rather than left in a commit message: the
+# shipped runner's reap-its-own-child property (job 279) is now asserted by
+# NOTHING in this suite. The hung-read arms still prove the bound FIRES (exit 3,
+# the ANCHOR-UNVERIFIABLE marker, a distinct TIMEOUT cause, and a runner-exit
+# control per arm); they no longer prove the runner left no process behind.
+printf 'DECLARED LOSS: leak reaping is NO LONGER ASSERTED by this suite (job 381). The hung-read\n'
+printf 'DECLARED LOSS: arms prove the bound fires and names its own cause; they do NOT prove the\n'
+printf 'DECLARED LOSS: bounded runner reaped its child. Strays are swept unconditionally at suite\n'
+printf 'DECLARED LOSS: exit by argv (run-scoped, no verdict), which is HYGIENE, not a check.\n'
 
 # --- 44(m): THE SENTINEL IS UNIQUE PER RUN (cross-lane blocker) --------------
 #

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -1099,9 +1099,18 @@ if run_anc 0 "anchored delta pair (full PASS at X + delta at Y) -> exit 0" \
     *) bad "delta pair: GATE-OF-RECORD line must name the anchor (got: $OUT)" ;;
   esac
   case "$OUT" in
-    *"PREMERGE: DELTA-RECERT anchor: $R_ANCHOR anchor-ancestry: BOUND commit: $RC7 tree-start: $RC12"*)
+    *"PREMERGE: DELTA-RECERT anchor: $R_ANCHOR anchor-ancestry: BOUND anchor-reads: "*"commit: $RC7 tree-start: $RC12"*)
       ok "delta pair: a DISTINCT DELTA-RECERT line names the anchor + the merged tree" ;;
     *) bad "delta pair: missing the DELTA-RECERT evidence line (got: $OUT)" ;;
+  esac
+  # `anchor-reads:` must be AFFIRMATIVE, never silent (job 358). The suite always
+  # puts a `--kill-after`-capable runner on PATH via the $BIN shim, so the bounded
+  # value is the only correct one here; the UNBOUNDED spelling is asserted by its
+  # own arm below, which constructs a PATH without one.
+  case "$OUT" in
+    *"anchor-reads: bounded-"*)
+      ok "delta pair: the evidence line AFFIRMS the reads were bounded" ;;
+    *) bad "delta pair: expected an affirmative bounded anchor-reads: token (got: $OUT)" ;;
   esac
   case "$OUT" in
     *"summary: $RGOODDELTA"*) ok "delta pair: the DELTA-RECERT line names the delta summary file" ;;
@@ -1725,6 +1734,185 @@ else
   printf 'ARM NOT TAKEN: UNEXERCISED on this run. Non-fatal by design: git support for grafts is\n'
   printf 'ARM NOT TAKEN: deprecated and may be removed, which is a host property, not a defect here.\n'
   ok "graft: SKIPPED (positive control did not fire — see the ARM NOT TAKEN lines; arm UNEXERCISED, declared not silent)"
+fi
+
+# --- 44(g): THE SCRATCH'S ENVIRONMENT IS LOAD-BEARING (roborev job 358) ------
+#
+# The scratch isolates the walk from the LANE's repository state — but only if
+# the environment cannot point git back at a grafted repository, or seed a graft
+# into the scratch as it is created. Two routes, each with a POSITIVE CONTROL
+# proving the attack executes (CLAUDE.md job 264: assert unreachability, with a
+# control, or the green means nothing).
+#
+# Both arms reuse Case 44(f)'s GRAFT_REPO, so they need its fixture.
+
+# --- 44(g)(1): an inherited GIT_DIR OVERRIDES `-C` --------------------------
+if [ "$graft_shape" -eq 1 ] && [ "$graft_attack" -eq 1 ]; then
+  # CONTROL: under this GIT_DIR a plain git call, given `-C` pointing at the
+  # CLEAN repository, still answers about the GRAFTED one — and the grafted
+  # ancestry answer comes with it.
+  gd_control=0
+  if [ "$(GIT_DIR="$GRAFT_REPO/.git" git -C "$ANC_REPO" rev-parse --git-dir 2>/dev/null)" = "$GRAFT_REPO/.git" ] &&
+     GIT_DIR="$GRAFT_REPO/.git" git -C "$ANC_REPO" merge-base --is-ancestor "$R_FOREIGN" "$R_CERT" >/dev/null 2>&1; then
+    gd_control=1
+  fi
+  if [ "$gd_control" -eq 1 ]; then
+    ok "GIT_DIR POSITIVE CONTROL: an inherited GIT_DIR overrides -C and carries the grafted ancestry answer"
+    OUT=$(cd "$ANC_REPO" && PATH="$BIN:$PATH" GIT_DIR="$GRAFT_REPO/.git" \
+      MOCK_GH_FAIL=0 MOCK_GH_OUT="$R_CERT OPEN" \
+      bash "$NEUTRAL_ASSERT" 2421 "$R_CERT" "$RFORFULL" "$RFORDELTA" 2>&1)
+    RC=$?
+    if [ "$RC" -ne 2 ]; then
+      bad "GIT_DIR: an inherited GIT_DIR redirected the guard (exit $RC, wanted 2) — the env allowlist is not reaching every git call (job 358) (got: $OUT)"
+    else
+      ok "GIT_DIR: an inherited GIT_DIR cannot redirect the guard — still refused (exit 2)"
+      case "$OUT" in
+        *"anchor-ancestry: BOUND"*) bad "GIT_DIR: the run claims BOUND (got: $OUT)" ;;
+        *) ok "GIT_DIR: no BOUND token appears in the redirected run's output" ;;
+      esac
+    fi
+    # NON-VACUITY: a genuine ancestor must still be BOUND with that GIT_DIR set,
+    # or the arm above would "pass" because nothing is ever BOUND any more.
+    OUT=$(cd "$ANC_REPO" && PATH="$BIN:$PATH" GIT_DIR="$GRAFT_REPO/.git" \
+      MOCK_GH_FAIL=0 MOCK_GH_OUT="$R_CERT OPEN" \
+      bash "$NEUTRAL_ASSERT" 2421 "$R_CERT" "$RANCFULL" "$RGOODDELTA" 2>&1)
+    RC=$?
+    if [ "$RC" -eq 0 ] && [ "${OUT#*anchor-ancestry: BOUND}" != "$OUT" ]; then
+      ok "GIT_DIR: NON-VACUITY — a genuine ancestor is still BOUND with GIT_DIR set"
+    else
+      bad "GIT_DIR: the genuine ancestor stopped being BOUND (exit $RC) — the refusal above proves nothing (got: $OUT)"
+    fi
+  else
+    printf 'ARM NOT TAKEN: GIT_DIR redirect (job 358) — the control did not fire: this git did not let\n'
+    printf 'ARM NOT TAKEN: an inherited GIT_DIR override -C, so a passing refusal would prove nothing.\n'
+    ok "GIT_DIR: SKIPPED (positive control did not fire — arm UNEXERCISED, declared not silent)"
+  fi
+else
+  printf 'ARM NOT TAKEN: GIT_DIR redirect (job 358) — depends on the graft fixture of 44(f), which was\n'
+  printf 'ARM NOT TAKEN: not built on this host.\n'
+  ok "GIT_DIR: SKIPPED (graft fixture unavailable — arm UNEXERCISED, declared not silent)"
+fi
+
+# --- 44(g)(2): a TEMPLATE seeds info/grafts INTO the scratch ----------------
+# `git init --template=<dir>` and `GIT_TEMPLATE_DIR=<dir> git init` both copy a
+# planted `info/grafts` into the NEW repository — so without an empty
+# `--template=` and a cleared environment, the scratch is born grafted and the
+# isolation buys nothing.
+#
+# WHAT THIS ARM CAN AND CANNOT SEPARATE, so nobody reads a green here as proof
+# that both closures are individually necessary. The two are REDUNDANT against
+# the route this arm constructs: removing ONLY the empty `--template=` still
+# refuses (the allowlist cleared GIT_TEMPLATE_DIR), removing ONLY the `env -i`
+# still refuses (the explicit flag beats the inherited variable), and removing
+# BOTH lands the attack at exit 0 — which is what this arm detects. The flag's
+# unique contribution, a config-FILE `init.templateDir`, is NOT exercised here:
+# constructing it would mean writing to /etc/gitconfig.
+TPL="$T/anchor-template"
+tpl_shape=0
+if [ "$anc_shape" -eq 1 ] && mkdir -p "$TPL/info" 2>/dev/null &&
+   printf '%s %s\n' "$R_CERT" "$R_FOREIGN" >"$TPL/info/grafts" 2>/dev/null; then
+  tpl_shape=1
+fi
+# CONTROL: build a scratch the NAIVE way (inherited GIT_TEMPLATE_DIR, no empty
+# --template=) over the lane's objects, and show the walk there answers 0. This
+# is the strongest available control: it proves the attack reaches the SCRATCH,
+# not merely that templates copy files.
+tpl_control=0
+if [ "$tpl_shape" -eq 1 ]; then
+  NAIVE="$T/anchor-naive-scratch"
+  if GIT_TEMPLATE_DIR="$TPL" git init -q "$NAIVE/repo" >/dev/null 2>&1 &&
+     [ -f "$NAIVE/repo/.git/info/grafts" ] &&
+     GIT_ALTERNATE_OBJECT_DIRECTORIES="$ANC_REPO/.git/objects" \
+       git -C "$NAIVE/repo" merge-base --is-ancestor "$R_FOREIGN" "$R_CERT" >/dev/null 2>&1; then
+    tpl_control=1
+  fi
+fi
+if [ "$tpl_control" -eq 1 ]; then
+  ok "TEMPLATE POSITIVE CONTROL: GIT_TEMPLATE_DIR seeds info/grafts into a naive scratch AND the walk there answers 0"
+  OUT=$(cd "$ANC_REPO" && PATH="$BIN:$PATH" GIT_TEMPLATE_DIR="$TPL" \
+    MOCK_GH_FAIL=0 MOCK_GH_OUT="$R_CERT OPEN" \
+    bash "$NEUTRAL_ASSERT" 2421 "$R_CERT" "$RFORFULL" "$RFORDELTA" 2>&1)
+  RC=$?
+  if [ "$RC" -ne 2 ]; then
+    bad "TEMPLATE: a templated graft reached the scratch (exit $RC, wanted 2) — the empty --template= and/or the env allowlist is missing (job 358) (got: $OUT)"
+  else
+    ok "TEMPLATE: a templated graft cannot reach the scratch — still refused (exit 2)"
+    case "$OUT" in
+      *"anchor-ancestry: BOUND"*) bad "TEMPLATE: the run claims BOUND (got: $OUT)" ;;
+      *) ok "TEMPLATE: no BOUND token appears in the templated run's output" ;;
+    esac
+  fi
+  OUT=$(cd "$ANC_REPO" && PATH="$BIN:$PATH" GIT_TEMPLATE_DIR="$TPL" \
+    MOCK_GH_FAIL=0 MOCK_GH_OUT="$R_CERT OPEN" \
+    bash "$NEUTRAL_ASSERT" 2421 "$R_CERT" "$RANCFULL" "$RGOODDELTA" 2>&1)
+  RC=$?
+  if [ "$RC" -eq 0 ] && [ "${OUT#*anchor-ancestry: BOUND}" != "$OUT" ]; then
+    ok "TEMPLATE: NON-VACUITY — a genuine ancestor is still BOUND with GIT_TEMPLATE_DIR set"
+  else
+    bad "TEMPLATE: the genuine ancestor stopped being BOUND (exit $RC) — the refusal above proves nothing (got: $OUT)"
+  fi
+else
+  printf 'ARM NOT TAKEN: template-seeded graft (job 358) — this host could not build the fixture, or a\n'
+  printf 'ARM NOT TAKEN: naive scratch built with GIT_TEMPLATE_DIR did NOT inherit the graft, so the\n'
+  printf 'ARM NOT TAKEN: positive control did not fire and a passing refusal would prove nothing.\n'
+  ok "TEMPLATE: SKIPPED (positive control did not fire — arm UNEXERCISED, declared not silent)"
+fi
+
+# --- 44(h): NO BOUNDED RUNNER -> UNBOUNDED, AFFIRMED, NOT REFUSED (job 358) --
+# A hang is a LIVENESS failure, not a correctness one: it produces NO verdict,
+# where a graft produced a WRONG one, and an unbounded read cannot manufacture a
+# false pass. So a box with no `timeout`/`gtimeout` must still MERGE — refusing
+# would be the guard that reds on correct input — but the degradation must be
+# VISIBLE, because a bounded path silently becoming unbounded is the real hazard.
+NOTO="$T/bin-no-timeout"
+mkdir -p "$NOTO"
+noto_ok=1
+# `dirname`/`basename` are the script's own helpers (advisory-path resolution and
+# the usage banner), not the ancestry check's — they are here so the run reaches
+# the check at all rather than dying at line 1.
+# `bash` is here for the gh MOCK's own `#!/usr/bin/env bash` shebang, not for the
+# script under test; without it the mock cannot start and the case fails on a
+# GH-FAILURE that says nothing about bounding.
+for _tool in git awk tr env mktemp rm dirname basename bash; do
+  _tp=$(command -v "$_tool" 2>/dev/null) || _tp=""
+  if [ -n "$_tp" ]; then ln -sf "$_tp" "$NOTO/$_tool"; else noto_ok=0; fi
+done
+cp "$BIN/gh" "$NOTO/gh" 2>/dev/null || noto_ok=0
+# NON-VACUITY: the fixture PATH must really have NEITHER runner on it.
+if [ "$noto_ok" -eq 1 ]; then
+  for _t in timeout gtimeout; do
+    if PATH="$NOTO" command -v "$_t" >/dev/null 2>&1; then noto_ok=0; fi
+  done
+fi
+if [ "$noto_ok" -ne 1 ]; then
+  printf 'ARM NOT TAKEN: unbounded-reads token (job 358) — could not build a PATH holding git/awk/tr/\n'
+  printf 'ARM NOT TAKEN: env/mktemp/rm/gh but NEITHER timeout nor gtimeout.\n'
+  ok "unbounded: SKIPPED (fixture unbuildable — arm UNEXERCISED, declared not silent)"
+else
+  ok "unbounded fixture: the fixture PATH has git but NEITHER timeout nor gtimeout"
+  OUT=$(cd "$ANC_REPO" && PATH="$NOTO" MOCK_GH_FAIL=0 MOCK_GH_OUT="$R_CERT OPEN" \
+    "${BASH:-/bin/bash}" "$NEUTRAL_ASSERT" 2421 "$R_CERT" "$RANCFULL" "$RGOODDELTA" 2>&1)
+  RC=$?
+  if [ "$RC" -ne 0 ]; then
+    bad "unbounded: a box with no timeout runner must still MERGE, not be refused (exit $RC) (got: $OUT)"
+  else
+    ok "unbounded: with no bounded runner the merge is NOT refused (exit 0)"
+    case "$OUT" in
+      *"anchor-reads: UNBOUNDED("*)
+        ok "unbounded: the evidence line AFFIRMS the degradation instead of staying silent" ;;
+      *) bad "unbounded: expected an affirmative anchor-reads: UNBOUNDED(...) token (got: $OUT)" ;;
+    esac
+    case "$OUT" in
+      *"anchor-reads: bounded-"*)
+        bad "unbounded: the line claims the reads were bounded on a box with no runner (got: $OUT)" ;;
+      *) ok "unbounded: the line does NOT claim a bound it did not have" ;;
+    esac
+    case "$OUT" in
+      *"anchor-ancestry: BOUND"*)
+        ok "unbounded: the ancestry verdict is still produced (the bound is liveness, not correctness)" ;;
+      *) bad "unbounded: the ancestry verdict should be unaffected by the missing runner (got: $OUT)" ;;
+    esac
+  fi
 fi
 
 # =============================================================================

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -1197,12 +1197,12 @@ if run_anc 0 "anchored delta pair (full PASS at X + delta at Y) -> exit 0" \
   # names both halves, and this arm pins BOTH — a reworded token that quietly
   # dropped the unbounded half would restore the overclaim.
   case "$OUT" in
-    *"anchor-reads: bounded-"*"external:git,mktemp"*)
+    *"anchor-reads: bounded-"*"external:git,mktemp,sh,rm"*)
       ok "delta pair: the token names WHAT is bounded (the external commands)" ;;
     *) bad "delta pair: the anchor-reads token must name the bounded externals (got: $OUT)" ;;
   esac
   case "$OUT" in
-    *"UNBOUNDED:cd/test-builtins"*)
+    *"UNBOUNDED:command-v+pwd-builtins"*)
       ok "delta pair: the token also names what is NOT bounded — no overclaim" ;;
     *) bad "delta pair: the anchor-reads token must declare the UNBOUNDED builtin probes (got: $OUT)" ;;
   esac

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -1609,9 +1609,26 @@ if [ "$shallow_shape" -eq 1 ]; then
     esac
   fi
 else
-  # DECLARED, not silently skipped: a host whose git cannot build the fixture
-  # leaves this arm unexercised, and an unexercised arm must say so.
-  bad "ancestry shallow: could not build the shallow fixture on this host — the rc-1-is-three-valued arm did NOT run"
+  # A DECLARED SKIP — visible, named, and NON-FATAL. Two rules pull against each
+  # other here and both are the repo's:
+  #   * a bare skip that prints nothing is refused — an unexercised arm must SAY
+  #     it was not taken, or the suite's green tally silently covers less than it
+  #     did yesterday;
+  #   * a lane that REDS on correct input is the lane agents learn to waive — and
+  #     an old or unusual git that cannot build a `--depth` clone over `file://`
+  #     is a property of the HOST, not a defect in the tree under test.
+  # So it reports on the suite's own `ok` channel (the `SKIPPED (...)` idiom Case
+  # 35 already uses for the root/mode-bit case) and additionally prints an
+  # affirmative `ARM NOT TAKEN` line, so an operator reading the output can see
+  # WHICH coverage was not taken and why. The arm itself is unchanged: on every
+  # host that CAN build the fixture it runs and asserts as before.
+  printf 'ARM NOT TAKEN: ancestry shallow (rc-1-is-three-valued) — this host could not build the\n'
+  printf 'ARM NOT TAKEN: fixture: a --depth 2 --no-local clone over file:// plus a --depth 1 fetch of\n'
+  printf 'ARM NOT TAKEN: the sibling branch, yielding a SHALLOW repo holding BOTH objects. The\n'
+  printf 'ARM NOT TAKEN: shallow branch of assert_anchor_on_history is therefore UNEXERCISED on this\n'
+  printf 'ARM NOT TAKEN: run. Non-fatal by design: an old/unusual git is a host property, not a\n'
+  printf 'ARM NOT TAKEN: defect in the tree under test.\n'
+  ok "ancestry shallow: SKIPPED (fixture unbuildable on this host — see the ARM NOT TAKEN lines; arm UNEXERCISED, declared not silent)"
 fi
 
 # =============================================================================

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -84,8 +84,15 @@ fi
 # invites reliance it cannot support.
 #
 # WHAT REPLACES IT NEEDS NO ADJUDICATION AT ALL. Every process this suite spawns
-# carries `$T/` in its argv — the shim paths and the sentinel sleep alike — and
-# `$T` is a per-run `mktemp -d`, so ANYTHING wearing it IS OURS. That makes the
+# wears ONE OF TWO run-unique argv shapes, and BOTH are needed — matching only the
+# first was a matcher bug (roborev job 382), not a return of the deleted class:
+#   (a) `$T/…`         the shim paths (the KILL shim blocked on its FIFO wears this)
+#   (b) `$TOSENTINEL`  the TERM shim `exec`s into `sleep <duration>`, which REPLACES
+#                      its argv and ERASES the shim path — so shape (a) misses
+#                      precisely the process the sweep exists to catch, and a
+#                      centuries-long sleep survives.
+# `$T` is a per-run `mktemp -d` and `$TOSENTINEL` is derived from this run's pid, so
+# ANYTHING wearing either IS OURS. That makes the
 # kill safe by CONSTRUCTION (job 279's argv validation, with a needle no peer can
 # produce) instead of by interpreting an exit status. Nothing here decides
 # anything, so nothing here can fail open: if `ps` cannot run, the sweep kills
@@ -98,27 +105,47 @@ fi
 # ORDER IS LOAD-BEARING: the sweep runs BEFORE `rm -rf "$T"`. A shim can be
 # blocked on a FIFO inside $T, and removing the FIFO does NOT unblock a reader
 # already waiting on it.
+# DECLARED EMPTY HERE, ~2000 lines before it is derived, because the traps below
+# read it AT FIRE TIME: under `set -u` a signal arriving before the derivation
+# would error inside the handler. Empty simply means the sentinel arm of the sweep
+# has nothing to match yet — the `$T/` arm still works.
+TOSENTINEL=""
+
 suite_cleanup() {
   to_sweep_run_processes
   rm -f "$T/ps-census.txt" 2>/dev/null
   rm -rf "$T"
 }
 
-# to_sweep_run_processes — kill every process whose argv names THIS RUN's scratch
-# dir. Best-effort by design: no status is inspected and no verdict is produced.
-# `wait` follows, for whatever was a direct child (it is a no-op for the rest).
+# to_sweep_run_processes — kill every process whose argv wears one of THIS RUN's
+# two unique shapes (see the block above). Best-effort by design: no status is
+# inspected and no verdict is produced. `wait` follows, for whatever was a direct
+# child (a harmless no-op for the rest).
+#
+# THE SNAPSHOT LIVES INSIDE `$T`, not in shared TMPDIR (roborev job 382). A
+# predictable name under a world-writable directory, truncated by shell
+# redirection, lets a stale or peer-created SYMLINK redirect the write. `$T` is
+# already run-unique and already created — it exists before these traps are
+# installed — so it costs nothing.
 to_sweep_run_processes() {
-  local snap p a
-  snap="${TMPDIR:-/tmp}/premerge-sweep.$$"
+  local snap p a hit
+  snap="$T/ps-sweep.txt"
   ps -eo pid=,args= >"$snap" 2>/dev/null || { rm -f "$snap"; return 0; }
   while read -r p a; do
     case "$p" in ''|*[!0-9]*) continue ;; esac
-    case "$a" in
-      *"$T/"*)
-        kill -KILL "$p" 2>/dev/null || true
-        wait "$p" 2>/dev/null || true
-        ;;
-    esac
+    # Two needles, tested separately rather than as one `case` alternative: an
+    # EMPTY `$TOSENTINEL` (before it is derived, see above) would otherwise be a
+    # pattern matching an empty argv, and "match nothing" must be explicit rather
+    # than an accident of what `ps` happens to print.
+    hit=0
+    case "$a" in *"$T/"*) hit=1 ;; esac
+    if [ "$hit" -eq 0 ] && [ -n "$TOSENTINEL" ] && [ "$a" = "$TOSENTINEL" ]; then
+      hit=1
+    fi
+    if [ "$hit" -eq 1 ]; then
+      kill -KILL "$p" 2>/dev/null || true
+      wait "$p" 2>/dev/null || true
+    fi
   done <"$snap"
   rm -f "$snap"
   return 0
@@ -1164,6 +1191,21 @@ if run_anc 0 "anchored delta pair (full PASS at X + delta at Y) -> exit 0" \
       ok "delta pair: the evidence line AFFIRMS the reads were bounded" ;;
     *) bad "delta pair: expected an affirmative bounded anchor-reads: token (got: $OUT)" ;;
   esac
+  # THE TOKEN MUST NOT CLAIM MORE THAN IS BOUNDED (job 382). `_anchor_canon`
+  # (`cd`+`pwd -P`) and the object-dir `[ -d … ]` probe are SHELL BUILTINS with no
+  # process to bound, so a bare `bounded-<n>s+<g>s` overclaimed. The token now
+  # names both halves, and this arm pins BOTH — a reworded token that quietly
+  # dropped the unbounded half would restore the overclaim.
+  case "$OUT" in
+    *"anchor-reads: bounded-"*"external:git,mktemp"*)
+      ok "delta pair: the token names WHAT is bounded (the external commands)" ;;
+    *) bad "delta pair: the anchor-reads token must name the bounded externals (got: $OUT)" ;;
+  esac
+  case "$OUT" in
+    *"UNBOUNDED:cd/test-builtins"*)
+      ok "delta pair: the token also names what is NOT bounded — no overclaim" ;;
+    *) bad "delta pair: the anchor-reads token must declare the UNBOUNDED builtin probes (got: $OUT)" ;;
+  esac
   case "$OUT" in
     *"summary: $RGOODDELTA"*) ok "delta pair: the DELTA-RECERT line names the delta summary file" ;;
     *) bad "delta pair: DELTA-RECERT must name the delta summary file (got: $OUT)" ;;
@@ -2128,9 +2170,14 @@ fi
 # ...and that every git invocation in the check consumes that array rather than
 # calling `git` bare. Counted, not eyeballed: this is the invariant that job 276
 # says has to reach the sites a later change adds.
+# Scans `_anchor_bounded` TOO (job 382): it is now where the raw command actually
+# executes, so a git call added there would bypass the options array. COMMENTS are
+# skipped — the first version matched the phrase "not inside a git work tree" in a
+# comment and reported a bypass that did not exist.
 anchor_bare=$(awk '
-  /^_anchor_(run|git)\(\) \{/ { inf = 1 }
+  /^_anchor_(run|git|bounded)\(\) \{/ { inf = 1 }
   inf && /^\}/ { inf = 0 }
+  inf && /^[[:space:]]*#/ { next }
   inf && /(^|[^_[:alnum:]])git / && !/ANCHOR_GIT_OPTS/ { c++ }
   END { print c + 0 }
 ' "$ASSERT")

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -1631,6 +1631,102 @@ else
   ok "ancestry shallow: SKIPPED (fixture unbuildable on this host — see the ARM NOT TAKEN lines; arm UNEXERCISED, declared not silent)"
 fi
 
+# --- 44(f): A GRAFT MUST NOT BE ABLE TO MANUFACTURE `BOUND` (roborev job 355) -
+#
+# `$GIT_DIR/info/grafts` rewrites parentage and **survives
+# `--no-replace-objects`** (CLAUDE.md, #3544 job 285: measured `no -> YES -> YES`
+# across before-graft / plain / `--no-replace-objects`). Every lane here is a
+# worktree of ONE shared `.git` and grafts live in the COMMON git dir, so the
+# planter is a PEER LANE — a non-invoker route — and a leftover debugging graft
+# is the accident route. Either alone makes it a defect, which is why the walk
+# was MOVED into an isolated scratch repository rather than the graft flagged.
+#
+# TWO ARMS OVER ONE FIXTURE, AND ARM 1 IS A POSITIVE CONTROL (CLAUDE.md's job-264
+# rule: assert UNREACHABILITY with a control proving the attack executes in a
+# plain repository, or the green means nothing).
+#   1. plain `git merge-base --is-ancestor` in the grafted repository answers 0
+#      — the attack works here, on this host's git;
+#   2. premerge-assert.sh on that SAME repository, with that SAME graft, still
+#      refuses (exit 2, NOT-ANCESTOR).
+# If arm 1 does not reproduce, arm 2 proves nothing and the case says so as a
+# declared not-taken arm rather than passing quietly.
+GRAFT_REPO="$T/ancestry-graft-repo"
+graft_shape=0
+if [ "$anc_shape" -eq 1 ] && cp -a "$ANC_REPO" "$GRAFT_REPO" 2>/dev/null; then
+  # The graft makes the FOREIGN commit a parent of the CERTIFIED head, which is
+  # precisely "make a foreign anchor look ancestral".
+  if printf '%s %s\n' "$R_CERT" "$R_FOREIGN" >"$GRAFT_REPO/.git/info/grafts" 2>/dev/null; then
+    graft_shape=1
+  fi
+fi
+graft_attack=0
+if [ "$graft_shape" -eq 1 ]; then
+  # NON-VACUITY, both directions: the UNGRAFTED copy must still answer "no", or
+  # a fixture that was ancestral all along would make arm 1 meaningless.
+  if git -C "$ANC_REPO" merge-base --is-ancestor "$R_FOREIGN" "$R_CERT" >/dev/null 2>&1; then
+    bad "graft control: the UNGRAFTED fixture already reports the foreign anchor as ancestral — the arm would be meaningless"
+    graft_shape=0
+  elif git -C "$GRAFT_REPO" merge-base --is-ancestor "$R_FOREIGN" "$R_CERT" >/dev/null 2>&1; then
+    graft_attack=1
+  fi
+fi
+if [ "$graft_shape" -eq 1 ] && [ "$graft_attack" -eq 1 ]; then
+  ok "graft POSITIVE CONTROL: plain merge-base --is-ancestor in the grafted repo answers 0 — the attack really executes on this host"
+  # And it survives --no-replace-objects, which is the half that makes the pins
+  # insufficient and the move necessary.
+  if git --no-replace-objects -C "$GRAFT_REPO" merge-base --is-ancestor "$R_FOREIGN" "$R_CERT" >/dev/null 2>&1; then
+    ok "graft POSITIVE CONTROL: the graft SURVIVES --no-replace-objects (so the pins alone cannot close it)"
+  else
+    bad "graft POSITIVE CONTROL: --no-replace-objects defeated the graft on this host — CLAUDE.md's #3544 job-285 measurement does not reproduce, so the stated rationale needs re-checking"
+  fi
+  OUT=$(cd "$GRAFT_REPO" && PATH="$BIN:$PATH" MOCK_GH_FAIL=0 MOCK_GH_OUT="$R_CERT OPEN" \
+    bash "$NEUTRAL_ASSERT" 2421 "$R_CERT" "$RFORFULL" "$RFORDELTA" 2>&1)
+  RC=$?
+  if [ "$RC" -ne 2 ]; then
+    bad "graft: a planted graft manufactured a non-refusal (exit $RC, wanted 2) — the ancestry walk is reading the live repository again (job 355) (got: $OUT)"
+  else
+    ok "graft: the planted graft does NOT manufacture BOUND — the walk is isolated from it (exit 2)"
+    case "$OUT" in
+      *"is NOT on the certified sha's history"*)
+        ok "graft: the refusal is the NOT-ANCESTOR verdict, not some other refusal firing first" ;;
+      *) bad "graft: expected the NOT-ANCESTOR cause (got: $OUT)" ;;
+    esac
+    case "$OUT" in
+      *"anchor-ancestry: BOUND"*)
+        bad "graft: the output claims BOUND — the graft was honoured (got: $OUT)" ;;
+      *) ok "graft: no BOUND token appears anywhere in the grafted run's output" ;;
+    esac
+  fi
+  # The ACCEPT direction must still work in the same grafted repository: the
+  # isolation must not have broken ordinary ancestry, or arm 2 would "pass" for
+  # the trivial reason that nothing is ever BOUND any more.
+  #
+  # IT IS ALSO A SECOND, INDEPENDENT DETECTOR OF THE REGRESSION, which is worth
+  # knowing before reading its failure message. This graft REPLACES the certified
+  # head's parent list, so under it the foreign commit becomes ancestral AND the
+  # REAL anchor stops being so. A walk that reads the live repository therefore
+  # fails BOTH arms — verified by reverting the walk: the refusal arm reported
+  # exit 0 and this one reported the genuine anchor refused at exit 2.
+  OUT=$(cd "$GRAFT_REPO" && PATH="$BIN:$PATH" MOCK_GH_FAIL=0 MOCK_GH_OUT="$R_CERT OPEN" \
+    bash "$NEUTRAL_ASSERT" 2421 "$R_CERT" "$RANCFULL" "$RGOODDELTA" 2>&1)
+  RC=$?
+  if [ "$RC" -eq 0 ] && [ "${OUT#*anchor-ancestry: BOUND}" != "$OUT" ]; then
+    ok "graft: NON-VACUITY — a genuine ancestor is still BOUND in the same grafted repository"
+  else
+    bad "graft: the genuine ancestor is no longer BOUND (exit $RC) — either the isolation broke ordinary ancestry, or the walk is reading the live repository and the graft masked the real parent (job 355). Arm 2 proves nothing either way (got: $OUT)"
+  fi
+else
+  # DECLARED, not silent, and non-fatal — the same treatment the shallow arm gets.
+  printf 'ARM NOT TAKEN: graft isolation (roborev job 355) — this host could not build the fixture\n'
+  printf 'ARM NOT TAKEN: (a copy of the ancestry repo with $GIT_DIR/info/grafts making the foreign\n'
+  printf 'ARM NOT TAKEN: commit a parent of the certified head) or the graft did not take effect, so\n'
+  printf 'ARM NOT TAKEN: the POSITIVE CONTROL did not fire. Without it a passing refusal would prove\n'
+  printf 'ARM NOT TAKEN: nothing, so BOTH arms are skipped and the graft-isolation property is\n'
+  printf 'ARM NOT TAKEN: UNEXERCISED on this run. Non-fatal by design: git support for grafts is\n'
+  printf 'ARM NOT TAKEN: deprecated and may be removed, which is a host property, not a defect here.\n'
+  ok "graft: SKIPPED (positive control did not fire — see the ARM NOT TAKEN lines; arm UNEXERCISED, declared not silent)"
+fi
+
 # =============================================================================
 # #3465 review — the remaining refusal branches
 # =============================================================================

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -1038,19 +1038,37 @@ run_anc() {
   return 0
 }
 
-# anc_delta <file> <anchor-sha> — a delta block at the fixture's certified head,
-# anchored at <anchor-sha>. ONE builder, ONE varying input: that is what makes
-# the accept arm and the RED arm differ in EXACTLY ONE PROPERTY (asserted below).
-anc_delta() {
-  delta_summary "$1" "$2" "$RC7" "$RC12" PASS PASS \
-    "MODE: delta (TEST/DOCS-ONLY RE-CERTIFICATION — NOT the gate of record; gate of record = the full agent-gate.sh PASS at anchor $2)"
+# anc_pair <tag> <anchor-sha> — build the whole Case B PAIR for one anchor: the
+# ANCHOR's full-gate block (whose own commit:/tree-start: ARE that anchor, which
+# is what the earlier checks require) plus a delta block naming it and covering
+# the fixture's certified head. Files land at $T/anc-full-<tag>.txt and
+# $T/anc-delta-<tag>.txt.
+#
+# ONE builder, ONE varying input — the anchor sha. That is what lets the accept
+# arm and the RED arm below differ in EXACTLY ONE PROPERTY, verifiably: mapping
+# the foreign sha (and its two abbreviations) onto the anchor's must reproduce
+# the accepted pair byte for byte.
+anc_pair() {
+  local tag="$1" a="$2"
+  full_summary "$T/anc-full-$tag.txt" "$(printf '%.7s' "$a")" "$(printf '%.12s' "$a")" PASS PASS
+  delta_summary "$T/anc-delta-$tag.txt" "$a" "$RC7" "$RC12" PASS PASS \
+    "MODE: delta (TEST/DOCS-ONLY RE-CERTIFICATION — NOT the gate of record; gate of record = the full agent-gate.sh PASS at anchor $a)"
 }
-RANCFULL="$T/anc-full.txt"
-full_summary "$RANCFULL" "$RA7" "$RA12" PASS PASS
+# anc_same_but_anchor <foreign-sha> <foreign-file> <anchor-file> — TRUE when the
+# only difference between the two files is the anchor sha, in every width the
+# gate writes it (40, 12, 7). Widest first, so a narrower substitution cannot
+# eat part of an already-rewritten value.
+anc_same_but_anchor() {
+  sed -e "s/$1/$R_ANCHOR/g" \
+      -e "s/$(printf '%.12s' "$1")/$RA12/g" \
+      -e "s/$(printf '%.7s' "$1")/$RA7/g" "$2" | cmp -s - "$3"
+}
+anc_pair good "$R_ANCHOR"
+anc_pair foreign "$R_FOREIGN"
+RANCFULL="$T/anc-full-good.txt"
 RGOODDELTA="$T/anc-delta-good.txt"
-anc_delta "$RGOODDELTA" "$R_ANCHOR"
+RFORFULL="$T/anc-full-foreign.txt"
 RFORDELTA="$T/anc-delta-foreign.txt"
-anc_delta "$RFORDELTA" "$R_FOREIGN"
 
 ANCHORFULL="$T/anchor-full.txt"
 full_summary "$ANCHORFULL" "$A7" "$A12" PASS PASS
@@ -1279,6 +1297,257 @@ refused_pair "delta block with NO dirty: field -> refuse" \
 full_summary "$T/anchor-dirty-absent.txt" "$A7" "$A12" PASS PASS -
 refused_pair "anchor block with NO dirty: field -> refuse" \
   "$T/anchor-dirty-absent.txt" "$GOODDELTA" "The full-gate block records NO 'dirty:' value"
+
+# =============================================================================
+# Case 44: THE CASE B ANCHOR IS BOUND TO THE CERTIFIED SHA'S HISTORY (#3653)
+# =============================================================================
+# The fixture (built above) is c0 -> c1 (ANCHOR) -> c2 (CERTIFIED), with cF a
+# sibling of c0 that is NOT an ancestor of c2. The accept arm ran at Case 28(b);
+# these are the refusing arms, the load-bearing proof, and the UNVERIFIABLE
+# family.
+
+# --- 44(a): the accept arm's AFFIRMATIVE record ------------------------------
+# A silent pass is indistinguishable from a check that never ran, so the passing
+# verdict must appear in the output. Pinned separately from 28(b)'s composite
+# needle so a reword of the surrounding line cannot take this assertion with it.
+if run_anc 0 "ancestry BOUND: anchor c1 IS an ancestor of the certified head -> exit 0" \
+  2421 "$R_CERT" "$RANCFULL" "$RGOODDELTA"; then
+  case "$OUT" in
+    *"anchor-ancestry: BOUND"*)
+      ok "ancestry: the success path RECORDS the binding affirmatively (anchor-ancestry: BOUND)" ;;
+    *) bad "ancestry: the success path must record anchor-ancestry: BOUND (got: $OUT)" ;;
+  esac
+fi
+
+# --- 44(b): THE RED ARM — one property different, and only one ---------------
+# The two delta summaries come from ONE builder (`anc_delta`) whose only varying
+# input is the anchor sha, so substituting the foreign sha for the anchor sha in
+# the foreign file must reproduce the accepted file BYTE FOR BYTE. Asserted, not
+# assumed: a RED arm that differs in some second property proves nothing about
+# the property under test (MEMORY.md: "a RED arm must differ in one property").
+# THE FOREIGN PAIR IS THE REALISTIC #3616 SHAPE, and it has to be: the checks
+# ABOVE the ancestry binding require the full block's own provenance to BE the
+# delta's anchor, so a foreign anchor pinned against the LOCAL full block refuses
+# earlier, for a different reason. What survives those checks — and what #3653
+# closes — is a peer lane's genuine, internally consistent full-gate PASS plus a
+# delta naming it. That is exactly `anc_pair foreign`.
+if anc_same_but_anchor "$R_FOREIGN" "$RFORDELTA" "$RGOODDELTA" &&
+   anc_same_but_anchor "$R_FOREIGN" "$RFORFULL" "$RANCFULL"; then
+  ok "ancestry RED arm: the foreign pair differs from the accepted pair in EXACTLY ONE property (the anchor sha)"
+else
+  bad "ancestry RED arm: the foreign and accepted pairs differ in more than the anchor sha — the arm would prove nothing"
+fi
+if ! cmp -s "$RFORDELTA" "$RGOODDELTA" && ! cmp -s "$RFORFULL" "$RANCFULL"; then
+  ok "ancestry RED arm: non-vacuity — both halves of the pair are genuinely different files"
+else
+  bad "ancestry RED arm: a half of the foreign pair is IDENTICAL to the accepted one — the arm is vacuous"
+fi
+if run_anc 2 "ancestry NOT-ANCESTOR: a FOREIGN anchor pair -> refuse (exit 2)" \
+  2421 "$R_CERT" "$RFORFULL" "$RFORDELTA"; then
+  case "$OUT" in
+    *"PREMERGE: NO-GATE-OF-RECORD"*)
+      ok "ancestry: a foreign anchor is refused under the NO-GATE-OF-RECORD verdict" ;;
+    *) bad "ancestry: a foreign anchor must carry the NO-GATE-OF-RECORD verdict (got: $OUT)" ;;
+  esac
+  case "$OUT" in
+    *"is NOT on the certified sha's history"*)
+      ok "ancestry: the refusal NAMES the cause (the anchor is not on this PR's history)" ;;
+    *) bad "ancestry: the refusal must name the cause (got: $OUT)" ;;
+  esac
+  case "$OUT" in
+    *"$R_FOREIGN"*) ok "ancestry: the refusal names the ANCHOR sha it rejected" ;;
+    *) bad "ancestry: the refusal must name the anchor sha (got: $OUT)" ;;
+  esac
+  case "$OUT" in
+    *"$R_CERT"*) ok "ancestry: the refusal names the CERTIFIED sha it compared against" ;;
+    *) bad "ancestry: the refusal must name the certified sha (got: $OUT)" ;;
+  esac
+  case "$OUT" in
+    *"#3616"*) ok "ancestry: the refusal names the class it closes (#3616 cross-lane)" ;;
+    *) bad "ancestry: the refusal should name the #3616 class (got: $OUT)" ;;
+  esac
+fi
+
+# --- 44(c): THE MUTATION ARM — the check is LOAD-BEARING ---------------------
+# 44(b) reds today; that alone does not prove the ANCESTRY CHECK is what refuses
+# it, because some other check might be doing the work. So: substitute the
+# ARTIFACT in a scratch tree (the `flow_copy` idiom — never a path variable or a
+# test-only seam, which would be one more thing a real invoker could set), NEUTER
+# the ancestry call there, and require the SAME foreign-anchor call to reach
+# exit 0. If it does not, 44(b) proves nothing.
+MUTDIR="$T/flow-anc-mutant"
+mkdir -p "$MUTDIR"
+mut_ok=0
+if ! cp "$ASSERT" "$MUTDIR/premerge-assert.sh"; then
+  bad "ancestry mutation: could not copy premerge-assert.sh into the scratch tree"
+else
+  printf '%s\n' "$NEUTRAL_ADV" >"$MUTDIR/base-staleness.sh"
+  chmod +x "$MUTDIR/base-staleness.sh"
+  # The call site, replaced by the assignment it would have made on success.
+  MUT_FROM='  assert_anchor_on_history "$delta_anchor" "$certified"'
+  MUT_TO='  ANCHOR_ANCESTRY=BOUND   # MUTANT: ancestry check removed'
+  if [ "$(grep -c -x -F -- "$MUT_FROM" "$MUTDIR/premerge-assert.sh" | tr -d ' ')" = 1 ]; then
+    ok "ancestry mutation: the shipped script has exactly ONE ancestry call site to neuter"
+    # awk rather than sed: the needle contains `$` and `"`, and a literal
+    # whole-line match is what the count above verified.
+    awk -v from="$MUT_FROM" -v to="$MUT_TO" '{ if ($0 == from) print to; else print }' \
+      "$MUTDIR/premerge-assert.sh" >"$MUTDIR/mutated.sh" &&
+      mv "$MUTDIR/mutated.sh" "$MUTDIR/premerge-assert.sh" && mut_ok=1
+  else
+    bad "ancestry mutation: expected exactly one ancestry call site in the shipped script (found $(grep -c -x -F -- "$MUT_FROM" "$MUTDIR/premerge-assert.sh" | tr -d ' '))"
+  fi
+fi
+if [ "$mut_ok" -eq 1 ]; then
+  # ASSERT THE MUTATION TOOK. A mutation that silently failed to apply would make
+  # this whole arm vacuously green — the exact failure mode it exists to catch.
+  if [ "$(grep -c -x -F -- "$MUT_FROM" "$MUTDIR/premerge-assert.sh" | tr -d ' ')" = 0 ] &&
+     [ "$(grep -c -x -F -- "$MUT_TO" "$MUTDIR/premerge-assert.sh" | tr -d ' ')" = 1 ]; then
+    ok "ancestry mutation: the scratch copy really differs from the shipped one in the expected way"
+  else
+    bad "ancestry mutation: the mutation did not apply — the arm would be vacuous"
+    mut_ok=0
+  fi
+fi
+if [ "$mut_ok" -eq 1 ]; then
+  MUTOUT=$(cd "$ANC_REPO" && PATH="$BIN:$PATH" MOCK_GH_FAIL=0 MOCK_GH_OUT="$R_CERT OPEN" \
+    bash "$MUTDIR/premerge-assert.sh" 2421 "$R_CERT" "$RFORFULL" "$RFORDELTA" 2>&1)
+  MUTRC=$?
+  if [ "$MUTRC" -eq 0 ]; then
+    ok "ancestry mutation: WITHOUT the check the foreign anchor reaches exit 0 — the check is load-bearing"
+  else
+    bad "ancestry mutation: the foreign-anchor call still fails (exit $MUTRC) with the check removed, so 44(b) proves nothing about it (got: $MUTOUT)"
+  fi
+fi
+
+# --- 44(d): UNVERIFIABLE — an absent object is UNKNOWN, never ok -------------
+# A pass may never be derived from the ABSENCE of a bad signal, so a sha this
+# repository does not hold is exit 3 under its OWN marker, not a silent accept
+# and not exit 2 (which would tell the operator their chain is wrong when the
+# real fault is the checkout).
+ABSENT_SHA="0123456789abcdef0123456789abcdef01234567"
+if git -C "$ANC_REPO" cat-file -e "$ABSENT_SHA^{commit}" >/dev/null 2>&1; then
+  bad "ancestry UNVERIFIABLE fixture: the 'absent' sha is present in the fixture repo"
+else
+  ok "ancestry UNVERIFIABLE fixture: the chosen 40-hex sha really is absent from the fixture repo"
+fi
+anc_pair absent "$ABSENT_SHA"
+if run_anc 3 "ancestry UNVERIFIABLE: an ANCHOR sha absent from this repository -> exit 3" \
+  2421 "$R_CERT" "$T/anc-full-absent.txt" "$T/anc-delta-absent.txt"; then
+  case "$OUT" in
+    *"PREMERGE: ANCHOR-UNVERIFIABLE"*)
+      ok "ancestry: an absent anchor object carries the ANCHOR-UNVERIFIABLE marker" ;;
+    *) bad "ancestry: an absent anchor object must carry ANCHOR-UNVERIFIABLE (got: $OUT)" ;;
+  esac
+  case "$OUT" in
+    *"the ANCHOR commit is not present in this repository"*)
+      ok "ancestry: the UNVERIFIABLE refusal names WHICH object is absent" ;;
+    *) bad "ancestry: the UNVERIFIABLE refusal must name the absent object (got: $OUT)" ;;
+  esac
+  case "$OUT" in
+    *"git fetch origin"*) ok "ancestry: the absent-object cause carries its own remedy (fetch the branch)" ;;
+    *) bad "ancestry: the absent-object cause must carry a fetch remedy (got: $OUT)" ;;
+  esac
+  # THE MARKER MUST BE TEXTUALLY DISTINCT from the other two verdicts, because
+  # exit 3 and exit 2 name DIFFERENT operator actions and the codes alone cannot
+  # carry that (the same reason nit 8 split USAGE from GH-FAILURE).
+  case "$OUT" in
+    *"PREMERGE: NO-GATE-OF-RECORD"*)
+      bad "ancestry: UNVERIFIABLE must NOT read as NO-GATE-OF-RECORD (got: $OUT)" ;;
+    *) ok "ancestry: UNVERIFIABLE is textually DISTINCT from NO-GATE-OF-RECORD" ;;
+  esac
+  case "$OUT" in
+    *"PREMERGE: TOOL-FAILURE"*)
+      bad "ancestry: UNVERIFIABLE must NOT read as TOOL-FAILURE (got: $OUT)" ;;
+    *) ok "ancestry: UNVERIFIABLE is textually DISTINCT from TOOL-FAILURE" ;;
+  esac
+fi
+
+# The CERTIFIED sha absent is its own cause with its own remedy (the two are
+# different operator actions in practice: a rebased-away anchor vs a PR branch
+# that was never fetched).
+NOREPO="$T/anc-not-a-repo"
+mkdir -p "$NOREPO"
+if (cd "$NOREPO" && git rev-parse --git-dir >/dev/null 2>&1); then
+  bad "ancestry UNVERIFIABLE fixture: $NOREPO is inside a git work tree — the no-work-tree case would not fire"
+else
+  ok "ancestry UNVERIFIABLE fixture: the scratch dir really is outside any git work tree"
+  OUT=$(cd "$NOREPO" && PATH="$BIN:$PATH" MOCK_GH_FAIL=0 MOCK_GH_OUT="$R_CERT OPEN" \
+    bash "$NEUTRAL_ASSERT" 2421 "$R_CERT" "$RANCFULL" "$RGOODDELTA" 2>&1)
+  RC=$?
+  if [ "$RC" -ne 3 ]; then
+    bad "ancestry UNVERIFIABLE: outside a work tree must be exit 3 (got $RC: $OUT)"
+  else
+    ok "ancestry UNVERIFIABLE: run outside a git work tree -> exit 3"
+    case "$OUT" in
+      *"PREMERGE: ANCHOR-UNVERIFIABLE"*)
+        ok "ancestry: the no-work-tree case carries the ANCHOR-UNVERIFIABLE marker" ;;
+      *) bad "ancestry: the no-work-tree case must carry ANCHOR-UNVERIFIABLE (got: $OUT)" ;;
+    esac
+    case "$OUT" in
+      *"not inside a git work tree"*)
+        ok "ancestry: the no-work-tree case names its OWN cause, not the absent-object one" ;;
+      *) bad "ancestry: the no-work-tree case must name its own cause (got: $OUT)" ;;
+    esac
+    case "$OUT" in
+      *"run this assert from the ISSUE'S WORKTREE"*)
+        ok "ancestry: the no-work-tree cause carries its own remedy" ;;
+      *) bad "ancestry: the no-work-tree cause must carry its own remedy (got: $OUT)" ;;
+    esac
+    case "$OUT" in
+      *"PREMERGE: NO-GATE-OF-RECORD"*|*"PREMERGE: TOOL-FAILURE"*)
+        bad "ancestry: the no-work-tree case must not read as another verdict (got: $OUT)" ;;
+      *) ok "ancestry: the no-work-tree marker is distinct from NO-GATE-OF-RECORD and TOOL-FAILURE" ;;
+    esac
+  fi
+fi
+
+# --- 44(e): UNVERIFIABLE — rc 1 in a SHALLOW clone is NOT a verdict ----------
+# The subtlest arm, and the reason the check is three-valued at all (#3544):
+# `--is-ancestor` exits 1 both for "not an ancestor" and for "the connecting
+# history is absent". A shallow clone that HOLDS both objects but not the history
+# between them produces rc 1 on a pair whose real relationship is unknown, so it
+# must be UNVERIFIABLE (exit 3) and NOT the exit-2 refusal.
+SHALLOW="$T/anc-shallow"
+shallow_shape=0
+if [ "$anc_shape" -eq 1 ] &&
+   git clone -q --depth 2 --no-local --branch feature "file://$ANC_REPO" "$SHALLOW" >/dev/null 2>&1 &&
+   git -C "$SHALLOW" fetch -q --depth 1 origin other:refs/remotes/origin/other >/dev/null 2>&1; then
+  if [ "$(git -C "$SHALLOW" rev-parse --is-shallow-repository 2>/dev/null)" = true ] &&
+     git -C "$SHALLOW" cat-file -e "$R_FOREIGN^{commit}" >/dev/null 2>&1 &&
+     git -C "$SHALLOW" cat-file -e "$R_CERT^{commit}" >/dev/null 2>&1; then
+    shallow_shape=1
+  fi
+fi
+if [ "$shallow_shape" -eq 1 ]; then
+  ok "ancestry shallow fixture: a SHALLOW clone that holds BOTH objects (so rc 1 is not a verdict)"
+  OUT=$(cd "$SHALLOW" && PATH="$BIN:$PATH" MOCK_GH_FAIL=0 MOCK_GH_OUT="$R_CERT OPEN" \
+    bash "$NEUTRAL_ASSERT" 2421 "$R_CERT" "$RFORFULL" "$RFORDELTA" 2>&1)
+  RC=$?
+  if [ "$RC" -ne 3 ]; then
+    bad "ancestry shallow: rc 1 in a shallow clone must be exit 3, not a verdict (got $RC: $OUT)"
+  else
+    ok "ancestry shallow: rc 1 in a repository NOT proven complete -> exit 3, never the exit-2 refusal"
+    case "$OUT" in
+      *"PREMERGE: ANCHOR-UNVERIFIABLE"*)
+        ok "ancestry shallow: the shallow case carries the ANCHOR-UNVERIFIABLE marker" ;;
+      *) bad "ancestry shallow: expected the ANCHOR-UNVERIFIABLE marker (got: $OUT)" ;;
+    esac
+    case "$OUT" in
+      *"NOT PROVEN COMPLETE"*)
+        ok "ancestry shallow: the refusal names shallowness as the cause, not 'not an ancestor'" ;;
+      *) bad "ancestry shallow: the refusal must name the incomplete history (got: $OUT)" ;;
+    esac
+    case "$OUT" in
+      *"git fetch --unshallow"*)
+        ok "ancestry shallow: the shallow cause carries its own remedy (git fetch --unshallow)" ;;
+      *) bad "ancestry shallow: the shallow cause must carry the unshallow remedy (got: $OUT)" ;;
+    esac
+  fi
+else
+  # DECLARED, not silently skipped: a host whose git cannot build the fixture
+  # leaves this arm unexercised, and an unexercised arm must say so.
+  bad "ancestry shallow: could not build the shallow fixture on this host — the rc-1-is-three-valued arm did NOT run"
+fi
 
 # =============================================================================
 # #3465 review — the remaining refusal branches

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -1648,69 +1648,141 @@ else
   fi
 fi
 
-# --- 44(e): UNVERIFIABLE — rc 1 in a SHALLOW clone is NOT a verdict ----------
+# --- 44(e): rc 1 IN A SHALLOW CLONE IS NOT A VERDICT (rebuilt, roborev job 410) -
+#
 # The subtlest arm, and the reason the check is three-valued at all (#3544):
-# `--is-ancestor` exits 1 both for "not an ancestor" and for "the connecting
-# history is absent". A shallow clone that HOLDS both objects but not the history
-# between them produces rc 1 on a pair whose real relationship is unknown, so it
-# must be UNVERIFIABLE (exit 3) and NOT the exit-2 refusal.
-SHALLOW="$T/anc-shallow"
+# `--is-ancestor` exits 1 both for "not an ancestor" AND for "the connecting
+# history is absent".
+#
+# THE PREVIOUS VERSION OF THIS ARM WAS VACUOUS, and that is what job 410 caught.
+# It compared `$R_FOREIGN`, which is genuinely NOT an ancestor even in the
+# complete repository — so rc 1 was the CORRECT answer and the arm never
+# exercised the ambiguous case at all. It passed without testing its own subject,
+# which is the class this whole issue treats as must-fix: a green that proves
+# nothing is worse than a missing test.
+#
+# WHAT THE CASE ACTUALLY REQUIRES is a TRUE ancestor that returns rc 1 SOLELY
+# because the connecting commits are gone. So: a 6-commit history, a shallow
+# clone holding only the tip, then a `--depth 1` fetch of a branch at the OLDEST
+# commit — which brings that endpoint in as its own shallow boundary while
+# c1..c4 stay absent. Both endpoints present, the path between them missing.
+#
+# AND THE ASSERTION IS THE DIFFERENTIAL, twice over, because either half alone
+# proves nothing:
+#   git level   : complete repo -> rc 0 (TRUE ancestor) | shallow -> rc 1
+#   guard level : complete repo -> exit 0 + BOUND       | shallow -> exit 3
+# The second pair is the one that matters: the SAME anchor/certified pair must be
+# BOUND where the history is complete and UNVERIFIABLE where it is not.
+SH_REPO="$T/shallow-src"
+SH_CLONE="$T/shallow-clone"
 shallow_shape=0
-if [ "$anc_shape" -eq 1 ] &&
-   git clone -q --depth 2 --no-local --branch feature "file://$ANC_REPO" "$SHALLOW" >/dev/null 2>&1 &&
-   git -C "$SHALLOW" fetch -q --depth 1 origin other:refs/remotes/origin/other >/dev/null 2>&1; then
-  if [ "$(git -C "$SHALLOW" rev-parse --is-shallow-repository 2>/dev/null)" = true ] &&
-     git -C "$SHALLOW" cat-file -e "$R_FOREIGN^{commit}" >/dev/null 2>&1 &&
-     git -C "$SHALLOW" cat-file -e "$R_CERT^{commit}" >/dev/null 2>&1; then
+SH_A=""; SH_C=""
+mkdir -p "$SH_REPO"
+if git init -q -b main "$SH_REPO" >/dev/null 2>&1; then
+  git -C "$SH_REPO" config user.email t@t
+  git -C "$SH_REPO" config user.name t
+  _sh_ok=1
+  for _i in 0 1 2 3 4 5; do
+    printf 'c%s\n' "$_i" >"$SH_REPO/f$_i"
+    git -C "$SH_REPO" add -- "f$_i" >/dev/null 2>&1 &&
+      git -C "$SH_REPO" commit -q -m "c$_i" >/dev/null 2>&1 || _sh_ok=0
+  done
+  if [ "$_sh_ok" -eq 1 ]; then
+    SH_A=$(git -C "$SH_REPO" rev-parse main~5 2>/dev/null) || SH_A=""
+    SH_C=$(git -C "$SH_REPO" rev-parse main 2>/dev/null) || SH_C=""
+    # a branch at the OLDEST commit, so the endpoint can be fetched at depth 1
+    # without needing uploadpack.allowAnySHA1InWant on the source.
+    [ -n "$SH_A" ] && git -C "$SH_REPO" branch old "$SH_A" >/dev/null 2>&1
+  fi
+fi
+if [ -n "$SH_A" ] && [ -n "$SH_C" ] && [ "$SH_A" != "$SH_C" ] &&
+   git clone -q --depth 1 --no-local --branch main "file://$SH_REPO" "$SH_CLONE" >/dev/null 2>&1 &&
+   git -C "$SH_CLONE" fetch -q --depth 1 origin old:refs/remotes/origin/old >/dev/null 2>&1; then
+  # FIXTURE SELF-CONSISTENCY: shallow, BOTH endpoints present, the CONNECTING
+  # commit absent. Without the third condition the fixture is not the shape the
+  # case claims, which is exactly how the previous version went vacuous.
+  _sh_mid=$(git -C "$SH_REPO" rev-parse main~2 2>/dev/null) || _sh_mid=""
+  if [ "$(git -C "$SH_CLONE" rev-parse --is-shallow-repository 2>/dev/null)" = true ] &&
+     git -C "$SH_CLONE" cat-file -e "$SH_A^{commit}" >/dev/null 2>&1 &&
+     git -C "$SH_CLONE" cat-file -e "$SH_C^{commit}" >/dev/null 2>&1 &&
+     [ -n "$_sh_mid" ] &&
+     ! git -C "$SH_CLONE" cat-file -e "$_sh_mid^{commit}" >/dev/null 2>&1; then
     shallow_shape=1
   fi
 fi
 if [ "$shallow_shape" -eq 1 ]; then
-  ok "ancestry shallow fixture: a SHALLOW clone that holds BOTH objects (so rc 1 is not a verdict)"
-  OUT=$(cd "$SHALLOW" && PATH="$BIN:$PATH" MOCK_GH_FAIL=0 MOCK_GH_OUT="$R_CERT OPEN" \
-    bash "$NEUTRAL_ASSERT" 2421 "$R_CERT" "$RFORFULL" "$RFORDELTA" 2>&1)
+  ok "shallow fixture: shallow clone holds BOTH endpoints and NOT the connecting commit"
+  # THE GIT-LEVEL DIFFERENTIAL, which is what makes rc 1 ambiguous rather than a
+  # verdict. Both halves asserted: either alone would prove nothing.
+  if git -C "$SH_REPO" merge-base --is-ancestor "$SH_A" "$SH_C" >/dev/null 2>&1; then
+    ok "shallow differential (git): in the COMPLETE repo the pair IS an ancestor (rc 0)"
+  else
+    bad "shallow differential (git): the pair is not an ancestor even in the complete repo — the fixture cannot exercise the ambiguous case (this was the previous arm's defect)"
+    shallow_shape=0
+  fi
+  if git -C "$SH_CLONE" merge-base --is-ancestor "$SH_A" "$SH_C" >/dev/null 2>&1; then
+    bad "shallow differential (git): the SHALLOW clone still reports the pair as an ancestor — rc 1 is not being produced, so the arm proves nothing"
+    shallow_shape=0
+  else
+    ok "shallow differential (git): in the SHALLOW clone the SAME pair returns rc 1 — history absent, not 'not an ancestor'"
+  fi
+fi
+if [ "$shallow_shape" -eq 1 ]; then
+  SHFULL="$T/shallow-full.txt"
+  SHDELTA="$T/shallow-delta.txt"
+  full_summary "$SHFULL" "$(printf '%.7s' "$SH_A")" "$(printf '%.12s' "$SH_A")" PASS PASS
+  delta_summary "$SHDELTA" "$SH_A" "$(printf '%.7s' "$SH_C")" "$(printf '%.12s' "$SH_C")" \
+    PASS PASS "MODE: delta (TEST/DOCS-ONLY RE-CERTIFICATION — anchor $SH_A)"
+  # GUARD LEVEL, half 1: the COMPLETE repository must BIND the same pair. Without
+  # this the shallow refusal below could be any unrelated refusal.
+  OUT=$(cd "$SH_REPO" && PATH="$BIN:$PATH" MOCK_GH_FAIL=0 MOCK_GH_OUT="$SH_C OPEN" \
+    bash "$NEUTRAL_ASSERT" 2421 "$SH_C" "$SHFULL" "$SHDELTA" 2>&1)
+  RC=$?
+  if [ "$RC" -eq 0 ] && [ "${OUT#*anchor-ancestry: BOUND}" != "$OUT" ]; then
+    ok "shallow differential (guard): the COMPLETE repo BINDS the pair (exit 0, anchor-ancestry: BOUND)"
+  else
+    bad "shallow differential (guard): the complete repo did not BIND the pair (exit $RC) — the shallow half below would prove nothing (got: $OUT)"
+  fi
+  # GUARD LEVEL, half 2: the SHALLOW clone must refuse UNVERIFIABLE, NOT exit 2.
+  OUT=$(cd "$SH_CLONE" && PATH="$BIN:$PATH" MOCK_GH_FAIL=0 MOCK_GH_OUT="$SH_C OPEN" \
+    bash "$NEUTRAL_ASSERT" 2421 "$SH_C" "$SHFULL" "$SHDELTA" 2>&1)
   RC=$?
   if [ "$RC" -ne 3 ]; then
-    bad "ancestry shallow: rc 1 in a shallow clone must be exit 3, not a verdict (got $RC: $OUT)"
+    bad "shallow (guard): a TRUE ancestor whose history is absent must be exit 3, never the exit-2 verdict (got $RC: $OUT)"
   else
-    ok "ancestry shallow: rc 1 in a repository NOT proven complete -> exit 3, never the exit-2 refusal"
+    ok "shallow (guard): the SAME pair in a shallow clone is exit 3, never the exit-2 refusal"
     case "$OUT" in
       *"PREMERGE: ANCHOR-UNVERIFIABLE"*)
-        ok "ancestry shallow: the shallow case carries the ANCHOR-UNVERIFIABLE marker" ;;
-      *) bad "ancestry shallow: expected the ANCHOR-UNVERIFIABLE marker (got: $OUT)" ;;
+        ok "shallow (guard): carries the ANCHOR-UNVERIFIABLE marker" ;;
+      *) bad "shallow (guard): expected the ANCHOR-UNVERIFIABLE marker (got: $OUT)" ;;
     esac
     case "$OUT" in
       *"NOT PROVEN COMPLETE"*)
-        ok "ancestry shallow: the refusal names shallowness as the cause, not 'not an ancestor'" ;;
-      *) bad "ancestry shallow: the refusal must name the incomplete history (got: $OUT)" ;;
+        ok "shallow (guard): the refusal names the incomplete history, not 'not an ancestor'" ;;
+      *) bad "shallow (guard): the refusal must name the incomplete history (got: $OUT)" ;;
+    esac
+    case "$OUT" in
+      *"is NOT on the certified sha's history"*)
+        bad "shallow (guard): a TRUE ancestor was reported as NOT on the history — the exact false verdict this arm exists to prevent (got: $OUT)" ;;
+      *) ok "shallow (guard): a TRUE ancestor is NOT reported as 'not on the history'" ;;
     esac
     case "$OUT" in
       *"git fetch --unshallow"*)
-        ok "ancestry shallow: the shallow cause carries its own remedy (git fetch --unshallow)" ;;
-      *) bad "ancestry shallow: the shallow cause must carry the unshallow remedy (got: $OUT)" ;;
+        ok "shallow (guard): the shallow cause carries its own remedy (git fetch --unshallow)" ;;
+      *) bad "shallow (guard): the shallow cause must carry the unshallow remedy (got: $OUT)" ;;
     esac
   fi
 else
-  # A DECLARED SKIP — visible, named, and NON-FATAL. Two rules pull against each
-  # other here and both are the repo's:
-  #   * a bare skip that prints nothing is refused — an unexercised arm must SAY
-  #     it was not taken, or the suite's green tally silently covers less than it
-  #     did yesterday;
-  #   * a lane that REDS on correct input is the lane agents learn to waive — and
-  #     an old or unusual git that cannot build a `--depth` clone over `file://`
-  #     is a property of the HOST, not a defect in the tree under test.
-  # So it reports on the suite's own `ok` channel (the `SKIPPED (...)` idiom Case
-  # 35 already uses for the root/mode-bit case) and additionally prints an
-  # affirmative `ARM NOT TAKEN` line, so an operator reading the output can see
-  # WHICH coverage was not taken and why. The arm itself is unchanged: on every
-  # host that CAN build the fixture it runs and asserts as before.
-  printf 'ARM NOT TAKEN: ancestry shallow (rc-1-is-three-valued) — this host could not build the\n'
-  printf 'ARM NOT TAKEN: fixture: a --depth 2 --no-local clone over file:// plus a --depth 1 fetch of\n'
-  printf 'ARM NOT TAKEN: the sibling branch, yielding a SHALLOW repo holding BOTH objects. The\n'
-  printf 'ARM NOT TAKEN: shallow branch of assert_anchor_on_history is therefore UNEXERCISED on this\n'
-  printf 'ARM NOT TAKEN: run. Non-fatal by design: an old/unusual git is a host property, not a\n'
-  printf 'ARM NOT TAKEN: defect in the tree under test.\n'
-  ok "ancestry shallow: SKIPPED (fixture unbuildable on this host — see the ARM NOT TAKEN lines; arm UNEXERCISED, declared not silent)"
+  # DECLARED, not silently skipped, and non-fatal: a host whose git cannot build a
+  # `--depth` clone over `file://` plus a `--depth 1` branch fetch is a HOST
+  # property, not a defect in the tree under test. A lane that reds on correct
+  # input is the lane agents learn to waive.
+  printf 'ARM NOT TAKEN: shallow rc-1-ambiguity (job 410) — this host could not build the fixture: a\n'
+  printf 'ARM NOT TAKEN: 6-commit history, a --depth 1 clone over file://, and a --depth 1 fetch of a\n'
+  printf 'ARM NOT TAKEN: branch at the OLDEST commit, yielding a shallow repo that holds BOTH endpoints\n'
+  printf 'ARM NOT TAKEN: and NOT the connecting commits. Without it rc 1 cannot be made ambiguous, so\n'
+  printf 'ARM NOT TAKEN: the shallow branch of assert_anchor_on_history is UNEXERCISED on this run.\n'
+  ok "shallow: SKIPPED (differential fixture unbuildable — arm UNEXERCISED, declared not silent)"
 fi
 
 # --- 44(f): A GRAFT MUST NOT BE ABLE TO MANUFACTURE `BOUND` (roborev job 355) -
@@ -2387,6 +2459,23 @@ to_run_arm() {
         | *"could not be resolved"* | *"scratch root"* | *"could not initialise"*)
         bad "hung-read ($label): a timeout was misreported as another cause — the operator would get the WRONG remedy (got: $out)" ;;
       *) ok "hung-read ($label): a timeout borrows NO other cause's remedy (not work-tree, TMPDIR, absent-object, shallow or NOT-ANCESTOR)" ;;
+    esac
+    # AND THE TIMEOUT MESSAGE MUST NAME ITS OWN SUBJECT (roborev job 410). The
+    # shared diagnostic used to assert "this is NOT about your TMPDIR" and send the
+    # operator to the OBJECT STORE — while being the destination for timeouts that
+    # occurred canonicalising TMPDIR, running `mktemp`, or canonicalising the
+    # scratch. Both halves are asserted here rather than per-arm, so every timeout
+    # arm covers the class: a SUBJECT line must be present, and the old
+    # object-store-only remedy must be gone.
+    case "$out" in
+      *"SUBJECT: the timed-out operation was acting on: "*)
+        ok "hung-read ($label): the timeout names the SUBJECT it was acting on" ;;
+      *) bad "hung-read ($label): the timeout must name its subject, or a TMPDIR-side hang reads as an object-store problem (got: $out)" ;;
+    esac
+    case "$out" in
+      *"check the object store under this repository"*)
+        bad "hung-read ($label): the refusal still sends the operator to the OBJECT STORE unconditionally (job 410) (got: $out)" ;;
+      *) ok "hung-read ($label): the remedy points at the named subject, not unconditionally at the object store" ;;
     esac
   fi
   # NO LEAK ASSERTION HERE ANY MORE (job 381). Reaping is covered by the

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -959,6 +959,99 @@ refused_pair() {
   fi
 }
 
+# =============================================================================
+# THE ANCESTRY FIXTURE (#3653) — A REAL SYNTHETIC REPOSITORY
+# =============================================================================
+# Case B's #3653 binding asks a REPOSITORY a question (`git merge-base
+# --is-ancestor <anchor> <certified>`), and it asks it of the CURRENT WORKING
+# DIRECTORY's repository with no env override (#3312's enforcer rule). So every
+# Case B case that reaches that check needs REAL shas in a REAL repository —
+# fabricated 40-hex constants are absent objects and land, correctly, on
+# UNVERIFIABLE. One fixture serves BOTH arms:
+#
+#     c0 ─── c1 (ANCHOR) ─── c2 (CERTIFIED head)        [branch feature]
+#      └──── cF (FOREIGN anchor: NOT an ancestor of c2)  [branch other]
+#
+# Built with `git init` in the scratch dir, so it is hermetic, bounded by
+# construction and identical on every host — the same discipline (and the same
+# fixture-self-consistency assertions) as the wiring case at the end of this file.
+ANC_REPO="$T/ancestry-repo"
+anc_shape=0
+R_ANCHOR=""; R_CERT=""; R_FOREIGN=""
+mkdir -p "$ANC_REPO"
+if git init -q -b mainline "$ANC_REPO" >/dev/null 2>&1; then
+  git -C "$ANC_REPO" config user.email t@t
+  git -C "$ANC_REPO" config user.name t
+  anc_commit() {
+    printf 'content %s\n' "$1" >>"$ANC_REPO/$1.txt"
+    git -C "$ANC_REPO" add -- "$1.txt" >/dev/null &&
+      git -C "$ANC_REPO" commit -q -m "$1" >/dev/null
+  }
+  anc_commit c0 &&
+    git -C "$ANC_REPO" checkout -q -b other &&
+    anc_commit cF &&
+    R_FOREIGN=$(git -C "$ANC_REPO" rev-parse HEAD) &&
+    git -C "$ANC_REPO" checkout -q -b feature mainline &&
+    anc_commit c1 &&
+    R_ANCHOR=$(git -C "$ANC_REPO" rev-parse HEAD) &&
+    anc_commit c2 &&
+    R_CERT=$(git -C "$ANC_REPO" rev-parse HEAD) &&
+    anc_shape=1
+fi
+# FIXTURE SELF-CONSISTENCY. Every property the cases below rely on is asserted
+# here, because a fixture that is not the shape the case claims makes the case
+# vacuous — green while proving nothing.
+anc_is_hex40() { case "$1" in *[!0-9a-f]*|'') return 1 ;; esac; [ "${#1}" -eq 40 ]; }
+if [ "$anc_shape" -eq 1 ]; then
+  anc_is_hex40 "$R_ANCHOR" && anc_is_hex40 "$R_CERT" && anc_is_hex40 "$R_FOREIGN" || anc_shape=0
+fi
+if [ "$anc_shape" -eq 1 ]; then
+  git -C "$ANC_REPO" merge-base --is-ancestor "$R_ANCHOR" "$R_CERT" || anc_shape=0
+  git -C "$ANC_REPO" merge-base --is-ancestor "$R_FOREIGN" "$R_CERT" && anc_shape=0
+  [ "$(git -C "$ANC_REPO" rev-parse --is-shallow-repository 2>/dev/null)" = false ] || anc_shape=0
+fi
+if [ "$anc_shape" -eq 1 ]; then
+  ok "ancestry fixture: c1 IS an ancestor of c2, cF is NOT, and the repo is proven complete"
+else
+  bad "ancestry fixture: the synthetic repo is not the shape the #3653 cases claim (anchor '$R_ANCHOR', certified '$R_CERT', foreign '$R_FOREIGN') — those cases would be vacuous"
+fi
+
+# The two abbreviations the gate writes for each fixture sha (`%.7s` / `%.12s`).
+RA7=$(printf '%.7s' "$R_ANCHOR");  RA12=$(printf '%.12s' "$R_ANCHOR")
+RC7=$(printf '%.7s' "$R_CERT");    RC12=$(printf '%.12s' "$R_CERT")
+
+# run_anc <expected-exit> <desc> <args...> — run() with the CURRENT DIRECTORY
+# inside the ancestry fixture, which is the repository the #3653 binding reads.
+# Still the NEUTRAL scratch copy of the assert (so no case scans the ambient
+# checkout) and still the gh mock, answering with the fixture's own head.
+run_anc() {
+  local want="$1" desc="$2"
+  shift 2
+  OUT=$(cd "$ANC_REPO" && PATH="$BIN:$PATH" MOCK_GH_FAIL=0 MOCK_GH_OUT="$R_CERT OPEN" \
+    bash "$NEUTRAL_ASSERT" "$@" 2>&1)
+  RC=$?
+  if [ "$RC" -ne "$want" ]; then
+    bad "$desc (exit $RC, wanted $want)"
+    printf '     output: %s\n' "$OUT"
+    return 1
+  fi
+  return 0
+}
+
+# anc_delta <file> <anchor-sha> — a delta block at the fixture's certified head,
+# anchored at <anchor-sha>. ONE builder, ONE varying input: that is what makes
+# the accept arm and the RED arm differ in EXACTLY ONE PROPERTY (asserted below).
+anc_delta() {
+  delta_summary "$1" "$2" "$RC7" "$RC12" PASS PASS \
+    "MODE: delta (TEST/DOCS-ONLY RE-CERTIFICATION — NOT the gate of record; gate of record = the full agent-gate.sh PASS at anchor $2)"
+}
+RANCFULL="$T/anc-full.txt"
+full_summary "$RANCFULL" "$RA7" "$RA12" PASS PASS
+RGOODDELTA="$T/anc-delta-good.txt"
+anc_delta "$RGOODDELTA" "$R_ANCHOR"
+RFORDELTA="$T/anc-delta-foreign.txt"
+anc_delta "$RFORDELTA" "$R_FOREIGN"
+
 ANCHORFULL="$T/anchor-full.txt"
 full_summary "$ANCHORFULL" "$A7" "$A12" PASS PASS
 GOODDELTA="$T/good-delta.txt"
@@ -972,24 +1065,28 @@ refused "anchor-only full summary at a MOVED head (3 args) -> refuse" \
   "$ANCHORFULL" "does not match the certified sha"
 
 # --- Case 28(b): the anchored delta PAIR at that same moved head -> accept ---
-if run 0 "anchored delta pair (full PASS at X + delta at Y) -> exit 0" \
-  2421 "$CERTIFIED" "$ANCHORFULL" "$GOODDELTA"; then
+# MIGRATED to the REAL ancestry fixture (#3653): the fabricated ANCHOR/CERTIFIED
+# constants are absent objects, so this case now lands on ANCHOR-UNVERIFIABLE
+# unless it runs in a repository that HOLDS the two shas. Everything it asserted
+# is preserved, at the fixture's own shas, plus the new affirmative token.
+if run_anc 0 "anchored delta pair (full PASS at X + delta at Y) -> exit 0" \
+  2421 "$R_CERT" "$RANCFULL" "$RGOODDELTA"; then
   case "$OUT" in
-    *"PREMERGE: OK $CERTIFIED"*) ok "delta pair: prints PREMERGE: OK <sha>" ;;
+    *"PREMERGE: OK $R_CERT"*) ok "delta pair: prints PREMERGE: OK <sha>" ;;
     *) bad "delta pair: missing PREMERGE: OK (got: $OUT)" ;;
   esac
   case "$OUT" in
-    *"PREMERGE: GATE-OF-RECORD commit: $A7 tree-start: $A12"*)
+    *"PREMERGE: GATE-OF-RECORD commit: $RA7 tree-start: $RA12"*)
       ok "delta pair: the GATE-OF-RECORD line names the ANCHOR's provenance" ;;
     *) bad "delta pair: GATE-OF-RECORD line must name the anchor (got: $OUT)" ;;
   esac
   case "$OUT" in
-    *"PREMERGE: DELTA-RECERT anchor: $ANCHOR commit: $C7 tree-start: $C12"*)
+    *"PREMERGE: DELTA-RECERT anchor: $R_ANCHOR anchor-ancestry: BOUND commit: $RC7 tree-start: $RC12"*)
       ok "delta pair: a DISTINCT DELTA-RECERT line names the anchor + the merged tree" ;;
     *) bad "delta pair: missing the DELTA-RECERT evidence line (got: $OUT)" ;;
   esac
   case "$OUT" in
-    *"summary: $GOODDELTA"*) ok "delta pair: the DELTA-RECERT line names the delta summary file" ;;
+    *"summary: $RGOODDELTA"*) ok "delta pair: the DELTA-RECERT line names the delta summary file" ;;
     *) bad "delta pair: DELTA-RECERT must name the delta summary file (got: $OUT)" ;;
   esac
 fi
@@ -1110,10 +1207,10 @@ refused_pair "anchor commit: non-hex -> refuse (a real sha is still required)" \
 # the same property, so both are held to the requirement.
 
 # 33(x)(a) POSITIVE CONTROL — both clean -> exit 0, both evidence lines report it.
-if run 0 "delta pair with BOTH blocks dirty: no -> exit 0" \
-  2421 "$CERTIFIED" "$ANCHORFULL" "$GOODDELTA"; then
+if run_anc 0 "delta pair with BOTH blocks dirty: no -> exit 0" \
+  2421 "$R_CERT" "$RANCFULL" "$RGOODDELTA"; then
   case "$OUT" in
-    *"GATE-OF-RECORD commit: $A7"*"dirty: no"*"DELTA-RECERT anchor:"*"dirty: no"*)
+    *"GATE-OF-RECORD commit: $RA7"*"dirty: no"*"DELTA-RECERT anchor:"*"dirty: no"*)
       ok "dirty (case B): BOTH evidence lines report the clean tree" ;;
     *) bad "dirty (case B): both evidence lines must report dirty: no (got: $OUT)" ;;
   esac
@@ -1326,8 +1423,8 @@ if run 0 "success path prints the SCOPE disclaimer" 2421 "$CERTIFIED" "$GOOD"; t
     *) bad "scope: the clause must state what was NOT proven (got: $OUT)" ;;
   esac
 fi
-if run 0 "success path prints SCOPE in the anchored-delta case too" \
-  2421 "$CERTIFIED" "$ANCHORFULL" "$GOODDELTA"; then
+if run_anc 0 "success path prints SCOPE in the anchored-delta case too" \
+  2421 "$R_CERT" "$RANCFULL" "$RGOODDELTA"; then
   case "$OUT" in
     *"PREMERGE: SCOPE"*) ok "scope: the delta pair carries the same disclaimer" ;;
     *) bad "scope: the delta pair must carry the SCOPE clause too (got: $OUT)" ;;
@@ -1345,7 +1442,7 @@ for shape in direct delta; do
   if [ "$shape" = direct ]; then
     run 0 "SCOPE retained (direct)" 2421 "$CERTIFIED" "$GOOD" || continue
   else
-    run 0 "SCOPE retained (anchored delta)" 2421 "$CERTIFIED" "$ANCHORFULL" "$GOODDELTA" || continue
+    run_anc 0 "SCOPE retained (anchored delta)" 2421 "$R_CERT" "$RANCFULL" "$RGOODDELTA" || continue
   fi
   missing=""
   for needle in "$SCOPE1" "$SCOPE2" "$SCOPE3"; do

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -1384,6 +1384,7 @@ else
   printf '%s\n' "$NEUTRAL_ADV" >"$MUTDIR/base-staleness.sh"
   chmod +x "$MUTDIR/base-staleness.sh"
   # The call site, replaced by the assignment it would have made on success.
+  # shellcheck disable=SC2016  # a LITERAL line of another script; it must not expand here
   MUT_FROM='  assert_anchor_on_history "$delta_anchor" "$certified"'
   MUT_TO='  ANCHOR_ANCESTRY=BOUND   # MUTANT: ancestry check removed'
   if [ "$(grep -c -x -F -- "$MUT_FROM" "$MUTDIR/premerge-assert.sh" | tr -d ' ')" = 1 ]; then
@@ -1497,6 +1498,70 @@ else
       *"PREMERGE: NO-GATE-OF-RECORD"*|*"PREMERGE: TOOL-FAILURE"*)
         bad "ancestry: the no-work-tree case must not read as another verdict (got: $OUT)" ;;
       *) ok "ancestry: the no-work-tree marker is distinct from NO-GATE-OF-RECORD and TOOL-FAILURE" ;;
+    esac
+  fi
+fi
+
+# The CERTIFIED object absent is the OTHER half of the presence probe, and it has
+# its own cause and its own remedy — a rebased-away anchor and a PR branch that
+# was never fetched are different operator actions. Probed separately so a single
+# combined message could not pass for both.
+FAKE_CERT="fedcba9876543210fedcba9876543210fedcba98"
+FC7=$(printf '%.7s' "$FAKE_CERT"); FC12=$(printf '%.12s' "$FAKE_CERT")
+if git -C "$ANC_REPO" cat-file -e "$FAKE_CERT^{commit}" >/dev/null 2>&1; then
+  bad "ancestry UNVERIFIABLE fixture: the 'absent certified' sha is present in the fixture repo"
+else
+  ok "ancestry UNVERIFIABLE fixture: the chosen certified sha really is absent from the fixture repo"
+fi
+delta_summary "$T/anc-delta-fakecert.txt" "$R_ANCHOR" "$FC7" "$FC12" PASS PASS \
+  "MODE: delta (TEST/DOCS-ONLY RE-CERTIFICATION — NOT the gate of record; gate of record = the full agent-gate.sh PASS at anchor $R_ANCHOR)"
+if run_anc 3 "ancestry UNVERIFIABLE: the CERTIFIED sha absent from this repository -> exit 3" \
+  2421 "$FAKE_CERT" "$RANCFULL" "$T/anc-delta-fakecert.txt"; then
+  case "$OUT" in
+    *"the CERTIFIED commit is not present in this repository"*)
+      ok "ancestry: the absent-CERTIFIED cause is named separately from the absent-ANCHOR one" ;;
+    *) bad "ancestry: expected the absent-CERTIFIED cause (got: $OUT)" ;;
+  esac
+  case "$OUT" in
+    *"PREMERGE: ANCHOR-UNVERIFIABLE"*)
+      ok "ancestry: an absent certified object also carries the ANCHOR-UNVERIFIABLE marker" ;;
+    *) bad "ancestry: expected ANCHOR-UNVERIFIABLE (got: $OUT)" ;;
+  esac
+fi
+
+# git ABSENT is a cause too, and it must not be mistaken for "the anchor is not
+# an ancestor". A PATH holding only what the parser needs (awk, tr) plus the gh
+# mock — and NOT git — is the whole fixture; the check must refuse before it ever
+# calls git. NON-VACUITY: the fixture PATH is asserted to really lack git.
+NOGIT="$T/bin-nogit"
+mkdir -p "$NOGIT"
+nogit_ok=1
+for _tool in awk tr; do
+  _tp=$(command -v "$_tool" 2>/dev/null) || _tp=""
+  if [ -n "$_tp" ]; then ln -sf "$_tp" "$NOGIT/$_tool"; else nogit_ok=0; fi
+done
+cp "$BIN/gh" "$NOGIT/gh" 2>/dev/null || nogit_ok=0
+if [ "$nogit_ok" -eq 1 ] && PATH="$NOGIT" command -v git >/dev/null 2>&1; then
+  nogit_ok=0
+fi
+if [ "$nogit_ok" -ne 1 ]; then
+  bad "ancestry no-git fixture: could not build a PATH that has awk/tr/gh but NOT git — the arm did NOT run"
+else
+  ok "ancestry no-git fixture: the fixture PATH really has no git on it"
+  # `bash` is invoked by ABSOLUTE path: the fixture PATH deliberately holds only
+  # awk/tr/gh, so a bare `bash` would be "command not found" — a 127 that looks
+  # like a refusal and proves nothing about the check.
+  OUT=$(cd "$ANC_REPO" && PATH="$NOGIT" MOCK_GH_FAIL=0 MOCK_GH_OUT="$R_CERT OPEN" \
+    "${BASH:-/bin/bash}" "$NEUTRAL_ASSERT" 2421 "$R_CERT" "$RANCFULL" "$RGOODDELTA" 2>&1)
+  RC=$?
+  if [ "$RC" -ne 3 ]; then
+    bad "ancestry no-git: git absent must be exit 3, never a pass (got $RC: $OUT)"
+  else
+    ok "ancestry no-git: git absent from PATH -> exit 3, never a silent accept"
+    case "$OUT" in
+      *"PREMERGE: ANCHOR-UNVERIFIABLE"*"git is not on PATH"*)
+        ok "ancestry no-git: the marker and the cause both name what could not be measured" ;;
+      *) bad "ancestry no-git: expected ANCHOR-UNVERIFIABLE naming the absent git (got: $OUT)" ;;
     esac
   fi
 fi

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -2308,7 +2308,39 @@ fi
 # A vacuous assertion is worse than a missing one, because it invites reliance it
 # cannot support. It is KEPT as a cheap second signal (it also catches a stray
 # sentinel from an earlier run) and is no longer the primary check.
-to_leaks() { ps -eo args= 2>/dev/null | grep -c -x -F "$TOSENTINEL"; }
+# THREE-VALUED SINCE roborev job 380, and it had TWO fail-open routes at once:
+#   * `ps` ran INSIDE A PIPELINE, so its exit status was DISCARDED entirely — the
+#     pipeline's status is grep's. A failing `ps` produced EMPTY input, grep
+#     counted 0, and the caller read "no leaks".
+#   * `grep -c` prints `0` AND EXITS 1 on no-match, so its status cannot be used
+#     naively either (that trap already cost this file one round).
+# So `ps` writes to a FILE, its status is inspected, and only then is the count
+# taken. Prints a NUMBER, or the literal `UNMEASURABLE` — never a silent 0. The
+# caller must FAIL on UNMEASURABLE: this suite tests a guard that is fail-closed
+# on an unmeasurable state, so its own checks being permissive there would be
+# incoherent.
+to_leaks() {
+  local psout n rc=0 grc=0
+  psout="$T/ps-census.txt"
+  ps -eo args= >"$psout" 2>/dev/null || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    rm -f "$psout"
+    printf 'UNMEASURABLE\n'
+    return 0
+  fi
+  n=$(grep -c -x -F "$TOSENTINEL" "$psout" 2>/dev/null)
+  grc=$?
+  rm -f "$psout"
+  # grep -c: 0 = matches, 1 = none (still prints a count), >=2 = ERROR.
+  if [ "$grc" -ge 2 ]; then
+    printf 'UNMEASURABLE\n'
+    return 0
+  fi
+  case "$n" in
+    ''|*[!0-9]*) printf 'UNMEASURABLE\n'; return 0 ;;
+  esac
+  printf '%s\n' "$n"
+}
 
 # to_check_pid <label> <pidfile> <expected-argv-needle> — the PRIMARY leak check
 # (job 367). The shim records its OWN pid before it blocks; `exec` PRESERVES the
@@ -2331,15 +2363,22 @@ to_leaks() { ps -eo args= 2>/dev/null | grep -c -x -F "$TOSENTINEL"; }
 # SELF-TESTED (see 44(l)): it prints exactly one verdict token and KILLS NOTHING.
 # A check whose only caller reports "no leak" cannot demonstrate that it would
 # ever say otherwise, which is the defect this whole round is about.
-#   NO-SUBJECT | BAD-PID | GONE | ZOMBIE | LEAK | RECYCLED
+#   NO-SUBJECT | BAD-PID | UNMEASURABLE | GONE | ZOMBIE | LEAK | RECYCLED
+#
+# `UNMEASURABLE` was added on roborev job 380: `args=$(ps …) || args=""` collapsed
+# a FAILED probe onto an EMPTY one, so a `ps` that could not run was reported as
+# `GONE` — a surviving timeout child read as successfully reaped while the suite
+# passed. Same measured split as `to_kill_decoy` uses: `ps -p <gone>` exits 1 with
+# no output (an affirmative "not found"), a broken `ps` exits >= 2.
 to_pid_verdict() {
-  local pidfile="$1" needle="$2" pid args
+  local pidfile="$1" needle="$2" pid args rc=0
   if [ ! -f "$pidfile" ]; then printf 'NO-SUBJECT\n'; return 0; fi
   pid=$(cat "$pidfile" 2>/dev/null)
   case "$pid" in
     ''|*[!0-9]*) printf 'BAD-PID\n'; return 0 ;;
   esac
-  args=$(ps -p "$pid" -o args= 2>/dev/null) || args=""
+  args=$(ps -p "$pid" -o args= 2>/dev/null) || rc=$?
+  if [ "$rc" -ge 2 ]; then printf 'UNMEASURABLE\n'; return 0; fi
   if [ -z "$args" ]; then printf 'GONE\n'; return 0; fi
   case "$args" in
     *"<defunct>"*) printf 'ZOMBIE\n' ;;
@@ -2360,6 +2399,11 @@ to_check_pid() {
       return 1 ;;
     BAD-PID)
       bad "hung-read ($label): the shim recorded a non-numeric pid ('$pid') — the leak check cannot be made"
+      return 1 ;;
+    UNMEASURABLE)
+      # NOT read as "no leak": the probe could not answer, so whether the runner
+      # reaped its child is UNKNOWN, and an unknown is never a pass (job 380).
+      bad "hung-read ($label): the process probe FAILED (ps unusable), so whether pid $pid survived the bound is UNKNOWN — never read as reaped"
       return 1 ;;
   esac
   ok "hung-read ($label): the shim recorded its own pid ($pid) — the leak check has a SUBJECT"
@@ -2443,7 +2487,9 @@ to_run_arm() {
   # SECONDARY: the sentinel census, kept as a cheap cross-check. It can only see
   # the TERM arm's `exec`ed sleep — see the note on to_leaks.
   leaks=$(to_leaks)
-  if [ "$leaks" = 0 ]; then
+  if [ "$leaks" = UNMEASURABLE ]; then
+    bad "hung-read ($label): the sentinel census could not be taken (ps unusable) — that is UNKNOWN, not 'no strays' (job 380)"
+  elif [ "$leaks" = 0 ]; then
     ok "hung-read ($label): the sentinel census also finds no stray sleep (secondary check)"
   else
     bad "hung-read ($label): $leaks stray process(es) matching the sentinel survived — the runner did not reap its child (job 279)"
@@ -2774,6 +2820,25 @@ else
     bad "leak self-test: an affirmatively-gone pid left the registration set — it would never be released"
   fi
   DECOY_CLEANUP_NEEDLE=""
+  # THE SAME FAIL-CLOSED PROPERTY FOR THE TWO *LEAK CHECKS* (job 380). The arm
+  # above covers `to_kill_decoy`; these cover the PRIMARY verdict and the
+  # SECONDARY census, which had the same permissive-on-unmeasurable read. Reuses
+  # the `$FAILPS` shim built above — no new machinery.
+  _kd_path="$PATH"
+  PATH="$FAILPS:$PATH"
+  v=$(to_pid_verdict "$DECOY_PID" "$DECOY_DIR/git")
+  n=$(to_leaks)
+  PATH="$_kd_path"
+  if [ "$v" = UNMEASURABLE ]; then
+    ok "leak self-test: a FAILED ps probe makes to_pid_verdict UNMEASURABLE, never GONE (job 380)"
+  else
+    bad "leak self-test: to_pid_verdict reported '$v' with an unusable ps — a surviving process would read as successfully reaped"
+  fi
+  if [ "$n" = UNMEASURABLE ]; then
+    ok "leak self-test: a FAILED ps makes the census UNMEASURABLE, never a silent 0 (job 380)"
+  else
+    bad "leak self-test: to_leaks reported '$n' with an unusable ps — a stray would read as absent"
+  fi
   # (the no-child property is asserted at the fixture, while the decoy is still
   # alive — see `decoy_kids` above. A post-hoc census for a `sleep` argv, which
   # is what stood here, became VACUOUS the moment the decoy stopped spawning one:

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -97,15 +97,48 @@ suite_cleanup() {
 # that has been recycled into something else is never signalled (job 279:
 # ownership ends at reap, not at exit; on this fleet the inheritor of a released
 # pid is most likely a peer lane's gate). Safe to call any number of times.
+#
+# THREE THINGS THE FIRST VERSION GOT WRONG (roborev job 378):
+#
+#  1. IT CLEARED THE REGISTRATION EVEN WHEN THE PROBE COULD NOT ANSWER. `args=$(ps
+#     …) || args=""` collapses "ps FAILED" onto "the process is GONE", and the
+#     unconditional clear then DISCARDED the registration — so a failed probe
+#     silently leaked the process. That is the fail-open shape this repo names
+#     explicitly: a probe that could not answer taking the permissive branch. And
+#     it is not niche — a failing `ps` is exactly when the registration matters
+#     most. MEASURED, which is what makes the split expressible: `ps -p <gone>`
+#     exits 1 with no output (an AFFIRMATIVE "not found"), while a broken `ps`
+#     exits >= 2. So rc >= 2 KEEPS the registration for a later call; only an
+#     affirmative determination may clear it.
+#  2. IT KILLED WITHOUT REAPING. The decoy is a DIRECT CHILD, so an unreaped
+#     SIGKILL leaves a zombie holding the pid. `wait` follows the kill, and the
+#     clear follows the wait — in that order.
+#  3. It relied on `rm -rf "$T"` as a backstop, which cannot work: REMOVING THE
+#     FIFO DOES NOT UNBLOCK A READER ALREADY BLOCKED ON IT. That is why the reap
+#     runs BEFORE the directory removal in `suite_cleanup`, not after.
+#
+# An EMPTY needle is also a "cannot validate" state: it neither signals nor
+# clears, because `*""*` matches anything and would authorise a blind kill.
 to_kill_decoy() {
-  local args
-  [ -n "$DECOY_CLEANUP_PID" ] || return 0
-  args=$(ps -p "$DECOY_CLEANUP_PID" -o args= 2>/dev/null) || args=""
-  if [ -n "$args" ] && [ -n "$DECOY_CLEANUP_NEEDLE" ] &&
-     [ "${args#*"$DECOY_CLEANUP_NEEDLE"}" != "$args" ]; then
-    kill -KILL "$DECOY_CLEANUP_PID" 2>/dev/null
+  local pid="$DECOY_CLEANUP_PID" args rc=0
+  [ -n "$pid" ] || return 0
+  args=$(ps -p "$pid" -o args= 2>/dev/null) || rc=$?
+  if [ "$rc" -ge 2 ]; then
+    return 0                      # the probe FAILED: keep the registration
   fi
-  DECOY_CLEANUP_PID=""
+  if [ -z "$args" ]; then
+    DECOY_CLEANUP_PID=""          # affirmatively gone (ps ran, found nothing)
+    return 0
+  fi
+  [ -n "$DECOY_CLEANUP_NEEDLE" ] || return 0   # cannot validate: never blind-kill
+  case "$args" in
+    *"$DECOY_CLEANUP_NEEDLE"*)
+      kill -KILL "$pid" 2>/dev/null
+      wait "$pid" 2>/dev/null || true          # reap: it is a direct child
+      DECOY_CLEANUP_PID=""
+      ;;
+    *) : ;;                       # RECYCLED: never signalled, never cleared
+  esac
   return 0
 }
 trap 'suite_cleanup' EXIT
@@ -2593,6 +2626,20 @@ DECOY_DIR="$T/leak-decoy"
 DECOY_PID="$T/leak-decoy.pid"
 DECOY_FIFO="$T/leak-decoy.fifo"
 decoy_shape=0
+# THE DECOY IS AN ORDINARY PROCESS ON PURPOSE — NO `trap '' TERM` (roborev job
+# 378). It used to ignore TERM, which was shaping carried over from the KILL-path
+# shim, where ignoring TERM IS the point. Here it bought NOTHING and cost the
+# entire cleanup problem: an unkillable-by-TERM child needs careful management,
+# and four findings in this scaffolding came from managing it.
+#   VERIFIED rather than assumed, because it is the premise of the change:
+#   `to_pid_verdict` contains ZERO `kill` — it only inspects `ps` — so none of the
+#   verdicts this arm tests (LEAK / RECYCLED / GONE / NO-SUBJECT / BAD-PID) needs
+#   the decoy to survive a signal. Nothing in this suite sends the decoy TERM
+#   either; the only TERM senders target `$$`. And on a Ctrl-C the decoy now dies
+#   with the foreground group by itself, which is strictly better.
+# So the hazardous PROPERTY is removed at its source rather than managed: a plain
+# direct child is removable with `kill` + `wait`, which reaps reliably.
+#
 # THE DECOY MUST NOT SPAWN A CHILD, and getting that wrong ONCE is why this
 # comment exists. The first version ran a bare `sleep`, so the decoy was TWO
 # processes: the bash wrapper (which carries the argv the needle matches, and is
@@ -2606,7 +2653,6 @@ rm -f "$DECOY_FIFO"
 if mkdir -p "$DECOY_DIR" 2>/dev/null && mkfifo "$DECOY_FIFO" 2>/dev/null; then
   cat >"$DECOY_DIR/git" <<DECOY
 #!/usr/bin/env bash
-trap '' TERM
 read -r _ < "$DECOY_FIFO"
 DECOY
   chmod +x "$DECOY_DIR/git"
@@ -2673,21 +2719,61 @@ else
   fi
   # (3) a dead pid is GONE, not a false alarm. Killed by pid AFTER validating the
   # argv is our own decoy — the same discipline the real check follows.
-  if [ "$(to_pid_verdict "$DECOY_PID" "$DECOY_DIR/git")" = LEAK ]; then
-    kill -KILL "$decoy_pid" 2>/dev/null
-    wait "$decoy_pid" 2>/dev/null || true
+  # ONE implementation of the validated kill+reap: the arm calls the same helper
+  # the traps do, rather than duplicating it. A second copy is a second place for
+  # the ordering (kill -> wait -> clear) to be wrong.
+  to_kill_decoy
+  if [ -z "$DECOY_CLEANUP_PID" ]; then
+    ok "leak self-test: the validated kill+reap cleared the registration (job 282's second half)"
+  else
+    bad "leak self-test: the registration survived the kill — either the probe could not answer or the argv did not match, and the decoy may still be running"
   fi
-  # Registration cleared once the resource is gone — the other half of job 282's
-  # rule (register the moment it exists, clear the moment it is reaped), so the
-  # exit trap cannot later signal a pid this arm no longer owns.
-  DECOY_CLEANUP_PID=""
   sleep 1
   v=$(to_pid_verdict "$DECOY_PID" "$DECOY_DIR/git")
-  if [ "$v" = GONE ] || [ "$v" = ZOMBIE ]; then
-    ok "leak self-test: once the decoy is dead the verdict is $v — no false alarm"
+  if [ "$v" = GONE ]; then
+    ok "leak self-test: once the decoy is killed the verdict is GONE — no false alarm, and it was REAPED"
+  elif [ "$v" = ZOMBIE ]; then
+    # NOT LOAD-BEARING ON THIS BASH, and said so rather than left to look pinned.
+    # MEASURED: deleting the `wait` from to_kill_decoy leaves this suite at 318/0,
+    # because bash reaps a background child asynchronously and the pid is gone from
+    # `ps` without an explicit wait. So the `wait` is defence in depth — correct,
+    # documented, and required by shells that do not auto-reap — while this arm can
+    # only catch a zombie that some other shell or a future refactor produces. A
+    # fixture that could provoke one would have to suppress bash's own SIGCHLD
+    # bookkeeping, which is not controllable from a script.
+    bad "leak self-test: the decoy is a ZOMBIE — it was killed without being reaped (job 378); it is a direct child, so \`wait\` must follow the kill"
   else
     bad "leak self-test: a dead decoy was reported '$v' — the check would red on a clean run"
   fi
+  # THE FAIL-CLOSED PROBE PROPERTY, which is job 378's core finding: when `ps`
+  # CANNOT ANSWER the registration must be KEPT, never discarded. Exercised with a
+  # `ps` that exits 2 shadowed onto PATH for exactly this call — the shipped
+  # helper is unchanged, only what it can see is.
+  FAILPS="$T/bin-failing-ps"
+  mkdir -p "$FAILPS"
+  printf '#!/bin/sh\nexit 2\n' >"$FAILPS/ps"
+  chmod +x "$FAILPS/ps"
+  DECOY_CLEANUP_PID=424242
+  DECOY_CLEANUP_NEEDLE="$DECOY_DIR/git"
+  _kd_path="$PATH"
+  PATH="$FAILPS:$PATH"
+  to_kill_decoy
+  PATH="$_kd_path"
+  if [ "$DECOY_CLEANUP_PID" = 424242 ]; then
+    ok "leak self-test: a FAILED ps probe KEEPS the registration — a probe that cannot answer never takes the permissive branch (job 378)"
+  else
+    bad "leak self-test: a failed ps probe DISCARDED the registration — the process would leak silently, which is the fail-open shape this repo forbids"
+  fi
+  # ...and the affirmative counterpart: a working `ps` that finds nothing DOES
+  # clear it, or the registration would pile up forever.
+  DECOY_CLEANUP_PID=424242
+  to_kill_decoy
+  if [ -z "$DECOY_CLEANUP_PID" ]; then
+    ok "leak self-test: an AFFIRMATIVE 'not found' clears the registration (rc 1 with no output)"
+  else
+    bad "leak self-test: an affirmatively-gone pid left the registration set — it would never be released"
+  fi
+  DECOY_CLEANUP_NEEDLE=""
   # (the no-child property is asserted at the fixture, while the decoy is still
   # alive — see `decoy_kids` above. A post-hoc census for a `sleep` argv, which
   # is what stood here, became VACUOUS the moment the decoy stopped spawning one:

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -2155,7 +2155,87 @@ fi
 # to_leaks — count processes whose FULL argv is exactly the sentinel. An exact
 # whole-line match, never a `pkill -f` pattern: on this fleet a pattern-based
 # kill has already taken out a peer lane's gate.
+#
+# THIS CENSUS IS NOT SUFFICIENT ON ITS OWN, and believing it was is roborev job
+# 367: only the TERM shim ever WEARS that argv (it `exec`s into the sentinel
+# sleep). The KILL shim stays a BASH process blocked on the FIFO — measured argv
+# `bash <shimdir>/git merge-base --is-ancestor <sha> <sha>` — so a surviving
+# KILL-path process passed this assertion untouched. The assertion was vacuous
+# for precisely the arm that needs it, the one where the runner had to escalate.
+# A vacuous assertion is worse than a missing one, because it invites reliance it
+# cannot support. It is KEPT as a cheap second signal (it also catches a stray
+# sentinel from an earlier run) and is no longer the primary check.
 to_leaks() { ps -eo args= 2>/dev/null | grep -c -x -F "$TOSENTINEL"; }
+
+# to_check_pid <label> <pidfile> <expected-argv-needle> — the PRIMARY leak check
+# (job 367). The shim records its OWN pid before it blocks; `exec` PRESERVES the
+# pid, so this covers the TERM arm as well as the KILL arm, uniformly.
+#
+# THREE-VALUED, and the middle value is the whole point of doing this carefully:
+#   gone                      -> no leak.
+#   present AND argv MATCHES  -> a real leak. Reported, then killed.
+#   present AND argv does NOT -> INDETERMINATE. The pid was RELEASED and RECYCLED
+#                                into another process, and on this fleet the most
+#                                likely inheritor is A PEER LANE'S GATE (this repo
+#                                has that incident). So the argv is validated
+#                                BEFORE any signal, and a mismatch is REPORTED and
+#                                NEVER SIGNALLED — job 279's "ownership ends at
+#                                REAP, not at exit".
+# A `<defunct>` entry is its own, fourth outcome: a zombie holds a pid but runs no
+# code and is reaped by init, so it is not a leak — named explicitly rather than
+# folded into either branch.
+# to_pid_verdict <pidfile> <needle> — the DECIDING half, split out so it can be
+# SELF-TESTED (see 44(l)): it prints exactly one verdict token and KILLS NOTHING.
+# A check whose only caller reports "no leak" cannot demonstrate that it would
+# ever say otherwise, which is the defect this whole round is about.
+#   NO-SUBJECT | BAD-PID | GONE | ZOMBIE | LEAK | RECYCLED
+to_pid_verdict() {
+  local pidfile="$1" needle="$2" pid args
+  if [ ! -f "$pidfile" ]; then printf 'NO-SUBJECT\n'; return 0; fi
+  pid=$(cat "$pidfile" 2>/dev/null)
+  case "$pid" in
+    ''|*[!0-9]*) printf 'BAD-PID\n'; return 0 ;;
+  esac
+  args=$(ps -p "$pid" -o args= 2>/dev/null) || args=""
+  if [ -z "$args" ]; then printf 'GONE\n'; return 0; fi
+  case "$args" in
+    *"<defunct>"*) printf 'ZOMBIE\n' ;;
+    *"$needle"*)   printf 'LEAK\n' ;;
+    *)             printf 'RECYCLED\n' ;;
+  esac
+  return 0
+}
+
+# to_check_pid <label> <pidfile> <expected-argv-needle> — the REPORTING half.
+to_check_pid() {
+  local label="$1" pidfile="$2" needle="$3" pid verdict args
+  verdict=$(to_pid_verdict "$pidfile" "$needle")
+  pid=$(cat "$pidfile" 2>/dev/null || true)
+  case "$verdict" in
+    NO-SUBJECT)
+      bad "hung-read ($label): the shim never recorded a pid — it did not run, so this arm proves nothing"
+      return 1 ;;
+    BAD-PID)
+      bad "hung-read ($label): the shim recorded a non-numeric pid ('$pid') — the leak check cannot be made"
+      return 1 ;;
+  esac
+  ok "hung-read ($label): the shim recorded its own pid ($pid) — the leak check has a SUBJECT"
+  case "$verdict" in
+    GONE)
+      ok "hung-read ($label): the shim process is GONE — nothing leaked past the bound" ;;
+    ZOMBIE)
+      ok "hung-read ($label): the shim pid is a ZOMBIE (runs no code, reaped by init) — not a leak" ;;
+    LEAK)
+      args=$(ps -p "$pid" -o args= 2>/dev/null || true)
+      bad "hung-read ($label): the shim process $pid SURVIVED the bound (argv: $args) — the runner did not reap its child (job 279)"
+      # Signalled ONLY because the argv was VALIDATED to be OUR shim.
+      kill -KILL "$pid" 2>/dev/null ;;
+    RECYCLED)
+      args=$(ps -p "$pid" -o args= 2>/dev/null || true)
+      bad "hung-read ($label): pid $pid is alive but its argv does NOT match this shim (argv: $args) — the pid was RECYCLED, so whether the shim leaked is INDETERMINATE. NOT signalled: on this fleet the inheritor of a released pid is most likely a peer lane's gate." ;;
+  esac
+  return 0
+}
 
 # to_run_arm <label> <shim-dir> <expected-runner-rc>
 #
@@ -2165,8 +2245,9 @@ to_leaks() { ps -eo args= 2>/dev/null | grep -c -x -F "$TOSENTINEL"; }
 # established. So each shim is first run UNDER THE RUNNER DIRECTLY and its exit
 # code asserted: 124 for the TERM shim, 137 for the TERM-ignoring one.
 to_run_arm() {
-  local label="$1" shimdir="$2" want_rc="$3"
+  local label="$1" shimdir="$2" want_rc="$3" pidfile="$4"
   local out rc leaks crc=0
+  rm -f "$pidfile"
   PATH="$shimdir:$PATH" "$REAL_TO" --kill-after=1 2 \
     git merge-base --is-ancestor "$R_CERT" "$R_CERT" >/dev/null 2>&1 || crc=$?
   if [ "$crc" = "$want_rc" ]; then
@@ -2199,13 +2280,18 @@ to_run_arm() {
       *) ok "hung-read ($label): a timeout is NOT misreported as an absent object, a shallow history or NOT-ANCESTOR" ;;
     esac
   fi
+  # PRIMARY: the shim's OWN recorded pid (job 367). Works for BOTH arms, because
+  # the KILL shim never wears the sentinel argv.
+  to_check_pid "$label" "$pidfile" "$shimdir/git"
+  # SECONDARY: the sentinel census, kept as a cheap cross-check. It can only see
+  # the TERM arm's `exec`ed sleep — see the note on to_leaks.
   leaks=$(to_leaks)
   if [ "$leaks" = 0 ]; then
-    ok "hung-read ($label): NO stray process survived the bound (exact-argv census, not a pkill pattern)"
+    ok "hung-read ($label): the sentinel census also finds no stray sleep (secondary check)"
   else
     bad "hung-read ($label): $leaks stray process(es) matching the sentinel survived — the runner did not reap its child (job 279)"
-    # Clean up ONLY pids whose full argv equals the sentinel: it cannot be a peer
-    # lane's gate, which is what a pattern-based kill would risk.
+    # Clean up ONLY pids whose full argv EQUALS the sentinel: an exact whole-argv
+    # match cannot be a peer lane's gate, which is what a pattern kill would risk.
     ps -eo pid=,args= 2>/dev/null | while read -r _p _a; do
       [ "$_a" = "$TOSENTINEL" ] && kill -KILL "$_p" 2>/dev/null
     done
@@ -2225,15 +2311,21 @@ if [ "$to_shape" -eq 1 ]; then
     # the escalation path by accident.)
     TSH="$T/bin-git-hang-term"
     mkdir -p "$TSH"
+    TPID="$T/hang-term.pid"
+    # The pid is recorded BEFORE the exec, and `exec` PRESERVES the pid — so the
+    # recorded value names the sentinel sleep itself, not a vanished parent.
     cat >"$TSH/git" <<TERMSHIM
 #!/usr/bin/env bash
 for a in "\$@"; do
-  if [ "\$a" = "--is-ancestor" ]; then exec $TOSENTINEL; fi
+  if [ "\$a" = "--is-ancestor" ]; then
+    printf '%s\n' "\$\$" >"$TPID"
+    exec $TOSENTINEL
+  fi
 done
 exec "$REALGIT" "\$@"
 TERMSHIM
     chmod +x "$TSH/git"
-    to_run_arm "TERM path / exit 124" "$TSH" 124
+    to_run_arm "TERM path / exit 124" "$TSH" 124 "$TPID"
 
     # ARM 2 — the KILL-after-grace path (exit 137). The shim IGNORES TERM and
     # blocks on opening a writer-less FIFO, which is uninterruptible while TERM is
@@ -2244,10 +2336,12 @@ TERMSHIM
     KFIFO="$T/hang-kill.fifo"
     rm -f "$KFIFO"
     if mkfifo "$KFIFO" 2>/dev/null; then
+      KPID="$T/hang-kill.pid"
       cat >"$KSH/git" <<KILLSHIM
 #!/usr/bin/env bash
 for a in "\$@"; do
   if [ "\$a" = "--is-ancestor" ]; then
+    printf '%s\n' "\$\$" >"$KPID"
     trap '' TERM
     read -r _ < "$KFIFO"
     exit 0
@@ -2256,13 +2350,127 @@ done
 exec "$REALGIT" "\$@"
 KILLSHIM
       chmod +x "$KSH/git"
-      to_run_arm "KILL after grace / exit 137" "$KSH" 137
+      to_run_arm "KILL after grace / exit 137" "$KSH" 137 "$KPID"
     else
       printf 'ARM NOT TAKEN: hung ancestry read, KILL path (job 364) — mkfifo failed on this host, so a\n'
       printf 'ARM NOT TAKEN: TERM-ignoring block with no child process cannot be constructed. The exit-137\n'
       printf 'ARM NOT TAKEN: escalation is UNEXERCISED (the TERM/124 arm above still ran).\n'
       ok "hung-read (KILL path): SKIPPED (mkfifo unavailable — arm UNEXERCISED, declared not silent)"
     fi
+  fi
+fi
+
+# --- 44(l): THE LEAK CHECK MUST BE ABLE TO SAY "LEAK" (roborev job 367) ------
+#
+# Round 4's leak assertion searched for the sentinel argv `sleep 987654321`. Only
+# the TERM shim ever wears it (it `exec`s into that sleep); the KILL shim stays a
+# BASH process blocked on the FIFO — measured argv
+# `bash <shimdir>/git merge-base --is-ancestor <sha> <sha>` — so a surviving
+# KILL-path process passed the assertion untouched. The check was VACUOUS for the
+# one arm that needs it, the arm where the runner had to escalate.
+#
+# A vacuous assertion is worse than a missing one: it invites reliance it cannot
+# support. So the deciding half is now `to_pid_verdict`, and THIS case proves it
+# has discriminating power — the same standard the mutation arm at 44(c) is held
+# to. Three properties, over a DECOY that is deliberately alive:
+#   1. a live process whose argv MATCHES -> LEAK        (the assert can fire)
+#   2. a live process whose argv does NOT -> RECYCLED, and it is NOT SIGNALLED
+#      (job 279: ownership ends at reap, and a released pid on this fleet is most
+#      likely inherited by a peer lane's gate)
+#   3. a dead pid -> GONE                               (no false alarm)
+# The decoy's argv is built to CONTAIN a shim-like path, so property 1 exercises
+# the same needle shape the real arms use.
+DECOY_DIR="$T/leak-decoy"
+DECOY_PID="$T/leak-decoy.pid"
+DECOY_FIFO="$T/leak-decoy.fifo"
+decoy_shape=0
+# THE DECOY MUST NOT SPAWN A CHILD, and getting that wrong ONCE is why this
+# comment exists. The first version ran `sleep 987654322`, so the decoy was TWO
+# processes: the bash wrapper (which carries the argv the needle matches, and is
+# the pid recorded) and its sleep CHILD. SIGKILLing the wrapper ORPHANED the
+# child, and five runs of this suite left five stray sleeps on the box —
+# precisely the "a test that leaks processes is its own hazard" failure this arm
+# exists to guard against, introduced BY the guard. So the decoy blocks the same
+# way the KILL shim does: opening a writer-less FIFO, which needs no child, so
+# one SIGKILL removes the whole thing. The arm asserts its own cleanup below.
+rm -f "$DECOY_FIFO"
+if mkdir -p "$DECOY_DIR" 2>/dev/null && mkfifo "$DECOY_FIFO" 2>/dev/null; then
+  cat >"$DECOY_DIR/git" <<DECOY
+#!/usr/bin/env bash
+trap '' TERM
+read -r _ < "$DECOY_FIFO"
+DECOY
+  chmod +x "$DECOY_DIR/git"
+  bash "$DECOY_DIR/git" merge-base --is-ancestor deadbeef deadbeef >/dev/null 2>&1 &
+  decoy_pid=$!
+  printf '%s\n' "$decoy_pid" >"$DECOY_PID"
+  # Give it a moment to appear in the process table, then CONFIRM it is really
+  # alive with the expected argv — a decoy that died makes every property below
+  # vacuous, which is the exact failure this case exists to remove.
+  sleep 1
+  if [ -n "$(ps -p "$decoy_pid" -o args= 2>/dev/null | grep -F "$DECOY_DIR/git")" ]; then
+    decoy_shape=1
+  fi
+fi
+if [ "$decoy_shape" -ne 1 ]; then
+  printf 'ARM NOT TAKEN: leak-check self-test (job 367) — a live decoy process carrying a shim-like argv\n'
+  printf 'ARM NOT TAKEN: could not be started on this host, so the leak checks discriminating power is\n'
+  printf 'ARM NOT TAKEN: UNPROVEN on this run.\n'
+  ok "leak self-test: SKIPPED (decoy unavailable — arm UNEXERCISED, declared not silent)"
+else
+  ok "leak self-test fixture: a live decoy carrying a shim-like argv really exists"
+  # (1) it can say LEAK.
+  v=$(to_pid_verdict "$DECOY_PID" "$DECOY_DIR/git")
+  if [ "$v" = LEAK ]; then
+    ok "leak self-test: a live process with a MATCHING argv is reported as LEAK — the assert can fire"
+  else
+    bad "leak self-test: a live matching process was reported '$v', not LEAK — the leak assertion is vacuous (job 367)"
+  fi
+  # (2) a NON-matching argv is RECYCLED, and the decoy must SURVIVE the check,
+  # because a mismatched pid must never be signalled.
+  v=$(to_pid_verdict "$DECOY_PID" "$T/no-such-shim-dir/git")
+  if [ "$v" = RECYCLED ]; then
+    ok "leak self-test: a live process with a NON-matching argv is reported RECYCLED, not LEAK"
+  else
+    bad "leak self-test: a non-matching argv was reported '$v', not RECYCLED — the argv is not being validated before cleanup"
+  fi
+  if [ -n "$(ps -p "$decoy_pid" -o args= 2>/dev/null)" ]; then
+    ok "leak self-test: the RECYCLED verdict did NOT signal the process (job 279)"
+  else
+    bad "leak self-test: the decoy was killed on a NON-matching argv — a recycled pid must never be signalled (job 279)"
+  fi
+  # (3) a dead pid is GONE, not a false alarm. Killed by pid AFTER validating the
+  # argv is our own decoy — the same discipline the real check follows.
+  if [ "$(to_pid_verdict "$DECOY_PID" "$DECOY_DIR/git")" = LEAK ]; then
+    kill -KILL "$decoy_pid" 2>/dev/null
+    wait "$decoy_pid" 2>/dev/null || true
+  fi
+  sleep 1
+  v=$(to_pid_verdict "$DECOY_PID" "$DECOY_DIR/git")
+  if [ "$v" = GONE ] || [ "$v" = ZOMBIE ]; then
+    ok "leak self-test: once the decoy is dead the verdict is $v — no false alarm"
+  else
+    bad "leak self-test: a dead decoy was reported '$v' — the check would red on a clean run"
+  fi
+  # THE ARM CLEANS UP AFTER ITSELF, and says so. The decoy needs no child (see
+  # the fixture note), so nothing can be orphaned — asserted rather than assumed,
+  # because the first version of this arm DID orphan a sleep on every run.
+  if [ "$(ps -eo args= 2>/dev/null | grep -c -x -F 'sleep 987654322')" = 0 ]; then
+    ok "leak self-test: the arm left NO orphan process of its own behind"
+  else
+    bad "leak self-test: the arm orphaned a process of its own — a leak guard that leaks is its own hazard"
+  fi
+  # And the absent/garbage subjects, so a silent NO-SUBJECT can never read as clean.
+  if [ "$(to_pid_verdict "$T/no-such-pidfile" "$DECOY_DIR/git")" = NO-SUBJECT ]; then
+    ok "leak self-test: a MISSING pidfile is NO-SUBJECT (the arm proves nothing), never 'no leak'"
+  else
+    bad "leak self-test: a missing pidfile must be NO-SUBJECT"
+  fi
+  printf 'x\n' >"$T/leak-decoy-garbage.pid"
+  if [ "$(to_pid_verdict "$T/leak-decoy-garbage.pid" "$DECOY_DIR/git")" = BAD-PID ]; then
+    ok "leak self-test: a non-numeric pidfile is BAD-PID, never 'no leak'"
+  else
+    bad "leak self-test: a non-numeric pidfile must be BAD-PID"
   fi
 fi
 

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -2093,6 +2093,179 @@ else
   bad "boundary (STRUCTURAL): the declaration appears $boundary_sites times — it must be ONE constant consumed by the ONE renderer"
 fi
 
+# --- 44(k): AN ACTUALLY HUNG READ (roborev job 364) --------------------------
+#
+# The arms above verify runner SELECTION and the `anchor-reads:` label; none of
+# them ever hangs a read, so the timeout handling — and specifically the exit
+# 124 / 137 recognition — could regress with the suite still green. These two
+# arms hang the ancestry call for real.
+#
+# CONSTRUCTION, and the two couplings a future reader could break:
+#   * A PATH-SHIM `git` that matches on ARGV and blocks ONLY on
+#     `merge-base --is-ancestor`, passing everything else through to the real
+#     binary. Discovery reads and the object reads must keep working or the
+#     fixture never reaches the code under test.
+#   * THE SHIM IS REACHABLE ONLY BECAUSE `PATH` IS IN THE `env -i` ALLOWLIST.
+#     That is a non-obvious coupling: tightening the allowlist to drop PATH
+#     would make these arms silently test nothing (git would not be found at
+#     all, so they would fail loudly — but a future variant that hard-coded an
+#     absolute git path would make them vacuous instead).
+#   * THE TIMEOUT IS SHORTENED BY SUBSTITUTING THE ARTIFACT, never a seam: a
+#     scratch copy of the shipped script with ONLY the two constants rewritten
+#     (60s/5s -> 2s/1s), asserted to have taken. A settable timeout would be one
+#     more thing a real invoker could set (#3312), and the runner is deliberately
+#     NOT refactored to make this easier to test.
+#
+# SAFETY, because a test that leaks processes is its own hazard (CLAUDE.md job
+# 279: a bounded runner's ownership ends at REAP, not at exit, and a
+# pattern-based kill on this fleet has already killed a peer lane's gate). Each
+# arm asserts NO stray process survives, matched on an EXACT argv sentinel that
+# no other process on the box can produce — never a `pkill -f` pattern.
+TOFLOW="$T/flow-timeout"
+TOSENTINEL="sleep 987654321"
+to_shape=0
+# A REAL bounding runner is REQUIRED for these arms. Without one the $BIN shim
+# discards the bound (see its own comment) and a hung read would hang FOREVER —
+# so the absence of a runner is a declared not-taken, never an attempt.
+if [ -n "$REAL_TO" ] && mkdir -p "$TOFLOW" && cp "$ASSERT" "$TOFLOW/premerge-assert.sh"; then
+  printf '%s\n' "$NEUTRAL_ADV" >"$TOFLOW/base-staleness.sh"
+  chmod +x "$TOFLOW/base-staleness.sh"
+  # ONLY the two constants change. sed on the exact assignment lines, then verify.
+  sed -e 's/^ADVISORY_TIMEOUT_SECS=60$/ADVISORY_TIMEOUT_SECS=2/' \
+      -e 's/^ADVISORY_KILL_GRACE=5$/ADVISORY_KILL_GRACE=1/' \
+      "$TOFLOW/premerge-assert.sh" >"$TOFLOW/x" && mv "$TOFLOW/x" "$TOFLOW/premerge-assert.sh"
+  if grep -q -x -F 'ADVISORY_TIMEOUT_SECS=2' "$TOFLOW/premerge-assert.sh" &&
+     grep -q -x -F 'ADVISORY_KILL_GRACE=1' "$TOFLOW/premerge-assert.sh" &&
+     ! grep -q -x -F 'ADVISORY_TIMEOUT_SECS=60' "$TOFLOW/premerge-assert.sh" &&
+     ! grep -q -x -F 'ADVISORY_KILL_GRACE=5' "$TOFLOW/premerge-assert.sh"; then
+    to_shape=1
+  fi
+fi
+if [ "$to_shape" -eq 1 ]; then
+  ok "hung-read fixture: a scratch copy with the bound shortened to 2s+1s (constants only, mutation verified)"
+else
+  printf 'ARM NOT TAKEN: hung ancestry read (job 364) — no real timeout/gtimeout runner on this host, or\n'
+  printf 'ARM NOT TAKEN: the shortened-bound scratch copy could not be built. BOTH arms are skipped\n'
+  printf 'ARM NOT TAKEN: DELIBERATELY: without a real runner the $BIN shim discards the bound and a hung\n'
+  printf 'ARM NOT TAKEN: read would hang forever, so attempting the arm is worse than declaring it. The\n'
+  printf 'ARM NOT TAKEN: exit 124/137 recognition is UNEXERCISED on this run.\n'
+  ok "hung-read: SKIPPED (no bounding runner / fixture unbuildable — arms UNEXERCISED, declared not silent)"
+fi
+
+# to_leaks — count processes whose FULL argv is exactly the sentinel. An exact
+# whole-line match, never a `pkill -f` pattern: on this fleet a pattern-based
+# kill has already taken out a peer lane's gate.
+to_leaks() { ps -eo args= 2>/dev/null | grep -c -x -F "$TOSENTINEL"; }
+
+# to_run_arm <label> <shim-dir> <expected-runner-rc>
+#
+# THE THIRD ARGUMENT IS WHAT KEEPS THE TWO ARMS DISTINCT. `_anchor_timed_out`
+# accepts BOTH 124 and 137, so without a control each arm would pass whichever
+# path it actually took — and "we tested the escalation" would be a claim nothing
+# established. So each shim is first run UNDER THE RUNNER DIRECTLY and its exit
+# code asserted: 124 for the TERM shim, 137 for the TERM-ignoring one.
+to_run_arm() {
+  local label="$1" shimdir="$2" want_rc="$3"
+  local out rc leaks crc=0
+  PATH="$shimdir:$PATH" "$REAL_TO" --kill-after=1 2 \
+    git merge-base --is-ancestor "$R_CERT" "$R_CERT" >/dev/null 2>&1 || crc=$?
+  if [ "$crc" = "$want_rc" ]; then
+    ok "hung-read ($label): CONTROL — the shim really produces runner exit $want_rc"
+  else
+    bad "hung-read ($label): CONTROL — expected runner exit $want_rc, got $crc; this arm is not exercising the path it names"
+  fi
+  out=$(cd "$ANC_REPO" && PATH="$shimdir:$BIN:$PATH" MOCK_GH_FAIL=0 MOCK_GH_OUT="$R_CERT OPEN" \
+    bash "$TOFLOW/premerge-assert.sh" 2421 "$R_CERT" "$RANCFULL" "$RGOODDELTA" 2>&1)
+  rc=$?
+  if [ "$rc" -ne 3 ]; then
+    bad "hung-read ($label): a hung ancestry read must be exit 3 (got $rc: $out)"
+  else
+    ok "hung-read ($label): a hung ancestry read is exit 3, not a hang and not a pass"
+    case "$out" in
+      *"PREMERGE: ANCHOR-UNVERIFIABLE"*)
+        ok "hung-read ($label): carries the ANCHOR-UNVERIFIABLE marker" ;;
+      *) bad "hung-read ($label): expected the ANCHOR-UNVERIFIABLE marker (got: $out)" ;;
+    esac
+    case "$out" in
+      *"the ancestry walk timed out after"*)
+        ok "hung-read ($label): the cause names the TIMEOUT, distinctly from the other UNVERIFIABLE causes" ;;
+      *) bad "hung-read ($label): the cause must name the timeout (got: $out)" ;;
+    esac
+    # Distinctness in both directions: it must not be reported as an absent
+    # object, a shallow history, or a NOT-ANCESTOR verdict.
+    case "$out" in
+      *"is not present in this repository"* | *"NOT PROVEN COMPLETE"* | *"is NOT on the certified sha's history"*)
+        bad "hung-read ($label): a timeout was misreported as another cause (got: $out)" ;;
+      *) ok "hung-read ($label): a timeout is NOT misreported as an absent object, a shallow history or NOT-ANCESTOR" ;;
+    esac
+  fi
+  leaks=$(to_leaks)
+  if [ "$leaks" = 0 ]; then
+    ok "hung-read ($label): NO stray process survived the bound (exact-argv census, not a pkill pattern)"
+  else
+    bad "hung-read ($label): $leaks stray process(es) matching the sentinel survived — the runner did not reap its child (job 279)"
+    # Clean up ONLY pids whose full argv equals the sentinel: it cannot be a peer
+    # lane's gate, which is what a pattern-based kill would risk.
+    ps -eo pid=,args= 2>/dev/null | while read -r _p _a; do
+      [ "$_a" = "$TOSENTINEL" ] && kill -KILL "$_p" 2>/dev/null
+    done
+  fi
+}
+
+if [ "$to_shape" -eq 1 ]; then
+  REALGIT=$(command -v git 2>/dev/null) || REALGIT=""
+  if [ -z "$REALGIT" ]; then
+    printf 'ARM NOT TAKEN: hung ancestry read (job 364) — the real git binary could not be resolved, so a\n'
+    printf 'ARM NOT TAKEN: pass-through shim cannot be built.\n'
+    ok "hung-read: SKIPPED (real git unresolvable — arms UNEXERCISED, declared not silent)"
+  else
+    # ARM 1 — the TERM path (exit 124). The shim `exec`s into the sentinel sleep,
+    # so it BECOMES the sleep and dies on the runner's SIGTERM. (Without `exec`,
+    # bash defers the trap until its foreground child finishes, which would test
+    # the escalation path by accident.)
+    TSH="$T/bin-git-hang-term"
+    mkdir -p "$TSH"
+    cat >"$TSH/git" <<TERMSHIM
+#!/usr/bin/env bash
+for a in "\$@"; do
+  if [ "\$a" = "--is-ancestor" ]; then exec $TOSENTINEL; fi
+done
+exec "$REALGIT" "\$@"
+TERMSHIM
+    chmod +x "$TSH/git"
+    to_run_arm "TERM path / exit 124" "$TSH" 124
+
+    # ARM 2 — the KILL-after-grace path (exit 137). The shim IGNORES TERM and
+    # blocks on opening a writer-less FIFO, which is uninterruptible while TERM is
+    # SIG_IGN and spawns NO child, so nothing else in the process group can die in
+    # its place. The runner must therefore escalate to SIGKILL.
+    KSH="$T/bin-git-hang-kill"
+    mkdir -p "$KSH"
+    KFIFO="$T/hang-kill.fifo"
+    rm -f "$KFIFO"
+    if mkfifo "$KFIFO" 2>/dev/null; then
+      cat >"$KSH/git" <<KILLSHIM
+#!/usr/bin/env bash
+for a in "\$@"; do
+  if [ "\$a" = "--is-ancestor" ]; then
+    trap '' TERM
+    read -r _ < "$KFIFO"
+    exit 0
+  fi
+done
+exec "$REALGIT" "\$@"
+KILLSHIM
+      chmod +x "$KSH/git"
+      to_run_arm "KILL after grace / exit 137" "$KSH" 137
+    else
+      printf 'ARM NOT TAKEN: hung ancestry read, KILL path (job 364) — mkfifo failed on this host, so a\n'
+      printf 'ARM NOT TAKEN: TERM-ignoring block with no child process cannot be constructed. The exit-137\n'
+      printf 'ARM NOT TAKEN: escalation is UNEXERCISED (the TERM/124 arm above still ran).\n'
+      ok "hung-read (KILL path): SKIPPED (mkfifo unavailable — arm UNEXERCISED, declared not silent)"
+    fi
+  fi
+fi
+
 # =============================================================================
 # #3465 review — the remaining refusal branches
 # =============================================================================

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -98,6 +98,20 @@ fi
 # pin at 44(m) — but NOTHING MAY KILL BASED ON IT.
 TOSENTINEL=""
 
+# THE SUITE'S OWN `rm -rf "$T"` HAS THE SAME RACE, AND IS DELIBERATELY KEPT
+# (roborev job 390, finding 2 — DECLARED AND ACCEPTED, not removed). A same-UID
+# peer can swap `$T` between the mktemp and this delete, exactly as it could for
+# the shipped scratch. Four reasons this is not the same decision:
+#   1. cleaning one's own `mktemp` root is universal test practice;
+#   2. the same-UID fleet means NO boundary exists for a test suite either, so
+#      removal would not buy isolation — it would only move the garbage;
+#   3. the consequence is bounded: a test scratch, not a merge verdict. The
+#      shipped delete could damage a concurrent lane while certifying a merge;
+#   4. never cleaning ACCUMULATES every run, which R68 measured as a real cost
+#      (240 stray directories) — and this delete is what contains those, since
+#      TMPDIR points here.
+# Consistency with the production path would be cargo-culting that rule past the
+# reason for it.
 suite_cleanup() {
   rm -rf "$T"
 }
@@ -2168,6 +2182,21 @@ if run_anc 0 "Case B success declares the ancestry provenance boundary" \
     *"SHARED object store"*)
       ok "boundary: the declaration names WHAT is trusted (this box's shared object store)" ;;
     *) bad "boundary: the declaration must name the shared object store (got: $OUT)" ;;
+  esac
+  # WIDENED AT job 390: the SCRATCH namespace is trusted for the SAME reason — a
+  # same-UID peer can write into it between `git init` and the walk, reproducing
+  # round 1's graft attack inside the thing built to prevent it. There is no
+  # permission boundary on a one-user fleet, so the claim is narrowed rather than
+  # the hole patched, and this arm stops the scratch half being quietly dropped.
+  case "$OUT" in
+    *"SCRATCH namespace"*)
+      ok "boundary: the declaration ALSO names the scratch namespace (job 390)" ;;
+    *) bad "boundary: the declaration must name the SCRATCH namespace too (got: $OUT)" ;;
+  esac
+  case "$OUT" in
+    *"NOT a same-UID peer"*)
+      ok "boundary: the declaration states what it does NOT close (a same-UID peer)" ;;
+    *) bad "boundary: the declaration must say it does not close a same-UID peer (got: $OUT)" ;;
   esac
   # It must not have displaced the tokens a reader greps for.
   case "$OUT" in

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -2122,7 +2122,40 @@ fi
 # arm asserts NO stray process survives, matched on an EXACT argv sentinel that
 # no other process on the box can produce — never a `pkill -f` pattern.
 TOFLOW="$T/flow-timeout"
-TOSENTINEL="sleep 987654321"
+# THE SENTINEL MUST BE UNIQUE PER RUN, AND A FIXED STRING WAS A REAL BLOCKER.
+# It used to be a FIXED `sleep <constant>` argv, while `to_leaks` and the cleanup
+# census the WHOLE BOX (`ps -eo …`). Measured, both directions: a suite run
+# CONCURRENTLY with another run of itself reported `293 passed, 1 FAILED —
+# 1 stray process(es) matching the sentinel survived`, and the same suite run
+# alone immediately after reported `294 passed, 0 failed` with no strays on the
+# box. Two consequences, the second far worse:
+#   1. FALSE RED ACROSS LANES. This suite runs in `tooling-tests`, i.e. in EVERY
+#      full gate, and this fleet reports `max-concurrency=3` — so two concurrent
+#      gates red each other. A flaky merge gate, fleet-wide.
+#   2. THE CLEANUP KILLED THE PEER'S PROCESS. The kill site iterated every
+#      process on the box and SIGKILLed any whose argv equalled the sentinel.
+#      Its comment claimed exactness made that safe "because it cannot be a peer
+#      lane's gate" — true, and worthless: it is exactly a peer lane's copy of
+#      THIS SUITE, because the argv was not unique per run. Exact-but-SHARED is
+#      job 279's incident wearing a safer-looking comment.
+# `$T` is already run-unique (`mktemp -d …premerge-assert-test.XXXXXX`), so the
+# sentinel is derived from it: the census can then only ever match this run's own
+# processes, and the cleanup can only ever kill its own.
+#
+# WHY A DURATION AND NOT A SUFFIX: `sleep` takes numeric operands only, so a
+# textual tag cannot be appended to its argv. The uniqueness therefore lives in
+# the NUMBER. `printf '9%09d'` keeps it a fixed 10 digits with a floor of ~285
+# years, so a short checksum can never yield a sleep that exits during the run
+# and makes the leak check pass for the wrong reason.
+to_derive_sentinel() {
+  local tok
+  tok=$(printf '%s' "$1" | cksum 2>/dev/null | awk '{print ($1 % 1000000000)}') || tok=""
+  case "$tok" in
+    ''|*[!0-9]*) tok=$(( $$ % 1000000000 )) ;;   # a live pid is unique among live processes
+  esac
+  printf 'sleep %s\n' "$(printf '9%09d' "$tok")"
+}
+TOSENTINEL=$(to_derive_sentinel "$T")
 to_shape=0
 # A REAL bounding runner is REQUIRED for these arms. Without one the $BIN shim
 # discards the bound (see its own comment) and a hung read would hang FOREVER —
@@ -2290,8 +2323,14 @@ to_run_arm() {
     ok "hung-read ($label): the sentinel census also finds no stray sleep (secondary check)"
   else
     bad "hung-read ($label): $leaks stray process(es) matching the sentinel survived — the runner did not reap its child (job 279)"
-    # Clean up ONLY pids whose full argv EQUALS the sentinel: an exact whole-argv
-    # match cannot be a peer lane's gate, which is what a pattern kill would risk.
+    # Clean up ONLY pids whose full argv EQUALS the sentinel. WHAT MAKES THIS
+    # SAFE IS THAT THE SENTINEL IS UNIQUE TO THIS RUN (derived from `$T`), NOT
+    # that the match is exact. The previous comment claimed exactness was the
+    # safety property — "an exact whole-argv match cannot be a peer lane's gate"
+    # — which is true and buys nothing: with a shared constant the match is
+    # exactly a PEER LANE'S COPY OF THIS SUITE, and this loop SIGKILLed it. Do
+    # not weaken the derivation back to a constant; the reasoning error is easy
+    # to reproduce, which is why it is written down here.
     ps -eo pid=,args= 2>/dev/null | while read -r _p _a; do
       [ "$_a" = "$TOSENTINEL" ] && kill -KILL "$_p" 2>/dev/null
     done
@@ -2362,7 +2401,7 @@ fi
 
 # --- 44(l): THE LEAK CHECK MUST BE ABLE TO SAY "LEAK" (roborev job 367) ------
 #
-# Round 4's leak assertion searched for the sentinel argv `sleep 987654321`. Only
+# Round 4's leak assertion searched for the sentinel sleep argv. Only
 # the TERM shim ever wears it (it `exec`s into that sleep); the KILL shim stays a
 # BASH process blocked on the FIFO — measured argv
 # `bash <shimdir>/git merge-base --is-ancestor <sha> <sha>` — so a surviving
@@ -2385,7 +2424,7 @@ DECOY_PID="$T/leak-decoy.pid"
 DECOY_FIFO="$T/leak-decoy.fifo"
 decoy_shape=0
 # THE DECOY MUST NOT SPAWN A CHILD, and getting that wrong ONCE is why this
-# comment exists. The first version ran `sleep 987654322`, so the decoy was TWO
+# comment exists. The first version ran a bare `sleep`, so the decoy was TWO
 # processes: the bash wrapper (which carries the argv the needle matches, and is
 # the pid recorded) and its sleep CHILD. SIGKILLing the wrapper ORPHANED the
 # child, and five runs of this suite left five stray sleeps on the box —
@@ -2410,6 +2449,19 @@ DECOY
   sleep 1
   if [ -n "$(ps -p "$decoy_pid" -o args= 2>/dev/null | grep -F "$DECOY_DIR/git")" ]; then
     decoy_shape=1
+  fi
+  # THE NO-CHILD PROPERTY, ASSERTED WHILE THE DECOY IS ALIVE — this is the check
+  # that would have caught round 7's orphaning decoy, and it can only be made
+  # here, because after the parent dies its children are reparented and the link
+  # is gone. A decoy with a child means SIGKILLing the recorded pid ORPHANS that
+  # child, which is the "a leak guard that leaks" hazard.
+  if [ "$decoy_shape" -eq 1 ]; then
+    decoy_kids=$(ps -eo ppid= 2>/dev/null | awk -v p="$decoy_pid" '$1 == p { n++ } END { print n + 0 }')
+    if [ "$decoy_kids" = 0 ]; then
+      ok "leak self-test fixture: the decoy has NO child process, so killing it cannot orphan anything"
+    else
+      bad "leak self-test fixture: the decoy has $decoy_kids child process(es) — killing the recorded pid would ORPHAN them (this is the round-7 defect)"
+    fi
   fi
 fi
 if [ "$decoy_shape" -ne 1 ]; then
@@ -2452,14 +2504,12 @@ else
   else
     bad "leak self-test: a dead decoy was reported '$v' — the check would red on a clean run"
   fi
-  # THE ARM CLEANS UP AFTER ITSELF, and says so. The decoy needs no child (see
-  # the fixture note), so nothing can be orphaned — asserted rather than assumed,
-  # because the first version of this arm DID orphan a sleep on every run.
-  if [ "$(ps -eo args= 2>/dev/null | grep -c -x -F 'sleep 987654322')" = 0 ]; then
-    ok "leak self-test: the arm left NO orphan process of its own behind"
-  else
-    bad "leak self-test: the arm orphaned a process of its own — a leak guard that leaks is its own hazard"
-  fi
+  # (the no-child property is asserted at the fixture, while the decoy is still
+  # alive — see `decoy_kids` above. A post-hoc census for a `sleep` argv, which
+  # is what stood here, became VACUOUS the moment the decoy stopped spawning one:
+  # nothing could ever wear that argv again, so the assertion could not fail.
+  # That is the same "worse than missing" class this whole round is about, one
+  # arm over.)
   # And the absent/garbage subjects, so a silent NO-SUBJECT can never read as clean.
   if [ "$(to_pid_verdict "$T/no-such-pidfile" "$DECOY_DIR/git")" = NO-SUBJECT ]; then
     ok "leak self-test: a MISSING pidfile is NO-SUBJECT (the arm proves nothing), never 'no leak'"
@@ -2472,6 +2522,65 @@ else
   else
     bad "leak self-test: a non-numeric pidfile must be BAD-PID"
   fi
+fi
+
+# --- 44(m): THE SENTINEL IS UNIQUE PER RUN (cross-lane blocker) --------------
+#
+# A single run cannot demonstrate cross-run isolation, so the property is pinned
+# two ways. Both matter: the derivation assert is what stops a future edit
+# quietly restoring a shared constant, and the shape assert is what stops the
+# derivation degrading into something a peer could also produce.
+#
+# (1) DERIVATION — two different scratch roots must yield two different
+#     sentinels. This is the actual property: `$T` is run-unique, so a peer
+#     lane's suite derives a different argv and neither census can see the other.
+sent_a=$(to_derive_sentinel "/tmp/premerge-assert-test.AAAAAA")
+sent_b=$(to_derive_sentinel "/tmp/premerge-assert-test.BBBBBB")
+if [ -n "$sent_a" ] && [ "$sent_a" != "$sent_b" ]; then
+  ok "sentinel: two different scratch roots derive DIFFERENT sentinels — a peer lane cannot collide with this run"
+else
+  bad "sentinel: two scratch roots derived the SAME sentinel ('$sent_a') — the census would count a peer lane's process as this run's leak, and the cleanup would SIGKILL it"
+fi
+# (2) THIS RUN's sentinel really is the derived one, not a constant someone
+#     reintroduced beside it.
+if [ "$TOSENTINEL" = "$(to_derive_sentinel "$T")" ]; then
+  ok "sentinel: the live TOSENTINEL is the value derived from this run's scratch root"
+else
+  bad "sentinel: TOSENTINEL ('$TOSENTINEL') is not the value derived from \$T — something is overriding the derivation"
+fi
+# (3) SHAPE — `sleep ` plus a fixed 10 digits. The width floor is not cosmetic:
+#     a short duration could EXPIRE mid-run and make the leak check pass because
+#     the sleep ended, not because the runner reaped it.
+case "$TOSENTINEL" in
+  "sleep "[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9])
+    ok "sentinel: the derived value has the expected shape (sleep + 10 digits, so it cannot expire mid-run)" ;;
+  *)
+    bad "sentinel: unexpected shape '$TOSENTINEL' — a short or non-numeric duration breaks either sleep or the leak check" ;;
+esac
+# (4) The historical SHARED constants must not be hard-coded anywhere in this
+#     file any more — not in a shim, not in a census, not in a comment (a comment
+#     carrying them would make this guard pass for the wrong reason if someone
+#     later grepped for them).
+# The needle is ASSEMBLED FROM TWO HALVES so this guard cannot match its own line
+# (the idiom Case 41d already uses), and it is the `sleep `-prefixed form so the
+# 40-hex FAKE_CERT fixture — which happens to contain the same digits — is not a
+# false positive.
+_sent_lit_a='sleep 9876'
+_sent_lit_b='5432'
+# `grep -c` PRINTS 0 AND EXITS 1 on no-match, so `$(grep -c … || printf 0)`
+# captures BOTH and yields "0\n0" — which is not `0` and reds a clean tree. (That
+# is exactly what the first version of this guard did.) The rc is read
+# THREE-VALUED: 0/1 mean the count is trustworthy, >=2 means grep FAILED and the
+# scan could not be made — which is `bad`, never a pass derived from an
+# unmeasurable read.
+shared_lits=$(grep -c -F -- "$_sent_lit_a$_sent_lit_b" "${BASH_SOURCE[0]}" 2>/dev/null)
+_sent_rc=$?
+if [ "$_sent_rc" -ge 2 ]; then
+  bad "sentinel: the shared-literal scan could not be made (grep exit $_sent_rc) — UNMEASURED, not clean"
+elif [ "$shared_lits" = 0 ]; then
+  ok "sentinel: no hard-coded shared sentinel literal survives anywhere in this suite"
+else
+  bad "sentinel: $shared_lits occurrence(s) of a hard-coded shared sentinel literal remain — a fixed argv is exactly the cross-lane blocker"
 fi
 
 # =============================================================================

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -2341,15 +2341,21 @@ fi
 #                   (default: the ancestry walk's)
 #   $6 control_args the argv the CONTROL invokes, which must be the one the shim
 #                   triggers on (default: the ancestry walk's)
+#   $7 control_bin  the BINARY the control invokes (default `git`). Added for job
+#                   395, whose shim intercepts `sh` — the canonicalisation helper
+#                   runs `sh -c 'cd -- "$1" && pwd -P'`, not git. Parameterising
+#                   the proven runner beats a second construction, which is where
+#                   every defect in this scaffolding came from.
 to_run_arm() {
   local label="$1" shimdir="$2" want_rc="$3" pidfile="$4"
   local want_cause="${5:-the ancestry walk timed out after}"
   local control_args="${6:-merge-base --is-ancestor $R_CERT $R_CERT}"
+  local control_bin="${7:-git}"
   local out rc leaks crc=0
   rm -f "$pidfile"
   # shellcheck disable=SC2086  # intentional word-split of the control argv list
   PATH="$shimdir:$PATH" "$REAL_TO" --kill-after=1 2 \
-    git $control_args >/dev/null 2>&1 || crc=$?
+    "$control_bin" $control_args >/dev/null 2>&1 || crc=$?
   if [ "$crc" = "$want_rc" ]; then
     ok "hung-read ($label): CONTROL — the shim really produces runner exit $want_rc"
   else
@@ -2476,6 +2482,50 @@ DISCSHIM
     to_run_arm "DISCOVERY path / exit 124" "$DSH" 124 "$DPID" \
       "the work-tree root probe (rev-parse --show-toplevel) timed out after" \
       "rev-parse --show-toplevel"
+
+    # ARM 5 — A HUNG *CANONICALISATION* (roborev job 395). `_anchor_canon` used to
+    # end in `|| true`, so a timeout there was reported as an unresolvable path and
+    # the operator got the stalled-mount cause's remedy from a completely different
+    # cause. It was the one site job 374's status propagation did not reach,
+    # because its own suppression hid the status.
+    #
+    # SAME TEMPLATE AS ARM 1, different INTERCEPTED BINARY: the helper runs
+    # `sh -c 'cd -- "$1" && pwd -P'`, so the shim is `sh`, and it `exec`s the real
+    # sh for everything else. The FIRST canonicalisation reached is the work-tree
+    # root, so that is the cause this arm expects.
+    #
+    # IT TRIGGERS ON `pwd`, NOT ON `cd -- `, and that is forced by the control
+    # rather than a preference: `to_run_arm`'s control argv is WORD-SPLIT, so a
+    # quoted `-c` body cannot survive it — `cd -- "$1" && pwd -P` arrives as
+    # separate words and no single arg contains `cd -- `, which made the control
+    # exit 2 instead of the runner's 124. `pwd` is one word, appears in the real
+    # helper's body, and the shim is only on PATH for this arm — where the
+    # assert's ONLY use of `sh` is that canonicalisation.
+    CSH="$T/bin-sh-hang-canon"
+    mkdir -p "$CSH"
+    CPID="$T/hang-canon.pid"
+    REALSH=$(command -v sh 2>/dev/null) || REALSH=""
+    if [ -z "$REALSH" ]; then
+      printf 'ARM NOT TAKEN: hung canonicalisation (job 395) — the real `sh` could not be resolved, so a\n'
+      printf 'ARM NOT TAKEN: pass-through shim cannot be built. The canonicalisation TIMEOUT cause is\n'
+      printf 'ARM NOT TAKEN: UNEXERCISED on this run.\n'
+      ok "hung-read (CANON path): SKIPPED (real sh unresolvable — arm UNEXERCISED, declared not silent)"
+    else
+      cat >"$CSH/sh" <<CANONSHIM
+#!/usr/bin/env bash
+for a in "\$@"; do
+  case "\$a" in
+    *pwd*) printf '%s\\n' "\$\$" >"$CPID"; exec $TOSENTINEL ;;
+  esac
+done
+exec "$REALSH" "\$@"
+CANONSHIM
+      chmod +x "$CSH/sh"
+      to_run_arm "CANON path / exit 124" "$CSH" 124 "$CPID" \
+        "canonicalising the work-tree root (cd + pwd -P) timed out after" \
+        "-c pwd" \
+        sh
+    fi
 
     # ARM 4 — A DISCOVERY CALL THAT *FAILS* (not hangs). Found while RED-verifying
     # arm 3, and it is the more serious half: `cd ""` SUCCEEDS in bash and leaves

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -75,7 +75,43 @@ if ! T=$(mktemp -d "${TMPDIR:-/tmp}/premerge-assert-test.XXXXXX" 2>/dev/null) ||
   printf 'FAIL - every path in this suite would resolve under / instead.\n' >&2
   exit 1
 fi
-trap 'rm -rf "$T"' EXIT
+# CLEANUP IS A FUNCTION SO IT CAN GROW, AND IT IS REGISTERED BEFORE ANY RESOURCE
+# EXISTS (CLAUDE.md job 282). The decoy of case 44(l) is a TERM-IGNORING process
+# blocked on a FIFO: if its recognition fails, or the suite is interrupted, it
+# would otherwise sit blocked forever. The trap reads DECOY_CLEANUP_PID at FIRE
+# time, so installing the handler here — before the decoy exists — is exactly the
+# ordering job 282 asks for. Signals get handlers too, because bash runs no EXIT
+# trap for a signal left at its default disposition; each re-raises so the process
+# still dies of what it was sent.
+#
+# ORDER IS LOAD-BEARING: the decoy is reaped BEFORE `rm -rf "$T"`, because it
+# blocks on a FIFO inside $T and removing the FIFO does NOT unblock an open() that
+# is already waiting.
+DECOY_CLEANUP_PID=""
+DECOY_CLEANUP_NEEDLE=""
+suite_cleanup() {
+  to_kill_decoy
+  rm -rf "$T"
+}
+# to_kill_decoy — kill the registered decoy, VALIDATING ITS ARGV FIRST so a pid
+# that has been recycled into something else is never signalled (job 279:
+# ownership ends at reap, not at exit; on this fleet the inheritor of a released
+# pid is most likely a peer lane's gate). Safe to call any number of times.
+to_kill_decoy() {
+  local args
+  [ -n "$DECOY_CLEANUP_PID" ] || return 0
+  args=$(ps -p "$DECOY_CLEANUP_PID" -o args= 2>/dev/null) || args=""
+  if [ -n "$args" ] && [ -n "$DECOY_CLEANUP_NEEDLE" ] &&
+     [ "${args#*"$DECOY_CLEANUP_NEEDLE"}" != "$args" ]; then
+    kill -KILL "$DECOY_CLEANUP_PID" 2>/dev/null
+  fi
+  DECOY_CLEANUP_PID=""
+  return 0
+}
+trap 'suite_cleanup' EXIT
+trap 'suite_cleanup; trap - INT;  kill -INT  $$' INT
+trap 'suite_cleanup; trap - TERM; kill -TERM $$' TERM
+trap 'suite_cleanup; trap - HUP;  kill -HUP  $$' HUP
 
 # --- gh mock -----------------------------------------------------------------
 # A fake `gh` on PATH. Since the script parses via gh's built-in `--jq`, the
@@ -1858,12 +1894,21 @@ else
   ok "TEMPLATE: SKIPPED (positive control did not fire — arm UNEXERCISED, declared not silent)"
 fi
 
-# --- 44(h): NO BOUNDED RUNNER -> UNBOUNDED, AFFIRMED, NOT REFUSED (job 358) --
-# A hang is a LIVENESS failure, not a correctness one: it produces NO verdict,
-# where a graft produced a WRONG one, and an unbounded read cannot manufacture a
-# false pass. So a box with no `timeout`/`gtimeout` must still MERGE — refusing
-# would be the guard that reds on correct input — but the degradation must be
-# VISIBLE, because a bounded path silently becoming unbounded is the real hazard.
+# --- 44(h): NO BOUNDED RUNNER -> REFUSE (job 370 finding 1, REVERSING job 358) --
+#
+# THIS ARM ASSERTS THE OPPOSITE OF WHAT IT USED TO, and the reversal is recorded
+# here as well as in the shipped header, because the old expectation was
+# reasonable and wrong. It used to require that a box with no `timeout`/`gtimeout`
+# still MERGED, with the degradation affirmed on the evidence line, on the ground
+# that a hang is a liveness failure and cannot manufacture a false pass.
+#
+# What that missed: A HANG IN THIS GUARD BLOCKS THE MERGE ANYWAY. The real
+# comparison is hang-forever-with-no-diagnosis vs refuse-now-with-a-named-remedy —
+# same outcome for the merge, and the refusal strictly dominates. So the arm now
+# requires exit 3 with `ANCHOR-UNVERIFIABLE`, AND requires the CAUSE to name the
+# absent runner: a refusal for some other UNVERIFIABLE reason (an absent object,
+# a shallow history) would satisfy the exit code while proving nothing about
+# bounding.
 NOTO="$T/bin-no-timeout"
 mkdir -p "$NOTO"
 noto_ok=1
@@ -1885,32 +1930,50 @@ if [ "$noto_ok" -eq 1 ]; then
   done
 fi
 if [ "$noto_ok" -ne 1 ]; then
-  printf 'ARM NOT TAKEN: unbounded-reads token (job 358) — could not build a PATH holding git/awk/tr/\n'
-  printf 'ARM NOT TAKEN: env/mktemp/rm/gh but NEITHER timeout nor gtimeout.\n'
-  ok "unbounded: SKIPPED (fixture unbuildable — arm UNEXERCISED, declared not silent)"
+  printf 'ARM NOT TAKEN: no-bounded-runner refusal (job 370) — could not build a PATH holding git/awk/\n'
+  printf 'ARM NOT TAKEN: tr/env/mktemp/rm/gh but NEITHER timeout nor gtimeout.\n'
+  ok "no-runner: SKIPPED (fixture unbuildable — arm UNEXERCISED, declared not silent)"
 else
-  ok "unbounded fixture: the fixture PATH has git but NEITHER timeout nor gtimeout"
+  ok "no-runner fixture: the fixture PATH has git but NEITHER timeout nor gtimeout"
   OUT=$(cd "$ANC_REPO" && PATH="$NOTO" MOCK_GH_FAIL=0 MOCK_GH_OUT="$R_CERT OPEN" \
     "${BASH:-/bin/bash}" "$NEUTRAL_ASSERT" 2421 "$R_CERT" "$RANCFULL" "$RGOODDELTA" 2>&1)
   RC=$?
-  if [ "$RC" -ne 0 ]; then
-    bad "unbounded: a box with no timeout runner must still MERGE, not be refused (exit $RC) (got: $OUT)"
+  if [ "$RC" -ne 3 ]; then
+    bad "no-runner: with no bounded runner the check must REFUSE at exit 3, not run unbounded (exit $RC) (got: $OUT)"
   else
-    ok "unbounded: with no bounded runner the merge is NOT refused (exit 0)"
+    ok "no-runner: with no bounded runner the check REFUSES at exit 3 rather than running unbounded"
     case "$OUT" in
-      *"anchor-reads: UNBOUNDED("*)
-        ok "unbounded: the evidence line AFFIRMS the degradation instead of staying silent" ;;
-      *) bad "unbounded: expected an affirmative anchor-reads: UNBOUNDED(...) token (got: $OUT)" ;;
+      *"PREMERGE: ANCHOR-UNVERIFIABLE"*)
+        ok "no-runner: the refusal carries the ANCHOR-UNVERIFIABLE marker" ;;
+      *) bad "no-runner: expected the ANCHOR-UNVERIFIABLE marker (got: $OUT)" ;;
+    esac
+    # THE REASON MUST BE THE ABSENT RUNNER. Without this the arm would pass on any
+    # other UNVERIFIABLE cause and prove nothing about bounding.
+    case "$OUT" in
+      *"cannot be BOUNDED"*)
+        ok "no-runner: the cause names the ABSENT RUNNER, not some other UNVERIFIABLE reason" ;;
+      *) bad "no-runner: the cause must name the unbounded-reads problem (got: $OUT)" ;;
     esac
     case "$OUT" in
+      *"is not present in this repository"* | *"NOT PROVEN COMPLETE"* | *"not inside a git work tree"* | *"timed out after"*)
+        bad "no-runner: refused for a DIFFERENT cause than the missing runner — the arm proves nothing (got: $OUT)" ;;
+      *) ok "no-runner: the refusal is NOT an absent-object, shallow, work-tree or timeout cause" ;;
+    esac
+    case "$OUT" in
+      *"install GNU coreutils"*)
+        ok "no-runner: the refusal names a ONE-COMMAND remedy (install coreutils / gtimeout)" ;;
+      *) bad "no-runner: the refusal must name the remedy (got: $OUT)" ;;
+    esac
+    # And it must not claim a bound, nor emit an ancestry verdict it never reached.
+    case "$OUT" in
       *"anchor-reads: bounded-"*)
-        bad "unbounded: the line claims the reads were bounded on a box with no runner (got: $OUT)" ;;
-      *) ok "unbounded: the line does NOT claim a bound it did not have" ;;
+        bad "no-runner: the output claims the reads were bounded on a box with no runner (got: $OUT)" ;;
+      *) ok "no-runner: the output does NOT claim a bound it did not have" ;;
     esac
     case "$OUT" in
       *"anchor-ancestry: BOUND"*)
-        ok "unbounded: the ancestry verdict is still produced (the bound is liveness, not correctness)" ;;
-      *) bad "unbounded: the ancestry verdict should be unaffected by the missing runner (got: $OUT)" ;;
+        bad "no-runner: the output claims an ancestry verdict it refused before reaching (got: $OUT)" ;;
+      *) ok "no-runner: no ancestry verdict is claimed — the check refused before the walk" ;;
     esac
   fi
 fi
@@ -2145,17 +2208,31 @@ TOFLOW="$T/flow-timeout"
 # WHY A DURATION AND NOT A SUFFIX: `sleep` takes numeric operands only, so a
 # textual tag cannot be appended to its argv. The uniqueness therefore lives in
 # the NUMBER. `printf '9%09d'` keeps it a fixed 10 digits with a floor of ~285
-# years, so a short checksum can never yield a sleep that exits during the run
-# and makes the leak check pass for the wrong reason.
+# years, so a small token can never yield a sleep that exits during the run and
+# makes the leak check pass for the wrong reason.
+#
+# THE TOKEN IS THE PID, AND THAT IS A GUARANTEE RATHER THAN A PROBABILITY. The
+# first version hashed `$T` with `cksum … % 1000000000`, which is LOSSY: two
+# concurrent runs could collide, and a collision hands the whole-box cleanup a
+# peer's process to SIGKILL. A PID IS UNIQUE AMONG LIVE PROCESSES, and live
+# processes are exactly what the census inspects — so two simultaneous runs
+# cannot collide, by construction. The cksum path is GONE rather than kept as a
+# fallback: a second derivation is a second thing to be wrong, and this one needs
+# no external tool.
+#
+# The residual, stated: a stale sleep left by a DEAD earlier run whose pid was
+# later recycled to this one would be seen as this run's leak. That direction is
+# benign — the stray really is garbage and killing it really is correct cleanup —
+# and it can only arise if an earlier run leaked, which these arms now assert
+# against.
 to_derive_sentinel() {
-  local tok
-  tok=$(printf '%s' "$1" | cksum 2>/dev/null | awk '{print ($1 % 1000000000)}') || tok=""
+  local tok="$1"
   case "$tok" in
-    ''|*[!0-9]*) tok=$(( $$ % 1000000000 )) ;;   # a live pid is unique among live processes
+    ''|*[!0-9]*) printf '%s\n' "INVALID-TOKEN"; return 0 ;;
   esac
-  printf 'sleep %s\n' "$(printf '9%09d' "$tok")"
+  printf 'sleep %s\n' "$(printf '9%09d' "$(( tok % 1000000000 ))")"
 }
-TOSENTINEL=$(to_derive_sentinel "$T")
+TOSENTINEL=$(to_derive_sentinel "$$")
 to_shape=0
 # A REAL bounding runner is REQUIRED for these arms. Without one the $BIN shim
 # discards the bound (see its own comment) and a hung read would hang FOREVER —
@@ -2442,6 +2519,11 @@ DECOY
   chmod +x "$DECOY_DIR/git"
   bash "$DECOY_DIR/git" merge-base --is-ancestor deadbeef deadbeef >/dev/null 2>&1 &
   decoy_pid=$!
+  # REGISTERED IMMEDIATELY, on the line after the spawn (job 282). Everything
+  # below this point — a failed recognition, a `bad`, an interrupt, a normal exit
+  # — is covered by the trap installed at the top of this file.
+  DECOY_CLEANUP_PID="$decoy_pid"
+  DECOY_CLEANUP_NEEDLE="$DECOY_DIR/git"
   printf '%s\n' "$decoy_pid" >"$DECOY_PID"
   # Give it a moment to appear in the process table, then CONFIRM it is really
   # alive with the expected argv — a decoy that died makes every property below
@@ -2465,9 +2547,14 @@ DECOY
   fi
 fi
 if [ "$decoy_shape" -ne 1 ]; then
+  # REAP BEFORE DECLARING THE SKIP: recognition may have failed with the decoy
+  # STILL ALIVE and blocked on its FIFO. Reporting a skip while leaving it running
+  # is the leak this arm exists to guard against (roborev job 370, finding 2). The
+  # exit trap would also get it, but a skip should not depend on that.
+  to_kill_decoy
   printf 'ARM NOT TAKEN: leak-check self-test (job 367) — a live decoy process carrying a shim-like argv\n'
   printf 'ARM NOT TAKEN: could not be started on this host, so the leak checks discriminating power is\n'
-  printf 'ARM NOT TAKEN: UNPROVEN on this run.\n'
+  printf 'ARM NOT TAKEN: UNPROVEN on this run. Any partially-started decoy has been reaped.\n'
   ok "leak self-test: SKIPPED (decoy unavailable — arm UNEXERCISED, declared not silent)"
 else
   ok "leak self-test fixture: a live decoy carrying a shim-like argv really exists"
@@ -2497,6 +2584,10 @@ else
     kill -KILL "$decoy_pid" 2>/dev/null
     wait "$decoy_pid" 2>/dev/null || true
   fi
+  # Registration cleared once the resource is gone — the other half of job 282's
+  # rule (register the moment it exists, clear the moment it is reaped), so the
+  # exit trap cannot later signal a pid this arm no longer owns.
+  DECOY_CLEANUP_PID=""
   sleep 1
   v=$(to_pid_verdict "$DECOY_PID" "$DECOY_DIR/git")
   if [ "$v" = GONE ] || [ "$v" = ZOMBIE ]; then
@@ -2534,19 +2625,37 @@ fi
 # (1) DERIVATION — two different scratch roots must yield two different
 #     sentinels. This is the actual property: `$T` is run-unique, so a peer
 #     lane's suite derives a different argv and neither census can see the other.
-sent_a=$(to_derive_sentinel "/tmp/premerge-assert-test.AAAAAA")
-sent_b=$(to_derive_sentinel "/tmp/premerge-assert-test.BBBBBB")
+sent_a=$(to_derive_sentinel 111)
+sent_b=$(to_derive_sentinel 222)
 if [ -n "$sent_a" ] && [ "$sent_a" != "$sent_b" ]; then
-  ok "sentinel: two different scratch roots derive DIFFERENT sentinels — a peer lane cannot collide with this run"
+  ok "sentinel: two different pids derive DIFFERENT sentinels — a concurrent run cannot collide with this one"
 else
-  bad "sentinel: two scratch roots derived the SAME sentinel ('$sent_a') — the census would count a peer lane's process as this run's leak, and the cleanup would SIGKILL it"
+  bad "sentinel: two pids derived the SAME sentinel ('$sent_a') — the census would count a peer run's process as this run's leak, and the cleanup would SIGKILL it"
+fi
+# (1b) The derivation must be INJECTIVE over the pid range, not merely different
+#      for two samples: `% 1000000000` is applied, so a pid could in principle
+#      alias. Asserted over the whole plausible pid space rather than argued —
+#      `/proc/sys/kernel/pid_max` where readable, else the 4194304 Linux default.
+pid_max=$(cat /proc/sys/kernel/pid_max 2>/dev/null) || pid_max=""
+case "$pid_max" in ''|*[!0-9]*) pid_max=4194304 ;; esac
+if [ "$pid_max" -lt 1000000000 ]; then
+  ok "sentinel: pid_max ($pid_max) is below the modulus, so the pid -> sentinel map is INJECTIVE — no aliasing is possible"
+else
+  bad "sentinel: pid_max ($pid_max) reaches the modulus, so two live pids could alias to one sentinel"
 fi
 # (2) THIS RUN's sentinel really is the derived one, not a constant someone
 #     reintroduced beside it.
-if [ "$TOSENTINEL" = "$(to_derive_sentinel "$T")" ]; then
-  ok "sentinel: the live TOSENTINEL is the value derived from this run's scratch root"
+if [ "$TOSENTINEL" = "$(to_derive_sentinel "$$")" ]; then
+  ok "sentinel: the live TOSENTINEL is the value derived from this run's own pid"
 else
-  bad "sentinel: TOSENTINEL ('$TOSENTINEL') is not the value derived from \$T — something is overriding the derivation"
+  bad "sentinel: TOSENTINEL ('$TOSENTINEL') is not the value derived from \$\$ — something is overriding the derivation"
+fi
+# (2b) A non-numeric token must be REFUSED loudly, never silently turned into a
+#      shared default — that is how a fixed sentinel would sneak back.
+if [ "$(to_derive_sentinel "not-a-pid")" = "INVALID-TOKEN" ]; then
+  ok "sentinel: a non-numeric token yields INVALID-TOKEN, never a silent shared default"
+else
+  bad "sentinel: a non-numeric token did not refuse — a bad token must not degrade into a shared value"
 fi
 # (3) SHAPE — `sleep ` plus a fixed 10 digits. The width floor is not cosmetic:
 #     a short duration could EXPIRE mid-run and make the leak check pass because

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -1915,6 +1915,184 @@ else
   fi
 fi
 
+# --- 44(i): A FORGED commit-graph (roborev job 361) --------------------------
+#
+# `objects/info/commit-graph` is reachable through the alternate, is NOT
+# content-addressed, and git TRUSTS its recorded parent edges — so it is a
+# parent-edge source the scratch isolation does not by itself remove. The control
+# is `-c core.commitGraph=false` on every isolated read.
+#
+# WHAT THIS ARM CAN HONESTLY CLAIM, WHICH IS LESS THAN THE OTHER TWO. Measured on
+# this suite's own fixture (see the forge below): the graph IS consulted and IS
+# trusted — `rev-list --parents` reports the FORGED parent and `-c
+# core.commitGraph=false` reports the real one — but `merge-base --is-ancestor`,
+# which is the call this guard makes, answered "no" in BOTH cases on git 2.43.0.
+# So the EXPLOIT AGAINST THIS CALL does not reproduce here, and an arm shaped like
+# 44(f)/44(g) ("plain merge-base answers 0, the guard still refuses") CANNOT be
+# built on this host. Pretending otherwise would be a green that proves nothing.
+#
+# What is asserted instead, split by what each half can actually establish:
+#   (1) BEHAVIOURAL, and it is a real positive control for the MECHANISM: the
+#       forged graph changes `rev-list`'s answer, and the flag changes it back.
+#       That proves the fixture is genuinely forged AND that git trusts the graph.
+#   (2) BEHAVIOURAL: the guard refuses the foreign pair in the forged repository,
+#       and still BINDs a genuine ancestor there. NOT load-bearing on this git —
+#       it would pass without the flag — and labelled as such.
+#   (3) STRUCTURAL, labelled: the isolated reads carry `-c core.commitGraph=false`
+#       from the single options array. This is the assertion that actually pins
+#       the control on a host where the behavioural one cannot, and it is declared
+#       structural rather than dressed up as behavioural (the convention CLAUDE.md
+#       records for roborev job 279's ownership invariant).
+CG_REPO="$T/ancestry-cg-repo"
+cg_shape=0
+cg_forged=0
+if [ "$anc_shape" -eq 1 ] && cp -a "$ANC_REPO" "$CG_REPO" 2>/dev/null &&
+   git -C "$CG_REPO" commit-graph write --reachable >/dev/null 2>&1 &&
+   [ -f "$CG_REPO/.git/objects/info/commit-graph" ]; then
+  cg_shape=1
+fi
+if [ "$cg_shape" -eq 1 ]; then
+  # THE FORGE: patch the CDAT record's first parent slot for the CERTIFIED commit
+  # to name the FOREIGN commit, then recompute the file's trailing checksum. git
+  # writes the graph read-only, which is not a control (a peer runs as the same
+  # user), so it is chmod'd first — exactly as a planter would.
+  chmod u+w "$CG_REPO/.git/objects/info/commit-graph" 2>/dev/null
+  if python3 - "$CG_REPO/.git/objects/info/commit-graph" "$R_CERT" "$R_FOREIGN" <<'FORGE' >/dev/null 2>&1
+import sys, struct, hashlib
+path, victim, newparent = sys.argv[1], sys.argv[2], sys.argv[3]
+d = bytearray(open(path, 'rb').read())
+if d[0:4] != b'CGPH' or d[4] != 1 or d[5] != 1:
+    raise SystemExit(1)                      # not a v1/SHA-1 graph: unsupported here
+nchunks = d[6]
+off, entries = 8, []
+for _ in range(nchunks + 1):
+    entries.append((bytes(d[off:off + 4]), struct.unpack('>Q', d[off + 4:off + 12])[0]))
+    off += 12
+chunks = {entries[i][0]: (entries[i][1], entries[i + 1][1]) for i in range(nchunks)}
+if b'OIDL' not in chunks or b'CDAT' not in chunks:
+    raise SystemExit(1)
+oidl, cdat = chunks[b'OIDL'], chunks[b'CDAT']
+n = (oidl[1] - oidl[0]) // 20
+oids = [d[oidl[0] + i * 20:oidl[0] + i * 20 + 20].hex() for i in range(n)]
+if victim not in oids or newparent not in oids:
+    raise SystemExit(1)
+rec = cdat[0] + oids.index(victim) * 36
+d[rec + 20:rec + 24] = struct.pack('>I', oids.index(newparent))
+d[len(d) - 20:] = hashlib.sha1(bytes(d[:len(d) - 20])).digest()
+open(path, 'wb').write(bytes(d))
+FORGE
+  then
+    cg_forged=1
+  fi
+fi
+# (1) THE MECHANISM CONTROL — the forge must actually change what git believes.
+cg_control=0
+if [ "$cg_forged" -eq 1 ]; then
+  cg_default=$(git -C "$CG_REPO" rev-list --parents -1 "$R_CERT" 2>/dev/null)
+  cg_off=$(git -C "$CG_REPO" -c core.commitGraph=false rev-list --parents -1 "$R_CERT" 2>/dev/null)
+  if [ "${cg_default#*"$R_FOREIGN"}" != "$cg_default" ] &&
+     [ "${cg_off#*"$R_FOREIGN"}" = "$cg_off" ]; then
+    cg_control=1
+  fi
+fi
+if [ "$cg_control" -eq 1 ]; then
+  ok "commit-graph POSITIVE CONTROL: the forged graph makes git report a FOREIGN parent, and -c core.commitGraph=false reports the real one"
+  # The reachability half of the same control, which is the property an ancestry
+  # walk would consume.
+  if [ "$(git -C "$CG_REPO" rev-list "$R_CERT" | grep -c "$R_FOREIGN")" = 1 ] &&
+     [ "$(git -C "$CG_REPO" -c core.commitGraph=false rev-list "$R_CERT" | grep -c "$R_FOREIGN")" = 0 ]; then
+    ok "commit-graph POSITIVE CONTROL: the forged graph makes the FOREIGN commit reachable from the certified head (and the flag removes it)"
+  else
+    bad "commit-graph POSITIVE CONTROL: the forge did not change reachability — the fixture is not the shape this arm claims"
+  fi
+  # (2) The guard's behaviour in that repository. Declared NOT load-bearing on a
+  # git whose --is-ancestor ignores the forged edge; it is here so a git that
+  # DOES honour it would red this arm rather than merge.
+  OUT=$(cd "$CG_REPO" && PATH="$BIN:$PATH" MOCK_GH_FAIL=0 MOCK_GH_OUT="$R_CERT OPEN" \
+    bash "$NEUTRAL_ASSERT" 2421 "$R_CERT" "$RFORFULL" "$RFORDELTA" 2>&1)
+  RC=$?
+  if [ "$RC" -ne 2 ]; then
+    bad "commit-graph: a forged commit-graph produced a non-refusal (exit $RC, wanted 2) — this git's --is-ancestor DOES honour the forged edge and the control is not reaching it (job 361) (got: $OUT)"
+  else
+    ok "commit-graph: the guard refuses the foreign pair in the forged repository (exit 2)"
+  fi
+  OUT=$(cd "$CG_REPO" && PATH="$BIN:$PATH" MOCK_GH_FAIL=0 MOCK_GH_OUT="$R_CERT OPEN" \
+    bash "$NEUTRAL_ASSERT" 2421 "$R_CERT" "$RANCFULL" "$RGOODDELTA" 2>&1)
+  RC=$?
+  if [ "$RC" -eq 0 ] && [ "${OUT#*anchor-ancestry: BOUND}" != "$OUT" ]; then
+    ok "commit-graph: NON-VACUITY — a genuine ancestor is still BOUND in the forged repository"
+  else
+    bad "commit-graph: the genuine ancestor stopped being BOUND (exit $RC) — the refusal above proves nothing (got: $OUT)"
+  fi
+  printf 'ARM NOT TAKEN: commit-graph EXPLOIT arm (job 361) — the mechanism control above FIRED, but on\n'
+  printf 'ARM NOT TAKEN: this git `merge-base --is-ancestor` answered "no" for the forged edge WITH and\n'
+  printf 'ARM NOT TAKEN: WITHOUT the flag, so no arm on this host can show the flag CHANGING this\n'
+  printf 'ARM NOT TAKEN: guard-s verdict. The control is pinned STRUCTURALLY below instead.\n'
+else
+  printf 'ARM NOT TAKEN: forged commit-graph (job 361) — this host could not build the fixture (no\n'
+  printf 'ARM NOT TAKEN: commit-graph support, a non-v1/SHA-1 graph format, or the forge did not change\n'
+  printf 'ARM NOT TAKEN: what git believes), so no behavioural claim is made about the graph route.\n'
+  printf 'ARM NOT TAKEN: The structural assertion below still applies.\n'
+  ok "commit-graph: SKIPPED (mechanism control did not fire — arm UNEXERCISED, declared not silent)"
+fi
+
+# (3) THE STRUCTURAL ASSERTION, labelled as such. On a git whose --is-ancestor
+# ignores a forged graph this is the ONLY thing pinning the control, so it is not
+# optional decoration: it asserts the shipped script disables the graph, from the
+# SINGLE options array, so a future option cannot reach some call sites and miss
+# others (roborev job 276's failure mode).
+if grep -q -F -- 'ANCHOR_GIT_OPTS=(--no-replace-objects -c core.commitGraph=false)' "$ASSERT"; then
+  ok "commit-graph (STRUCTURAL): the shipped script disables core.commitGraph in the ONE options array"
+else
+  bad "commit-graph (STRUCTURAL): the shipped script no longer disables core.commitGraph in ANCHOR_GIT_OPTS (job 361)"
+fi
+# ...and that every git invocation in the check consumes that array rather than
+# calling `git` bare. Counted, not eyeballed: this is the invariant that job 276
+# says has to reach the sites a later change adds.
+anchor_bare=$(awk '
+  /^_anchor_(run|git)\(\) \{/ { inf = 1 }
+  inf && /^\}/ { inf = 0 }
+  inf && /(^|[^_[:alnum:]])git / && !/ANCHOR_GIT_OPTS/ { c++ }
+  END { print c + 0 }
+' "$ASSERT")
+if [ "$anchor_bare" = 0 ]; then
+  ok "commit-graph (STRUCTURAL): every git invocation in the isolated wrappers passes ANCHOR_GIT_OPTS"
+else
+  bad "commit-graph (STRUCTURAL): $anchor_bare git invocation(s) in the isolated wrappers bypass ANCHOR_GIT_OPTS — an option would reach some sites and miss others (job 276)"
+fi
+
+# --- 44(j): THE BOUNDARY IS DECLARED ON EVERY SUCCESS LINE (job 361) ---------
+# Three rounds found three routes into one mechanism, so the guard now DECLARES
+# what it cannot prove instead of implying a closure it does not deliver: the
+# ancestry verdict is derived from a shared object store that is TRUSTED, not
+# VERIFIED, and that hazard belongs to #3746.
+if run_anc 0 "Case B success declares the ancestry provenance boundary" \
+  2421 "$R_CERT" "$RANCFULL" "$RGOODDELTA"; then
+  case "$OUT" in
+    *"TRUSTED, not verified (#3746)"*)
+      ok "boundary: the DELTA-RECERT line declares the store is TRUSTED, not verified, naming #3746" ;;
+    *) bad "boundary: the success line must declare the trusted-store boundary (got: $OUT)" ;;
+  esac
+  case "$OUT" in
+    *"SHARED object store"*)
+      ok "boundary: the declaration names WHAT is trusted (this box's shared object store)" ;;
+    *) bad "boundary: the declaration must name the shared object store (got: $OUT)" ;;
+  esac
+  # It must not have displaced the tokens a reader greps for.
+  case "$OUT" in
+    *"anchor-ancestry: BOUND"*) ok "boundary: the ancestry token is unchanged beside the declaration" ;;
+    *) bad "boundary: the declaration must not displace anchor-ancestry: BOUND (got: $OUT)" ;;
+  esac
+fi
+# ONE renderer, never per-arm: two spellings of a boundary drift, and a drifted
+# boundary is worse than none. Asserted structurally, for the same reason (3) is.
+boundary_sites=$(grep -c -F -- 'TRUSTED, not verified (#3746)' "$ASSERT")
+if [ "$boundary_sites" = 1 ]; then
+  ok "boundary (STRUCTURAL): the declaration text exists in exactly ONE place in the shipped script"
+else
+  bad "boundary (STRUCTURAL): the declaration appears $boundary_sites times — it must be ONE constant consumed by the ONE renderer"
+fi
+
 # =============================================================================
 # #3465 review — the remaining refusal branches
 # =============================================================================

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -75,80 +75,31 @@ if ! T=$(mktemp -d "${TMPDIR:-/tmp}/premerge-assert-test.XXXXXX" 2>/dev/null) ||
   printf 'FAIL - every path in this suite would resolve under / instead.\n' >&2
   exit 1
 fi
-# CLEANUP IS UNCONDITIONAL, RUN-SCOPED, AND MAKES NO VERDICT (roborev job 381,
-# firing the stop line). The leak ADJUDICATION that used to live here — deciding
-# LEAK vs RECYCLED vs GONE vs ZOMBIE vs UNMEASURABLE from a two-valued `ps` probe
-# — is DELETED. Six findings in that apparatus, three of them the same fail-open
-# read after three correct fixes, and the standing ruling applies: a guard with a
-# persistent documented false-PASS record is worse than no guard, because it
-# invites reliance it cannot support.
+# NOTHING IN THIS SUITE KILLS ANY PROCESS (roborev job 388). The box-wide sweep
+# that used to live here is DELETED, and for the same reason as every other
+# removal in this apparatus: it killed from a STALE `ps` snapshot, so a pid that
+# had exited and been RECYCLED between the snapshot and the signal got SIGKILLed —
+# on a shared box, most likely a peer lane's process. It was a hazard introduced
+# while removing a different one.
 #
-# WHAT REPLACES IT NEEDS NO ADJUDICATION AT ALL. Every process this suite spawns
-# wears ONE OF TWO run-unique argv shapes, and BOTH are needed — matching only the
-# first was a matcher bug (roborev job 382), not a return of the deleted class:
-#   (a) `$T/…`         the shim paths (the KILL shim blocked on its FIFO wears this)
-#   (b) `$TOSENTINEL`  the TERM shim `exec`s into `sleep <duration>`, which REPLACES
-#                      its argv and ERASES the shim path — so shape (a) misses
-#                      precisely the process the sweep exists to catch, and a
-#                      centuries-long sleep survives.
-# `$T` is a per-run `mktemp -d` and `$TOSENTINEL` is derived from this run's pid, so
-# ANYTHING wearing either IS OURS. That makes the
-# kill safe by CONSTRUCTION (job 279's argv validation, with a needle no peer can
-# produce) instead of by interpreting an exit status. Nothing here decides
-# anything, so nothing here can fail open: if `ps` cannot run, the sweep kills
-# nothing and no assertion depends on it.
+# NARROWING IT WAS NOT AVAILABLE. Holding an ownership handle is impossible here:
+# the shim is spawned by the bounded runner through `timeout`, so it is NOT this
+# suite's direct child and there is no pid this suite legitimately owns.
 #
-# Registered BEFORE any resource exists (CLAUDE.md job 282), signals included,
-# because bash runs no EXIT trap for a signal at its default disposition; each
-# re-raises so the process still dies of what it was sent.
+# SO THE RESOURCE WAS MADE SELF-LIMITING AND THE CODE WENT AWAY WITH THE HAZARD.
+# Every process the arms can leak now terminates ON ITS OWN within ~120s — the
+# sentinel is a bounded fractional sleep, and the TERM-ignoring shim counts
+# bounded 1s sleeps. Nothing needs hunting, nothing is signalled, and the whole
+# recycled-pid class is GONE rather than reduced. 120s is comfortably longer than
+# the arms' 2s+1s bound, so it cannot mask a bound that failed to fire, and short
+# enough in absolute terms that a leak is self-clearing.
 #
-# ORDER IS LOAD-BEARING: the sweep runs BEFORE `rm -rf "$T"`. A shim can be
-# blocked on a FIFO inside $T, and removing the FIFO does NOT unblock a reader
-# already waiting on it.
-# DECLARED EMPTY HERE, ~2000 lines before it is derived, because the traps below
-# read it AT FIRE TIME: under `set -u` a signal arriving before the derivation
-# would error inside the handler. Empty simply means the sentinel arm of the sweep
-# has nothing to match yet — the `$T/` arm still works.
+# The run-unique sentinel argv is KEPT — for diagnostics and for the structural
+# pin at 44(m) — but NOTHING MAY KILL BASED ON IT.
 TOSENTINEL=""
 
 suite_cleanup() {
-  to_sweep_run_processes
-  rm -f "$T/ps-census.txt" 2>/dev/null
   rm -rf "$T"
-}
-
-# to_sweep_run_processes — kill every process whose argv wears one of THIS RUN's
-# two unique shapes (see the block above). Best-effort by design: no status is
-# inspected and no verdict is produced. `wait` follows, for whatever was a direct
-# child (a harmless no-op for the rest).
-#
-# THE SNAPSHOT LIVES INSIDE `$T`, not in shared TMPDIR (roborev job 382). A
-# predictable name under a world-writable directory, truncated by shell
-# redirection, lets a stale or peer-created SYMLINK redirect the write. `$T` is
-# already run-unique and already created — it exists before these traps are
-# installed — so it costs nothing.
-to_sweep_run_processes() {
-  local snap p a hit
-  snap="$T/ps-sweep.txt"
-  ps -eo pid=,args= >"$snap" 2>/dev/null || { rm -f "$snap"; return 0; }
-  while read -r p a; do
-    case "$p" in ''|*[!0-9]*) continue ;; esac
-    # Two needles, tested separately rather than as one `case` alternative: an
-    # EMPTY `$TOSENTINEL` (before it is derived, see above) would otherwise be a
-    # pattern matching an empty argv, and "match nothing" must be explicit rather
-    # than an accident of what `ps` happens to print.
-    hit=0
-    case "$a" in *"$T/"*) hit=1 ;; esac
-    if [ "$hit" -eq 0 ] && [ -n "$TOSENTINEL" ] && [ "$a" = "$TOSENTINEL" ]; then
-      hit=1
-    fi
-    if [ "$hit" -eq 1 ]; then
-      kill -KILL "$p" 2>/dev/null || true
-      wait "$p" 2>/dev/null || true
-    fi
-  done <"$snap"
-  rm -f "$snap"
-  return 0
 }
 
 trap 'suite_cleanup' EXIT
@@ -1197,7 +1148,7 @@ if run_anc 0 "anchored delta pair (full PASS at X + delta at Y) -> exit 0" \
   # names both halves, and this arm pins BOTH — a reworded token that quietly
   # dropped the unbounded half would restore the overclaim.
   case "$OUT" in
-    *"anchor-reads: bounded-"*"external:git,mktemp,sh,rm"*)
+    *"anchor-reads: bounded-"*"external:git,mktemp,sh"*)
       ok "delta pair: the token names WHAT is bounded (the external commands)" ;;
     *) bad "delta pair: the anchor-reads token must name the bounded externals (got: $OUT)" ;;
   esac
@@ -2293,7 +2244,7 @@ to_derive_sentinel() {
   case "$tok" in
     ''|*[!0-9]*) printf '%s\n' "INVALID-TOKEN"; return 0 ;;
   esac
-  printf 'sleep %s\n' "$(printf '9%09d' "$(( tok % 1000000000 ))")"
+  printf 'sleep 120.%s\n' "$(printf '%09d' "$(( tok % 1000000000 ))")"
 }
 TOSENTINEL=$(to_derive_sentinel "$$")
 to_shape=0
@@ -2423,36 +2374,36 @@ TERMSHIM
     chmod +x "$TSH/git"
     to_run_arm "TERM path / exit 124" "$TSH" 124 "$TPID"
 
-    # ARM 2 — the KILL-after-grace path (exit 137). The shim IGNORES TERM and
-    # blocks on opening a writer-less FIFO, which is uninterruptible while TERM is
-    # SIG_IGN and spawns NO child, so nothing else in the process group can die in
-    # its place. The runner must therefore escalate to SIGKILL.
+    # ARM 2 — the KILL-after-grace path (exit 137). The shim IGNORES TERM, so the
+    # runner must escalate to SIGKILL.
+    #
+    # NO FIFO ANY MORE (roborev job 388). It used to block on opening a writer-less
+    # FIFO: uninterruptible, which was the point, but also UNBOUNDED — a leaked
+    # shim blocked forever and needed hunting, which is exactly what the deleted
+    # sweep existed for. It now counts BOUNDED 1s sleeps instead. The shim itself
+    # still ignores TERM (so the escalation fires), each `sleep 1` child is
+    # trivially short, and the whole thing self-terminates in ~120s if leaked.
+    # Measured on this box: runner rc 137 in 3s, the shim survives TERM, and a
+    # leaked one goes away on its own. The mkfifo not-taken branch went with the
+    # FIFO — one fewer host-dependent skip.
     KSH="$T/bin-git-hang-kill"
     mkdir -p "$KSH"
-    KFIFO="$T/hang-kill.fifo"
-    rm -f "$KFIFO"
-    if mkfifo "$KFIFO" 2>/dev/null; then
-      KPID="$T/hang-kill.pid"
-      cat >"$KSH/git" <<KILLSHIM
+    KPID="$T/hang-kill.pid"
+    cat >"$KSH/git" <<KILLSHIM
 #!/usr/bin/env bash
 for a in "\$@"; do
   if [ "\$a" = "--is-ancestor" ]; then
-    printf '%s\n' "\$\$" >"$KPID"
+    printf '%s\\n' "\$\$" >"$KPID"
     trap '' TERM
-    read -r _ < "$KFIFO"
+    _n=0
+    while [ "\$_n" -lt 120 ]; do sleep 1; _n=\$((_n + 1)); done
     exit 0
   fi
 done
 exec "$REALGIT" "\$@"
 KILLSHIM
-      chmod +x "$KSH/git"
-      to_run_arm "KILL after grace / exit 137" "$KSH" 137 "$KPID"
-    else
-      printf 'ARM NOT TAKEN: hung ancestry read, KILL path (job 364) — mkfifo failed on this host, so a\n'
-      printf 'ARM NOT TAKEN: TERM-ignoring block with no child process cannot be constructed. The exit-137\n'
-      printf 'ARM NOT TAKEN: escalation is UNEXERCISED (the TERM/124 arm above still ran).\n'
-      ok "hung-read (KILL path): SKIPPED (mkfifo unavailable — arm UNEXERCISED, declared not silent)"
-    fi
+    chmod +x "$KSH/git"
+    to_run_arm "KILL after grace / exit 137" "$KSH" 137 "$KPID"
 
     # ARM 3 — A HUNG *DISCOVERY* CALL (roborev job 374). Several bounded calls
     # used to discard their status via `|| true` / an empty-value fallback /
@@ -2550,8 +2501,10 @@ fi
 # control per arm); they no longer prove the runner left no process behind.
 printf 'DECLARED LOSS: leak reaping is NO LONGER ASSERTED by this suite (job 381). The hung-read\n'
 printf 'DECLARED LOSS: arms prove the bound fires and names its own cause; they do NOT prove the\n'
-printf 'DECLARED LOSS: bounded runner reaped its child. Strays are swept unconditionally at suite\n'
-printf 'DECLARED LOSS: exit by argv (run-scoped, no verdict), which is HYGIENE, not a check.\n'
+printf 'DECLARED LOSS: bounded runner reaped its child. AND SINCE job 388 nothing sweeps either:\n'
+printf 'DECLARED LOSS: killing from a stale ps snapshot could SIGKILL a RECYCLED pid, so instead\n'
+printf 'DECLARED LOSS: every process these arms can leak is SELF-LIMITING (~120s) and nothing is\n'
+printf 'DECLARED LOSS: signalled at all. A leak is SELF-CLEARING, not detected.\n'
 
 # --- 44(m): THE SENTINEL IS UNIQUE PER RUN (cross-lane blocker) --------------
 #
@@ -2599,10 +2552,10 @@ fi
 #     a short duration could EXPIRE mid-run and make the leak check pass because
 #     the sleep ended, not because the runner reaped it.
 case "$TOSENTINEL" in
-  "sleep "[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9])
-    ok "sentinel: the derived value has the expected shape (sleep + 10 digits, so it cannot expire mid-run)" ;;
+  "sleep 120."[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9])
+    ok "sentinel: the derived value has the expected shape (sleep 120.<9 digits> — BOUNDED and run-unique)" ;;
   *)
-    bad "sentinel: unexpected shape '$TOSENTINEL' — a short or non-numeric duration breaks either sleep or the leak check" ;;
+    bad "sentinel: unexpected shape '$TOSENTINEL' — it must be a BOUNDED (self-limiting) and run-unique duration" ;;
 esac
 # (4) The historical SHARED constants must not be hard-coded anywhere in this
 #     file any more — not in a shim, not in a census, not in a comment (a comment

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -2354,12 +2354,23 @@ to_check_pid() {
 # path it actually took — and "we tested the escalation" would be a claim nothing
 # established. So each shim is first run UNDER THE RUNNER DIRECTLY and its exit
 # code asserted: 124 for the TERM shim, 137 for the TERM-ignoring one.
+# Params 5 and 6 were added for roborev job 374: the same arms must be able to
+# hang a DISCOVERY call, whose expected CAUSE differs from the ancestry walk's.
+# Parameterising the proven runner is deliberate reuse — a second construction is
+# where every defect in this scaffolding has come from.
+#   $5 want_cause   the timeout cause substring this arm must see
+#                   (default: the ancestry walk's)
+#   $6 control_args the argv the CONTROL invokes, which must be the one the shim
+#                   triggers on (default: the ancestry walk's)
 to_run_arm() {
   local label="$1" shimdir="$2" want_rc="$3" pidfile="$4"
+  local want_cause="${5:-the ancestry walk timed out after}"
+  local control_args="${6:-merge-base --is-ancestor $R_CERT $R_CERT}"
   local out rc leaks crc=0
   rm -f "$pidfile"
+  # shellcheck disable=SC2086  # intentional word-split of the control argv list
   PATH="$shimdir:$PATH" "$REAL_TO" --kill-after=1 2 \
-    git merge-base --is-ancestor "$R_CERT" "$R_CERT" >/dev/null 2>&1 || crc=$?
+    git $control_args >/dev/null 2>&1 || crc=$?
   if [ "$crc" = "$want_rc" ]; then
     ok "hung-read ($label): CONTROL — the shim really produces runner exit $want_rc"
   else
@@ -2369,25 +2380,28 @@ to_run_arm() {
     bash "$TOFLOW/premerge-assert.sh" 2421 "$R_CERT" "$RANCFULL" "$RGOODDELTA" 2>&1)
   rc=$?
   if [ "$rc" -ne 3 ]; then
-    bad "hung-read ($label): a hung ancestry read must be exit 3 (got $rc: $out)"
+    bad "hung-read ($label): a hung bounded call must be exit 3 (got $rc: $out)"
   else
-    ok "hung-read ($label): a hung ancestry read is exit 3, not a hang and not a pass"
+    ok "hung-read ($label): a hung bounded call is exit 3, not a hang and not a pass"
     case "$out" in
       *"PREMERGE: ANCHOR-UNVERIFIABLE"*)
         ok "hung-read ($label): carries the ANCHOR-UNVERIFIABLE marker" ;;
       *) bad "hung-read ($label): expected the ANCHOR-UNVERIFIABLE marker (got: $out)" ;;
     esac
     case "$out" in
-      *"the ancestry walk timed out after"*)
-        ok "hung-read ($label): the cause names the TIMEOUT, distinctly from the other UNVERIFIABLE causes" ;;
-      *) bad "hung-read ($label): the cause must name the timeout (got: $out)" ;;
+      *"$want_cause"*)
+        ok "hung-read ($label): the cause names the TIMEOUT of the call that hung, distinctly from the other UNVERIFIABLE causes" ;;
+      *) bad "hung-read ($label): the cause must name '$want_cause' (got: $out)" ;;
     esac
-    # Distinctness in both directions: it must not be reported as an absent
-    # object, a shallow history, or a NOT-ANCESTOR verdict.
+    # Distinctness in both directions: a timeout must never BORROW another
+    # cause's remedy — that is job 374's whole subject. The forbidden set covers
+    # every non-timeout UNVERIFIABLE cause this script can print.
     case "$out" in
-      *"is not present in this repository"* | *"NOT PROVEN COMPLETE"* | *"is NOT on the certified sha's history"*)
-        bad "hung-read ($label): a timeout was misreported as another cause (got: $out)" ;;
-      *) ok "hung-read ($label): a timeout is NOT misreported as an absent object, a shallow history or NOT-ANCESTOR" ;;
+      *"is not present in this repository"* | *"NOT PROVEN COMPLETE"* \
+        | *"is NOT on the certified sha's history"* | *"not inside a git work tree"* \
+        | *"could not be resolved"* | *"scratch root"* | *"could not initialise"*)
+        bad "hung-read ($label): a timeout was misreported as another cause — the operator would get the WRONG remedy (got: $out)" ;;
+      *) ok "hung-read ($label): a timeout borrows NO other cause's remedy (not work-tree, TMPDIR, absent-object, shallow or NOT-ANCESTOR)" ;;
     esac
   fi
   # PRIMARY: the shim's OWN recorded pid (job 367). Works for BOTH arms, because
@@ -2472,6 +2486,85 @@ KILLSHIM
       printf 'ARM NOT TAKEN: TERM-ignoring block with no child process cannot be constructed. The exit-137\n'
       printf 'ARM NOT TAKEN: escalation is UNEXERCISED (the TERM/124 arm above still ran).\n'
       ok "hung-read (KILL path): SKIPPED (mkfifo unavailable — arm UNEXERCISED, declared not silent)"
+    fi
+
+    # ARM 3 — A HUNG *DISCOVERY* CALL (roborev job 374). Several bounded calls
+    # used to discard their status via `|| true` / an empty-value fallback /
+    # `if !`, so a timeout during repository discovery was reported as "not
+    # inside a git work tree" or an unusable TMPDIR — sending the operator to
+    # check their cwd when the real answer is a stalled filesystem. The arms
+    # above only ever hung `merge-base`, so nothing caught it.
+    #
+    # SAME TEMPLATE AS ARM 1, different trigger argv: `--show-toplevel`, which
+    # `_anchor_build_scratch` calls. `--git-dir` runs BEFORE it and passes
+    # through to the real binary, so the fixture proves the status is propagated
+    # from a call that is not the walk.
+    DSH="$T/bin-git-hang-discovery"
+    mkdir -p "$DSH"
+    DPID="$T/hang-discovery.pid"
+    cat >"$DSH/git" <<DISCSHIM
+#!/usr/bin/env bash
+for a in "\$@"; do
+  if [ "\$a" = "--show-toplevel" ]; then
+    printf '%s\n' "\$\$" >"$DPID"
+    exec $TOSENTINEL
+  fi
+done
+exec "$REALGIT" "\$@"
+DISCSHIM
+    chmod +x "$DSH/git"
+    to_run_arm "DISCOVERY path / exit 124" "$DSH" 124 "$DPID" \
+      "the work-tree root probe (rev-parse --show-toplevel) timed out after" \
+      "rev-parse --show-toplevel"
+
+    # ARM 4 — A DISCOVERY CALL THAT *FAILS* (not hangs). Found while RED-verifying
+    # arm 3, and it is the more serious half: `cd ""` SUCCEEDS in bash and leaves
+    # the shell where it is, so `(cd "$x" && pwd -P)` with an EMPTY $x printed the
+    # CURRENT DIRECTORY. A discovery call that failed therefore yielded cwd, every
+    # `[ -z … ]` guard was unreachable, and the check ran on a plausible-looking
+    # wrong value — arm 3's RED control exited 0 with `PREMERGE: OK`, a FALSE PASS.
+    # Status propagation cannot close this route, because here the value really IS
+    # empty; only refusing an empty argument can.
+    #
+    # No timeout involved, so this runs the NEUTRAL assert (real bound, real
+    # constants) rather than the shortened scratch copy.
+    FSH="$T/bin-git-fail-discovery"
+    mkdir -p "$FSH"
+    cat >"$FSH/git" <<FAILSHIM
+#!/usr/bin/env bash
+for a in "\$@"; do
+  if [ "\$a" = "--show-toplevel" ]; then exit 1; fi
+done
+exec "$REALGIT" "\$@"
+FAILSHIM
+    chmod +x "$FSH/git"
+    # NON-VACUITY: the shim must really make that one call fail while others work.
+    if PATH="$FSH:$PATH" git rev-parse --show-toplevel >/dev/null 2>&1; then
+      bad "discovery-fail fixture: the shim did not make rev-parse --show-toplevel fail"
+    elif ! PATH="$FSH:$PATH" git rev-parse --git-dir >/dev/null 2>&1; then
+      bad "discovery-fail fixture: the shim broke OTHER git calls too — the arm would not reach the code under test"
+    else
+      ok "discovery-fail fixture: --show-toplevel fails while other git calls pass through"
+      OUT=$(cd "$ANC_REPO" && PATH="$FSH:$BIN:$PATH" MOCK_GH_FAIL=0 MOCK_GH_OUT="$R_CERT OPEN" \
+        bash "$NEUTRAL_ASSERT" 2421 "$R_CERT" "$RANCFULL" "$RGOODDELTA" 2>&1)
+      RC=$?
+      if [ "$RC" -eq 0 ]; then
+        bad "discovery-fail: a FAILED work-tree-root probe produced PREMERGE: OK — an empty canonicalisation is being read as the current directory (got: $OUT)"
+      elif [ "$RC" -ne 3 ]; then
+        bad "discovery-fail: expected exit 3 (got $RC: $OUT)"
+      else
+        ok "discovery-fail: a FAILED discovery probe refuses at exit 3, never a false PREMERGE: OK"
+        case "$OUT" in
+          *"could not be resolved"*)
+            ok "discovery-fail: the refusal names the unresolvable root — the guard is REACHABLE at last" ;;
+          *) bad "discovery-fail: expected the unresolvable-root cause (got: $OUT)" ;;
+        esac
+        case "$OUT" in
+          *"timed out after"*)
+            bad "discovery-fail: a plain failure must NOT be reported as a timeout (got: $OUT)" ;;
+          *) ok "discovery-fail: a plain failure is not misreported as a timeout" ;;
+        esac
+      fi
     fi
   fi
 fi

--- a/scripts/tests/test_premerge_assert.sh
+++ b/scripts/tests/test_premerge_assert.sh
@@ -1785,6 +1785,134 @@ else
   ok "shallow: SKIPPED (differential fixture unbuildable — arm UNEXERCISED, declared not silent)"
 fi
 
+# --- 44(e2): AN INCOMPLETE OBJECT STORE WITHOUT A SHALLOW MARKER (job 412) ----
+#
+# THE VERDICT DEFECT this arm exists for: `--is-shallow-repository = false` says
+# there is no shallow MARKER, not that the history is COMPLETE. A missing
+# intermediate COMMIT object in a non-shallow repository produces the same rc 1
+# from the ancestry walk — and the script used to call that NOT-ANCESTOR at
+# exit 2, i.e. "your chain is wrong", when the truth was "this box could not
+# measure it". A false DEFINITIVE verdict, which is the bad direction.
+#
+# THE DIFFERENTIAL IS THE PROOF, exactly as for the shallow arm: the same pair
+# must be BOUND in the INTACT copy and UNVERIFIABLE once one intermediate commit
+# object is removed. Without the intact half, the refusal could be anything.
+BR_SRC="$T/broken-src"
+BR_INTACT="$T/broken-intact"
+broken_shape=0
+BR_A=""; BR_C=""; BR_MID=""
+mkdir -p "$BR_SRC"
+if git init -q -b main "$BR_SRC" >/dev/null 2>&1; then
+  git -C "$BR_SRC" config user.email t@t
+  git -C "$BR_SRC" config user.name t
+  _br_ok=1
+  for _i in 0 1 2 3 4 5; do
+    printf 'c%s\n' "$_i" >"$BR_SRC/f$_i"
+    git -C "$BR_SRC" add -- "f$_i" >/dev/null 2>&1 &&
+      git -C "$BR_SRC" commit -q -m "c$_i" >/dev/null 2>&1 || _br_ok=0
+  done
+  if [ "$_br_ok" -eq 1 ]; then
+    BR_A=$(git -C "$BR_SRC" rev-parse main~5 2>/dev/null) || BR_A=""
+    BR_C=$(git -C "$BR_SRC" rev-parse main 2>/dev/null) || BR_C=""
+    BR_MID=$(git -C "$BR_SRC" rev-parse main~2 2>/dev/null) || BR_MID=""
+  fi
+fi
+# The INTACT copy is the differential's other half; the SOURCE is the one broken.
+if [ -n "$BR_A" ] && [ -n "$BR_C" ] && [ -n "$BR_MID" ] &&
+   cp -a "$BR_SRC" "$BR_INTACT" 2>/dev/null; then
+  # Objects are loose here (no repack was run), so removing the intermediate
+  # COMMIT object is a single unlink. Trees and blobs are untouched: the point is
+  # that the COMMIT graph — what `--is-ancestor` traverses — is broken.
+  _br_obj="$BR_SRC/.git/objects/$(printf '%s' "$BR_MID" | cut -c1-2)/$(printf '%s' "$BR_MID" | cut -c3-)"
+  if [ -f "$_br_obj" ] && rm -f "$_br_obj"; then
+    # FIXTURE SELF-CONSISTENCY, four conditions. The third is the whole subject
+    # (no shallow marker) and the fourth is what makes the case ambiguous.
+    if [ "$(git -C "$BR_SRC" rev-parse --is-shallow-repository 2>/dev/null)" = false ] &&
+       ! git -C "$BR_SRC" cat-file -e "$BR_MID^{commit}" >/dev/null 2>&1 &&
+       git -C "$BR_SRC" cat-file -e "$BR_A^{commit}" >/dev/null 2>&1 &&
+       git -C "$BR_SRC" cat-file -e "$BR_C^{commit}" >/dev/null 2>&1; then
+      broken_shape=1
+    fi
+  fi
+fi
+if [ "$broken_shape" -eq 1 ]; then
+  ok "incomplete-store fixture: NO shallow marker, both endpoints present, an INTERMEDIATE commit removed"
+  # THE GIT-LEVEL DIFFERENTIAL: intact -> rc 0, broken -> rc 1 with no shallow
+  # marker. That second line is the exact input that produced the false verdict.
+  if git -C "$BR_INTACT" merge-base --is-ancestor "$BR_A" "$BR_C" >/dev/null 2>&1; then
+    ok "incomplete-store differential (git): the INTACT copy reports the pair as an ancestor (rc 0)"
+  else
+    bad "incomplete-store differential (git): the pair is not an ancestor even intact — the fixture cannot exercise the case"
+    broken_shape=0
+  fi
+  if git -C "$BR_SRC" merge-base --is-ancestor "$BR_A" "$BR_C" >/dev/null 2>&1; then
+    bad "incomplete-store differential (git): the BROKEN copy still reports an ancestor — rc 1 is not being produced, so the arm proves nothing"
+    broken_shape=0
+  else
+    ok "incomplete-store differential (git): the BROKEN copy returns rc 1 with NO shallow marker — the false-verdict input"
+  fi
+fi
+if [ "$broken_shape" -eq 1 ]; then
+  BRFULL="$T/broken-full.txt"
+  BRDELTA="$T/broken-delta.txt"
+  full_summary "$BRFULL" "$(printf '%.7s' "$BR_A")" "$(printf '%.12s' "$BR_A")" PASS PASS
+  delta_summary "$BRDELTA" "$BR_A" "$(printf '%.7s' "$BR_C")" "$(printf '%.12s' "$BR_C")" \
+    PASS PASS "MODE: delta (TEST/DOCS-ONLY RE-CERTIFICATION — anchor $BR_A)"
+  # GUARD LEVEL, half 1 — the INTACT copy must BIND, or half 2 proves nothing.
+  OUT=$(cd "$BR_INTACT" && PATH="$BIN:$PATH" MOCK_GH_FAIL=0 MOCK_GH_OUT="$BR_C OPEN" \
+    bash "$NEUTRAL_ASSERT" 2421 "$BR_C" "$BRFULL" "$BRDELTA" 2>&1)
+  RC=$?
+  if [ "$RC" -eq 0 ] && [ "${OUT#*anchor-ancestry: BOUND}" != "$OUT" ]; then
+    ok "incomplete-store differential (guard): the INTACT copy BINDS the pair (exit 0, anchor-ancestry: BOUND)"
+  else
+    bad "incomplete-store differential (guard): the intact copy did not BIND (exit $RC) — the broken half proves nothing (got: $OUT)"
+  fi
+  # GUARD LEVEL, half 2 — the BROKEN copy must be UNVERIFIABLE, never exit 2.
+  OUT=$(cd "$BR_SRC" && PATH="$BIN:$PATH" MOCK_GH_FAIL=0 MOCK_GH_OUT="$BR_C OPEN" \
+    bash "$NEUTRAL_ASSERT" 2421 "$BR_C" "$BRFULL" "$BRDELTA" 2>&1)
+  RC=$?
+  if [ "$RC" -eq 2 ]; then
+    bad "incomplete-store (guard): a VALID anchor was refused at exit 2 as NOT-ANCESTOR — the false definitive verdict this arm exists to prevent (got: $OUT)"
+  elif [ "$RC" -ne 3 ]; then
+    bad "incomplete-store (guard): expected exit 3 (got $RC: $OUT)"
+  else
+    ok "incomplete-store (guard): an incomplete store is exit 3, NEVER the exit-2 NOT-ANCESTOR verdict"
+    case "$OUT" in
+      *"PREMERGE: ANCHOR-UNVERIFIABLE"*)
+        ok "incomplete-store (guard): carries the ANCHOR-UNVERIFIABLE marker" ;;
+      *) bad "incomplete-store (guard): expected the ANCHOR-UNVERIFIABLE marker (got: $OUT)" ;;
+    esac
+    case "$OUT" in
+      *"reachable history is INCOMPLETE"*)
+        ok "incomplete-store (guard): the cause names the incomplete history" ;;
+      *) bad "incomplete-store (guard): the cause must name the incomplete history (got: $OUT)" ;;
+    esac
+    # THE THREE REASONS rc 1 IS NOT A VERDICT MUST BE DISTINGUISHABLE. This one is
+    # neither the shallow cause nor a timeout, and it must not read as either.
+    case "$OUT" in
+      *"NOT PROVEN COMPLETE"*)
+        bad "incomplete-store (guard): reported as the SHALLOW cause — the operator would run git fetch --unshallow on a repo with no shallow marker (got: $OUT)" ;;
+      *) ok "incomplete-store (guard): NOT reported as the shallow cause" ;;
+    esac
+    case "$OUT" in
+      *"timed out after"*)
+        bad "incomplete-store (guard): reported as a TIMEOUT (got: $OUT)" ;;
+      *) ok "incomplete-store (guard): NOT reported as a timeout" ;;
+    esac
+    case "$OUT" in
+      *"git fsck"*)
+        ok "incomplete-store (guard): the cause carries its own remedy (git fsck / git fetch)" ;;
+      *) bad "incomplete-store (guard): the cause must carry a repair remedy (got: $OUT)" ;;
+    esac
+  fi
+else
+  printf 'ARM NOT TAKEN: incomplete object store (job 412) — this host could not build the fixture: a\n'
+  printf 'ARM NOT TAKEN: 6-commit history with an INTERMEDIATE loose commit object removed, no shallow\n'
+  printf 'ARM NOT TAKEN: marker, both endpoints intact, plus an untouched copy for the differential.\n'
+  printf 'ARM NOT TAKEN: Without it the connectivity branch of assert_anchor_on_history is UNEXERCISED.\n'
+  ok "incomplete-store: SKIPPED (differential fixture unbuildable — arm UNEXERCISED, declared not silent)"
+fi
+
 # --- 44(f): A GRAFT MUST NOT BE ABLE TO MANUFACTURE `BOUND` (roborev job 355) -
 #
 # `$GIT_DIR/info/grafts` rewrites parentage and **survives

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -202,8 +202,10 @@ roborev pass actually ran on. Three mechanical rules keep the merge honest:
   plus `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM=/dev/null` and an explicit empty `--template=`. The reads
   are bounded by the runner the advisory already resolves, but **only the external commands** (git and
   `mktemp -d`) — the token names both halves,
-  `anchor-reads: bounded-<n>s+<g>s(external:git,mktemp;UNBOUNDED:cd/test-builtins)`, since `cd`/`pwd -P`
-  and an object-dir `[ -d … ]` probe are shell builtins no runner can signal;
+  `anchor-reads: bounded-<n>s+<g>s(external:git,mktemp,sh,rm;UNBOUNDED:command-v+pwd-builtins)`, and an
+  **anchor-path operation audit** in the script header records for EVERY operation whether it is bounded
+  and whether its target is validated (the `workspace-test-disposition.txt` idiom), with the two
+  deliberate gaps — `command -v` PATH lookups and one `$(pwd)` diagnostic — declared;
   **where none exists the check REFUSES** (`ANCHOR-UNVERIFIABLE` + a one-command remedy). That reverses
   the first ruling — "a hang is only a liveness failure, so run unbounded and declare it" — because **a
   hang in this guard blocks the merge anyway**: the real comparison is hang-forever-with-no-diagnosis vs

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -194,9 +194,17 @@ roborev pass actually ran on. Three mechanical rules keep the merge honest:
   object storage, no config, hence no grafts, no replace refs, no promisor — and a scratch that cannot
   be built is UNVERIFIABLE, never a fall-back to the live repository. `--is-shallow-repository` still
   reads the LANE on purpose (a fresh scratch is never shallow, so probing it there would turn the
-  shallow guard into a vacuous pass). No env override (#3312); the pins stay as belt. Residual: it
-  proves ancestry **in the local object store only** — not that the anchor is on the PR as GitHub sees
-  it.
+  shallow guard into a vacuous pass). **And the scratch's environment is load-bearing where a lane
+  read's is not** (job 358): a variable there does not bend the object, it bends WHICH REPOSITORY
+  ANSWERS — measured, `GIT_DIR` overrides `-C`, and `GIT_TEMPLATE_DIR`/`--template=` seed a planted
+  `info/grafts` into the new repository. So every git call, the lane discovery reads included, runs under
+  `env -i` + an allowlist admitting only `PATH` and `TMPDIR` (no network here, so no `HOME`/`SSH_*`/proxy)
+  plus `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM=/dev/null` and an explicit empty `--template=`. The reads
+  are bounded by the runner the advisory already resolves; where none exists they run unbounded and the
+  evidence line affirms it (`anchor-reads: bounded-…` / `UNBOUNDED(…)`) rather than refusing — a hang is
+  a liveness failure yielding no verdict, and refusing a box with no `timeout` would red correct input.
+  Residual: it proves ancestry **in the local object store only** — not that the anchor is on the PR as
+  GitHub sees it.
   **And what `PREMERGE: OK` does NOT prove (#3650), which the success path states itself on a
   `PREMERGE: SCOPE` line:** it proves the diff is unchanged since certification and that a full gate
   PASSed on THAT EXACT TREE — not that the change was certified against the `main` it will join. A

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -185,10 +185,18 @@ roborev pass actually ran on. Three mechanical rules keep the merge honest:
   either object absent, shallow or shallowness unknown, `--is-ancestor` exiting ≥ 2 — is exit 3 under
   its own `PREMERGE: ANCHOR-UNVERIFIABLE` marker, each cause carrying its own remedy, because an
   unmeasurable result is UNKNOWN and "fix the box" is a different operator action from "your chain is
-  wrong". The reads run against the CURRENT DIRECTORY's repository with no env override (#3312), under
-  `GIT_NO_LAZY_FETCH=1` + `GIT_NO_REPLACE_OBJECTS=1` + `--no-replace-objects`. Residual: it proves
-  ancestry **in the local repository only** — not that the anchor is on the PR as GitHub sees it — and
-  a manipulated local object store is invoker-class and out of model.
+  wrong". **The walk does not run in the lane** (roborev job 355): `$GIT_DIR/info/grafts` rewrites
+  parentage and SURVIVES `--no-replace-objects` (#3544 job 285's measurement, re-measured for this
+  check), so a graft alone manufactures `BOUND` — and grafts live in the COMMON git dir every lane on
+  this fleet shares, so the planter is a PEER LANE as well as an accident. As in `agent-gate.sh`'s
+  component-set pre-flight, the ruling is to MOVE the walk: the object reads and `merge-base` run in a
+  throwaway `git init` scratch whose only view of the lane is `GIT_ALTERNATE_OBJECT_DIRECTORIES` — pure
+  object storage, no config, hence no grafts, no replace refs, no promisor — and a scratch that cannot
+  be built is UNVERIFIABLE, never a fall-back to the live repository. `--is-shallow-repository` still
+  reads the LANE on purpose (a fresh scratch is never shallow, so probing it there would turn the
+  shallow guard into a vacuous pass). No env override (#3312); the pins stay as belt. Residual: it
+  proves ancestry **in the local object store only** — not that the anchor is on the PR as GitHub sees
+  it.
   **And what `PREMERGE: OK` does NOT prove (#3650), which the success path states itself on a
   `PREMERGE: SCOPE` line:** it proves the diff is unchanged since certification and that a full gate
   PASSed on THAT EXACT TREE — not that the change was certified against the `main` it will join. A

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -200,9 +200,13 @@ roborev pass actually ran on. Three mechanical rules keep the merge honest:
   `info/grafts` into the new repository. So every git call, the lane discovery reads included, runs under
   `env -i` + an allowlist admitting only `PATH` and `TMPDIR` (no network here, so no `HOME`/`SSH_*`/proxy)
   plus `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM=/dev/null` and an explicit empty `--template=`. The reads
-  are bounded by the runner the advisory already resolves; where none exists they run unbounded and the
-  evidence line affirms it (`anchor-reads: bounded-…` / `UNBOUNDED(…)`) rather than refusing — a hang is
-  a liveness failure yielding no verdict, and refusing a box with no `timeout` would red correct input.
+  are bounded by the runner the advisory already resolves, recorded as `anchor-reads: bounded-<n>s+<g>s`;
+  **where none exists the check REFUSES** (`ANCHOR-UNVERIFIABLE` + a one-command remedy). That reverses
+  the first ruling — "a hang is only a liveness failure, so run unbounded and declare it" — because **a
+  hang in this guard blocks the merge anyway**: the real comparison is hang-forever-with-no-diagnosis vs
+  refuse-now-with-a-cause, which have the same outcome for the merge while the refusal adds a diagnosis.
+  Hand-rolling a portable bounded runner is ruled out: it is new process-lifetime code, and that family
+  already produced three defects in this change's own test scaffolding.
   The **commit-graph is disabled** on those reads (job 361) — it is reachable through the alternate, is
   not content-addressed, and git trusts its parent edges; measured, a forged graph changes
   `rev-list --parents`, but on git 2.43.0 it did not change `merge-base --is-ancestor`, so the flag ships

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -200,7 +200,10 @@ roborev pass actually ran on. Three mechanical rules keep the merge honest:
   `info/grafts` into the new repository. So every git call, the lane discovery reads included, runs under
   `env -i` + an allowlist admitting only `PATH` and `TMPDIR` (no network here, so no `HOME`/`SSH_*`/proxy)
   plus `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM=/dev/null` and an explicit empty `--template=`. The reads
-  are bounded by the runner the advisory already resolves, recorded as `anchor-reads: bounded-<n>s+<g>s`;
+  are bounded by the runner the advisory already resolves, but **only the external commands** (git and
+  `mktemp -d`) — the token names both halves,
+  `anchor-reads: bounded-<n>s+<g>s(external:git,mktemp;UNBOUNDED:cd/test-builtins)`, since `cd`/`pwd -P`
+  and an object-dir `[ -d … ]` probe are shell builtins no runner can signal;
   **where none exists the check REFUSES** (`ANCHOR-UNVERIFIABLE` + a one-command remedy). That reverses
   the first ruling — "a hang is only a liveness failure, so run unbounded and declare it" — because **a
   hang in this guard blocks the merge anyway**: the real comparison is hang-forever-with-no-diagnosis vs

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -169,6 +169,26 @@ roborev pass actually ran on. Three mechanical rules keep the merge honest:
   naming exactly that anchor (an `(UNRESOLVED)` anchor refuses), and its OWN `commit:`/`tree-start:`
   at the certified sha. A block carrying `nested-under:` (#2874) is refused in either shape: a nested
   sub-gate runs at the SAME tree, so the sha binding provably cannot distinguish it.
+  **In Case B the anchor must ALSO be on the certified sha's history (#3653).** Everything above only
+  proves the two blocks AGREE about a sha — never that the sha is on THIS PR. The anchor's identity
+  rested on the delta run's SELF-DECLARED `delta-anchor:` line, so any full-gate PASS plus a delta
+  naming it satisfied the chain: the #3616 cross-lane class surviving in the one path Case A's sha
+  binding does not cover. (The accident route was narrowed by `agent-gate.sh --delta`'s own
+  fail-closed diff classification — i.e. by ANOTHER script, which is not a constraint stated where
+  this guard is read.) So the script runs `git merge-base --is-ancestor <anchor> <certified>`, and the
+  verdict is **three-valued**, because `--is-ancestor`'s rc 1 is itself three-valued (#3544: in a
+  shallow clone it also means "the connecting history is absent", so rc 1 is a verdict only in a
+  repository proven complete). **BOUND** (rc 0) proceeds and is RECORDED as `anchor-ancestry: BOUND`
+  on the `PREMERGE: DELTA-RECERT` line — a silent pass is indistinguishable from a check that never
+  ran. **NOT-ANCESTOR** (rc 1, both objects present, `git rev-parse --is-shallow-repository` =
+  `false`) is exit 2, naming both shas. Everything **UNMEASURABLE** — no git, not inside a work tree,
+  either object absent, shallow or shallowness unknown, `--is-ancestor` exiting ≥ 2 — is exit 3 under
+  its own `PREMERGE: ANCHOR-UNVERIFIABLE` marker, each cause carrying its own remedy, because an
+  unmeasurable result is UNKNOWN and "fix the box" is a different operator action from "your chain is
+  wrong". The reads run against the CURRENT DIRECTORY's repository with no env override (#3312), under
+  `GIT_NO_LAZY_FETCH=1` + `GIT_NO_REPLACE_OBJECTS=1` + `--no-replace-objects`. Residual: it proves
+  ancestry **in the local repository only** — not that the anchor is on the PR as GitHub sees it — and
+  a manipulated local object store is invoker-class and out of model.
   **And what `PREMERGE: OK` does NOT prove (#3650), which the success path states itself on a
   `PREMERGE: SCOPE` line:** it proves the diff is unchanged since certification and that a full gate
   PASSed on THAT EXACT TREE — not that the change was certified against the `main` it will join. A

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -203,8 +203,19 @@ roborev pass actually ran on. Three mechanical rules keep the merge honest:
   are bounded by the runner the advisory already resolves; where none exists they run unbounded and the
   evidence line affirms it (`anchor-reads: bounded-…` / `UNBOUNDED(…)`) rather than refusing — a hang is
   a liveness failure yielding no verdict, and refusing a box with no `timeout` would red correct input.
-  Residual: it proves ancestry **in the local object store only** — not that the anchor is on the PR as
-  GitHub sees it.
+  The **commit-graph is disabled** on those reads (job 361) — it is reachable through the alternate, is
+  not content-addressed, and git trusts its parent edges; measured, a forged graph changes
+  `rev-list --parents`, but on git 2.43.0 it did not change `merge-base --is-ancestor`, so the flag ships
+  as defence in depth and is pinned structurally. `core.multiPackIndex` and reachability bitmaps were
+  measured as not consulted and left alone, because widening past a measurement is guessing.
+  **And there the enumeration STOPS and the boundary is DECLARED** (#3746 / job 311's precedent, after
+  three rounds produced three routes into one mechanism — #3544 job 264's "one axis closed, space
+  declared done" shape): every Case B success line ends with one constant, `ancestry over this box's
+  SHARED object store: objects+metadata TRUSTED, not verified (#3746)`. The binding proves ancestry over
+  the objects and metadata this box's shared store presents, isolated with a positive control from
+  grafts, replace refs, an inherited `GIT_DIR`, an ambient template and the commit-graph; it does NOT
+  prove the anchor is on the PR as GitHub sees it, nor anything against a peer that can WRITE that store.
+  A fifth route is a residual under the declaration, not a false claim.
   **And what `PREMERGE: OK` does NOT prove (#3650), which the success path states itself on a
   `PREMERGE: SCOPE` line:** it proves the diff is unchanged since certification and that a full gate
   PASSed on THAT EXACT TREE — not that the change was certified against the `main` it will join. A

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -222,7 +222,12 @@ roborev pass actually ran on. Three mechanical rules keep the merge honest:
   **And there the enumeration STOPS and the boundary is DECLARED** (#3746 / job 311's precedent, after
   three rounds produced three routes into one mechanism — #3544 job 264's "one axis closed, space
   declared done" shape): every Case B success line ends with one constant, `ancestry over this box's
-  SHARED object store: objects+metadata TRUSTED, not verified (#3746)`. The binding proves ancestry over
+  SHARED object store and SCRATCH namespace: objects, metadata and scratch TRUSTED, not verified (#3746)
+  — closes accident/drift, NOT a same-UID peer`. **Terminus (job 390):** every lane runs as the same user,
+  so a peer can write our scratch as well as the object store — planting a graft there between `git init`
+  and the walk reproduces the very attack the scratch exists to stop — and no permission boundary is
+  available, so the claim is narrowed and the hazard assigned to #3746. A later same-UID-peer instance is
+  that declared boundary, not a new defect. The binding proves ancestry over
   the objects and metadata this box's shared store presents, isolated with a positive control from
   grafts, replace refs, an inherited `GIT_DIR`, an ambient template and the commit-graph; it does NOT
   prove the anchor is on the PR as GitHub sees it, nor anything against a peer that can WRITE that store.

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -202,7 +202,9 @@ roborev pass actually ran on. Three mechanical rules keep the merge honest:
   plus `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM=/dev/null` and an explicit empty `--template=`. The reads
   are bounded by the runner the advisory already resolves, but **only the external commands** (git and
   `mktemp -d`) — the token names both halves,
-  `anchor-reads: bounded-<n>s+<g>s(external:git,mktemp,sh,rm;UNBOUNDED:command-v+pwd-builtins)`, and an
+  `anchor-reads: bounded-<n>s+<g>s(external:git,mktemp,sh;UNBOUNDED:command-v+pwd-builtins)`; the scratch
+  dir is deliberately **not deleted** and left for the OS to reap, because a race-free delete needs
+  `openat`/`unlinkat` and all lanes run as one user; and an
   **anchor-path operation audit** in the script header records for EVERY operation whether it is bounded
   and whether its target is validated (the `workspace-test-disposition.txt` idiom), with the two
   deliberate gaps — `command -v` PATH lookups and one `$(pwd)` diagnostic — declared;

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -132,7 +132,10 @@ carry).
   `GIT_TEMPLATE_DIR`/`--template=` seed a planted `info/grafts` into the new repository — so every git
   call, discovery reads included, runs under `env -i` + an allowlist (`PATH`, `TMPDIR`, then
   `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM=/dev/null`) with an explicit empty `--template=`. The reads are
-  bounded by the advisory's own runner, recorded affirmatively as `anchor-reads: bounded-<n>s+<g>s` — and
+  bounded by the advisory's own runner — **the EXTERNAL commands only** (git and `mktemp -d`), recorded as
+  `anchor-reads: bounded-<n>s+<g>s(external:git,mktemp;UNBOUNDED:cd/test-builtins)`, because `cd`/`pwd -P`
+  and one `[ -d … ]` probe are shell builtins a runner cannot signal and a bare `bounded-…` would
+  overclaim — and
   with **no `timeout`/`gtimeout` supporting `--kill-after` the check REFUSES**, naming a one-command
   remedy. That reverses an earlier ruling ("run unbounded, declare it, never refuse"): a hang in this
   guard blocks the merge anyway, so the choice is *hang silently* vs *refuse with a cause*, and the

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -134,8 +134,18 @@ carry).
   `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM=/dev/null`) with an explicit empty `--template=`. The reads are
   bounded by the advisory's own runner; with no `timeout`/`gtimeout` they run unbounded and the evidence
   line affirms it (`anchor-reads: bounded-…` / `UNBOUNDED(…)`) instead of refusing, because a hang yields
-  no verdict rather than a false pass. Residual, stated: it proves ancestry **in the local object store
-  only** — not that the anchor is on the PR as GitHub sees it.
+  no verdict rather than a false pass. The **commit-graph is disabled** on those reads
+  (`-c core.commitGraph=false`, job 361): it reaches the scratch through the alternate, is not
+  content-addressed, and git trusts its parent edges — measured, a forged graph changes what
+  `rev-list --parents` reports, though on git 2.43.0 it did NOT change `merge-base --is-ancestor`, so the
+  flag is defence in depth pinned structurally. `core.multiPackIndex` and reachability bitmaps were
+  measured as not consulted for this call and deliberately left alone.
+  **Then the boundary is DECLARED, not enumerated again** (the #3746 / job-311 precedent, after three
+  rounds found three routes into one mechanism): every Case B success line carries one constant —
+  `ancestry over this box's SHARED object store: objects+metadata TRUSTED, not verified (#3746)`. It
+  proves ancestry over what this box's shared store presents; it does NOT prove the anchor is on the PR
+  as GitHub sees it, nor anything against a peer that can WRITE that store. A further route in the family
+  is a residual under that declaration rather than a false claim here.
   **What a `PREMERGE: OK` does NOT prove (#3650), printed on the success path as `PREMERGE: SCOPE`.**
   It proves the diff is unchanged since certification and that a full gate PASSed on THAT EXACT TREE.
   It does not prove the change was certified against the `main` it will join: a squash-merge composes

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -151,7 +151,12 @@ carry).
   measured as not consulted for this call and deliberately left alone.
   **Then the boundary is DECLARED, not enumerated again** (the #3746 / job-311 precedent, after three
   rounds found three routes into one mechanism): every Case B success line carries one constant —
-  `ancestry over this box's SHARED object store: objects+metadata TRUSTED, not verified (#3746)`. It
+  `ancestry over this box's SHARED object store and SCRATCH namespace: objects, metadata and scratch
+  TRUSTED, not verified (#3746) — closes accident/drift, NOT a same-UID peer`. **That is the terminus of
+  the hardening line (job 390):** all lanes run as one user, so a peer can write the scratch as well as the
+  object store (it can plant a graft in the scratch between `git init` and the walk), no permission
+  boundary exists, so the claim is narrowed and the hazard assigned to #3746. A later same-UID-peer
+  instance is that declared boundary, not a new defect. It
   proves ancestry over what this box's shared store presents; it does NOT prove the anchor is on the PR
   as GitHub sees it, nor anything against a peer that can WRITE that store. A further route in the family
   is a residual under that declaration rather than a false claim here.

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -106,6 +106,24 @@ carry).
   `delta-anchor:` naming exactly that anchor — an `(UNRESOLVED)` anchor refuses — and its own
   `commit:`/`tree-start:` at the certified sha. The chain is closed end to end; a delta block ALONE
   is still the #3408 escape and still refused.
+  **And since #3653 the anchor must be ON THE CERTIFIED SHA'S HISTORY.** Everything above proves the
+  two blocks AGREE about a sha, never that the sha belongs to THIS PR: Case B's anchor identity rested
+  on the delta run's SELF-DECLARED `delta-anchor:` line, so any full-gate PASS plus a delta naming it
+  satisfied the chain — the #3616 cross-lane class surviving in the one path Case A's sha binding does
+  not cover. `git merge-base --is-ancestor <anchor> <certified>` closes it offline, and the verdict is
+  **three-valued** because `--is-ancestor`'s rc 1 is itself three-valued (#3544: in a shallow clone it
+  also means "the connecting history is absent"). **BOUND** (rc 0) proceeds and is recorded
+  affirmatively as `anchor-ancestry: BOUND` on the `PREMERGE: DELTA-RECERT` line — a silent pass is
+  indistinguishable from a check that never ran. **NOT-ANCESTOR** (rc 1, both objects present, the
+  repository proven complete via `git rev-parse --is-shallow-repository` = `false`) is exit 2, naming
+  both shas. Everything **UNMEASURABLE** — no git, not inside a work tree, either object absent,
+  shallow or shallowness unknown, `--is-ancestor` exiting ≥ 2 — is exit 3 under its own
+  `PREMERGE: ANCHOR-UNVERIFIABLE` marker with a per-cause remedy, because an unmeasurable result is
+  UNKNOWN and "fix the box" is a different operator action from "your chain is wrong". The reads run
+  against the CURRENT DIRECTORY's repository with no env override (#3312), under
+  `GIT_NO_LAZY_FETCH=1` + `GIT_NO_REPLACE_OBJECTS=1` + `--no-replace-objects`. Residual, stated: it
+  proves ancestry **in the local repository only** — not that the anchor is on the PR as GitHub sees
+  it, and a manipulated local object store is invoker-class and out of model.
   **What a `PREMERGE: OK` does NOT prove (#3650), printed on the success path as `PREMERGE: SCOPE`.**
   It proves the diff is unchanged since certification and that a full gate PASSed on THAT EXACT TREE.
   It does not prove the change was certified against the `main` it will join: a squash-merge composes

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -132,9 +132,11 @@ carry).
   `GIT_TEMPLATE_DIR`/`--template=` seed a planted `info/grafts` into the new repository — so every git
   call, discovery reads included, runs under `env -i` + an allowlist (`PATH`, `TMPDIR`, then
   `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM=/dev/null`) with an explicit empty `--template=`. The reads are
-  bounded by the advisory's own runner; with no `timeout`/`gtimeout` they run unbounded and the evidence
-  line affirms it (`anchor-reads: bounded-…` / `UNBOUNDED(…)`) instead of refusing, because a hang yields
-  no verdict rather than a false pass. The **commit-graph is disabled** on those reads
+  bounded by the advisory's own runner, recorded affirmatively as `anchor-reads: bounded-<n>s+<g>s` — and
+  with **no `timeout`/`gtimeout` supporting `--kill-after` the check REFUSES**, naming a one-command
+  remedy. That reverses an earlier ruling ("run unbounded, declare it, never refuse"): a hang in this
+  guard blocks the merge anyway, so the choice is *hang silently* vs *refuse with a cause*, and the
+  refusal strictly dominates. Hand-rolling a portable runner is ruled out as new process-lifetime code. The **commit-graph is disabled** on those reads
   (`-c core.commitGraph=false`, job 361): it reaches the scratch through the alternate, is not
   content-addressed, and git trusts its parent edges — measured, a forged graph changes what
   `rev-list --parents` reports, though on git 2.43.0 it did NOT change `merge-base --is-ancestor`, so the

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -133,9 +133,11 @@ carry).
   call, discovery reads included, runs under `env -i` + an allowlist (`PATH`, `TMPDIR`, then
   `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM=/dev/null`) with an explicit empty `--template=`. The reads are
   bounded by the advisory's own runner — **the EXTERNAL commands only** (git and `mktemp -d`), recorded as
-  `anchor-reads: bounded-<n>s+<g>s(external:git,mktemp;UNBOUNDED:cd/test-builtins)`, because `cd`/`pwd -P`
-  and one `[ -d … ]` probe are shell builtins a runner cannot signal and a bare `bounded-…` would
-  overclaim — and
+  `anchor-reads: bounded-<n>s+<g>s(external:git,mktemp,sh,rm;UNBOUNDED:command-v+pwd-builtins)`. An
+  **anchor-path operation audit** in the script header records, per operation, whether it is bounded and
+  whether its target is validated — added because seven findings here were those two questions asked of
+  different operations one round at a time. What remains unbounded is `command -v` and one `$(pwd)`
+  diagnostic, both builtins over local state — and
   with **no `timeout`/`gtimeout` supporting `--kill-after` the check REFUSES**, naming a one-command
   remedy. That reverses an earlier ruling ("run unbounded, declare it, never refuse"): a hang in this
   guard blocks the merge anyway, so the choice is *hang silently* vs *refuse with a cause*, and the

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -128,8 +128,14 @@ carry).
   config, hence no grafts, no replace refs, no promisor), and failing to build it is UNVERIFIABLE,
   never a fall-back to the live repository. `--is-shallow-repository` deliberately still reads the
   LANE: a fresh scratch is never shallow, so probing it there would make the shallow guard a vacuous
-  pass. No env override (#3312); the pins remain as belt. Residual, stated: it proves ancestry **in the
-  local object store only** — not that the anchor is on the PR as GitHub sees it.
+  pass. **The scratch's environment is load-bearing** (job 358) — measured, `GIT_DIR` overrides `-C`, and
+  `GIT_TEMPLATE_DIR`/`--template=` seed a planted `info/grafts` into the new repository — so every git
+  call, discovery reads included, runs under `env -i` + an allowlist (`PATH`, `TMPDIR`, then
+  `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM=/dev/null`) with an explicit empty `--template=`. The reads are
+  bounded by the advisory's own runner; with no `timeout`/`gtimeout` they run unbounded and the evidence
+  line affirms it (`anchor-reads: bounded-…` / `UNBOUNDED(…)`) instead of refusing, because a hang yields
+  no verdict rather than a false pass. Residual, stated: it proves ancestry **in the local object store
+  only** — not that the anchor is on the PR as GitHub sees it.
   **What a `PREMERGE: OK` does NOT prove (#3650), printed on the success path as `PREMERGE: SCOPE`.**
   It proves the diff is unchanged since certification and that a full gate PASSed on THAT EXACT TREE.
   It does not prove the change was certified against the `main` it will join: a squash-merge composes

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -133,7 +133,9 @@ carry).
   call, discovery reads included, runs under `env -i` + an allowlist (`PATH`, `TMPDIR`, then
   `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM=/dev/null`) with an explicit empty `--template=`. The reads are
   bounded by the advisory's own runner — **the EXTERNAL commands only** (git and `mktemp -d`), recorded as
-  `anchor-reads: bounded-<n>s+<g>s(external:git,mktemp,sh,rm;UNBOUNDED:command-v+pwd-builtins)`. An
+  `anchor-reads: bounded-<n>s+<g>s(external:git,mktemp,sh;UNBOUNDED:command-v+pwd-builtins)`. The scratch
+  dir is deliberately **not deleted** (a race-free delete needs `openat`/`unlinkat`, absent in shell, and
+  all lanes run as one user), so it is left for the OS to reap. An
   **anchor-path operation audit** in the script header records, per operation, whether it is bounded and
   whether its target is validated — added because seven findings here were those two questions asked of
   different operations one round at a time. What remains unbounded is `command -v` and one `$(pwd)`

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -119,11 +119,17 @@ carry).
   both shas. Everything **UNMEASURABLE** — no git, not inside a work tree, either object absent,
   shallow or shallowness unknown, `--is-ancestor` exiting ≥ 2 — is exit 3 under its own
   `PREMERGE: ANCHOR-UNVERIFIABLE` marker with a per-cause remedy, because an unmeasurable result is
-  UNKNOWN and "fix the box" is a different operator action from "your chain is wrong". The reads run
-  against the CURRENT DIRECTORY's repository with no env override (#3312), under
-  `GIT_NO_LAZY_FETCH=1` + `GIT_NO_REPLACE_OBJECTS=1` + `--no-replace-objects`. Residual, stated: it
-  proves ancestry **in the local repository only** — not that the anchor is on the PR as GitHub sees
-  it, and a manipulated local object store is invoker-class and out of model.
+  UNKNOWN and "fix the box" is a different operator action from "your chain is wrong". **The walk does
+  not run in the lane** (roborev job 355): `$GIT_DIR/info/grafts` rewrites parentage and SURVIVES
+  `--no-replace-objects` (#3544 job 285's measurement, re-measured here), so a graft alone manufactures
+  `BOUND` — and on this fleet grafts live in the COMMON git dir every lane shares, so the planter is a
+  peer lane as well as an accident. The reads and the walk therefore run in a throwaway `git init`
+  scratch whose only view of the lane is `GIT_ALTERNATE_OBJECT_DIRECTORIES` (pure object storage: no
+  config, hence no grafts, no replace refs, no promisor), and failing to build it is UNVERIFIABLE,
+  never a fall-back to the live repository. `--is-shallow-repository` deliberately still reads the
+  LANE: a fresh scratch is never shallow, so probing it there would make the shallow guard a vacuous
+  pass. No env override (#3312); the pins remain as belt. Residual, stated: it proves ancestry **in the
+  local object store only** — not that the anchor is on the PR as GitHub sees it.
   **What a `PREMERGE: OK` does NOT prove (#3650), printed on the success path as `PREMERGE: SCOPE`.**
   It proves the diff is unchanged since certification and that a full gate PASSed on THAT EXACT TREE.
   It does not prove the change was certified against the `main` it will join: a squash-merge composes


### PR DESCRIPTION
Closes #3653.

Case B of `premerge-assert.sh` (the #1892 anchored-delta route) accepted any full-gate PASS plus a delta naming it: the anchor's identity rested entirely on the delta run's **self-declared** `delta-anchor:` line. That is the #3616 cross-lane class surviving in the one path Case A's sha binding does not cover.

## What lands

**AC1 — the anchor is bound to the certified sha's history, fail-closed and three-valued.** `git merge-base --is-ancestor <anchor> <certified>`, because rc 1 is itself three-valued (#3544: in a shallow clone it also means the connecting history is absent):

| outcome | verdict |
|---|---|
| rc 0 | `anchor-ancestry: BOUND`, recorded affirmatively on the `DELTA-RECERT` line |
| rc 1, repo proven complete, both objects present | **exit 2** — the anchor is not on this PR's history |
| git absent / not a work tree / object absent / shallow-or-unknown / rc >= 2 / timeout | **exit 3**, `PREMERGE: ANCHOR-UNVERIFIABLE`, each cause with its own remedy |

Exit 3 is deliberate and distinct: "this box could not measure it" is a different operator action from "your chain is wrong". Fail-closed does not red on correct input — `agent-gate.sh --delta` resolves the anchor with `git rev-parse --verify` in the same checkout, so a sanctioned Case B call always lands on BOUND.

**AC2 — the red arm reds if the check is removed.** Accept and refuse arms differ in exactly one property (asserted: substituting the foreign sha reproduces the accepted files byte-for-byte), plus a mutation arm that verifies exactly one call site exists, that neutering applied, and that the foreign anchor then reaches exit 0.

**AC3** — residual 2 corrected: #3408's escape was accident/drift, which the triage rule puts squarely *in* the model. Now reads "this guard cannot make itself invoked; the documents that route workers here are the control."

**AC4** — `flow-lead.md` carries both call shapes.

Doctrine updated in the same change: CLAUDE.md, `gate-contract.md`, `delivery-pipeline.md`.

## Hardening, and the boundary it stops at

Sixteen roborev rounds, every one returning a real Medium or High. The walk runs in an isolated scratch repository (grafts survive `--no-replace-objects` — measured `no -> YES -> YES`, reproducing #3544 job 285), under `env -i` + an allowlist with the config files neutralised, with `core.commitGraph` disabled, all reads bounded, and every operation recorded in a committed **anchor-path audit table** (`bounded?` / `target validated?`, two declared `NONE` gaps with reasons) — a maintenance obligation in the idiom of `workspace-test-disposition.txt`.

**The declared terminus:** this closes **accident and drift**. It is explicitly **not** a boundary against a hostile **same-UID peer**, who can write into the scratch just as into the shared object store — no permission boundary exists on this fleet. That hazard is named in the header and assigned to **#3746**, which already owns "lanes share an object store".

Positive controls, each proving the attack executes on this host before proving the guard refuses it: graft, inherited `GIT_DIR`, `GIT_TEMPLATE_DIR`-seeded graft, forged commit-graph. The commit-graph **exploit** arm is a declared not-taken — the mechanism control fired (`rev-list` takes the forged edge) but `merge-base --is-ancestor` does not on git 2.43.0, so the flag ships as defence in depth and the control is pinned structurally.

## Tests

`scripts/tests/test_premerge_assert.sh`: **204 -> 302 passing, 0 failing** (`tooling-tests`). Verified alone and **two suites concurrently**, zero strays, zero leftover scratch dirs.

One defect found by concurrent execution rather than review: the leak sentinel was a fixed string and its cleanup killed box-wide on it, so two runs of this suite would red each other **and SIGKILL each other's processes** — in every full gate, on boxes permitting 3 concurrent gates. Reproduced (293/1 concurrent vs 294/0 alone), fixed by deriving the sentinel from the run's pid, structurally pinned.

## Residuals

Batched into **#3933**: the runner's reap property is asserted by nothing (the leak adjudication was removed after six findings, three of them the same fail-open `ps` read), and Case B leaves one object-less scratch dir per invocation (the unsafe `rm -rf` was removed rather than narrowed — no descriptor-relative delete exists in shell).

`shellcheck` is not installed on this fleet and no gate component runs it; `bash -n` passes.
