### PR TITLE
fix(#3749): sweep the shared object store for accidental corruption (fsck at bootstrap + a throttled supervisor hook), and declare the fast path's trust boundary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -337,6 +337,10 @@ trino-connector/docker/field-repro-artifacts/
 # repo, and leaving them untracked stamps `dirty: yes` on the certification block.
 .review-*.md
 .followup-*.md
+# Same class, fourth instance (#3749): an implementer's hand-off report to the lead.
+# Written as the LAST action of a fix round and read by a human, never shipped — and an
+# untracked-but-not-ignored file stamps `dirty: yes` on the next certification block.
+.fix-report.md
 # Same class, third instance (#3414 gate #7 prep): a stage-C intent audit's verdict file. A
 # spec-auditor writes it MID-RUN, and an untracked-but-not-ignored write while the gate of
 # record is running is `tree-integrity: FAIL (tree-mutated-midrun)` — which is exactly how

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -596,6 +596,39 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   `obj_sweep_stop_if_latched` helper called before the throttled, `VERIFIED` and `UNMEASURED`
   returns alike — one rule ("no such return without a fresh latch read") instead of a set of paths
   someone must remember to audit.
+  **AND ORDERING WAS NOT ENOUGH: THE STAMP IS WRITTEN ONLY IF THE LATCH IS CONFIRMED PRESENT,
+  ELSE IT IS FORCED STALE (round 9, item 1).** "Latch first, stamp second" left the stamp
+  UNCONDITIONAL, so on the one branch where the latch could not be PERSISTED — a writable stamp
+  inside a directory that is not writable, so creating `<stamp>.CORRUPT` fails while rewriting
+  `<stamp>` succeeds — the detecting lane stopped (correct) and still advertised a freshly swept box
+  (not correct): its peers read the fresh stamp, skipped their own sweep for the whole interval, and
+  kept working against a store already confirmed damaged. Round 1's harm, surviving in the one branch
+  that never got round 1's treatment, under a round-2 note ("journalled, and this lane still stops")
+  that was true and said nothing about the peers. The stamp write is now GATED on
+  `obj_sweep_latch_present` — the AFTERWARDS-EXISTENCE check, never the create's exit status, which
+  cannot tell "a peer got there first" from "the directory is unwritable" — and where the latch is
+  missing the stamp is FORCED to epoch `0` rather than merely left alone, because a peer whose sweep
+  started earlier can finish DURING this one and write a fresh timestamp. Forcing can only ever cause
+  MORE sweeping, so it cannot manufacture a false clean; a repeated sweep per lane is the correct
+  price for a verdict with nowhere durable to live, and six hours of silence is not.
+  **AND THE PRINTED REMEDY HAS TO WORK, WHICH IT DID NOT (round 9, item 2).** All three copies of the
+  repair instruction said `git fetch --force origin`, which repairs NOTHING: `--force` only permits
+  non-fast-forward REF updates and re-downloads no objects at all, so with the advertised tips
+  unchanged the negotiation can transfer nothing — an operator following it exactly kept the
+  corruption AND gained the impression of a repair, this repo's false-rationale class landing on the
+  one text a human gets at the moment the box has stopped. MEASURED on git 2.43.0 against planted
+  damage, by the sweep's own verdict: `--force` leaves a corrupt loose object, a flipped pack byte
+  and a missing object exactly as they were; `git fetch --refetch origin` (git 2.36+) restores a
+  MISSING object but NOT damaged content, because the damaged bytes stay in the object directory
+  where fsck still finds them — so content damage needs the pack/loose object DELETED first, and then
+  `--refetch` verifies clean. A fresh clone works, **but only from the canonical remote over the
+  network**: `git clone <local path>` HARDLINKS the object files, so a clone of the damaged
+  repository is damaged too (measured). Two rules follow. The sweep OWNS the text — it knows the
+  damage class and the measurements live beside it — and both consumers QUOTE its `verdict-detail`
+  lines rather than paraphrasing (the #3369 ruling this file already carries; three paraphrases is
+  three places to correct and one of them will be missed), with a fail-closed fallback so a stopped
+  box is never left with no remedy. And clearing the latch is gated on a RE-RUN of the sweep
+  reporting its affirmative verdict: "I think I fixed it" is not an exit condition.
   **THAT RULE WAS STILL A SET OF SITES, AND ROUND 5 FOUND THE FOURTH — SO THE READ IS NOW AT
   ENTRY, ABOVE EVERY BRANCH (round 5, item 1).** The documented opt-out
   `OBJ_SWEEP_INTERVAL_HOURS=0` returned before ANY latch read, so switching the sweep off also

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -452,10 +452,11 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   defends against the party that controls the process. **ACCIDENTAL corruption IS in model**, and
   its control is a periodic full-rehash sweep: `scripts/check-object-store-integrity.sh` (full
   `git fsck`, never `--connectivity-only`, which does not rehash content), emitting an anchored
-  three-valued `VERIFIED`/`CORRUPT`/`UNMEASURED` verdict — run at machine onboarding
+  four-valued `VERIFIED`/`CORRUPT`/`UNSWEEPABLE`/`UNMEASURED` verdict — run at machine onboarding
   (`bootstrap-agent-machine.sh` section 5d, where VERIFIED is the ONLY `[ok]`) and on the
   worker supervisor's throttled per-iteration cadence (default 6h; `CORRUPT` **stops that
-  supervisor loudly** rather than holding, because corruption is non-self-clearing, while
+  supervisor loudly** rather than holding, because corruption is non-self-clearing, and so does
+  `UNSWEEPABLE` (round 10, below), while
   `UNMEASURED` is reported and deliberately does NOT stop the loop — refusing to run any worker
   **THE FATAL VERDICT IS AFFIRMATIVE, AND IT HAD TO BE MADE SO (#3749 review).** A `git fsck` over
   a store up to eight peer lanes are concurrently writing prints `error:` lines on a **healthy**
@@ -484,8 +485,12 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   structurally over the shipped call sites. Where the attribution itself fails (a third walk
   killed, unlaunchable or unclassifiable) the complaint is `UNATTRIBUTED` and non-passing, and a
   damage bit appearing ONLY in the third walk has not reproduced across the sweep walks: neither
-  is `CORRUPT` and neither is clean. The verdict set stays **closed at three** — the split is in
-  the CAUSE text, not in a fourth token two readers and a structural assert would have to learn.
+  is `CORRUPT` and neither is clean. That split stays in the CAUSE text rather than in a new token,
+  because both its outcomes CONTINUE the loop. **The rule generalises to DISPOSITION, not to a
+  count, and round 10 is where that mattered:** `UNSWEEPABLE` STOPS the box, and a token is what
+  every consumer keys its disposition on, so a state whose disposition differs from all existing
+  ones CANNOT be expressed as cause text — the verdict set is closed at **four**, and a fifth needs
+  a fifth disposition, not a fifth cause.
   **AND "THE ROOTS THE WALK HAS" WAS ITSELF AN UNCHECKED ASSUMPTION, WRONG IN BOTH DIRECTIONS
   (review round 7).** A review finding held that `--git-dir=<common>` discards linked worktrees'
   private administrative context, so a missing object needed only by a lane's private HEAD or index
@@ -537,7 +542,26 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   bits are tested INDEPENDENTLY, and FIRST**, before any completeness check on the rest of the
   status, and an unrelated bit can therefore never MASK damage — it only travels with it. Only a
   status at or above **124** (the timeout/shell conventions, and `die()`/signal deaths above them) is
-  refused bit-testing outright, and a status carrying a bit OUTSIDE the supported mask is
+  refused bit-testing outright — **and that range HAS TWO HALVES, WHICH SHARING ONE VERDICT MADE A
+  FALSE NEGATIVE ON REAL COMMIT-OBJECT CORRUPTION (round 10).** Measured on git 2.43.0: overwrite
+  the loose object a live ref points AT with unparseable bytes and fsck prints `fatal: loose object
+  <sha> … is corrupt` and exits **128**, while the same damage to a BLOB — or a VALID object stored
+  under the commit's name — exits 3 (`2|1`) and is caught. So the exact damage this control exists
+  for has a shape landing OUTSIDE the mask, where `unclassified` ⇒ `UNMEASURED` ⇒ the supervisor
+  writes a fresh throttle stamp and keeps spawning workers. **`124..127` is the timeout/exec
+  convention — the fsck NEVER RAN**, which is a fact about this box's tooling and stays permissive
+  (`unrunnable`); **`128`+ is git's own `die()` or a signal death — it RAN and did not finish**
+  (`fatal`), and reproduced on BOTH walks it is the STOPPING verdict `UNSWEEPABLE` (exit 6). The
+  boundary is argued from the exec chain, not assumed: `env`/`nice`/`timeout` each report their own
+  failures inside `125..127`, so a status at or above 128 is the innermost command having actually
+  started, which together with the `.started` marker below makes "fsck ran and died" an
+  AFFIRMATIVE observation rather than an absence. **`UNSWEEPABLE` CLAIMS NO CAUSE AND PRINTS NO
+  REPAIR** — the alternative was to read the `fatal:` text for a damage signature, i.e. round 1's
+  classifier again, narrower, and with every wording nobody enumerated falling back to the SAME
+  permissive state, so it would close only the cases somebody thought of. It tells the operator to
+  run the walk by hand and act on what the `fatal:` line names (that line is now kept in the
+  findings **for DISPLAY only** — it reaches no branch), and it makes a completed sweep the
+  condition for resuming. A status carrying a bit OUTSIDE the supported mask is
   `unclassified` rather than folded into a class whose remedy would be wrong. That is what makes it
   **degrade safely** as git adds bits: a new bit alongside damage is still damage, a new bit alone is
   non-passing, and widening `FSCK_KNOWN_MASK` is then a wording change rather than a correctness fix. **AND A STATUS IS ONLY A BITMASK IF THE COMMAND THAT PRODUCED IT ACTUALLY RAN
@@ -569,7 +593,12 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   `UNMEASURED` and **NAMED** (`INCONSISTENT sweep result`) rather than folded into the generic
   "could not measure" line. The `UNMEASURED` tests stay disjunctive on purpose: a disjunction that
   can only reach a NON-PASSING branch cannot manufacture a verdict. **The `CORRUPT` verdict is PERSISTED
-  for the box in its OWN CREATE-ONLY FILE** (`<stamp>.CORRUPT`), because a timestamp-only stamp let
+  for the box in its OWN CREATE-ONLY FILE** (`<stamp>.STOP`, which RECORDS WHICH stopping verdict it
+  is, read affirmatively — round 10 renamed it from `.CORRUPT`, because a file whose NAME asserts
+  damage is a confidently-wrong claim on disk for a verdict that establishes no cause, and every
+  message naming that path would have sent an operator to the re-clone remedy; an unrecognised
+  second line is a cause-free stop and is never defaulted to the damage text), because a
+  timestamp-only stamp let
   the detecting lane stop while its three peers saw a fresh stamp, skipped their own sweep for the
   whole interval and kept spawning workers over the damaged store. **PUTTING THE VERDICT IN THE
   THROTTLE STAMP WAS THE FIRST FIX FOR THAT AND WAS ITSELF A DEFECT (round 2):** stamp writes are
@@ -599,7 +628,7 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   **AND ORDERING WAS NOT ENOUGH: THE STAMP IS WRITTEN ONLY IF THE LATCH IS CONFIRMED PRESENT,
   ELSE IT IS FORCED STALE (round 9, item 1).** "Latch first, stamp second" left the stamp
   UNCONDITIONAL, so on the one branch where the latch could not be PERSISTED — a writable stamp
-  inside a directory that is not writable, so creating `<stamp>.CORRUPT` fails while rewriting
+  inside a directory that is not writable, so creating `<stamp>.STOP` fails while rewriting
   `<stamp>` succeeds — the detecting lane stopped (correct) and still advertised a freshly swept box
   (not correct): its peers read the fresh stamp, skipped their own sweep for the whole interval, and
   kept working against a store already confirmed damaged. Round 1's harm, surviving in the one branch
@@ -647,7 +676,14 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   **AND THE LATCH QUESTION IS FOUR-VALUED, BECAUSE A FILE PREDICATE IS NOT.** `[[ -e "$latch" ]]`
   is false both for an absent latch and for one the process cannot look at — CLAUDE.md's standing
   two-valued-predicate rule, landing on the single file whose job is to stop the box. `present` and
-  `absent` (an affirmative measurement: the directory was searchable, or does not exist) join
+  `absent` (an affirmative measurement: the absence was ESTABLISHED THROUGH SEARCHABLE ANCESTORS —
+  **`-d` on the holding directory is ITSELF two-valued and reading it as absence was the same trap
+  one level up (round 10, item 2): it is false both for a directory that does not exist and for one
+  whose ANCESTOR cannot be searched, so a latch under an inaccessible ancestor answered `absent`,
+  the permissive value, bypassing the fail-closed state built for exactly it.** The probe now walks
+  up to the deepest ancestor it can stat and counts the absence only if THAT one is searchable,
+  which is what makes it a measurement: with a searchable ancestor every stat below it gives a true
+  answer, by induction) join
   **`unknown`**, which STOPS under its own reason `object-store-latch-unreadable` — never as
   CORRUPT, since nothing observed damage and that remedy would send an operator to re-clone a
   healthy store — and **`unkeyed`**, the one permissive answer, announced once: no key means no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -789,23 +789,33 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   neither its claim nor its lock — for the claim a delay rather than a wedge, and adding signal
   handlers changes the LOCK's lifetime too (#3683's subject).
   **WHAT IS NOT CLOSED, PER PATH AND WITH ITS REAL MAGNITUDE — because a residual whose size is
-  understated is worse than one described honestly (round 12).** The earlier version of this text
-  gave ONE figure for every path ("ONE worker can still start on a box latched **moments** earlier")
-  and it was wrong twice. **PATH 1, the claim loser: CLOSED** — it was the peer's whole sweep
-  (13-80s measured, 600s by construction), and is now bounded by one `OBJ_SWEEP_CLAIM_POLL_SECS`.
-  **PATH 2, a lane's own sweep: COVERED** by the entry read plus the post-sweep reads. **PATH 3, the
-  last latch read to the worker spawn: OPEN, AND THE LARGEST OF THE THREE.** `object_store_sweep`
-  returns and the caller then runs the preflight hold loop, which does **not** re-read the latch: on
-  a clear box the gap is milliseconds, but every hold sleeps `HOLD_POLL_SECS` and the loop tolerates
-  up to `BUILD_HOLD_MAX` of them, so at the shipped defaults the gap is up to **12 x 300s = 3600s,
-  ONE HOUR** (the leftover-worker family bounds at `LEFTOVER_HOLD_MAX` x `HOLD_POLL_SECS` = 900s) —
-  "minutes" understated it by 12x. The harm bound is unchanged: it is not silent and not durable —
-  that lane's next iteration reads the latch at the top of its sweep and stops, and nothing certifies
-  a merge in that window without a full gate, which a latched box refuses. The atomic guarantee needs per-store
-  synchronisation shared by the sweep and the spawn decision, which is **split to its own issue** —
-  and so is the cheapest partial (a latch read inside the hold loop, which would cut 3600s to one
-  `HOLD_POLL_SECS`), which belongs with that redesign rather than smuggled into the path-1 fix where
-  it would arrive untested. **Path 1 is closed; path 3 is open. Do not describe the race as gone.**
+  understated is worse than one described honestly (rounds 12 and 13), AND A RESIDUAL LEFT
+  STANDING WHEN IT COULD BE CLOSED IS THE OTHER HALF OF THAT.** **PATH 1, the claim loser: CLOSED**
+  — it was the peer's whole sweep (13-80s measured, 600s by construction), and is now bounded by one
+  `OBJ_SWEEP_CLAIM_POLL_SECS`. **PATH 2, a lane's own sweep: COVERED** by the entry read plus the
+  post-sweep reads. **PATH 3, the last latch read to the worker spawn: NARROWED FROM UP TO AN HOUR
+  TO ONE PRE-SPAWN PROLOGUE, AND IT IS NOT ZERO.** The hold loop used to run after the last latch
+  read and never re-read it, so at the shipped defaults a lane could sit for `BUILD_HOLD_MAX` x
+  `HOLD_POLL_SECS` = **12 x 300s = 3600s** (leftover-worker family: `LEFTOVER_HOLD_MAX` x
+  `HOLD_POLL_SECS` = 900s) and then spawn onto a box a peer had latched meanwhile. `preflight_wait`
+  is now a WRAPPER: the loop lives in `preflight_wait_holds` and the STOP latch is re-read on
+  **every** return out of it, so the hold window is closed STRUCTURALLY — a property of the function
+  boundary, not an enumerated set of returns (round 3 fixed three such returns, round 5 found a
+  fourth; that shape does not converge). **What remains is `run_iteration`'s pre-spawn prologue**:
+  `stamp_claim`, i.e. ONE `claim-heartbeat.sh stamp` ref push to `origin` (plus a best-effort delete
+  push on a lane transition), around an `rm`/`mkdir`/assignments. Measured lower bound on this
+  fleet: a bare `git ls-remote origin HEAD` is **0.26-0.28s**, and a push negotiates and updates a
+  ref on top of that; the supervisor puts NO timeout on it, so the window is
+  sub-second-to-seconds in practice and unbounded in principle if the network stalls — **not the
+  "milliseconds" a purely local prologue would give** (a lane with `CLAIM_CMD` empty does pay only
+  that). The harm bound is unchanged: it is not silent and not durable — that lane's next iteration
+  reads the latch at the top of its sweep and stops, and nothing certifies a merge in that window
+  without a full gate, which a latched box refuses. Closing it entirely still needs per-store
+  synchronisation shared by the sweep and the spawn decision (a lock held across both, with the
+  spawn decision inside it), which is **split to its own issue**; a further read immediately before
+  the spawn would shrink the window again and cannot remove it, because a read and a spawn are two
+  operations. **Path 1 and the hold window are closed; the pre-spawn window is open. Do not
+  describe the race as gone.**
   **The sweep is also NOT INTERRUPTIBLE, so its cost is bounded in WALL TIME instead:** its
   walks run in a CHILD process, so the supervisor cannot check the stop file between them; it checks
   it (and the wall-clock budget) immediately BEFORE the sweep, and the supervisor's per-walk bound

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -491,6 +491,41 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   every consumer keys its disposition on, so a state whose disposition differs from all existing
   ones CANNOT be expressed as cause text — the verdict set is closed at **four**, and a fifth needs
   a fifth disposition, not a fifth cause.
+  **`UNSWEEPABLE` HAS A SECOND CAUSE, AND IT IS THE ONE THE ENVIRONMENT ALLOWLIST CANNOT REACH
+  (round 11).** `env -i` + the allowlist closes git's *environment* config sources; it cannot close
+  the store's OWN config, because **a local config is a FILE in the repository, not an environment
+  variable** — the same distinction this file already records for the transport hop. And `git fsck`
+  is CONFIGURABLE: measured on git 2.43.0 against a real fixture (a commit object with no author
+  email — an ERROR-severity message, exit bit 1, the sweep's own damage class), plain fsck exits
+  **1** while both `fsck.<msg-id>=ignore` and a `fsck.skipList` naming that object exit **0**, so
+  the sweep reported **`VERIFIED` about a damaged store** — the exact false affirmative this whole
+  control exists to prevent, and it is IN MODEL because the file is the SHARED
+  `/data/lanes/repo/.git/config` a peer lane (or an accident — one `skipList` added to work around
+  one known-bad object) writes. It is **REFUSED, not overridden**: `fsck.<msg-id>` is an
+  OPEN-ENDED key space (one key per message id, new ids with new git versions), so a `-c` per key is
+  a list that is wrong the moment git adds a message and a partial override is the "one axis closed,
+  space declared done" shape this issue has hit five times — the same ruling as the protocol
+  allowlist (*"a protocol allowlist is not expressible either … So there is no import at all"*).
+  So: **any `fsck.*` key in the configuration the walk would read ⇒ no walk at all ⇒ `UNSWEEPABLE`**,
+  naming the keys and the `config --list --show-origin --name-only` that lists them, claiming **NO
+  damage** (nothing was rehashed). It **STOPS** rather than reporting, on the round-10 disposition
+  argument plus one that decides it: an `fsck.<msg-id>` for an id THIS git does not know **already**
+  stops the box (exit 128 twice, the fatal cause), so the permissive reading would stop a box whose
+  config merely BREAKS fsck while letting one that SUPPRESSES REAL DAMAGE carry on. Zero such keys
+  exist on this fleet's shared store (measured 2026-09-02), the remedy is local and repairs nothing,
+  and detection would otherwise be OFF on that box forever. **"Could not ASK" stays permissive and
+  is its own state**: a failed probe — or an rc-0 answer listing NO key at all, which is an UNREAD
+  policy and not an empty one, since every repository's config declares
+  `core.repositoryformatversion` — is `UNMEASURED` with its own cause and no walk, so `VERIFIED` is
+  reachable only from a policy that was READ and found empty. **And the CONSUMERS' text is now
+  derived from the TOKEN alone**: the latch records only the verdict, so a reader that named the
+  fatal mechanism was affirmatively false on the other cause — they say the store's content is
+  UNKNOWN and NO DAMAGE was established, and quote the sweep's own `verdict-detail` lines for the
+  cause. Two rejected shapes, recorded: sweeping through a scratch repository with a clean config
+  (it loses round 7's measured worktree roots and would have to reconstruct git's administrative
+  layout — a second implementation of it, with its own false-clean routes), and walking anyway while
+  downgrading only the affirmative verdict (it keeps a `VERIFIED` path alive under a policy nobody
+  read).
   **AND "THE ROOTS THE WALK HAS" WAS ITSELF AN UNCHECKED ASSUMPTION, WRONG IN BOTH DIRECTIONS
   (review round 7).** A review finding held that `--git-dir=<common>` discards linked worktrees'
   private administrative context, so a missing object needed only by a lane's private HEAD or index
@@ -555,8 +590,9 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   boundary is argued from the exec chain, not assumed: `env`/`nice`/`timeout` each report their own
   failures inside `125..127`, so a status at or above 128 is the innermost command having actually
   started, which together with the `.started` marker below makes "fsck ran and died" an
-  AFFIRMATIVE observation rather than an absence. **`UNSWEEPABLE` CLAIMS NO CAUSE AND PRINTS NO
-  REPAIR** — the alternative was to read the `fatal:` text for a damage signature, i.e. round 1's
+  AFFIRMATIVE observation rather than an absence. **ON THAT CAUSE `UNSWEEPABLE` CLAIMS NO CAUSE AND
+  PRINTS NO REPAIR** — scoped to the FATAL cause since round 11 gave the verdict a second one, below,
+  which does name its cause — the alternative was to read the `fatal:` text for a damage signature, i.e. round 1's
   classifier again, narrower, and with every wording nobody enumerated falling back to the SAME
   permissive state, so it would close only the cases somebody thought of. It tells the operator to
   run the walk by hand and act on what the `fatal:` line names (that line is now kept in the
@@ -716,7 +752,21 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   unrecoverable claim is worse than the herd it prevents. The claim is a **REGISTERED** resource
   (`OBJ_SWEEP_CLAIM_OWNED`, read by the EXIT trap installed before any sweep can run), so the
   CORRUPT path — which ends the process — does not leave its peers waiting out the bound; CLAUDE.md's
-  roborev-job-282 ruling, applied to a resource this fix ADDED. Still not closed, and it is the
+  roborev-job-282 ruling, applied to a resource this fix ADDED.
+  **AND A CLAIM IS RELEASED ONLY WHILE IT IS STILL OURS — A PATH IS NOT AN IDENTITY (round 11).**
+  The release `rm -rf`'d the claim path unconditionally, so a lane whose sweep overran the recovery
+  bound deleted the claim of the SUCCESSOR that had legitimately taken over — permitting the second
+  concurrent full-store fsck the claim exists to prevent — and a lane on the `unavailable` path,
+  which never owned the claim at all, did the same at the end of its own sweep. The claim now carries
+  an ownership TOKEN written **before** its `started` file (so a claim a peer can AGE already names
+  its owner), and only an AFFIRMATIVE token match deletes: the question is four-valued
+  (`ours`/`other`/`gone`/`unknown`) and the three non-affirmative answers all LEAVE the directory,
+  because deleting costs a concurrent sweep while keeping costs one skipped 6-hourly probe that the
+  staleness bound recovers. **It is NOT atomic and does not claim to be**: the read and the `rm` are
+  two operations, so a takeover landing between them is still deleted — a microsecond window against
+  the previous "always". A rename-then-verify was rejected (it moves a successor's claim aside before
+  it can be checked, and restoring it is not atomic either, since `mv` onto an existing directory
+  moves INTO it). Still not closed, and it is the
   pre-existing half: this file installs no INT/TERM handlers, so a SIGNALLED supervisor releases
   neither its claim nor its lock — for the claim a delay rather than a wedge, and adding signal
   handlers changes the LOCK's lifetime too (#3683's subject).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -752,7 +752,28 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   waiting for it", so a dead peer cannot wedge the wait and no second, driftable constant exists.
   **The timeout is NOT a clean result and does not carry on**: when the peer neither finishes nor
   vacates, that claim is by construction stale at the deadline, so the next acquire RECOVERS it and
-  **the loser becomes the sweeper** rather than proceeding unmeasured. Only where peers keep handing
+  **the loser becomes the sweeper** rather than proceeding unmeasured.
+  **AND A COMPLETED PEER ENDS THE WAIT — IT DOES NOT SEND THE LOSER BACK TO CONTEND (round 14).**
+  The wait's `completed` (the throttle stamp went FRESH) was treated as "go round and acquire
+  again", and it is reached **WITHOUT SLEEPING**, on the pass that observes the stamp. So a peer
+  that writes the stamp and then DIES before releasing leaves the claim PRESENT and the stamp
+  FRESH — a state in which every acquire answers `held` and every wait answers `completed` in
+  microseconds — and the lane **spun CPU-hot until the supervisor's whole `MAX_HOURS` budget
+  expired** (measured: **2165** completions in 20s). A liveness and CPU defect, not a wrong
+  verdict, and on a four-lane box it is a burnt core that reads as *"the fleet got slow"* with no
+  attributable cause. **The age-based recovery built for exactly this dead peer could not save it,
+  which is the transferable part: `completed` was tested BEFORE the claim's deadline on every
+  pass, so the recovery the design relies on never ran.** The fix adds no second notion of "the
+  peer is gone" — a second mechanism is a second thing to drift: a fresh stamp is the SAME answer
+  the throttle at the top of `object_store_sweep` gives, so the lane SKIPS exactly as it would
+  have there and stops contending, which is strictly LESS work than the acquire-and-release round
+  trip the ordinary case used to make (so the common case — a peer that released a moment ago —
+  gains no latency). **The loop is now bounded in WALL TIME BY CONSTRUCTION and by a value it
+  already derived**: `exhausted` and `completed` break, and because neither surviving state
+  (`vacated`, `expired`) is REQUIRED to have slept, the loop itself is bounded by the iteration's
+  own `claim_stale` budget — never `MAX_HOURS`, and never a second constant. **The general rule:
+  a state a loop can reach WITHOUT SLEEPING must not be a loop-CONTINUING state**, and a bound
+  placed after a fast-path test is not a bound at all. Only where peers keep handing
   the claim around for the whole budget does the lane skip — journalled, paged once, reported as
   `NOT SWEPT AND NOT MEASURED`, never as clean. It does NOT stop the box there: a peer sweeping is
   also the shape of a HEALTHY box recovering a wedged claim, and stopping four lanes over a hygiene

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -485,7 +485,43 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   killed, unlaunchable or unclassifiable) the complaint is `UNATTRIBUTED` and non-passing, and a
   damage bit appearing ONLY in the third walk has not reproduced across the sweep walks: neither
   is `CORRUPT` and neither is clean. The verdict set stays **closed at three** — the split is in
-  the CAUSE text, not in a fourth token two readers and a structural assert would have to learn. **THE MASK DOES NOT END AT 31, AND
+  the CAUSE text, not in a fourth token two readers and a structural assert would have to learn.
+  **AND "THE ROOTS THE WALK HAS" WAS ITSELF AN UNCHECKED ASSUMPTION, WRONG IN BOTH DIRECTIONS
+  (review round 7).** A review finding held that `--git-dir=<common>` discards linked worktrees'
+  private administrative context, so a missing object needed only by a lane's private HEAD or index
+  would be overlooked — *"the normal state of eight lanes"*. **Measured on git 2.43.0, that is
+  FALSE**: a common-dir fsck DOES walk every registered worktree's private `HEAD` (it names it
+  `worktrees/<name>/HEAD`), its private INDEX, and the HEAD of a **prunable** worktree whose
+  directory has been deleted — all three surviving `--no-reflogs`, hence already `CORRUPT`. What it
+  does NOT walk is a LINKED worktree's **per-worktree refs** (`refs/worktree/*`, `refs/bisect/*`,
+  `refs/rewritten/*`; the MAIN worktree's live in the common dir and ARE walked). Delete an object
+  named only by one and the sweep exits **0 VERIFIED** — the HEAD reflog echoes the id and that echo
+  CLEARS under `--no-reflogs`, so the attribution walk calls real damage reflog-scoped. So the
+  finding's premise was wrong and there was a hole one namespace over; **both halves are now
+  measured rather than believed** — the covered roots are PINNED by fixtures (a future git that
+  narrows fsck's enumeration reds a case) and the gap is closed by a **private-root probe**. Three
+  measurements shaped it and are recorded so they are not re-derived: `git fsck <sha>` **REPLACES**
+  the default heads (a missing blob reachable from HEAD went undetected), so private roots can never
+  be appended to the sweep walk; an explicit-head fsck still scans the whole object directory, so it
+  costs a FULL rehash; and `rev-list <missing-root>` dies 128, so `--missing=print` cannot answer the
+  case that fires. The probe is therefore O(refs), not an fsck: list each linked worktree's refs,
+  subtract the common ones, ask `cat-file --batch-check` whether the remainder's targets are present
+  (measured **0.22 s** against the live 15-worktree store; the whole sweep 12.8–15.8 s, unchanged
+  within noise). **Its enumeration is FILESYSTEM-FIRST because the git command is FAIL-OPEN** —
+  `git worktree list --porcelain` SILENTLY DROPS a worktree whose admin `gitdir` file is missing (rc
+  0, no diagnostic), so `$GIT_COMMON_DIR/worktrees/*`, which is git's own administrative directory
+  and not a guess about lane layout, is the subject set and the command is kept only as a
+  cross-check in the direction it can fail (it names MORE than the directory holds ⇒ `UNMEASURED`).
+  A worktree that cannot be inspected is **not a clean one**: it contributes a named `UNREADABLE`
+  record, never a silent zero-root contribution to `VERIFIED`. **And it costs no caller a wider
+  window, by PLACEMENT rather than by arithmetic**: it runs as ONE bounded child stage immediately
+  before the single affirmative branch, and every branch of the reachability block above EXITS, so a
+  run that spent a third fsck walk never reaches it — worst case stays `MAX_SWEEP_WALKS` stages and
+  no derived bound (the supervisor's per-walk default, the claim's recovery bound, bootstrap's outer
+  belt) moves. That is a property of WHERE the call sits, so it is asserted BEHAVIOURALLY against the
+  fixture that really spends three walks. **Declared residual: the probe asks whether each private
+  ref's TARGET is present, not whether its whole CLOSURE is** — an object missing deeper in a
+  per-worktree ref's ancestry and named by nothing else is not recognised. **THE MASK DOES NOT END AT 31, AND
   ASSUMING IT DID DROPPED REAL DAMAGE (review round 2).** A range check over `1..31` — reasoned from
   128 being `die()` and `127 & 1` being 1 — classified **33** (`32|1`) and **36** (`32|4`) as
   unclassified and so `UNMEASURED`: a FALSE NEGATIVE on genuine object corruption, the one direction

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -477,7 +477,19 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   refused bit-testing outright, and a status carrying a bit OUTSIDE the supported mask is
   `unclassified` rather than folded into a class whose remedy would be wrong. That is what makes it
   **degrade safely** as git adds bits: a new bit alongside damage is still damage, a new bit alone is
-  non-passing, and widening `FSCK_KNOWN_MASK` is then a wording change rather than a correctness fix. And **no non-clean walk is fatal on ONE observation**: it is re-run exactly ONCE as
+  non-passing, and widening `FSCK_KNOWN_MASK` is then a wording change rather than a correctness fix. **AND A STATUS IS ONLY A BITMASK IF THE COMMAND THAT PRODUCED IT ACTUALLY RAN
+  (round 3).** The status space fsck uses is SHARED with the shell's, so the classifier had a
+  precondition it never checked: the two capture redirections are part of the fsck command, and a
+  failure to open the scratch output file (a full or reaped `TMPDIR`) means bash execs nothing and
+  exits **1** — `ERROR_OBJECT`. Both passes then fail identically, both "reproduce", and the sweep
+  emitted **`CORRUPT` about a store it never opened** — the same false-CORRUPT harm as the `/^error/p`
+  classifier above, arriving through the shell instead of through a concurrent writer. It CANNOT be
+  inferred from the status, which is the whole point; the evidence is **affirmative** — a marker
+  written INSIDE the redirected group as its first statement (a redirection failure on a compound
+  command means the body does not execute at all), plus both capture files existing afterwards — and
+  its absence is a `launchfail` class routed to `UNMEASURED` and **never bit-tested**. The
+  generalisation: **before reading a status as a structured value, establish that the process whose
+  convention you are applying is the process that produced it.**  And **no non-clean walk is fatal on ONE observation**: it is re-run exactly ONCE as
   a **discriminator** — a concurrency artefact does not survive a second independent walk, real
   damage does — never a retry-until-clean loop, and a damage class seen once and not twice is
   `UNMEASURED`, neither established damage nor a clean store. **The `CORRUPT` verdict is PERSISTED
@@ -498,6 +510,26 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   its own could-not-acquire path that must then not silently skip the latch. The latch does not
   expire (corruption is non-self-clearing) and is cleared by hand with the `rm -f <latch>` that every
   message naming it prints; a create that could not happen is REPORTED, never read as a latched box.
+  **THE LATCH IS CREATED BEFORE THE THROTTLE STAMP, AND RE-READ BEFORE EVERY RETURN THAT LEADS TO A
+  SPAWN — AND THE REMAINING RACE IS DECLARED, NOT CLOSED (round 3).** Two ordering defects, neither
+  needing a lock. The stamp used to be written for EVERY outcome BEFORE the CORRUPT branch ran, so
+  between those two writes a peer read a fresh non-corrupt stamp and throttled past a corruption
+  about to be recorded — round 1's own harm, one instruction earlier. And a lane whose OWN sweep
+  said `VERIFIED` returned toward a spawn without re-reading the latch, so a peer latching the box
+  DURING that lane's two fsck walks was simply not seen. So: latch first, stamp second, and one
+  `obj_sweep_stop_if_latched` helper called before the throttled, `VERIFIED` and `UNMEASURED`
+  returns alike — one rule ("no such return without a fresh latch read") instead of a set of paths
+  someone must remember to audit. **What is NOT closed, stated because a narrowed race described as
+  closed is worse than one described honestly:** the latch read and the worker spawn are still
+  unsynchronised, and the preflight hold loop can poll for minutes between them, so ONE worker can
+  still start on a box latched moments earlier. It is bounded — that lane's next iteration reads the
+  latch at the top of its sweep and stops — and the atomic guarantee needs per-store
+  synchronisation shared by the sweep and the spawn decision, which is **split to its own issue**.
+  **The sweep is also NOT INTERRUPTIBLE, so its cost is bounded in WALL TIME instead:** its two
+  walks run in a CHILD process, so the supervisor cannot check the stop file between them; it checks
+  it (and the wall-clock budget) immediately BEFORE the sweep, and the supervisor's per-walk bound
+  defaults to **half** the sweep script's own (300 vs 600) so two walks cost no more than one walk
+  at the script's bound. Raising a bound is a change to somebody's stop latency.
   **And the stamp's KEY is resolved by the sweep script itself (`--print-store`), never by a `git`
   call in the supervisor:** a bare `git rev-parse --git-common-dir` inherits the caller's
   environment, so an inherited `GIT_DIR`/`GIT_COMMON_DIR` keyed the stamp — and hence the latch — on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -497,31 +497,38 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   `refs/rewritten/*`; the MAIN worktree's live in the common dir and ARE walked). Delete an object
   named only by one and the sweep exits **0 VERIFIED** — the HEAD reflog echoes the id and that echo
   CLEARS under `--no-reflogs`, so the attribution walk calls real damage reflog-scoped. So the
-  finding's premise was wrong and there was a hole one namespace over; **both halves are now
-  measured rather than believed** — the covered roots are PINNED by fixtures (a future git that
-  narrows fsck's enumeration reds a case) and the gap is closed by a **private-root probe**. Three
-  measurements shaped it and are recorded so they are not re-derived: `git fsck <sha>` **REPLACES**
-  the default heads (a missing blob reachable from HEAD went undetected), so private roots can never
-  be appended to the sweep walk; an explicit-head fsck still scans the whole object directory, so it
-  costs a FULL rehash; and `rev-list <missing-root>` dies 128, so `--missing=print` cannot answer the
-  case that fires. The probe is therefore O(refs), not an fsck: list each linked worktree's refs,
-  subtract the common ones, ask `cat-file --batch-check` whether the remainder's targets are present
-  (measured **0.22 s** against the live 15-worktree store; the whole sweep 12.8–15.8 s, unchanged
-  within noise). **Its enumeration is FILESYSTEM-FIRST because the git command is FAIL-OPEN** —
-  `git worktree list --porcelain` SILENTLY DROPS a worktree whose admin `gitdir` file is missing (rc
-  0, no diagnostic), so `$GIT_COMMON_DIR/worktrees/*`, which is git's own administrative directory
-  and not a guess about lane layout, is the subject set and the command is kept only as a
-  cross-check in the direction it can fail (it names MORE than the directory holds ⇒ `UNMEASURED`).
-  A worktree that cannot be inspected is **not a clean one**: it contributes a named `UNREADABLE`
-  record, never a silent zero-root contribution to `VERIFIED`. **And it costs no caller a wider
-  window, by PLACEMENT rather than by arithmetic**: it runs as ONE bounded child stage immediately
-  before the single affirmative branch, and every branch of the reachability block above EXITS, so a
-  run that spent a third fsck walk never reaches it — worst case stays `MAX_SWEEP_WALKS` stages and
-  no derived bound (the supervisor's per-walk default, the claim's recovery bound, bootstrap's outer
-  belt) moves. That is a property of WHERE the call sits, so it is asserted BEHAVIOURALLY against the
-  fixture that really spends three walks. **Declared residual: the probe asks whether each private
-  ref's TARGET is present, not whether its whole CLOSURE is** — an object missing deeper in a
-  per-worktree ref's ancestry and named by nothing else is not recognised. **THE MASK DOES NOT END AT 31, AND
+  finding's premise was wrong and there was a hole one namespace over. The covered roots are
+  PINNED by fixtures (a future git that narrows fsck's enumeration reds a case); **the hole is a
+  DECLARED GAP, and the probe built to close it was REMOVED (review round 8).** Three measurements
+  rule out the fsck-shaped fixes and are recorded so they are not re-derived: `git fsck <sha>`
+  **REPLACES** the default heads (a missing blob reachable from HEAD went undetected), so private
+  roots can never be appended to the sweep walk; an explicit-head fsck still scans the whole object
+  directory, so it costs a FULL rehash; and `rev-list <missing-root>` dies 128, so `--missing=print`
+  cannot answer the case that fires. What was built instead was O(refs) — enumerate each linked
+  worktree's refs, subtract the common ones, ask `cat-file --batch-check` whether the remainder's
+  targets are present — and **its first review returned three false-`VERIFIED` routes of its own,
+  two of them High**: a present root whose reachable **CHILD** is missing is invisible to a
+  target-presence check; a per-worktree ref is DISCARDED by a name subtraction when a common ref
+  shares its name, even pointing at a different, missing object; and a failed `awk`/`sort`/`comm`
+  degrades to a zero-root census and then permits `VERIFIED`. **A mechanism added to prevent one
+  false clean produced three new ways to reach one, in one review** — #3229's ruling (*a guard with
+  known documented false-PASSes is worse than no guard, because it invites reliance it cannot
+  support*), its companion (*subtraction cannot introduce a false PASS*) and #3544's posture on this
+  very subject (*a check that claims nothing false is worth more than one claiming a closure it does
+  not deliver*) all point the same way. **And the class has ZERO INSTANCES on this fleet** —
+  measured twice, independently, 2026-09-02: 14 registered worktrees, all three namespaces absent
+  from every linked worktree's admin dir AND from the common dir, 0 mentions in `packed-refs`. The
+  falsifier was stated before acting: **live per-worktree refs would have made removal leave a live
+  hole**, and the right answer would then have been to fix the three findings instead. **The
+  declaration is EMITTED ON EVERY RUN** — `declared-gap` lines, on all three verdict classes,
+  because what a run did not walk does not depend on what it found — in **`1 RECOGNISED`** form
+  (never a bare count, which reads as a completed census), naming the un-walked namespaces, the
+  coverage that is NOT in the gap (the measurement above, which is what keeps the gap one namespace
+  wide) and the fleet measurement WITH ITS DATE, since "zero instances" expires. One measurement is
+  kept for whoever revisits this: **`git worktree list --porcelain` is FAIL-OPEN** — it silently
+  drops a worktree whose admin `gitdir` file is missing (rc 0, no diagnostic) — so any future
+  enumeration must be filesystem-first over `$GIT_COMMON_DIR/worktrees/*`, git's own administrative
+  directory, with the command only as a cross-check in the direction it can fail. **THE MASK DOES NOT END AT 31, AND
   ASSUMING IT DID DROPPED REAL DAMAGE (review round 2).** A range check over `1..31` — reasoned from
   128 being `die()` and `127 & 1` being 1 — classified **33** (`32|1`) and **36** (`32|4`) as
   unclassified and so `UNMEASURED`: a FALSE NEGATIVE on genuine object corruption, the one direction

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -552,7 +552,63 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   DURING that lane's two fsck walks was simply not seen. So: latch first, stamp second, and one
   `obj_sweep_stop_if_latched` helper called before the throttled, `VERIFIED` and `UNMEASURED`
   returns alike — one rule ("no such return without a fresh latch read") instead of a set of paths
-  someone must remember to audit. **What is NOT closed, stated because a narrowed race described as
+  someone must remember to audit.
+  **THAT RULE WAS STILL A SET OF SITES, AND ROUND 5 FOUND THE FOURTH — SO THE READ IS NOW AT
+  ENTRY, ABOVE EVERY BRANCH (round 5, item 1).** The documented opt-out
+  `OBJ_SWEEP_INTERVAL_HOURS=0` returned before ANY latch read, so switching the sweep off also
+  switched off an already-recorded CORRUPT verdict — while this paragraph asserted a latch ignores
+  the interval. Round 3 fixed three such returns and introduced the helper *for* them; round 5's
+  fourth is the same defect through a new door, because the design required every early return to
+  independently REMEMBER the check, and patching site four leaves site five to the next reviewer.
+  So the read is hoisted to the TOP of `object_store_sweep` — the prologue before it is
+  declarations and assignments ONLY — and the invariant becomes a property of the FUNCTION ("it
+  cannot be entered without a latch read") rather than of an audited list, which holds for branches
+  nobody has written yet; it is asserted structurally, both that the first control-flow line comes
+  after the gate and that nothing before it can branch, call out or return. The post-sweep reads
+  STAY: a peer can latch the box while this lane spends up to `MAX_SWEEP_WALKS` walks, which is a
+  different question. Cost: one `--print-store` resolution per iteration (measured **5 ms**), which
+  the opt-out path did not pay before, against a supervisor iteration measured in minutes.
+  **AND THE LATCH QUESTION IS FOUR-VALUED, BECAUSE A FILE PREDICATE IS NOT.** `[[ -e "$latch" ]]`
+  is false both for an absent latch and for one the process cannot look at — CLAUDE.md's standing
+  two-valued-predicate rule, landing on the single file whose job is to stop the box. `present` and
+  `absent` (an affirmative measurement: the directory was searchable, or does not exist) join
+  **`unknown`**, which STOPS under its own reason `object-store-latch-unreadable` — never as
+  CORRUPT, since nothing observed damage and that remedy would send an operator to re-clone a
+  healthy store — and **`unkeyed`**, the one permissive answer, announced once: no key means no
+  latch was ever NAMED, the writer derives the name through the same resolver, and stopping instead
+  would make a missing `check-object-store-integrity.sh` (ordinary on any branch cut before #3749)
+  halt every lane for want of a hygiene probe. Its residual is stated at the branch: a TRANSIENT
+  resolver failure in one lane misses a peer's verdict for one iteration.
+  **THE THUNDERING HERD IS CLOSED, WITH THE HAZARD ITS FIX INTRODUCES (round 5, item 2 — a Low in
+  round 1, "not disposed of" in round 2, a Medium in round 5).** The throttle read and the sweep
+  invocation were unsynchronised and the stamp is written at the END of a sweep, so at the moment
+  the interval expires every lane read the same stale stamp and started its own full-store fsck —
+  and the consequence is not merely CPU: the walks are I/O-bound, so contention pushes them toward
+  the per-walk bound, and an expired bound is `UNMEASURED`, i.e. a CORRELATED loss of the
+  measurement on every lane at once. The serialiser is a per-store claim DIRECTORY created with
+  `mkdir` — the same kernel-arbitrated create-only primitive as the latch, and deliberately **not
+  `flock`**, because this file's own single-instance lock is mkdir-based precisely since **macOS
+  ships no `flock(1)`**, and a second locking mechanism is a second set of failure modes. A loser
+  does NOT wait: it skips that iteration's probe and carries on (after the usual latch read), since
+  "a peer is doing it right now" is a complete answer for a 6-hourly hygiene sweep and waiting would
+  put the box's whole spawn path behind one fsck. The throttle is **RE-READ after acquiring**, which
+  is what stops the claim converting a herd into a QUEUE of redundant sweeps. **A stale claim must
+  not wedge the box, which would be strictly worse than the herd**, so the recovery threshold is
+  DERIVED and not chosen — a claim cannot be stale while the sweep it represents could legitimately
+  still be running, so it is the sweep's own `MAX_SWEEP_WALKS` (**read from that script**, never
+  re-typed) x this supervisor's per-walk bound + slack = 3 x 200 + 60 = 660s — and a claim carrying
+  NO parseable start time reads as stale, deliberately: its cause is a lane killed in the
+  microseconds between the `mkdir` and the write, and the other reading wedges the sweep forever on
+  a file nobody can age (cost of this direction: one extra sweep, once). Where the bound cannot be
+  derived, **no claim is taken at all** and the previous behaviour is restored, announced — an
+  unrecoverable claim is worse than the herd it prevents. The claim is a **REGISTERED** resource
+  (`OBJ_SWEEP_CLAIM_OWNED`, read by the EXIT trap installed before any sweep can run), so the
+  CORRUPT path — which ends the process — does not leave its peers waiting out the bound; CLAUDE.md's
+  roborev-job-282 ruling, applied to a resource this fix ADDED. Still not closed, and it is the
+  pre-existing half: this file installs no INT/TERM handlers, so a SIGNALLED supervisor releases
+  neither its claim nor its lock — for the claim a delay rather than a wedge, and adding signal
+  handlers changes the LOCK's lifetime too (#3683's subject).
+  **What is NOT closed, stated because a narrowed race described as
   closed is worse than one described honestly:** the latch read and the worker spawn are still
   unsynchronised, and the preflight hold loop can poll for minutes between them, so ONE worker can
   still start on a box latched moments earlier. It is bounded — that lane's next iteration reads the
@@ -578,7 +634,20 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   every unsupported character with `_` maps `/tmp/a/b/objects` and `/tmp/a_b/objects` to ONE name, so
   two repositories on a box shared a throttle stamp *and* a CORRUPT latch — one store suppressing the
   other's sweep, or stopping every lane with the other's damage. `<sanitised tail>.<16 hex of
-  sha256>`: the tail is READABILITY ONLY and carries no identity. Three digest tools (`sha256sum`,
+  sha256>`: the tail is READABILITY ONLY and carries no identity.
+  **AND THE DIGEST IS OVER THE RAW PATH, COMPUTED IN THE RESOLVER — DIGESTING THE RENDERED VALUE WAS
+  ITSELF THE NEXT DEFECT (round 5, item 3).** Round 4 made the key injective over the flattening and
+  then fed the digest the value `--print-store` had already passed through the sweep's `sane()`
+  escaper: a DISPLAY encoding, and a LOSSY one, so a path holding a real newline and one holding the
+  two literal characters `\n` produced ONE key — the same shared-stamp-and-latch harm, arriving
+  through the fix for it. `sane()` exists so a control character cannot break the anchored output; it
+  is not reversible and was never an identity. So `store_key` lives in the sweep script, the only
+  process holding the raw bytes, and publishes a second anchored `store-key` line the caller
+  VALIDATES and uses verbatim; the supervisor's own digest helper is GONE, so there is no lossy value
+  left for a future caller to digest. The general rule, worth more than the instance: **a value
+  sanitised for DISPLAY is not an IDENTITY, and a comparison key must be derived before any rendering
+  — where both are needed, publish them as two fields rather than deriving one from the other.**
+  Three digest tools (`sha256sum`,
   `shasum -a 256`, `openssl dgst -sha256`) cover both platforms, the output is parsed from both ends
   and then VALIDATED as hex, and a host with none **fails closed to the EMPTY key** — no throttle, no
   latch, announced once naming both causes — never a silent fall back to the colliding form on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -453,7 +453,7 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   its control is a periodic full-rehash sweep: `scripts/check-object-store-integrity.sh` (full
   `git fsck`, never `--connectivity-only`, which does not rehash content), emitting an anchored
   three-valued `VERIFIED`/`CORRUPT`/`UNMEASURED` verdict — run at machine onboarding
-  (`bootstrap-agent-machine.sh` section 5b-obj, where VERIFIED is the ONLY `[ok]`) and on the
+  (`bootstrap-agent-machine.sh` section 5d, where VERIFIED is the ONLY `[ok]`) and on the
   worker supervisor's throttled per-iteration cadence (default 6h; `CORRUPT` **stops that
   supervisor loudly** rather than holding, because corruption is non-self-clearing, while
   `UNMEASURED` is reported and deliberately does NOT stop the loop — refusing to run any worker

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -736,10 +736,28 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   measurement on every lane at once. The serialiser is a per-store claim DIRECTORY created with
   `mkdir` — the same kernel-arbitrated create-only primitive as the latch, and deliberately **not
   `flock`**, because this file's own single-instance lock is mkdir-based precisely since **macOS
-  ships no `flock(1)`**, and a second locking mechanism is a second set of failure modes. A loser
-  does NOT wait: it skips that iteration's probe and carries on (after the usual latch read), since
-  "a peer is doing it right now" is a complete answer for a 6-hourly hygiene sweep and waiting would
-  put the box's whole spawn path behind one fsck. The throttle is **RE-READ after acquiring**, which
+  ships no `flock(1)`**, and a second locking mechanism is a second set of failure modes.
+  **A LOSER *DOES* WAIT, WHICH REVERSES THE ORIGINAL DESIGN (round 12).** It used to skip its probe
+  and carry straight on to the spawn path after one latch read, on the argument that *"a peer is
+  doing it right now"* is a complete answer for a 6-hourly hygiene sweep. That is a complete answer
+  about the SWEEP and no answer at all about the SPAWN: the loser KNOWS a full-store fsck is in
+  flight — that is why its claim failed — and that fsck can end in `CORRUPT` or `UNSWEEPABLE`, in
+  which case the peer latches the box. So the discarded window was the peer's **ENTIRE SWEEP**,
+  measured **13-80s** on this fleet and up to `MAX_SWEEP_WALKS` x `OBJ_SWEEP_TIMEOUT_SECS` (**600s**
+  at the shipped defaults) by construction — **not** the narrow post-read spawn gap the residual note
+  described, which is the false-rationale class landing on the very text that discloses the race.
+  The loser now waits, re-reading the latch, the stamp, the claim and the STOP FILE every
+  `OBJ_SWEEP_CLAIM_POLL_SECS` (5s; granularity, not a bound), and **the bound is the claim's OWN
+  derived staleness value** — the same 660s that says "this claim may be TAKEN OVER" says "stop
+  waiting for it", so a dead peer cannot wedge the wait and no second, driftable constant exists.
+  **The timeout is NOT a clean result and does not carry on**: when the peer neither finishes nor
+  vacates, that claim is by construction stale at the deadline, so the next acquire RECOVERS it and
+  **the loser becomes the sweeper** rather than proceeding unmeasured. Only where peers keep handing
+  the claim around for the whole budget does the lane skip — journalled, paged once, reported as
+  `NOT SWEPT AND NOT MEASURED`, never as clean. It does NOT stop the box there: a peer sweeping is
+  also the shape of a HEALTHY box recovering a wedged claim, and stopping four lanes over a hygiene
+  probe's contention is the self-DoS refused everywhere else in that file. Cost is paid only when a
+  sweep is genuinely running, i.e. at most once per throttle interval per lane. The throttle is **RE-READ after acquiring**, which
   is what stops the claim converting a herd into a QUEUE of redundant sweeps. **A stale claim must
   not wedge the box, which would be strictly worse than the herd**, so the recovery threshold is
   DERIVED and not chosen — a claim cannot be stale while the sweep it represents could legitimately
@@ -770,12 +788,24 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   pre-existing half: this file installs no INT/TERM handlers, so a SIGNALLED supervisor releases
   neither its claim nor its lock — for the claim a delay rather than a wedge, and adding signal
   handlers changes the LOCK's lifetime too (#3683's subject).
-  **What is NOT closed, stated because a narrowed race described as
-  closed is worse than one described honestly:** the latch read and the worker spawn are still
-  unsynchronised, and the preflight hold loop can poll for minutes between them, so ONE worker can
-  still start on a box latched moments earlier. It is bounded — that lane's next iteration reads the
-  latch at the top of its sweep and stops — and the atomic guarantee needs per-store
-  synchronisation shared by the sweep and the spawn decision, which is **split to its own issue**.
+  **WHAT IS NOT CLOSED, PER PATH AND WITH ITS REAL MAGNITUDE — because a residual whose size is
+  understated is worse than one described honestly (round 12).** The earlier version of this text
+  gave ONE figure for every path ("ONE worker can still start on a box latched **moments** earlier")
+  and it was wrong twice. **PATH 1, the claim loser: CLOSED** — it was the peer's whole sweep
+  (13-80s measured, 600s by construction), and is now bounded by one `OBJ_SWEEP_CLAIM_POLL_SECS`.
+  **PATH 2, a lane's own sweep: COVERED** by the entry read plus the post-sweep reads. **PATH 3, the
+  last latch read to the worker spawn: OPEN, AND THE LARGEST OF THE THREE.** `object_store_sweep`
+  returns and the caller then runs the preflight hold loop, which does **not** re-read the latch: on
+  a clear box the gap is milliseconds, but every hold sleeps `HOLD_POLL_SECS` and the loop tolerates
+  up to `BUILD_HOLD_MAX` of them, so at the shipped defaults the gap is up to **12 x 300s = 3600s,
+  ONE HOUR** (the leftover-worker family bounds at `LEFTOVER_HOLD_MAX` x `HOLD_POLL_SECS` = 900s) —
+  "minutes" understated it by 12x. The harm bound is unchanged: it is not silent and not durable —
+  that lane's next iteration reads the latch at the top of its sweep and stops, and nothing certifies
+  a merge in that window without a full gate, which a latched box refuses. The atomic guarantee needs per-store
+  synchronisation shared by the sweep and the spawn decision, which is **split to its own issue** —
+  and so is the cheapest partial (a latch read inside the hold loop, which would cut 3600s to one
+  `HOLD_POLL_SECS`), which belongs with that redesign rather than smuggled into the path-1 fix where
+  it would arrive untested. **Path 1 is closed; path 3 is open. Do not describe the race as gone.**
   **The sweep is also NOT INTERRUPTIBLE, so its cost is bounded in WALL TIME instead:** its
   walks run in a CHILD process, so the supervisor cannot check the stop file between them; it checks
   it (and the wall-clock budget) immediately BEFORE the sweep, and the supervisor's per-walk bound

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -436,33 +436,49 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   deleted FOUR cases and the suite reported `failed: 0` at 102 instead of 105 for a whole round —
   a green tally over a shrunken suite is #3544's own subject inside its own test file. That suite
   now asserts a CASE FLOOR**, the idiom `test_agent_gate_summary.sh` already used.
-  **THE SHARED OBJECT STORE IS TRUSTED, NOT VERIFIED — DECLARED IN THE EMITTED LINE, AND OWNED BY
-  #3746 (roborev job 311; lead ruling on `REQ-3544-OBJTRUST`).** Git does not rehash a packed
-  object against the id it was asked for on an ordinary read, and on this fleet **every lane on a
-  box is a worktree of ONE shared `.git`** (measured: `/data/lanes/repo/.git/objects` for
-  lane-3544, lane-3473 and lane-3629 alike), so a peer lane planting a forged pack/index can make
-  a canonical sha resolve to a shortened manifest — a **false PASS**, and a NON-INVOKER route,
-  hence a defect. **The recorded "a third finding here should REMOVE the reuse optimisation"
-  ruling does NOT dispose of it, because removal does not CLOSE it:** the ancestry walk and the
-  provenance leg read HEAD's **committed** content, which has no source other than that store —
-  the working tree cannot substitute, since `UNCOMMITTED` exists precisely to compare against what
-  is committed — so a forged HEAD object still turns `UNCOMMITTED` (fatal) into `DECLARED`
-  (non-fatal) after removal, while charging every `--lite` round for the privilege (measured
-  2026-08-31: **3.41 s / 93 MB** full, **3.58 s / 45 MB** at `--depth=1` — shallow is NOT cheaper,
-  it still ships the tip's whole tree). **A permanent tax for a half-closure is the guard agents
-  learn to waive**, and a bounded re-hash of the consumed objects is the FOURTH carve in this
-  family. So the boundary is **DECLARED**: every baseline-bearing verdict line ends by naming the
-  object provenance (`REUSED` from the shared store / `FETCHED` from the canonical remote / `NOT
-  RECORDED`) plus `store TRUSTED, not verified (#3746)`. **A check that claims nothing false is
-  worth more than one claiming a closure it does not deliver** — the same move the roborev
+  **THE SHARED OBJECT STORE IS TRUSTED, NOT VERIFIED PER-READ — DECLARED IN THE EMITTED LINE, AND
+  RESOLVED BY #3749 (roborev job 311; lead ruling on `REQ-3544-OBJTRUST`, then #3749's owner ruling
+  2026-09-01).** Git does not rehash a packed object against the id it was asked for on an ordinary
+  read, and on this fleet **every lane on a box is a worktree of ONE shared `.git`** (measured:
+  `/data/lanes/repo/.git/objects` for lane-3544, lane-3473 and lane-3629 alike), so a planted
+  pack/index can make a canonical sha resolve to a shortened manifest — a **false PASS**. What an
+  ordinary read DOES verify is the pack CRC and the zlib stream, which catch **accidental** damage
+  (bit rot, a truncated or torn write) but never rehash content against its own name.
+  **#3749 SPLIT THAT INTO TWO SUBJECTS AND OVERTURNED THE EARLIER FRAMING, which this text used to
+  carry: "a NON-INVOKER route, hence a defect" is RETRACTED.** DELIBERATE forgery by a same-host
+  peer is **INVOKER-CLASS and OUT OF MODEL** — the #3312 triage rule already says same-host actors
+  able to write these scripts are invoker-class, and a peer wanting a false PASS can simply edit
+  `scripts/agent-gate.sh`, which is cheaper than forging pack data; no check inside a process
+  defends against the party that controls the process. **ACCIDENTAL corruption IS in model**, and
+  its control is a periodic full-rehash sweep: `scripts/check-object-store-integrity.sh` (full
+  `git fsck`, never `--connectivity-only`, which does not rehash content), emitting an anchored
+  three-valued `VERIFIED`/`CORRUPT`/`UNMEASURED` verdict — run at machine onboarding
+  (`bootstrap-agent-machine.sh` section 5b-obj, where VERIFIED is the ONLY `[ok]`) and on the
+  worker supervisor's throttled per-iteration cadence (default 6h; `CORRUPT` **stops that
+  supervisor loudly** rather than holding, because corruption is non-self-clearing, while
+  `UNMEASURED` is reported and deliberately does NOT stop the loop — refusing to run any worker
+  because a hygiene probe could not run is a self-DoS). **That sweep is PERIODIC, NOT PER-READ, so
+  the emitted clause still says `store TRUSTED, not verified (#3749)` — do not inflate it.**
+  **THREE ALTERNATIVES WERE REJECTED and the reasons are recorded so they are not re-derived:**
+  per-lane full clones (a permanent multi-GB tax for an out-of-model threat); per-read rehashing
+  (the FOURTH carve into one pre-flight, charged to every `--lite` round); and **removing the reuse
+  optimisation, whose original argument still stands** — the recorded "a third finding here should
+  REMOVE the reuse optimisation" ruling does NOT dispose of it, because removal does not CLOSE it:
+  the ancestry walk and the provenance leg read HEAD's **committed** content, which has no source
+  other than that store — the working tree cannot substitute, since `UNCOMMITTED` exists precisely
+  to compare against what is committed — so a forged HEAD object still turns `UNCOMMITTED` (fatal)
+  into `DECLARED` (non-fatal) after removal, while charging every `--lite` round for the privilege
+  (measured 2026-08-31: **3.41 s / 93 MB** full, **3.58 s / 45 MB** at `--depth=1` — shallow is NOT
+  cheaper, it still ships the tip's whole tree). **A permanent tax for a half-closure is the guard
+  agents learn to waive.** So the boundary is **DECLARED**: every baseline-bearing verdict line ends
+  by naming the object provenance (`REUSED` from the shared store / `FETCHED` from the canonical
+  remote / `NOT RECORDED`) plus `store TRUSTED, not verified (#3749)`. **A check that claims nothing
+  false is worth more than one claiming a closure it does not deliver** — the same move the roborev
   waiver's threat model makes where a dependency cannot be removed. The declaration is folded into
   the ONE `src_note` suffix eleven printf arms already consume, never appended per-arm, and the
   self-test pins it as a **closed set of three renderings** by string equality: pinning one
   literal would red on correct input (which clause fires depends on whether this box's store
-  already held the commit), pinning nothing would let a wording pass delete it. **#3746 may
-  conclude the subject is not this pre-flight at all but the infrastructure decision that lanes
-  share an object store** — a peer able to plant objects there is a hazard to every gate on the
-  box, not to one component-set comparison.
+  already held the commit), pinning nothing would let a wording pass delete it.
   **STOP RENDERING THE VALUE, DO NOT SANITISE IT AGAIN — AND A FIX THAT ADDS A RESOURCE INHERITS
   THAT RESOURCE'S LIFETIME BUGS (roborev job 282).** Two closures. (1) The rejected-origin
   diagnostic was the FIFTH finding in one family — raw URL rendered (227) → redacted but not

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -464,8 +464,28 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   (`/^error/p`) made a healthy box page high, stop its supervisor and fail `--strict` bootstrap.
   The class now comes from fsck's exit **BITMASK**: bits `1 ERROR_OBJECT` / `4 ERROR_PACK` are this
   sweep's subject; `2 ERROR_REACHABLE` / `8 ERROR_REFS` / `16 ERROR_COMMIT_GRAPH` /
-  `32 ERROR_MULTI_PACK_INDEX` are **not demoted to clean** (a genuinely MISSING object reports bit
-  2) but land on their own non-passing `UNMEASURED` cause. **THE MASK DOES NOT END AT 31, AND
+  `32 ERROR_MULTI_PACK_INDEX` are **not demoted to clean** but land on their own non-passing
+  `UNMEASURED` cause — **except that `2 ERROR_REACHABLE` HAS TWO CAUSES AND ROUTING BOTH TO
+  `UNMEASURED` WAS A FALSE NEGATIVE ON REAL CORRUPTION (round 4).** That bit fires for a stale
+  reflog entry naming an object a peer's gc pruned (routine, not the subject) **and** for an
+  object genuinely ABSENT while a live ref, the index or HEAD still needs it (corruption). Both
+  reproduce, so the reproduction discriminator cannot separate them, and `UNMEASURED` is
+  deliberately non-fatal to the supervisor's loop — so workers kept running against a
+  demonstrably damaged store, reported as "not measured". They are separated by a **THIRD walk
+  with `--no-reflogs`**, which drops the reflogs from the reachability roots and keeps everything
+  else: a complaint that SURVIVES it is reachable from a live root and is **`CORRUPT`** (with a
+  remedy that says the reflog remedy does not apply); one that CLEARS is `REFLOG-SCOPED` and stays
+  `UNMEASURED` where it was. Measured on git 2.43.0 on real fixtures, both directions: a blob
+  deleted while HEAD's tree names it exits 2 with AND without reflogs; a commit deleted after
+  `reset --hard`, named only by the reflog, exits 2 with and **0** without. **This is NOT the
+  `--no-reflogs` SUPPRESSION rejected in round 1** — that proposal decided whether to REPORT and
+  was measured not to help; this decides WHICH CAUSE, on a class that has already reproduced
+  twice, and can only make the verdict stronger. Passes 1 and 2 never carry the flag, asserted
+  structurally over the shipped call sites. Where the attribution itself fails (a third walk
+  killed, unlaunchable or unclassifiable) the complaint is `UNATTRIBUTED` and non-passing, and a
+  damage bit appearing ONLY in the third walk has not reproduced across the sweep walks: neither
+  is `CORRUPT` and neither is clean. The verdict set stays **closed at three** — the split is in
+  the CAUSE text, not in a fourth token two readers and a structural assert would have to learn. **THE MASK DOES NOT END AT 31, AND
   ASSUMING IT DID DROPPED REAL DAMAGE (review round 2).** A range check over `1..31` — reasoned from
   128 being `die()` and `127 & 1` being 1 — classified **33** (`32|1`) and **36** (`32|4`) as
   unclassified and so `UNMEASURED`: a FALSE NEGATIVE on genuine object corruption, the one direction
@@ -492,7 +512,20 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   convention you are applying is the process that produced it.**  And **no non-clean walk is fatal on ONE observation**: it is re-run exactly ONCE as
   a **discriminator** — a concurrency artefact does not survive a second independent walk, real
   damage does — never a retry-until-clean loop, and a damage class seen once and not twice is
-  `UNMEASURED`, neither established damage nor a clean store. **The `CORRUPT` verdict is PERSISTED
+  `UNMEASURED`, neither established damage nor a clean store. (The reachability ATTRIBUTION walk
+  above is a third walk and a different question; `MAX_SWEEP_WALKS` in the sweep script is the
+  declared ceiling, and every caller's bound is derived from it.)
+  **AND THE TWO CHANNELS MUST AGREE BEFORE THE FATAL VERDICT IS ACTED ON (round 4).** Both
+  consumers read the exit status AND the anchored `verdict ` line, and both tested them with `||`
+  while the comment above each asserted the conjunction — the false-rationale class, and the
+  reason nobody looked. An exit 4 with no verdict line, or a stray `CORRUPT` line under any other
+  status, was therefore enough to create a **STICKY, BOX-WIDE, operator-cleared latch that halts
+  every lane on the box**. Blast radius decides the direction: a false latch stops four lanes
+  until a human notices, while one more iteration over a genuinely damaged store costs the next
+  sweep, which reproduces the damage and latches it properly. So a disagreement is routed to
+  `UNMEASURED` and **NAMED** (`INCONSISTENT sweep result`) rather than folded into the generic
+  "could not measure" line. The `UNMEASURED` tests stay disjunctive on purpose: a disjunction that
+  can only reach a NON-PASSING branch cannot manufacture a verdict. **The `CORRUPT` verdict is PERSISTED
   for the box in its OWN CREATE-ONLY FILE** (`<stamp>.CORRUPT`), because a timestamp-only stamp let
   the detecting lane stop while its three peers saw a fresh stamp, skipped their own sweep for the
   whole interval and kept spawning workers over the damaged store. **PUTTING THE VERDICT IN THE
@@ -525,17 +558,32 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   still start on a box latched moments earlier. It is bounded — that lane's next iteration reads the
   latch at the top of its sweep and stops — and the atomic guarantee needs per-store
   synchronisation shared by the sweep and the spawn decision, which is **split to its own issue**.
-  **The sweep is also NOT INTERRUPTIBLE, so its cost is bounded in WALL TIME instead:** its two
+  **The sweep is also NOT INTERRUPTIBLE, so its cost is bounded in WALL TIME instead:** its
   walks run in a CHILD process, so the supervisor cannot check the stop file between them; it checks
   it (and the wall-clock budget) immediately BEFORE the sweep, and the supervisor's per-walk bound
-  defaults to **half** the sweep script's own (300 vs 600) so two walks cost no more than one walk
-  at the script's bound. Raising a bound is a change to somebody's stop latency.
+  defaults to the sweep script's own bound **divided by `MAX_SWEEP_WALKS`** (200 vs 600/3), so every
+  walk it can pay for still costs no more than one walk at the script's bound. **THE WALK COUNT IS
+  READ FROM THE SHIPPED SCRIPT, NOT RE-TYPED IN THE TEST (round 4):** the relation was asserted with
+  a hard-coded factor 2, so ADDING the third walk would have kept it green while the supervisor's
+  real worst case rose to 900s — a relation whose own constant is restated is two magic numbers
+  wearing a relation's clothes. Raising a bound, or the walk count, is a change to somebody's stop
+  latency.
   **And the stamp's KEY is resolved by the sweep script itself (`--print-store`), never by a `git`
   call in the supervisor:** a bare `git rev-parse --git-common-dir` inherits the caller's
   environment, so an inherited `GIT_DIR`/`GIT_COMMON_DIR` keyed the stamp — and hence the latch — on
   ANOTHER repository, which is roborev job 276's "the allowlist did not reach the sites the fix
   added" at a site the same round left behind. ONE resolver, in the file that owns the `env -i`
-  allowlist, so a future caller has no un-isolated shape available to it.
+  allowlist, so a future caller has no un-isolated shape available to it. **And that key is a
+  DIGEST of the canonical path, because flattening is not INJECTIVE (round 4):** replacing `/` and
+  every unsupported character with `_` maps `/tmp/a/b/objects` and `/tmp/a_b/objects` to ONE name, so
+  two repositories on a box shared a throttle stamp *and* a CORRUPT latch — one store suppressing the
+  other's sweep, or stopping every lane with the other's damage. `<sanitised tail>.<16 hex of
+  sha256>`: the tail is READABILITY ONLY and carries no identity. Three digest tools (`sha256sum`,
+  `shasum -a 256`, `openssl dgst -sha256`) cover both platforms, the output is parsed from both ends
+  and then VALIDATED as hex, and a host with none **fails closed to the EMPTY key** — no throttle, no
+  latch, announced once naming both causes — never a silent fall back to the colliding form on
+  exactly the hosts nobody tested. `cksum` is present everywhere and deliberately unused: CRC32 is
+  not collision-resistant, and a colliding key is the defect being removed.
   because a hygiene probe could not run is a self-DoS). **That sweep is PERIODIC, NOT PER-READ, so
   the emitted clause still says `store TRUSTED, not verified (#3749)` — do not inflate it.**
   **THREE ALTERNATIVES WERE REJECTED and the reasons are recorded so they are not re-derived:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -463,17 +463,47 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   quarter to a half of all runs — so recognising damage from the TEXT SHAPE of a diagnostic
   (`/^error/p`) made a healthy box page high, stop its supervisor and fail `--strict` bootstrap.
   The class now comes from fsck's exit **BITMASK**: bits `1 ERROR_OBJECT` / `4 ERROR_PACK` are this
-  sweep's subject; `2 ERROR_REACHABLE` / `8 ERROR_REFS` / `16 ERROR_COMMIT_GRAPH` are **not demoted
-  to clean** (a genuinely MISSING object reports bit 2) but land on their own non-passing
-  `UNMEASURED` cause; a status outside `1..31` is not a bitmask at all (128 is git's `die()`) and is
-  unclassified. And **no non-clean walk is fatal on ONE observation**: it is re-run exactly ONCE as
+  sweep's subject; `2 ERROR_REACHABLE` / `8 ERROR_REFS` / `16 ERROR_COMMIT_GRAPH` /
+  `32 ERROR_MULTI_PACK_INDEX` are **not demoted to clean** (a genuinely MISSING object reports bit
+  2) but land on their own non-passing `UNMEASURED` cause. **THE MASK DOES NOT END AT 31, AND
+  ASSUMING IT DID DROPPED REAL DAMAGE (review round 2).** A range check over `1..31` — reasoned from
+  128 being `die()` and `127 & 1` being 1 — classified **33** (`32|1`) and **36** (`32|4`) as
+  unclassified and so `UNMEASURED`: a FALSE NEGATIVE on genuine object corruption, the one direction
+  this control exists to prevent. Measured on git 2.43.0 rather than read off a header: a truncated
+  `multi-pack-index` exits 32, and that same store with one corrupted blob exits 35. So the **damage
+  bits are tested INDEPENDENTLY, and FIRST**, before any completeness check on the rest of the
+  status, and an unrelated bit can therefore never MASK damage — it only travels with it. Only a
+  status at or above **124** (the timeout/shell conventions, and `die()`/signal deaths above them) is
+  refused bit-testing outright, and a status carrying a bit OUTSIDE the supported mask is
+  `unclassified` rather than folded into a class whose remedy would be wrong. That is what makes it
+  **degrade safely** as git adds bits: a new bit alongside damage is still damage, a new bit alone is
+  non-passing, and widening `FSCK_KNOWN_MASK` is then a wording change rather than a correctness fix. And **no non-clean walk is fatal on ONE observation**: it is re-run exactly ONCE as
   a **discriminator** — a concurrency artefact does not survive a second independent walk, real
   damage does — never a retry-until-clean loop, and a damage class seen once and not twice is
   `UNMEASURED`, neither established damage nor a clean store. **The `CORRUPT` verdict is PERSISTED
-  in the box-wide throttle stamp**, because a timestamp-only stamp let the detecting lane stop while
-  its three peers saw a fresh stamp, skipped their own sweep for the whole interval and kept
-  spawning workers over the damaged store; the latch does not expire (corruption is
-  non-self-clearing) and is cleared by hand with the `rm -f <stamp>` the remedy names.
+  for the box in its OWN CREATE-ONLY FILE** (`<stamp>.CORRUPT`), because a timestamp-only stamp let
+  the detecting lane stop while its three peers saw a fresh stamp, skipped their own sweep for the
+  whole interval and kept spawning workers over the damaged store. **PUTTING THE VERDICT IN THE
+  THROTTLE STAMP WAS THE FIRST FIX FOR THAT AND WAS ITSELF A DEFECT (round 2):** stamp writes are
+  unsynchronised overwrites, so a lane whose sweep STARTED before the detection can finish AFTER it
+  and replace `CORRUPT` with `VERIFIED`, after which the peers throttle on a fresh non-corrupt stamp
+  and keep working — the same harm through a different door. **Two consecutive rounds found a defect
+  in that ONE shared mutable cell, so the channel is REMOVED rather than serialised** (CLAUDE.md's
+  standing ruling for this family): the latch's only transition is ABSENT -> PRESENT, created under
+  `set -C` so the KERNEL arbitrates and a losing writer cannot overwrite the winner, while the
+  timestamp stays a freely overwritable cell because moving a timestamp backwards costs one extra
+  sweep and nothing else. **A LOCK WAS CONSIDERED AND REJECTED**, and the reason generalises: it
+  makes the read-modify-write atomic but leaves a value any writer can move BACKWARDS, so "CORRUPT is
+  sticky" would rest on every present and future writer remembering to honour it — plus a lock has
+  its own could-not-acquire path that must then not silently skip the latch. The latch does not
+  expire (corruption is non-self-clearing) and is cleared by hand with the `rm -f <latch>` that every
+  message naming it prints; a create that could not happen is REPORTED, never read as a latched box.
+  **And the stamp's KEY is resolved by the sweep script itself (`--print-store`), never by a `git`
+  call in the supervisor:** a bare `git rev-parse --git-common-dir` inherits the caller's
+  environment, so an inherited `GIT_DIR`/`GIT_COMMON_DIR` keyed the stamp — and hence the latch — on
+  ANOTHER repository, which is roborev job 276's "the allowlist did not reach the sites the fix
+  added" at a site the same round left behind. ONE resolver, in the file that owns the `env -i`
+  allowlist, so a future caller has no un-isolated shape available to it.
   because a hygiene probe could not run is a self-DoS). **That sweep is PERIODIC, NOT PER-READ, so
   the emitted clause still says `store TRUSTED, not verified (#3749)` — do not inflate it.**
   **THREE ALTERNATIVES WERE REJECTED and the reasons are recorded so they are not re-derived:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -457,6 +457,23 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   worker supervisor's throttled per-iteration cadence (default 6h; `CORRUPT` **stops that
   supervisor loudly** rather than holding, because corruption is non-self-clearing, while
   `UNMEASURED` is reported and deliberately does NOT stop the loop — refusing to run any worker
+  **THE FATAL VERDICT IS AFFIRMATIVE, AND IT HAD TO BE MADE SO (#3749 review).** A `git fsck` over
+  a store up to eight peer lanes are concurrently writing prints `error:` lines on a **healthy**
+  store — measured on this fleet: `invalid reflog entry` naming a DIFFERENT branch each run, on a
+  quarter to a half of all runs — so recognising damage from the TEXT SHAPE of a diagnostic
+  (`/^error/p`) made a healthy box page high, stop its supervisor and fail `--strict` bootstrap.
+  The class now comes from fsck's exit **BITMASK**: bits `1 ERROR_OBJECT` / `4 ERROR_PACK` are this
+  sweep's subject; `2 ERROR_REACHABLE` / `8 ERROR_REFS` / `16 ERROR_COMMIT_GRAPH` are **not demoted
+  to clean** (a genuinely MISSING object reports bit 2) but land on their own non-passing
+  `UNMEASURED` cause; a status outside `1..31` is not a bitmask at all (128 is git's `die()`) and is
+  unclassified. And **no non-clean walk is fatal on ONE observation**: it is re-run exactly ONCE as
+  a **discriminator** — a concurrency artefact does not survive a second independent walk, real
+  damage does — never a retry-until-clean loop, and a damage class seen once and not twice is
+  `UNMEASURED`, neither established damage nor a clean store. **The `CORRUPT` verdict is PERSISTED
+  in the box-wide throttle stamp**, because a timestamp-only stamp let the detecting lane stop while
+  its three peers saw a fresh stamp, skipped their own sweep for the whole interval and kept
+  spawning workers over the damaged store; the latch does not expire (corruption is
+  non-self-clearing) and is cleared by hand with the `rm -f <stamp>` the remedy names.
   because a hygiene probe could not run is a self-DoS). **That sweep is PERIODIC, NOT PER-READ, so
   the emitted clause still says `store TRUSTED, not verified (#3749)` — do not inflate it.**
   **THREE ALTERNATIVES WERE REJECTED and the reasons are recorded so they are not re-derived:**

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -4988,6 +4988,17 @@ _component_set_probe_inner() {
   if [ "$_cs_complete" = yes ]; then
     _CS_SHA="$remote_sha"
     _CS_BASE_OBJ=reused
+    # WHAT THIS FAST PATH RELIES ON, AND WHAT IT DOES NOT (#3749 owner ruling; the full argument,
+    # including the three REJECTED alternatives, is at the `src_note` object-provenance block in
+    # `_component_set_line`). It reads the baseline's committed manifest out of THIS LANE'S SHARED
+    # object store instead of transferring it: every lane on a box is a worktree of one `.git`, and
+    # an ordinary git read verifies the pack CRC and the zlib stream — enough to catch ACCIDENTAL
+    # damage — but does NOT rehash content against the requested object id. DELIBERATE forgery by a
+    # same-host peer is INVOKER-CLASS and OUT OF MODEL (#3312 triage rule: a peer able to plant
+    # objects can equally edit this script). ACCIDENTAL corruption is in model, and its control is
+    # NOT here: it is the periodic full `git fsck` sweep in
+    # `scripts/check-object-store-integrity.sh`, run at bootstrap and on the worker supervisor's
+    # throttled cadence. The emitted `component-set:` line DECLARES this boundary on every run.
     # THE SCRATCH REPOSITORY IS KEPT EVEN HERE (roborev job 285, High — and a decision the lead
     # made explicitly). It used to be dropped, because "nothing was fetched, so nothing needs an
     # isolated store" — and that left the ancestry walk running in the LIVE repository, where
@@ -5315,36 +5326,65 @@ _component_set_line() {
     declaration) src_note=" — baseline read via the TEXTUAL FALLBACK: $_CS_MANIFEST_REL is VERIFIED ABSENT at that sha (#3544 transitional; the declaration is parsed as TEXT, never executed)" ;;
   esac
   # THE OBJECT STORE IS TRUSTED, NOT VERIFIED — AND THAT IS DECLARED IN THE LINE (roborev job 311,
-  # High; lead ruling on REQ-3544-OBJTRUST, option A; owned by #3746).
+  # High; lead ruling on REQ-3544-OBJTRUST, option A; RESOLVED by #3749).
   #
   # Git does not rehash a packed object against the id it was asked for on an ordinary read, and on
   # this fleet EVERY LANE ON A BOX IS A WORKTREE OF ONE SHARED `.git` (measured:
-  # `/data/lanes/repo/.git/objects` for lane-3544, lane-3473 and lane-3629 alike). So a peer lane
-  # that plants a forged pack/index can make a canonical sha resolve to different content — a
-  # shortened manifest, and a false PASS. Under the triage rule that is a NON-INVOKER route, hence
-  # a defect and not an out-of-model bypass.
+  # `/data/lanes/repo/.git/objects` for lane-3544, lane-3473 and lane-3629 alike). What an ordinary
+  # read DOES check is the pack CRC and the zlib stream, which catch ACCIDENTAL damage — bit rot, a
+  # truncated or torn pack write — but NOT a whole object whose content fails to hash to its own
+  # name. So a planted pack/index could make a canonical sha resolve to different content: a
+  # shortened manifest, and a false PASS.
   #
-  # WHY IT IS DECLARED RATHER THAN CLOSED HERE, which is a ruling and not a shrug. The recorded
-  # "a third finding here should REMOVE the reuse optimisation" ruling assumes removal CLOSES the
-  # exposure, and it does not: the ancestry walk and the provenance leg read HEAD's COMMITTED
-  # content, which has no source other than this store — the working tree cannot substitute,
-  # because `UNCOMMITTED` exists precisely to compare against what is committed. So removing the
-  # fast path leaves a forged HEAD object still able to turn `UNCOMMITTED` (fatal) into `DECLARED`
-  # (non-fatal), while charging every `--lite` round for it: measured 2026-08-31, 3.41 s / 93 MB
-  # full and 3.58 s / 45 MB at `--depth=1` (shallow is NOT cheaper — it still ships the tip's whole
-  # tree). A permanent tax for a half-closure is the guard people learn to waive.
+  # THE THREAT MODEL, AND A RULING THAT OVERTURNED WHAT THIS COMMENT USED TO SAY (#3749, owner
+  # ruling 2026-09-01). This block previously read that a peer lane planting objects "is a
+  # NON-INVOKER route, hence a defect and not an out-of-model bypass". THAT IS OVERTURNED, and the
+  # reversal is recorded here rather than quietly edited so it reads as a decision and not as
+  # drift. DELIBERATE forgery by a same-host peer is INVOKER-CLASS and OUT OF MODEL: CLAUDE.md's
+  # #3312 triage rule is explicit that "same-host actors able to write these scripts or roborev's
+  # database are invoker-class, not third parties" — and a peer that wants a false PASS can simply
+  # EDIT THIS FILE, which is cheaper than forging pack data and is not defended against by anything
+  # inside this process. No check inside a process defends against a party that controls the
+  # process; pretending otherwise is the false-assurance shape #3312 exists to remove.
+  #
+  # WHAT IS IN MODEL IS ACCIDENTAL CORRUPTION, AND ITS CONTROL IS A PERIODIC SWEEP, NAMED HERE SO
+  # THE POINTER SURVIVES: `scripts/check-object-store-integrity.sh` rehashes the whole shared store
+  # with a full `git fsck` (NOT `--connectivity-only`, which does not rehash content and could not
+  # detect this), reporting VERIFIED / CORRUPT / UNMEASURED. It runs at machine onboarding
+  # (`scripts/bootstrap-agent-machine.sh` section 5b-obj) and on the worker supervisor's throttled
+  # per-iteration cadence (`scripts/local/worker-supervisor.sh`, default every 6h; a CORRUPT verdict
+  # stops that supervisor loudly rather than letting a worker certify against a damaged store).
+  # THAT IS PERIODIC, NOT PER-READ — which is exactly why the emitted clause still says TRUSTED,
+  # not verified. Do not inflate it.
+  #
+  # THREE ALTERNATIVES WERE CONSIDERED AND REJECTED BY THAT RULING. Recorded so they are not
+  # re-derived a fourth time:
+  #   * PER-LANE FULL CLONES — a permanent multi-GB, multi-minute tax on every lane for a threat
+  #     that is out of model.
+  #   * PER-READ REHASHING of the consumed objects — the FOURTH carve into this one pre-flight, and
+  #     a permanent cost on every `--lite` round.
+  #   * REMOVING THE REUSE OPTIMISATION — and this one is worth keeping the original argument for,
+  #     because it is still correct and still load-bearing: the recorded "a third finding here
+  #     should REMOVE the reuse optimisation" ruling assumes removal CLOSES the exposure, and it
+  #     does not. The ancestry walk and the provenance leg read HEAD's COMMITTED content, which has
+  #     no source other than this store — the working tree cannot substitute, because `UNCOMMITTED`
+  #     exists precisely to compare against what is committed. So removing the fast path leaves a
+  #     forged HEAD object still able to turn `UNCOMMITTED` (fatal) into `DECLARED` (non-fatal),
+  #     while charging every `--lite` round for it: measured 2026-08-31, 3.41 s / 93 MB full and
+  #     3.58 s / 45 MB at `--depth=1` (shallow is NOT cheaper — it still ships the tip's whole
+  #     tree). A permanent tax for a HALF-closure is the guard people learn to waive.
   #
   # So the line says what it depends on. A check that claims nothing false is worth more than one
   # claiming a closure it does not deliver — the same move the roborev waiver's threat model makes
   # where a dependency cannot be removed. It is FOLDED INTO `src_note` deliberately: that suffix is
   # already the uniform "this line ends by naming its baseline source", eleven printf arms consume
-  # it, and appending an twelfth-argument clause to each would be one fact written eleven times.
+  # it, and appending a twelfth-argument clause to each would be one fact written eleven times.
   case "${src_note:+set}" in
     set)
       case "$_CS_BASE_OBJ" in
-        reused)  src_note="$src_note; objects: baseline REUSED from this lane's SHARED store — store TRUSTED, not verified (#3746)" ;;
-        fetched) src_note="$src_note; objects: baseline FETCHED from the canonical remote, HEAD's own from this lane's SHARED store — store TRUSTED, not verified (#3746)" ;;
-        *)       src_note="$src_note; objects: provenance NOT RECORDED — treat the store as TRUSTED, not verified (#3746)" ;;
+        reused)  src_note="$src_note; objects: baseline REUSED from this lane's SHARED store — store TRUSTED, not verified (#3749)" ;;
+        fetched) src_note="$src_note; objects: baseline FETCHED from the canonical remote, HEAD's own from this lane's SHARED store — store TRUSTED, not verified (#3749)" ;;
+        *)       src_note="$src_note; objects: provenance NOT RECORDED — treat the store as TRUSTED, not verified (#3749)" ;;
       esac ;;
   esac
   case "$verdict" in

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -4998,7 +4998,9 @@ _component_set_probe_inner() {
     # objects can equally edit this script). ACCIDENTAL corruption is in model, and its control is
     # NOT here: it is the periodic full `git fsck` sweep in
     # `scripts/check-object-store-integrity.sh`, run at bootstrap and on the worker supervisor's
-    # throttled cadence. The emitted `component-set:` line DECLARES this boundary on every run.
+    # throttled cadence. The emitted `component-set:` line DECLARES this boundary on every
+    # BASELINE-BEARING arm (the `src_note` suffix); the UNMEASURED arms have no baseline to name
+    # and so do not carry it, which is CLAUDE.md's scoping of the same sentence.
     # THE SCRATCH REPOSITORY IS KEPT EVEN HERE (roborev job 285, High — and a decision the lead
     # made explicitly). It used to be dropped, because "nothing was fetched, so nothing needs an
     # isolated store" — and that left the ancestry walk running in the LIVE repository, where

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -5351,7 +5351,7 @@ _component_set_line() {
   # THE POINTER SURVIVES: `scripts/check-object-store-integrity.sh` rehashes the whole shared store
   # with a full `git fsck` (NOT `--connectivity-only`, which does not rehash content and could not
   # detect this), reporting VERIFIED / CORRUPT / UNMEASURED. It runs at machine onboarding
-  # (`scripts/bootstrap-agent-machine.sh` section 5b-obj) and on the worker supervisor's throttled
+  # (`scripts/bootstrap-agent-machine.sh` section 5d) and on the worker supervisor's throttled
   # per-iteration cadence (`scripts/local/worker-supervisor.sh`, default every 6h; a CORRUPT verdict
   # stops that supervisor loudly rather than letting a worker certify against a damaged store).
   # THAT IS PERIODIC, NOT PER-READ — which is exactly why the emitted clause still says TRUSTED,

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -16510,6 +16510,22 @@ run_tooling_tests() {
     return 0
   fi
 
+  # shared-object-store sweep guard (#3749): ABOVE the python3 gate on purpose. This suite
+  # needs nothing beyond bash + git, and folding a never-SKIPping suite into a SKIP-aware
+  # block would be a coverage hole wearing a SKIP's clothes (#3522's ruling). A failure
+  # here FAILs the component, mirroring the two guards above.
+  echo ">>> [$name] bash scripts/tests/test_check_object_store_integrity.sh"
+  if ! bash "$REPO_ROOT/scripts/tests/test_check_object_store_integrity.sh" >>"$log" 2>&1; then
+    status=FAIL
+    echo "--- [$name] FAILED (object-store integrity sweep #3749); last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
   if ! command -v python3 >/dev/null 2>&1; then
     status=SKIP
     echo ">>> [$name] SKIP (no python3 on PATH; selftest truncation reader needs it)"

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -122,6 +122,20 @@
 #                                                      #   CQLITE_BOOTSTRAP_SKIP_GATE_PIN=1 is the
 #                                                      #   env spelling, for harnesses that drive
 #                                                      #   bootstrap on a fixed command line.
+#   bash scripts/bootstrap-agent-machine.sh --skip-object-store-sweep  # skip ONLY section
+#                                                      #   5b-obj (the `git fsck` rehash of this
+#                                                      #   box's SHARED git object store, #3749).
+#                                                      #   Same posture as --skip-push-probe /
+#                                                      #   --skip-gate-pin: it emits
+#                                                      #   `object-store: OPT-OUT` as a [warn], so
+#                                                      #   it withholds "All checks green." and can
+#                                                      #   never buy a vacuous green. The sweep
+#                                                      #   costs ~20s on a 331M store, so the
+#                                                      #   sibling self-suites (which drive
+#                                                      #   bootstrap dozens of times against the
+#                                                      #   real checkout) opt out via
+#                                                      #   CQLITE_BOOTSTRAP_SKIP_OBJECT_STORE_SWEEP=1,
+#                                                      #   the env spelling.
 #   bash scripts/bootstrap-agent-machine.sh --skip-smoke   # skip the final GATE run (section 6).
 #                                                      #   DISTINCT from --skip-push-probe: this
 #                                                      #   one is about the gate fmt smoke, that
@@ -152,6 +166,25 @@ SKIP_GATE_PIN_HOW=""
 if [ "${CQLITE_BOOTSTRAP_SKIP_GATE_PIN:-0}" = 1 ]; then
   SKIP_GATE_PIN=1; SKIP_GATE_PIN_HOW="CQLITE_BOOTSTRAP_SKIP_GATE_PIN=1"
 fi
+# --skip-object-store-sweep / CQLITE_BOOTSTRAP_SKIP_OBJECT_STORE_SWEEP=1 (issue #3749):
+# skip section 5b-obj, the `git fsck` rehash of this box's SHARED git object store. A
+# FOURTH subject, so a fourth switch — the one-flag-per-subject rule the three above
+# already follow. LOUD and NON-PASSING (an `object-store: OPT-OUT` [warn]), so it
+# withholds "All checks green." and --strict still exits 1: an opt-out that returned `ok`
+# would be a switch for buying a vacuous green, and a vacuously-green integrity sweep is
+# worse than none because it invites reliance it cannot support.
+#
+# THE ENV SPELLING IS NOT A CONVENIENCE, IT IS WHAT KEEPS THE SELF-SUITES USABLE.
+# scripts/tests/test_bootstrap_agent_machine.sh drives this script ~37 times against the
+# REAL checkout, whose shared store measures 19.83s per sweep — ~12 minutes added to a
+# MANDATORY gate component for a property those cases are not about. They export the
+# variable once; the cases that ARE about this section unset it and run against their own
+# small scratch repos.
+SKIP_OBJ_SWEEP=0
+SKIP_OBJ_SWEEP_HOW=""
+if [ "${CQLITE_BOOTSTRAP_SKIP_OBJECT_STORE_SWEEP:-0}" = 1 ]; then
+  SKIP_OBJ_SWEEP=1; SKIP_OBJ_SWEEP_HOW="CQLITE_BOOTSTRAP_SKIP_OBJECT_STORE_SWEEP=1"
+fi
 # --fix-gate-pin (issue #3414): perform section 5b's /etc/environment write WITHOUT --yes,
 # and nothing else. A SIBLING of --fix-credentials, deliberately not a widening of it:
 # that flag documents itself as running section 3b's auto-fix "and NOTHING else", and
@@ -174,6 +207,7 @@ for arg in "$@"; do
     --skip-smoke) SKIP_SMOKE=1 ;;
     --skip-push-probe) SKIP_PUSH_PROBE=1 ;;
     --skip-gate-pin) SKIP_GATE_PIN=1; SKIP_GATE_PIN_HOW="--skip-gate-pin" ;;
+    --skip-object-store-sweep) SKIP_OBJ_SWEEP=1; SKIP_OBJ_SWEEP_HOW="--skip-object-store-sweep" ;;
     --fix-gate-pin) FIX_GATE_PIN=1 ;;
     --fix-credentials) FIX_CREDENTIALS=1 ;;
     --strict) STRICT=1 ;;
@@ -2910,6 +2944,93 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   fi
 fi
 
+# ---- 5b-obj. Shared object-store integrity (issue #3749) ----
+#
+# WHY THIS SECTION EXISTS. Every lane on this box is a `git worktree` of ONE shared
+# `.git`, and git does not rehash an object against the id it was asked for on an
+# ordinary read. So the gate's component-set pre-flight — which reads origin/main's
+# committed manifest and HEAD's committed component declaration THROUGH that store — is
+# trusting content nothing verified, and a corrupt store can change ANY gate's verdict on
+# this box. #3749's owner ruling scoped the in-model subject to ACCIDENTAL corruption
+# (bit rot, a torn pack write, a SIGKILLed gc); DELIBERATE peer forgery is invoker-class
+# and out of model per the #3312 triage rule. This is the bootstrap half of the control;
+# the recurring half is scripts/local/worker-supervisor.sh's throttled sweep.
+#
+# ONE IMPLEMENTATION, TWO CALLERS: both go through scripts/check-object-store-integrity.sh,
+# because a second implementation is a second place for the verdict to drift.
+#
+# VERIFIED IS THE ONLY [ok] — CLAUDE.md's recorded lesson from #3414 verbatim: scoping a
+# case out is not the same as passing it, and an [ok] is what --strict reads, so an [ok]
+# on an unmeasured host is a false certification.
+hdr "Shared object-store integrity (git fsck, issue #3749)"
+OBJ_SWEEP_SH="$REPO_ROOT/scripts/check-object-store-integrity.sh"
+# The sweep bounds its own fsck; this outer bound is belt, and it is LOOSER than the inner
+# one on purpose — a wrapper that expires first would report "the sweep produced no
+# verdict" for a run the sweep was about to classify itself.
+OBJ_SWEEP_INNER_BOUND=300
+OBJ_SWEEP_OUTER_BOUND=360
+OBJ_STORE_CORRUPT=0
+if [ "$SKIP_OBJ_SWEEP" = 1 ]; then
+  warn "object-store: OPT-OUT ($SKIP_OBJ_SWEEP_HOW) — this box's SHARED git object store was NOT swept"
+  info "this run cannot certify that the store every lane here reads is intact; drop the opt-out to measure it"
+elif ! have git; then
+  warn "object-store: UNMEASURED (git is not installed — nothing to rehash the store with)"
+elif [ ! -r "$OBJ_SWEEP_SH" ]; then
+  warn "object-store: UNMEASURED (no scripts/check-object-store-integrity.sh under $REPO_ROOT — the sanctioned sweep is not in this checkout)"
+else
+  obj_out=""
+  obj_rc=0
+  obj_out=$(bounded "$OBJ_SWEEP_OUTER_BOUND" bash "$OBJ_SWEEP_SH" \
+    --repo "$REPO_ROOT" --timeout "$OBJ_SWEEP_INNER_BOUND" 2>&1) || obj_rc=$?
+  # THE VERDICT IS READ FROM THE ANCHORED `verdict ` LINE *AND* THE EXIT STATUS, both
+  # required. The line alone is text (and the sweep prints repository-controlled paths
+  # verbatim, so an unanchored match could land on one); the status alone cannot
+  # distinguish a sweep that classified itself from a wrapper that killed it. Every match
+  # below is anchored on `OBJECT-STORE: verdict `, which is the sweep's own control token
+  # and a position no dynamic field of its output can reach.
+  obj_verdict=$(printf '%s\n' "$obj_out" | grep '^OBJECT-STORE: verdict ' | head -1)
+  obj_verdict=${obj_verdict#OBJECT-STORE: verdict }
+  obj_verdict=${obj_verdict%% *}
+  if [ "$obj_rc" -eq 0 ] && [ "$obj_verdict" = VERIFIED ]; then
+    # The ONE affirmative branch. `git fsck` rehashed every object in the shared store and
+    # found nothing damaged — a POINT-IN-TIME sweep, which the message says so nobody reads
+    # it as a per-read guarantee.
+    ok "object-store: VERIFIED ($(printf '%s\n' "$obj_out" | grep '^OBJECT-STORE: measured ' | head -1 | sed 's/^OBJECT-STORE: measured //')) — a point-in-time full rehash, not a per-read guarantee"
+  elif [ "$obj_rc" -eq 4 ] || [ "$obj_verdict" = CORRUPT ]; then
+    # CORRUPT FAILS LOUDLY AND NAMES THE OBJECTS. Not a hard exit: this script's contract
+    # is that every section runs and the verdicts accumulate (a mid-script exit would
+    # silently skip sections 5c/6 and change what a caller sees). What makes it loud is
+    # three things instead — the [warn] (which withholds "All checks green." and fails
+    # --strict), the verbatim fsck findings, and a restatement in the summary banner.
+    OBJ_STORE_CORRUPT=1
+    warn "object-store: CORRUPT — the SHARED git object store on this box holds damaged objects. NO GATE RUN HERE CAN BE TRUSTED."
+    printf '%s\n' "$obj_out" | grep -E '^OBJECT-STORE: (finding|object) ' | head -20 | while IFS= read -r obj_line; do
+      info "$obj_line"
+    done
+    info "REMEDY: stop every lane on this box, then re-obtain the objects from the canonical remote"
+    info "  (a fresh clone of pmcfadin/cqlite, or 'git fetch --force origin' if only fetched packs are damaged)."
+    info "  A LOCAL 'git gc'/'git repack' CANNOT repair this — escalate rather than improvising (#3749)."
+  elif [ "$obj_rc" -eq 5 ] || [ "$obj_verdict" = UNMEASURED ]; then
+    # UNMEASURED IS A [warn] NAMING WHAT COULD NOT BE MEASURED — never an [ok]. The
+    # sweep's own `unmeasured-cause` lines are quoted rather than re-worded: a diagnostic
+    # improved in one file and thrown away by its consumer is a defect this repo has
+    # already paid for (#3369).
+    warn "object-store: UNMEASURED — the shared store was NOT rehashed, so its integrity is UNKNOWN, not ok"
+    printf '%s\n' "$obj_out" | grep '^OBJECT-STORE: unmeasured-cause ' | head -8 | while IFS= read -r obj_line; do
+      info "$obj_line"
+    done
+    info "verify by hand once the cause is cleared:  bash scripts/check-object-store-integrity.sh"
+  else
+    # NO RECOGNISED VERDICT AT ALL: the sweep was killed by the outer bound, died before it
+    # could classify itself, or emitted something this reader does not know. Unknown is
+    # never ok.
+    warn "object-store: UNMEASURED (the sweep produced no recognised verdict, rc=$obj_rc — integrity is UNKNOWN, not ok)"
+    printf '%s\n' "$obj_out" | head -4 | while IFS= read -r obj_line; do
+      [ -n "$obj_line" ] && info "$obj_line"
+    done
+  fi
+fi
+
 # ---- 5c. Notification channel (ntfy) — issue #3119 ----
 # The gate's push signal (#2667) and the worker supervisor page over ntfy. That
 # dependency used to be an out-of-band, per-machine `/usr/local/bin/agent-notify`
@@ -3010,6 +3131,12 @@ fi
 
 # ---- Summary ----
 hdr "Bootstrap summary"
+# RESTATED HERE BECAUSE ONE [warn] AMONG MANY IS MISSABLE, and this one means every gate
+# verdict on this box is untrustworthy (#3749). It changes no exit status — the [warn]
+# already withholds green and fails --strict; this is the loudness half.
+if [ "${OBJ_STORE_CORRUPT:-0}" = 1 ]; then
+  printf '  \033[31mSHARED OBJECT STORE CORRUPT.\033[0m Do NOT run a gate on this box until it is resolved (section 5b-obj above, #3749).\n'
+fi
 if [ "$WARNINGS" -eq 0 ]; then
   printf '  \033[32mAll checks green.\033[0m This machine is ready for CQLite agent work.\n'
 else

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -3089,6 +3089,15 @@ else
   # distinguish a sweep that classified itself from a wrapper that killed it. Every match
   # below is anchored on `OBJECT-STORE: verdict `, which is the sweep's own control token
   # and a position no dynamic field of its output can reach.
+  #
+  # THE TWO ACTIONABLE VERDICTS REQUIRE THE TWO CHANNELS TO AGREE; THE NON-PASSING ONES DO
+  # NOT, AND THE ASYMMETRY IS DELIBERATE (#3749 review round 4, item 2). CORRUPT was `||`
+  # while this comment already asserted the conjunction, so an exit 4 with no verdict line
+  # — or a stray `CORRUPT` line under any other status — reported CORRUPT here and, in the
+  # sibling supervisor, created a persistent box-wide latch that halts every lane until an
+  # operator clears it by hand. A disjunction that can only reach a NON-PASSING branch
+  # cannot manufacture a verdict, so the UNMEASURED test below stays `||`: every path it
+  # does not take lands on the final `else`, which also warns.
   # `{ grep || true; }` throughout: a grep with no match exits 1 and `pipefail` is on, so
   # a bare pipeline or an assignment from such a substitution would carry a non-zero status
   # — and "no match" is reachable (a sweep killed at its bound prints no verdict line). This
@@ -3104,7 +3113,7 @@ else
     # found nothing damaged — a POINT-IN-TIME sweep, which the message says so nobody reads
     # it as a per-read guarantee.
     ok "object-store: VERIFIED ($(printf '%s\n' "$obj_out" | { grep '^OBJECT-STORE: measured ' || true; } | head -1 | sed 's/^OBJECT-STORE: measured //')) — a point-in-time full rehash, not a per-read guarantee"
-  elif [ "$obj_rc" -eq 4 ] || [ "$obj_verdict" = CORRUPT ]; then
+  elif [ "$obj_rc" -eq 4 ] && [ "$obj_verdict" = CORRUPT ]; then
     # CORRUPT FAILS LOUDLY AND NAMES THE OBJECTS. Not a hard exit: this script's contract
     # is that every section runs and the verdicts accumulate (a mid-script exit would
     # silently skip sections 5c/6 and change what a caller sees). What makes it loud is
@@ -3118,6 +3127,17 @@ else
     info "REMEDY: stop every lane on this box, then re-obtain the objects from the canonical remote"
     info "  (a fresh clone of pmcfadin/cqlite, or 'git fetch --force origin' if only fetched packs are damaged)."
     info "  A LOCAL 'git gc'/'git repack' CANNOT repair this — escalate rather than improvising (#3749)."
+  elif [ "$obj_rc" -eq 4 ] || [ "$obj_verdict" = CORRUPT ]; then
+    # EXACTLY ONE CHANNEL SAYS CORRUPT (the conjunction above has already failed), so this
+    # run neither established damage nor ruled it out. NAMED rather than folded into the
+    # generic UNMEASURED message below, which would read as an ordinary missing line — and
+    # deliberately NOT escalated to CORRUPT: see the conjunction note above for why an
+    # unrecognised or incomplete sweep must not be able to produce that verdict.
+    warn "object-store: UNMEASURED — INCONSISTENT sweep result (rc=$obj_rc verdict='${obj_verdict:-<none>}'): exactly ONE of the exit status and the anchored verdict line says CORRUPT, so damage was neither established nor ruled out"
+    printf '%s\n' "$obj_out" | { grep -E '^OBJECT-STORE: (unmeasured-cause|finding|object) ' || true; } | head -8 | while IFS= read -r obj_line; do
+      info "$obj_line"
+    done
+    info "investigate the sweep itself, then re-run by hand:  bash scripts/check-object-store-integrity.sh"
   elif [ "$obj_rc" -eq 5 ] || [ "$obj_verdict" = UNMEASURED ]; then
     # UNMEASURED IS A [warn] NAMING WHAT COULD NOT BE MEASURED — never an [ok]. The
     # sweep's own `unmeasured-cause` lines are quoted rather than re-worded: a diagnostic

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -3071,6 +3071,7 @@ OBJ_SWEEP_SH="$REPO_ROOT/scripts/check-object-store-integrity.sh"
 OBJ_SWEEP_INNER_BOUND=600
 OBJ_SWEEP_OUTER_BOUND=1980
 OBJ_STORE_CORRUPT=0
+OBJ_STORE_UNSWEEPABLE=0
 if [ "$SKIP_OBJ_SWEEP" = 1 ]; then
   warn "object-store: OPT-OUT ($SKIP_OBJ_SWEEP_HOW) — this box's SHARED git object store was NOT swept"
   info "this run cannot certify that the store every lane here reads is intact; drop the opt-out to measure it"
@@ -3145,13 +3146,38 @@ else
       info "  Re-run it by hand for the full remedy:  bash scripts/check-object-store-integrity.sh"
       info "  A LOCAL 'git gc'/'git repack' CANNOT repair this — escalate rather than improvising (#3749)."
     fi
-  elif [ "$obj_rc" -eq 4 ] || [ "$obj_verdict" = CORRUPT ]; then
+  elif [ "$obj_rc" -eq 6 ] && [ "$obj_verdict" = UNSWEEPABLE ]; then
+    # THE SWEEP RAN AND REPRODUCIBLY DIED WITHOUT FINISHING (#3749 review round 10, item
+    # 1). A [warn] like CORRUPT — it withholds "All checks green.", fails --strict and is
+    # restated in the banner — but it CLAIMS NO CAUSE, and the difference is the whole
+    # point of the verdict: "the probe could not START" (UNMEASURED, below, permissive
+    # because it is a fact about this box's tooling) and "the probe RAN, twice, and died
+    # on this store" are different facts. No damage was established here, so this branch
+    # names none and quotes the sweep's own guidance instead of restating a repair.
+    OBJ_STORE_UNSWEEPABLE=1
+    warn "object-store: UNSWEEPABLE — git fsck RAN and reproducibly DIED without finishing over the SHARED git object store on this box, so its integrity is UNKNOWN, not ok. NO GATE RUN HERE CAN BE TRUSTED. No cause was established."
+    printf '%s\n' "$obj_out" | { grep -E '^OBJECT-STORE: (finding|object) ' || true; } | head -20 | while IFS= read -r obj_line; do
+      info "$obj_line"
+    done
+    obj_remedy=$(printf '%s\n' "$obj_out" | { grep '^OBJECT-STORE: verdict-detail ' || true; } | head -40)
+    if [ -n "$obj_remedy" ]; then
+      printf '%s\n' "$obj_remedy" | while IFS= read -r obj_line; do
+        info "$obj_line"
+      done
+    else
+      # FAIL-CLOSED ON THE DIAGNOSTIC, and deliberately WITHOUT a repair instruction: this
+      # verdict established no cause, so naming one would be the round-9 defect (a printed
+      # remedy that does not match what was measured).
+      info "REMEDY: this sweep printed no operator guidance (an older or stubbed check-object-store-integrity.sh)."
+      info "  Re-run it by hand and act on what its 'fatal:' line names:  bash scripts/check-object-store-integrity.sh"
+    fi
+  elif [ "$obj_rc" -eq 4 ] || [ "$obj_rc" -eq 6 ] || [ "$obj_verdict" = CORRUPT ] || [ "$obj_verdict" = UNSWEEPABLE ]; then
     # EXACTLY ONE CHANNEL SAYS CORRUPT (the conjunction above has already failed), so this
     # run neither established damage nor ruled it out. NAMED rather than folded into the
     # generic UNMEASURED message below, which would read as an ordinary missing line — and
     # deliberately NOT escalated to CORRUPT: see the conjunction note above for why an
     # unrecognised or incomplete sweep must not be able to produce that verdict.
-    warn "object-store: UNMEASURED — INCONSISTENT sweep result (rc=$obj_rc verdict='${obj_verdict:-<none>}'): exactly ONE of the exit status and the anchored verdict line says CORRUPT, so damage was neither established nor ruled out"
+    warn "object-store: UNMEASURED — INCONSISTENT sweep result (rc=$obj_rc verdict='${obj_verdict:-<none>}'): exactly ONE of the exit status and the anchored verdict line reports a STOPPING verdict, or the two name different ones, so nothing was established nor ruled out"
     printf '%s\n' "$obj_out" | { grep -E '^OBJECT-STORE: (unmeasured-cause|finding|object) ' || true; } | head -8 | while IFS= read -r obj_line; do
       info "$obj_line"
     done
@@ -3200,6 +3226,12 @@ hdr "Bootstrap summary"
 # already withholds green and fails --strict; this is the loudness half.
 if [ "${OBJ_STORE_CORRUPT:-0}" = 1 ]; then
   printf '  \033[31mSHARED OBJECT STORE CORRUPT.\033[0m Do NOT run a gate on this box until it is resolved (section 5d above, #3749).\n'
+fi
+# ITS OWN LINE, NOT FOLDED INTO THE ONE ABOVE (#3749 review round 10, item 1): the store
+# could not be SWEPT and NO cause was established, so claiming damage in the banner would
+# be exactly the confidently-wrong text this verdict exists to avoid.
+if [ "${OBJ_STORE_UNSWEEPABLE:-0}" = 1 ]; then
+  printf '  \033[31mSHARED OBJECT STORE COULD NOT BE SWEPT.\033[0m Its integrity is UNKNOWN and no cause was established: do NOT run a gate on this box until it is resolved (section 5d above, #3749).\n'
 fi
 if [ "$WARNINGS" -eq 0 ]; then
   printf '  \033[32mAll checks green.\033[0m This machine is ready for CQLite agent work.\n'

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -3230,10 +3230,13 @@ if [ "${OBJ_STORE_CORRUPT:-0}" = 1 ]; then
   printf '  \033[31mSHARED OBJECT STORE CORRUPT.\033[0m Do NOT run a gate on this box until it is resolved (section 5d above, #3749).\n'
 fi
 # ITS OWN LINE, NOT FOLDED INTO THE ONE ABOVE (#3749 review round 10, item 1): the store
-# could not be SWEPT and NO cause was established, so claiming damage in the banner would
-# be exactly the confidently-wrong text this verdict exists to avoid.
+# could not be SWEPT and NO DAMAGE was established, so claiming damage in the banner would
+# be exactly the confidently-wrong text this verdict exists to avoid. It says "no damage"
+# rather than "no cause" because since round 11, item 1 this verdict has TWO causes and one
+# of them — the store's own `fsck.*` config — IS named; what holds for both is that nothing
+# was rehashed, so no damage was found either way.
 if [ "${OBJ_STORE_UNSWEEPABLE:-0}" = 1 ]; then
-  printf '  \033[31mSHARED OBJECT STORE COULD NOT BE SWEPT.\033[0m Its integrity is UNKNOWN and no cause was established: do NOT run a gate on this box until it is resolved (section 5d above, #3749).\n'
+  printf '  \033[31mSHARED OBJECT STORE COULD NOT BE SWEPT.\033[0m Its integrity is UNKNOWN and NO damage was established: do NOT run a gate on this box until it is resolved (section 5d above, #3749).\n'
 fi
 if [ "$WARNINGS" -eq 0 ]; then
   printf '  \033[32mAll checks green.\033[0m This machine is ready for CQLite agent work.\n'

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -3124,9 +3124,27 @@ else
     printf '%s\n' "$obj_out" | { grep -E '^OBJECT-STORE: (finding|object) ' || true; } | head -20 | while IFS= read -r obj_line; do
       info "$obj_line"
     done
-    info "REMEDY: stop every lane on this box, then re-obtain the objects from the canonical remote"
-    info "  (a fresh clone of pmcfadin/cqlite, or 'git fetch --force origin' if only fetched packs are damaged)."
-    info "  A LOCAL 'git gc'/'git repack' CANNOT repair this — escalate rather than improvising (#3749)."
+    # THE REMEDY IS QUOTED FROM THE SWEEP, NOT RESTATED HERE (#3749 review round 9, item
+    # 2). This section used to carry its own paraphrase, and it said `git fetch --force
+    # origin` — which repairs nothing: `--force` only permits non-fast-forward REF updates
+    # and re-downloads no objects, so an operator who followed it exactly kept the
+    # corruption and believed it fixed. A remedy duplicated in three files is a remedy
+    # that will be corrected in one of them, and this file already carries the ruling for
+    # exactly that (#3369: a diagnostic improved in one file and thrown away by its
+    # consumer is a defect this repo has paid for). So the sweep owns the text, where the
+    # measurements that justify it live beside it, and this consumer prints it verbatim.
+    obj_remedy=$(printf '%s\n' "$obj_out" | { grep '^OBJECT-STORE: verdict-detail ' || true; } | head -40)
+    if [ -n "$obj_remedy" ]; then
+      printf '%s\n' "$obj_remedy" | while IFS= read -r obj_line; do
+        info "$obj_line"
+      done
+    else
+      # FAIL-CLOSED ON THE DIAGNOSTIC: an older, newer or stubbed sweep may print no
+      # guidance at all, and a stopped box must never be left with none.
+      info "REMEDY: this sweep printed no operator guidance (an older or stubbed check-object-store-integrity.sh)."
+      info "  Re-run it by hand for the full remedy:  bash scripts/check-object-store-integrity.sh"
+      info "  A LOCAL 'git gc'/'git repack' CANNOT repair this — escalate rather than improvising (#3749)."
+    fi
   elif [ "$obj_rc" -eq 4 ] || [ "$obj_verdict" = CORRUPT ]; then
     # EXACTLY ONE CHANNEL SAYS CORRUPT (the conjunction above has already failed), so this
     # run neither established damage nor ruled it out. NAMED rather than folded into the

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -3060,12 +3060,16 @@ OBJ_SWEEP_SH="$REPO_ROOT/scripts/check-object-store-integrity.sh"
 # one on purpose — a wrapper that expires first would report "the sweep produced no
 # verdict" for a run the sweep was about to classify itself.
 #
-# THE INNER BOUND IS PER WALK, AND THE SWEEP TAKES TWO WHEN THE FIRST IS NOT CLEAN (the
-# #3749 reproduction discriminator), so the outer one has to clear 2x the inner one plus
-# process overhead — sized from a MEASURED range (13-24s warm, 47-80s cold on this
-# fleet's 366M store), not from the single warm number an earlier revision quoted.
+# THE INNER BOUND IS PER WALK, AND THE SWEEP CAN TAKE THREE (MAX_SWEEP_WALKS in the sweep
+# script: the sweep, the reproduction discriminator when walk 1 is not clean, and the
+# `--no-reflogs` reachability-cause discriminator when both walks report ERROR_REACHABLE
+# — #3749 review round 4), so the outer one has to clear 3x the inner one plus process
+# overhead — sized from a MEASURED range (13-24s warm, 47-80s cold on this fleet's 366M
+# store), not from the single warm number an earlier revision quoted. A wrapper that
+# expired first would report "the sweep produced no verdict" for a run the sweep was
+# about to classify itself, which is why it is the LOOSER of the two.
 OBJ_SWEEP_INNER_BOUND=600
-OBJ_SWEEP_OUTER_BOUND=1320
+OBJ_SWEEP_OUTER_BOUND=1980
 OBJ_STORE_CORRUPT=0
 if [ "$SKIP_OBJ_SWEEP" = 1 ]; then
   warn "object-store: OPT-OUT ($SKIP_OBJ_SWEEP_HOW) — this box's SHARED git object store was NOT swept"

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -123,7 +123,7 @@
 #                                                      #   env spelling, for harnesses that drive
 #                                                      #   bootstrap on a fixed command line.
 #   bash scripts/bootstrap-agent-machine.sh --skip-object-store-sweep  # skip ONLY section
-#                                                      #   5b-obj (the `git fsck` rehash of this
+#                                                      #   5d (the `git fsck` rehash of this
 #                                                      #   box's SHARED git object store, #3749).
 #                                                      #   Same posture as --skip-push-probe /
 #                                                      #   --skip-gate-pin: it emits
@@ -167,7 +167,7 @@ if [ "${CQLITE_BOOTSTRAP_SKIP_GATE_PIN:-0}" = 1 ]; then
   SKIP_GATE_PIN=1; SKIP_GATE_PIN_HOW="CQLITE_BOOTSTRAP_SKIP_GATE_PIN=1"
 fi
 # --skip-object-store-sweep / CQLITE_BOOTSTRAP_SKIP_OBJECT_STORE_SWEEP=1 (issue #3749):
-# skip section 5b-obj, the `git fsck` rehash of this box's SHARED git object store. A
+# skip section 5d, the `git fsck` rehash of this box's SHARED git object store. A
 # FOURTH subject, so a fourth switch — the one-flag-per-subject rule the three above
 # already follow. LOUD and NON-PASSING (an `object-store: OPT-OUT` [warn]), so it
 # withholds "All checks green." and --strict still exits 1: an opt-out that returned `ok`
@@ -2944,93 +2944,6 @@ if [ "$PIN_SECTION_OK" = 1 ]; then
   fi
 fi
 
-# ---- 5b-obj. Shared object-store integrity (issue #3749) ----
-#
-# WHY THIS SECTION EXISTS. Every lane on this box is a `git worktree` of ONE shared
-# `.git`, and git does not rehash an object against the id it was asked for on an
-# ordinary read. So the gate's component-set pre-flight — which reads origin/main's
-# committed manifest and HEAD's committed component declaration THROUGH that store — is
-# trusting content nothing verified, and a corrupt store can change ANY gate's verdict on
-# this box. #3749's owner ruling scoped the in-model subject to ACCIDENTAL corruption
-# (bit rot, a torn pack write, a SIGKILLed gc); DELIBERATE peer forgery is invoker-class
-# and out of model per the #3312 triage rule. This is the bootstrap half of the control;
-# the recurring half is scripts/local/worker-supervisor.sh's throttled sweep.
-#
-# ONE IMPLEMENTATION, TWO CALLERS: both go through scripts/check-object-store-integrity.sh,
-# because a second implementation is a second place for the verdict to drift.
-#
-# VERIFIED IS THE ONLY [ok] — CLAUDE.md's recorded lesson from #3414 verbatim: scoping a
-# case out is not the same as passing it, and an [ok] is what --strict reads, so an [ok]
-# on an unmeasured host is a false certification.
-hdr "Shared object-store integrity (git fsck, issue #3749)"
-OBJ_SWEEP_SH="$REPO_ROOT/scripts/check-object-store-integrity.sh"
-# The sweep bounds its own fsck; this outer bound is belt, and it is LOOSER than the inner
-# one on purpose — a wrapper that expires first would report "the sweep produced no
-# verdict" for a run the sweep was about to classify itself.
-OBJ_SWEEP_INNER_BOUND=300
-OBJ_SWEEP_OUTER_BOUND=360
-OBJ_STORE_CORRUPT=0
-if [ "$SKIP_OBJ_SWEEP" = 1 ]; then
-  warn "object-store: OPT-OUT ($SKIP_OBJ_SWEEP_HOW) — this box's SHARED git object store was NOT swept"
-  info "this run cannot certify that the store every lane here reads is intact; drop the opt-out to measure it"
-elif ! have git; then
-  warn "object-store: UNMEASURED (git is not installed — nothing to rehash the store with)"
-elif [ ! -r "$OBJ_SWEEP_SH" ]; then
-  warn "object-store: UNMEASURED (no scripts/check-object-store-integrity.sh under $REPO_ROOT — the sanctioned sweep is not in this checkout)"
-else
-  obj_out=""
-  obj_rc=0
-  obj_out=$(bounded "$OBJ_SWEEP_OUTER_BOUND" bash "$OBJ_SWEEP_SH" \
-    --repo "$REPO_ROOT" --timeout "$OBJ_SWEEP_INNER_BOUND" 2>&1) || obj_rc=$?
-  # THE VERDICT IS READ FROM THE ANCHORED `verdict ` LINE *AND* THE EXIT STATUS, both
-  # required. The line alone is text (and the sweep prints repository-controlled paths
-  # verbatim, so an unanchored match could land on one); the status alone cannot
-  # distinguish a sweep that classified itself from a wrapper that killed it. Every match
-  # below is anchored on `OBJECT-STORE: verdict `, which is the sweep's own control token
-  # and a position no dynamic field of its output can reach.
-  obj_verdict=$(printf '%s\n' "$obj_out" | grep '^OBJECT-STORE: verdict ' | head -1)
-  obj_verdict=${obj_verdict#OBJECT-STORE: verdict }
-  obj_verdict=${obj_verdict%% *}
-  if [ "$obj_rc" -eq 0 ] && [ "$obj_verdict" = VERIFIED ]; then
-    # The ONE affirmative branch. `git fsck` rehashed every object in the shared store and
-    # found nothing damaged — a POINT-IN-TIME sweep, which the message says so nobody reads
-    # it as a per-read guarantee.
-    ok "object-store: VERIFIED ($(printf '%s\n' "$obj_out" | grep '^OBJECT-STORE: measured ' | head -1 | sed 's/^OBJECT-STORE: measured //')) — a point-in-time full rehash, not a per-read guarantee"
-  elif [ "$obj_rc" -eq 4 ] || [ "$obj_verdict" = CORRUPT ]; then
-    # CORRUPT FAILS LOUDLY AND NAMES THE OBJECTS. Not a hard exit: this script's contract
-    # is that every section runs and the verdicts accumulate (a mid-script exit would
-    # silently skip sections 5c/6 and change what a caller sees). What makes it loud is
-    # three things instead — the [warn] (which withholds "All checks green." and fails
-    # --strict), the verbatim fsck findings, and a restatement in the summary banner.
-    OBJ_STORE_CORRUPT=1
-    warn "object-store: CORRUPT — the SHARED git object store on this box holds damaged objects. NO GATE RUN HERE CAN BE TRUSTED."
-    printf '%s\n' "$obj_out" | grep -E '^OBJECT-STORE: (finding|object) ' | head -20 | while IFS= read -r obj_line; do
-      info "$obj_line"
-    done
-    info "REMEDY: stop every lane on this box, then re-obtain the objects from the canonical remote"
-    info "  (a fresh clone of pmcfadin/cqlite, or 'git fetch --force origin' if only fetched packs are damaged)."
-    info "  A LOCAL 'git gc'/'git repack' CANNOT repair this — escalate rather than improvising (#3749)."
-  elif [ "$obj_rc" -eq 5 ] || [ "$obj_verdict" = UNMEASURED ]; then
-    # UNMEASURED IS A [warn] NAMING WHAT COULD NOT BE MEASURED — never an [ok]. The
-    # sweep's own `unmeasured-cause` lines are quoted rather than re-worded: a diagnostic
-    # improved in one file and thrown away by its consumer is a defect this repo has
-    # already paid for (#3369).
-    warn "object-store: UNMEASURED — the shared store was NOT rehashed, so its integrity is UNKNOWN, not ok"
-    printf '%s\n' "$obj_out" | grep '^OBJECT-STORE: unmeasured-cause ' | head -8 | while IFS= read -r obj_line; do
-      info "$obj_line"
-    done
-    info "verify by hand once the cause is cleared:  bash scripts/check-object-store-integrity.sh"
-  else
-    # NO RECOGNISED VERDICT AT ALL: the sweep was killed by the outer bound, died before it
-    # could classify itself, or emitted something this reader does not know. Unknown is
-    # never ok.
-    warn "object-store: UNMEASURED (the sweep produced no recognised verdict, rc=$obj_rc — integrity is UNKNOWN, not ok)"
-    printf '%s\n' "$obj_out" | head -4 | while IFS= read -r obj_line; do
-      [ -n "$obj_line" ] && info "$obj_line"
-    done
-  fi
-fi
-
 # ---- 5c. Notification channel (ntfy) — issue #3119 ----
 # The gate's push signal (#2667) and the worker supervisor page over ntfy. That
 # dependency used to be an out-of-band, per-machine `/usr/local/bin/agent-notify`
@@ -3113,6 +3026,107 @@ else
   fi
 fi
 
+# ---- 5d. Shared object-store integrity (issue #3749) ----
+#
+# PLACED AFTER 5c, NOT BETWEEN 5b AND 5c, AND THAT IS DELIBERATE: block 11i of
+# scripts/tests/test_bootstrap_agent_machine.sh asserts STRUCTURALLY that section 5b
+# contains exactly ONE `ok` call (its VERIFIED verdict), reading the range
+# `/^# ---- 5b\./,/^# ---- 5c\./` out of this file. A new section with its own `ok`
+# inside that range would red that guard — so this one lives outside it rather than the
+# guard being widened to accommodate it.
+#
+# WHY THIS SECTION EXISTS. Every lane on this box is a `git worktree` of ONE shared
+# `.git`, and git does not rehash an object against the id it was asked for on an
+# ordinary read. So the gate's component-set pre-flight — which reads origin/main's
+# committed manifest and HEAD's committed component declaration THROUGH that store — is
+# trusting content nothing verified, and a corrupt store can change ANY gate's verdict on
+# this box. #3749's owner ruling scoped the in-model subject to ACCIDENTAL corruption
+# (bit rot, a torn pack write, a SIGKILLed gc); DELIBERATE peer forgery is invoker-class
+# and out of model per the #3312 triage rule. This is the bootstrap half of the control;
+# the recurring half is scripts/local/worker-supervisor.sh's throttled sweep.
+#
+# ONE IMPLEMENTATION, TWO CALLERS: both go through scripts/check-object-store-integrity.sh,
+# because a second implementation is a second place for the verdict to drift.
+#
+# VERIFIED IS THE ONLY [ok] — CLAUDE.md's recorded lesson from #3414 verbatim: scoping a
+# case out is not the same as passing it, and an [ok] is what --strict reads, so an [ok]
+# on an unmeasured host is a false certification.
+hdr "Shared object-store integrity (git fsck, issue #3749)"
+OBJ_SWEEP_SH="$REPO_ROOT/scripts/check-object-store-integrity.sh"
+# The sweep bounds its own fsck; this outer bound is belt, and it is LOOSER than the inner
+# one on purpose — a wrapper that expires first would report "the sweep produced no
+# verdict" for a run the sweep was about to classify itself.
+OBJ_SWEEP_INNER_BOUND=300
+OBJ_SWEEP_OUTER_BOUND=360
+OBJ_STORE_CORRUPT=0
+if [ "$SKIP_OBJ_SWEEP" = 1 ]; then
+  warn "object-store: OPT-OUT ($SKIP_OBJ_SWEEP_HOW) — this box's SHARED git object store was NOT swept"
+  info "this run cannot certify that the store every lane here reads is intact; drop the opt-out to measure it"
+elif ! have git; then
+  warn "object-store: UNMEASURED (git is not installed — nothing to rehash the store with)"
+elif [ ! -r "$OBJ_SWEEP_SH" ]; then
+  warn "object-store: UNMEASURED (no scripts/check-object-store-integrity.sh under $REPO_ROOT — the sanctioned sweep is not in this checkout)"
+else
+  obj_out=""
+  obj_rc=0
+  obj_out=$(bounded "$OBJ_SWEEP_OUTER_BOUND" bash "$OBJ_SWEEP_SH" \
+    --repo "$REPO_ROOT" --timeout "$OBJ_SWEEP_INNER_BOUND" 2>&1) || obj_rc=$?
+  # THE VERDICT IS READ FROM THE ANCHORED `verdict ` LINE *AND* THE EXIT STATUS, both
+  # required. The line alone is text (and the sweep prints repository-controlled paths
+  # verbatim, so an unanchored match could land on one); the status alone cannot
+  # distinguish a sweep that classified itself from a wrapper that killed it. Every match
+  # below is anchored on `OBJECT-STORE: verdict `, which is the sweep's own control token
+  # and a position no dynamic field of its output can reach.
+  # `{ grep || true; }` throughout: a grep with no match exits 1 and `pipefail` is on, so
+  # a bare pipeline or an assignment from such a substitution would carry a non-zero status
+  # — and "no match" is reachable (a sweep killed at its bound prints no verdict line). This
+  # file has no `errexit`, so the cost here is only a misleading status, but the sibling
+  # caller in scripts/local/worker-supervisor.sh DOES run under `set -e`, where the same
+  # shape killed the loop. Same shape, same guard, so nobody has to remember which file has
+  # which options (#3749).
+  obj_verdict=$(printf '%s\n' "$obj_out" | { grep '^OBJECT-STORE: verdict ' || true; } | head -1)
+  obj_verdict=${obj_verdict#OBJECT-STORE: verdict }
+  obj_verdict=${obj_verdict%% *}
+  if [ "$obj_rc" -eq 0 ] && [ "$obj_verdict" = VERIFIED ]; then
+    # The ONE affirmative branch. `git fsck` rehashed every object in the shared store and
+    # found nothing damaged — a POINT-IN-TIME sweep, which the message says so nobody reads
+    # it as a per-read guarantee.
+    ok "object-store: VERIFIED ($(printf '%s\n' "$obj_out" | { grep '^OBJECT-STORE: measured ' || true; } | head -1 | sed 's/^OBJECT-STORE: measured //')) — a point-in-time full rehash, not a per-read guarantee"
+  elif [ "$obj_rc" -eq 4 ] || [ "$obj_verdict" = CORRUPT ]; then
+    # CORRUPT FAILS LOUDLY AND NAMES THE OBJECTS. Not a hard exit: this script's contract
+    # is that every section runs and the verdicts accumulate (a mid-script exit would
+    # silently skip sections 5c/6 and change what a caller sees). What makes it loud is
+    # three things instead — the [warn] (which withholds "All checks green." and fails
+    # --strict), the verbatim fsck findings, and a restatement in the summary banner.
+    OBJ_STORE_CORRUPT=1
+    warn "object-store: CORRUPT — the SHARED git object store on this box holds damaged objects. NO GATE RUN HERE CAN BE TRUSTED."
+    printf '%s\n' "$obj_out" | { grep -E '^OBJECT-STORE: (finding|object) ' || true; } | head -20 | while IFS= read -r obj_line; do
+      info "$obj_line"
+    done
+    info "REMEDY: stop every lane on this box, then re-obtain the objects from the canonical remote"
+    info "  (a fresh clone of pmcfadin/cqlite, or 'git fetch --force origin' if only fetched packs are damaged)."
+    info "  A LOCAL 'git gc'/'git repack' CANNOT repair this — escalate rather than improvising (#3749)."
+  elif [ "$obj_rc" -eq 5 ] || [ "$obj_verdict" = UNMEASURED ]; then
+    # UNMEASURED IS A [warn] NAMING WHAT COULD NOT BE MEASURED — never an [ok]. The
+    # sweep's own `unmeasured-cause` lines are quoted rather than re-worded: a diagnostic
+    # improved in one file and thrown away by its consumer is a defect this repo has
+    # already paid for (#3369).
+    warn "object-store: UNMEASURED — the shared store was NOT rehashed, so its integrity is UNKNOWN, not ok"
+    printf '%s\n' "$obj_out" | { grep '^OBJECT-STORE: unmeasured-cause ' || true; } | head -8 | while IFS= read -r obj_line; do
+      info "$obj_line"
+    done
+    info "verify by hand once the cause is cleared:  bash scripts/check-object-store-integrity.sh"
+  else
+    # NO RECOGNISED VERDICT AT ALL: the sweep was killed by the outer bound, died before it
+    # could classify itself, or emitted something this reader does not know. Unknown is
+    # never ok.
+    warn "object-store: UNMEASURED (the sweep produced no recognised verdict, rc=$obj_rc — integrity is UNKNOWN, not ok)"
+    printf '%s\n' "$obj_out" | head -4 | while IFS= read -r obj_line; do
+      [ -n "$obj_line" ] && info "$obj_line"
+    done
+  fi
+fi
+
 # ---- 6. Health check: gate fmt + authoritative accelerators line ----
 hdr "Health check (gate fmt + accelerators line)"
 if [ "$SKIP_SMOKE" = 1 ]; then
@@ -3135,7 +3149,7 @@ hdr "Bootstrap summary"
 # verdict on this box is untrustworthy (#3749). It changes no exit status — the [warn]
 # already withholds green and fails --strict; this is the loudness half.
 if [ "${OBJ_STORE_CORRUPT:-0}" = 1 ]; then
-  printf '  \033[31mSHARED OBJECT STORE CORRUPT.\033[0m Do NOT run a gate on this box until it is resolved (section 5b-obj above, #3749).\n'
+  printf '  \033[31mSHARED OBJECT STORE CORRUPT.\033[0m Do NOT run a gate on this box until it is resolved (section 5d above, #3749).\n'
 fi
 if [ "$WARNINGS" -eq 0 ]; then
   printf '  \033[32mAll checks green.\033[0m This machine is ready for CQLite agent work.\n'

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -130,7 +130,8 @@
 #                                                      #   `object-store: OPT-OUT` as a [warn], so
 #                                                      #   it withholds "All checks green." and can
 #                                                      #   never buy a vacuous green. The sweep
-#                                                      #   costs ~20s on a 331M store, so the
+#                                                      #   costs 13-24s warm and 47-80s cold on
+#                                                      #   this fleet's 366M store, so the
 #                                                      #   sibling self-suites (which drive
 #                                                      #   bootstrap dozens of times against the
 #                                                      #   real checkout) opt out via
@@ -176,10 +177,12 @@ fi
 #
 # THE ENV SPELLING IS NOT A CONVENIENCE, IT IS WHAT KEEPS THE SELF-SUITES USABLE.
 # scripts/tests/test_bootstrap_agent_machine.sh drives this script ~37 times against the
-# REAL checkout, whose shared store measures 19.83s per sweep — ~12 minutes added to a
-# MANDATORY gate component for a property those cases are not about. They export the
-# variable once; the cases that ARE about this section unset it and run against their own
-# small scratch repos.
+# REAL checkout, whose shared store measures 13-24s per sweep warm and 47-80s cold or
+# under concurrent gates (two independent measurement sets, 366M store, git 2.43.0) —
+# i.e. roughly 8 to 45 MINUTES added to a MANDATORY gate component for a property those
+# cases are not about. The single "19.83s" an earlier revision quoted was one warm run
+# and understated the cold case by 2.5-4x. They export the variable once; the cases that
+# ARE about this section unset it and run against their own small scratch repos.
 SKIP_OBJ_SWEEP=0
 SKIP_OBJ_SWEEP_HOW=""
 if [ "${CQLITE_BOOTSTRAP_SKIP_OBJECT_STORE_SWEEP:-0}" = 1 ]; then
@@ -3056,8 +3059,13 @@ OBJ_SWEEP_SH="$REPO_ROOT/scripts/check-object-store-integrity.sh"
 # The sweep bounds its own fsck; this outer bound is belt, and it is LOOSER than the inner
 # one on purpose — a wrapper that expires first would report "the sweep produced no
 # verdict" for a run the sweep was about to classify itself.
-OBJ_SWEEP_INNER_BOUND=300
-OBJ_SWEEP_OUTER_BOUND=360
+#
+# THE INNER BOUND IS PER WALK, AND THE SWEEP TAKES TWO WHEN THE FIRST IS NOT CLEAN (the
+# #3749 reproduction discriminator), so the outer one has to clear 2x the inner one plus
+# process overhead — sized from a MEASURED range (13-24s warm, 47-80s cold on this
+# fleet's 366M store), not from the single warm number an earlier revision quoted.
+OBJ_SWEEP_INNER_BOUND=600
+OBJ_SWEEP_OUTER_BOUND=1320
 OBJ_STORE_CORRUPT=0
 if [ "$SKIP_OBJ_SWEEP" = 1 ]; then
   warn "object-store: OPT-OUT ($SKIP_OBJ_SWEEP_HOW) — this box's SHARED git object store was NOT swept"

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -3147,15 +3147,17 @@ else
       info "  A LOCAL 'git gc'/'git repack' CANNOT repair this — escalate rather than improvising (#3749)."
     fi
   elif [ "$obj_rc" -eq 6 ] && [ "$obj_verdict" = UNSWEEPABLE ]; then
-    # THE SWEEP RAN AND REPRODUCIBLY DIED WITHOUT FINISHING (#3749 review round 10, item
-    # 1). A [warn] like CORRUPT — it withholds "All checks green.", fails --strict and is
-    # restated in the banner — but it CLAIMS NO CAUSE, and the difference is the whole
-    # point of the verdict: "the probe could not START" (UNMEASURED, below, permissive
-    # because it is a fact about this box's tooling) and "the probe RAN, twice, and died
-    # on this store" are different facts. No damage was established here, so this branch
-    # names none and quotes the sweep's own guidance instead of restating a repair.
+    # THE STORE COULD NOT BE SWEPT TO AN AFFIRMATIVE VERDICT (#3749 review round 10, item
+    # 1; two causes since round 11, item 1 — a reproducible fatal death, or a store whose
+    # own config sets fsck.* keys, in which case no walk is run at all). A [warn] like
+    # CORRUPT — it withholds "All checks green.", fails --strict and is restated in the
+    # banner — but it CLAIMS NO DAMAGE, and the difference is the whole point of the
+    # verdict: "the probe could not START" (UNMEASURED, below, permissive because it is a
+    # fact about this box's tooling) and "no affirmative sweep of this store is obtainable"
+    # are different facts. Nothing was established about the objects here, so this branch
+    # asserts no mechanism of its own and quotes the sweep's own guidance instead.
     OBJ_STORE_UNSWEEPABLE=1
-    warn "object-store: UNSWEEPABLE — git fsck RAN and reproducibly DIED without finishing over the SHARED git object store on this box, so its integrity is UNKNOWN, not ok. NO GATE RUN HERE CAN BE TRUSTED. No cause was established."
+    warn "object-store: UNSWEEPABLE — the sweep could NOT obtain an affirmative verdict for the SHARED git object store on this box, so its integrity is UNKNOWN, not ok. NO GATE RUN HERE CAN BE TRUSTED. No damage was established; the sweep's own lines below name the cause."
     printf '%s\n' "$obj_out" | { grep -E '^OBJECT-STORE: (finding|object) ' || true; } | head -20 | while IFS= read -r obj_line; do
       info "$obj_line"
     done
@@ -3169,7 +3171,7 @@ else
       # verdict established no cause, so naming one would be the round-9 defect (a printed
       # remedy that does not match what was measured).
       info "REMEDY: this sweep printed no operator guidance (an older or stubbed check-object-store-integrity.sh)."
-      info "  Re-run it by hand and act on what its 'fatal:' line names:  bash scripts/check-object-store-integrity.sh"
+      info "  Re-run it by hand and act on what THAT run reports:  bash scripts/check-object-store-integrity.sh"
     fi
   elif [ "$obj_rc" -eq 4 ] || [ "$obj_rc" -eq 6 ] || [ "$obj_verdict" = CORRUPT ] || [ "$obj_verdict" = UNSWEEPABLE ]; then
     # EXACTLY ONE CHANNEL SAYS CORRUPT (the conjunction above has already failed), so this

--- a/scripts/check-object-store-integrity.sh
+++ b/scripts/check-object-store-integrity.sh
@@ -963,9 +963,11 @@ if [ "$FIRST_WALK_CLEAN" -eq 0 ]; then
     # shape CLAUDE.md warns about.
     emit_findings p2 unmeasured-cause
     unmeasured "git fsck reported reachability problems on both sweep walks (pass 1 rc=$RC1," \
-      "pass 2 rc=$RC2) which CLEARED when the reflogs were excluded from the reachability" \
-      "roots (pass 3 --no-reflogs rc=$RC3): the complaint is REFLOG-SCOPED, so nothing a" \
-      "live ref, the index or HEAD needs is missing, and this is NOT the damage class." \
+      "pass 2 rc=$RC2) and the ERROR_REACHABLE bit CLEARED when the reflogs were excluded" \
+      "from the reachability roots (pass 3 --no-reflogs rc=$RC3, that bit absent): the" \
+      "reachability complaint is REFLOG-SCOPED, so nothing a live ref, the index or HEAD" \
+      "needs is missing, and this is NOT the damage class. Any other non-damage bit in" \
+      "pass 3's status is named by the diagnostics above." \
       "It is not certified clean either - an fsck in this sweep's own configuration did" \
       "not complete quietly. Clear it with 'git reflog expire --expire-unreachable=now" \
       "--all' on this box's shared repository, then re-run (#3749)."

--- a/scripts/check-object-store-integrity.sh
+++ b/scripts/check-object-store-integrity.sh
@@ -111,17 +111,43 @@
 # it `worktrees/<name>/HEAD`), its private INDEX (`missing blob <sha>`), and the HEAD of
 # a PRUNABLE worktree whose working directory has been deleted - and all three survive
 # `--no-reflogs`, so a missing object needed by one reaches the CORRUPT branch above.
-# It does NOT walk a LINKED worktree's per-worktree REFS (`refs/worktree/*`,
-# `refs/bisect/*`, `refs/rewritten/*`); those are roots only for an fsck run with THAT
-# worktree's own git dir. Measured consequence, and it is the one this control exists to
-# prevent: delete an object named only by `refs/worktree/private` in a linked worktree
-# and the sweep exits **0 VERIFIED** (the worktree's HEAD reflog echoes the id, and that
-# echo CLEARS under `--no-reflogs`, so even the attribution walk reads it as
-# reflog-scoped). The MAIN worktree's per-worktree refs live in the common dir itself and
-# ARE walked. That gap is closed by the PRIVATE-ROOT PROBE below - a separate, cheap
-# question asked before the affirmative branch - and the coverage above is PINNED by the
-# test suite rather than believed, so a future git that narrows fsck's worktree
-# enumeration reds a case instead of silently shrinking this control.
+# That coverage is PINNED by the test suite rather than believed, so a future git that
+# narrows fsck's worktree enumeration reds a case instead of silently shrinking this
+# control. It is also what makes the DECLARED GAP below narrow enough to be honest.
+#
+# THE ONE GAP, DECLARED AND NOT CLOSED (#3749 review round 8). A common-dir fsck does
+# NOT use a LINKED worktree's per-worktree REFS as reachability roots
+# (`refs/worktree/*`, `refs/bisect/*`, `refs/rewritten/*`); those are roots only for an
+# fsck run with THAT worktree's own git dir. The MAIN worktree's per-worktree refs live
+# in the common dir itself and ARE walked. Measured consequence: delete an object named
+# ONLY by `refs/worktree/private` in a linked worktree and the sweep exits 0 with the
+# affirmative verdict (the worktree's HEAD reflog echoes the id, and that echo CLEARS
+# under `--no-reflogs`, so even the attribution walk reads it as reflog-scoped). The
+# declaration is EMITTED ON EVERY RUN (see the `declared-gap` lines at the sweep below),
+# because a control that omits coverage silently is indistinguishable from one that
+# covers it.
+#
+# WHY IT IS DECLARED RATHER THAN PROBED, and the measurements that decide it. A probe
+# for it WAS built and REMOVED: in one review it produced three separate false-clean
+# routes of its own (a private root's missing CHILD is invisible to a target-presence
+# check; a per-worktree ref whose NAME also exists among the common refs is discarded by
+# a name subtraction even when it points elsewhere; and a failed `awk`/`sort`/`comm`
+# degraded to a zero-root census). CLAUDE.md's standing ruling applies - a guard with
+# known documented false-PASSes is worse than no guard, because it invites reliance it
+# cannot support - and subtraction cannot introduce a false pass, while the class has
+# ZERO INSTANCES on this fleet (measured 2026-09-02: 14 registered worktrees, all three
+# namespaces absent from every linked worktree's admin dir AND from the common dir, 0
+# mentions in `packed-refs`; re-measured independently, same answer).
+#
+# THREE MEASUREMENTS RULE OUT THE fsck-SHAPED FIXES, recorded so they are not
+# re-derived by whoever revisits this (git 2.43.0):
+#   * `git fsck <sha>...` REPLACES the default heads - a missing blob reachable from
+#     HEAD went UNDETECTED (rc 0) when an unrelated head was passed - so private roots
+#     can never simply be APPENDED to the sweep walk;
+#   * a separate explicit-head `git fsck <sha>` still scans the whole object directory,
+#     so it costs a FULL rehash - the N-fsck design the #3749 lead ruling rejected;
+#   * `git rev-list <missing-root>` dies 128 (`bad object`), so `--missing=print` cannot
+#     answer the case that actually fires - the ROOT itself being gone.
 #   2   usage error — and `--help` exits 2 as well, deliberately: exit 0 MEANS
 #                    VERIFIED here, so a run that measured nothing must never
 #                    produce it.
@@ -332,18 +358,13 @@ usage() {
     "$P" "$(sane "${0##*/}")" >&2
   printf '%s USAGE        %s [--repo <path>] --print-store\n' \
     "$P" "$(sane "${0##*/}")" >&2
-  printf '%s USAGE        %s [--repo <path>] --probe-private-roots\n' \
-    "$P" "$(sane "${0##*/}")" >&2
   printf '%s USAGE Rehashes the SHARED git object store behind <path> with git fsck\n' "$P" >&2
   printf '%s USAGE and reports whether it is intact (#3749). Read-only; mutates nothing.\n' "$P" >&2
   printf '%s USAGE --print-store resolves and prints the store this run WOULD sweep\n' "$P" >&2
   printf '%s USAGE (one `store <abs-path>` line) and exits 0 WITHOUT sweeping. It is\n' "$P" >&2
   printf '%s USAGE the ONE isolated resolver callers key a throttle/latch on, so no\n' "$P" >&2
   printf '%s USAGE caller has to run its own un-isolated git to name the store.\n' "$P" >&2
-  printf '%s USAGE --probe-private-roots asks the ONE question a common-dir fsck cannot:\n' "$P" >&2
-  printf '%s USAGE are the objects named by LINKED worktrees per-worktree refs present?\n' "$P" >&2
-  printf '%s USAGE It sweeps nothing and prints `private-root` lines plus one terminal\n' "$P" >&2
-  printf '%s USAGE `private-roots` census line. The sweep runs it as a bounded child.\n' "$P" >&2
+  printf '%s USAGE Every run DECLARES what it does not walk (`declared-gap` lines).\n' "$P" >&2
   printf '%s USAGE Exits 0 verified / 4 corrupt / 5 unmeasured / 2 usage.\n' "$P" >&2
   printf '%s USAGE A CONSUMER MUST NOT READ EXIT 5 AS CLEAN (nothing was measured).\n' "$P" >&2
   printf '%s USAGE Scope is ACCIDENTAL corruption. Deliberate peer forgery is\n' "$P" >&2
@@ -369,13 +390,6 @@ BOUND_SECS=600
 repo_set=0
 bound_set=0
 PRINT_STORE=0
-PROBE_PRIVATE_ROOTS=0
-# THE PATH THIS SCRIPT RE-INVOKES FOR THE PRIVATE-ROOT PROBE. Captured ONCE, before
-# anything can change the working directory, because `$0` is resolved against the cwd in
-# effect when bash started. Nothing here cd's on the main path (the store canonicalisation
-# cd's inside a `$( )` subshell), so this stays valid - but capturing it is cheaper than
-# depending on that staying true.
-SELF="$0"
 while [ "$#" -gt 0 ]; do
   case "$1" in
     -h | --help)
@@ -393,22 +407,7 @@ while [ "$#" -gt 0 ]; do
       # RESOLVE-AND-PRINT, NO SWEEP. See the block after the store resolution for what
       # this mode is for and why it deliberately does not require a timeout binary.
       [ "$PRINT_STORE" -eq 0 ] || { usage; exit 2; }
-      [ "$PROBE_PRIVATE_ROOTS" -eq 0 ] || { usage; exit 2; }
       PRINT_STORE=1
-      shift
-      ;;
-    --probe-private-roots)
-      # THE PER-WORKTREE PRIVATE-ROOT PROBE, AS ITS OWN CHILD MODE. It is a mode rather
-      # than an inline loop for ONE reason: the whole probe has to be BOUNDED, and a
-      # bound needs a single child process to wrap. Inlining it would mean either an
-      # UNBOUNDED sequence of git calls in a script whose header says an unboundable host
-      # does not get to run it (measured: those calls took 27.9s on this box at load 132),
-      # or a shell body passed as a string to `bash -c`, which is neither reviewable nor
-      # directly testable. As a mode the body is ordinary code, the suite can drive it
-      # head-on, and the sweep pays exactly one bounded stage for it.
-      [ "$PROBE_PRIVATE_ROOTS" -eq 0 ] || { usage; exit 2; }
-      [ "$PRINT_STORE" -eq 0 ] || { usage; exit 2; }
-      PROBE_PRIVATE_ROOTS=1
       shift
       ;;
     --timeout)
@@ -455,7 +454,7 @@ done
 TIMEOUT_BIN=""
 TIMEOUT_KILL_AFTER=0
 for _tb_name in timeout gtimeout; do
-  [ "$PRINT_STORE" -eq 0 ] && [ "$PROBE_PRIVATE_ROOTS" -eq 0 ] || break
+  [ "$PRINT_STORE" -eq 0 ] || break
   _tb_path="$(command -v "$_tb_name" 2>/dev/null || true)"
   [ -n "$_tb_path" ] || continue
   if "$_tb_path" --kill-after=1 1 true >/dev/null 2>&1; then
@@ -482,7 +481,7 @@ ENV_BIN="$(command -v env 2>/dev/null || true)"
     "fsck run under an inherited GIT_DIR/GIT_OBJECT_DIRECTORY can report about a" \
     "DIFFERENT store than the one it names. Refusing rather than measuring the wrong thing."
 
-if [ -z "$TIMEOUT_BIN" ] && [ "$PRINT_STORE" -eq 0 ] && [ "$PROBE_PRIVATE_ROOTS" -eq 0 ]; then
+if [ -z "$TIMEOUT_BIN" ] && [ "$PRINT_STORE" -eq 0 ]; then
   unmeasured "no timeout/gtimeout on PATH - refusing to run an UNBOUNDED fsck: both" \
     "callers are hang-sensitive (machine onboarding, and the supervisor's" \
     "per-iteration preflight). Install GNU coreutils and re-run."
@@ -553,197 +552,6 @@ if [ "$PRINT_STORE" -eq 1 ]; then
   exit 0
 fi
 
-# --- `--probe-private-roots`: THE ROOTS A COMMON-DIR fsck DOES NOT HAVE -------
-#
-# THE QUESTION, AND WHY IT IS A DIFFERENT ONE FROM THE SWEEP'S. The sweep REHASHES every
-# object PRESENT in the store, so object CONTENT is answered store-wide and is not a
-# per-worktree question at all. The only worktree-dependent half is PRESENCE: an object
-# that is absent cannot be rehashed, and is found only by walking from a root that needs
-# it. Measured (header above): a common-dir fsck already walks every worktree's HEAD,
-# index and reflogs, and MISSES a LINKED worktree's per-worktree refs. So this probe asks
-# exactly the missing half and nothing else.
-#
-# IT IS NOT AN fsck AND MUST NEVER BECOME ONE. Three measurements rule out the obvious
-# shapes, and they are recorded so they are not re-derived:
-#   * `git fsck <sha>...` REPLACES the default heads - a missing blob reachable from HEAD
-#     went UNDETECTED (rc 0) when an unrelated head was passed - so the private roots can
-#     never be appended to the sweep walk;
-#   * `git fsck <sha>` still scans the whole object directory, so a separate explicit-head
-#     fsck costs a FULL rehash, which is the N-fsck design the #3749 lead ruling rejected;
-#   * `git rev-list <missing-root>` dies 128 (`bad object`), so `--missing=print` cannot
-#     answer the case that actually fires - the ROOT itself being gone.
-# What it does instead is O(refs): list each linked worktree's refs, subtract the common
-# ones, and ask `cat-file --batch-check` whether the remainder's targets are in the store.
-# Measured on the live 15-worktree store: 0.02s warm.
-#
-# THE ENUMERATION IS FILESYSTEM-FIRST **BECAUSE THE GIT COMMAND IS FAIL-OPEN**, which is
-# the opposite of what one would assume. Measured: `git worktree list --porcelain`
-# SILENTLY DROPS a worktree whose admin `gitdir` file is missing - rc 0, no diagnostic,
-# the worktree simply absent - so a git-only enumeration answers "clean" about a worktree
-# it could not see. `$GIT_COMMON_DIR/worktrees/*` is not a guess about this fleet's
-# layout, it is git's OWN administrative directory, and it is a SUPERSET of what the
-# command reports. The command is still run, as a CROSS-CHECK in the other direction:
-# if it names more linked worktrees than the directory holds, something is being hidden
-# from us and that is UNREADABLE, never clean.
-#
-# WHAT IT DOES NOT ASK, STATED RATHER THAN IMPLIED: the CLOSURE of a private root. It
-# asks whether each private ref's TARGET is present, not whether every object in that
-# target's history is. An object missing DEEPER in a per-worktree ref's ancestry, and
-# named by no common ref, no worktree HEAD, no index and no reflog, is not recognised
-# here. That residual is declared rather than closed because closing it needs a graph
-# walk from roots whose ancestry is normally shared with the common refs anyway, and the
-# walk would be a second bounded stage (see MAX_SWEEP_WALKS).
-
-# _prp_observe <records-file> <census-file> - ONE observation. Writes TAB-separated
-# records, one per line:
-#     ABSENT<TAB><sha><TAB><worktree><TAB><refname>
-#     UNREADABLE<TAB><worktree><TAB><cause>
-# and `<roots> <linked-worktrees>` to the census file. Returns 0 always: every failure it
-# can name is a record, because a worktree that cannot be inspected is NOT a clean one.
-_prp_observe() {
-  local out="$1" census="$2"
-  local commonrefs="$PRP_TMPD/common.refs" pairs="$PRP_TMPD/wt.pairs"
-  local names="$PRP_TMPD/wt.names" priv="$PRP_TMPD/wt.priv" cand="$PRP_TMPD/cand"
-  local bc="$PRP_TMPD/bc" miss="$PRP_TMPD/miss"
-  local wtdir name nwt=0 nroot=0 gitwt=0
-  : >"$out"
-  : >"$cand"
-  printf '0 0\n' >"$census"
-
-  if ! git_isolated git --git-dir="$GIT_COMMON_DIR" for-each-ref --format='%(refname)' \
-    >"$commonrefs" 2>/dev/null; then
-    printf 'UNREADABLE\t(common)\tthe common ref list could not be read, so no ref can be told apart from a per-worktree one\n' >>"$out"
-    return 0
-  fi
-  LC_ALL=C sort -u "$commonrefs" -o "$commonrefs" 2>/dev/null ||
-    printf 'UNREADABLE\t(common)\tthe common ref list could not be sorted for comparison\n' >>"$out"
-
-  for wtdir in "$GIT_COMMON_DIR"/worktrees/*; do
-    [ -d "$wtdir" ] || continue
-    nwt=$((nwt + 1))
-    name="${wtdir##*/}"
-    # A CONTROL CHARACTER IN AN ADMIN NAME IS REFUSED, NOT ESCAPED. These records are
-    # line- and TAB-delimited and are INTERSECTED between the two observations, so the
-    # name is an IDENTITY here and not a display value (#3749 round 5: a value sanitised
-    # for display is not an identity). Refusing keeps every name that is compared RAW.
-    case "$name" in
-      *[[:cntrl:]]* | *"$(printf '\t')"*)
-        printf 'UNREADABLE\t%s\tthe worktree admin directory name carries a control character, so its private refs cannot be reported on one anchored line\n' \
-          "$(sane "$name")" >>"$out"
-        continue
-        ;;
-    esac
-    if [ ! -r "$wtdir" ] || [ ! -x "$wtdir" ]; then
-      printf 'UNREADABLE\t%s\tthe worktree admin directory is not readable/searchable\n' "$name" >>"$out"
-      continue
-    fi
-    if ! git_isolated git --git-dir="$wtdir" for-each-ref --format='%(refname) %(objectname)' \
-      >"$pairs" 2>/dev/null; then
-      printf 'UNREADABLE\t%s\tits ref list could not be read (git for-each-ref failed against its admin dir)\n' "$name" >>"$out"
-      continue
-    fi
-    # `%(objectname)` is the REF VALUE and reads no object; `%(objecttype)` would, and
-    # dies 128 on exactly the missing object this probe exists to find (measured).
-    awk 'NF >= 2 { print $1 }' "$pairs" 2>/dev/null | LC_ALL=C sort -u >"$names" 2>/dev/null || : >"$names"
-    LC_ALL=C comm -13 "$commonrefs" "$names" >"$priv" 2>/dev/null || : >"$priv"
-    awk -v wt="$name" 'NR == FNR { p[$0] = 1; next }
-      (NF >= 2 && ($1 in p)) { printf "%s\t%s\t%s\n", $2, wt, $1 }' \
-      "$priv" "$pairs" >>"$cand" 2>/dev/null || true
-  done
-
-  # THE CROSS-CHECK IN THE FAIL-OPEN DIRECTION (see the block comment above).
-  if gitwt=$(git_isolated git --git-dir="$GIT_COMMON_DIR" worktree list --porcelain 2>/dev/null |
-    awk '/^worktree /{n++} END{print n + 0}'); then
-    case "$gitwt" in '' | *[!0-9]*) gitwt=0 ;; esac
-    # minus the main worktree, which `worktree list` always names first.
-    [ "$gitwt" -ge 1 ] && gitwt=$((gitwt - 1))
-    if [ "$gitwt" -gt "$nwt" ]; then
-      printf 'UNREADABLE\t(common)\tgit names %s linked worktree(s) but only %s admin directory(ies) exist under the common dir - one is being hidden from this probe\n' \
-        "$gitwt" "$nwt" >>"$out"
-    fi
-  else
-    printf 'UNREADABLE\t(common)\tthe worktree list could not be read as a cross-check on the admin directories\n' >>"$out"
-  fi
-
-  nroot=$(awk 'END{print NR + 0}' "$cand" 2>/dev/null || echo 0)
-  case "$nroot" in '' | *[!0-9]*) nroot=0 ;; esac
-  printf '%s %s\n' "$nroot" "$nwt" >"$census"
-  [ "$nroot" -gt 0 ] || return 0
-
-  # ONE batch presence question for every private root. `cat-file --batch-check` prints
-  # `<sha> missing` for an object the store does not hold and exits 0 (measured).
-  if ! cut -f1 "$cand" 2>/dev/null | LC_ALL=C sort -u |
-    git_isolated git --git-dir="$GIT_COMMON_DIR" cat-file --batch-check='%(objectname) %(objecttype)' \
-      >"$bc" 2>/dev/null; then
-    printf 'UNREADABLE\t(common)\tthe presence check (git cat-file --batch-check) could not be run over %s private root(s)\n' \
-      "$nroot" >>"$out"
-    return 0
-  fi
-  awk '$2 == "missing" { print $1 }' "$bc" 2>/dev/null | LC_ALL=C sort -u >"$miss" 2>/dev/null || : >"$miss"
-  awk -F'\t' 'NR == FNR { m[$0] = 1; next }
-    ($1 in m) { printf "ABSENT\t%s\t%s\t%s\n", $1, $2, $3 }' "$miss" "$cand" >>"$out" 2>/dev/null || true
-  return 0
-}
-
-# probe_private_roots - TWO independent observations, INTERSECTED, then printed.
-#
-# THE SECOND OBSERVATION IS THE SAME DISCRIMINATOR THE SWEEP USES, FOR THE SAME REASON.
-# Up to eight peer lanes write this store: a lane running `git worktree remove`, or
-# deleting a bisect ref, between the enumeration and the presence check makes a root look
-# absent when nothing is wrong, and a worktree whose admin dir is being torn down looks
-# unreadable for a second. A transient does not survive a second independent
-# enumeration; real damage does. Both observations RE-ENUMERATE from scratch - reusing
-# the first one's root list would make the second observation answer a stale question.
-#
-# BOTH OBSERVATIONS RUN INSIDE THIS ONE CHILD PROCESS, which is what keeps the sweep's
-# worst case at MAX_SWEEP_WALKS bounded stages: two bounded children would have been a
-# fourth stage, and every caller's bound is derived from that number.
-probe_private_roots() {
-  local o1="$PRP_TMPD/o1" o2="$PRP_TMPD/o2" c1="$PRP_TMPD/c1" c2="$PRP_TMPD/c2"
-  local both="$PRP_TMPD/both" nabs=0 nunr=0 nroot=0 nwt=0 kind f1 f2 f3
-  _prp_observe "$o1" "$c1"
-  _prp_observe "$o2" "$c2"
-  LC_ALL=C sort -u "$o1" -o "$o1" 2>/dev/null || : >"$o1"
-  LC_ALL=C sort -u "$o2" -o "$o2" 2>/dev/null || : >"$o2"
-  LC_ALL=C comm -12 "$o1" "$o2" >"$both" 2>/dev/null || : >"$both"
-
-  while IFS="$(printf '\t')" read -r kind f1 f2 f3; do
-    case "$kind" in
-      ABSENT)
-        nabs=$((nabs + 1))
-        printf '%s private-root ABSENT %s %s %s\n' "$P" "$(sane "$f1")" "$(sane "$f2")" "$(sane "$f3")"
-        ;;
-      UNREADABLE)
-        nunr=$((nunr + 1))
-        printf '%s private-root UNREADABLE %s %s\n' "$P" "$(sane "$f1")" "$(sane "$f2")"
-        ;;
-    esac
-  done <"$both"
-
-  # The census reports the SECOND observation's counts: it is the one whose enumeration
-  # is current at the moment the answer is given.
-  read -r nroot nwt <"$c2" 2>/dev/null || { nroot=0; nwt=0; }
-  case "$nroot" in '' | *[!0-9]*) nroot=0 ;; esac
-  case "$nwt" in '' | *[!0-9]*) nwt=0 ;; esac
-  # THE TERMINAL CENSUS LINE IS THE COMPLETENESS MARKER, and the caller requires EXACTLY
-  # ONE of them: a probe that died halfway prints records and no census, which is
-  # UNMEASURED rather than "nothing was found" (the `.started` idiom, one function over).
-  printf '%s private-roots checked=%s worktrees=%s absent=%s unreadable=%s (two observations, intersected)\n' \
-    "$P" "$nroot" "$nwt" "$nabs" "$nunr"
-  return 0
-}
-
-if [ "$PROBE_PRIVATE_ROOTS" -eq 1 ]; then
-  if ! PRP_TMPD=$(mktemp -d "${TMPDIR:-/tmp}/object-store-private-roots.XXXXXX" 2>/dev/null) ||
-    [ -z "$PRP_TMPD" ] || [ ! -d "$PRP_TMPD" ]; then
-    unmeasured "could not create a scratch dir under $(sane "${TMPDIR:-/tmp}") for the" \
-      "private-root probe"
-  fi
-  trap 'rm -rf "$PRP_TMPD" 2>/dev/null' EXIT
-  probe_private_roots
-  exit 0
-fi
-
 # --- scratch space (outside the repository: this script writes nothing in it) --
 if ! TMPD=$(mktemp -d "${TMPDIR:-/tmp}/object-store-integrity.XXXXXX" 2>/dev/null) ||
   [ -z "$TMPD" ] || [ ! -d "$TMPD" ]; then
@@ -760,6 +568,36 @@ else
   printf '%s bound %ss (SIGTERM-only: %s does not accept --kill-after; git fsck does not trap SIGTERM)\n' \
     "$P" "$BOUND_SECS" "$(sane "$TIMEOUT_BIN")"
 fi
+
+# --- WHAT THIS SWEEP DOES NOT WALK, DECLARED ON EVERY RUN --------------------
+#
+# WHY THIS IS PRINTED AT ALL, AND WHY EVERY RUN PAYS FOR IT. A control that omits a
+# class of coverage SILENTLY is indistinguishable from one that covers it - the reason
+# this repo's narrowed gate lanes declare their narrowing at run time. The gap is real,
+# it is one namespace wide, and the reasoning that keeps it declared rather than probed
+# (including the probe that was built and removed for producing false-clean routes of
+# its own) is in the header. It is printed BEFORE the walk, not beside the affirmative
+# branch, so a CORRUPT or UNMEASURED run says it too: what was not walked does not
+# depend on what was found.
+#
+# `N RECOGNISED`, NEVER A BARE COUNT. A bare `0`/`1` in a log reads as a verified
+# all-clear from a scan documented as incomplete. This count is the number of gaps THIS
+# SCRIPT RECOGNISES, and the line says so; it is STATIC TEXT and costs no git call, so
+# it adds no wall time and no new failure mode to the sweep.
+printf '%s declared-gap 1 RECOGNISED (this list states its own non-exhaustiveness)\n' "$P"
+printf '%s declared-gap 1/1: the per-worktree ref namespaces of LINKED worktrees -\n' "$P"
+printf '%s declared-gap refs/worktree/*, refs/bisect/*, refs/rewritten/* - are NOT\n' "$P"
+printf '%s declared-gap reachability roots of a common-dir git fsck, so an object named\n' "$P"
+printf '%s declared-gap ONLY by one of them is NOT detected by this run and does NOT hold\n' "$P"
+printf '%s declared-gap back the affirmative verdict below. Measured on this fleet\n' "$P"
+printf '%s declared-gap 2026-09-02: 0 such refs across 14 registered worktrees (all three\n' "$P"
+printf '%s declared-gap namespaces absent from every linked worktree admin dir and from\n' "$P"
+printf '%s declared-gap the common dir), so the gap has zero instances here - it is\n' "$P"
+printf '%s declared-gap declared because that is a measurement, not a guarantee (#3749).\n' "$P"
+printf '%s declared-gap NOT in the gap, measured rather than assumed: every registered\n' "$P"
+printf '%s declared-gap worktree private HEAD and INDEX (prunable worktrees included) and\n' "$P"
+printf '%s declared-gap the COMMON refs ARE walked, and a missing object needed by one is\n' "$P"
+printf '%s declared-gap reported. That is what makes this gap one namespace wide.\n' "$P"
 
 # --- THE SWEEP --------------------------------------------------------------
 #
@@ -808,19 +646,15 @@ FINDING_LIST_LIMIT=40
 # raises every caller's worst-case uninterruptible block.
 #   1. the sweep;
 #   2. the reproduction discriminator, when walk 1 was not clean;
-#   3. EITHER the reachability-CAUSE discriminator (`--no-reflogs`, when walks 1 and 2
-#      both reported ERROR_REACHABLE and neither reported damage) OR the PRIVATE-ROOT
-#      PROBE - never both, and that is why adding the probe did not raise this number.
+#   3. the reachability-CAUSE discriminator (`--no-reflogs`), when walks 1 and 2 both
+#      reported ERROR_REACHABLE and neither reported damage.
 #
-# WHY STAGE 3 IS AN EITHER/OR AND NOT A SUM (#3749 review round 7). Every branch of the
-# reachability block exits (CORRUPT, or one of three UNMEASURED causes), so a run that
-# spends walk 3 TERMINATES THERE and never reaches the private-root probe; and the probe
-# sits immediately before the ONE affirmative branch, which is reachable only when pass 2
-# was clean. So the worst case is max(3 fsck walks, 2 fsck walks + 1 probe) = 3 bounded
-# stages, unchanged - no caller's bound moves. That is a PLACEMENT property, not an
-# arithmetic one, so it is asserted BEHAVIOURALLY by the suite (the 3-walk fixtures must
-# emit no `private-root` line at all); moving the probe earlier would silently widen
-# every caller's uninterruptible window.
+# NOTHING ELSE MAY BE ADDED HERE WITHOUT MOVING EVERY CALLER'S BOUND. The declared gap
+# in the header (a linked worktree's per-worktree refs) is DECLARED rather than probed,
+# and one reason among several is that a probe is a further bounded stage: a stage added
+# below the reachability block is free only while every branch of that block exits,
+# which is a PLACEMENT property nothing arithmetic can check. If a stage is ever added,
+# raise this number and re-derive the callers' bounds from it (#3749 rounds 7/8).
 MAX_SWEEP_WALKS=3
 
 # git fsck's exit BITMASK, from fsck.h and CONFIRMED against the git in use (2.43.0):
@@ -1335,101 +1169,6 @@ if [ "$FIRST_WALK_CLEAN" -eq 0 ]; then
   printf '%s note which is the signature of a concurrent writer on this shared store rather\n' "$P"
   printf '%s note than damage. The verdict below rests on the second walk, which completed.\n' "$P"
 fi
-
-# --- THE PRIVATE-ROOT GATE ON `VERIFIED` ------------------------------------
-#
-# THE LAST QUESTION BEFORE THE ONLY AFFIRMATIVE VERDICT, and it is placed here for two
-# reasons that are both load-bearing. (1) SEMANTICS: `VERIFIED` may not rest on a rehash
-# alone when a whole class of roots was not walked, so the probe gates the affirmative
-# branch rather than sitting beside it. (2) THE BOUND: every branch of the reachability
-# block above exits, so a run that spent a third fsck walk never arrives here - the worst
-# case stays at MAX_SWEEP_WALKS bounded child stages and no caller's derived bound moves
-# (see MAX_SWEEP_WALKS). Moving this call earlier would silently widen every caller's
-# uninterruptible window, which is why the suite asserts the placement behaviourally.
-#
-# IT IS RUN AS A BOUNDED CHILD OF THIS SAME SCRIPT, under the same isolation and the same
-# timeout machinery as an fsck walk: the body is a mode of this file (see
-# `--probe-private-roots`), so it is ordinary reviewable code that the suite drives
-# head-on, while the caller still pays exactly one boundable process for it.
-PRP_OUT="$TMPD/prp.out"
-prp_rc=0
-if [ ! -r "$SELF" ]; then
-  unmeasured "the private-root probe could not be run: this script's own path" \
-    "($(sane "$SELF")) is not readable, so the per-worktree roots a common-dir fsck does" \
-    "NOT walk (a linked worktree's refs/worktree, refs/bisect, refs/rewritten) were not" \
-    "checked. The rehash said nothing about them, so this run is NOT clean (#3749)."
-fi
-if [ "$TIMEOUT_KILL_AFTER" -eq 1 ]; then
-  git_isolated nice -n 19 "$TIMEOUT_BIN" --kill-after="$BOUND_KILL_GRACE" "$BOUND_SECS" \
-    bash "$SELF" --repo "$REPO" --probe-private-roots >"$PRP_OUT" 2>&1 || prp_rc=$?
-else
-  git_isolated nice -n 19 "$TIMEOUT_BIN" "$BOUND_SECS" \
-    bash "$SELF" --repo "$REPO" --probe-private-roots >"$PRP_OUT" 2>&1 || prp_rc=$?
-fi
-
-# THE TWO CHANNELS MUST AGREE BEFORE EITHER IS ACTED ON (#3749 review round 4, applied to
-# the channel this round adds): the child's EXIT STATUS and its terminal census line are
-# two independent signals, and a run is only complete when BOTH say so. Exactly one
-# census line is required - the `store-key` contract idiom - so a child that died halfway
-# through printing records is UNMEASURED and never "nothing was found".
-PRP_CENSUS=""
-prp_complete=0
-if PRP_CENSUS=$(awk '/^OBJECT-STORE: private-roots /{ line = $0; n++ }
-  END { if (n == 1) { print line; exit 0 } exit 1 }' "$PRP_OUT" 2>/dev/null); then
-  prp_complete=1
-fi
-PRP_ABSENT=$(awk '/^OBJECT-STORE: private-root ABSENT /{ n++ } END { print n + 0 }' "$PRP_OUT" 2>/dev/null)
-PRP_UNREAD=$(awk '/^OBJECT-STORE: private-root UNREADABLE /{ n++ } END { print n + 0 }' "$PRP_OUT" 2>/dev/null)
-case "$PRP_ABSENT" in '' | *[!0-9]*) PRP_ABSENT=0 ;; esac
-case "$PRP_UNREAD" in '' | *[!0-9]*) PRP_UNREAD=0 ;; esac
-
-# Its own lines are already anchored, and ONLY anchored lines are re-emitted: a child that
-# died could put an unanchored shell diagnostic on this stream, and output property (a) is
-# what every consumer and every test rests on.
-awk '/^OBJECT-STORE: private-root/ { print }' "$PRP_OUT" 2>/dev/null || true
-
-if [ "$prp_rc" -eq 124 ] || [ "$prp_rc" -eq 137 ]; then
-  unmeasured "the private-root probe exceeded its ${BOUND_SECS}s bound (rc=$prp_rc), so the" \
-    "per-worktree roots a common-dir fsck does NOT walk were not checked. The rehash" \
-    "above says nothing about them. Re-run with a larger --timeout on an idle box."
-fi
-if [ "$prp_complete" -eq 0 ] || [ "$prp_rc" -ne 0 ]; then
-  unmeasured "the private-root probe did not complete (child rc=$prp_rc," \
-    "census line $([ "$prp_complete" -eq 1 ] && printf 'present' || printf 'ABSENT')): its" \
-    "exit status and its terminal census line must AGREE before either is read, and they" \
-    "do not. The per-worktree roots a common-dir fsck does NOT walk (a linked worktree's" \
-    "refs/worktree, refs/bisect, refs/rewritten) were therefore not checked, so the rehash" \
-    "above is not a clean answer about them. Run" \
-    "'bash $(sane "${0##*/}") --probe-private-roots' by hand to see what it said (#3749)."
-fi
-if [ "$PRP_ABSENT" -gt 0 ]; then
-  printf '%s measured %s\n' "$P" "$(sane "${PRP_CENSUS#"$P "}")"
-  printf '%s verdict CORRUPT\n' "$P"
-  printf '%s verdict-detail %s object(s) named by a LINKED WORKTREE'"'"'s per-worktree ref are\n' "$P" "$PRP_ABSENT"
-  printf '%s verdict-detail NOT in this box'"'"'s SHARED store, on TWO independent enumerations.\n' "$P"
-  printf '%s verdict-detail A common-dir `git fsck` does not walk those refs (it walks every\n' "$P"
-  printf '%s verdict-detail worktree'"'"'s HEAD, index and reflogs, and the COMMON refs), so the rehash\n' "$P"
-  printf '%s verdict-detail above reported nothing about them: this is exactly the missing-object\n' "$P"
-  printf '%s verdict-detail class the reachability discriminator treats as damage, found at a root\n' "$P"
-  printf '%s verdict-detail that walk never had. Every lane on this box reads this store, so do NOT\n' "$P"
-  printf '%s verdict-detail certify anything against this checkout.\n' "$P"
-  printf '%s verdict-detail REMEDY: stop the lanes on this box and re-obtain the objects from the\n' "$P"
-  printf '%s verdict-detail canonical remote (`git fetch --force origin`, or a fresh clone of\n' "$P"
-  printf '%s verdict-detail pmcfadin/cqlite). If the ref is a leftover (`refs/bisect/*` from an\n' "$P"
-  printf '%s verdict-detail abandoned bisect, a tool'"'"'s `refs/worktree/*`) and the object only ever\n' "$P"
-  printf '%s verdict-detail existed locally, DELETE THE REF in that worktree rather than improvising\n' "$P"
-  printf '%s verdict-detail on the store - but establish which it is first (#3749).\n' "$P"
-  exit 4
-fi
-if [ "$PRP_UNREAD" -gt 0 ]; then
-  unmeasured "$PRP_UNREAD registered worktree(s) could not be INSPECTED for their" \
-    "per-worktree refs, on both observations (see the private-root lines above). A" \
-    "worktree this probe cannot read is not a clean one: a common-dir fsck does not walk" \
-    "those refs, so nothing in this run establishes whether the objects they name are" \
-    "present. Fix the named admin directory under $(sane "$GIT_COMMON_DIR")/worktrees" \
-    "(or prune the worktree with 'git worktree prune') and re-run (#3749)."
-fi
-printf '%s measured %s\n' "$P" "$(sane "${PRP_CENSUS#"$P "}")"
 
 # --- THE ONE AFFIRMATIVE BRANCH --------------------------------------------
 #

--- a/scripts/check-object-store-integrity.sh
+++ b/scripts/check-object-store-integrity.sh
@@ -1,0 +1,431 @@
+#!/usr/bin/env bash
+#
+# check-object-store-integrity.sh — the #3749 SHARED-OBJECT-STORE integrity sweep.
+#
+# WHAT QUESTION THIS ANSWERS
+# --------------------------
+# On this fleet EVERY LANE ON A BOX IS A `git worktree` OF ONE SHARED `.git`
+# (measured: `/data/lanes/repo/.git/objects` for lane-3544, lane-3473 and lane-3629
+# alike). Git does NOT rehash a packed or loose object against the id it was asked
+# for on an ordinary read: it verifies the pack CRC and the zlib stream, which catch
+# bit rot and a truncated or torn write, but a whole object whose CONTENT does not
+# hash to its own name is returned without complaint. So every consumer of that
+# store — including the gate's component-set pre-flight, which reads `origin/main`'s
+# committed manifest and HEAD's committed component declaration THROUGH it
+# (`scripts/agent-gate.sh`, the `_CS_BASE_OBJ=reused` fast path) — is trusting
+# content it never verified.
+#
+# THE SCOPE OF THIS SCRIPT IS ACCIDENTAL CORRUPTION, AND THAT IS AN OWNER RULING
+# (#3749, 2026-09-01), NOT AN OVERSIGHT
+# -----------------------------------------------------------------------------
+# DELIBERATE peer forgery is INVOKER-CLASS and OUT OF MODEL. Per the #3312 triage
+# rule recorded in CLAUDE.md — *same-host actors able to write these scripts are
+# invoker-class, not third parties* — a peer lane that wants a false gate PASS can
+# simply edit `scripts/agent-gate.sh`, which is cheaper than forging pack data. The
+# ruling REJECTED all three hardening alternatives, and the reasons are recorded so
+# they are not re-derived:
+#   * per-lane full clones — a permanent multi-GB tax on every lane for a threat
+#     that is out of model;
+#   * per-read rehashing — the fourth carve into one pre-flight, and a permanent
+#     cost on every `--lite` round;
+#   * removing the object-reuse fast path — a HALF-closure: the ancestry walk and
+#     the provenance leg must still read HEAD's COMMITTED content, which has no
+#     source other than this store.
+# What IS in model is corruption nobody intended: bit rot, a torn pack write, a
+# full disk mid-write, a SIGKILLed `git gc`. That is what this sweep closes, and
+# `git fsck` is the only thing that answers it, because it REHASHES.
+#
+# NOT `--connectivity-only`, EVER. `--connectivity-only` walks the reachability
+# graph and does NOT rehash object content, so it cannot detect the corruption this
+# script exists to find. It would make the sweep fast and vacuous. Do not
+# "optimise" it in.
+#
+# NOT `--strict` either, and for the opposite reason: `--strict` promotes legitimate
+# historical warnings (a malformed committer line, a zero-padded file mode) to
+# errors, so it would report CORRUPT on a healthy store — the guard operators learn
+# to waive.
+#
+# THE VOCABULARY IS CHOSEN SO THIS CANNOT BE READ AS A CERTIFICATION
+# ------------------------------------------------------------------
+# The house idiom is `scripts/flow/base-staleness.sh`, and the properties are the
+# same ones (CLAUDE.md documents why each is load-bearing):
+#   (a) EVERY output line, stdout AND stderr, begins with `OBJECT-STORE: `.
+#   (b) Every dynamic field is CONTROL-CHARACTER SANITIZED (newline, CR, other C0,
+#       DEL -> a visible escape). GIT PERMITS NEWLINES IN PATHS and an fsck
+#       diagnostic quotes paths verbatim, so an unsanitized field emits a line with
+#       NO PREFIX AT ALL, breaking the one invariant every consumer and every test
+#       rests on. Fields are otherwise kept VERBATIM: an object id or a path that
+#       has been masked is useless to the operator who has to act on it.
+#   (c) The verdict appears ONLY on an `OBJECT-STORE: verdict ` line, and its token
+#       is from the CLOSED set {VERIFIED, CORRUPT, UNMEASURED}. Continuation prose
+#       goes on `verdict-detail` lines, so the verdict line's token position can
+#       never hold a word.
+#   (d) This script's own STATIC TEMPLATE TEXT contains no other verdict
+#       vocabulary — asserted STRUCTURALLY over the source file by
+#       `scripts/tests/test_check_object_store_integrity.sh`, because that is a
+#       provable property while a claim about one sample run is not.
+#
+# EXIT CODES, AND THE CONSUMER CONTRACT
+# -------------------------------------
+#   0   VERIFIED   — the sweep RAN TO COMPLETION and reported no corruption.
+#   4   CORRUPT    — fsck reported corruption. The affected object ids are named.
+#   5   UNMEASURED — the answer was not obtained: no git, no resolvable object
+#                    store, no usable timeout binary, the bound expired, or an fsck
+#                    failure this script cannot classify.
+#   2   usage error — and `--help` exits 2 as well, deliberately: exit 0 MEANS
+#                    VERIFIED here, so a run that measured nothing must never
+#                    produce it.
+#
+# *** A CONSUMER MUST NOT READ `UNMEASURED` AS CLEAN. ***
+# That is CLAUDE.md's standing rule: never derive a pass from the absence of a bad
+# signal; where the sole oracle could not be consulted the verdict is non-passing
+# and its text names what was unverifiable. It is stated here and asserted by a
+# test, because the shape that keeps recurring in this repo is a multi-state signal
+# whose unmeasured state inherits the permissive branch.
+#
+# THERE IS DELIBERATELY NO KNOB THAT CAN PRODUCE `VERIFIED`. `--timeout` can only
+# make the bound tighter or looser, and a tighter bound can only yield UNMEASURED;
+# nothing here can be set to manufacture a clean verdict (#3312: an override is
+# settable by the party it constrains).
+#
+# IT MUTATES NOTHING. `git fsck` is read-only, and this script writes no file, no
+# ref and no config. Callers that need a throttle keep their own stamp file
+# (`scripts/local/worker-supervisor.sh` does).
+#
+# USAGE
+#   scripts/check-object-store-integrity.sh [--repo <path>] [--timeout <secs>]
+#   scripts/check-object-store-integrity.sh --help
+#
+# CALLERS (both go through THIS script — a second implementation would be a second
+# place for the verdict to drift):
+#   * scripts/bootstrap-agent-machine.sh          — once, at machine onboarding
+#   * scripts/local/worker-supervisor.sh          — throttled, per-iteration
+#
+# macOS bash 3.2 compatible, shellcheck-clean.
+set -uo pipefail
+
+# Ambient git state that would otherwise bend this measurement, pinned in one
+# place (the idiom and the rationale are base-staleness.sh's):
+#   GIT_NO_LAZY_FETCH=1     — in a partial/promisor clone an object read fetches
+#                             over the network and WRITES a packfile into the store
+#                             this script is auditing. Honoured from git 2.36.
+#   GIT_NO_REPLACE_OBJECTS=1 — `refs/replace/*` substitutes objects, so a single
+#                             local replacement ref could change which objects the
+#                             sweep visits.
+export GIT_NO_LAZY_FETCH=1
+export GIT_NO_REPLACE_OBJECTS=1
+
+P='OBJECT-STORE:'
+
+# sane <string> -> the string with every C0 control character and DEL replaced by a
+# VISIBLE escape, on stdout. Applied to EVERY dynamic field (property (b)).
+sane() {
+  local s="$1" out c i n
+  s="${s//$'\r'/'\r'}"
+  s="${s//$'\n'/'\n'}"
+  s="${s//$'\t'/'\t'}"
+  case "$s" in
+    *[[:cntrl:]]*) ;;
+    *)
+      printf '%s' "$s"
+      return 0
+      ;;
+  esac
+  out=""
+  n=${#s}
+  i=0
+  while [ "$i" -lt "$n" ]; do
+    c="${s:i:1}"
+    case "$c" in
+      [[:cntrl:]]) out=$(printf '%s\\x%02x' "$out" "'$c") ;;
+      *) out="$out$c" ;;
+    esac
+    i=$((i + 1))
+  done
+  printf '%s' "$out"
+}
+
+# EVERY line here is prefixed too: under property (a) the prefix is THE
+# load-bearing invariant, so an unprefixed usage line is a hole in it. `${0##*/}`
+# rather than `basename` — an external command whose stderr is not captured here
+# would emit an unprefixed diagnostic from the one function whose job is to be
+# readable when the call was wrong.
+usage() {
+  printf '%s USAGE - the call is wrong (this is NOT a measurement verdict)\n' "$P" >&2
+  printf '%s USAGE usage: %s [--repo <path>] [--timeout <secs>]\n' \
+    "$P" "$(sane "${0##*/}")" >&2
+  printf '%s USAGE Rehashes the SHARED git object store behind <path> with git fsck\n' "$P" >&2
+  printf '%s USAGE and reports whether it is intact (#3749). Read-only; mutates nothing.\n' "$P" >&2
+  printf '%s USAGE Exits 0 verified / 4 corrupt / 5 unmeasured / 2 usage.\n' "$P" >&2
+  printf '%s USAGE A CONSUMER MUST NOT READ EXIT 5 AS CLEAN (nothing was measured).\n' "$P" >&2
+  printf '%s USAGE Scope is ACCIDENTAL corruption. Deliberate peer forgery is\n' "$P" >&2
+  printf '%s USAGE invoker-class and OUT OF MODEL (#3749 owner ruling, #3312 triage).\n' "$P" >&2
+}
+
+# unmeasured <cause...> — exit 5. Prints NO clean signal of any kind, so it can
+# never be misread as a completed sweep.
+unmeasured() {
+  while [ "$#" -gt 0 ]; do
+    printf '%s unmeasured-cause %s\n' "$P" "$(sane "$1")"
+    shift
+  done
+  printf '%s verdict UNMEASURED\n' "$P"
+  printf '%s verdict-detail the sweep could not be performed. A CONSUMER MUST NOT READ THIS\n' "$P"
+  printf '%s verdict-detail AS CLEAN (#3749); it is not a certification.\n' "$P"
+  exit 5
+}
+
+# --- argument parsing: every unrecognised argument is refused ----------------
+REPO="."
+BOUND_SECS=300
+repo_set=0
+bound_set=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -h | --help)
+      usage
+      exit 2
+      ;;
+    --repo)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      [ "$repo_set" -eq 0 ] || { usage; exit 2; }
+      REPO="$2"
+      repo_set=1
+      shift 2
+      ;;
+    --timeout)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      [ "$bound_set" -eq 0 ] || { usage; exit 2; }
+      # Validated as a POSITIVE integer, never coerced: a bare word would evaluate
+      # to 0 in the bound and kill the sweep instantly, which under the
+      # classification below is UNMEASURED — a silently self-disabling bound.
+      case "$2" in
+        '' | *[!0-9]*) usage; exit 2 ;;
+      esac
+      [ "$2" -ge 1 ] || { usage; exit 2; }
+      BOUND_SECS="$2"
+      bound_set=1
+      shift 2
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+# --- the bound: resolve it BEFORE running anything ---------------------------
+#
+# THE SWEEP IS BOUNDED, AND AN UNBOUNDABLE HOST DOES NOT GET TO RUN IT. Both
+# callers are hang-sensitive: an unbounded fsck can wedge machine onboarding, and
+# in the supervisor it sits in the per-iteration preflight path. Refusing is
+# UNMEASURED, which is non-passing, so nothing is certified on the strength of a
+# probe we declined to run.
+#
+# The candidate is PROBED for `--kill-after` rather than sniffed by name (the
+# idiom, and the reasoning, are bootstrap-agent-machine.sh's): BusyBox and older
+# implementations reject the flag, and a selected binary that rejects it would make
+# every bounded call fail. SIGTERM-only is ACCEPTED here — unlike a credential
+# helper, `git fsck` does not trap or ignore SIGTERM — and the degradation is
+# NAMED in the output rather than left silent.
+TIMEOUT_BIN=""
+TIMEOUT_KILL_AFTER=0
+for _tb_name in timeout gtimeout; do
+  _tb_path="$(command -v "$_tb_name" 2>/dev/null || true)"
+  [ -n "$_tb_path" ] || continue
+  if "$_tb_path" --kill-after=1 1 true >/dev/null 2>&1; then
+    TIMEOUT_BIN="$_tb_path"
+    TIMEOUT_KILL_AFTER=1
+    break
+  fi
+  [ -n "$TIMEOUT_BIN" ] || TIMEOUT_BIN="$_tb_path"
+done
+unset _tb_name _tb_path
+BOUND_KILL_GRACE=5
+
+command -v git >/dev/null 2>&1 ||
+  unmeasured "git is not on PATH, so the object store cannot be rehashed at all"
+
+if [ -z "$TIMEOUT_BIN" ]; then
+  unmeasured "no timeout/gtimeout on PATH - refusing to run an UNBOUNDED fsck: both" \
+    "callers are hang-sensitive (machine onboarding, and the supervisor's" \
+    "per-iteration preflight). Install GNU coreutils and re-run."
+fi
+
+# --- resolve the SHARED object store ----------------------------------------
+#
+# `--git-common-dir`, NEVER `--git-dir`: in a linked worktree `--git-dir` answers
+# `<repo>/.git/worktrees/<lane>`, which is the LANE's private administrative
+# directory, while the objects every lane on the box shares live under the COMMON
+# dir (measured on this fleet: toplevel /data/lanes/lane-NNNN, common dir
+# /data/lanes/repo/.git). Sweeping the per-worktree dir would audit the wrong
+# thing and report VERIFIED about a store it never read.
+if ! GIT_COMMON_DIR_RAW=$(git -C "$REPO" rev-parse --git-common-dir 2>/dev/null) ||
+  [ -z "$GIT_COMMON_DIR_RAW" ]; then
+  unmeasured "git -C $(sane "$REPO") rev-parse --git-common-dir failed: not a git" \
+    "repository, or the repository is unreadable"
+fi
+# The value may be RELATIVE (a plain `.git`), and it is relative to the REPO, not
+# to this script's cwd.
+if ! GIT_COMMON_DIR=$(cd "$REPO" 2>/dev/null && cd "$GIT_COMMON_DIR_RAW" 2>/dev/null && pwd -P); then
+  GIT_COMMON_DIR=""
+fi
+if [ -z "$GIT_COMMON_DIR" ]; then
+  unmeasured "the git common directory ($(sane "$GIT_COMMON_DIR_RAW")) could not be" \
+    "canonicalized from $(sane "$REPO") - absent, unreadable, or not a directory"
+fi
+OBJ_DIR="$GIT_COMMON_DIR/objects"
+if [ ! -d "$OBJ_DIR" ] || [ ! -r "$OBJ_DIR" ]; then
+  unmeasured "the object store $(sane "$OBJ_DIR") is absent or unreadable, so there is" \
+    "nothing this run can rehash"
+fi
+
+# --- scratch space (outside the repository: this script writes nothing in it) --
+if ! TMPD=$(mktemp -d "${TMPDIR:-/tmp}/object-store-integrity.XXXXXX" 2>/dev/null) ||
+  [ -z "$TMPD" ] || [ ! -d "$TMPD" ]; then
+  unmeasured "could not create a scratch dir under $(sane "${TMPDIR:-/tmp}")"
+fi
+trap 'rm -rf "$TMPD" 2>/dev/null' EXIT
+
+printf '%s store %s\n' "$P" "$(sane "$OBJ_DIR")"
+printf '%s subject %s (resolved via git rev-parse --git-common-dir, NOT --git-dir)\n' \
+  "$P" "$(sane "$REPO")"
+if [ "$TIMEOUT_KILL_AFTER" -eq 1 ]; then
+  printf '%s bound %ss (hard: SIGTERM then SIGKILL after %ss)\n' "$P" "$BOUND_SECS" "$BOUND_KILL_GRACE"
+else
+  printf '%s bound %ss (SIGTERM-only: %s does not accept --kill-after; git fsck does not trap SIGTERM)\n' \
+    "$P" "$BOUND_SECS" "$(sane "$TIMEOUT_BIN")"
+fi
+
+# --- THE SWEEP --------------------------------------------------------------
+#
+# Full fsck: it REHASHES object content, which is the whole point (see the header
+# on why `--connectivity-only` would be vacuous here and `--strict` would be a
+# false positive). `--no-dangling` because an unreachable object is ordinary in a
+# store that has held reset branches, not corruption. `--no-progress` because
+# progress output is not a finding and would pollute the anchored stream.
+#
+# `nice`d: this is a hygiene sweep on a box that runs up to 4 gates. Measured on
+# this fleet's 331M shared store (one 219M pack): 19.83s elapsed, 64% cpu, 426MB
+# maxrss. The 300s default bound is ~15x that headroom — generous on purpose,
+# because the bound exists to stop a HANG, not to police duration: a cold cache
+# under four concurrent gates can legitimately be several times slower, and a
+# bound that expires on a healthy-but-busy box produces UNMEASURED noise nobody
+# acts on.
+START_TS=$(date +%s 2>/dev/null || echo 0)
+fsck_rc=0
+if [ "$TIMEOUT_KILL_AFTER" -eq 1 ]; then
+  nice -n 19 "$TIMEOUT_BIN" --kill-after="$BOUND_KILL_GRACE" "$BOUND_SECS" \
+    git --git-dir="$GIT_COMMON_DIR" fsck --no-progress --no-dangling \
+    >"$TMPD/fsck.out" 2>"$TMPD/fsck.err" || fsck_rc=$?
+else
+  nice -n 19 "$TIMEOUT_BIN" "$BOUND_SECS" \
+    git --git-dir="$GIT_COMMON_DIR" fsck --no-progress --no-dangling \
+    >"$TMPD/fsck.out" 2>"$TMPD/fsck.err" || fsck_rc=$?
+fi
+END_TS=$(date +%s 2>/dev/null || echo 0)
+ELAPSED=$((END_TS - START_TS))
+[ "$ELAPSED" -ge 0 ] || ELAPSED=0
+
+cat "$TMPD/fsck.out" "$TMPD/fsck.err" >"$TMPD/fsck.all" 2>/dev/null || : >"$TMPD/fsck.all"
+
+# --- CLASSIFY ---------------------------------------------------------------
+#
+# CORRUPTION IS RECOGNISED FROM fsck's OWN DIAGNOSTIC SHAPES, not from "the exit
+# status was non-zero" — because a non-zero fsck also covers `fatal: not a git
+# repository` and every other way the invocation can fail, and calling that CORRUPT
+# would send an operator hunting for damage that is not there. The recognised
+# shapes (verified against git 2.43.0 on planted fixtures, both of which the test
+# suite plants):
+#   error: inflate: data stream error ...                 (a torn/rotted object)
+#   error: <sha>: object corrupt or missing: <path>
+#   error: <sha>: hash-path mismatch, found at: <path>    (content != its own name)
+#   missing blob|tree|commit|tag <sha>
+#   broken link from ... to ...
+# Anything containing `corrupt` is included too, wherever git puts it.
+#
+# WARNINGS ARE NOT CORRUPTION and are deliberately not matched: `warning in commit
+# <sha>: missingSpaceBeforeEmail` is legitimate historical sloppiness, git exits 0
+# on it, and matching it would report CORRUPT on a healthy store.
+: >"$TMPD/findings"
+sed -n -e '/^error/p' -e '/^missing /p' -e '/^broken link/p' -e '/corrupt/p' \
+  "$TMPD/fsck.all" >"$TMPD/findings" 2>/dev/null || : >"$TMPD/findings"
+n_findings=$(grep -c . "$TMPD/findings" 2>/dev/null | tr -d ' ')
+case "$n_findings" in '' | *[!0-9]*) n_findings=0 ;; esac
+
+# The affected object ids: every 40-hex token in the findings, deduped. Extracted
+# from the findings themselves so an id can never be reported without the
+# diagnostic that named it; the diagnostics are printed verbatim as well, because
+# a shape this extractor does not recognise must still reach the operator.
+: >"$TMPD/ids"
+tr -c '0-9a-f' '\n' <"$TMPD/findings" 2>/dev/null |
+  awk 'length($0) == 40 { print }' | sort -u >"$TMPD/ids" 2>/dev/null || : >"$TMPD/ids"
+
+FINDING_LIST_LIMIT=40
+
+if [ "$n_findings" -gt 0 ]; then
+  n=0
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    n=$((n + 1))
+    [ "$n" -le "$FINDING_LIST_LIMIT" ] && printf '%s finding %s\n' "$P" "$(sane "$line")"
+  done <"$TMPD/findings"
+  [ "$n" -gt "$FINDING_LIST_LIMIT" ] &&
+    printf '%s finding (+%s further fsck diagnostics, not listed)\n' "$P" "$((n - FINDING_LIST_LIMIT))"
+  while IFS= read -r oid; do
+    [ -n "$oid" ] || continue
+    printf '%s object %s\n' "$P" "$(sane "$oid")"
+  done <"$TMPD/ids"
+  printf '%s measured fsck rc=%s in %ss over %s\n' "$P" "$fsck_rc" "$ELAPSED" "$(sane "$OBJ_DIR")"
+  printf '%s verdict CORRUPT\n' "$P"
+  printf '%s verdict-detail %s fsck diagnostic(s) name damaged or unhashable objects in the\n' "$P" "$n_findings"
+  printf '%s verdict-detail SHARED store. Every lane on this box reads it, so it can change ANY\n' "$P"
+  printf '%s verdict-detail gate verdict here: do NOT certify anything against this checkout.\n' "$P"
+  printf '%s verdict-detail REMEDY: stop the lanes on this box, then re-obtain the objects from the\n' "$P"
+  printf '%s verdict-detail canonical remote (a fresh clone of pmcfadin/cqlite, or\n' "$P"
+  printf '%s verdict-detail `git fetch --force origin` if the damage is confined to fetched packs).\n' "$P"
+  printf '%s verdict-detail A LOCAL `git gc`/`git repack` CANNOT REPAIR THIS - it rewrites the same\n' "$P"
+  printf '%s verdict-detail damaged content, or refuses. Escalate rather than improvising (#3749).\n' "$P"
+  exit 4
+fi
+
+# 124 = SIGTERM'd at the bound; 137 = it ignored SIGTERM and --kill-after
+# escalated to SIGKILL. A KILLED SWEEP IS UNMEASURED, NEVER VERIFIED: it exited
+# without having rehashed the rest of the store, and its silence up to that point
+# is the absence of a bad signal, not a clean answer.
+if [ "$fsck_rc" -eq 124 ] || [ "$fsck_rc" -eq 137 ]; then
+  unmeasured "the fsck exceeded its ${BOUND_SECS}s bound and was killed (rc=$fsck_rc) after" \
+    "${ELAPSED}s - it never finished rehashing the store, so its silence is NOT a" \
+    "clean result. Re-run with a larger --timeout on an idle box."
+fi
+
+# ANY OTHER NON-ZERO STATUS IS UNMEASURED, NOT CLEAN AND NOT CORRUPT. fsck failed
+# in a way this script does not recognise (an unreadable pack directory, a git too
+# old for a flag, a `fatal:` about the repository itself). Guessing CORRUPT would
+# send an operator after damage that may not exist; guessing VERIFIED would be the
+# permissive-unknown branch this whole file refuses.
+if [ "$fsck_rc" -ne 0 ]; then
+  unmeasured "git fsck exited $fsck_rc after ${ELAPSED}s with no recognised corruption" \
+    "diagnostic, so this run can classify it as neither clean nor corrupt." \
+    "fsck said: $(head -c 400 "$TMPD/fsck.all" 2>/dev/null)"
+fi
+
+# --- THE ONE AFFIRMATIVE BRANCH --------------------------------------------
+#
+# VERIFIED REQUIRES EVIDENCE THE SWEEP RAN AND COMPLETED, not merely that nothing
+# bad was printed. The evidence is the fsck PROCESS's OWN exit status 0, and it is
+# affirmative for a stated reason: the process ran under a bound whose kill
+# statuses (124/137) are distinguishable and are routed to UNMEASURED above, and an
+# fsck that could not start, could not read the store or died on a signal cannot
+# produce 0. `git fsck` exits 0 only after walking and REHASHING every object it
+# was asked to check. So `rc == 0` here means "it finished, and it found nothing" —
+# two facts, not one — while every state in which the first fact is unknown has
+# already been routed to UNMEASURED.
+printf '%s measured fsck rc=0 in %ss over %s (full rehash: not --connectivity-only)\n' \
+  "$P" "$ELAPSED" "$(sane "$OBJ_DIR")"
+printf '%s verdict VERIFIED\n' "$P"
+printf '%s verdict-detail git fsck ran to completion and reported no damaged objects.\n' "$P"
+printf '%s verdict-detail SCOPE: this is a POINT-IN-TIME sweep of ACCIDENTAL corruption, not a\n' "$P"
+printf '%s verdict-detail per-read guarantee and not a defence against deliberate forgery, which\n' "$P"
+printf '%s verdict-detail is invoker-class and out of model (#3749 owner ruling, #3312 triage).\n' "$P"
+exit 0

--- a/scripts/check-object-store-integrity.sh
+++ b/scripts/check-object-store-integrity.sh
@@ -67,7 +67,8 @@
 #       rests on. Fields are otherwise kept VERBATIM: an object id or a path that
 #       has been masked is useless to the operator who has to act on it.
 #   (c) The verdict appears ONLY on an `OBJECT-STORE: verdict ` line, and its token
-#       is from the CLOSED set {VERIFIED, CORRUPT, UNMEASURED}. Continuation prose
+#       is from the CLOSED set {VERIFIED, CORRUPT, UNMEASURED, UNSWEEPABLE}.
+#       Continuation prose
 #       goes on `verdict-detail` lines, so the verdict line's token position can
 #       never hold a word.
 #   (d) This script's own STATIC TEMPLATE TEXT contains no other verdict
@@ -84,10 +85,18 @@
 #                    (bit 2, see the reachability discriminator below). The findings
 #                    are named.
 #   5   UNMEASURED — the answer was not obtained: no git, no resolvable object
-#                    store, no usable timeout binary, the bound expired, an fsck
-#                    failure this script cannot classify, a damage class that did
-#                    NOT reproduce, or a reachability/ref/commit-graph/multi-pack-index
-#                    complaint that reproduced but could not be ATTRIBUTED.
+#                    store, no usable timeout binary, the bound expired, the fsck
+#                    could not be STARTED, an fsck failure this script cannot
+#                    classify, a damage class that did NOT reproduce, or a
+#                    reachability/ref/commit-graph/multi-pack-index complaint that
+#                    reproduced but could not be ATTRIBUTED.
+#   6   UNSWEEPABLE — git fsck RAN and DIED without finishing, on TWO independent
+#                    walks (its own `die()` or a signal death: a status at or above
+#                    128, which is never read as its error bitmask). NO CAUSE IS
+#                    CLAIMED: the store's object content is UNKNOWN, and no lane on
+#                    this box can obtain an affirmative sweep of it. It is a STOPPING
+#                    verdict, and it is NOT the same fact as UNMEASURED - see the
+#                    branch at PASS 2 for why only one of the two is permissive.
 #
 # A REACHABILITY COMPLAINT HAS TWO CAUSES AND THEY GET DIFFERENT VERDICTS (#3749
 # review round 4, item 1). fsck's exit bit 2 (ERROR_REACHABLE) fires for BOTH:
@@ -668,6 +677,27 @@ MAX_SWEEP_WALKS=3
 FSCK_DAMAGE_MASK=5
 FSCK_KNOWN_MASK=63
 FSCK_NONMASK_FLOOR=124
+# FSCK_FATAL_FLOOR splits the non-bitmask range in TWO, because "we could not run it" and
+# "it ran and reproducibly died" are DIFFERENT FACTS and only the first is a property of
+# this box's tooling (#3749 review round 10, item 1).
+#
+#   124..127 — the timeout and shell EXEC conventions. 124 is `timeout`'s own "I killed
+#              it" (handled as `killed` above this test), 125 is `timeout` itself failing,
+#              126 "found but not executable", 127 "not found". Every one of them means
+#              the fsck did NOT run: no store was read, nothing about it was learned.
+#   128+     — git's own `die()` (exactly 128) and signal deaths (128+N; 137 SIGKILL is
+#              the bound's escalation and is handled as `killed`). Something in the exec
+#              chain RAN and then failed fatally.
+#
+# THE STATUS SPACE IS SHARED, SO THE SPLIT IS ARGUED FROM THE EXEC CHAIN, NOT ASSUMED. The
+# chain is `env -i <allowlist> nice -n 19 timeout <bound> git --git-dir=... fsck ...`, and
+# every wrapper in it reports its OWN failures inside 125..127 (coreutils' documented
+# convention for `env`, `nice` and `timeout` alike). 128 and above therefore cannot be a
+# wrapper refusing to exec: it is the innermost command having actually started. Combined
+# with the `.started` marker (RULE 0 below), which establishes that the redirections took
+# and the group body ran, a status at or above this floor is an AFFIRMATIVE observation
+# that `git fsck` ran and died without finishing.
+FSCK_FATAL_FLOOR=128
 # ERROR_REACHABLE alone. It is NOT in FSCK_DAMAGE_MASK because the bit does not by
 # itself say which of its two causes fired (a pruned object named by a reflog, or an
 # object a LIVE ref still needs); the third walk is what attributes it.
@@ -720,10 +750,13 @@ FSCK_REACHABLE_BIT=2
 # callers and never bit-tested.
 #
 # THE THREE RULES BELOW, IN THIS ORDER, AND THE ORDER IS THE POINT:
-#   1. A status at or above 124 IS NOT A BITMASK. 124/125/126/127 are the
-#      timeout/shell conventions (this fsck runs under `timeout`), 128+N is git's
-#      `die()` and signal deaths. Testing bits in that range is how `127 & 1` reads as
-#      object damage. `unclassified`, never bit-tested.
+#   1. A status at or above 124 IS NOT A BITMASK, and it splits in two. Testing bits in
+#      that range is how `127 & 1` reads as object damage, so NEITHER half is ever
+#      bit-tested — but they are DIFFERENT FACTS and they get different classes:
+#      124..127 (the timeout/exec conventions) => `unrunnable`, the fsck never ran;
+#      128 and above (git's `die()`, a signal death) => `fatal`, it RAN and did not
+#      finish. See FSCK_FATAL_FLOOR for why the boundary is where it is, and the PASS 2
+#      dispatch for why only one of the two is permissive.
 #   2. THE DAMAGE BITS ARE TESTED INDEPENDENTLY, before any completeness check on the
 #      rest of the status. An unrelated bit - one git added after this was written -
 #      can then never MASK object or pack damage; it only travels with it.
@@ -828,9 +861,20 @@ fsck_pass() {
   #   error: <sha>: hash-path mismatch, found at: <path>    (content != its own name)
   #   missing blob|tree|commit|tag <sha>
   #   broken link from ... to ...
+  #   fatal: loose object <sha> (stored in <path>) is corrupt   (git DIED here)
   # Anything containing `corrupt` is included too, wherever git puts it. WARNINGS
   # ARE NOT MATCHED: `warning in commit <sha>: missingSpaceBeforeEmail` is
   # legitimate historical sloppiness and fsck exits 0 on it.
+  #
+  # `^fatal` IS MATCHED FOR THE OPERATOR, AND IT DECIDES NOTHING (#3749 review round 10,
+  # item 1). When fsck dies its LAST line is the only account of why, and some of those
+  # lines match none of the shapes above (measured on git 2.43.0: a repository-local
+  # `fsck.<msgid>=ignore` for an id this git does not know exits 128 with `fatal:
+  # Unhandled message id`, and nothing else). A stopping verdict that leaves the operator
+  # with no text at all is the round-9 defect in a new place. THE CLASS STILL COMES FROM
+  # THE EXIT BITMASK AND NEVER FROM THIS TEXT: matching here only decides what is PRINTED,
+  # which is why it is not round 1's `/^error/p` classifier coming back — that pattern
+  # DECIDED the verdict, and this one cannot reach any branch.
   #
   # A DIAGNOSTIC IS READ WHOLE, NOT LINE BY LINE. git permits newlines in paths and
   # quotes them verbatim, so `sed` would split such a diagnostic in two and the
@@ -840,7 +884,7 @@ fsck_pass() {
   # one, and the whole thing is escaped by sane() at print time.
   : >"$TMPD/$tag.findings"
   awk '
-    /^error/ || /^missing / || /^broken link/ || /corrupt/ {
+    /^error/ || /^missing / || /^broken link/ || /^fatal/ || /corrupt/ {
       if (have) printf "%s%c", buf, 0
       buf = $0; have = 1; next
     }
@@ -861,8 +905,10 @@ fsck_pass() {
     WALK_CLASS=clean
   elif [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
     WALK_CLASS=killed
+  elif [ "$rc" -ge "$FSCK_FATAL_FLOOR" ]; then
+    WALK_CLASS=fatal
   elif [ "$rc" -ge "$FSCK_NONMASK_FLOOR" ]; then
-    WALK_CLASS=unclassified
+    WALK_CLASS=unrunnable
   elif [ $((rc & FSCK_DAMAGE_MASK)) -ne 0 ]; then
     WALK_CLASS=damage
   elif [ $((rc & ~FSCK_KNOWN_MASK)) -ne 0 ]; then
@@ -1032,6 +1078,97 @@ if [ "$FIRST_WALK_CLEAN" -eq 0 ]; then
     exit 4
   fi
 
+  # BOTH PASSES RAN AND BOTH DIED FATALLY: the store cannot be SWEPT, and that is its own
+  # verdict. THE FINDING THIS EXISTS FOR (#3749 review round 10, item 1).
+  #
+  # Real commit-object corruption in the shared store makes `git fsck` DIE rather than
+  # report a bit. MEASURED on git 2.43.0, on fixtures the suite builds: overwrite the
+  # loose object a live ref points AT with unparseable bytes and fsck prints `fatal: loose
+  # object <sha> ... is corrupt` and exits **128**; overwrite a blob, or the same commit
+  # with a VALID object of the wrong name, and it exits 3 (bits 2|1). So the exact damage
+  # this control exists to catch has a shape that lands OUTSIDE the bitmask range, where
+  # the previous version called it `unclassified` -> UNMEASURED -> the supervisor writes a
+  # fresh throttle stamp and keeps spawning workers. A FALSE NEGATIVE on genuine
+  # corruption, one status range over from round 4's.
+  #
+  # WHY THIS DOES NOT CLAIM CORRUPTION, AND WHY THAT IS THE STRONGER FIX. The alternative
+  # was to read the `fatal:` diagnostic for an object-damage signature and emit the fatal
+  # damage verdict. That is round 1's classifier again — narrower, and with two costs the
+  # bit-based rule does not have: git's fatal-message space is prose this script would
+  # have to enumerate, and every wording it did not enumerate would fall back to the SAME
+  # permissive state, so the fix would close only the cases somebody thought of. A status
+  # at or above FSCK_FATAL_FLOOR closes the whole class regardless of cause, and it needs
+  # no parsing at all: what it asserts is exactly what was observed.
+  #
+  # WHAT IS AFFIRMATIVELY ESTABLISHED, and it is why this is not the permissive state:
+  #   * the `.started` marker proves the redirections took and the group body ran (RULE 0);
+  #   * every wrapper in the exec chain reports its own failures in 125..127, so a status
+  #     at or above 128 is the innermost command having actually started (FSCK_FATAL_FLOOR);
+  #   * it happened TWICE, on two independent walks, so it is not a concurrent writer.
+  # "The probe could not run" and "the probe ran, twice, and reproducibly died on this
+  # store" were sharing one verdict. They are different facts: the first is a property of
+  # this box's tooling and is deliberately permissive (see the UNMEASURED reasoning), while
+  # every cause of the second is a persistent property of the REPOSITORY - its objects, its
+  # refs, its own local config. A store no lane can ever obtain an affirmative sweep of is
+  # not a hygiene probe that could not run, so this one STOPS the box.
+  #
+  # AND IT PRINTS NO REPAIR INSTRUCTION, DELIBERATELY. No cause was established, and round
+  # 9's lesson is that the text a human gets when the box has stopped must match what was
+  # measured: a repair chosen for the wrong cause is worse than none.
+  if [ "$C1" = fatal ] && [ "$C2" = fatal ]; then
+    emit_findings p2 finding
+    printf '%s measured fsck rc=%s then rc=%s (%ss + %ss) over %s\n' \
+      "$P" "$RC1" "$RC2" "$EL1" "$EL2" "$(sane "$OBJ_DIR")"
+    printf '%s verdict UNSWEEPABLE\n' "$P"
+    printf '%s verdict-detail git fsck RAN and DIED without finishing, on TWO independent\n' "$P"
+    printf '%s verdict-detail walks over the SHARED store (exit %s then %s: a fatal error from git\n' "$P" "$RC1" "$RC2"
+    printf '%s verdict-detail itself or a signal death, not its error bitmask), so it never rehashed the\n' "$P"
+    printf '%s verdict-detail store to the end. This is NOT a concurrent writer - a transient does not\n' "$P"
+    printf '%s verdict-detail survive a second independent walk - and it is NOT the same fact as a\n' "$P"
+    printf '%s verdict-detail probe that could not START: the launch was established affirmatively and\n' "$P"
+    printf '%s verdict-detail every wrapper in the chain reports its own failures below 128.\n' "$P"
+    printf '%s verdict-detail NO CAUSE IS CLAIMED HERE. The object content of this store is UNKNOWN,\n' "$P"
+    printf '%s verdict-detail which is not clean: every lane on this box reads it, so do NOT certify\n' "$P"
+    printf '%s verdict-detail anything against this checkout until a sweep of it completes.\n' "$P"
+    printf '%s verdict-detail REMEDY: stop the lanes on this box, then run the walk BY HAND and read\n' "$P"
+    printf '%s verdict-detail what it says - the `fatal:` line is the account git gives of why it\n' "$P"
+    printf '%s verdict-detail stopped, and any diagnostics it managed to print are quoted above:\n' "$P"
+    printf '%s verdict-detail   git --git-dir=%s fsck --no-progress --no-dangling\n' "$P" "$(sane "$GIT_COMMON_DIR")"
+    printf '%s verdict-detail ACT ON WHAT THAT LINE NAMES, and on nothing else. This sweep prints no\n' "$P"
+    printf '%s verdict-detail repair instruction because it established no cause, and a repair chosen\n' "$P"
+    printf '%s verdict-detail for the wrong one is worse than none: re-obtaining objects cannot fix a\n' "$P"
+    printf '%s verdict-detail malformed local config, and a config edit cannot fix damaged bytes.\n' "$P"
+    printf '%s verdict-detail THEN re-run this sweep and require its affirmative verdict before\n' "$P"
+    printf '%s verdict-detail clearing any latch or resuming the lanes: "I think I fixed it" is not an\n' "$P"
+    printf '%s verdict-detail exit condition (#3749).\n' "$P"
+    exit 6
+  fi
+
+  # A FATAL DEATH IN EXACTLY ONE PASS: it did not reproduce, so it is neither an
+  # established un-sweepable store nor a clean one. Same rule as the one-pass damage
+  # branch below, and the same reason: one observation cannot separate a transient from a
+  # durable fact on a store eight lanes are writing.
+  if [ "$C1" = fatal ] || [ "$C2" = fatal ]; then
+    emit_findings p2 unmeasured-cause
+    unmeasured "git fsck RAN and DIED without finishing (a fatal error from git itself, or a" \
+      "signal death - not its error bitmask) in ONE of two walks and did not reproduce (pass 1" \
+      "class=$C1 rc=$RC1, pass 2 class=$C2 rc=$RC2). Nothing about the store's object" \
+      "content was established, so this is NOT clean. Re-run on an IDLE box; if it recurs" \
+      "the second walk will confirm it and this sweep will stop the box (#3749)."
+  fi
+
+  # THE FSCK NEVER RAN, IN EITHER PASS: 124..127 are the timeout and shell EXEC
+  # conventions, so no store was read. Its own cause text, because the fatal branch above
+  # would claim a walk that never started and the bitmask text below would name a class
+  # that was never established.
+  if [ "$C1" = unrunnable ] || [ "$C2" = unrunnable ]; then
+    unmeasured "the fsck could not be RUN (pass 1 class=$C1 rc=$RC1, pass 2 class=$C2" \
+      "rc=$RC2): a status of 125, 126 or 127 is the timeout/exec convention for 'the" \
+      "command was not started', not an fsck status, so nothing about this store was" \
+      "measured. Usual causes: no usable timeout binary, a git that is not executable, or" \
+      "a PATH that does not reach one. Fix the tooling on this box and re-run (#3749)."
+  fi
+
   # A DAMAGE CLASS IN EXACTLY ONE PASS: non-passing, and NOT the fatal branch. It is
   # neither established damage (it did not reproduce) nor a clean store (something
   # named an object as unhashable once).
@@ -1099,7 +1236,14 @@ if [ "$FIRST_WALK_CLEAN" -eq 0 ]; then
     # complaint must not be read as either verdict. `killed`, `launchfail` and
     # `unclassified` all mean the third walk produced no usable answer; each keeps the
     # reproduced complaint visible and says which walk went wrong.
-    if [ "$C3" = killed ] || [ "$C3" = launchfail ] || [ "$C3" = unclassified ]; then
+    # ENUMERATED FROM THE USABLE SIDE, so a class added to fsck_pass later cannot join the
+    # usable set by default: `killed`, `launchfail`, `unrunnable`, `fatal` and
+    # `unclassified` all mean this walk produced no usable answer (#3749 rounds 4 and 10).
+    case "$C3" in
+    clean | nondamage | damage) C3_USABLE=1 ;;
+    *) C3_USABLE=0 ;;
+    esac
+    if [ "$C3_USABLE" -eq 0 ]; then
       emit_findings p2 unmeasured-cause
       unmeasured "git fsck reported reachability problems on BOTH walks (pass 1 rc=$RC1," \
         "pass 2 rc=$RC2) and the confirming --no-reflogs walk produced no usable answer" \

--- a/scripts/check-object-store-integrity.sh
+++ b/scripts/check-object-store-integrity.sh
@@ -68,10 +68,19 @@
 # EXIT CODES, AND THE CONSUMER CONTRACT
 # -------------------------------------
 #   0   VERIFIED   — the sweep RAN TO COMPLETION and reported no corruption.
-#   4   CORRUPT    — fsck reported corruption. The affected object ids are named.
+#   4   CORRUPT    — fsck reported OBJECT/PACK damage (its exit bits 1/4) on TWO
+#                    independent walks. The affected object ids are named.
 #   5   UNMEASURED — the answer was not obtained: no git, no resolvable object
-#                    store, no usable timeout binary, the bound expired, or an fsck
-#                    failure this script cannot classify.
+#                    store, no usable timeout binary, the bound expired, an fsck
+#                    failure this script cannot classify, a damage class that did
+#                    NOT reproduce, or reachability/ref complaints that did.
+#
+# REACHABILITY IS ITS OWN NON-PASSING STATE, NEITHER CLEAN NOR CORRUPT. fsck's exit
+# bit 2 (ERROR_REACHABLE) fires for a stale reflog entry on a store peer lanes are
+# writing — routine on this fleet, and NOT this script's subject — but also for a
+# genuinely MISSING object, so it can be demoted to neither. It lands on UNMEASURED
+# with a cause that names the class. And NO verdict is fatal on ONE observation:
+# see the discriminator at the sweep below.
 #   2   usage error — and `--help` exits 2 as well, deliberately: exit 0 MEANS
 #                    VERIFIED here, so a run that measured nothing must never
 #                    produce it.
@@ -104,16 +113,69 @@
 # macOS bash 3.2 compatible, shellcheck-clean.
 set -uo pipefail
 
-# Ambient git state that would otherwise bend this measurement, pinned in one
-# place (the idiom and the rationale are base-staleness.sh's):
-#   GIT_NO_LAZY_FETCH=1     — in a partial/promisor clone an object read fetches
-#                             over the network and WRITES a packfile into the store
-#                             this script is auditing. Honoured from git 2.36.
-#   GIT_NO_REPLACE_OBJECTS=1 — `refs/replace/*` substitutes objects, so a single
-#                             local replacement ref could change which objects the
-#                             sweep visits.
-export GIT_NO_LAZY_FETCH=1
-export GIT_NO_REPLACE_OBJECTS=1
+# THE GIT ENVIRONMENT IS AN ALLOWLIST, NOT A PIN-TWO-AND-HOPE (#3749 review, and
+# CLAUDE.md's recorded ruling for exactly this family, roborev job 276: `env -i`
+# plus ONE allowlist for every git call in a verdict-bearing probe, "precisely
+# because per-site fixes kept missing new sites").
+#
+# THE FIRST VERSION EXPORTED TWO VARIABLES AND LET THE REST OF THE CALLER'S
+# ENVIRONMENT THROUGH, AND THAT PRODUCED A FALSE `VERIFIED` NAMING THE CORRUPT
+# STORE. Reproduced: `GIT_OBJECT_DIRECTORY=<good>/objects` with `--repo <bad>`
+# printed `store <bad>/.git/objects` and `verdict VERIFIED`, exit 0 - every emitted
+# line affirmatively false, with no signal to either consumer. `GIT_DIR` and
+# `GIT_ALTERNATE_OBJECT_DIRECTORIES` reproduce variants of it. It is ACCIDENT-CLASS
+# (an exported `GIT_DIR` in the shell that launched the supervisor), which the
+# #3312 triage rule says to fix; and the inherited house pattern it copied
+# (`base-staleness.sh`) emits a NON-FATAL ADVISORY COUNT, while this one stops a
+# supervisor and gates `--strict` onboarding.
+#
+# So every git call in this script runs under `env -i` with the list below, which
+# makes a git environment variable nobody has thought of CLEARED BY DEFAULT rather
+# than needing to be discovered. ADMIT only what git needs to REACH the store;
+# SET, rather than inherit, anything that decides WHICH objects it reads, WHAT it
+# runs, or how it SPEAKS.
+#
+#   PATH                     ADMITTED. `git`, `nice` and the timeout binary are
+#                            invoked by name, and the test suite's hermetic-PATH
+#                            cases depend on the caller's PATH being the one in
+#                            effect. It cannot redirect the sweep to another
+#                            STORE - only to another git, which is the same trust
+#                            as `command -v git` above.
+#   LC_ALL=C                 SET. Localised diagnostics would change the text the
+#                            operator is shown; the class comes from the exit
+#                            status, but the evidence lines should not vary by
+#                            locale.
+#   GIT_NO_LAZY_FETCH=1      SET. In a partial/promisor clone an object read
+#                            fetches over the network and WRITES a packfile into
+#                            the store this script is auditing. Honoured from
+#                            git 2.36.
+#   GIT_NO_REPLACE_OBJECTS=1 SET. `refs/replace/*` substitutes objects, so a single
+#                            local replacement ref could change which objects the
+#                            sweep visits.
+#   GIT_CONFIG_GLOBAL,       SET to /dev/null. `~/.gitconfig` and the system config
+#   GIT_CONFIG_SYSTEM        can carry `fsck.*` severities, alternates and
+#                            `url.*.insteadOf`; HOME is shared on this fleet, so a
+#                            peer lane's edit there is not the invoker's.
+#   everything else          CLEARED - notably GIT_DIR, GIT_COMMON_DIR,
+#                            GIT_OBJECT_DIRECTORY, GIT_ALTERNATE_OBJECT_DIRECTORIES,
+#                            GIT_INDEX_FILE, GIT_CEILING_DIRECTORIES,
+#                            GIT_CONFIG_COUNT/_KEY_*/_VALUE_*, GIT_CONFIG_PARAMETERS,
+#                            GIT_TEMPLATE_DIR, GIT_ALLOW_PROTOCOL, HOME.
+#
+# git_isolated <cmd...> - run <cmd> with exactly that environment. Used for EVERY
+# git call here (the `--git-common-dir` resolution and both fsck passes), because
+# an allowlist that reaches only some call sites is the hole it was written to
+# close.
+git_isolated() {
+  "$ENV_BIN" -i \
+    PATH="${PATH:-/usr/bin:/bin}" \
+    LC_ALL=C \
+    GIT_NO_LAZY_FETCH=1 \
+    GIT_NO_REPLACE_OBJECTS=1 \
+    GIT_CONFIG_GLOBAL=/dev/null \
+    GIT_CONFIG_SYSTEM=/dev/null \
+    "$@"
+}
 
 P='OBJECT-STORE:'
 
@@ -177,7 +239,7 @@ unmeasured() {
 
 # --- argument parsing: every unrecognised argument is refused ----------------
 REPO="."
-BOUND_SECS=300
+BOUND_SECS=600
 repo_set=0
 bound_set=0
 while [ "$#" -gt 0 ]; do
@@ -246,6 +308,17 @@ BOUND_KILL_GRACE=5
 command -v git >/dev/null 2>&1 ||
   unmeasured "git is not on PATH, so the object store cannot be rehashed at all"
 
+# `env` IS A HARD DEPENDENCY BECAUSE THE ISOLATION IS (see git_isolated above), so a
+# host without it is UNMEASURED rather than silently downgraded to running git in the
+# caller's environment. That downgrade is exactly the defect the allowlist closes: a
+# measurement taken under an inherited GIT_OBJECT_DIRECTORY can name one store and
+# read another.
+ENV_BIN="$(command -v env 2>/dev/null || true)"
+[ -n "$ENV_BIN" ] ||
+  unmeasured "env is not on PATH, so this run cannot ISOLATE git's environment - and an" \
+    "fsck run under an inherited GIT_DIR/GIT_OBJECT_DIRECTORY can report about a" \
+    "DIFFERENT store than the one it names. Refusing rather than measuring the wrong thing."
+
 if [ -z "$TIMEOUT_BIN" ]; then
   unmeasured "no timeout/gtimeout on PATH - refusing to run an UNBOUNDED fsck: both" \
     "callers are hang-sensitive (machine onboarding, and the supervisor's" \
@@ -260,7 +333,7 @@ fi
 # dir (measured on this fleet: toplevel /data/lanes/lane-NNNN, common dir
 # /data/lanes/repo/.git). Sweeping the per-worktree dir would audit the wrong
 # thing and report VERIFIED about a store it never read.
-if ! GIT_COMMON_DIR_RAW=$(git -C "$REPO" rev-parse --git-common-dir 2>/dev/null) ||
+if ! GIT_COMMON_DIR_RAW=$(git_isolated git -C "$REPO" rev-parse --git-common-dir 2>/dev/null) ||
   [ -z "$GIT_COMMON_DIR_RAW" ]; then
   unmeasured "git -C $(sane "$REPO") rev-parse --git-common-dir failed: not a git" \
     "repository, or the repository is unreadable"
@@ -305,109 +378,263 @@ fi
 # store that has held reset branches, not corruption. `--no-progress` because
 # progress output is not a finding and would pollute the anchored stream.
 #
-# `nice`d: this is a hygiene sweep on a box that runs up to 4 gates. Measured on
-# this fleet's 331M shared store (one 219M pack): 19.83s elapsed, 64% cpu, 426MB
-# maxrss. The 300s default bound is ~15x that headroom — generous on purpose,
-# because the bound exists to stop a HANG, not to police duration: a cold cache
-# under four concurrent gates can legitimately be several times slower, and a
-# bound that expires on a healthy-but-busy box produces UNMEASURED noise nobody
-# acts on.
-START_TS=$(date +%s 2>/dev/null || echo 0)
-fsck_rc=0
-if [ "$TIMEOUT_KILL_AFTER" -eq 1 ]; then
-  nice -n 19 "$TIMEOUT_BIN" --kill-after="$BOUND_KILL_GRACE" "$BOUND_SECS" \
-    git --git-dir="$GIT_COMMON_DIR" fsck --no-progress --no-dangling \
-    >"$TMPD/fsck.out" 2>"$TMPD/fsck.err" || fsck_rc=$?
-else
-  nice -n 19 "$TIMEOUT_BIN" "$BOUND_SECS" \
-    git --git-dir="$GIT_COMMON_DIR" fsck --no-progress --no-dangling \
-    >"$TMPD/fsck.out" 2>"$TMPD/fsck.err" || fsck_rc=$?
-fi
-END_TS=$(date +%s 2>/dev/null || echo 0)
-ELAPSED=$((END_TS - START_TS))
-[ "$ELAPSED" -ge 0 ] || ELAPSED=0
-
-cat "$TMPD/fsck.out" "$TMPD/fsck.err" >"$TMPD/fsck.all" 2>/dev/null || : >"$TMPD/fsck.all"
-
-# --- CLASSIFY ---------------------------------------------------------------
+# `nice`d: this is a hygiene sweep on a box that runs up to 4 gates.
 #
-# CORRUPTION IS RECOGNISED FROM fsck's OWN DIAGNOSTIC SHAPES, not from "the exit
-# status was non-zero" — because a non-zero fsck also covers `fatal: not a git
-# repository` and every other way the invocation can fail, and calling that CORRUPT
-# would send an operator hunting for damage that is not there. The recognised
-# shapes (verified against git 2.43.0 on planted fixtures, both of which the test
-# suite plants):
-#   error: inflate: data stream error ...                 (a torn/rotted object)
-#   error: <sha>: object corrupt or missing: <path>
-#   error: <sha>: hash-path mismatch, found at: <path>    (content != its own name)
-#   missing blob|tree|commit|tag <sha>
-#   broken link from ... to ...
-# Anything containing `corrupt` is included too, wherever git puts it.
+# COST IS A RANGE WITH CONDITIONS, NOT A NUMBER (#3749 review). This file used to
+# quote "19.83s" from a single warm run and derive "~15x headroom" from it; both
+# were wrong. Two independent measurement sets on this fleet's shared store
+# (366M, one ~220M pack, git 2.43.0) give:
+#   * warm page cache, quiet box:      13-24s  (5 runs)
+#   * cold-ish cache / concurrent gates: 47-80s (3 runs)
+# The sweep is I/O-bound (user time is only 17-19s of an 80s wall), so it is CACHE
+# STATE and box load that dominate, and any single number is a measurement of the
+# machine's mood rather than of the sweep.
 #
-# WARNINGS ARE NOT CORRUPTION and are deliberately not matched: `warning in commit
-# <sha>: missingSpaceBeforeEmail` is legitimate historical sloppiness, git exits 0
-# on it, and matching it would report CORRUPT on a healthy store.
-: >"$TMPD/findings"
-sed -n -e '/^error/p' -e '/^missing /p' -e '/^broken link/p' -e '/corrupt/p' \
-  "$TMPD/fsck.all" >"$TMPD/findings" 2>/dev/null || : >"$TMPD/findings"
-n_findings=$(grep -c . "$TMPD/findings" 2>/dev/null | tr -d ' ')
-case "$n_findings" in '' | *[!0-9]*) n_findings=0 ;; esac
-
-# The affected object ids: every 40-hex token in the findings, deduped. Extracted
-# from the findings themselves so an id can never be reported without the
-# diagnostic that named it; the diagnostics are printed verbatim as well, because
-# a shape this extractor does not recognise must still reach the operator.
-: >"$TMPD/ids"
-tr -c '0-9a-f' '\n' <"$TMPD/findings" 2>/dev/null |
-  awk 'length($0) == 40 { print }' | sort -u >"$TMPD/ids" 2>/dev/null || : >"$TMPD/ids"
-
+# THE 600s DEFAULT BOUND IS SIZED FROM THE TOP OF THAT RANGE: ~7.5x the observed
+# cold worst case, not the ~4x that 300s would give. The bound exists to stop a
+# HANG, not to police duration - an expired bound is UNMEASURED, which is a page
+# nobody can act on, and a bound that fires on a healthy-but-busy box is the guard
+# operators learn to waive. WORST-CASE WALL TIME IS 2x THE BOUND, because a
+# non-clean first pass is re-run once (see the discriminator below); only the rare
+# non-clean path pays it.
 FINDING_LIST_LIMIT=40
 
-if [ "$n_findings" -gt 0 ]; then
-  n=0
-  while IFS= read -r line; do
-    [ -n "$line" ] || continue
-    n=$((n + 1))
-    [ "$n" -le "$FINDING_LIST_LIMIT" ] && printf '%s finding %s\n' "$P" "$(sane "$line")"
-  done <"$TMPD/findings"
-  [ "$n" -gt "$FINDING_LIST_LIMIT" ] &&
-    printf '%s finding (+%s further fsck diagnostics, not listed)\n' "$P" "$((n - FINDING_LIST_LIMIT))"
-  while IFS= read -r oid; do
-    [ -n "$oid" ] || continue
-    printf '%s object %s\n' "$P" "$(sane "$oid")"
-  done <"$TMPD/ids"
-  printf '%s measured fsck rc=%s in %ss over %s\n' "$P" "$fsck_rc" "$ELAPSED" "$(sane "$OBJ_DIR")"
-  printf '%s verdict CORRUPT\n' "$P"
-  printf '%s verdict-detail %s fsck diagnostic(s) name damaged or unhashable objects in the\n' "$P" "$n_findings"
-  printf '%s verdict-detail SHARED store. Every lane on this box reads it, so it can change ANY\n' "$P"
-  printf '%s verdict-detail gate verdict here: do NOT certify anything against this checkout.\n' "$P"
-  printf '%s verdict-detail REMEDY: stop the lanes on this box, then re-obtain the objects from the\n' "$P"
-  printf '%s verdict-detail canonical remote (a fresh clone of pmcfadin/cqlite, or\n' "$P"
-  printf '%s verdict-detail `git fetch --force origin` if the damage is confined to fetched packs).\n' "$P"
-  printf '%s verdict-detail A LOCAL `git gc`/`git repack` CANNOT REPAIR THIS - it rewrites the same\n' "$P"
-  printf '%s verdict-detail damaged content, or refuses. Escalate rather than improvising (#3749).\n' "$P"
-  exit 4
-fi
+# fsck_pass <tag> - ONE bounded fsck over the shared store. Sets WALK_RC,
+# WALK_ELAPSED, WALK_CLASS, WALK_NFIND and writes $TMPD/<tag>.findings (the
+# recognised diagnostic lines, verbatim) and $TMPD/<tag>.ids (the 40-hex tokens in
+# them).
+#
+# THE CLASS COMES FROM fsck's EXIT BITMASK, NOT FROM THE TEXT SHAPE OF ITS
+# DIAGNOSTICS, AND THAT IS THE #3749 REVIEW'S CORRECTION. `git fsck` returns a
+# bitmask: 1 ERROR_OBJECT, 2 ERROR_REACHABLE, 4 ERROR_PACK, 8 ERROR_REFS,
+# 16 ERROR_COMMIT_GRAPH. The first version of this script recognised damage from
+# `/^error/p` and short-circuited to the fatal branch on any hit - and `error:` is
+# ALSO what fsck prints for a reflog entry naming a pruned object, which on a store
+# eight lanes are concurrently writing (branch create/delete, fetch, gc) happens
+# routinely on a PERFECTLY HEALTHY store. Measured on this fleet: 2 of 4 raw fsck
+# runs in one sitting exited 2 with `invalid reflog entry` diagnostics naming a
+# DIFFERENT branch each time. Under the old classifier every one of those was a
+# `CORRUPT` that pages high, stops the supervisor and fails `--strict` bootstrap.
+#
+# Only bits 1 and 4 are the subject of this script (an object that failed to
+# rehash, a damaged pack). Bits 2/8/16 are NOT demoted to clean - a genuinely
+# missing object also reports ERROR_REACHABLE, so treating reachability as clean
+# would convert a real corruption symptom into a pass - they land in their own
+# NON-PASSING state (UNMEASURED, with a cause that names the class).
+#
+# A status OUTSIDE 1..31 is not a bitmask at all (128 is git's `die()`, 127 is a
+# missing binary), so it is `unclassified`, never bit-tested: `127 & 1` is 1 and
+# would read as object damage.
+fsck_pass() {
+  local tag="$1" rc=0 t0 t1 el
+  local out="$TMPD/$tag.out" err="$TMPD/$tag.err" all="$TMPD/$tag.all"
+  t0=$(date +%s 2>/dev/null || echo 0)
+  if [ "$TIMEOUT_KILL_AFTER" -eq 1 ]; then
+    git_isolated nice -n 19 "$TIMEOUT_BIN" --kill-after="$BOUND_KILL_GRACE" "$BOUND_SECS" \
+      git --git-dir="$GIT_COMMON_DIR" fsck --no-progress --no-dangling \
+      >"$out" 2>"$err" || rc=$?
+  else
+    git_isolated nice -n 19 "$TIMEOUT_BIN" "$BOUND_SECS" \
+      git --git-dir="$GIT_COMMON_DIR" fsck --no-progress --no-dangling \
+      >"$out" 2>"$err" || rc=$?
+  fi
+  t1=$(date +%s 2>/dev/null || echo 0)
+  el=$((t1 - t0))
+  [ "$el" -ge 0 ] || el=0
+  WALK_RC="$rc"
+  WALK_ELAPSED="$el"
+  cat "$out" "$err" >"$all" 2>/dev/null || : >"$all"
 
-# 124 = SIGTERM'd at the bound; 137 = it ignored SIGTERM and --kill-after
-# escalated to SIGKILL. A KILLED SWEEP IS UNMEASURED, NEVER VERIFIED: it exited
-# without having rehashed the rest of the store, and its silence up to that point
-# is the absence of a bad signal, not a clean answer.
-if [ "$fsck_rc" -eq 124 ] || [ "$fsck_rc" -eq 137 ]; then
-  unmeasured "the fsck exceeded its ${BOUND_SECS}s bound and was killed (rc=$fsck_rc) after" \
-    "${ELAPSED}s - it never finished rehashing the store, so its silence is NOT a" \
+  # The recognised diagnostic shapes, kept for the OPERATOR (the class above is
+  # decided by the status). Verified against git 2.43.0 on the planted fixtures the
+  # test suite builds:
+  #   error: inflate: data stream error ...                 (a torn/rotted object)
+  #   error: <sha>: object corrupt or missing: <path>
+  #   error: <sha>: hash-path mismatch, found at: <path>    (content != its own name)
+  #   missing blob|tree|commit|tag <sha>
+  #   broken link from ... to ...
+  # Anything containing `corrupt` is included too, wherever git puts it. WARNINGS
+  # ARE NOT MATCHED: `warning in commit <sha>: missingSpaceBeforeEmail` is
+  # legitimate historical sloppiness and fsck exits 0 on it.
+  #
+  # A DIAGNOSTIC IS READ WHOLE, NOT LINE BY LINE. git permits newlines in paths and
+  # quotes them verbatim, so `sed` would split such a diagnostic in two and the
+  # CONTINUATION - which carries the rest of the path the operator has to act on -
+  # matches no pattern and would be dropped silently (#3749 review NIT 1). So a
+  # line that matches nothing is APPENDED to the previous finding when there is
+  # one, and the whole thing is escaped by sane() at print time.
+  : >"$TMPD/$tag.findings"
+  awk '
+    /^error/ || /^missing / || /^broken link/ || /corrupt/ {
+      if (have) printf "%s%c", buf, 0
+      buf = $0; have = 1; next
+    }
+    have { buf = buf "\n" $0 }
+    END { if (have) printf "%s%c", buf, 0 }
+  ' "$all" >"$TMPD/$tag.findings" 2>/dev/null || : >"$TMPD/$tag.findings"
+  WALK_NFIND=$(tr -cd '\000' <"$TMPD/$tag.findings" 2>/dev/null | wc -c | tr -d ' ')
+  case "$WALK_NFIND" in '' | *[!0-9]*) WALK_NFIND=0 ;; esac
+
+  # The affected object ids: every 40-hex token in the findings, deduped. Extracted
+  # FROM the findings so an id can never be reported without the diagnostic that
+  # named it.
+  : >"$TMPD/$tag.ids"
+  tr -c '0-9a-f' '\n' <"$TMPD/$tag.findings" 2>/dev/null |
+    awk 'length($0) == 40 { print }' | sort -u >"$TMPD/$tag.ids" 2>/dev/null || : >"$TMPD/$tag.ids"
+
+  if [ "$rc" -eq 0 ]; then
+    WALK_CLASS=clean
+  elif [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
+    WALK_CLASS=killed
+  elif [ "$rc" -ge 1 ] && [ "$rc" -le 31 ]; then
+    if [ $((rc & 5)) -ne 0 ]; then
+      WALK_CLASS=damage
+    else
+      WALK_CLASS=reachability
+    fi
+  else
+    WALK_CLASS=unclassified
+  fi
+}
+
+# emit_findings <tag> <label> - print the pass's diagnostics (NUL-separated records,
+# so a newline inside one is not a record boundary) and, for the fatal branch only,
+# the object ids. Bounded, and the overflow is COUNTED rather than dropped.
+emit_findings() {
+  local tag="$1" label="$2" n=0 rec
+  while IFS= read -r -d '' rec; do
+    [ -n "$rec" ] || continue
+    n=$((n + 1))
+    [ "$n" -le "$FINDING_LIST_LIMIT" ] && printf '%s %s %s\n' "$P" "$label" "$(sane "$rec")"
+  done <"$TMPD/$tag.findings"
+  [ "$n" -gt "$FINDING_LIST_LIMIT" ] &&
+    printf '%s %s (+%s further fsck diagnostics, not listed)\n' "$P" "$label" "$((n - FINDING_LIST_LIMIT))"
+  return 0
+}
+
+# --- PASS 1 ------------------------------------------------------------------
+fsck_pass p1
+C1="$WALK_CLASS"
+RC1="$WALK_RC"
+EL1="$WALK_ELAPSED"
+N1="$WALK_NFIND"
+
+# 124 = SIGTERM'd at the bound; 137 = it ignored SIGTERM and --kill-after escalated
+# to SIGKILL. A KILLED SWEEP IS UNMEASURED, NEVER VERIFIED: it exited without having
+# rehashed the rest of the store, and its silence up to that point is the absence of
+# a bad signal, not a clean answer. No second pass: a killed pass says nothing to
+# reproduce, and re-running would double the wall time of the one case that is
+# already too slow.
+if [ "$C1" = killed ]; then
+  unmeasured "the fsck exceeded its ${BOUND_SECS}s bound and was killed (rc=$RC1) after" \
+    "${EL1}s - it never finished rehashing the store, so its silence is NOT a" \
     "clean result. Re-run with a larger --timeout on an idle box."
 fi
 
-# ANY OTHER NON-ZERO STATUS IS UNMEASURED, NOT CLEAN AND NOT CORRUPT. fsck failed
-# in a way this script does not recognise (an unreadable pack directory, a git too
-# old for a flag, a `fatal:` about the repository itself). Guessing CORRUPT would
-# send an operator after damage that may not exist; guessing VERIFIED would be the
-# permissive-unknown branch this whole file refuses.
-if [ "$fsck_rc" -ne 0 ]; then
-  unmeasured "git fsck exited $fsck_rc after ${ELAPSED}s with no recognised corruption" \
-    "diagnostic, so this run can classify it as neither clean nor corrupt." \
-    "fsck said: $(head -c 400 "$TMPD/fsck.all" 2>/dev/null)"
+if [ "$C1" = clean ]; then
+  FIRST_WALK_CLEAN=1
+else
+  FIRST_WALK_CLEAN=0
+fi
+
+# --- PASS 2: THE DISCRIMINATOR ----------------------------------------------
+#
+# WHY A SECOND WALK, AND WHAT IT IS FOR. This control CANNOT DISTINGUISH A
+# CONCURRENCY-INDUCED TRANSIENT FROM REAL DAMAGE IN A SINGLE OBSERVATION: the store
+# is being written by up to 8 peer lanes while fsck walks it, so a ref that vanishes
+# mid-walk, a pack being replaced by gc, or a reflog entry naming a just-pruned
+# object all produce diagnostics on a healthy store. What separates the two is
+# REPRODUCTION: a transient does not survive a second independent walk, and real
+# damage does. So the fatal verdict is affirmative - it rests on the SAME class
+# being observed twice - rather than on one observation plus an argument.
+#
+# IT IS DELIBERATELY NOT A RETRY-UNTIL-CLEAN LOOP. Exactly one re-run, and its
+# result can only make the verdict weaker or confirm it, never sweep it away: a
+# damage class seen once and not the second time is NOT clean either, it is
+# UNMEASURED (a flickering corruption signal is not something to certify).
+#
+# It is nearly free: only the non-clean path pays a second bound, and on this fleet
+# that path is the exception.
+if [ "$FIRST_WALK_CLEAN" -eq 0 ]; then
+  printf '%s measured pass 1: fsck rc=%s in %ss over %s (full rehash: not --connectivity-only)\n' \
+    "$P" "$RC1" "$EL1" "$(sane "$OBJ_DIR")"
+  printf '%s note pass 1 was not clean (class=%s, rc=%s, %s diagnostic(s)); re-running once\n' \
+    "$P" "$C1" "$RC1" "$N1"
+  printf '%s note the second walk is a DISCRIMINATOR, not a retry: a concurrent writer on\n' "$P"
+  printf '%s note this shared store produces diagnostics that do not survive a second walk,\n' "$P"
+  printf '%s note while real damage does. It is never re-run until it comes back clean.\n' "$P"
+  emit_findings p1 note
+  fsck_pass p2
+  printf '%s measured pass 2: fsck rc=%s in %ss over %s (full rehash: not --connectivity-only)\n' \
+    "$P" "$WALK_RC" "$WALK_ELAPSED" "$(sane "$OBJ_DIR")"
+  C2="$WALK_CLASS"
+  RC2="$WALK_RC"
+  EL2="$WALK_ELAPSED"
+  N2="$WALK_NFIND"
+
+  if [ "$C2" = killed ]; then
+    unmeasured "pass 1 was not clean (class=$C1, rc=$RC1) and the confirming pass exceeded" \
+      "its ${BOUND_SECS}s bound (rc=$RC2) after ${EL2}s, so the first observation could" \
+      "not be confirmed or dismissed. Re-run with a larger --timeout on an idle box."
+  fi
+
+  # BOTH PASSES SAW OBJECT/PACK DAMAGE: the fatal branch, and the only path to it.
+  if [ "$C1" = damage ] && [ "$C2" = damage ]; then
+    emit_findings p2 finding
+    while IFS= read -r oid; do
+      [ -n "$oid" ] || continue
+      printf '%s object %s\n' "$P" "$(sane "$oid")"
+    done <"$TMPD/p2.ids"
+    printf '%s measured fsck rc=%s then rc=%s (%ss + %ss) over %s\n' \
+      "$P" "$RC1" "$RC2" "$EL1" "$EL2" "$(sane "$OBJ_DIR")"
+    printf '%s verdict CORRUPT\n' "$P"
+    printf '%s verdict-detail %s fsck diagnostic(s) name damaged or unhashable objects in the\n' "$P" "$N2"
+    printf '%s verdict-detail SHARED store, on TWO independent walks (fsck exit bits 1/4 both\n' "$P"
+    printf '%s verdict-detail times), so this is damage and not a concurrent writer. Every lane on\n' "$P"
+    printf '%s verdict-detail this box reads it, so it can change ANY gate verdict here: do NOT\n' "$P"
+    printf '%s verdict-detail certify anything against this checkout.\n' "$P"
+    printf '%s verdict-detail REMEDY: stop the lanes on this box, then re-obtain the objects from the\n' "$P"
+    printf '%s verdict-detail canonical remote (a fresh clone of pmcfadin/cqlite, or\n' "$P"
+    printf '%s verdict-detail `git fetch --force origin` if the damage is confined to fetched packs).\n' "$P"
+    printf '%s verdict-detail A LOCAL `git gc`/`git repack` CANNOT REPAIR THIS - it rewrites the same\n' "$P"
+    printf '%s verdict-detail damaged content, or refuses. Escalate rather than improvising (#3749).\n' "$P"
+    exit 4
+  fi
+
+  # A DAMAGE CLASS IN EXACTLY ONE PASS: non-passing, and NOT the fatal branch. It is
+  # neither established damage (it did not reproduce) nor a clean store (something
+  # named an object as unhashable once).
+  if [ "$C1" = damage ] || [ "$C2" = damage ]; then
+    emit_findings p2 unmeasured-cause
+    unmeasured "an object/pack damage class (fsck exit bit 1 or 4) was observed in ONE of two" \
+      "walks and did not reproduce (pass 1 class=$C1 rc=$RC1, pass 2 class=$C2 rc=$RC2)." \
+      "That is neither established damage nor a clean store: re-run on an IDLE box," \
+      "and if it recurs treat the store as suspect and escalate (#3749)."
+  fi
+
+  # BOTH PASSES NON-CLEAN, NEITHER OBJECT/PACK DAMAGE: reachability, refs or
+  # commit-graph complaints that survived a second walk. Its OWN non-passing state
+  # with its OWN cause text - never the fatal branch (this is not the class this
+  # script exists for) and never VERIFIED (a genuinely MISSING object reports
+  # exactly this, so reading it as clean would hide real damage). No `object` lines:
+  # the 40-hex tokens in a reflog diagnostic name INTACT objects.
+  if [ "$C2" != clean ]; then
+    emit_findings p2 unmeasured-cause
+    unmeasured "git fsck reported reachability/ref/commit-graph problems on BOTH walks" \
+      "(pass 1 class=$C1 rc=$RC1, pass 2 class=$C2 rc=$RC2) and NO object or pack" \
+      "damage. This script's subject is object content, and that question is therefore" \
+      "not answered: a missing object reports the same class. Inspect the diagnostics" \
+      "above; a stale reflog clears with 'git reflog expire --expire-unreachable=now" \
+      "--all', a genuinely absent object does not."
+  fi
+
+  # PASS 2 CLEAN, and pass 1 carried no damage class: the first observation did not
+  # reproduce. The store gets the affirmative verdict below on the strength of the
+  # SECOND walk (a complete rehash that found nothing), and the non-reproducing
+  # observation is RECORDED rather than swallowed.
+  printf '%s note the pass-1 diagnostics did NOT reproduce on the second walk (pass 2 rc=0),\n' "$P"
+  printf '%s note which is the signature of a concurrent writer on this shared store rather\n' "$P"
+  printf '%s note than damage. The verdict below rests on the second walk, which completed.\n' "$P"
 fi
 
 # --- THE ONE AFFIRMATIVE BRANCH --------------------------------------------
@@ -418,11 +645,11 @@ fi
 # statuses (124/137) are distinguishable and are routed to UNMEASURED above, and an
 # fsck that could not start, could not read the store or died on a signal cannot
 # produce 0. `git fsck` exits 0 only after walking and REHASHING every object it
-# was asked to check. So `rc == 0` here means "it finished, and it found nothing" —
-# two facts, not one — while every state in which the first fact is unknown has
+# was asked to check. So `rc == 0` here means "it finished, and it found nothing" -
+# two facts, not one - while every state in which the first fact is unknown has
 # already been routed to UNMEASURED.
 printf '%s measured fsck rc=0 in %ss over %s (full rehash: not --connectivity-only)\n' \
-  "$P" "$ELAPSED" "$(sane "$OBJ_DIR")"
+  "$P" "$WALK_ELAPSED" "$(sane "$OBJ_DIR")"
 printf '%s verdict VERIFIED\n' "$P"
 printf '%s verdict-detail git fsck ran to completion and reported no damaged objects.\n' "$P"
 printf '%s verdict-detail SCOPE: this is a POINT-IN-TIME sweep of ACCIDENTAL corruption, not a\n' "$P"

--- a/scripts/check-object-store-integrity.sh
+++ b/scripts/check-object-store-integrity.sh
@@ -445,6 +445,16 @@ fi
 # operators learn to waive. WORST-CASE WALL TIME IS 2x THE BOUND, because a
 # non-clean first pass is re-run once (see the discriminator below); only the rare
 # non-clean path pays it.
+#
+# A CALLER MAY WANT A TIGHTER BOUND THAN THIS DEFAULT, AND ONE DOES. This bound is a
+# property of the WALK; how long a caller may block is a property of the CALLER.
+# scripts/local/worker-supervisor.sh passes 300 rather than accepting 600, because the
+# sweep runs inside a child process and nothing in that supervisor can read its stop
+# file between the two walks - so its worst case of two walks is deliberately capped at
+# one walk's worth of this default (#3749 review round 3). Machine onboarding
+# (bootstrap-agent-machine.sh) keeps 600: nobody is waiting on a stop file there. If you
+# change this number, the supervisor's own default is asserted to stay at most half of
+# it, so that relation reds rather than drifting silently.
 FINDING_LIST_LIMIT=40
 
 # git fsck's exit BITMASK, from fsck.h and CONFIRMED against the git in use (2.43.0):

--- a/scripts/check-object-store-integrity.sh
+++ b/scripts/check-object-store-integrity.sh
@@ -992,11 +992,43 @@ if [ "$FIRST_WALK_CLEAN" -eq 0 ]; then
     printf '%s verdict-detail times), so this is damage and not a concurrent writer. Every lane on\n' "$P"
     printf '%s verdict-detail this box reads it, so it can change ANY gate verdict here: do NOT\n' "$P"
     printf '%s verdict-detail certify anything against this checkout.\n' "$P"
-    printf '%s verdict-detail REMEDY: stop the lanes on this box, then re-obtain the objects from the\n' "$P"
-    printf '%s verdict-detail canonical remote (a fresh clone of pmcfadin/cqlite, or\n' "$P"
-    printf '%s verdict-detail `git fetch --force origin` if the damage is confined to fetched packs).\n' "$P"
+    # THE REMEDY IS MEASURED, NOT ASSERTED (#3749 review round 9, item 2). It used to say
+    # `git fetch --force origin`, which repairs NOTHING: `--force` only permits
+    # non-fast-forward REF updates, and with the advertised tips unchanged the negotiation
+    # can transfer no objects at all — so an operator who followed the instruction exactly
+    # was left with the corruption intact AND the impression they had repaired it. That is
+    # this repo's false-rationale class landing on the one text a human gets at the moment
+    # the box has stopped, which is why it is now measured on scratch repositories with
+    # planted damage before being printed. git 2.43.0, 2026-09-02, fsck rc per arm:
+    #
+    #   damage class                     --force   --refetch   delete + --refetch
+    #   corrupt loose object content      3 (no)    3 (no)      0  (repaired)
+    #   flipped byte inside a .pack       4 (no)    4 (no)      0  (repaired)
+    #   object MISSING under live HEAD    2 (no)    0 (yes)     -
+    #
+    # And the fourth arm, which is why "a fresh clone" is not enough on its own: a
+    # `git clone <local path>` of the damaged repository HARDLINKS its object files and the
+    # copy is damaged too (fsck rc 3). The clone must come from the canonical remote over
+    # the network. The harness is recorded in the round-9 report.
+    printf '%s verdict-detail REMEDY: stop the lanes on this box, then REPLACE the damaged objects.\n' "$P"
+    printf '%s verdict-detail `git fetch --force origin` DOES NOT DO IT: --force only permits\n' "$P"
+    printf '%s verdict-detail non-fast-forward REF updates and re-downloads no objects at all, so with\n' "$P"
+    printf '%s verdict-detail the advertised tips unchanged it can transfer nothing (measured on git\n' "$P"
+    printf '%s verdict-detail 2.43: a corrupt loose object and a flipped pack byte both survive it).\n' "$P"
+    printf '%s verdict-detail EITHER (a) clone pmcfadin/cqlite AFRESH FROM THE CANONICAL REMOTE over\n' "$P"
+    printf '%s verdict-detail the network and rebuild the lanes from it - never `git clone` a path on\n' "$P"
+    printf '%s verdict-detail THIS box, which HARDLINKS the object files and inherits the damage\n' "$P"
+    printf '%s verdict-detail (measured) - OR (b) DELETE the damaged pack (its .pack, .idx and .rev)\n' "$P"
+    printf '%s verdict-detail or loose object named above, THEN `git fetch --refetch origin` (git\n' "$P"
+    printf '%s verdict-detail 2.36+), which re-obtains what a fresh clone would. Deleting FIRST is\n' "$P"
+    printf '%s verdict-detail required: --refetch adds good copies and leaves the damaged bytes in the\n' "$P"
+    printf '%s verdict-detail object directory, where fsck still finds them (measured).\n' "$P"
     printf '%s verdict-detail A LOCAL `git gc`/`git repack` CANNOT REPAIR THIS - it rewrites the same\n' "$P"
-    printf '%s verdict-detail damaged content, or refuses. Escalate rather than improvising (#3749).\n' "$P"
+    printf '%s verdict-detail damaged content, or refuses. Content that only ever existed locally - an\n' "$P"
+    printf '%s verdict-detail unpushed commit - cannot be re-obtained: escalate rather than\n' "$P"
+    printf '%s verdict-detail improvising. THEN re-run this sweep and require its affirmative verdict\n' "$P"
+    printf '%s verdict-detail before clearing any latch or resuming the lanes: "I think I fixed it" is\n' "$P"
+    printf '%s verdict-detail not an exit condition (#3749).\n' "$P"
     exit 4
   fi
 
@@ -1103,13 +1135,22 @@ if [ "$FIRST_WALK_CLEAN" -eq 0 ]; then
       printf '%s verdict-detail needs them. That is not a stale reflog and not a concurrent writer.\n' "$P"
       printf '%s verdict-detail Every lane on this box reads this store, so it can change ANY gate\n' "$P"
       printf '%s verdict-detail verdict here: do NOT certify anything against this checkout.\n' "$P"
-      printf '%s verdict-detail REMEDY: stop the lanes on this box, then re-obtain the objects from the\n' "$P"
-      printf '%s verdict-detail canonical remote (`git fetch --force origin`, or a fresh clone of\n' "$P"
-      printf '%s verdict-detail pmcfadin/cqlite). An object that only ever existed locally - an\n' "$P"
-      printf '%s verdict-detail unpushed commit - cannot be re-obtained: escalate rather than\n' "$P"
-      printf '%s verdict-detail improvising. `git reflog expire` is the remedy for the OTHER cause of\n' "$P"
-      printf '%s verdict-detail this bit and does nothing here; a local `git gc`/`git repack` cannot\n' "$P"
-      printf '%s verdict-detail repair it either, and may prune what is left (#3749).\n' "$P"
+      printf '%s verdict-detail REMEDY: stop the lanes on this box, then RE-OBTAIN the missing objects.\n' "$P"
+      printf '%s verdict-detail `git fetch --force origin` DOES NOT DO IT: --force only permits\n' "$P"
+      printf '%s verdict-detail non-fast-forward REF updates and re-downloads nothing, and negotiation\n' "$P"
+      printf '%s verdict-detail transfers nothing while the advertised tips are unchanged (measured on\n' "$P"
+      printf '%s verdict-detail git 2.43: the object stayed missing). Use `git fetch --refetch origin`\n' "$P"
+      printf '%s verdict-detail (git 2.36+), which re-obtains what a fresh clone would and restored\n' "$P"
+      printf '%s verdict-detail exactly this shape in measurement; or clone pmcfadin/cqlite AFRESH FROM\n' "$P"
+      printf '%s verdict-detail THE CANONICAL REMOTE over the network and rebuild the lanes - never\n' "$P"
+      printf '%s verdict-detail `git clone` a path on THIS box, which HARDLINKS the object files and\n' "$P"
+      printf '%s verdict-detail inherits the damage (measured). An object that only ever existed\n' "$P"
+      printf '%s verdict-detail locally - an unpushed commit - cannot be re-obtained: escalate rather\n' "$P"
+      printf '%s verdict-detail than improvising. `git reflog expire` is the remedy for the OTHER cause\n' "$P"
+      printf '%s verdict-detail of this bit and does nothing here; a local `git gc`/`git repack` cannot\n' "$P"
+      printf '%s verdict-detail repair it either, and may prune what is left. THEN re-run this sweep\n' "$P"
+      printf '%s verdict-detail and require its affirmative verdict before clearing any latch or\n' "$P"
+      printf '%s verdict-detail resuming the lanes (#3749).\n' "$P"
       # NO `object` lines here, deliberately, and the reason is not the same as the reflog
       # branch's. A `broken link from <A> to <B>` diagnostic names the INTACT source as
       # well as the absent target, so labelling every 40-hex token an affected `object`

--- a/scripts/check-object-store-integrity.sh
+++ b/scripts/check-object-store-integrity.sh
@@ -1410,7 +1410,7 @@ if [ "$PRP_ABSENT" -gt 0 ]; then
   printf '%s verdict-detail A common-dir `git fsck` does not walk those refs (it walks every\n' "$P"
   printf '%s verdict-detail worktree'"'"'s HEAD, index and reflogs, and the COMMON refs), so the rehash\n' "$P"
   printf '%s verdict-detail above reported nothing about them: this is exactly the missing-object\n' "$P"
-  printf '%s verdict-detail class the reachability discriminator treats as CORRUPT, found at a root\n' "$P"
+  printf '%s verdict-detail class the reachability discriminator treats as damage, found at a root\n' "$P"
   printf '%s verdict-detail that walk never had. Every lane on this box reads this store, so do NOT\n' "$P"
   printf '%s verdict-detail certify anything against this checkout.\n' "$P"
   printf '%s verdict-detail REMEDY: stop the lanes on this box and re-obtain the objects from the\n' "$P"

--- a/scripts/check-object-store-integrity.sh
+++ b/scripts/check-object-store-integrity.sh
@@ -73,7 +73,8 @@
 #   5   UNMEASURED — the answer was not obtained: no git, no resolvable object
 #                    store, no usable timeout binary, the bound expired, an fsck
 #                    failure this script cannot classify, a damage class that did
-#                    NOT reproduce, or reachability/ref complaints that did.
+#                    NOT reproduce, or reachability/ref/commit-graph/multi-pack-index
+#                    complaints that did.
 #
 # REACHABILITY IS ITS OWN NON-PASSING STATE, NEITHER CLEAN NOR CORRUPT. fsck's exit
 # bit 2 (ERROR_REACHABLE) fires for a stale reflog entry on a store peer lanes are
@@ -216,8 +217,14 @@ usage() {
   printf '%s USAGE - the call is wrong (this is NOT a measurement verdict)\n' "$P" >&2
   printf '%s USAGE usage: %s [--repo <path>] [--timeout <secs>]\n' \
     "$P" "$(sane "${0##*/}")" >&2
+  printf '%s USAGE        %s [--repo <path>] --print-store\n' \
+    "$P" "$(sane "${0##*/}")" >&2
   printf '%s USAGE Rehashes the SHARED git object store behind <path> with git fsck\n' "$P" >&2
   printf '%s USAGE and reports whether it is intact (#3749). Read-only; mutates nothing.\n' "$P" >&2
+  printf '%s USAGE --print-store resolves and prints the store this run WOULD sweep\n' "$P" >&2
+  printf '%s USAGE (one `store <abs-path>` line) and exits 0 WITHOUT sweeping. It is\n' "$P" >&2
+  printf '%s USAGE the ONE isolated resolver callers key a throttle/latch on, so no\n' "$P" >&2
+  printf '%s USAGE caller has to run its own un-isolated git to name the store.\n' "$P" >&2
   printf '%s USAGE Exits 0 verified / 4 corrupt / 5 unmeasured / 2 usage.\n' "$P" >&2
   printf '%s USAGE A CONSUMER MUST NOT READ EXIT 5 AS CLEAN (nothing was measured).\n' "$P" >&2
   printf '%s USAGE Scope is ACCIDENTAL corruption. Deliberate peer forgery is\n' "$P" >&2
@@ -242,6 +249,7 @@ REPO="."
 BOUND_SECS=600
 repo_set=0
 bound_set=0
+PRINT_STORE=0
 while [ "$#" -gt 0 ]; do
   case "$1" in
     -h | --help)
@@ -254,6 +262,13 @@ while [ "$#" -gt 0 ]; do
       REPO="$2"
       repo_set=1
       shift 2
+      ;;
+    --print-store)
+      # RESOLVE-AND-PRINT, NO SWEEP. See the block after the store resolution for what
+      # this mode is for and why it deliberately does not require a timeout binary.
+      [ "$PRINT_STORE" -eq 0 ] || { usage; exit 2; }
+      PRINT_STORE=1
+      shift
       ;;
     --timeout)
       [ "$#" -ge 2 ] || { usage; exit 2; }
@@ -290,9 +305,16 @@ done
 # every bounded call fail. SIGTERM-only is ACCEPTED here — unlike a credential
 # helper, `git fsck` does not trap or ignore SIGTERM — and the degradation is
 # NAMED in the output rather than left silent.
+#
+# `--print-store` DOES NOT NEED ONE, and is exempted rather than being made to fail for
+# a reason that has nothing to do with the question it asks: it runs one `rev-parse`,
+# not an fsck, so "this host cannot bound a long walk" says nothing about whether the
+# store can be NAMED. Making it depend on `timeout` would leave a caller keying a
+# throttle on nothing on exactly the hosts where the sweep is already UNMEASURED.
 TIMEOUT_BIN=""
 TIMEOUT_KILL_AFTER=0
 for _tb_name in timeout gtimeout; do
+  [ "$PRINT_STORE" -eq 0 ] || break
   _tb_path="$(command -v "$_tb_name" 2>/dev/null || true)"
   [ -n "$_tb_path" ] || continue
   if "$_tb_path" --kill-after=1 1 true >/dev/null 2>&1; then
@@ -319,7 +341,7 @@ ENV_BIN="$(command -v env 2>/dev/null || true)"
     "fsck run under an inherited GIT_DIR/GIT_OBJECT_DIRECTORY can report about a" \
     "DIFFERENT store than the one it names. Refusing rather than measuring the wrong thing."
 
-if [ -z "$TIMEOUT_BIN" ]; then
+if [ -z "$TIMEOUT_BIN" ] && [ "$PRINT_STORE" -eq 0 ]; then
   unmeasured "no timeout/gtimeout on PATH - refusing to run an UNBOUNDED fsck: both" \
     "callers are hang-sensitive (machine onboarding, and the supervisor's" \
     "per-iteration preflight). Install GNU coreutils and re-run."
@@ -351,6 +373,32 @@ OBJ_DIR="$GIT_COMMON_DIR/objects"
 if [ ! -d "$OBJ_DIR" ] || [ ! -r "$OBJ_DIR" ]; then
   unmeasured "the object store $(sane "$OBJ_DIR") is absent or unreadable, so there is" \
     "nothing this run can rehash"
+fi
+
+# --- `--print-store`: the ONE isolated resolver, shared with the callers ------
+#
+# WHY THIS MODE EXISTS (#3749 review round 2, BLOCKER 2). A caller that throttles or
+# latches on the shared store has to NAME it, and naming it means resolving
+# `--git-common-dir` — a git call. `scripts/local/worker-supervisor.sh` was doing that
+# with a BARE `git`, inheriting the caller's environment, while this script had just
+# moved every one of its own git calls under `env -i` + one allowlist. An inherited
+# `GIT_DIR`/`GIT_COMMON_DIR` therefore keyed the supervisor's stamp on ANOTHER
+# repository, so the real store's sweep was throttled away or its verdict recorded under
+# the wrong key: the closed hole re-opened at a site the same round left behind.
+#
+# The remedy CLAUDE.md records for this family (roborev job 276) is one allowlist
+# reaching every site, not a second copy of it. A second copy in the supervisor would be
+# a second place for the list to drift, so instead the resolution has exactly ONE
+# implementation — the one above, isolated — and callers ASK for it. There is then no
+# un-isolated shape available to a future caller: it would have to write a git call of
+# its own, which is the thing review looks for.
+#
+# It prints the same anchored `store <abs>` line the sweep prints, and nothing else:
+# a consumer reads that one line and never has to parse a verdict that this mode, by
+# construction, does not produce.
+if [ "$PRINT_STORE" -eq 1 ]; then
+  printf '%s store %s\n' "$P" "$(sane "$OBJ_DIR")"
+  exit 0
 fi
 
 # --- scratch space (outside the repository: this script writes nothing in it) --
@@ -399,6 +447,18 @@ fi
 # non-clean path pays it.
 FINDING_LIST_LIMIT=40
 
+# git fsck's exit BITMASK, from fsck.h and CONFIRMED against the git in use (2.43.0):
+#   1 ERROR_OBJECT   2 ERROR_REACHABLE   4 ERROR_PACK
+#   8 ERROR_REFS    16 ERROR_COMMIT_GRAPH  32 ERROR_MULTI_PACK_INDEX
+# FSCK_DAMAGE_MASK is this script's subject: object content and pack integrity.
+# FSCK_KNOWN_MASK is every bit it can NAME; a status carrying anything else is
+# unclassified rather than guessed at (see the ordering note above fsck_pass).
+# FSCK_NONMASK_FLOOR is where shell/timeout/die() statuses live and bit-testing stops
+# being meaningful: 124-127 are the timeout and exec conventions, 128+N is a signal.
+FSCK_DAMAGE_MASK=5
+FSCK_KNOWN_MASK=63
+FSCK_NONMASK_FLOOR=124
+
 # fsck_pass <tag> - ONE bounded fsck over the shared store. Sets WALK_RC,
 # WALK_ELAPSED, WALK_CLASS, WALK_NFIND and writes $TMPD/<tag>.findings (the
 # recognised diagnostic lines, verbatim) and $TMPD/<tag>.ids (the 40-hex tokens in
@@ -417,14 +477,34 @@ FINDING_LIST_LIMIT=40
 # `CORRUPT` that pages high, stops the supervisor and fails `--strict` bootstrap.
 #
 # Only bits 1 and 4 are the subject of this script (an object that failed to
-# rehash, a damaged pack). Bits 2/8/16 are NOT demoted to clean - a genuinely
-# missing object also reports ERROR_REACHABLE, so treating reachability as clean
-# would convert a real corruption symptom into a pass - they land in their own
-# NON-PASSING state (UNMEASURED, with a cause that names the class).
+# rehash, a damaged pack). The OTHER known bits are NOT demoted to clean - a
+# genuinely missing object also reports ERROR_REACHABLE, so treating reachability
+# as clean would convert a real corruption symptom into a pass - they land in their
+# own NON-PASSING state (UNMEASURED, with a cause that names the class).
 #
-# A status OUTSIDE 1..31 is not a bitmask at all (128 is git's `die()`, 127 is a
-# missing binary), so it is `unclassified`, never bit-tested: `127 & 1` is 1 and
-# would read as object damage.
+# THE MASK DOES NOT END AT 31, AND ASSUMING IT DID DROPPED REAL DAMAGE (#3749 review
+# round 2, BLOCKER 3). git 2.43 also defines 32 ERROR_MULTI_PACK_INDEX, so the
+# supported mask is 63. The previous version classified only statuses in 1..31 and
+# called everything else `unclassified`, which meant 33 (32|1: a multi-pack-index
+# complaint PLUS object damage) and 36 (32|4) became UNMEASURED - a FALSE NEGATIVE on
+# genuine object corruption, the one direction this whole control exists to prevent.
+# MEASURED on git 2.43.0 rather than reasoned from the header: a repo with a truncated
+# `multi-pack-index` exits 32, and the same repo with one loose object overwritten
+# exits 35 (32|2|1).
+#
+# THE THREE RULES BELOW, IN THIS ORDER, AND THE ORDER IS THE POINT:
+#   1. A status at or above 124 IS NOT A BITMASK. 124/125/126/127 are the
+#      timeout/shell conventions (this fsck runs under `timeout`), 128+N is git's
+#      `die()` and signal deaths. Testing bits in that range is how `127 & 1` reads as
+#      object damage. `unclassified`, never bit-tested.
+#   2. THE DAMAGE BITS ARE TESTED INDEPENDENTLY, before any completeness check on the
+#      rest of the status. An unrelated bit - one git added after this was written -
+#      can then never MASK object or pack damage; it only travels with it.
+#   3. Only then, a status carrying a bit OUTSIDE the supported mask is
+#      `unclassified`. That is the safe degradation: a bit this script has never heard
+#      of means something it cannot name, so it goes to a NON-PASSING state rather
+#      than being folded into the class whose remedy would be wrong. Adding a bit to
+#      FSCK_KNOWN_MASK is then a wording change, not a correctness fix.
 fsck_pass() {
   local tag="$1" rc=0 t0 t1 el
   local out="$TMPD/$tag.out" err="$TMPD/$tag.err" all="$TMPD/$tag.all"
@@ -486,14 +566,14 @@ fsck_pass() {
     WALK_CLASS=clean
   elif [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
     WALK_CLASS=killed
-  elif [ "$rc" -ge 1 ] && [ "$rc" -le 31 ]; then
-    if [ $((rc & 5)) -ne 0 ]; then
-      WALK_CLASS=damage
-    else
-      WALK_CLASS=reachability
-    fi
-  else
+  elif [ "$rc" -ge "$FSCK_NONMASK_FLOOR" ]; then
     WALK_CLASS=unclassified
+  elif [ $((rc & FSCK_DAMAGE_MASK)) -ne 0 ]; then
+    WALK_CLASS=damage
+  elif [ $((rc & ~FSCK_KNOWN_MASK)) -ne 0 ]; then
+    WALK_CLASS=unclassified
+  else
+    WALK_CLASS=nondamage
   fi
 }
 
@@ -612,20 +692,35 @@ if [ "$FIRST_WALK_CLEAN" -eq 0 ]; then
       "and if it recurs treat the store as suspect and escalate (#3749)."
   fi
 
-  # BOTH PASSES NON-CLEAN, NEITHER OBJECT/PACK DAMAGE: reachability, refs or
-  # commit-graph complaints that survived a second walk. Its OWN non-passing state
-  # with its OWN cause text - never the fatal branch (this is not the class this
-  # script exists for) and never VERIFIED (a genuinely MISSING object reports
-  # exactly this, so reading it as clean would hide real damage). No `object` lines:
-  # the 40-hex tokens in a reflog diagnostic name INTACT objects.
+  # A STATUS THIS SCRIPT CANNOT READ AS A BITMASK, in either pass. Its own cause,
+  # because the nondamage text below would name a class that was never established:
+  # a `die()` or an exec failure says nothing about reachability, and describing it as
+  # a reflog problem would send the operator to the wrong remedy.
+  if [ "$C1" = unclassified ] || [ "$C2" = unclassified ]; then
+    emit_findings p2 unmeasured-cause
+    unmeasured "git fsck exited with a status this script cannot read as its error" \
+      "bitmask (pass 1 class=$C1 rc=$RC1, pass 2 class=$C2 rc=$RC2). The bits it" \
+      "supports are 1|2|4|8|16|32; a status carrying anything else is a die(), an" \
+      "exec failure, or a git newer than this classifier. Nothing about the store's" \
+      "object content was established, so this is NOT clean. Run the fsck by hand to" \
+      "see what it said."
+  fi
+
+  # BOTH PASSES NON-CLEAN, NEITHER OBJECT/PACK DAMAGE: reachability, refs,
+  # commit-graph or multi-pack-index complaints that survived a second walk. Its OWN
+  # non-passing state with its OWN cause text - never the fatal branch (this is not
+  # the class this script exists for) and never VERIFIED (a genuinely MISSING object
+  # reports exactly this, so reading it as clean would hide real damage). No `object`
+  # lines: the 40-hex tokens in a reflog diagnostic name INTACT objects.
   if [ "$C2" != clean ]; then
     emit_findings p2 unmeasured-cause
-    unmeasured "git fsck reported reachability/ref/commit-graph problems on BOTH walks" \
+    unmeasured "git fsck reported reachability/ref/commit-graph/multi-pack-index problems on BOTH walks" \
       "(pass 1 class=$C1 rc=$RC1, pass 2 class=$C2 rc=$RC2) and NO object or pack" \
       "damage. This script's subject is object content, and that question is therefore" \
       "not answered: a missing object reports the same class. Inspect the diagnostics" \
       "above; a stale reflog clears with 'git reflog expire --expire-unreachable=now" \
-      "--all', a genuinely absent object does not."
+      "--all', a stale multi-pack-index with 'git multi-pack-index write', and a" \
+      "genuinely absent object with neither."
   fi
 
   # PASS 2 CLEAN, and pass 1 carried no damage class: the first observation did not

--- a/scripts/check-object-store-integrity.sh
+++ b/scripts/check-object-store-integrity.sh
@@ -492,6 +492,13 @@ FSCK_NONMASK_FLOOR=124
 # `multi-pack-index` exits 32, and the same repo with one loose object overwritten
 # exits 35 (32|2|1).
 #
+# RULE 0, AND IT COMES BEFORE ALL OF THEM: A STATUS IS ONLY READ AS A BITMASK IF WE
+# ESTABLISHED, AFFIRMATIVELY, THAT fsck WAS ACTUALLY LAUNCHED AND ITS OUTPUT CAPTURED
+# (#3749 review round 3). The shell's status space overlaps fsck's, and a failed
+# capture redirection exits 1 - fsck's ERROR_OBJECT bit. See the launch block inside
+# fsck_pass: marker absent => WALK_CLASS=launchfail, routed to UNMEASURED by the
+# callers and never bit-tested.
+#
 # THE THREE RULES BELOW, IN THIS ORDER, AND THE ORDER IS THE POINT:
 #   1. A status at or above 124 IS NOT A BITMASK. 124/125/126/127 are the
 #      timeout/shell conventions (this fsck runs under `timeout`), 128+N is git's
@@ -508,21 +515,75 @@ FSCK_NONMASK_FLOOR=124
 fsck_pass() {
   local tag="$1" rc=0 t0 t1 el
   local out="$TMPD/$tag.out" err="$TMPD/$tag.err" all="$TMPD/$tag.all"
+  local started="$TMPD/$tag.started"
+  rm -f "$started" 2>/dev/null || true
   t0=$(date +%s 2>/dev/null || echo 0)
+  # THE LAUNCH IS WRAPPED SO THAT "fsck RAN AND RETURNED A STATUS" CAN BE TOLD APART
+  # FROM "WE NEVER GOT AS FAR AS RUNNING IT" (#3749 review round 3, item 2).
+  #
+  # THE DEFECT THIS EXISTS FOR. The two capture redirections are part of the command,
+  # so if opening `$out` or `$err` FAILS - a full scratch filesystem, a `$TMPDIR`
+  # reaped by a tmp cleaner mid-run, an unwritable scratch dir - bash never execs
+  # anything and the status is **1**. 1 is also fsck's ERROR_OBJECT bit. The
+  # classifier below then reads that 1 as object damage, BOTH passes fail the same
+  # way, both "reproduce", and the sweep emits **CORRUPT** on a store it never opened.
+  # That is round 1's BLOCKER B - a false CORRUPT on a healthy box - coming back
+  # through a different door: this time the borrowed bit comes from the shell, not
+  # from a concurrent writer.
+  #
+  # IT CANNOT BE INFERRED FROM THE STATUS, WHICH IS THE WHOLE POINT: fsck's status
+  # space and the shell's overlap, so no value of `rc` distinguishes them. The
+  # evidence is AFFIRMATIVE instead, and it is the `.started` marker:
+  #   * the marker is written INSIDE the redirected group, as its FIRST statement, so
+  #     it exists only if bash established BOTH capture redirections - a redirection
+  #     error on a compound command means the body does not execute at all (verified
+  #     on bash 5.2: the group's status is 1 and nothing inside it runs);
+  #   * `$out` and `$err` are required to EXIST afterwards for the same reason.
+  # So marker present => the capture was established and control reached the fsck
+  # invocation; marker absent => we could not launch or could not capture, and the
+  # status is NOT a bitmask. The latter becomes WALK_CLASS=launchfail, which is routed
+  # to UNMEASURED by its callers and is never bit-tested.
+  #
+  # WHAT THIS DOES NOT PROVE, STATED RATHER THAN IMPLIED: the marker proves the
+  # redirections took and the group ran, not that `env`/`nice`/`timeout`/`git` were
+  # successfully exec'd. That residual is already covered from the other side - an
+  # exec failure exits 126/127, which is at or above FSCK_NONMASK_FLOOR and therefore
+  # `unclassified` (UNMEASURED), never damage.
+  #
+  # `2>/dev/null` PRECEDES the capture redirections deliberately (the NIT-4 lesson,
+  # one file over): bash applies redirections LEFT TO RIGHT and reports a failure on
+  # the stderr in effect at that moment, so without it a failed `>"$out"` would print
+  # bash's own UNANCHORED error and break output property (a) for every consumer.
   if [ "$TIMEOUT_KILL_AFTER" -eq 1 ]; then
-    git_isolated nice -n 19 "$TIMEOUT_BIN" --kill-after="$BOUND_KILL_GRACE" "$BOUND_SECS" \
-      git --git-dir="$GIT_COMMON_DIR" fsck --no-progress --no-dangling \
-      >"$out" 2>"$err" || rc=$?
+    (
+      true >"$started"
+      git_isolated nice -n 19 "$TIMEOUT_BIN" --kill-after="$BOUND_KILL_GRACE" "$BOUND_SECS" \
+        git --git-dir="$GIT_COMMON_DIR" fsck --no-progress --no-dangling
+    ) 2>/dev/null >"$out" 2>"$err" || rc=$?
   else
-    git_isolated nice -n 19 "$TIMEOUT_BIN" "$BOUND_SECS" \
-      git --git-dir="$GIT_COMMON_DIR" fsck --no-progress --no-dangling \
-      >"$out" 2>"$err" || rc=$?
+    (
+      true >"$started"
+      git_isolated nice -n 19 "$TIMEOUT_BIN" "$BOUND_SECS" \
+        git --git-dir="$GIT_COMMON_DIR" fsck --no-progress --no-dangling
+    ) 2>/dev/null >"$out" 2>"$err" || rc=$?
   fi
   t1=$(date +%s 2>/dev/null || echo 0)
   el=$((t1 - t0))
   [ "$el" -ge 0 ] || el=0
   WALK_RC="$rc"
   WALK_ELAPSED="$el"
+
+  # ASKED BEFORE ANYTHING ELSE READS `rc`, and before any file under $TMPD is written:
+  # on this path the scratch dir may be exactly what is broken, so an unguarded
+  # `: >"$TMPD/..."` here would itself emit an unanchored bash error. The callers go
+  # straight to `unmeasured` on this class without calling emit_findings, so the
+  # findings/ids files are deliberately not created.
+  if [ ! -f "$started" ] || [ ! -f "$out" ] || [ ! -f "$err" ]; then
+    WALK_NFIND=0
+    WALK_CLASS=launchfail
+    return 0
+  fi
+
   cat "$out" "$err" >"$all" 2>/dev/null || : >"$all"
 
   # The recognised diagnostic shapes, kept for the OPERATOR (the class above is
@@ -611,6 +672,20 @@ if [ "$C1" = killed ]; then
     "clean result. Re-run with a larger --timeout on an idle box."
 fi
 
+# LAUNCH/CAPTURE FAILURE: fsck NEVER RAN, so there is nothing to classify and NO SECOND
+# PASS (a walk that did not happen has nothing to reproduce, and the second attempt
+# would fail on the same broken scratch dir). This is the one branch whose status is
+# deliberately NOT read as a bitmask - it is the shell's, not fsck's.
+if [ "$C1" = launchfail ]; then
+  unmeasured "the fsck could not be LAUNCHED, or its output could not be CAPTURED (pass 1," \
+    "shell status $RC1): the scratch capture files under $(sane "$TMPD") were not" \
+    "established, so NO fsck status was produced. That status is the SHELL's, and a" \
+    "failed redirection exits 1 - which is also fsck's ERROR_OBJECT bit, so reading it" \
+    "as a bitmask would report DAMAGE about a store this run never opened (#3749)." \
+    "Usual cause: the scratch filesystem is full, unwritable, or was reaped mid-run." \
+    "Free space under $(sane "${TMPDIR:-/tmp}") and re-run."
+fi
+
 if [ "$C1" = clean ]; then
   FIRST_WALK_CLEAN=1
 else
@@ -656,6 +731,16 @@ if [ "$FIRST_WALK_CLEAN" -eq 0 ]; then
     unmeasured "pass 1 was not clean (class=$C1, rc=$RC1) and the confirming pass exceeded" \
       "its ${BOUND_SECS}s bound (rc=$RC2) after ${EL2}s, so the first observation could" \
       "not be confirmed or dismissed. Re-run with a larger --timeout on an idle box."
+  fi
+
+  # Same rule on the confirming pass: an unlaunchable second walk confirms and dismisses
+  # nothing, and its shell status must not join the bitmask reasoning below.
+  if [ "$C2" = launchfail ]; then
+    unmeasured "pass 1 was not clean (class=$C1, rc=$RC1) and the confirming pass could not" \
+      "be LAUNCHED or CAPTURED (shell status $RC2, not an fsck status), so the first" \
+      "observation was neither confirmed nor dismissed. Usual cause: the scratch" \
+      "filesystem under $(sane "${TMPDIR:-/tmp}") is full, unwritable, or was reaped" \
+      "mid-run. Clear it and re-run (#3749)."
   fi
 
   # BOTH PASSES SAW OBJECT/PACK DAMAGE: the fatal branch, and the only path to it.

--- a/scripts/check-object-store-integrity.sh
+++ b/scripts/check-object-store-integrity.sh
@@ -229,6 +229,79 @@ sane() {
   printf '%s' "$out"
 }
 
+# --- THE BOX-WIDE KEY FOR THIS STORE ----------------------------------------
+#
+# WHY THE KEY IS COMPUTED HERE AND NOT BY THE CALLER (#3749 review round 5, item 3).
+# A caller that throttles or latches on the shared store needs a filesystem-safe,
+# INJECTIVE name for it. Round 4 made that name injective over the FLATTENING —
+# `<sanitised tail>.<16 hex of sha256(path)>`, because replacing `/` with `_` maps
+# `/tmp/a/b/objects` and `/tmp/a_b/objects` onto one name — and then fed the digest the
+# value THIS script had already passed through `sane()`. That is a DISPLAY encoding and
+# it is LOSSY: a path containing a real newline and one containing the two literal
+# characters `\n` render identically, so two different stores shared a throttle stamp AND
+# a CORRUPT latch — one suppressing the other's sweep, or stopping every lane on the box
+# with the other store's damage. `sane()` exists so a control character cannot break the
+# anchored output; it was never reversible and was never an identity.
+#
+# So the digest is taken from the RAW canonical path, in the one place that has it, and
+# the caller receives a finished key. There is then no lossy value left for a caller to
+# digest — the same "remove the shape, not the site" move as the isolated resolver below:
+# the non-injective form is UNAVAILABLE rather than discouraged.
+#
+# store_digest <value> -> 16 lowercase hex chars of sha256(value), or nothing (exit 1) on
+# a host with no usable digest tool. THREE TOOLS because the two platforms this file
+# supports ship different ones: `sha256sum` (GNU coreutils), `shasum -a 256` (macOS, via
+# perl), `openssl dgst -sha256` (both). `cksum` is present everywhere and is deliberately
+# NOT used: CRC32 is not collision-resistant, and a colliding key is the defect being
+# removed. The output is parsed from BOTH ENDS and then VALIDATED AS HEX — first field for
+# the coreutils/perl tools, last for openssl (`SHA2-256(stdin)= <hex>` on 3.x, `(stdin)=
+# <hex>` on 1.1.x) — so a tool whose output shape is neither FAILS CLOSED instead of
+# contributing a garbage key.
+store_digest() {
+  local v="$1" out='' hex=''
+  if command -v sha256sum >/dev/null 2>&1; then
+    out=$(printf '%s' "$v" | sha256sum 2>/dev/null || true)
+  elif command -v shasum >/dev/null 2>&1; then
+    out=$(printf '%s' "$v" | shasum -a 256 2>/dev/null || true)
+  elif command -v openssl >/dev/null 2>&1; then
+    out=$(printf '%s' "$v" | openssl dgst -sha256 2>/dev/null || true)
+  else
+    return 1
+  fi
+  for hex in "${out%% *}" "${out##* }"; do
+    case "$hex" in
+      '' | *[!0-9a-f]*) continue ;;
+    esac
+    [ "${#hex}" -ge 32 ] || continue
+    printf '%s' "${hex:0:16}"
+    return 0
+  done
+  return 1
+}
+
+# store_key <raw-store-path> -> `<sanitised tail>.<digest>`, or nothing (exit 1).
+#
+# THE TAIL IS READABILITY ONLY AND CARRIES NO IDENTITY: an operator reading `ls /tmp`
+# should be able to tell which store a stamp belongs to, while the DIGEST is what makes two
+# stores two files. It is the TAIL because the distinguishing part of these paths is the
+# end, and the length is checked explicitly because `${v: -40}` yields the EMPTY STRING —
+# not the whole value — when the value is shorter than the offset.
+store_key() {
+  local raw="$1" tail='' digest=''
+  [ -n "$raw" ] || return 1
+  tail=$(printf '%s' "$raw" | tr -c 'A-Za-z0-9._-' '_')
+  [ -n "$tail" ] || return 1
+  if [ "${#tail}" -gt 40 ]; then
+    tail="${tail:${#tail}-40}"
+  fi
+  digest=$(store_digest "$raw") || return 1
+  case "$digest" in
+    '' | *[!0-9a-f]*) return 1 ;;
+  esac
+  [ "${#digest}" -eq 16 ] || return 1
+  printf '%s.%s' "$tail" "$digest"
+}
+
 # EVERY line here is prefixed too: under property (a) the prefix is THE
 # load-bearing invariant, so an unprefixed usage line is a hole in it. `${0##*/}`
 # rather than `basename` — an external command whose stderr is not captured here
@@ -414,11 +487,22 @@ fi
 # un-isolated shape available to a future caller: it would have to write a git call of
 # its own, which is the thing review looks for.
 #
-# It prints the same anchored `store <abs>` line the sweep prints, and nothing else:
-# a consumer reads that one line and never has to parse a verdict that this mode, by
-# construction, does not produce.
+# It prints the same anchored `store <abs>` line the sweep prints, plus the box-wide
+# `store-key` a caller keys its throttle and latch on — and no verdict, which this mode by
+# construction does not produce.
+#
+# TWO LINES, AND THE SECOND ONE IS THE IDENTITY (#3749 review round 5, item 3). The `store`
+# line is passed through `sane()` for the anchored-output invariant, which makes it a
+# DISPLAY value and NOT injective: a caller that digested it keyed two different stores onto
+# one stamp and one CORRUPT latch. `store-key` is derived from the RAW path here (see
+# store_key above) so the caller never has to reconstruct an identity from a rendering. A
+# host with no digest tool prints NO key line at all — the caller then has no box-wide key,
+# which it announces and handles, rather than being handed a name two stores could share.
 if [ "$PRINT_STORE" -eq 1 ]; then
   printf '%s store %s\n' "$P" "$(sane "$OBJ_DIR")"
+  if STORE_KEY=$(store_key "$OBJ_DIR"); then
+    printf '%s store-key %s\n' "$P" "$STORE_KEY"
+  fi
   exit 0
 fi
 

--- a/scripts/check-object-store-integrity.sh
+++ b/scripts/check-object-store-integrity.sh
@@ -1144,31 +1144,6 @@ if [ "$FIRST_WALK_CLEAN" -eq 0 ]; then
     exit 6
   fi
 
-  # A FATAL DEATH IN EXACTLY ONE PASS: it did not reproduce, so it is neither an
-  # established un-sweepable store nor a clean one. Same rule as the one-pass damage
-  # branch below, and the same reason: one observation cannot separate a transient from a
-  # durable fact on a store eight lanes are writing.
-  if [ "$C1" = fatal ] || [ "$C2" = fatal ]; then
-    emit_findings p2 unmeasured-cause
-    unmeasured "git fsck RAN and DIED without finishing (a fatal error from git itself, or a" \
-      "signal death - not its error bitmask) in ONE of two walks and did not reproduce (pass 1" \
-      "class=$C1 rc=$RC1, pass 2 class=$C2 rc=$RC2). Nothing about the store's object" \
-      "content was established, so this is NOT clean. Re-run on an IDLE box; if it recurs" \
-      "the second walk will confirm it and this sweep will stop the box (#3749)."
-  fi
-
-  # THE FSCK NEVER RAN, IN EITHER PASS: 124..127 are the timeout and shell EXEC
-  # conventions, so no store was read. Its own cause text, because the fatal branch above
-  # would claim a walk that never started and the bitmask text below would name a class
-  # that was never established.
-  if [ "$C1" = unrunnable ] || [ "$C2" = unrunnable ]; then
-    unmeasured "the fsck could not be RUN (pass 1 class=$C1 rc=$RC1, pass 2 class=$C2" \
-      "rc=$RC2): a status of 125, 126 or 127 is the timeout/exec convention for 'the" \
-      "command was not started', not an fsck status, so nothing about this store was" \
-      "measured. Usual causes: no usable timeout binary, a git that is not executable, or" \
-      "a PATH that does not reach one. Fix the tooling on this box and re-run (#3749)."
-  fi
-
   # A DAMAGE CLASS IN EXACTLY ONE PASS: non-passing, and NOT the fatal branch. It is
   # neither established damage (it did not reproduce) nor a clean store (something
   # named an object as unhashable once).
@@ -1178,6 +1153,34 @@ if [ "$FIRST_WALK_CLEAN" -eq 0 ]; then
       "walks and did not reproduce (pass 1 class=$C1 rc=$RC1, pass 2 class=$C2 rc=$RC2)." \
       "That is neither established damage nor a clean store: re-run on an IDLE box," \
       "and if it recurs treat the store as suspect and escalate (#3749)."
+  fi
+
+  # A FATAL DEATH IN EXACTLY ONE PASS: it did not reproduce, so it is neither an
+  # established un-sweepable store nor a clean one. Same rule as the one-pass damage
+  # branch ABOVE, and the same reason: one observation cannot separate a transient from a
+  # durable fact on a store eight lanes are writing. It is TESTED AFTER that branch on
+  # purpose: when the two walks carry different classes, a DAMAGE observation is the more
+  # informative thing to name, and its text prints both classes anyway.
+  if [ "$C1" = fatal ] || [ "$C2" = fatal ]; then
+    emit_findings p2 unmeasured-cause
+    unmeasured "git fsck RAN and DIED without finishing (a fatal error from git itself, or a" \
+      "signal death - not its error bitmask) in ONE of two walks and did not reproduce (pass 1" \
+      "class=$C1 rc=$RC1, pass 2 class=$C2 rc=$RC2). Nothing about the store's object" \
+      "content was established, so this is NOT clean. Re-run on an IDLE box; if it recurs" \
+      "the second walk will confirm it and this sweep will stop the box (#3749)."
+  fi
+
+  # THE FSCK NEVER RAN, IN EITHER PASS: 125..127 are the timeout and shell EXEC
+  # conventions, so no store was read (124 is the bound firing, handled as `killed`). Its
+  # own cause text, because the fatal branch above would claim a walk that never started
+  # and the bitmask text below would name a class that was never established.
+  if [ "$C1" = unrunnable ] || [ "$C2" = unrunnable ]; then
+    emit_findings p2 unmeasured-cause
+    unmeasured "the fsck could not be RUN (pass 1 class=$C1 rc=$RC1, pass 2 class=$C2" \
+      "rc=$RC2): a status of 125, 126 or 127 is the timeout/exec convention for 'the" \
+      "command was not started', not an fsck status, so nothing about this store was" \
+      "measured. Usual causes: no usable timeout binary, a git that is not executable, or" \
+      "a PATH that does not reach one. Fix the tooling on this box and re-run (#3749)."
   fi
 
   # A STATUS THIS SCRIPT CANNOT READ AS A BITMASK, in either pass. Its own cause,

--- a/scripts/check-object-store-integrity.sh
+++ b/scripts/check-object-store-integrity.sh
@@ -44,6 +44,16 @@
 # historical warnings (a malformed committer line, a zero-padded file mode) to
 # errors, so it would report CORRUPT on a healthy store — the guard operators learn
 # to waive.
+
+# `--no-reflogs` IS USED, ON THE THIRD WALK ONLY, AND NEVER TO SUPPRESS A COMPLAINT
+# (#3749 review round 4, item 1). Using it on the SWEEP was proposed in round 1 as a
+# way to make the intermittent reflog false positive go away, MEASURED, and REJECTED
+# by the lead — the concurrency transients hit that form too, so it bought nothing and
+# would have hidden a real signal. Using it as a DISCRIMINATOR for a complaint that has
+# ALREADY reproduced twice is a different operation with the opposite effect: it does
+# not decide whether to report, it decides WHICH CAUSE to report, and its answer can
+# only make the verdict STRONGER (UNMEASURED -> CORRUPT). Passes 1 and 2 — the sweep
+# proper — never carry it, and that is asserted structurally by the test suite.
 #
 # THE VOCABULARY IS CHOSEN SO THIS CANNOT BE READ AS A CERTIFICATION
 # ------------------------------------------------------------------
@@ -68,20 +78,31 @@
 # EXIT CODES, AND THE CONSUMER CONTRACT
 # -------------------------------------
 #   0   VERIFIED   — the sweep RAN TO COMPLETION and reported no corruption.
-#   4   CORRUPT    — fsck reported OBJECT/PACK damage (its exit bits 1/4) on TWO
-#                    independent walks. The affected object ids are named.
+#   4   CORRUPT    — damage established on TWO independent walks. Either OBJECT/PACK
+#                    damage (fsck exit bits 1/4), or an object MISSING from the
+#                    reachability walk that is still reachable with reflogs EXCLUDED
+#                    (bit 2, see the reachability discriminator below). The findings
+#                    are named.
 #   5   UNMEASURED — the answer was not obtained: no git, no resolvable object
 #                    store, no usable timeout binary, the bound expired, an fsck
 #                    failure this script cannot classify, a damage class that did
-#                    NOT reproduce, or reachability/ref/commit-graph/multi-pack-index
-#                    complaints that did.
+#                    NOT reproduce, or a reachability/ref/commit-graph/multi-pack-index
+#                    complaint that reproduced but could not be ATTRIBUTED.
 #
-# REACHABILITY IS ITS OWN NON-PASSING STATE, NEITHER CLEAN NOR CORRUPT. fsck's exit
-# bit 2 (ERROR_REACHABLE) fires for a stale reflog entry on a store peer lanes are
-# writing — routine on this fleet, and NOT this script's subject — but also for a
-# genuinely MISSING object, so it can be demoted to neither. It lands on UNMEASURED
-# with a cause that names the class. And NO verdict is fatal on ONE observation:
-# see the discriminator at the sweep below.
+# A REACHABILITY COMPLAINT HAS TWO CAUSES AND THEY GET DIFFERENT VERDICTS (#3749
+# review round 4, item 1). fsck's exit bit 2 (ERROR_REACHABLE) fires for BOTH:
+#   * a stale reflog entry naming an object a peer lane's gc has pruned — routine on
+#     a store eight lanes write, and NOT this script's subject; and
+#   * an object that is genuinely MISSING while a LIVE ref, the index or HEAD still
+#     needs it — which IS corruption of the shared store, in the one direction this
+#     whole control exists to prevent.
+# Reading the class as "unmeasurable" for both was a FALSE NEGATIVE on real damage:
+# UNMEASURED is deliberately non-fatal to the supervisor's loop, so workers kept
+# running against a demonstrably damaged store. The two are separated by a THIRD walk
+# with `--no-reflogs`: a complaint that survives with the reflogs excluded from the
+# reachability roots is not a reflog artefact, and it is CORRUPT. One that clears
+# stays UNMEASURED with the reflog remedy. And NO verdict is fatal on ONE
+# observation: see the discriminator at the sweep below.
 #   2   usage error — and `--help` exits 2 as well, deliberately: exit 0 MEANS
 #                    VERIFIED here, so a run that measured nothing must never
 #                    produce it.
@@ -442,20 +463,32 @@ fi
 # cold worst case, not the ~4x that 300s would give. The bound exists to stop a
 # HANG, not to police duration - an expired bound is UNMEASURED, which is a page
 # nobody can act on, and a bound that fires on a healthy-but-busy box is the guard
-# operators learn to waive. WORST-CASE WALL TIME IS 2x THE BOUND, because a
-# non-clean first pass is re-run once (see the discriminator below); only the rare
-# non-clean path pays it.
+# operators learn to waive. WORST-CASE WALL TIME IS MAX_SWEEP_WALKS x THE BOUND: a
+# non-clean first pass is re-run once (the discriminator below), and a REPRODUCED
+# reachability complaint costs one further walk to attribute (#3749 review round 4).
+# Only those paths pay it; a clean store takes exactly one walk.
 #
 # A CALLER MAY WANT A TIGHTER BOUND THAN THIS DEFAULT, AND ONE DOES. This bound is a
 # property of the WALK; how long a caller may block is a property of the CALLER.
-# scripts/local/worker-supervisor.sh passes 300 rather than accepting 600, because the
-# sweep runs inside a child process and nothing in that supervisor can read its stop
-# file between the two walks - so its worst case of two walks is deliberately capped at
-# one walk's worth of this default (#3749 review round 3). Machine onboarding
-# (bootstrap-agent-machine.sh) keeps 600: nobody is waiting on a stop file there. If you
-# change this number, the supervisor's own default is asserted to stay at most half of
-# it, so that relation reds rather than drifting silently.
+# scripts/local/worker-supervisor.sh passes a smaller number rather than accepting 600,
+# because the sweep runs inside a child process and nothing in that supervisor can read
+# its stop file BETWEEN the walks - so its worst case of MAX_SWEEP_WALKS walks is
+# deliberately capped at one walk's worth of this default (#3749 review round 3, widened
+# for the third walk in round 4). Machine onboarding (bootstrap-agent-machine.sh) keeps
+# 600: nobody is waiting on a stop file there. If you change this number, or
+# MAX_SWEEP_WALKS, the supervisor's own default is asserted to stay at or below
+# BOUND_SECS / MAX_SWEEP_WALKS, so that relation reds rather than drifting silently.
 FINDING_LIST_LIMIT=40
+
+# MAX_SWEEP_WALKS - the most bounded fsck walks ONE invocation can spend, and it is
+# declared here as a NUMBER A CALLER CAN READ because the supervisor's own bound is
+# derived from it by an asserted relation rather than by someone remembering. Raising it
+# raises every caller's worst-case uninterruptible block.
+#   1. the sweep;
+#   2. the reproduction discriminator, when walk 1 was not clean;
+#   3. the reachability-CAUSE discriminator (`--no-reflogs`), when walks 1 and 2 both
+#      reported ERROR_REACHABLE and neither reported damage.
+MAX_SWEEP_WALKS=3
 
 # git fsck's exit BITMASK, from fsck.h and CONFIRMED against the git in use (2.43.0):
 #   1 ERROR_OBJECT   2 ERROR_REACHABLE   4 ERROR_PACK
@@ -468,11 +501,21 @@ FINDING_LIST_LIMIT=40
 FSCK_DAMAGE_MASK=5
 FSCK_KNOWN_MASK=63
 FSCK_NONMASK_FLOOR=124
+# ERROR_REACHABLE alone. It is NOT in FSCK_DAMAGE_MASK because the bit does not by
+# itself say which of its two causes fired (a pruned object named by a reflog, or an
+# object a LIVE ref still needs); the third walk is what attributes it.
+FSCK_REACHABLE_BIT=2
 
-# fsck_pass <tag> - ONE bounded fsck over the shared store. Sets WALK_RC,
-# WALK_ELAPSED, WALK_CLASS, WALK_NFIND and writes $TMPD/<tag>.findings (the
+# fsck_pass <tag> [--no-reflogs] - ONE bounded fsck over the shared store. Sets
+# WALK_RC, WALK_ELAPSED, WALK_CLASS, WALK_NFIND and writes $TMPD/<tag>.findings (the
 # recognised diagnostic lines, verbatim) and $TMPD/<tag>.ids (the 40-hex tokens in
 # them).
+#
+# THE SECOND ARGUMENT IS A CLOSED SET OF ONE, AND AN UNRECOGNISED VALUE IS A REFUSAL,
+# not a silently ignored typo: `--no-reflogs` belongs to the reachability-CAUSE
+# discriminator (walk 3) and to nothing else. Passes 1 and 2 - the sweep proper - pass
+# no mode at all, so a future edit that widened the reachability walk into the sweep
+# would have to change a call site the test suite reads structurally.
 #
 # THE CLASS COMES FROM fsck's EXIT BITMASK, NOT FROM THE TEXT SHAPE OF ITS
 # DIAGNOSTICS, AND THAT IS THE #3749 REVIEW'S CORRECTION. `git fsck` returns a
@@ -526,6 +569,20 @@ fsck_pass() {
   local tag="$1" rc=0 t0 t1 el
   local out="$TMPD/$tag.out" err="$TMPD/$tag.err" all="$TMPD/$tag.all"
   local started="$TMPD/$tag.started"
+  # The argv is built as an ARRAY (never an unquoted string), so an empty mode cannot
+  # word-split and the array is never empty - `"${fargs[@]}"` under `set -u` on bash 3.2
+  # is only safe for a non-empty array, and the two base flags guarantee that.
+  local -a fargs
+  fargs=(--no-progress --no-dangling)
+  case "${2:-}" in
+    '') ;;
+    --no-reflogs) fargs=("${fargs[@]}" --no-reflogs) ;;
+    *)
+      unmeasured "internal: fsck_pass was called with an unsupported walk mode" \
+        "$(sane "${2:-}") - refusing rather than running a walk whose configuration" \
+        "this script cannot describe in its own verdict (#3749)."
+      ;;
+  esac
   rm -f "$started" 2>/dev/null || true
   t0=$(date +%s 2>/dev/null || echo 0)
   # THE LAUNCH IS WRAPPED SO THAT "fsck RAN AND RETURNED A STATUS" CAN BE TOLD APART
@@ -568,13 +625,13 @@ fsck_pass() {
     (
       true >"$started"
       git_isolated nice -n 19 "$TIMEOUT_BIN" --kill-after="$BOUND_KILL_GRACE" "$BOUND_SECS" \
-        git --git-dir="$GIT_COMMON_DIR" fsck --no-progress --no-dangling
+        git --git-dir="$GIT_COMMON_DIR" fsck "${fargs[@]}"
     ) 2>/dev/null >"$out" 2>"$err" || rc=$?
   else
     (
       true >"$started"
       git_isolated nice -n 19 "$TIMEOUT_BIN" "$BOUND_SECS" \
-        git --git-dir="$GIT_COMMON_DIR" fsck --no-progress --no-dangling
+        git --git-dir="$GIT_COMMON_DIR" fsck "${fargs[@]}"
     ) 2>/dev/null >"$out" 2>"$err" || rc=$?
   fi
   t1=$(date +%s 2>/dev/null || echo 0)
@@ -801,21 +858,138 @@ if [ "$FIRST_WALK_CLEAN" -eq 0 ]; then
       "see what it said."
   fi
 
-  # BOTH PASSES NON-CLEAN, NEITHER OBJECT/PACK DAMAGE: reachability, refs,
-  # commit-graph or multi-pack-index complaints that survived a second walk. Its OWN
-  # non-passing state with its OWN cause text - never the fatal branch (this is not
-  # the class this script exists for) and never VERIFIED (a genuinely MISSING object
-  # reports exactly this, so reading it as clean would hide real damage). No `object`
-  # lines: the 40-hex tokens in a reflog diagnostic name INTACT objects.
+  # --- PASS 3: THE REACHABILITY-CAUSE DISCRIMINATOR -------------------------
+  #
+  # THE FALSE NEGATIVE THIS EXISTS FOR (#3749 review round 4, item 1). ERROR_REACHABLE
+  # has two causes and only one of them is benign. A stale reflog entry naming an object
+  # a peer lane pruned is routine on this store; an object that is MISSING while a LIVE
+  # ref, the index or HEAD still needs it is corruption of exactly the kind this control
+  # exists to catch. Both reproduce across walks 1 and 2, so the reproduction
+  # discriminator cannot tell them apart, and both used to land on UNMEASURED - which is
+  # NON-FATAL to the supervisor's loop by design. So a demonstrably damaged store kept
+  # spawning workers, reported as "not measured".
+  #
+  # HOW THEY ARE SEPARATED. `git fsck --no-reflogs` drops the reflogs from the
+  # REACHABILITY ROOTS and keeps everything else, so a complaint that survives it is
+  # reachable from a live root. Measured on git 2.43.0, both directions, on real
+  # fixtures the suite builds:
+  #   * a blob deleted while HEAD's tree still names it: rc 2 WITH reflogs and rc 2
+  #     WITHOUT them -> live-reachable, and CORRUPT;
+  #   * a commit deleted after `reset --hard`, so only the reflog names it: rc 2 WITH
+  #     reflogs and rc 0 WITHOUT -> reflog-scoped, and it stays where it was.
+  #
+  # IT IS NOT A THIRD OPINION ON WHETHER TO REPORT. The class has already reproduced
+  # twice when this runs; this walk decides WHICH CAUSE, and it can only make the
+  # verdict stronger. Nothing here can turn a reported complaint into VERIFIED.
+  if [ "$C1" = nondamage ] && [ "$C2" = nondamage ] &&
+    [ $((RC1 & FSCK_REACHABLE_BIT)) -ne 0 ] && [ $((RC2 & FSCK_REACHABLE_BIT)) -ne 0 ]; then
+    printf '%s note both walks report ERROR_REACHABLE (fsck exit bit 2) and NO object/pack\n' "$P"
+    printf '%s note damage. That bit covers a stale reflog entry AND an object a live ref\n' "$P"
+    printf '%s note still needs, so it is attributed by a third walk with --no-reflogs:\n' "$P"
+    printf '%s note a complaint that survives with the reflogs excluded is reachable from a\n' "$P"
+    printf '%s note LIVE root and is damage; one that clears was reflog-scoped.\n' "$P"
+    fsck_pass p3 --no-reflogs
+    C3="$WALK_CLASS"
+    RC3="$WALK_RC"
+    EL3="$WALK_ELAPSED"
+    N3="$WALK_NFIND"
+    printf '%s measured pass 3: fsck --no-reflogs rc=%s in %ss over %s (reachability attribution)\n' \
+      "$P" "$RC3" "$EL3" "$(sane "$OBJ_DIR")"
+
+    # THE ATTRIBUTION FAILED, so the cause is UNKNOWN - and an unattributed reachability
+    # complaint must not be read as either verdict. `killed`, `launchfail` and
+    # `unclassified` all mean the third walk produced no usable answer; each keeps the
+    # reproduced complaint visible and says which walk went wrong.
+    if [ "$C3" = killed ] || [ "$C3" = launchfail ] || [ "$C3" = unclassified ]; then
+      emit_findings p2 unmeasured-cause
+      unmeasured "git fsck reported reachability problems on BOTH walks (pass 1 rc=$RC1," \
+        "pass 2 rc=$RC2) and the confirming --no-reflogs walk produced no usable answer" \
+        "(class=$C3 rc=$RC3), so the cause could NOT be attributed: a stale reflog entry" \
+        "and an object a LIVE ref still needs report the same bit, and only the second is" \
+        "damage. This is NOT clean. Re-run on an idle box; if the third walk keeps failing," \
+        "run 'git fsck --no-reflogs' by hand and read what it says (#3749)."
+    fi
+
+    # A DAMAGE BIT THAT SHOWS UP FOR THE FIRST TIME IN THE THIRD WALK has not reproduced
+    # either: the two sweep walks both said there was none. Same rule as the one-pass
+    # damage branch above - neither established damage nor a clean store.
+    if [ $((RC3 & FSCK_DAMAGE_MASK)) -ne 0 ]; then
+      emit_findings p3 unmeasured-cause
+      unmeasured "an object/pack damage class (fsck exit bit 1 or 4) appeared ONLY in the" \
+        "third walk (pass 1 rc=$RC1, pass 2 rc=$RC2, pass 3 --no-reflogs rc=$RC3), so it" \
+        "did not reproduce across the two sweep walks. That is neither established damage" \
+        "nor a clean store: re-run on an IDLE box, and if it recurs treat the store as" \
+        "suspect and escalate (#3749)."
+    fi
+
+    # THE FATAL BRANCH FOR THIS CLASS: reproduced across walks 1 and 2, and STILL present
+    # with the reflogs excluded. Something a live ref, the index or HEAD needs is not in
+    # the store.
+    if [ $((RC3 & FSCK_REACHABLE_BIT)) -ne 0 ]; then
+      emit_findings p3 finding
+      printf '%s measured fsck rc=%s then rc=%s then rc=%s --no-reflogs (%ss + %ss + %ss) over %s\n' \
+        "$P" "$RC1" "$RC2" "$RC3" "$EL1" "$EL2" "$EL3" "$(sane "$OBJ_DIR")"
+      printf '%s verdict CORRUPT\n' "$P"
+      printf '%s verdict-detail %s fsck diagnostic(s) name objects MISSING from this box'"'"'s SHARED\n' "$P" "$N3"
+      printf '%s verdict-detail store, on THREE walks - and they are still missing with the reflogs\n' "$P"
+      printf '%s verdict-detail EXCLUDED from the reachability roots, so a live ref, the index or HEAD\n' "$P"
+      printf '%s verdict-detail needs them. That is not a stale reflog and not a concurrent writer.\n' "$P"
+      printf '%s verdict-detail Every lane on this box reads this store, so it can change ANY gate\n' "$P"
+      printf '%s verdict-detail verdict here: do NOT certify anything against this checkout.\n' "$P"
+      printf '%s verdict-detail REMEDY: stop the lanes on this box, then re-obtain the objects from the\n' "$P"
+      printf '%s verdict-detail canonical remote (`git fetch --force origin`, or a fresh clone of\n' "$P"
+      printf '%s verdict-detail pmcfadin/cqlite). An object that only ever existed locally - an\n' "$P"
+      printf '%s verdict-detail unpushed commit - cannot be re-obtained: escalate rather than\n' "$P"
+      printf '%s verdict-detail improvising. `git reflog expire` is the remedy for the OTHER cause of\n' "$P"
+      printf '%s verdict-detail this bit and does nothing here; a local `git gc`/`git repack` cannot\n' "$P"
+      printf '%s verdict-detail repair it either, and may prune what is left (#3749).\n' "$P"
+      # NO `object` lines here, deliberately, and the reason is not the same as the reflog
+      # branch's. A `broken link from <A> to <B>` diagnostic names the INTACT source as
+      # well as the absent target, so labelling every 40-hex token an affected `object`
+      # would be a false claim about half of them. The diagnostics above name them in
+      # context, which is what the operator needs.
+      exit 4
+    fi
+
+    # THE COMPLAINT CLEARED WITH REFLOGS EXCLUDED: reflog-scoped. It stays exactly where
+    # it was before this discriminator existed - NON-PASSING, with the reflog remedy.
+    #
+    # WHY IT IS NOT PROMOTED TO VERIFIED, since walks 1 and 2 did rehash every object and
+    # reported no damage bit: the affirmative verdict in this script means "an fsck in the
+    # configuration this sweep uses ran to completion and found nothing", and that did not
+    # happen. A reflog naming an absent object can also be the SHADOW of an object that
+    # went missing while nothing live needed it any more, which is a fact about this store
+    # an operator is entitled to see. Deriving a pass from a NARROWED question is the
+    # shape CLAUDE.md warns about.
+    emit_findings p2 unmeasured-cause
+    unmeasured "git fsck reported reachability problems on both sweep walks (pass 1 rc=$RC1," \
+      "pass 2 rc=$RC2) which CLEARED when the reflogs were excluded from the reachability" \
+      "roots (pass 3 --no-reflogs rc=$RC3): the complaint is REFLOG-SCOPED, so nothing a" \
+      "live ref, the index or HEAD needs is missing, and this is NOT the damage class." \
+      "It is not certified clean either - an fsck in this sweep's own configuration did" \
+      "not complete quietly. Clear it with 'git reflog expire --expire-unreachable=now" \
+      "--all' on this box's shared repository, then re-run (#3749)."
+  fi
+
+  # WHAT IS LEFT: both passes non-clean, neither carrying object/pack damage, and NOT
+  # the reproduced-reachability shape the third walk above attributes. So this is a
+  # ref, commit-graph or multi-pack-index complaint, or a reachability bit that appeared
+  # in only ONE of the two walks (in which case the class itself did not reproduce and
+  # there is nothing for walk 3 to attribute). Its OWN non-passing state with its OWN
+  # cause text - never the fatal branch (these are not the class this script exists
+  # for) and never VERIFIED (the object-content question is not what these bits answer).
+  # No `object` lines: the 40-hex tokens in these diagnostics name INTACT objects.
   if [ "$C2" != clean ]; then
     emit_findings p2 unmeasured-cause
-    unmeasured "git fsck reported reachability/ref/commit-graph/multi-pack-index problems on BOTH walks" \
-      "(pass 1 class=$C1 rc=$RC1, pass 2 class=$C2 rc=$RC2) and NO object or pack" \
-      "damage. This script's subject is object content, and that question is therefore" \
-      "not answered: a missing object reports the same class. Inspect the diagnostics" \
-      "above; a stale reflog clears with 'git reflog expire --expire-unreachable=now" \
-      "--all', a stale multi-pack-index with 'git multi-pack-index write', and a" \
-      "genuinely absent object with neither."
+    unmeasured "git fsck reported ref/commit-graph/multi-pack-index problems, or a reachability" \
+      "complaint that did not reproduce identically, on BOTH walks (pass 1 class=$C1" \
+      "rc=$RC1, pass 2 class=$C2 rc=$RC2) and NO object or pack damage. This script's" \
+      "subject is object content, and that question is therefore not answered. Inspect" \
+      "the diagnostics above; a stale reflog clears with 'git reflog expire" \
+      "--expire-unreachable=now --all', a stale multi-pack-index with 'git" \
+      "multi-pack-index write', and a genuinely absent object with neither - if an" \
+      "object IS absent, re-run: a reachability bit on both walks is attributed" \
+      "(#3749)."
   fi
 
   # PASS 2 CLEAN, and pass 1 carried no damage class: the first observation did not

--- a/scripts/check-object-store-integrity.sh
+++ b/scripts/check-object-store-integrity.sh
@@ -103,6 +103,25 @@
 # reachability roots is not a reflog artefact, and it is CORRUPT. One that clears
 # stays UNMEASURED with the reflog remedy. And NO verdict is fatal on ONE
 # observation: see the discriminator at the sweep below.
+#
+# WHAT THE SWEEP'S REACHABILITY ROOTS ACTUALLY ARE, MEASURED RATHER THAN ASSUMED
+# (#3749 review round 7). `git --git-dir=<common> fsck` does NOT discard linked
+# worktrees: measured on git 2.43.0, with the object removed and the complaint checked
+# in both directions, it DOES walk every registered worktree's private `HEAD` (it names
+# it `worktrees/<name>/HEAD`), its private INDEX (`missing blob <sha>`), and the HEAD of
+# a PRUNABLE worktree whose working directory has been deleted - and all three survive
+# `--no-reflogs`, so a missing object needed by one reaches the CORRUPT branch above.
+# It does NOT walk a LINKED worktree's per-worktree REFS (`refs/worktree/*`,
+# `refs/bisect/*`, `refs/rewritten/*`); those are roots only for an fsck run with THAT
+# worktree's own git dir. Measured consequence, and it is the one this control exists to
+# prevent: delete an object named only by `refs/worktree/private` in a linked worktree
+# and the sweep exits **0 VERIFIED** (the worktree's HEAD reflog echoes the id, and that
+# echo CLEARS under `--no-reflogs`, so even the attribution walk reads it as
+# reflog-scoped). The MAIN worktree's per-worktree refs live in the common dir itself and
+# ARE walked. That gap is closed by the PRIVATE-ROOT PROBE below - a separate, cheap
+# question asked before the affirmative branch - and the coverage above is PINNED by the
+# test suite rather than believed, so a future git that narrows fsck's worktree
+# enumeration reds a case instead of silently shrinking this control.
 #   2   usage error — and `--help` exits 2 as well, deliberately: exit 0 MEANS
 #                    VERIFIED here, so a run that measured nothing must never
 #                    produce it.
@@ -313,12 +332,18 @@ usage() {
     "$P" "$(sane "${0##*/}")" >&2
   printf '%s USAGE        %s [--repo <path>] --print-store\n' \
     "$P" "$(sane "${0##*/}")" >&2
+  printf '%s USAGE        %s [--repo <path>] --probe-private-roots\n' \
+    "$P" "$(sane "${0##*/}")" >&2
   printf '%s USAGE Rehashes the SHARED git object store behind <path> with git fsck\n' "$P" >&2
   printf '%s USAGE and reports whether it is intact (#3749). Read-only; mutates nothing.\n' "$P" >&2
   printf '%s USAGE --print-store resolves and prints the store this run WOULD sweep\n' "$P" >&2
   printf '%s USAGE (one `store <abs-path>` line) and exits 0 WITHOUT sweeping. It is\n' "$P" >&2
   printf '%s USAGE the ONE isolated resolver callers key a throttle/latch on, so no\n' "$P" >&2
   printf '%s USAGE caller has to run its own un-isolated git to name the store.\n' "$P" >&2
+  printf '%s USAGE --probe-private-roots asks the ONE question a common-dir fsck cannot:\n' "$P" >&2
+  printf '%s USAGE are the objects named by LINKED worktrees per-worktree refs present?\n' "$P" >&2
+  printf '%s USAGE It sweeps nothing and prints `private-root` lines plus one terminal\n' "$P" >&2
+  printf '%s USAGE `private-roots` census line. The sweep runs it as a bounded child.\n' "$P" >&2
   printf '%s USAGE Exits 0 verified / 4 corrupt / 5 unmeasured / 2 usage.\n' "$P" >&2
   printf '%s USAGE A CONSUMER MUST NOT READ EXIT 5 AS CLEAN (nothing was measured).\n' "$P" >&2
   printf '%s USAGE Scope is ACCIDENTAL corruption. Deliberate peer forgery is\n' "$P" >&2
@@ -344,6 +369,13 @@ BOUND_SECS=600
 repo_set=0
 bound_set=0
 PRINT_STORE=0
+PROBE_PRIVATE_ROOTS=0
+# THE PATH THIS SCRIPT RE-INVOKES FOR THE PRIVATE-ROOT PROBE. Captured ONCE, before
+# anything can change the working directory, because `$0` is resolved against the cwd in
+# effect when bash started. Nothing here cd's on the main path (the store canonicalisation
+# cd's inside a `$( )` subshell), so this stays valid - but capturing it is cheaper than
+# depending on that staying true.
+SELF="$0"
 while [ "$#" -gt 0 ]; do
   case "$1" in
     -h | --help)
@@ -361,7 +393,22 @@ while [ "$#" -gt 0 ]; do
       # RESOLVE-AND-PRINT, NO SWEEP. See the block after the store resolution for what
       # this mode is for and why it deliberately does not require a timeout binary.
       [ "$PRINT_STORE" -eq 0 ] || { usage; exit 2; }
+      [ "$PROBE_PRIVATE_ROOTS" -eq 0 ] || { usage; exit 2; }
       PRINT_STORE=1
+      shift
+      ;;
+    --probe-private-roots)
+      # THE PER-WORKTREE PRIVATE-ROOT PROBE, AS ITS OWN CHILD MODE. It is a mode rather
+      # than an inline loop for ONE reason: the whole probe has to be BOUNDED, and a
+      # bound needs a single child process to wrap. Inlining it would mean either an
+      # UNBOUNDED sequence of git calls in a script whose header says an unboundable host
+      # does not get to run it (measured: those calls took 27.9s on this box at load 132),
+      # or a shell body passed as a string to `bash -c`, which is neither reviewable nor
+      # directly testable. As a mode the body is ordinary code, the suite can drive it
+      # head-on, and the sweep pays exactly one bounded stage for it.
+      [ "$PROBE_PRIVATE_ROOTS" -eq 0 ] || { usage; exit 2; }
+      [ "$PRINT_STORE" -eq 0 ] || { usage; exit 2; }
+      PROBE_PRIVATE_ROOTS=1
       shift
       ;;
     --timeout)
@@ -408,7 +455,7 @@ done
 TIMEOUT_BIN=""
 TIMEOUT_KILL_AFTER=0
 for _tb_name in timeout gtimeout; do
-  [ "$PRINT_STORE" -eq 0 ] || break
+  [ "$PRINT_STORE" -eq 0 ] && [ "$PROBE_PRIVATE_ROOTS" -eq 0 ] || break
   _tb_path="$(command -v "$_tb_name" 2>/dev/null || true)"
   [ -n "$_tb_path" ] || continue
   if "$_tb_path" --kill-after=1 1 true >/dev/null 2>&1; then
@@ -435,7 +482,7 @@ ENV_BIN="$(command -v env 2>/dev/null || true)"
     "fsck run under an inherited GIT_DIR/GIT_OBJECT_DIRECTORY can report about a" \
     "DIFFERENT store than the one it names. Refusing rather than measuring the wrong thing."
 
-if [ -z "$TIMEOUT_BIN" ] && [ "$PRINT_STORE" -eq 0 ]; then
+if [ -z "$TIMEOUT_BIN" ] && [ "$PRINT_STORE" -eq 0 ] && [ "$PROBE_PRIVATE_ROOTS" -eq 0 ]; then
   unmeasured "no timeout/gtimeout on PATH - refusing to run an UNBOUNDED fsck: both" \
     "callers are hang-sensitive (machine onboarding, and the supervisor's" \
     "per-iteration preflight). Install GNU coreutils and re-run."
@@ -506,6 +553,197 @@ if [ "$PRINT_STORE" -eq 1 ]; then
   exit 0
 fi
 
+# --- `--probe-private-roots`: THE ROOTS A COMMON-DIR fsck DOES NOT HAVE -------
+#
+# THE QUESTION, AND WHY IT IS A DIFFERENT ONE FROM THE SWEEP'S. The sweep REHASHES every
+# object PRESENT in the store, so object CONTENT is answered store-wide and is not a
+# per-worktree question at all. The only worktree-dependent half is PRESENCE: an object
+# that is absent cannot be rehashed, and is found only by walking from a root that needs
+# it. Measured (header above): a common-dir fsck already walks every worktree's HEAD,
+# index and reflogs, and MISSES a LINKED worktree's per-worktree refs. So this probe asks
+# exactly the missing half and nothing else.
+#
+# IT IS NOT AN fsck AND MUST NEVER BECOME ONE. Three measurements rule out the obvious
+# shapes, and they are recorded so they are not re-derived:
+#   * `git fsck <sha>...` REPLACES the default heads - a missing blob reachable from HEAD
+#     went UNDETECTED (rc 0) when an unrelated head was passed - so the private roots can
+#     never be appended to the sweep walk;
+#   * `git fsck <sha>` still scans the whole object directory, so a separate explicit-head
+#     fsck costs a FULL rehash, which is the N-fsck design the #3749 lead ruling rejected;
+#   * `git rev-list <missing-root>` dies 128 (`bad object`), so `--missing=print` cannot
+#     answer the case that actually fires - the ROOT itself being gone.
+# What it does instead is O(refs): list each linked worktree's refs, subtract the common
+# ones, and ask `cat-file --batch-check` whether the remainder's targets are in the store.
+# Measured on the live 15-worktree store: 0.02s warm.
+#
+# THE ENUMERATION IS FILESYSTEM-FIRST **BECAUSE THE GIT COMMAND IS FAIL-OPEN**, which is
+# the opposite of what one would assume. Measured: `git worktree list --porcelain`
+# SILENTLY DROPS a worktree whose admin `gitdir` file is missing - rc 0, no diagnostic,
+# the worktree simply absent - so a git-only enumeration answers "clean" about a worktree
+# it could not see. `$GIT_COMMON_DIR/worktrees/*` is not a guess about this fleet's
+# layout, it is git's OWN administrative directory, and it is a SUPERSET of what the
+# command reports. The command is still run, as a CROSS-CHECK in the other direction:
+# if it names more linked worktrees than the directory holds, something is being hidden
+# from us and that is UNREADABLE, never clean.
+#
+# WHAT IT DOES NOT ASK, STATED RATHER THAN IMPLIED: the CLOSURE of a private root. It
+# asks whether each private ref's TARGET is present, not whether every object in that
+# target's history is. An object missing DEEPER in a per-worktree ref's ancestry, and
+# named by no common ref, no worktree HEAD, no index and no reflog, is not recognised
+# here. That residual is declared rather than closed because closing it needs a graph
+# walk from roots whose ancestry is normally shared with the common refs anyway, and the
+# walk would be a second bounded stage (see MAX_SWEEP_WALKS).
+
+# _prp_observe <records-file> <census-file> - ONE observation. Writes TAB-separated
+# records, one per line:
+#     ABSENT<TAB><sha><TAB><worktree><TAB><refname>
+#     UNREADABLE<TAB><worktree><TAB><cause>
+# and `<roots> <linked-worktrees>` to the census file. Returns 0 always: every failure it
+# can name is a record, because a worktree that cannot be inspected is NOT a clean one.
+_prp_observe() {
+  local out="$1" census="$2"
+  local commonrefs="$PRP_TMPD/common.refs" pairs="$PRP_TMPD/wt.pairs"
+  local names="$PRP_TMPD/wt.names" priv="$PRP_TMPD/wt.priv" cand="$PRP_TMPD/cand"
+  local bc="$PRP_TMPD/bc" miss="$PRP_TMPD/miss"
+  local wtdir name nwt=0 nroot=0 gitwt=0
+  : >"$out"
+  : >"$cand"
+  printf '0 0\n' >"$census"
+
+  if ! git_isolated git --git-dir="$GIT_COMMON_DIR" for-each-ref --format='%(refname)' \
+    >"$commonrefs" 2>/dev/null; then
+    printf 'UNREADABLE\t(common)\tthe common ref list could not be read, so no ref can be told apart from a per-worktree one\n' >>"$out"
+    return 0
+  fi
+  LC_ALL=C sort -u "$commonrefs" -o "$commonrefs" 2>/dev/null ||
+    printf 'UNREADABLE\t(common)\tthe common ref list could not be sorted for comparison\n' >>"$out"
+
+  for wtdir in "$GIT_COMMON_DIR"/worktrees/*; do
+    [ -d "$wtdir" ] || continue
+    nwt=$((nwt + 1))
+    name="${wtdir##*/}"
+    # A CONTROL CHARACTER IN AN ADMIN NAME IS REFUSED, NOT ESCAPED. These records are
+    # line- and TAB-delimited and are INTERSECTED between the two observations, so the
+    # name is an IDENTITY here and not a display value (#3749 round 5: a value sanitised
+    # for display is not an identity). Refusing keeps every name that is compared RAW.
+    case "$name" in
+      *[[:cntrl:]]* | *"$(printf '\t')"*)
+        printf 'UNREADABLE\t%s\tthe worktree admin directory name carries a control character, so its private refs cannot be reported on one anchored line\n' \
+          "$(sane "$name")" >>"$out"
+        continue
+        ;;
+    esac
+    if [ ! -r "$wtdir" ] || [ ! -x "$wtdir" ]; then
+      printf 'UNREADABLE\t%s\tthe worktree admin directory is not readable/searchable\n' "$name" >>"$out"
+      continue
+    fi
+    if ! git_isolated git --git-dir="$wtdir" for-each-ref --format='%(refname) %(objectname)' \
+      >"$pairs" 2>/dev/null; then
+      printf 'UNREADABLE\t%s\tits ref list could not be read (git for-each-ref failed against its admin dir)\n' "$name" >>"$out"
+      continue
+    fi
+    # `%(objectname)` is the REF VALUE and reads no object; `%(objecttype)` would, and
+    # dies 128 on exactly the missing object this probe exists to find (measured).
+    awk 'NF >= 2 { print $1 }' "$pairs" 2>/dev/null | LC_ALL=C sort -u >"$names" 2>/dev/null || : >"$names"
+    LC_ALL=C comm -13 "$commonrefs" "$names" >"$priv" 2>/dev/null || : >"$priv"
+    awk -v wt="$name" 'NR == FNR { p[$0] = 1; next }
+      (NF >= 2 && ($1 in p)) { printf "%s\t%s\t%s\n", $2, wt, $1 }' \
+      "$priv" "$pairs" >>"$cand" 2>/dev/null || true
+  done
+
+  # THE CROSS-CHECK IN THE FAIL-OPEN DIRECTION (see the block comment above).
+  if gitwt=$(git_isolated git --git-dir="$GIT_COMMON_DIR" worktree list --porcelain 2>/dev/null |
+    awk '/^worktree /{n++} END{print n + 0}'); then
+    case "$gitwt" in '' | *[!0-9]*) gitwt=0 ;; esac
+    # minus the main worktree, which `worktree list` always names first.
+    [ "$gitwt" -ge 1 ] && gitwt=$((gitwt - 1))
+    if [ "$gitwt" -gt "$nwt" ]; then
+      printf 'UNREADABLE\t(common)\tgit names %s linked worktree(s) but only %s admin directory(ies) exist under the common dir - one is being hidden from this probe\n' \
+        "$gitwt" "$nwt" >>"$out"
+    fi
+  else
+    printf 'UNREADABLE\t(common)\tthe worktree list could not be read as a cross-check on the admin directories\n' >>"$out"
+  fi
+
+  nroot=$(awk 'END{print NR + 0}' "$cand" 2>/dev/null || echo 0)
+  case "$nroot" in '' | *[!0-9]*) nroot=0 ;; esac
+  printf '%s %s\n' "$nroot" "$nwt" >"$census"
+  [ "$nroot" -gt 0 ] || return 0
+
+  # ONE batch presence question for every private root. `cat-file --batch-check` prints
+  # `<sha> missing` for an object the store does not hold and exits 0 (measured).
+  if ! cut -f1 "$cand" 2>/dev/null | LC_ALL=C sort -u |
+    git_isolated git --git-dir="$GIT_COMMON_DIR" cat-file --batch-check='%(objectname) %(objecttype)' \
+      >"$bc" 2>/dev/null; then
+    printf 'UNREADABLE\t(common)\tthe presence check (git cat-file --batch-check) could not be run over %s private root(s)\n' \
+      "$nroot" >>"$out"
+    return 0
+  fi
+  awk '$2 == "missing" { print $1 }' "$bc" 2>/dev/null | LC_ALL=C sort -u >"$miss" 2>/dev/null || : >"$miss"
+  awk -F'\t' 'NR == FNR { m[$0] = 1; next }
+    ($1 in m) { printf "ABSENT\t%s\t%s\t%s\n", $1, $2, $3 }' "$miss" "$cand" >>"$out" 2>/dev/null || true
+  return 0
+}
+
+# probe_private_roots - TWO independent observations, INTERSECTED, then printed.
+#
+# THE SECOND OBSERVATION IS THE SAME DISCRIMINATOR THE SWEEP USES, FOR THE SAME REASON.
+# Up to eight peer lanes write this store: a lane running `git worktree remove`, or
+# deleting a bisect ref, between the enumeration and the presence check makes a root look
+# absent when nothing is wrong, and a worktree whose admin dir is being torn down looks
+# unreadable for a second. A transient does not survive a second independent
+# enumeration; real damage does. Both observations RE-ENUMERATE from scratch - reusing
+# the first one's root list would make the second observation answer a stale question.
+#
+# BOTH OBSERVATIONS RUN INSIDE THIS ONE CHILD PROCESS, which is what keeps the sweep's
+# worst case at MAX_SWEEP_WALKS bounded stages: two bounded children would have been a
+# fourth stage, and every caller's bound is derived from that number.
+probe_private_roots() {
+  local o1="$PRP_TMPD/o1" o2="$PRP_TMPD/o2" c1="$PRP_TMPD/c1" c2="$PRP_TMPD/c2"
+  local both="$PRP_TMPD/both" nabs=0 nunr=0 nroot=0 nwt=0 kind f1 f2 f3
+  _prp_observe "$o1" "$c1"
+  _prp_observe "$o2" "$c2"
+  LC_ALL=C sort -u "$o1" -o "$o1" 2>/dev/null || : >"$o1"
+  LC_ALL=C sort -u "$o2" -o "$o2" 2>/dev/null || : >"$o2"
+  LC_ALL=C comm -12 "$o1" "$o2" >"$both" 2>/dev/null || : >"$both"
+
+  while IFS="$(printf '\t')" read -r kind f1 f2 f3; do
+    case "$kind" in
+      ABSENT)
+        nabs=$((nabs + 1))
+        printf '%s private-root ABSENT %s %s %s\n' "$P" "$(sane "$f1")" "$(sane "$f2")" "$(sane "$f3")"
+        ;;
+      UNREADABLE)
+        nunr=$((nunr + 1))
+        printf '%s private-root UNREADABLE %s %s\n' "$P" "$(sane "$f1")" "$(sane "$f2")"
+        ;;
+    esac
+  done <"$both"
+
+  # The census reports the SECOND observation's counts: it is the one whose enumeration
+  # is current at the moment the answer is given.
+  read -r nroot nwt <"$c2" 2>/dev/null || { nroot=0; nwt=0; }
+  case "$nroot" in '' | *[!0-9]*) nroot=0 ;; esac
+  case "$nwt" in '' | *[!0-9]*) nwt=0 ;; esac
+  # THE TERMINAL CENSUS LINE IS THE COMPLETENESS MARKER, and the caller requires EXACTLY
+  # ONE of them: a probe that died halfway prints records and no census, which is
+  # UNMEASURED rather than "nothing was found" (the `.started` idiom, one function over).
+  printf '%s private-roots checked=%s worktrees=%s absent=%s unreadable=%s (two observations, intersected)\n' \
+    "$P" "$nroot" "$nwt" "$nabs" "$nunr"
+  return 0
+}
+
+if [ "$PROBE_PRIVATE_ROOTS" -eq 1 ]; then
+  if ! PRP_TMPD=$(mktemp -d "${TMPDIR:-/tmp}/object-store-private-roots.XXXXXX" 2>/dev/null) ||
+    [ -z "$PRP_TMPD" ] || [ ! -d "$PRP_TMPD" ]; then
+    unmeasured "could not create a scratch dir under $(sane "${TMPDIR:-/tmp}") for the" \
+      "private-root probe"
+  fi
+  trap 'rm -rf "$PRP_TMPD" 2>/dev/null' EXIT
+  probe_private_roots
+  exit 0
+fi
+
 # --- scratch space (outside the repository: this script writes nothing in it) --
 if ! TMPD=$(mktemp -d "${TMPDIR:-/tmp}/object-store-integrity.XXXXXX" 2>/dev/null) ||
   [ -z "$TMPD" ] || [ ! -d "$TMPD" ]; then
@@ -564,14 +802,25 @@ fi
 # BOUND_SECS / MAX_SWEEP_WALKS, so that relation reds rather than drifting silently.
 FINDING_LIST_LIMIT=40
 
-# MAX_SWEEP_WALKS - the most bounded fsck walks ONE invocation can spend, and it is
+# MAX_SWEEP_WALKS - the most bounded CHILD STAGES one invocation can spend, and it is
 # declared here as a NUMBER A CALLER CAN READ because the supervisor's own bound is
 # derived from it by an asserted relation rather than by someone remembering. Raising it
 # raises every caller's worst-case uninterruptible block.
 #   1. the sweep;
 #   2. the reproduction discriminator, when walk 1 was not clean;
-#   3. the reachability-CAUSE discriminator (`--no-reflogs`), when walks 1 and 2 both
-#      reported ERROR_REACHABLE and neither reported damage.
+#   3. EITHER the reachability-CAUSE discriminator (`--no-reflogs`, when walks 1 and 2
+#      both reported ERROR_REACHABLE and neither reported damage) OR the PRIVATE-ROOT
+#      PROBE - never both, and that is why adding the probe did not raise this number.
+#
+# WHY STAGE 3 IS AN EITHER/OR AND NOT A SUM (#3749 review round 7). Every branch of the
+# reachability block exits (CORRUPT, or one of three UNMEASURED causes), so a run that
+# spends walk 3 TERMINATES THERE and never reaches the private-root probe; and the probe
+# sits immediately before the ONE affirmative branch, which is reachable only when pass 2
+# was clean. So the worst case is max(3 fsck walks, 2 fsck walks + 1 probe) = 3 bounded
+# stages, unchanged - no caller's bound moves. That is a PLACEMENT property, not an
+# arithmetic one, so it is asserted BEHAVIOURALLY by the suite (the 3-walk fixtures must
+# emit no `private-root` line at all); moving the probe earlier would silently widen
+# every caller's uninterruptible window.
 MAX_SWEEP_WALKS=3
 
 # git fsck's exit BITMASK, from fsck.h and CONFIRMED against the git in use (2.43.0):
@@ -1086,6 +1335,101 @@ if [ "$FIRST_WALK_CLEAN" -eq 0 ]; then
   printf '%s note which is the signature of a concurrent writer on this shared store rather\n' "$P"
   printf '%s note than damage. The verdict below rests on the second walk, which completed.\n' "$P"
 fi
+
+# --- THE PRIVATE-ROOT GATE ON `VERIFIED` ------------------------------------
+#
+# THE LAST QUESTION BEFORE THE ONLY AFFIRMATIVE VERDICT, and it is placed here for two
+# reasons that are both load-bearing. (1) SEMANTICS: `VERIFIED` may not rest on a rehash
+# alone when a whole class of roots was not walked, so the probe gates the affirmative
+# branch rather than sitting beside it. (2) THE BOUND: every branch of the reachability
+# block above exits, so a run that spent a third fsck walk never arrives here - the worst
+# case stays at MAX_SWEEP_WALKS bounded child stages and no caller's derived bound moves
+# (see MAX_SWEEP_WALKS). Moving this call earlier would silently widen every caller's
+# uninterruptible window, which is why the suite asserts the placement behaviourally.
+#
+# IT IS RUN AS A BOUNDED CHILD OF THIS SAME SCRIPT, under the same isolation and the same
+# timeout machinery as an fsck walk: the body is a mode of this file (see
+# `--probe-private-roots`), so it is ordinary reviewable code that the suite drives
+# head-on, while the caller still pays exactly one boundable process for it.
+PRP_OUT="$TMPD/prp.out"
+prp_rc=0
+if [ ! -r "$SELF" ]; then
+  unmeasured "the private-root probe could not be run: this script's own path" \
+    "($(sane "$SELF")) is not readable, so the per-worktree roots a common-dir fsck does" \
+    "NOT walk (a linked worktree's refs/worktree, refs/bisect, refs/rewritten) were not" \
+    "checked. The rehash said nothing about them, so this run is NOT clean (#3749)."
+fi
+if [ "$TIMEOUT_KILL_AFTER" -eq 1 ]; then
+  git_isolated nice -n 19 "$TIMEOUT_BIN" --kill-after="$BOUND_KILL_GRACE" "$BOUND_SECS" \
+    bash "$SELF" --repo "$REPO" --probe-private-roots >"$PRP_OUT" 2>&1 || prp_rc=$?
+else
+  git_isolated nice -n 19 "$TIMEOUT_BIN" "$BOUND_SECS" \
+    bash "$SELF" --repo "$REPO" --probe-private-roots >"$PRP_OUT" 2>&1 || prp_rc=$?
+fi
+
+# THE TWO CHANNELS MUST AGREE BEFORE EITHER IS ACTED ON (#3749 review round 4, applied to
+# the channel this round adds): the child's EXIT STATUS and its terminal census line are
+# two independent signals, and a run is only complete when BOTH say so. Exactly one
+# census line is required - the `store-key` contract idiom - so a child that died halfway
+# through printing records is UNMEASURED and never "nothing was found".
+PRP_CENSUS=""
+prp_complete=0
+if PRP_CENSUS=$(awk '/^OBJECT-STORE: private-roots /{ line = $0; n++ }
+  END { if (n == 1) { print line; exit 0 } exit 1 }' "$PRP_OUT" 2>/dev/null); then
+  prp_complete=1
+fi
+PRP_ABSENT=$(awk '/^OBJECT-STORE: private-root ABSENT /{ n++ } END { print n + 0 }' "$PRP_OUT" 2>/dev/null)
+PRP_UNREAD=$(awk '/^OBJECT-STORE: private-root UNREADABLE /{ n++ } END { print n + 0 }' "$PRP_OUT" 2>/dev/null)
+case "$PRP_ABSENT" in '' | *[!0-9]*) PRP_ABSENT=0 ;; esac
+case "$PRP_UNREAD" in '' | *[!0-9]*) PRP_UNREAD=0 ;; esac
+
+# Its own lines are already anchored, and ONLY anchored lines are re-emitted: a child that
+# died could put an unanchored shell diagnostic on this stream, and output property (a) is
+# what every consumer and every test rests on.
+awk '/^OBJECT-STORE: private-root/ { print }' "$PRP_OUT" 2>/dev/null || true
+
+if [ "$prp_rc" -eq 124 ] || [ "$prp_rc" -eq 137 ]; then
+  unmeasured "the private-root probe exceeded its ${BOUND_SECS}s bound (rc=$prp_rc), so the" \
+    "per-worktree roots a common-dir fsck does NOT walk were not checked. The rehash" \
+    "above says nothing about them. Re-run with a larger --timeout on an idle box."
+fi
+if [ "$prp_complete" -eq 0 ] || [ "$prp_rc" -ne 0 ]; then
+  unmeasured "the private-root probe did not complete (child rc=$prp_rc," \
+    "census line $([ "$prp_complete" -eq 1 ] && printf 'present' || printf 'ABSENT')): its" \
+    "exit status and its terminal census line must AGREE before either is read, and they" \
+    "do not. The per-worktree roots a common-dir fsck does NOT walk (a linked worktree's" \
+    "refs/worktree, refs/bisect, refs/rewritten) were therefore not checked, so the rehash" \
+    "above is not a clean answer about them. Run" \
+    "'bash $(sane "${0##*/}") --probe-private-roots' by hand to see what it said (#3749)."
+fi
+if [ "$PRP_ABSENT" -gt 0 ]; then
+  printf '%s measured %s\n' "$P" "$(sane "${PRP_CENSUS#"$P "}")"
+  printf '%s verdict CORRUPT\n' "$P"
+  printf '%s verdict-detail %s object(s) named by a LINKED WORKTREE'"'"'s per-worktree ref are\n' "$P" "$PRP_ABSENT"
+  printf '%s verdict-detail NOT in this box'"'"'s SHARED store, on TWO independent enumerations.\n' "$P"
+  printf '%s verdict-detail A common-dir `git fsck` does not walk those refs (it walks every\n' "$P"
+  printf '%s verdict-detail worktree'"'"'s HEAD, index and reflogs, and the COMMON refs), so the rehash\n' "$P"
+  printf '%s verdict-detail above reported nothing about them: this is exactly the missing-object\n' "$P"
+  printf '%s verdict-detail class the reachability discriminator treats as CORRUPT, found at a root\n' "$P"
+  printf '%s verdict-detail that walk never had. Every lane on this box reads this store, so do NOT\n' "$P"
+  printf '%s verdict-detail certify anything against this checkout.\n' "$P"
+  printf '%s verdict-detail REMEDY: stop the lanes on this box and re-obtain the objects from the\n' "$P"
+  printf '%s verdict-detail canonical remote (`git fetch --force origin`, or a fresh clone of\n' "$P"
+  printf '%s verdict-detail pmcfadin/cqlite). If the ref is a leftover (`refs/bisect/*` from an\n' "$P"
+  printf '%s verdict-detail abandoned bisect, a tool'"'"'s `refs/worktree/*`) and the object only ever\n' "$P"
+  printf '%s verdict-detail existed locally, DELETE THE REF in that worktree rather than improvising\n' "$P"
+  printf '%s verdict-detail on the store - but establish which it is first (#3749).\n' "$P"
+  exit 4
+fi
+if [ "$PRP_UNREAD" -gt 0 ]; then
+  unmeasured "$PRP_UNREAD registered worktree(s) could not be INSPECTED for their" \
+    "per-worktree refs, on both observations (see the private-root lines above). A" \
+    "worktree this probe cannot read is not a clean one: a common-dir fsck does not walk" \
+    "those refs, so nothing in this run establishes whether the objects they name are" \
+    "present. Fix the named admin directory under $(sane "$GIT_COMMON_DIR")/worktrees" \
+    "(or prune the worktree with 'git worktree prune') and re-run (#3749)."
+fi
+printf '%s measured %s\n' "$P" "$(sane "${PRP_CENSUS#"$P "}")"
 
 # --- THE ONE AFFIRMATIVE BRANCH --------------------------------------------
 #

--- a/scripts/check-object-store-integrity.sh
+++ b/scripts/check-object-store-integrity.sh
@@ -90,13 +90,21 @@
 #                    classify, a damage class that did NOT reproduce, or a
 #                    reachability/ref/commit-graph/multi-pack-index complaint that
 #                    reproduced but could not be ATTRIBUTED.
-#   6   UNSWEEPABLE — git fsck RAN and DIED without finishing, on TWO independent
-#                    walks (its own `die()` or a signal death: a status at or above
-#                    128, which is never read as its error bitmask). NO CAUSE IS
-#                    CLAIMED: the store's object content is UNKNOWN, and no lane on
-#                    this box can obtain an affirmative sweep of it. It is a STOPPING
-#                    verdict, and it is NOT the same fact as UNMEASURED - see the
-#                    branch at PASS 2 for why only one of the two is permissive.
+#   6   UNSWEEPABLE — no lane on this box can obtain an affirmative sweep of this
+#                    store. It is a STOPPING verdict, it is NOT the same fact as
+#                    UNMEASURED (see the branch at PASS 2 for why only one of the two
+#                    is permissive), and it has TWO CAUSES:
+#                      * git fsck RAN and DIED without finishing, on TWO independent
+#                        walks (its own `die()` or a signal death: a status at or
+#                        above 128, never read as its error bitmask). NO CAUSE IS
+#                        CLAIMED there - the store's object content is UNKNOWN.
+#                      * the store's OWN CONFIGURATION sets `fsck.*` keys, which can
+#                        suppress or downgrade the very diagnostics this sweep reads
+#                        its verdict from, so NO WALK IS RUN at all. The offending
+#                        keys ARE named; no damage is claimed, because nothing was
+#                        rehashed (#3749 review round 11, item 1).
+#                    Both are persistent properties of the REPOSITORY, which is why
+#                    they stop the box rather than being reported and passed over.
 #
 # A REACHABILITY COMPLAINT HAS TWO CAUSES AND THEY GET DIFFERENT VERDICTS (#3749
 # review round 4, item 1). fsck's exit bit 2 (ERROR_REACHABLE) fires for BOTH:
@@ -232,6 +240,14 @@ set -uo pipefail
 #   GIT_CONFIG_SYSTEM        can carry `fsck.*` severities, alternates and
 #                            `url.*.insteadOf`; HOME is shared on this fleet, so a
 #                            peer lane's edit there is not the invoker's.
+#
+# WHAT THIS ALLOWLIST DOES NOT AND CANNOT CLOSE, SAID HERE RATHER THAN IMPLIED: the
+# REPOSITORY'S OWN config. It is a FILE in the store, not an environment variable, so
+# no environment can neutralise it - and it can carry `fsck.*` keys that change the
+# exit status this script's verdict comes from. That is REFUSED rather than overridden,
+# and the refusal (with its measurements, its verdict choice and the shapes rejected)
+# is the `fsck_policy_probe` block below. Read no claim of total configuration
+# isolation into this list: it isolates the ENVIRONMENT.
 #   everything else          CLEARED - notably GIT_DIR, GIT_COMMON_DIR,
 #                            GIT_OBJECT_DIRECTORY, GIT_ALTERNATE_OBJECT_DIRECTORIES,
 #                            GIT_INDEX_FILE, GIT_CEILING_DIRECTORIES,
@@ -374,7 +390,9 @@ usage() {
   printf '%s USAGE the ONE isolated resolver callers key a throttle/latch on, so no\n' "$P" >&2
   printf '%s USAGE caller has to run its own un-isolated git to name the store.\n' "$P" >&2
   printf '%s USAGE Every run DECLARES what it does not walk (`declared-gap` lines).\n' "$P" >&2
-  printf '%s USAGE Exits 0 verified / 4 corrupt / 5 unmeasured / 2 usage.\n' "$P" >&2
+  printf '%s USAGE Exits 0 verified / 4 corrupt / 5 unmeasured / 6 unsweepable /\n' "$P" >&2
+  printf '%s USAGE 2 usage. Exit 6 is a STOPPING verdict: the store cannot be swept\n' "$P" >&2
+  printf '%s USAGE (git fsck died reproducibly, or the store config sets fsck.* keys).\n' "$P" >&2
   printf '%s USAGE A CONSUMER MUST NOT READ EXIT 5 AS CLEAN (nothing was measured).\n' "$P" >&2
   printf '%s USAGE Scope is ACCIDENTAL corruption. Deliberate peer forgery is\n' "$P" >&2
   printf '%s USAGE invoker-class and OUT OF MODEL (#3749 owner ruling, #3312 triage).\n' "$P" >&2
@@ -607,6 +625,215 @@ printf '%s declared-gap NOT in the gap, measured rather than assumed: every regi
 printf '%s declared-gap worktree private HEAD and INDEX (prunable worktrees included) and\n' "$P"
 printf '%s declared-gap the COMMON refs ARE walked, and a missing object needed by one is\n' "$P"
 printf '%s declared-gap reported. That is what makes this gap one namespace wide.\n' "$P"
+
+
+# --- THE STORE'S OWN fsck POLICY: REFUSED, NOT OVERRIDDEN --------------------
+#
+# THE FINDING (#3749 review round 11, item 1). Everything above closes the git
+# ENVIRONMENT. It cannot close the store's own config, because A LOCAL CONFIG IS A
+# FILE IN THE REPOSITORY, NOT AN ENVIRONMENT VARIABLE — the same distinction
+# CLAUDE.md records for the transport hop ("only the *environment* is sanitisable — a
+# `.git/config` is a file"). And `git fsck` is CONFIGURABLE: `fsck.skipList` names
+# objects whose validation messages are dropped, and `fsck.<msg-id>=ignore` downgrades
+# an individual diagnostic. Both change the EXIT STATUS this script reads its verdict
+# from, in the one direction that matters.
+#
+# MEASURED, git 2.43.0, 2026-09-02, on a fixture the suite builds (a commit object
+# whose author line carries no email — an ERROR-severity fsck message, exit bit 1,
+# this script's own damage class):
+#   plain                                 -> rc 1  => CORRUPT
+#   -c fsck.missingEmail=ignore           -> rc 0  => a FALSE `VERIFIED`
+#   -c fsck.skipList=<file naming the id> -> rc 0  => a FALSE `VERIFIED`
+# A false affirmative verdict is precisely the failure this whole control exists to
+# prevent, and it is reported about a store every lane on the box certifies against.
+#
+# IT IS IN MODEL, not invoker-class. The file in question is the SHARED
+# `/data/lanes/repo/.git/config`, so its writer is a PEER LANE and not the invoker
+# (#3312's triage rule: a non-invoker route, or an accidental one, is a defect). The
+# accidental path is the likelier one: somebody adds a `fsck.skipList` to work around
+# one known-bad object in history, and every lane's corruption sweep silently stops
+# detecting that class forever, with nothing saying so.
+#
+# WHY IT REFUSES INSTEAD OF NEUTRALISING. `fsck.<msg-id>` is an OPEN-ENDED KEY SPACE:
+# one key per fsck message id, and new ids arrive with new git versions. A `-c
+# fsck.<id>=error` for each is a list that is wrong the moment git adds a message, and
+# neutralising ONE axis (forcing `fsck.skipList=` empty and leaving the ids) is the
+# "one axis closed, space declared done" shape this issue has already hit five times.
+# CLAUDE.md's precedent for exactly this situation is to REFUSE rather than enumerate
+# (the protocol-allowlist case: "a protocol allowlist is not expressible either ... So
+# there is no import at all"). Refusing is also the HONEST answer: under an unknown
+# fsck policy this script cannot make a trustworthy statement about the store, and
+# saying so is worth more than a verdict that might mean nothing.
+#
+# TWO OTHER SHAPES WERE CONSIDERED AND REJECTED, recorded so they are not re-derived:
+#   * sweeping through a scratch repository that has a clean config and reaches the
+#     real objects (an alternate, or GIT_OBJECT_DIRECTORY). It loses round 7's
+#     measured reachability roots — the registered worktrees' private HEADs and
+#     INDEXes are roots only for the REAL repository — so it would have to
+#     reconstruct git's administrative layout, which is a second implementation of it
+#     and comes with its own false-clean routes (round 8's ruling);
+#   * running the walk anyway and downgrading only the affirmative verdict. That keeps
+#     a `VERIFIED` path alive under a policy nobody read, one edit away from being
+#     reachable, and buys nothing this refusal does not.
+#
+# WHY THIS IS `UNSWEEPABLE` (STOP) AND NOT `UNMEASURED` (CONTINUE) — the disposition
+# argument, since a token is what every consumer keys disposition on:
+#   1. It is a PERSISTENT PROPERTY OF THE REPOSITORY, not of this box's tooling. It
+#      does not clear itself, and every sweep by every lane will hit it forever: the
+#      permissive reading is not "measure again later", it is "detection is OFF on this
+#      box until somebody happens to read a journal line".
+#   2. THE SAME CAUSE ALREADY STOPS THE BOX in one of its variants, and splitting them
+#      would be incoherent: an `fsck.<msg-id>` naming an id THIS git does not know makes
+#      git exit 128 (`fatal: Unhandled message id`, measured), which reproduces on both
+#      walks and is the fatal UNSWEEPABLE branch below. So a config key that merely
+#      breaks fsck stops the box while one that SUPPRESSES REAL DAMAGE would not.
+#   3. The remedy is local, cheap and needs no repair of anything: remove or relocate
+#      the key and re-run. Nothing legitimately needs an `fsck.*` key here — measured
+#      2026-09-02 on this fleet's shared store: ZERO such keys — so this cannot stop a
+#      box that is doing something reasonable.
+#   4. It fits UNSWEEPABLE's meaning exactly: the store's object content is UNKNOWN and
+#      no lane on this box can obtain an affirmative sweep of it. It differs from the
+#      fatal branch only in whether a cause is known, and here one IS: the keys are
+#      named. It claims NO corruption — nothing was rehashed.
+#
+# AND "COULD NOT ASK" IS ITS OWN, PERMISSIVE STATE. A probe that fails, or answers with
+# no keys at all, means this run does not know the policy — which is a "could not
+# measure" fact of the same kind as the `unrunnable` class below, so it lands on
+# UNMEASURED with its own cause and does NOT stop the box. It can never reach
+# `VERIFIED`: the affirmative verdict requires the policy to have been READ and found
+# empty of `fsck.*`, which is an affirmative measurement rather than the absence of a
+# bad signal (CLAUDE.md's standing rule).
+#
+# THE PROBE ASKS ABOUT THE CONFIGURATION THE WALK WILL ACTUALLY READ, and that is the
+# whole of its correctness: same `--git-dir`, same `git_isolated` environment (so
+# global and system config are /dev/null on both sides), and `git config --list` there
+# reports the local file, ANY `include.path`/`includeIf` it pulls in, and the
+# per-worktree `config.worktree` scope — all three verified on git 2.43.0.
+#
+# `--name-only`: the VALUES are not needed, and a config value may contain a literal
+# newline, which would let a value's continuation line pose as a key. Keys cannot —
+# git's parser reads a section header and a variable name on one line — so a
+# line-oriented read of names is exact where a read of `--list` would not be.
+FSCK_POLICY_KEY_LIMIT=8
+FSCK_POLICY_STATE=""
+FSCK_POLICY_KEYS=""
+FSCK_POLICY_KEY_COUNT=0
+FSCK_POLICY_READ_COUNT=0
+FSCK_POLICY_CAUSE=""
+
+# fsck_policy_probe <git-dir> — sets FSCK_POLICY_STATE to exactly one of:
+#   none     — the configuration was READ and carries no `fsck.*` key (affirmative)
+#   present  — it carries at least one; FSCK_POLICY_KEYS names up to FSCK_POLICY_KEY_LIMIT
+#   unknown  — the question could not be asked; FSCK_POLICY_CAUSE says why
+# Globals rather than stdout: `unknown` has to carry its cause, and a command
+# substitution would also have to encode WHICH state it is in one string.
+fsck_policy_probe() {
+  local dir="$1" out="" rc=0 line pre n=0 hits=0
+  FSCK_POLICY_STATE=unknown
+  FSCK_POLICY_KEYS=""
+  FSCK_POLICY_KEY_COUNT=0
+  FSCK_POLICY_READ_COUNT=0
+  FSCK_POLICY_CAUSE=""
+  out=$(git_isolated git --git-dir="$dir" config --list --name-only 2>/dev/null) || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    FSCK_POLICY_CAUSE="git --git-dir=$(sane "$dir") config --list --name-only exited $rc"
+    return 0
+  fi
+  # RC 0 WITH NO KEYS IS NOT AN EMPTY POLICY, IT IS AN UNREAD ONE. Every git repository's
+  # own config declares at least core.repositoryformatversion (git init writes four keys),
+  # so an empty listing means this run did not read a config it can reason about — the
+  # affirmative-measurement rule again: `none` must come from having read something.
+  if [ -z "$out" ]; then
+    FSCK_POLICY_CAUSE="the probe exited 0 but listed NO configuration key at all for $(sane "$dir"), so no policy was read (a git repository's own config always declares core.repositoryformatversion)"
+    return 0
+  fi
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    n=$((n + 1))
+    # git lowercases the section and variable names it prints, but the match is made
+    # case-insensitively anyway: this decides whether the box stops, so it does not rest
+    # on a rendering convention. Only the first 5 characters are folded — the rest of the
+    # line is a subsection whose case git PRESERVES and which is printed verbatim below.
+    pre=$(printf '%s' "${line:0:5}" | tr 'A-Z' 'a-z')
+    case "$pre" in
+      'fsck.')
+        hits=$((hits + 1))
+        if [ "$hits" -le "$FSCK_POLICY_KEY_LIMIT" ]; then
+          FSCK_POLICY_KEYS="${FSCK_POLICY_KEYS}${FSCK_POLICY_KEYS:+ }$(sane "$line")"
+        fi
+        ;;
+    esac
+  done <<POLICY_KEYS
+$out
+POLICY_KEYS
+  FSCK_POLICY_READ_COUNT="$n"
+  FSCK_POLICY_KEY_COUNT="$hits"
+  if [ "$hits" -gt 0 ]; then
+    FSCK_POLICY_STATE=present
+  else
+    FSCK_POLICY_STATE=none
+  fi
+  return 0
+}
+
+fsck_policy_probe "$GIT_COMMON_DIR"
+case "$FSCK_POLICY_STATE" in
+  present)
+    printf '%s finding fsck policy: %s key(s) set in the configuration this sweep reads\n' \
+      "$P" "$FSCK_POLICY_KEY_COUNT"
+    printf '%s finding fsck policy key(s): %s\n' "$P" "$FSCK_POLICY_KEYS"
+    if [ "$FSCK_POLICY_KEY_COUNT" -gt "$FSCK_POLICY_KEY_LIMIT" ]; then
+      printf '%s finding (+%s further fsck.* key(s), not listed)\n' \
+        "$P" "$((FSCK_POLICY_KEY_COUNT - FSCK_POLICY_KEY_LIMIT))"
+    fi
+    printf '%s measured fsck-policy present: %s of %s configuration key(s) are fsck.* over %s\n' \
+      "$P" "$FSCK_POLICY_KEY_COUNT" "$FSCK_POLICY_READ_COUNT" "$(sane "$OBJ_DIR")"
+    printf '%s verdict UNSWEEPABLE\n' "$P"
+    printf '%s verdict-detail this store CANNOT BE SWEPT TO A TRUSTWORTHY VERDICT while its own\n' "$P"
+    printf '%s verdict-detail configuration sets fsck.* keys, so NO WALK WAS RUN. git fsck is\n' "$P"
+    printf '%s verdict-detail configurable: fsck.skipList drops the validation messages of the objects\n' "$P"
+    printf '%s verdict-detail it names, and fsck.<msg-id>=ignore downgrades an individual diagnostic -\n' "$P"
+    printf '%s verdict-detail both change the EXIT STATUS this sweep reads its verdict from. Measured on\n' "$P"
+    printf '%s verdict-detail git 2.43.0: a damaged object reported as fsck exit bit 1 becomes exit 0,\n' "$P"
+    printf '%s verdict-detail i.e. a FALSE affirmative verdict about a store every lane on this box\n' "$P"
+    printf '%s verdict-detail reads. The keys are NAMED above.\n' "$P"
+    printf '%s verdict-detail NO DAMAGE IS CLAIMED HERE: nothing was rehashed, so nothing is known\n' "$P"
+    printf '%s verdict-detail about this store one way or the other. Its object content is UNKNOWN,\n' "$P"
+    printf '%s verdict-detail which is NOT clean - do NOT certify anything against this checkout until\n' "$P"
+    printf '%s verdict-detail a sweep of it completes.\n' "$P"
+    printf '%s verdict-detail WHY THIS IS NOT OVERRIDDEN INSTEAD: fsck.<msg-id> is one key per fsck\n' "$P"
+    printf '%s verdict-detail message id and new ids arrive with new git versions, so a -c override for\n' "$P"
+    printf '%s verdict-detail each is a list that is wrong the moment git adds a message. A partial\n' "$P"
+    printf '%s verdict-detail override would leave a suppression route open under a line claiming there\n' "$P"
+    printf '%s verdict-detail was none.\n' "$P"
+    printf '%s verdict-detail REMEDY: INSPECT the keys, with the same scopes this sweep reads -\n' "$P"
+    printf '%s verdict-detail   git --git-dir=%s config --list --show-origin --name-only\n' "$P" "$(sane "$GIT_COMMON_DIR")"
+    printf '%s verdict-detail (the origin column names the FILE: the local config, an include it pulls\n' "$P"
+    printf '%s verdict-detail in, or a per-worktree config.worktree). Then REMOVE or RELOCATE every\n' "$P"
+    printf '%s verdict-detail fsck.* key from the scopes of this repository - `git --git-dir=%s\n' "$P" "$(sane "$GIT_COMMON_DIR")"
+    printf '%s verdict-detail config --unset-all <key>` - and re-run this sweep. If a key is there\n' "$P"
+    printf '%s verdict-detail deliberately, move it to the ONE command that needs it (`git -c\n' "$P"
+    printf '%s verdict-detail fsck.<id>=... fsck`) instead of the shared repository config, which every\n' "$P"
+    printf '%s verdict-detail lane on this box reads.\n' "$P"
+    printf '%s verdict-detail THEN require this sweep to report its affirmative verdict before\n' "$P"
+    printf '%s verdict-detail clearing any latch or resuming the lanes: "I think I fixed it" is not an\n' "$P"
+    printf '%s verdict-detail exit condition (#3749).\n' "$P"
+    exit 6
+    ;;
+  unknown)
+    unmeasured "the fsck POLICY of this store's own configuration could not be read" \
+      "($FSCK_POLICY_CAUSE), so no walk was run: git fsck is configurable" \
+      "(fsck.skipList, fsck.<msg-id>=ignore) and under an unread policy an affirmative" \
+      "verdict could mean nothing. This is a 'could not ask', not a finding - nothing" \
+      "was rehashed and no damage is claimed. Check that the repository's config is" \
+      "readable and parseable ('git --git-dir=$(sane "$GIT_COMMON_DIR") config --list" \
+      "--show-origin --name-only') and re-run (#3749)."
+    ;;
+esac
+# THE AFFIRMATIVE HALF IS STAMPED, so a pasted run shows the check RAN rather than
+# leaving its silence to be read as coverage.
+printf '%s measured fsck-policy: no fsck.* key among %s configuration key(s) read from the scopes this sweep reads (local + includes + per-worktree; global and system are /dev/null under this run)\n' \
+  "$P" "$FSCK_POLICY_READ_COUNT"
 
 # --- THE SWEEP --------------------------------------------------------------
 #

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -3431,6 +3431,42 @@ obj_sweep_write_stamp() {
   return 0
 }
 
+# obj_sweep_force_stamp_stale <path> — make the throttle stamp read as EXPIRED, so no lane
+# on this box can throttle past a CORRUPT verdict that could NOT be latched (#3749 review
+# round 9, item 1).
+#
+# THE DEFECT IT EXISTS FOR. The CORRUPT branch wrote the throttle stamp unconditionally,
+# INCLUDING on the path where the latch could not be persisted (a stamp that is writable
+# inside a directory that is not — so the create of `<stamp>.CORRUPT` fails while the
+# rewrite of `<stamp>` succeeds). The detecting lane stopped, correctly; its peers then
+# read that FRESH stamp, skipped their own sweep for the whole interval, and kept spawning
+# workers over a store already confirmed damaged. That is round 1's harm surviving in the
+# one branch that never got round 1's treatment: the latch is what a peer must not
+# throttle past, and where there is no latch the ONLY thing that stops a peer is a stamp
+# it reads as expired.
+#
+# WHY IT FORCES RATHER THAN MERELY LEAVING THE STAMP ALONE. Not writing would be enough
+# for the stamp THIS lane read as stale — but a peer whose own sweep started earlier can
+# finish DURING this one and write a fresh timestamp, and then "leave it alone" throttles
+# every lane for the full interval on that peer's stamp. `0` is an affirmative statement
+# that this box's last sweep is to be treated as expired, and obj_sweep_stamp_is_fresh
+# reads it as expired for any plausible clock.
+#
+# IT CANNOT MANUFACTURE A FALSE CLEAN. Its only effect is MORE sweeping: every lane
+# re-measures the store, reproduces the damage and stops on its own finding. The cost is a
+# repeated sweep per lane per iteration until an operator repairs the store, which is the
+# correct price for a corruption verdict that has nowhere durable to live.
+obj_sweep_force_stamp_stale() {
+  local path="$1"
+  [[ -n "$path" ]] || return 0
+  if printf '0\n' 2>/dev/null >"$path"; then
+    log "object-store: the throttle stamp $path has been FORCED STALE (epoch 0) because the CORRUPT verdict could not be latched — every lane on this box will re-sweep, reproduce the damage and stop on its own finding rather than throttling past it (#3749)."
+  else
+    log "object-store: the throttle stamp $path could NEITHER be advanced nor forced stale, so peer lanes will throttle on whatever it already holds. If it is fresh they will skip their own sweep for up to ${OBJ_SWEEP_INTERVAL_HOURS}h over a store found DAMAGED: stop every lane on this box by hand (#3749)."
+  fi
+  return 0
+}
+
 # ---------------------------------------------------------------------------
 # THE IN-PROGRESS CLAIM: ONE SWEEP PER BOX AT A TIME (#3749 review round 5, item 2 —
 # raised as a Low in round 1, recorded as "not disposed of" in round 2, returned as a
@@ -3905,19 +3941,38 @@ object_store_sweep() {
   # is non-passing, journalled, and paged once — and it is named explicitly there, so the
   # signal is not swallowed on the way past.
   if [[ "$rc" -eq 4 && "$verdict" == "CORRUPT" ]]; then
-    local findings
+    local findings latched=0
     # LATCH FIRST, THEN EVERYTHING ELSE. A failure to persist it is REPORTED, never
     # silent: this lane stops either way, but without the latch the peers on this box
     # will re-run their own sweep and rediscover the damage rather than inheriting the
     # verdict, and an operator reading only this journal would otherwise never learn that.
     if [[ -z "$latch" ]]; then
       log "object-store: the CORRUPT verdict could NOT be latched — this box's shared store could not be resolved, so there is no box-wide file to record it in. Peer lanes will re-sweep and rediscover it (#3749)."
-    elif ! obj_sweep_set_latch "$latch"; then
-      log "object-store: the CORRUPT verdict could NOT be latched at $latch (unwritable?) — peer lanes will re-sweep and rediscover it rather than inheriting this verdict (#3749)."
+    else
+      obj_sweep_set_latch "$latch" || true
+      # CONFIRMED BY ASKING THE FILE AFTERWARDS, NEVER BY THE CREATE'S EXIT STATUS — the
+      # same test obj_sweep_set_latch itself ends on, and for the same reason: a create's
+      # status cannot tell "a peer got there first" (fine, the box IS latched) from "the
+      # directory is unwritable" (not fine). One extra stat, and it makes the gate below
+      # a property of the file rather than of a return value.
+      if obj_sweep_latch_present "$latch"; then
+        latched=1
+      else
+        log "object-store: the CORRUPT verdict could NOT be latched at $latch (unwritable?) — peer lanes will re-sweep and rediscover it rather than inheriting this verdict (#3749)."
+      fi
     fi
-    # ONLY NOW the throttle stamp: it says "this box paid for a sweep", and a peer
-    # reading it will also read the latch that is already there.
-    obj_sweep_write_stamp "$stamp"
+    # THE THROTTLE STAMP IS WRITTEN ONLY WHEN THE LATCH IS CONFIRMED IN PLACE (#3749
+    # review round 9, item 1). A fresh stamp tells every peer on this box "somebody swept
+    # recently, do not spend another fsck" — which is safe ONLY because the latch they
+    # will also read stops them. With no latch there is nothing to stop them, so
+    # advertising a swept box would buy six hours of silence over a store confirmed
+    # damaged. See obj_sweep_force_stamp_stale for why the stamp is forced expired rather
+    # than merely left alone.
+    if [[ "$latched" -eq 1 ]]; then
+      obj_sweep_write_stamp "$stamp"
+    else
+      obj_sweep_force_stamp_stale "$stamp"
+    fi
     findings="$(printf '%s\n' "$out" | { grep -E '^OBJECT-STORE: (finding|object) ' || true; } | head -6 | tr '\n' ';' | cut -c1-600)"
     notify "high" "worker-supervisor: SHARED OBJECT STORE CORRUPT" \
       "git fsck reports damaged objects in this box's shared git object store — every lane here reads it, so NO gate verdict on this box can be trusted. Stopping. ${findings:-<no findings captured>}"

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -3273,41 +3273,6 @@ OBJ_SWEEP_CLAIM_STATE=""
 # a bound in its own right, which is why it is a small constant and not a measurement.
 OBJ_SWEEP_CLAIM_SLACK_SECS=60
 
-# obj_sweep_digest <value> — a COLLISION-RESISTANT, filesystem-safe fingerprint of
-# <value>, 16 lowercase hex characters, or nothing (exit 1) when this host has no usable
-# digest tool. It is what makes the stamp/latch key INJECTIVE; see obj_sweep_stamp_path.
-#
-# THREE TOOLS, BECAUSE THE TWO PLATFORMS THIS FILE SUPPORTS SHIP DIFFERENT ONES:
-# `sha256sum` (GNU coreutils, every Linux box here), `shasum -a 256` (macOS, via perl),
-# `openssl dgst -sha256` (both, and the fallback if the first two are absent). `cksum` is
-# present everywhere and is NOT used: CRC32 is not collision-resistant, and a key that
-# collides is the defect this exists to remove.
-#
-# THE OUTPUT IS PARSED FROM BOTH ENDS AND THEN VALIDATED AS HEX. The hex is the FIRST
-# field for the coreutils/perl tools (`<hex>  -`) and the LAST for openssl
-# (`SHA2-256(stdin)= <hex>` on 3.x, `(stdin)= <hex>` on 1.1.x). A tool whose output shape
-# is neither must FAIL CLOSED rather than contribute a garbage key, which is why the
-# candidate is required to match hex rather than merely to be non-empty.
-obj_sweep_digest() {
-  local v="$1" out="" hex=""
-  if command -v sha256sum >/dev/null 2>&1; then
-    out="$(printf '%s' "$v" | sha256sum 2>/dev/null || true)"
-  elif command -v shasum >/dev/null 2>&1; then
-    out="$(printf '%s' "$v" | shasum -a 256 2>/dev/null || true)"
-  elif command -v openssl >/dev/null 2>&1; then
-    out="$(printf '%s' "$v" | openssl dgst -sha256 2>/dev/null || true)"
-  else
-    return 1
-  fi
-  for hex in "${out%% *}" "${out##* }"; do
-    if [[ "$hex" =~ ^[0-9a-f]{32,}$ ]]; then
-      printf '%s' "${hex:0:16}"
-      return 0
-    fi
-  done
-  return 1
-}
-
 # obj_sweep_stamp_path <sweep-script> — the THROTTLE stamp: WHEN this box last SPENT a
 # sweep. Keyed on the SHARED OBJECT STORE, not on the lane, so four lanes of one box
 # share one cadence instead of sweeping four times.
@@ -3350,7 +3315,7 @@ obj_sweep_digest() {
 # an un-throttled sweep per iteration, which is loud and visible rather than a key two
 # stores can share.
 obj_sweep_stamp_path() {
-  local script="$1" line common key dir digest
+  local script="$1" line key dir
   if [[ -n "$OBJ_SWEEP_STAMP" ]]; then
     printf '%s' "$OBJ_SWEEP_STAMP"
     return 0
@@ -3360,38 +3325,33 @@ obj_sweep_stamp_path() {
   # file runs under `set -euo pipefail`, so a grep that matches nothing (an older or
   # stubbed sweep script that has no --print-store mode) would take the supervisor down.
   line="$(bash "$script" --repo "$REPO_ROOT" --print-store 2>/dev/null |
-    { grep '^OBJECT-STORE: store ' || true; } | head -1)"
-  common="${line#OBJECT-STORE: store }"
+    { grep '^OBJECT-STORE: store-key ' || true; } | head -1)"
+  key="${line#OBJECT-STORE: store-key }"
   # Both halves are required: an empty line yields an empty value, and a line the prefix
   # did NOT strip is not the answer to this question.
-  [[ -n "$common" && "$common" != "$line" ]] || return 0
-  # THE KEY IS A DIGEST OF THE CANONICAL PATH, NOT A FLATTENING OF IT (#3749 review round
-  # 4, item 3). Replacing `/` — and every unsupported character — with `_` is NOT
-  # INJECTIVE: `/tmp/a/b/objects` and `/tmp/a_b/objects` flatten to the same name, so two
-  # different repositories on one box shared a throttle stamp AND a CORRUPT latch. Either
-  # direction is a defect: one store suppresses the other's sweep for the whole interval,
-  # or one store's damage stops every lane working on the other. Low likelihood on this
-  # fleet (the real store is `/data/lanes/repo/.git/objects`) and cheap to remove, and the
-  # failure mode is the sticky box-wide latch again.
+  [[ -n "$key" && "$key" != "$line" ]] || return 0
+  # THE KEY IS DERIVED BY THE SWEEP SCRIPT, FROM THE RAW CANONICAL PATH — NOT HERE, AND NOT
+  # FROM THE `store` LINE (#3749 review round 5, item 3). Round 4 made this key injective
+  # over the FLATTENING (`/tmp/a/b/objects` and `/tmp/a_b/objects` collapse to one name) by
+  # digesting the path — and digested the value from the resolver's `store` line, which is
+  # passed through that script's `sane()` display encoding. That encoding is LOSSY: a path
+  # holding a real newline and one holding the literal characters `\n` print identically, so
+  # two stores shared a throttle stamp AND a CORRUPT latch. Either direction is a defect —
+  # one store suppresses the other's sweep, or one store's damage stops every lane working
+  # on the other.
   #
-  # THE SANITISED TAIL IS READABILITY ONLY AND CARRIES NO IDENTITY — an operator reading
-  # `ls /tmp` should be able to tell which store a stamp belongs to; the digest is what
-  # makes two stores two files. It is the TAIL because the distinguishing part of these
-  # paths is the end, and it is length-checked explicitly because `${v: -40}` yields the
-  # EMPTY STRING (not the whole value) when the value is shorter than the offset.
-  key="$(printf '%s' "$common" | tr -c 'A-Za-z0-9._-' '_')"
-  if [[ "${#key}" -gt 40 ]]; then
-    key="${key:${#key}-40}"
-  fi
-  # FAIL CLOSED: with no usable digest tool this returns the EMPTY path, so the caller
-  # neither reads nor writes a stamp and the sweep simply runs every iteration. Falling
-  # back to the flattened name would be the non-injective form again, silently, on exactly
-  # the hosts nobody tested.
-  digest="$(obj_sweep_digest "$common")" || return 0
-  [[ "$digest" =~ ^[0-9a-f]{16}$ ]] || return 0
+  # So the identity now arrives already computed, from the only process that has the raw
+  # bytes, and there is no lossy value left here to digest. See `store_key` in
+  # check-object-store-integrity.sh for the tail/digest split and the three digest tools.
+  #
+  # IT IS STILL VALIDATED, because it is another process's stdout and not a fact: the shape
+  # is checked rather than assumed, and anything else yields the EMPTY path — no throttle,
+  # no latch, announced once by the caller — instead of a filename built out of whatever
+  # arrived. A host with no digest tool prints no key line at all and lands here too.
+  [[ "$key" =~ ^[A-Za-z0-9._-]{1,64}\.[0-9a-f]{16}$ ]] || return 0
   dir="/tmp"
   [[ -d "$dir" && -w "$dir" ]] || dir="${TMPDIR:-/tmp}"
-  printf '%s' "${dir}/cqlite-object-store-sweep.${key}.${digest}.stamp"
+  printf '%s' "${dir}/cqlite-object-store-sweep.${key}.stamp"
 }
 
 # obj_sweep_latch_path <stamp-path> — the CORRUPT latch that belongs to that stamp.

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -205,25 +205,32 @@ UNVERIFIED_MAX="${UNVERIFIED_MAX:-2}"
 #   no green anywhere — this sweep certifies nothing, it only refuses to run workers over
 #   a store known to be damaged.
 # OBJ_SWEEP_TIMEOUT_SECS — passed through as the sweep's own `--timeout`, and it is the
-#   bound on EACH of the sweep's walks (a non-clean first walk is re-run once as a
-#   discriminator), so the worst-case wall time is TWICE it. The bound exists to stop a
-#   HANG, not to police duration, and a bound that expires on a healthy-but-busy box
-#   yields UNMEASURED noise nobody acts on.
-#   THE SUPERVISOR'S DEFAULT IS HALF THE SWEEP SCRIPT'S OWN (300 vs 600), AND THAT IS
-#   THIS CALLER'S LATENCY BUDGET RATHER THAN A DIFFERENT VIEW OF THE STORE (#3749 review
-#   round 3, item 3). The sweep runs inside a CHILD process, so nothing here can check
-#   the stop file or the wall-clock budget BETWEEN its two walks; the only lever this
-#   caller has is how long those two walks can take. At 300 the worst case is 600s — one
-#   walk at the script's own bound — instead of the 1200s that raising the per-walk bound
-#   to 600 in round 2 silently bought. 300s is still ~3.75x the observed COLD worst case
-#   (47-80s on this fleet's 366M store) and ~12x the warm one, so it costs no realistic
-#   sweep its verdict. The other caller, scripts/bootstrap-agent-machine.sh, keeps 600:
-#   machine onboarding is a one-shot step where nobody is waiting on a stop file.
+#   bound on EACH of the sweep's walks, of which there can be MAX_SWEEP_WALKS (declared
+#   in the sweep script: the sweep, the reproduction discriminator when walk 1 is not
+#   clean, and the `--no-reflogs` reachability-cause discriminator when both walks report
+#   ERROR_REACHABLE). Worst-case wall time is therefore MAX_SWEEP_WALKS x this value. The
+#   bound exists to stop a HANG, not to police duration, and a bound that expires on a
+#   healthy-but-busy box yields UNMEASURED noise nobody acts on.
+#   THE SUPERVISOR'S DEFAULT IS THE SCRIPT'S BOUND DIVIDED BY MAX_SWEEP_WALKS (200 vs
+#   600/3), AND THAT IS THIS CALLER'S LATENCY BUDGET RATHER THAN A DIFFERENT VIEW OF THE
+#   STORE (#3749 review round 3, item 3; re-derived in round 4 when the third walk was
+#   added). The sweep runs inside a CHILD process, so nothing here can check the stop
+#   file or the wall-clock budget BETWEEN its walks; the only lever this caller has is
+#   how long they may take in total. At 200 the worst case stays 600s — one walk at the
+#   script's own bound — which is the property round 3 fixed and round 4 must not undo by
+#   adding a walk. 200s is ~2.5x the observed COLD worst case (47-80s on this fleet's
+#   366M store) and ~12x the warm one; the third walk is the CHEAPEST of the three
+#   (measured 12.5s vs 24s on the live store, because excluding the reflogs is what it
+#   does). The other caller, scripts/bootstrap-agent-machine.sh, keeps 600: machine
+#   onboarding is a one-shot step where nobody is waiting on a stop file.
+#   THE TRADE, STATED: this is stop latency bought with UNMEASURED headroom. A walk that
+#   runs past 200s under load pages UNMEASURED here where it would have completed at 300.
+#   Nothing on this fleet has been observed above 80s, and nothing monitors it either.
 #   STRICTLY POSITIVE: the sweep rejects 0 as a usage error, which would turn the probe
 #   into a permanent UNMEASURED — a silently self-disabling bound, the shape
 #   validate_numeric_knobs exists for.
 OBJ_SWEEP_INTERVAL_HOURS="${OBJ_SWEEP_INTERVAL_HOURS:-6}"
-OBJ_SWEEP_TIMEOUT_SECS="${OBJ_SWEEP_TIMEOUT_SECS:-300}"
+OBJ_SWEEP_TIMEOUT_SECS="${OBJ_SWEEP_TIMEOUT_SECS:-200}"
 # Empty => derived per SHARED STORE in obj_sweep_stamp_path (below), so lanes sharing one
 # object store share one throttle. It also names the CORRUPT latch (`<stamp>.CORRUPT`),
 # so pinning it relocates both files together.
@@ -3391,7 +3398,7 @@ obj_sweep_set_latch() {
 # (#3749 review round 3, item 1a). The question has to be asked again IMMEDIATELY BEFORE
 # every path that lets this lane go on to spawn a worker, because a PEER can latch the
 # box at any moment — including while this lane's own sweep is in flight, which is up to
-# two fsck walks. A lane that swept CLEAN while a peer was recording CORRUPT would
+# MAX_SWEEP_WALKS fsck walks. A lane that swept CLEAN while a peer was recording CORRUPT would
 # otherwise return 0 from a sweep whose answer is already known to be superseded.
 obj_sweep_stop_if_latched() {
   local latch="$1" latch_ts
@@ -3542,7 +3549,7 @@ object_store_sweep() {
   if [[ "$rc" -eq 0 && "$verdict" == "VERIFIED" ]]; then
     log "object-store: VERIFIED — $(printf '%s\n' "$out" | { grep '^OBJECT-STORE: measured ' || true; } | head -1)"
     # RE-ASKED AFTER THE SWEEP, BEFORE RETURNING TO THE SPAWN PATH. This lane's own walk
-    # said VERIFIED, but it took up to two fsck bounds to say it, and a PEER may have
+    # said VERIFIED, but it took up to MAX_SWEEP_WALKS fsck bounds to say it, and a PEER may have
     # latched the box in the meantime. The peer's finding is about the same store and is
     # strictly newer than this measurement, so it wins.
     obj_sweep_stop_if_latched "$latch"
@@ -3665,7 +3672,8 @@ preflight_wait() {
   # inside (see object_store_sweep).
   #
   # THE IN-FLIGHT SWEEP IS STILL NOT INTERRUPTIBLE, AND THAT IS A DELIBERATE LIMIT, NOT
-  # AN OVERSIGHT. The sweep's two fsck walks happen inside a CHILD PROCESS
+  # AN OVERSIGHT. The sweep's fsck walks (up to MAX_SWEEP_WALKS of them) happen inside a
+  # CHILD PROCESS
   # (`bash scripts/check-object-store-integrity.sh`), so "check the stop file between the
   # passes" is not something this function can do: there is no point between them that
   # executes here. Making it interruptible means running the child in its own process
@@ -3673,8 +3681,9 @@ preflight_wait() {
   # lifetime and process-ownership hazards this repo has already paid for once
   # (CLAUDE.md: never signal a process group you no longer own), for a stop-latency win.
   # So the exposure is BOUNDED IN WALL TIME INSTEAD: see OBJ_SWEEP_TIMEOUT_SECS, whose
-  # supervisor default is half the sweep script's own, precisely so that TWO walks here
-  # cost no more than ONE walk at the script's bound. The stop file is re-read the moment
+  # supervisor default is the sweep script's own bound DIVIDED BY MAX_SWEEP_WALKS,
+  # precisely so that every walk this caller can pay for still costs no more than ONE
+  # walk at the script's bound. The stop file is re-read the moment
   # the sweep returns (the loop's first statement, below).
   object_store_sweep
   while true; do

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -3247,6 +3247,42 @@ acquire_lock() {
 # ---------------------------------------------------------------------------
 OBJ_SWEEP_ANNOUNCED=0
 OBJ_SWEEP_UNMEASURED_NOTIFIED=0
+OBJ_SWEEP_NOSTAMP_NOTIFIED=0
+
+# obj_sweep_digest <value> — a COLLISION-RESISTANT, filesystem-safe fingerprint of
+# <value>, 16 lowercase hex characters, or nothing (exit 1) when this host has no usable
+# digest tool. It is what makes the stamp/latch key INJECTIVE; see obj_sweep_stamp_path.
+#
+# THREE TOOLS, BECAUSE THE TWO PLATFORMS THIS FILE SUPPORTS SHIP DIFFERENT ONES:
+# `sha256sum` (GNU coreutils, every Linux box here), `shasum -a 256` (macOS, via perl),
+# `openssl dgst -sha256` (both, and the fallback if the first two are absent). `cksum` is
+# present everywhere and is NOT used: CRC32 is not collision-resistant, and a key that
+# collides is the defect this exists to remove.
+#
+# THE OUTPUT IS PARSED FROM BOTH ENDS AND THEN VALIDATED AS HEX. The hex is the FIRST
+# field for the coreutils/perl tools (`<hex>  -`) and the LAST for openssl
+# (`SHA2-256(stdin)= <hex>` on 3.x, `(stdin)= <hex>` on 1.1.x). A tool whose output shape
+# is neither must FAIL CLOSED rather than contribute a garbage key, which is why the
+# candidate is required to match hex rather than merely to be non-empty.
+obj_sweep_digest() {
+  local v="$1" out="" hex=""
+  if command -v sha256sum >/dev/null 2>&1; then
+    out="$(printf '%s' "$v" | sha256sum 2>/dev/null || true)"
+  elif command -v shasum >/dev/null 2>&1; then
+    out="$(printf '%s' "$v" | shasum -a 256 2>/dev/null || true)"
+  elif command -v openssl >/dev/null 2>&1; then
+    out="$(printf '%s' "$v" | openssl dgst -sha256 2>/dev/null || true)"
+  else
+    return 1
+  fi
+  for hex in "${out%% *}" "${out##* }"; do
+    if [[ "$hex" =~ ^[0-9a-f]{32,}$ ]]; then
+      printf '%s' "${hex:0:16}"
+      return 0
+    fi
+  done
+  return 1
+}
 
 # obj_sweep_stamp_path <sweep-script> — the THROTTLE stamp: WHEN this box last SPENT a
 # sweep. Keyed on the SHARED OBJECT STORE, not on the lane, so four lanes of one box
@@ -3280,15 +3316,17 @@ OBJ_SWEEP_UNMEASURED_NOTIFIED=0
 # for a host without one. OBJ_SWEEP_STAMP still overrides both (the self-suite pins it
 # per case), and the latch follows it, so a pinned stamp relocates BOTH files together.
 #
-# AN UNRESOLVABLE STORE DOES NOT THROTTLE AT ALL — it prints the empty string, and the
-# caller then neither reads nor writes a stamp. The old fallback collapsed every
-# unresolvable store on a box onto ONE name, so two different checkouts shared a 6-hour
-# throttle and one suppressed the other's sweep: a MISSED sweep, not an extra one. Not
-# throttling costs nothing here, because the sweep resolves the same store itself and
-# fails FAST (a sub-second UNMEASURED) in exactly the states where this resolution
-# failed.
+# AN UNRESOLVABLE STORE — OR A HOST WITH NO DIGEST TOOL — DOES NOT THROTTLE AT ALL: this
+# prints the empty string, and the caller then neither reads nor writes a stamp (and says
+# so once in the journal). The old fallback collapsed every unresolvable store on a box
+# onto ONE name, so two different checkouts shared a 6-hour throttle and one suppressed
+# the other's sweep: a MISSED sweep, not an extra one. Not throttling costs nothing in the
+# unresolvable case, because the sweep resolves the same store itself and fails FAST (a
+# sub-second UNMEASURED) in exactly those states; on a host with no digest tool it costs
+# an un-throttled sweep per iteration, which is loud and visible rather than a key two
+# stores can share.
 obj_sweep_stamp_path() {
-  local script="$1" line common key dir
+  local script="$1" line common key dir digest
   if [[ -n "$OBJ_SWEEP_STAMP" ]]; then
     printf '%s' "$OBJ_SWEEP_STAMP"
     return 0
@@ -3303,14 +3341,33 @@ obj_sweep_stamp_path() {
   # Both halves are required: an empty line yields an empty value, and a line the prefix
   # did NOT strip is not the answer to this question.
   [[ -n "$common" && "$common" != "$line" ]] || return 0
-  key="$common"
-  # Flatten to one path component; keep only characters that cannot surprise a shell or
-  # a filesystem.
-  key="${key//\//_}"
-  key="$(printf '%s' "$key" | tr -c 'A-Za-z0-9._-' '_')"
+  # THE KEY IS A DIGEST OF THE CANONICAL PATH, NOT A FLATTENING OF IT (#3749 review round
+  # 4, item 3). Replacing `/` — and every unsupported character — with `_` is NOT
+  # INJECTIVE: `/tmp/a/b/objects` and `/tmp/a_b/objects` flatten to the same name, so two
+  # different repositories on one box shared a throttle stamp AND a CORRUPT latch. Either
+  # direction is a defect: one store suppresses the other's sweep for the whole interval,
+  # or one store's damage stops every lane working on the other. Low likelihood on this
+  # fleet (the real store is `/data/lanes/repo/.git/objects`) and cheap to remove, and the
+  # failure mode is the sticky box-wide latch again.
+  #
+  # THE SANITISED TAIL IS READABILITY ONLY AND CARRIES NO IDENTITY — an operator reading
+  # `ls /tmp` should be able to tell which store a stamp belongs to; the digest is what
+  # makes two stores two files. It is the TAIL because the distinguishing part of these
+  # paths is the end, and it is length-checked explicitly because `${v: -40}` yields the
+  # EMPTY STRING (not the whole value) when the value is shorter than the offset.
+  key="$(printf '%s' "$common" | tr -c 'A-Za-z0-9._-' '_')"
+  if [[ "${#key}" -gt 40 ]]; then
+    key="${key:${#key}-40}"
+  fi
+  # FAIL CLOSED: with no usable digest tool this returns the EMPTY path, so the caller
+  # neither reads nor writes a stamp and the sweep simply runs every iteration. Falling
+  # back to the flattened name would be the non-injective form again, silently, on exactly
+  # the hosts nobody tested.
+  digest="$(obj_sweep_digest "$common")" || return 0
+  [[ "$digest" =~ ^[0-9a-f]{16}$ ]] || return 0
   dir="/tmp"
   [[ -d "$dir" && -w "$dir" ]] || dir="${TMPDIR:-/tmp}"
-  printf '%s' "${dir}/cqlite-object-store-sweep.${key}.stamp"
+  printf '%s' "${dir}/cqlite-object-store-sweep.${key}.${digest}.stamp"
 }
 
 # obj_sweep_latch_path <stamp-path> — the CORRUPT latch that belongs to that stamp.
@@ -3439,6 +3496,15 @@ object_store_sweep() {
   fi
   stamp="$(obj_sweep_stamp_path "$script")"
   latch="$(obj_sweep_latch_path "$stamp")"
+  # NO KEY MEANS NO THROTTLE AND NO LATCH, AND THAT IS ANNOUNCED RATHER THAN INFERRED.
+  # Two causes, both named: the sweep script could not resolve the shared store, or this
+  # host has no usable digest tool (see obj_sweep_digest — the key must be injective, so
+  # there is deliberately no fallback to a name two stores could share). Once per run: it
+  # is a property of the box, not of the iteration.
+  if [[ -z "$stamp" && "$OBJ_SWEEP_NOSTAMP_NOTIFIED" -eq 0 ]]; then
+    log "object-store sweep: no box-wide key for this store — the shared store could not be resolved, or this host has no sha256 digest tool. The sweep will run EVERY iteration and a CORRUPT verdict cannot be latched for peer lanes (#3749)."
+    OBJ_SWEEP_NOSTAMP_NOTIFIED=1
+  fi
   now="$(date +%s)"
   last=0
   if [[ -n "$stamp" && -r "$stamp" ]]; then

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -187,7 +187,7 @@ UNVERIFIED_MAX="${UNVERIFIED_MAX:-2}"
 # issue #3749: the SHARED git object store on this box (every lane here is a worktree of
 # ONE `.git`) is rehashed with `git fsck` on a THROTTLED cadence from the per-iteration
 # preflight path. This is the recurring half of #3749's control; the one-shot half is
-# scripts/bootstrap-agent-machine.sh section 5b-obj. Both go through the SAME script,
+# scripts/bootstrap-agent-machine.sh section 5d. Both go through the SAME script,
 # scripts/check-object-store-integrity.sh — a second implementation would be a second
 # place for the verdict to drift.
 #
@@ -3294,16 +3294,24 @@ object_store_sweep() {
   # its output prints repository-controlled paths verbatim, so an unanchored match could
   # land on one. Both the line AND the exit status are required to agree for the two
   # actionable verdicts.
-  verdict="$(printf '%s\n' "$out" | grep '^OBJECT-STORE: verdict ' | head -1)"
+  # `{ grep || true; }` ON EVERY PIPELINE BELOW, AND IT IS LOAD-BEARING, NOT DEFENSIVE.
+  # This file runs under `set -euo pipefail`: a `grep` that matches NOTHING exits 1, and
+  # with `pipefail` that status becomes the pipeline's — so an ASSIGNMENT from such a
+  # substitution, or a bare pipeline, KILLS THE SUPERVISOR with rc=1. And "no match" is
+  # exactly the reachable case here: a sweep killed at its bound prints no `verdict ` line
+  # at all, and an UNMEASURED one need not print an `unmeasured-cause` line. Caught by
+  # scripts/tests/test_worker_supervisor.sh's obj-sweep(UNMEASURED) case, which planted a
+  # verdict with no cause line and observed the whole loop exit 1.
+  verdict="$(printf '%s\n' "$out" | { grep '^OBJECT-STORE: verdict ' || true; } | head -1)"
   verdict="${verdict#OBJECT-STORE: verdict }"
   verdict="${verdict%% *}"
   if [[ "$rc" -eq 0 && "$verdict" == "VERIFIED" ]]; then
-    log "object-store: VERIFIED — $(printf '%s\n' "$out" | grep '^OBJECT-STORE: measured ' | head -1)"
+    log "object-store: VERIFIED — $(printf '%s\n' "$out" | { grep '^OBJECT-STORE: measured ' || true; } | head -1)"
     return 0
   fi
   if [[ "$rc" -eq 4 || "$verdict" == "CORRUPT" ]]; then
     local findings
-    findings="$(printf '%s\n' "$out" | grep -E '^OBJECT-STORE: (finding|object) ' | head -6 | tr '\n' ';' | cut -c1-600)"
+    findings="$(printf '%s\n' "$out" | { grep -E '^OBJECT-STORE: (finding|object) ' || true; } | head -6 | tr '\n' ';' | cut -c1-600)"
     notify "high" "worker-supervisor: SHARED OBJECT STORE CORRUPT" \
       "git fsck reports damaged objects in this box's shared git object store — every lane here reads it, so NO gate verdict on this box can be trusted. Stopping. ${findings:-<no findings captured>}"
     log "object-store: CORRUPT — stopping loudly; no worker may certify against a damaged shared store (#3749). ${findings:-<no findings captured>}"
@@ -3319,7 +3327,7 @@ object_store_sweep() {
   # journalled every time and paged ONCE per run — loud enough to fix, never a silent
   # swallow and never a latch.
   log "object-store: UNMEASURED (rc=$rc verdict='${verdict:-<none>}') — the shared store was NOT rehashed, so its integrity is UNKNOWN, not clean. Continuing: a hygiene probe that cannot run must not stop the fleet (#3749)."
-  printf '%s\n' "$out" | grep '^OBJECT-STORE: unmeasured-cause ' | head -4 | while IFS= read -r obj_line; do
+  printf '%s\n' "$out" | { grep '^OBJECT-STORE: unmeasured-cause ' || true; } | head -4 | while IFS= read -r obj_line; do
     log "object-store: $obj_line"
   done
   if [[ "$OBJ_SWEEP_UNMEASURED_NOTIFIED" -eq 0 ]]; then

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -2696,7 +2696,18 @@ supervisor_lock_take() {
     if ! rm -f -- "$marker" 2>/dev/null; then
       log "$(supervisor_one_line "startup: could not remove our own ownership marker $(supervisor_shell_quote "$marker") after acquiring the lock. Harmless to this run — the lock is held and its release removes the directory wholesale — but a non-recursive manual clear of that lock would refuse until the marker is gone (#3601).")"
     fi
-    trap 'supervisor_lock_release' EXIT
+    # THE CLAIM IS RELEASED BEFORE THE LOCK, AND IT IS REGISTERED HERE RATHER THAN AT ITS
+    # CREATE SITE (#3749 review round 5, item 2; CLAUDE.md's roborev-job-282 ruling that a
+    # fix which ADDS a resource inherits that resource's lifetime bugs). The trap is
+    # installed before any sweep can run, so the handler exists before the resource does,
+    # and the resource's identity travels in OBJ_SWEEP_CLAIM_OWNED — empty until a claim is
+    # created, cleared the moment it is released, so this is a no-op on every other path.
+    # KNOWN AND NOT CLOSED HERE: this file installs no INT/TERM handlers, so a SIGNALLED
+    # supervisor releases neither its claim nor its lock. For the claim that is a delay and
+    # not a wedge — a peer recovers it once it ages past the staleness bound — and adding
+    # signal handlers to this process is a change to the LOCK's lifetime too, which is
+    # #3683's subject and not this one's.
+    trap 'obj_sweep_claim_release "$OBJ_SWEEP_CLAIM_OWNED"; supervisor_lock_release' EXIT
     return 0
   fi
   SUPERVISOR_LOCK_TAKE_CAUSE="$pub"
@@ -3248,6 +3259,19 @@ acquire_lock() {
 OBJ_SWEEP_ANNOUNCED=0
 OBJ_SWEEP_UNMEASURED_NOTIFIED=0
 OBJ_SWEEP_NOSTAMP_NOTIFIED=0
+OBJ_SWEEP_CLAIM_NOTIFIED=0
+# The in-progress claim this process currently owns, or empty. Read by the EXIT trap, so
+# it is assigned before anything can create a claim (`set -u`), and it is what makes the
+# claim a REGISTERED resource rather than one whose lifetime nobody owns (CLAUDE.md's
+# roborev-job-282 ruling: a fix that adds a resource inherits that resource's lifetime
+# bugs, so register it the moment it exists and clear it the moment it is released).
+OBJ_SWEEP_CLAIM_OWNED=""
+OBJ_SWEEP_CLAIM_STATE=""
+# SLACK on the claim-staleness bound: what a sweep spends OUTSIDE its bounded fsck walks —
+# process startup, the `--print-store` resolution, output capture, and the notify/journal
+# writes. It is additive to a DERIVED product (see obj_sweep_claim_stale_secs) rather than
+# a bound in its own right, which is why it is a small constant and not a measurement.
+OBJ_SWEEP_CLAIM_SLACK_SECS=60
 
 # obj_sweep_digest <value> — a COLLISION-RESISTANT, filesystem-safe fingerprint of
 # <value>, 16 lowercase hex characters, or nothing (exit 1) when this host has no usable
@@ -3443,6 +3467,181 @@ obj_sweep_write_stamp() {
   return 0
 }
 
+# ---------------------------------------------------------------------------
+# THE IN-PROGRESS CLAIM: ONE SWEEP PER BOX AT A TIME (#3749 review round 5, item 2 —
+# raised as a Low in round 1, recorded as "not disposed of" in round 2, returned as a
+# Medium with a consequence attached in round 5).
+#
+# THE DEFECT. The throttle read and the sweep invocation are unsynchronised, and the stamp
+# is written at the END of a sweep — so when the interval expires EVERY lane on the box
+# reads the same stale stamp and starts its own full-store `git fsck`. On a four-lane box
+# that is four concurrent rehashes of one 366M store, and the consequence is not merely
+# CPU: the walks are I/O-bound (17-19s of user time inside an 80s wall), so contention
+# pushes them toward the per-walk bound — and an expired bound is UNMEASURED. That is a
+# CORRELATED loss of the measurement on every lane at once, which is the state this whole
+# feature exists to prevent.
+#
+# THE CLAIM IS A DIRECTORY CREATED WITH `mkdir`: the same kernel-arbitrated create-only
+# primitive as the CORRUPT latch, for the same reason — exactly one caller can win and
+# there is no read-modify-write to serialise. NOT `flock`: this file's single-instance lock
+# is an atomic mkdir + pid-liveness precisely because MACOS SHIPS NO `flock(1)` (see the
+# SUPERVISOR_LOCK header), and a second locking mechanism in one file is a second set of
+# failure modes.
+#
+# A LOSER DOES NOT WAIT. It skips this iteration's sweep and carries on, after the usual
+# latch read: the sweep is a 6-hourly hygiene probe, so "a peer is doing it right now" is a
+# complete answer, and waiting would put the box's whole spawn path behind one fsck.
+# ---------------------------------------------------------------------------
+
+# obj_sweep_claim_path <stamp-path> — the claim that belongs to that stamp. Derived from
+# the stamp, so it is keyed on the SHARED STORE (the resource being contended) and a pinned
+# OBJ_SWEEP_STAMP relocates the stamp, the latch and the claim together.
+obj_sweep_claim_path() {
+  local stamp="$1"
+  [[ -n "$stamp" ]] || return 0
+  printf '%s.sweeping' "$stamp"
+}
+
+# obj_sweep_claim_stale_secs <sweep-script> — the age at which a claim may be TAKEN OVER;
+# nothing (exit 1) when it cannot be derived.
+#
+# DERIVED, NOT A CONSTANT, BECAUSE THE HAZARD IS REAL IN BOTH DIRECTIONS. A lane killed
+# mid-sweep leaves its claim behind, and with no recovery no lane on the box ever sweeps
+# again — strictly worse than the herd. But a threshold shorter than a legitimate sweep
+# would let a peer take over a claim whose sweep is still running, which is the herd back
+# again with a stolen claim on top. So: one invocation spends at most MAX_SWEEP_WALKS
+# bounded walks — DECLARED in the sweep script and READ FROM IT here rather than re-typed
+# (round 4's lesson: a relation whose own constant is restated in its consumer is two magic
+# numbers wearing a relation's clothes) — and each walk is bounded by the
+# OBJ_SWEEP_TIMEOUT_SECS this supervisor passes. The earliest safe threshold is their
+# PRODUCT, plus OBJ_SWEEP_CLAIM_SLACK_SECS for what is not inside a walk. With the shipped
+# defaults that is 3 x 200 + 60 = 660s.
+#
+# IF IT CANNOT BE DERIVED, NO CLAIM IS TAKEN AT ALL and the caller announces it once. That
+# is the non-wedging direction: without a bound a stale claim could never be recovered, and
+# an unrecoverable claim is worse than the herd it prevents, so the mechanism degrades to
+# exactly the previous behaviour instead of inventing a number nobody measured.
+obj_sweep_claim_stale_secs() {
+  local script="$1" walks
+  [[ -n "$script" && -r "$script" ]] || return 1
+  walks="$({ grep -m1 '^MAX_SWEEP_WALKS=' "$script" || true; } 2>/dev/null)"
+  walks="${walks#MAX_SWEEP_WALKS=}"
+  walks="${walks%%[!0-9]*}"
+  [[ "$walks" =~ ^[0-9]+$ ]] || return 1
+  [[ "$walks" -ge 1 ]] || return 1
+  printf '%s' "$((walks * OBJ_SWEEP_TIMEOUT_SECS + OBJ_SWEEP_CLAIM_SLACK_SECS))"
+}
+
+# obj_sweep_claim_acquire <claim-dir> <stale-secs> — try to become the one lane sweeping
+# this store. Sets OBJ_SWEEP_CLAIM_STATE to exactly one of:
+#
+#   acquired    — this lane created the claim and owns it
+#   taken       — this lane RECOVERED a stale claim and owns it
+#   held        — a peer lane is sweeping; this lane must skip
+#   unavailable — no claim could be taken at all (no key, or no derivable recovery bound),
+#                 so the caller sweeps unserialised exactly as it did before this existed
+#
+# IT SETS GLOBALS RATHER THAN PRINTING, deliberately: a command substitution would run it
+# in a SUBSHELL, and OBJ_SWEEP_CLAIM_OWNED — the registration the EXIT trap reads — would
+# be lost with that subshell. The registration must happen in THIS shell, on the line after
+# the create, or a lane killed a moment later leaves a claim its own exit will not release.
+obj_sweep_claim_acquire() {
+  local claim="$1" stale="$2" now started age
+  OBJ_SWEEP_CLAIM_STATE=unavailable
+  [[ -n "$claim" ]] || return 0
+  [[ "$stale" =~ ^[0-9]+$ ]] || return 0
+  now="$(date +%s)"
+  if mkdir "$claim" 2>/dev/null; then
+    OBJ_SWEEP_CLAIM_OWNED="$claim"
+    obj_sweep_claim_mark_started "$claim" "$now"
+    OBJ_SWEEP_CLAIM_STATE=acquired
+    return 0
+  fi
+  # Not ours, and not creatable. If there is no directory there at all, this is not
+  # contention — it is a name we cannot use (an unwritable parent, a file in the way) — and
+  # claiming nothing is the honest answer rather than reading it as a peer.
+  [[ -d "$claim" ]] || return 0
+  # THE AGE COMES FROM A FILE THIS CODE WROTE, NOT FROM mtime. `stat` is GNU-vs-BSD
+  # incompatible (the same reason bootstrap verifies a mode with `find -perm`), and the
+  # throttle stamp beside it already records an epoch this way.
+  started=""
+  { read -r started || true; } <"$claim/started" 2>/dev/null || true
+  if [[ "$started" =~ ^[0-9]+$ ]] && [[ "$started" -le "$now" ]]; then
+    age=$((now - started))
+    if [[ "$age" -le "$stale" ]]; then
+      OBJ_SWEEP_CLAIM_STATE=held
+      return 0
+    fi
+  fi
+  # NO PARSEABLE START TIME — OR ONE IN THE FUTURE — COUNTS AS STALE, and the direction is
+  # deliberate. Its cause is a lane killed in the microseconds between the `mkdir` and the
+  # `started` write (or a clock that moved), and the alternative reading — "keep it" —
+  # wedges the box's sweep FOREVER on a file nobody can age. Cost of this direction: if a
+  # peer is taken over inside that microsecond window, two lanes sweep once. One extra
+  # sweep is recoverable; an unrecoverable claim is not. The throttle stamp treats a future
+  # timestamp the same way, for the same reason.
+  #
+  # `mv` THEN `mkdir`: rename(2) is atomic, so of N lanes finding one stale claim exactly
+  # ONE can move it aside — and the `mkdir` that follows is the arbiter of ownership
+  # anyway, so a lane whose rename lost still ends up `held` rather than sweeping beside
+  # the winner.
+  mv "$claim" "$claim.stale.$$" 2>/dev/null || true
+  rm -rf "$claim.stale.$$" 2>/dev/null || true
+  if mkdir "$claim" 2>/dev/null; then
+    OBJ_SWEEP_CLAIM_OWNED="$claim"
+    obj_sweep_claim_mark_started "$claim" "$now"
+    OBJ_SWEEP_CLAIM_STATE=taken
+    return 0
+  fi
+  OBJ_SWEEP_CLAIM_STATE=held
+  return 0
+}
+
+# obj_sweep_claim_mark_started <claim-dir> <epoch> — record WHEN the sweep this claim
+# represents began, which is the only thing that makes the claim recoverable. A failed
+# write is not fatal and is not silent: the claim still serialises, and a peer will read it
+# as unageable and therefore stale, which is the recoverable direction.
+obj_sweep_claim_mark_started() {
+  local claim="$1" epoch="$2"
+  printf '%s\n' "$epoch" 2>/dev/null >"$claim/started" ||
+    log "object-store sweep: could not record a start time in the sweep claim $claim — a peer will read it as unageable and may sweep beside this lane (#3749)"
+  return 0
+}
+
+# obj_sweep_claim_release <claim-dir> — give the claim up. Called BOTH from the sweep path
+# (so the next interval is contended honestly) AND from the EXIT trap (so a lane that stops
+# mid-iteration does not make its peers wait out the staleness bound). Removing a claim that
+# is no longer ours is not a hazard the way it is for the supervisor lock: a claim is
+# advisory, its only effect is to make a peer skip ONE 6-hourly probe, and this only ever
+# runs for the exact path this process recorded in OBJ_SWEEP_CLAIM_OWNED.
+obj_sweep_claim_release() {
+  local claim="$1"
+  [[ -n "$claim" ]] || return 0
+  rm -rf -- "$claim" 2>/dev/null || true
+  [[ "$OBJ_SWEEP_CLAIM_OWNED" != "$claim" ]] || OBJ_SWEEP_CLAIM_OWNED=""
+  return 0
+}
+
+# obj_sweep_stamp_is_fresh <stamp-path> — 0 when this box swept inside the interval.
+#
+# ONE implementation, because the throttle is now read TWICE: once before contending for
+# the claim, and again after winning it — the winner of a race may have finished sweeping
+# and written the stamp while this lane was deciding, and re-reading is what stops the
+# claim from converting a herd into a queue of redundant sweeps.
+#
+# A stamp in the FUTURE (clock skew, a hand-edited file, a restored snapshot) must not park
+# the sweep forever: it reads as never-swept. It does NOT clear the CORRUPT latch, which is
+# a fact about the store rather than about when it was last measured.
+obj_sweep_stamp_is_fresh() {
+  local stamp="$1" now last=0 ts=""
+  [[ -n "$stamp" && -r "$stamp" ]] || return 1
+  now="$(date +%s)"
+  { read -r ts || true; } <"$stamp" 2>/dev/null || true
+  [[ "$ts" =~ ^[0-9]+$ ]] && last="$ts"
+  [[ "$last" -gt "$now" ]] && last=0
+  [[ $((now - last)) -lt $((OBJ_SWEEP_INTERVAL_HOURS * 3600)) ]]
+}
+
 # obj_sweep_set_latch <latch-path> — record MONOTONICALLY that this box's shared object
 # store has been found damaged. Exits 0 when the latch is in place AFTERWARDS (whether
 # this call created it or found a peer's), 1 when it could not be persisted at all.
@@ -3554,7 +3753,7 @@ obj_sweep_stop_if_latched() {
 }
 
 object_store_sweep() {
-  local script stamp latch latch_ts now last rc out verdict stamp_ts
+  local script stamp latch claim claim_stale rc out verdict
   # ---------------------------------------------------------------------------
   # THE ENTRY LATCH READ. IT IS ABOVE EVERY BRANCH IN THIS FUNCTION, AND THE LINES
   # BEFORE IT ARE ASSIGNMENTS ONLY — NO `if`, NO `return`, NOTHING THAT CAN LEAVE
@@ -3622,20 +3821,6 @@ object_store_sweep() {
   # THE STAMP AND LATCH WERE RESOLVED AT ENTRY, ABOVE, and the "no box-wide key" state is
   # announced there by obj_sweep_stop_if_latched's `unkeyed` branch — the one place that
   # can say it, because it is the branch that could not ask the latch question.
-  now="$(date +%s)"
-  last=0
-  if [[ -n "$stamp" && -r "$stamp" ]]; then
-    stamp_ts=""
-    { read -r stamp_ts || true; } <"$stamp" 2>/dev/null || true
-    last="$stamp_ts"
-  fi
-  [[ "$last" =~ ^[0-9]+$ ]] || last=0
-  # A stamp in the FUTURE (clock skew, a hand-edited file, a restored snapshot) must not
-  # park the sweep forever: treat it as never-swept. It does NOT clear the CORRUPT latch,
-  # which is a fact about the store rather than about when it was last measured — and,
-  # since round 2, is not even in this file.
-  [[ "$last" -gt "$now" ]] && last=0
-
   # A LATCHED BOX STOPS THIS LANE WITHOUT RE-SWEEPING, AND IT IGNORES THE INTERVAL —
   # WHICH IS WHY THE READ THAT ENFORCES IT IS AT THE TOP OF THIS FUNCTION AND NOT HERE.
   #
@@ -3660,10 +3845,48 @@ object_store_sweep() {
   # below: nothing between them can change the latch except a peer, in the microseconds it
   # takes to stat one file, and the reads that DO cover a real window (this lane's own
   # multi-walk sweep) are the ones after it.
-  if [[ -n "$stamp" ]] && [[ $((now - last)) -lt $((OBJ_SWEEP_INTERVAL_HOURS * 3600)) ]]; then
+  if obj_sweep_stamp_is_fresh "$stamp"; then
     # RE-ASKED ON THE THROTTLED PATH. Cheap (one stat), and it keeps ONE rule —
     # "no return that leads to a spawn without a fresh latch read" — instead of a set of
     # paths someone has to remember to audit individually.
+    obj_sweep_stop_if_latched "$latch"
+    return 0
+  fi
+
+  # --- ONE SWEEP PER BOX AT A TIME (#3749 review round 5, item 2) -------------
+  # The throttle alone cannot prevent the herd: the stamp is written at the END of a sweep,
+  # so every lane reads the same stale stamp at the same moment and all of them start their
+  # own full-store fsck. See the obj_sweep_claim_* header for the mechanism and for why the
+  # loser skips instead of waiting.
+  claim="$(obj_sweep_claim_path "$stamp")"
+  claim_stale="$(obj_sweep_claim_stale_secs "$script" || true)"
+  obj_sweep_claim_acquire "$claim" "$claim_stale"
+  case "$OBJ_SWEEP_CLAIM_STATE" in
+    held)
+      log "object-store sweep: SKIPPED — a peer lane on this box holds the sweep claim ($claim), so the shared store is being rehashed by that lane right now. Not waiting, and not sweeping beside it: the sweep is a 6-hourly hygiene probe and one lane paying for it is the whole box's answer (#3749)."
+      obj_sweep_stop_if_latched "$latch"
+      return 0
+      ;;
+    taken)
+      log "object-store sweep: RECOVERED a stale sweep claim ($claim, older than ${claim_stale}s = the sweep's own MAX_SWEEP_WALKS x this supervisor's per-walk bound + slack, so the sweep it represented cannot still be running) — the lane holding it was killed mid-sweep. Sweeping (#3749)."
+      ;;
+    unavailable)
+      # ANNOUNCED ONCE, never inferred from missing lines: without a claim the herd is back,
+      # and that is a property of the box (no box-wide key, or a sweep script whose
+      # MAX_SWEEP_WALKS could not be read to derive a recovery bound), not of the iteration.
+      if [[ "$OBJ_SWEEP_CLAIM_NOTIFIED" -eq 0 ]]; then
+        log "object-store sweep: NO in-progress claim is being taken — there is no box-wide key for this store, or the sweep's own MAX_SWEEP_WALKS could not be read to derive a recovery bound. Every lane on this box may sweep at once when the interval expires (#3749)."
+        OBJ_SWEEP_CLAIM_NOTIFIED=1
+      fi
+      ;;
+  esac
+  # RE-READ THE THROTTLE UNDER THE CLAIM, AND THAT SECOND READ IS WHAT MAKES THE CLAIM
+  # WORTH TAKING. The winner of the race may have finished its sweep and written the stamp
+  # between this lane's first read and its own acquire, so without this the claim would
+  # merely convert N simultaneous sweeps into N sequential ones.
+  if [[ "$OBJ_SWEEP_CLAIM_STATE" != unavailable ]] && obj_sweep_stamp_is_fresh "$stamp"; then
+    log "object-store sweep: SKIPPED — a peer lane finished sweeping this store while this lane was taking the claim, so the box is inside the interval again (#3749)."
+    obj_sweep_claim_release "$claim"
     obj_sweep_stop_if_latched "$latch"
     return 0
   fi
@@ -3744,6 +3967,12 @@ object_store_sweep() {
   # every iteration — and it says nothing about what was found. What a peer lane must
   # not throttle past is recorded separately, and monotonically, by the latch above.
   obj_sweep_write_stamp "$stamp"
+  # AND ONLY THEN THE CLAIM, IN THAT ORDER: a peer that acquires the claim next reads the
+  # stamp this lane just wrote and throttles, instead of paying for a sweep that has just
+  # happened. The CORRUPT branch above does not reach this line — it ends the process — and
+  # the EXIT trap releases the claim there, which is why the claim is registered in
+  # OBJ_SWEEP_CLAIM_OWNED on the line after it is created rather than here.
+  obj_sweep_claim_release "$claim"
 
   if [[ "$rc" -eq 0 && "$verdict" == "VERIFIED" ]]; then
     log "object-store: VERIFIED — $(printf '%s\n' "$out" | { grep '^OBJECT-STORE: measured ' || true; } | head -1)"

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -3746,9 +3746,18 @@ obj_sweep_stop_if_latched() {
   latch_ts="$(head -1 "$latch" 2>/dev/null || true)"
   [[ "$latch_ts" =~ ^[0-9]+$ ]] || latch_ts="<unrecorded>"
   notify "high" "worker-supervisor: SHARED OBJECT STORE CORRUPT (latched)" \
-    "a sweep on this box recorded CORRUPT for the shared git object store every lane here reads. Stopping without re-sweeping. Repair the store, then remove $latch."
+    "a sweep on this box recorded CORRUPT for the shared git object store every lane here reads. Stopping without re-sweeping. Repair the store, then re-run the sweep and require its affirmative verdict BEFORE removing $latch."
   log "object-store: CORRUPT (cached at $latch_ts by a sweep on this box) — stopping; no worker may certify against a damaged shared store (#3749)."
-  log "object-store: REMEDY — stop every lane on this box and re-obtain the objects from the canonical remote; a local 'git gc'/'git repack' CANNOT repair it. THEN CLEAR THE LATCH: rm -f $latch"
+  # THE REMEDY NAMES WHAT ACTUALLY REPAIRS THE STORE (#3749 review round 9, item 2). It
+  # used to say "re-obtain the objects from the canonical remote", which read as
+  # `git fetch --force origin` — the instruction the sweep itself used to print, and
+  # measured to repair NOTHING: `--force` only permits non-fast-forward REF updates and
+  # re-downloads no objects at all. This lane did NOT sweep (that is the point of the
+  # latch), so it has no damage class and no fsck output to quote: it names the two things
+  # that are true for every class, points at the sweep for the class-specific text, and
+  # makes a successful sweep — not a belief — the condition for clearing the latch.
+  log "object-store: REMEDY — stop every lane on this box, then repair the shared store. 'git fetch --force origin' does NOT repair it (--force only permits non-fast-forward REF updates; it re-downloads no objects), and neither does a local 'git gc'/'git repack'. Run 'bash scripts/check-object-store-integrity.sh' for the measured remedy for the damage class it finds (#3749)."
+  log "object-store: CLEAR THE LATCH ONLY AFTER that sweep completes and reports its affirmative verdict — 'I think I fixed it' is not an exit condition: rm -f $latch"
   finalize_exit "object-store-corrupt" 1
 }
 
@@ -3977,7 +3986,20 @@ object_store_sweep() {
     notify "high" "worker-supervisor: SHARED OBJECT STORE CORRUPT" \
       "git fsck reports damaged objects in this box's shared git object store — every lane here reads it, so NO gate verdict on this box can be trusted. Stopping. ${findings:-<no findings captured>}"
     log "object-store: CORRUPT — stopping loudly; no worker may certify against a damaged shared store (#3749). ${findings:-<no findings captured>}"
-    log "object-store: REMEDY — stop every lane on this box and re-obtain the objects from the canonical remote; a local 'git gc'/'git repack' CANNOT repair it.${latch:+ THEN CLEAR THE LATCH: rm -f $latch}"
+    # THE REMEDY IS QUOTED FROM THE SWEEP, NEVER RESTATED (#3749 review round 9, item 2).
+    # This lane HAS the sweep's output, and the sweep knows which damage class it found —
+    # the repair differs by class, and it was measured there. Restating it here is how the
+    # wrong instruction ('git fetch --force origin', which re-downloads no objects and
+    # repairs nothing) survived in three files at once.
+    printf '%s\n' "$out" | { grep '^OBJECT-STORE: verdict-detail ' || true; } | head -40 | while IFS= read -r obj_line; do
+      log "object-store: $obj_line"
+    done
+    # FAIL-CLOSED ON THE DIAGNOSTIC: an older, newer or stubbed sweep may print no
+    # guidance, and a stopping lane must never leave an operator with none.
+    if ! printf '%s\n' "$out" | grep -q '^OBJECT-STORE: verdict-detail REMEDY'; then
+      log "object-store: REMEDY — this sweep printed no operator guidance (an older or stubbed check-object-store-integrity.sh). Stop every lane on this box and run 'bash scripts/check-object-store-integrity.sh' by hand for the measured remedy; 'git fetch --force origin' does NOT repair a damaged store and neither does a local 'git gc'/'git repack' (#3749)."
+    fi
+    log "object-store: CLEAR THE LATCH ONLY AFTER a re-run of that sweep reports its affirmative verdict — 'I think I fixed it' is not an exit condition.${latch:+ rm -f $latch}"
     finalize_exit "object-store-corrupt" 1
   fi
 

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -3266,6 +3266,11 @@ OBJ_SWEEP_CLAIM_NOTIFIED=0
 # roborev-job-282 ruling: a fix that adds a resource inherits that resource's lifetime
 # bugs, so register it the moment it exists and clear it the moment it is released).
 OBJ_SWEEP_CLAIM_OWNED=""
+# THE OWNERSHIP TOKEN THIS PROCESS WRITES INTO ITS OWN CLAIM (#3749 review round 11, item
+# 2). It is what makes a release ASK before deleting: the path alone cannot tell this
+# lane's claim from a SUCCESSOR's claim at the same path. Set once, on the line after the
+# claim is created; empty until then, and an empty token can never match anything.
+OBJ_SWEEP_CLAIM_TOKEN=""
 OBJ_SWEEP_CLAIM_STATE=""
 # SLACK on the claim-staleness bound: what a sweep spends OUTSIDE its bounded fsck walks —
 # process startup, the `--print-store` resolution, output capture, and the notify/journal
@@ -3602,6 +3607,7 @@ obj_sweep_claim_acquire() {
   now="$(date +%s)"
   if mkdir "$claim" 2>/dev/null; then
     OBJ_SWEEP_CLAIM_OWNED="$claim"
+    obj_sweep_claim_mark_owner "$claim"
     obj_sweep_claim_mark_started "$claim" "$now"
     OBJ_SWEEP_CLAIM_STATE=acquired
     return 0
@@ -3638,6 +3644,7 @@ obj_sweep_claim_acquire() {
   rm -rf "$claim.stale.$$" 2>/dev/null || true
   if mkdir "$claim" 2>/dev/null; then
     OBJ_SWEEP_CLAIM_OWNED="$claim"
+    obj_sweep_claim_mark_owner "$claim"
     obj_sweep_claim_mark_started "$claim" "$now"
     OBJ_SWEEP_CLAIM_STATE=taken
     return 0
@@ -3657,17 +3664,110 @@ obj_sweep_claim_mark_started() {
   return 0
 }
 
-# obj_sweep_claim_release <claim-dir> — give the claim up. Called BOTH from the sweep path
-# (so the next interval is contended honestly) AND from the EXIT trap (so a lane that stops
-# mid-iteration does not make its peers wait out the staleness bound). Removing a claim that
-# is no longer ours is not a hazard the way it is for the supervisor lock: a claim is
-# advisory, its only effect is to make a peer skip ONE 6-hourly probe, and this only ever
-# runs for the exact path this process recorded in OBJ_SWEEP_CLAIM_OWNED.
-obj_sweep_claim_release() {
+# obj_sweep_claim_mark_owner <claim-dir> — write THIS process's ownership token into the
+# claim it has just created, and remember it in OBJ_SWEEP_CLAIM_TOKEN.
+#
+# WHY THE CLAIM CARRIES AN OWNER AT ALL (#3749 review round 11, item 2). The release used
+# to `rm -rf` the claim PATH unconditionally, and a path is not an identity: round 5 gave
+# this claim a stale-recovery route, so the directory at that path may be a SUCCESSOR's
+# claim by the time the original owner releases — a lane whose sweep overran the staleness
+# bound, or one on the `unavailable` path that never owned the claim at all and still ran
+# the release at the end of its own sweep. Deleting it then permits a second concurrent
+# full-store fsck, which is exactly the herd the claim exists to prevent.
+#
+# THE TOKEN IS WRITTEN BEFORE `started`, and that ordering is the one property worth
+# having: `started` is what makes a claim AGEABLE by a peer, so writing the owner first
+# means a claim a peer can age is a claim that also names its owner. The only way to get
+# `started` without `owner` is a write failure, which is reported.
+#
+# IT IS NOT A SECURITY BOUNDARY. `$$` plus the epoch plus `$RANDOM` distinguishes
+# concurrent and successive lanes on one box, which is the entire question here; a peer
+# that wanted to forge it could simply write the file, and a same-host peer able to do
+# that is invoker-class (#3312's triage rule).
+obj_sweep_claim_mark_owner() {
   local claim="$1"
+  OBJ_SWEEP_CLAIM_TOKEN="$$.$(date +%s).${RANDOM}${RANDOM}"
+  printf '%s\n' "$OBJ_SWEEP_CLAIM_TOKEN" 2>/dev/null >"$claim/owner" || {
+    # THE TOKEN IS DROPPED, NOT KEPT, when it could not be recorded: keeping it would make
+    # every later ownership test answer `unknown` for a claim this lane does own, and the
+    # honest state is "this lane cannot prove ownership of that claim". The consequence is
+    # named: this lane will not delete it, so peers wait out the staleness bound once.
+    OBJ_SWEEP_CLAIM_TOKEN=""
+    log "object-store sweep: could not record an ownership token in the sweep claim $claim — this lane will NOT remove that claim when it finishes (it cannot prove the claim is still its own), so peer lanes will skip their sweep until the claim ages past the recovery bound (#3749)"
+  }
+  return 0
+}
+
+# obj_sweep_claim_owner_state <claim-dir> — FOUR-VALUED, on stdout:
+#   ours     — the token in that claim is the one THIS process wrote (affirmative)
+#   other    — a token was read and it is NOT ours: a successor owns this claim
+#   gone     — there is no claim at that path (nothing to release)
+#   unknown  — the token could not be read while something IS at that path
+# Only `ours` licenses a delete. `other`, `gone` and `unknown` are all non-deleting, so a
+# probe that fails cannot destroy a peer's claim — the cost of that direction is a claim
+# left behind, which round 5's stale recovery already handles.
+obj_sweep_claim_owner_state() {
+  local claim="$1" tok=""
+  [[ -n "$claim" ]] || { printf 'gone'; return 0; }
+  { read -r tok || true; } <"$claim/owner" 2>/dev/null || tok=""
+  if [[ -n "$tok" && -n "$OBJ_SWEEP_CLAIM_TOKEN" && "$tok" == "$OBJ_SWEEP_CLAIM_TOKEN" ]]; then
+    printf 'ours'
+    return 0
+  fi
+  if [[ -n "$tok" ]]; then
+    printf 'other'
+    return 0
+  fi
+  # NO TOKEN READ. Distinguish "the claim is not there" from "it is there and its token
+  # could not be read" — same answer (do not delete), different journal line, and the
+  # unreadable case is the one worth seeing. `-e` is asked SECOND and only to choose the
+  # message, so its own two-valuedness cannot make a delete happen.
+  if [[ -e "$claim" || -L "$claim" ]]; then
+    printf 'unknown'
+  else
+    printf 'gone'
+  fi
+  return 0
+}
+
+# obj_sweep_claim_release <claim-dir> — give the claim up, IF IT IS STILL OURS. Called BOTH
+# from the sweep path (so the next interval is contended honestly) AND from the EXIT trap
+# (so a lane that stops mid-iteration does not make its peers wait out the staleness
+# bound).
+#
+# WHAT THIS GUARANTEES, AND WHAT IT DOES NOT (#3749 review round 11, item 2). It removes
+# the claim only after reading an ownership token that is this process's own, so the
+# "delete a successor's claim" route is closed for every case except one: the read and the
+# `rm` are two operations, so a takeover landing BETWEEN them is still deleted. That window
+# is microseconds wide and needs a claim to be taken over in it; the previous behaviour was
+# to delete unconditionally, always. THIS IS NOT ATOMIC and is not claimed to be — a
+# rename-then-verify would make the removal atomic but would move a successor's claim
+# aside before it could be checked, and restoring it is not atomic either (and `mv` onto an
+# existing directory moves INTO it). The harm bound is unchanged from the claim's own
+# design: a wrongly-removed claim costs a second concurrent 6-hourly probe, never a wrong
+# verdict.
+obj_sweep_claim_release() {
+  local claim="$1" state
   [[ -n "$claim" ]] || return 0
-  rm -rf -- "$claim" 2>/dev/null || true
-  [[ "$OBJ_SWEEP_CLAIM_OWNED" != "$claim" ]] || OBJ_SWEEP_CLAIM_OWNED=""
+  state="$(obj_sweep_claim_owner_state "$claim")"
+  case "$state" in
+    ours)
+      rm -rf -- "$claim" 2>/dev/null || true
+      OBJ_SWEEP_CLAIM_TOKEN=""
+      ;;
+    other)
+      log "object-store sweep: NOT removing the sweep claim $claim — it carries another lane's ownership token, so this claim was taken over after this lane acquired it (its sweep overran the recovery bound, or this lane never owned it). Removing it would permit a second concurrent full-store fsck (#3749)."
+      ;;
+    unknown)
+      log "object-store sweep: NOT removing the sweep claim $claim — its ownership token could not be read, so this lane cannot tell its own claim from a successor's. Leaving it for the staleness bound to recover (#3749)."
+      ;;
+  esac
+  # THE REGISTRATION IS CLEARED FOR EVERY STATE EXCEPT `unknown`, where the read itself may
+  # have failed transiently and the EXIT trap gets one more attempt. `other` and `gone` are
+  # settled answers: there is nothing at that path for this lane to release.
+  if [[ "$state" != unknown ]]; then
+    [[ "$OBJ_SWEEP_CLAIM_OWNED" != "$claim" ]] || OBJ_SWEEP_CLAIM_OWNED=""
+  fi
   return 0
 }
 
@@ -3842,9 +3942,17 @@ obj_sweep_stop_if_latched() {
       stop_reason="object-store-corrupt"
       ;;
     UNSWEEPABLE)
+      # THE LATCH RECORDS THE TOKEN AND NOTHING ELSE, so this text may only assert what is
+      # true of EVERY cause of that token — and since #3749 review round 11 there are two
+      # (git fsck ran and reproducibly died; or the store's own config sets fsck.* keys, so
+      # no walk was run at all). The earlier wording named the first mechanism as though it
+      # were the only one, which on the second cause is a confidently-wrong sentence in the
+      # one place an operator reads when the box has stopped. What the reader knows is the
+      # DISPOSITION, so that is all it says; the CAUSE is named by the sweep that recorded
+      # it, in the journal of the lane that stopped.
       notify "high" "worker-supervisor: SHARED OBJECT STORE could not be SWEPT (latched)" \
-        "a sweep on this box recorded that git fsck RAN and reproducibly DIED without finishing over the shared git object store every lane here reads, so its integrity is UNKNOWN and NO cause was established. Stopping without re-sweeping. Run 'bash scripts/check-object-store-integrity.sh' by hand, act on what its fatal line names, and require its affirmative verdict BEFORE removing $latch."
-      log "object-store: UNSWEEPABLE (cached at $latch_ts by a sweep on this box) — git fsck ran and reproducibly died without finishing over this store, so its object content is UNKNOWN, not clean. Stopping. NO cause was established: this is NOT a damage finding (#3749)."
+        "a sweep on this box recorded that the shared git object store every lane here reads could NOT be swept to an affirmative verdict, so its integrity is UNKNOWN and NO damage was established. Stopping without re-sweeping. Run 'bash scripts/check-object-store-integrity.sh' by hand, act on what THAT run reports, and require its affirmative verdict BEFORE removing $latch."
+      log "object-store: UNSWEEPABLE (cached at $latch_ts by a sweep on this box) — that sweep could not obtain an affirmative verdict for this store, so its object content is UNKNOWN, not clean. Stopping. NO damage was established: this is NOT a damage finding, and this reader knows only the verdict, not which of its causes fired (#3749)."
       stop_reason="object-store-unsweepable"
       ;;
     *)
@@ -4092,9 +4200,13 @@ object_store_sweep() {
         stop_reason="object-store-corrupt"
         ;;
       *)
-        stop_headline="UNSWEEPABLE — git fsck RAN and reproducibly DIED without finishing over this box's shared store, so its object content is UNKNOWN, not clean. Stopping. NO cause was established: this is NOT a damage finding (#3749)."
+        # ONE TOKEN, TWO CAUSES (#3749 review round 11, item 1): the fatal-death branch and
+        # the refusal to walk a store whose own config sets fsck.* keys. This text is
+        # derived from the TOKEN, so it asserts only the disposition; the sweep's own
+        # verdict-detail lines are quoted verbatim below and they name the cause.
+        stop_headline="UNSWEEPABLE — this box's shared store could NOT be swept to an affirmative verdict, so its object content is UNKNOWN, not clean. Stopping. NO damage was established: this is NOT a damage finding, and the sweep's own lines below say what it observed (#3749)."
         stop_title="worker-supervisor: SHARED OBJECT STORE could not be SWEPT"
-        stop_body="git fsck ran and DIED without finishing on TWO independent walks over this box's shared git object store — every lane here reads it, so NO gate verdict on this box can be trusted. Stopping. NO cause was established; act on what the sweep's fatal line names."
+        stop_body="the sweep could NOT obtain an affirmative verdict for this box's shared git object store — every lane here reads it, so NO gate verdict on this box can be trusted. Stopping. NO damage was established; act on what the sweep reported."
         stop_reason="object-store-unsweepable"
         ;;
     esac

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -3999,7 +3999,16 @@ object_store_sweep() {
     if ! printf '%s\n' "$out" | grep -q '^OBJECT-STORE: verdict-detail REMEDY'; then
       log "object-store: REMEDY — this sweep printed no operator guidance (an older or stubbed check-object-store-integrity.sh). Stop every lane on this box and run 'bash scripts/check-object-store-integrity.sh' by hand for the measured remedy; 'git fetch --force origin' does NOT repair a damaged store and neither does a local 'git gc'/'git repack' (#3749)."
     fi
-    log "object-store: CLEAR THE LATCH ONLY AFTER a re-run of that sweep reports its affirmative verdict — 'I think I fixed it' is not an exit condition.${latch:+ rm -f $latch}"
+    # AND THE CLEARING INSTRUCTION IS PRINTED ONLY WHERE THERE IS SOMETHING TO CLEAR. On
+    # the un-latchable path (above) no latch exists, and naming one would be a second
+    # confidently-wrong instruction — the exact class item 2 removed — pointing an operator
+    # at a file that is not there while the real state (peers will re-sweep) was logged
+    # separately.
+    if [[ "$latched" -eq 1 ]]; then
+      log "object-store: CLEAR THE LATCH ONLY AFTER a re-run of that sweep reports its affirmative verdict — 'I think I fixed it' is not an exit condition: rm -f $latch"
+    else
+      log "object-store: there is NO latch to clear (this verdict could not be recorded box-wide) — repair the store, then re-run the sweep and require its affirmative verdict before resuming any lane (#3749)."
+    fi
     finalize_exit "object-store-corrupt" 1
   fi
 

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -3322,6 +3322,10 @@ object_store_sweep() {
     cached="$stamp_verdict"
   fi
   [[ "$last" =~ ^[0-9]+$ ]] || last=0
+  # A stamp in the FUTURE (clock skew, a hand-edited file, a restored snapshot) must not
+  # park the sweep forever: treat it as never-swept. It does NOT clear a recorded CORRUPT,
+  # which is a fact about the store rather than about when it was last measured.
+  [[ "$last" -gt "$now" ]] && last=0
   # Only the exact token is honoured; anything else is treated as no cached verdict.
   [[ "$cached" == "CORRUPT" ]] || cached=""
 

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -3379,15 +3379,54 @@ obj_sweep_latch_path() {
   printf '%s.CORRUPT' "$stamp"
 }
 
-# obj_sweep_latch_present <latch-path> — is the latch in place?
+# obj_sweep_latch_state <latch-path> — the latch question, answered in FOUR values on
+# stdout: `present`, `absent`, `unknown` or `unkeyed`.
 #
-# `-e || -L` rather than a bare `-e`: a DANGLING symlink at that name is `-e`-false, and
-# the fail-safe reading of "something is at the latch path" is that the box is latched.
-# Same idiom, same reason, as the supervisor lock's existence test above.
+# WHY IT IS NOT A FILE PREDICATE (CLAUDE.md's standing rule, #3749 review round 5 item 1).
+# Every `test`/`[` file predicate is TWO-valued, so it has to collapse "cannot tell" onto
+# one of its two answers — and it always picks the permissive one. `[[ -e "$latch" ]]` is
+# FALSE both for a latch that is genuinely absent and for a latch this process cannot look
+# at, and reading the second as the first is a fail-open on the one file whose entire job
+# is to stop this box.
+#
+#   present — something is at that path. `-e || -L`, because a DANGLING symlink is
+#             `-e`-false and the fail-safe reading of "something is at the latch path" is
+#             LATCHED. Same idiom, same reason, as the supervisor lock's existence test.
+#   absent  — nothing is there AND the directory that would hold it was searchable and
+#             readable, so this is a MEASUREMENT and not a failure to look. A directory
+#             that does not exist yields `absent` too: no file can be inside it.
+#   unknown — the directory exists and this process cannot search or read it, so a latch
+#             may be sitting there unread. NEVER folded into `absent`.
+#   unkeyed — there is no latch PATH at all, because the box-wide key could not be
+#             derived. A different statement from all three above: it is not that the file
+#             is unreadable, it is that no file was ever named. The caller decides, and
+#             says why at the branch.
+obj_sweep_latch_state() {
+  local latch="$1" dir
+  [[ -n "$latch" ]] || {
+    printf 'unkeyed'
+    return 0
+  }
+  if [[ -e "$latch" || -L "$latch" ]]; then
+    printf 'present'
+    return 0
+  fi
+  dir="${latch%/*}"
+  [[ "$dir" == "$latch" ]] && dir="."
+  [[ -n "$dir" ]] || dir="/"
+  if [[ ! -d "$dir" ]] || { [[ -x "$dir" ]] && [[ -r "$dir" ]]; }; then
+    printf 'absent'
+    return 0
+  fi
+  printf 'unknown'
+}
+
+# obj_sweep_latch_present <latch-path> — is the latch in place? The affirmative half of
+# obj_sweep_latch_state, kept as its own name because obj_sweep_set_latch asks exactly
+# this question (did the file end up there?) and nothing else.
 obj_sweep_latch_present() {
   local latch="$1"
-  [[ -n "$latch" ]] || return 1
-  [[ -e "$latch" || -L "$latch" ]]
+  [[ "$(obj_sweep_latch_state "$latch")" == present ]]
 }
 
 # obj_sweep_write_stamp <path> — record WHEN this box last swept. One line, the epoch.
@@ -3447,19 +3486,64 @@ obj_sweep_set_latch() {
   obj_sweep_latch_present "$latch"
 }
 
-# obj_sweep_stop_if_latched <latch-path> — ASK THE LATCH QUESTION AND STOP IF THE ANSWER
-# IS YES. Returns 0 (carry on) when the box is not latched; never returns at all when it
-# is, because finalize_exit ends the process.
+# obj_sweep_stop_if_latched <latch-path> — ASK THE LATCH QUESTION AND STOP UNLESS THE
+# ANSWER IS AN AFFIRMATIVE "no". Returns 0 (carry on) only for `absent` and `unkeyed`;
+# never returns at all for `present` or `unknown`, because finalize_exit ends the process.
 #
-# WHY IT IS A FUNCTION CALLED FROM SEVERAL PLACES RATHER THAN ONE CHECK AT THE TOP
-# (#3749 review round 3, item 1a). The question has to be asked again IMMEDIATELY BEFORE
-# every path that lets this lane go on to spawn a worker, because a PEER can latch the
-# box at any moment — including while this lane's own sweep is in flight, which is up to
-# MAX_SWEEP_WALKS fsck walks. A lane that swept CLEAN while a peer was recording CORRUPT would
-# otherwise return 0 from a sweep whose answer is already known to be superseded.
+# IT IS CALLED AT THE TOP OF object_store_sweep, BEFORE EVERY BRANCH, AND AGAIN BEFORE
+# EVERY RETURN THAT LEADS TO A SPAWN (#3749 review rounds 3 and 5, item 1). Round 3 found
+# THREE returns that reached a spawn without re-reading the latch and fixed all three;
+# round 5 found a FOURTH — the OBJ_SWEEP_INTERVAL_HOURS=0 opt-out, which returned before
+# any latch read at all, so the documented way to disable the sweep also disabled an
+# already-recorded CORRUPT verdict. That is ONE defect arriving through a new door each
+# round, because the shape required every early return to independently remember the
+# check. So the ENTRY read is hoisted above every branch in object_store_sweep: the
+# invariant is now "this function cannot be ENTERED without a latch read", which holds for
+# branches nobody has written yet, and the post-sweep reads stay because a PEER can latch
+# the box WHILE this lane sweeps (up to MAX_SWEEP_WALKS fsck walks).
+#
+# `unknown` STOPS, AND HERE IS THE REASONING AT THE BRANCH. It means the directory holding
+# the latch exists and this process cannot search it, so a CORRUPT verdict may be sitting
+# there unread. The two directions are not symmetric: a false stop is ONE lane exiting with
+# a named, actionable reason an operator fixes in seconds, while a false carry-on is
+# workers certifying merges against a store already known to be damaged. It is also not a
+# plausible self-DoS — that directory is the same box-wide `/tmp` this supervisor puts its
+# own flock in, so a box on which it is unsearchable cannot get this far anyway. It is
+# reported as its OWN reason (`object-store-latch-unreadable`), never as CORRUPT: nothing
+# here observed damage, and claiming it would send an operator to re-clone a healthy store.
+#
+# `unkeyed` CARRIES ON, AND THAT IS THE ONE PERMISSIVE ANSWER (CLAUDE.md #3229: where a
+# signal genuinely SHOULD be permissive, record the why at the branch). No key means no
+# latch was ever NAMED — and the writer derives the name through the same resolver, so on
+# the two box-wide causes (the store cannot be resolved; this host has no digest tool) no
+# lane here could have recorded one either. It is announced once and it costs this lane its
+# throttle, so it re-measures the store itself every iteration and would rediscover damage
+# rather than inherit it. What it does NOT cover is a TRANSIENT resolver failure in THIS
+# lane while a peer keyed and latched successfully: that lane misses the peer's verdict for
+# one iteration. Stopping instead would make a missing or older `check-object-store-
+# integrity.sh` — an ordinary state on any branch cut before #3749 merged — halt every lane
+# on the box for want of a hygiene probe, which is the self-DoS CLAUDE.md rules out.
 obj_sweep_stop_if_latched() {
-  local latch="$1" latch_ts
-  obj_sweep_latch_present "$latch" || return 0
+  local latch="$1" latch_ts state
+  state="$(obj_sweep_latch_state "$latch")"
+  case "$state" in
+    absent)
+      return 0
+      ;;
+    unkeyed)
+      if [[ "$OBJ_SWEEP_NOSTAMP_NOTIFIED" -eq 0 ]]; then
+        log "object-store sweep: no box-wide key for this store — the shared store could not be resolved, or this host has no sha256 digest tool. There is no throttle and NO LATCH: a CORRUPT verdict recorded by a peer cannot be read here, and one found here cannot be recorded for peers. The sweep runs every iteration instead (#3749)."
+        OBJ_SWEEP_NOSTAMP_NOTIFIED=1
+      fi
+      return 0
+      ;;
+    unknown)
+      notify "high" "worker-supervisor: object-store CORRUPT latch UNREADABLE" \
+        "the directory holding this box's CORRUPT latch ($latch) exists and cannot be searched, so a recorded CORRUPT verdict may be sitting there unread. Stopping this lane rather than spawning a worker on an unknown store. This is NOT a corruption finding."
+      log "object-store: the CORRUPT latch state could NOT be read at $latch (its directory exists and is not searchable) — stopping. UNKNOWN is not clean: a peer's verdict may be unread. This is NOT a corruption finding; fix the directory's permissions (#3749)."
+      finalize_exit "object-store-latch-unreadable" 1
+      ;;
+  esac
   latch_ts="$(head -1 "$latch" 2>/dev/null || true)"
   [[ "$latch_ts" =~ ^[0-9]+$ ]] || latch_ts="<unrecorded>"
   notify "high" "worker-supervisor: SHARED OBJECT STORE CORRUPT (latched)" \
@@ -3471,17 +3555,58 @@ obj_sweep_stop_if_latched() {
 
 object_store_sweep() {
   local script stamp latch latch_ts now last rc out verdict stamp_ts
+  # ---------------------------------------------------------------------------
+  # THE ENTRY LATCH READ. IT IS ABOVE EVERY BRANCH IN THIS FUNCTION, AND THE LINES
+  # BEFORE IT ARE ASSIGNMENTS ONLY — NO `if`, NO `return`, NOTHING THAT CAN LEAVE
+  # (#3749 review round 5, item 1).
+  #
+  # THE HISTORY IS THE POINT. Round 3 found "a return path that reaches a spawn without
+  # re-reading the latch" at THREE sites and fixed all three; round 5 found a FOURTH, the
+  # OBJ_SWEEP_INTERVAL_HOURS=0 opt-out, which returned before any latch read — so the
+  # documented way to switch the sweep OFF also switched off an already-recorded CORRUPT
+  # verdict, contradicting "a latch ignores the interval". Patching the fourth site would
+  # have left a fifth for the next reviewer, because the design required EVERY early
+  # return to independently remember the check. The read is therefore hoisted here, ONCE,
+  # at entry: "this function cannot be entered without a latch read" is a property of the
+  # function rather than of a set of sites, and it holds for branches nobody has written
+  # yet. Asserted STRUCTURALLY (test_worker_supervisor.sh, obj-sweep(entry-latch-read)):
+  # the first control-flow line in this body must come AFTER this call, so a future early
+  # return cannot be placed above it without reddening that case.
+  #
+  # THE POST-SWEEP READS STAY. They answer a DIFFERENT question — a peer can latch the box
+  # WHILE this lane sweeps, which is up to MAX_SWEEP_WALKS fsck walks — so the entry read
+  # does not subsume them (round 3, and its RED arm is still in the suite).
+  #
+  # THE COST IS ONE `--print-store` RESOLUTION PER ITERATION, MEASURED AT 5 ms on this
+  # fleet's store (10 runs, 2026-09-02; round 2 measured 7 ms for the same call). The
+  # opt-out path did not pay it before and now does. A supervisor iteration is minutes, so
+  # this is not a trade worth making conditional: a cache would be one more piece of
+  # process-scoped state on a question ("is this box latched?") whose whole value is that
+  # it is asked FRESH.
+  #
+  # THE LATCH PATH CANNOT ALWAYS BE DERIVED, and that is a NAMED state rather than an
+  # absent latch: obj_sweep_latch_state answers `unkeyed`, and obj_sweep_stop_if_latched
+  # announces it once and carries on, with the reasoning — and the residual it leaves — at
+  # that branch.
+  # ---------------------------------------------------------------------------
+  script="$REPO_ROOT/scripts/check-object-store-integrity.sh"
+  stamp="$(obj_sweep_stamp_path "$script")"
+  latch="$(obj_sweep_latch_path "$stamp")"
+  obj_sweep_stop_if_latched "$latch"
   if [[ "$OBJ_SWEEP_INTERVAL_HOURS" -le 0 ]]; then
     # ANNOUNCED, never silent (the CLAIM_CMD-disabled precedent in main()): a hygiene
     # probe that is off must be visible in the journal rather than inferred from missing
     # lines.
+    #
+    # AND IT IS REACHED ONLY AFTER THE ENTRY LATCH READ ABOVE. Disabling the sweep means
+    # "do not spend fsck walks on this box", never "ignore a verdict a sweep already
+    # recorded": the latch is a fact about the store, not a schedule.
     if [[ "$OBJ_SWEEP_ANNOUNCED" -eq 0 ]]; then
-      log "object-store sweep DISABLED (OBJ_SWEEP_INTERVAL_HOURS=0) — this box's SHARED git object store is NOT being rehashed this run (#3749)"
+      log "object-store sweep DISABLED (OBJ_SWEEP_INTERVAL_HOURS=0) — this box's SHARED git object store is NOT being rehashed this run; an existing CORRUPT latch is still honoured (#3749)"
       OBJ_SWEEP_ANNOUNCED=1
     fi
     return 0
   fi
-  script="$REPO_ROOT/scripts/check-object-store-integrity.sh"
   if [[ ! -r "$script" ]]; then
     # PERMISSIVE, AND HERE IS THE REASON, IN CODE (CLAUDE.md #3229: where a signal
     # genuinely SHOULD be permissive, record the why at the branch). The sweep is absent
@@ -3494,17 +3619,9 @@ object_store_sweep() {
     fi
     return 0
   fi
-  stamp="$(obj_sweep_stamp_path "$script")"
-  latch="$(obj_sweep_latch_path "$stamp")"
-  # NO KEY MEANS NO THROTTLE AND NO LATCH, AND THAT IS ANNOUNCED RATHER THAN INFERRED.
-  # Two causes, both named: the sweep script could not resolve the shared store, or this
-  # host has no usable digest tool (see obj_sweep_digest — the key must be injective, so
-  # there is deliberately no fallback to a name two stores could share). Once per run: it
-  # is a property of the box, not of the iteration.
-  if [[ -z "$stamp" && "$OBJ_SWEEP_NOSTAMP_NOTIFIED" -eq 0 ]]; then
-    log "object-store sweep: no box-wide key for this store — the shared store could not be resolved, or this host has no sha256 digest tool. The sweep will run EVERY iteration and a CORRUPT verdict cannot be latched for peer lanes (#3749)."
-    OBJ_SWEEP_NOSTAMP_NOTIFIED=1
-  fi
+  # THE STAMP AND LATCH WERE RESOLVED AT ENTRY, ABOVE, and the "no box-wide key" state is
+  # announced there by obj_sweep_stop_if_latched's `unkeyed` branch — the one place that
+  # can say it, because it is the branch that could not ask the latch question.
   now="$(date +%s)"
   last=0
   if [[ -n "$stamp" && -r "$stamp" ]]; then
@@ -3519,9 +3636,10 @@ object_store_sweep() {
   # since round 2, is not even in this file.
   [[ "$last" -gt "$now" ]] && last=0
 
-  # A LATCHED BOX STOPS THIS LANE WITHOUT RE-SWEEPING, AND IT IGNORES THE INTERVAL.
+  # A LATCHED BOX STOPS THIS LANE WITHOUT RE-SWEEPING, AND IT IGNORES THE INTERVAL —
+  # WHICH IS WHY THE READ THAT ENFORCES IT IS AT THE TOP OF THIS FUNCTION AND NOT HERE.
   #
-  # THE DEFECT THIS EXISTS FOR (#3749 review, BLOCKER A). The throttle is keyed on the
+  # THE DEFECT IT EXISTS FOR (#3749 review, BLOCKER A). The throttle is keyed on the
   # SHARED store and lives in a box-wide directory, so it is genuinely box-wide. When it
   # recorded only a timestamp, the lane that DETECTED corruption stopped — and its three
   # peers then saw a FRESH stamp, skipped their own sweep for the whole interval, and kept
@@ -3530,17 +3648,20 @@ object_store_sweep() {
   #
   # THE LATCH IS A DIFFERENT FILE FROM THE STAMP, ON PURPOSE (round 2, BLOCKER 1): see
   # obj_sweep_set_latch for why a verdict field in the mutable stamp is not monotonic
-  # under concurrency and why a lock was rejected. Here the consequence is simply that
-  # this test is an EXISTENCE test, which no concurrent writer can undo.
+  # under concurrency and why a lock was rejected. The consequence here is simply that the
+  # test is an EXISTENCE test, which no concurrent writer can undo.
   #
   # IT DOES NOT EXPIRE, and it is CLEARED BY HAND. Corruption is non-self-clearing, so an
   # age-based expiry would resume workers over a still-damaged store; the operator who
-  # repairs the store removes the file, and the remedy line below NAMES the path and the
-  # command, because a latch nobody can clear bricks the box after the repair.
-  obj_sweep_stop_if_latched "$latch"
-
+  # repairs the store removes the file, and every message that names the latch names that
+  # exact command, because a latch nobody can clear bricks the box after the repair.
+  #
+  # There is deliberately NO second read between the entry read and the throttle branch
+  # below: nothing between them can change the latch except a peer, in the microseconds it
+  # takes to stat one file, and the reads that DO cover a real window (this lane's own
+  # multi-walk sweep) are the ones after it.
   if [[ -n "$stamp" ]] && [[ $((now - last)) -lt $((OBJ_SWEEP_INTERVAL_HOURS * 3600)) ]]; then
-    # RE-ASKED ON THE THROTTLED PATH TOO. Cheap (one stat), and it keeps ONE rule —
+    # RE-ASKED ON THE THROTTLED PATH. Cheap (one stat), and it keeps ONE rule —
     # "no return that leads to a spawn without a fresh latch read" — instead of a set of
     # paths someone has to remember to audit individually.
     obj_sweep_stop_if_latched "$latch"

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -232,8 +232,8 @@ UNVERIFIED_MAX="${UNVERIFIED_MAX:-2}"
 OBJ_SWEEP_INTERVAL_HOURS="${OBJ_SWEEP_INTERVAL_HOURS:-6}"
 OBJ_SWEEP_TIMEOUT_SECS="${OBJ_SWEEP_TIMEOUT_SECS:-200}"
 # Empty => derived per SHARED STORE in obj_sweep_stamp_path (below), so lanes sharing one
-# object store share one throttle. It also names the CORRUPT latch (`<stamp>.CORRUPT`),
-# so pinning it relocates both files together.
+# object store share one throttle. It also names the STOP latch (`<stamp>.STOP`), so
+# pinning it relocates both files together.
 OBJ_SWEEP_STAMP="${OBJ_SWEEP_STAMP:-}"
 # issue #2670 (roborev 1813): before escalating a non-merged PR state to a
 # mismatch, re-read gh a few times to absorb read-after-merge lag. Env-tunable so
@@ -3354,13 +3354,30 @@ obj_sweep_stamp_path() {
   printf '%s' "${dir}/cqlite-object-store-sweep.${key}.stamp"
 }
 
-# obj_sweep_latch_path <stamp-path> — the CORRUPT latch that belongs to that stamp.
-# Derived from the stamp so the two always live in the same box-wide directory and a
-# pinned OBJ_SWEEP_STAMP relocates both.
+# obj_sweep_latch_path <stamp-path> — the STOP latch that belongs to that stamp. Derived
+# from the stamp so the two always live in the same box-wide directory and a pinned
+# OBJ_SWEEP_STAMP relocates both.
+#
+# ONE FILE, ONE QUESTION: "is this box stopped?" — AND ITS NAME CLAIMS NO CAUSE (#3749
+# review round 10, item 1). It was `<stamp>.CORRUPT`, which was accurate while damage was
+# the only stopping verdict. It is not any more: a sweep that RAN and reproducibly DIED
+# without finishing also stops the box, and it establishes NO cause — so a file called
+# `.CORRUPT` would have been a confidently-wrong claim in the one artifact an operator
+# finds on disk, and every message naming that path would have sent them to the re-clone
+# remedy for a store nothing observed damage in. That is round 9's defect (a printed
+# remedy that does not match what was measured) arriving through a file name.
+#
+# WHICH verdict was recorded is therefore CONTENT, read affirmatively by
+# obj_sweep_latch_verdict, and it is safe as content for a reason the throttle stamp's
+# verdict field was not: this file is CREATE-ONLY, so its bytes are written once by the
+# lane that wins the create and no later writer can move them (see obj_sweep_set_latch).
+# TWO FILES WERE THE OTHER OPTION and were rejected: the latch question is answered in
+# four values already, and asking it of two paths multiplies those states (present-here,
+# present-there, both, one-unreadable) for no gain — a lane reading either must stop.
 obj_sweep_latch_path() {
   local stamp="$1"
   [[ -n "$stamp" ]] || return 0
-  printf '%s.CORRUPT' "$stamp"
+  printf '%s.STOP' "$stamp"
 }
 
 # obj_sweep_latch_state <latch-path> — the latch question, answered in FOUR values on
@@ -3704,17 +3721,49 @@ obj_sweep_stamp_is_fresh() {
 #     expire either; the operator who repairs the store removes the file, and every
 #     message that mentions the latch names that exact command.
 #
-# THE VERDICT IS THE FILE'S EXISTENCE, ASKED AFTERWARDS — never this call's own exit
+# THE LATCH IS THE FILE'S EXISTENCE, ASKED AFTERWARDS — never this call's own exit
 # status, which cannot tell "a peer got there first" (fine, the box is latched) from
 # "the directory is unwritable" (not fine, and the caller must say so out loud).
+#
+# THE SECOND ARGUMENT IS THE STOPPING VERDICT, FROM A CLOSED SET OF TWO, AND AN
+# UNRECOGNISED VALUE CREATES NOTHING (#3749 review round 10, item 1). A latch whose
+# content a reader cannot recognise can only be reported as a cause-free stop, so writing
+# one would record a fact nobody can act on; refusing instead makes the caller take its
+# own could-not-persist path, which is journalled and forces the throttle stamp stale.
+# Validated here rather than at the two call sites, so a third caller cannot invent a
+# token, and asserted structurally by the suite.
 obj_sweep_set_latch() {
-  local latch="$1"
+  local latch="$1" verdict="${2:-}"
   [[ -n "$latch" ]] || return 1
+  case "$verdict" in
+    CORRUPT | UNSWEEPABLE) ;;
+    *) return 1 ;;
+  esac
   (
     set -C
-    printf '%s\nCORRUPT\n' "$(date +%s)" >"$latch"
+    printf '%s\n%s\n' "$(date +%s)" "$verdict" >"$latch"
   ) 2>/dev/null || true
   obj_sweep_latch_present "$latch"
+}
+
+# obj_sweep_latch_verdict <latch-path> — WHICH stopping verdict the latch records, on
+# stdout: `CORRUPT`, `UNSWEEPABLE`, or `UNRECOGNISED`.
+#
+# AFFIRMATIVE RECOGNITION, AND NOTHING ELSE (CLAUDE.md: a positive verdict requires an
+# affirmative measurement). Only a second line that IS one of the two tokens is reported
+# as that token. Anything else — an empty file, a dangling symlink, a latch written by a
+# newer supervisor, a truncated write — is `UNRECOGNISED`, which its caller reports as a
+# cause-free stop. It is never guessed at and never defaulted to CORRUPT: that would name
+# a cause the box may not have, which is the whole reason the file is no longer called
+# `.CORRUPT`.
+obj_sweep_latch_verdict() {
+  local latch="$1" line
+  line="$(sed -n '2p' "$latch" 2>/dev/null || true)"
+  case "$line" in
+    CORRUPT) printf 'CORRUPT' ;;
+    UNSWEEPABLE) printf 'UNSWEEPABLE' ;;
+    *) printf 'UNRECOGNISED' ;;
+  esac
 }
 
 # obj_sweep_stop_if_latched <latch-path> — ASK THE LATCH QUESTION AND STOP UNLESS THE
@@ -3755,7 +3804,7 @@ obj_sweep_set_latch() {
 # integrity.sh` — an ordinary state on any branch cut before #3749 merged — halt every lane
 # on the box for want of a hygiene probe, which is the self-DoS CLAUDE.md rules out.
 obj_sweep_stop_if_latched() {
-  local latch="$1" latch_ts state
+  local latch="$1" latch_ts state latch_verdict stop_reason
   state="$(obj_sweep_latch_state "$latch")"
   case "$state" in
     absent)
@@ -3769,32 +3818,69 @@ obj_sweep_stop_if_latched() {
       return 0
       ;;
     unknown)
-      notify "high" "worker-supervisor: object-store CORRUPT latch UNREADABLE" \
-        "the directory holding this box's CORRUPT latch ($latch) exists and cannot be searched, so a recorded CORRUPT verdict may be sitting there unread. Stopping this lane rather than spawning a worker on an unknown store. This is NOT a corruption finding."
-      log "object-store: the CORRUPT latch state could NOT be read at $latch (its directory exists and is not searchable) — stopping. UNKNOWN is not clean: a peer's verdict may be unread. This is NOT a corruption finding; fix the directory's permissions (#3749)."
+      notify "high" "worker-supervisor: object-store STOP latch UNREADABLE" \
+        "the directory holding this box's object-store STOP latch ($latch) exists and cannot be searched, so a recorded stopping verdict may be sitting there unread. Stopping this lane rather than spawning a worker on an unknown store. This is NOT a corruption finding."
+      log "object-store: the STOP latch state could NOT be read at $latch (its directory exists and is not searchable) — stopping. UNKNOWN is not clean: a peer's verdict may be unread. This is NOT a corruption finding; fix the directory's permissions (#3749)."
       finalize_exit "object-store-latch-unreadable" 1
       ;;
   esac
   latch_ts="$(head -1 "$latch" 2>/dev/null || true)"
   [[ "$latch_ts" =~ ^[0-9]+$ ]] || latch_ts="<unrecorded>"
-  notify "high" "worker-supervisor: SHARED OBJECT STORE CORRUPT (latched)" \
-    "a sweep on this box recorded CORRUPT for the shared git object store every lane here reads. Stopping without re-sweeping. Repair the store, then re-run the sweep and require its affirmative verdict BEFORE removing $latch."
-  log "object-store: CORRUPT (cached at $latch_ts by a sweep on this box) — stopping; no worker may certify against a damaged shared store (#3749)."
+  # WHICH STOPPING VERDICT WAS RECORDED DECIDES WHAT THIS LANE SAYS, AND IT IS READ
+  # AFFIRMATIVELY (#3749 review round 10, item 1). This lane did NOT sweep — that is the
+  # point of the latch — so everything it can say about the store comes from the file. A
+  # latch recording that the store could not be SWEPT must not be reported as damage: the
+  # detecting sweep established no cause, and repeating a claim it did not make would send
+  # an operator to re-clone a store nothing observed damage in (round 9's defect class).
+  # An unrecognised token is a cause-free stop, never a default to the damage text.
+  latch_verdict="$(obj_sweep_latch_verdict "$latch")"
+  case "$latch_verdict" in
+    CORRUPT)
+      notify "high" "worker-supervisor: SHARED OBJECT STORE CORRUPT (latched)" \
+        "a sweep on this box recorded CORRUPT for the shared git object store every lane here reads. Stopping without re-sweeping. Repair the store, then re-run the sweep and require its affirmative verdict BEFORE removing $latch."
+      log "object-store: CORRUPT (cached at $latch_ts by a sweep on this box) — stopping; no worker may certify against a damaged shared store (#3749)."
+      stop_reason="object-store-corrupt"
+      ;;
+    UNSWEEPABLE)
+      notify "high" "worker-supervisor: SHARED OBJECT STORE could not be SWEPT (latched)" \
+        "a sweep on this box recorded that git fsck RAN and reproducibly DIED without finishing over the shared git object store every lane here reads, so its integrity is UNKNOWN and NO cause was established. Stopping without re-sweeping. Run 'bash scripts/check-object-store-integrity.sh' by hand, act on what its fatal line names, and require its affirmative verdict BEFORE removing $latch."
+      log "object-store: UNSWEEPABLE (cached at $latch_ts by a sweep on this box) — git fsck ran and reproducibly died without finishing over this store, so its object content is UNKNOWN, not clean. Stopping. NO cause was established: this is NOT a damage finding (#3749)."
+      stop_reason="object-store-unsweepable"
+      ;;
+    *)
+      notify "high" "worker-supervisor: shared object store LATCHED (verdict unrecognised)" \
+        "a sweep on this box latched the shared git object store with a stopping verdict this supervisor does not recognise (an older or newer check-object-store-integrity.sh, or a latch that could not be read). Stopping rather than guessing which verdict it was. Run 'bash scripts/check-object-store-integrity.sh' by hand and require its affirmative verdict BEFORE removing $latch."
+      log "object-store: LATCHED with an UNRECOGNISED stopping verdict at $latch (cached at $latch_ts) — stopping. NO cause is claimed: this supervisor will not guess whether damage was found (#3749)."
+      stop_reason="object-store-latch-unrecognised"
+      ;;
+  esac
   # THE REMEDY NAMES WHAT ACTUALLY REPAIRS THE STORE (#3749 review round 9, item 2). It
   # used to say "re-obtain the objects from the canonical remote", which read as
   # `git fetch --force origin` — the instruction the sweep itself used to print, and
   # measured to repair NOTHING: `--force` only permits non-fast-forward REF updates and
   # re-downloads no objects at all. This lane did NOT sweep (that is the point of the
-  # latch), so it has no damage class and no fsck output to quote: it names the two things
-  # that are true for every class, points at the sweep for the class-specific text, and
-  # makes a successful sweep — not a belief — the condition for clearing the latch.
-  log "object-store: REMEDY — stop every lane on this box, then repair the shared store. 'git fetch --force origin' does NOT repair it (--force only permits non-fast-forward REF updates; it re-downloads no objects), and neither does a local 'git gc'/'git repack'. Run 'bash scripts/check-object-store-integrity.sh' for the measured remedy for the damage class it finds (#3749)."
+  # latch), so it has no damage class and no fsck output to quote: for the damage verdict
+  # it names the two things that are true of every damage class, for the others it names
+  # nothing at all (see the branch), it points at the sweep for the class-specific text,
+  # and it makes a successful sweep — not a belief — the condition for clearing the latch.
+  if [[ "$latch_verdict" == CORRUPT ]]; then
+    log "object-store: REMEDY — stop every lane on this box, then repair the shared store. 'git fetch --force origin' does NOT repair it (--force only permits non-fast-forward REF updates; it re-downloads no objects), and neither does a local 'git gc'/'git repack'. Run 'bash scripts/check-object-store-integrity.sh' for the measured remedy for the damage class it finds (#3749)."
+  else
+    # NO REPAIR INSTRUCTION WHERE NO CAUSE WAS ESTABLISHED. The two other verdicts this
+    # latch can carry say the store could not be swept, or say something this supervisor
+    # cannot recognise; naming a repair for either would be a second confidently-wrong
+    # instruction, which is the class round 9 removed. The one thing that is true for all
+    # of them is where to get the class-specific text: the sweep itself.
+    log "object-store: REMEDY — stop every lane on this box, then run 'bash scripts/check-object-store-integrity.sh' by hand and act on what IT names. NO repair instruction is given here because the latched verdict established no cause, and a repair chosen for the wrong cause is worse than none (#3749)."
+  fi
   log "object-store: CLEAR THE LATCH ONLY AFTER that sweep completes and reports its affirmative verdict — 'I think I fixed it' is not an exit condition: rm -f $latch"
-  finalize_exit "object-store-corrupt" 1
+  # PER-VERDICT, so the journal records WHICH stopping fact ended this lane rather than a
+  # generic "it was latched" a reader would have to correlate by timestamp.
+  finalize_exit "$stop_reason" 1
 }
 
 object_store_sweep() {
-  local script stamp latch claim claim_stale rc out verdict
+  local script stamp latch claim claim_stale rc out verdict stop_verdict
   # ---------------------------------------------------------------------------
   # THE ENTRY LATCH READ. IT IS ABOVE EVERY BRANCH IN THIS FUNCTION, AND THE LINES
   # BEFORE IT ARE ASSIGNMENTS ONLY — NO `if`, NO `return`, NOTHING THAT CAN LEAVE
@@ -3981,16 +4067,45 @@ object_store_sweep() {
   # properly. A disagreement therefore falls through to the UNMEASURED path below, which
   # is non-passing, journalled, and paged once — and it is named explicitly there, so the
   # signal is not swallowed on the way past.
+  # ONE STOPPING PATH FOR BOTH STOPPING VERDICTS, AND THAT IS DELIBERATE (#3749 review
+  # round 10, item 1). `UNSWEEPABLE` (the sweep RAN and reproducibly DIED without
+  # finishing; see the sweep script's PASS 2 branch) has to stop this box for the same
+  # reason CORRUPT does — a peer must not throttle past a durable finding — so it goes
+  # through the SAME latch-then-stamp ordering rather than a second copy of it. Four
+  # review rounds hardened that ordering (round 3's latch-before-stamp, round 4's
+  # two-channel conjunction, round 9's stamp gated on a CONFIRMED latch); a copied branch
+  # would inherit none of them, and the structural write-order assert reads THIS body.
+  # Only the operator-facing text differs, and it differs where a `case` says so.
+  stop_verdict=""
   if [[ "$rc" -eq 4 && "$verdict" == "CORRUPT" ]]; then
-    local findings latched=0
+    stop_verdict=CORRUPT
+  elif [[ "$rc" -eq 6 && "$verdict" == "UNSWEEPABLE" ]]; then
+    stop_verdict=UNSWEEPABLE
+  fi
+  if [[ -n "$stop_verdict" ]]; then
+    local findings latched=0 stop_headline stop_title stop_body stop_reason
+    case "$stop_verdict" in
+      CORRUPT)
+        stop_headline="CORRUPT — stopping loudly; no worker may certify against a damaged shared store (#3749)."
+        stop_title="worker-supervisor: SHARED OBJECT STORE CORRUPT"
+        stop_body="git fsck reports damaged objects in this box's shared git object store — every lane here reads it, so NO gate verdict on this box can be trusted. Stopping."
+        stop_reason="object-store-corrupt"
+        ;;
+      *)
+        stop_headline="UNSWEEPABLE — git fsck RAN and reproducibly DIED without finishing over this box's shared store, so its object content is UNKNOWN, not clean. Stopping. NO cause was established: this is NOT a damage finding (#3749)."
+        stop_title="worker-supervisor: SHARED OBJECT STORE could not be SWEPT"
+        stop_body="git fsck ran and DIED without finishing on TWO independent walks over this box's shared git object store — every lane here reads it, so NO gate verdict on this box can be trusted. Stopping. NO cause was established; act on what the sweep's fatal line names."
+        stop_reason="object-store-unsweepable"
+        ;;
+    esac
     # LATCH FIRST, THEN EVERYTHING ELSE. A failure to persist it is REPORTED, never
     # silent: this lane stops either way, but without the latch the peers on this box
     # will re-run their own sweep and rediscover the damage rather than inheriting the
     # verdict, and an operator reading only this journal would otherwise never learn that.
     if [[ -z "$latch" ]]; then
-      log "object-store: the CORRUPT verdict could NOT be latched — this box's shared store could not be resolved, so there is no box-wide file to record it in. Peer lanes will re-sweep and rediscover it (#3749)."
+      log "object-store: the $stop_verdict verdict could NOT be latched — this box's shared store could not be resolved, so there is no box-wide file to record it in. Peer lanes will re-sweep and rediscover it (#3749)."
     else
-      obj_sweep_set_latch "$latch" || true
+      obj_sweep_set_latch "$latch" "$stop_verdict" || true
       # CONFIRMED BY ASKING THE FILE AFTERWARDS, NEVER BY THE CREATE'S EXIT STATUS — the
       # same test obj_sweep_set_latch itself ends on, and for the same reason: a create's
       # status cannot tell "a peer got there first" (fine, the box IS latched) from "the
@@ -3999,7 +4114,7 @@ object_store_sweep() {
       if obj_sweep_latch_present "$latch"; then
         latched=1
       else
-        log "object-store: the CORRUPT verdict could NOT be latched at $latch (unwritable?) — peer lanes will re-sweep and rediscover it rather than inheriting this verdict (#3749)."
+        log "object-store: the $stop_verdict verdict could NOT be latched at $latch (unwritable?) — peer lanes will re-sweep and rediscover it rather than inheriting this verdict (#3749)."
       fi
     fi
     # THE THROTTLE STAMP IS WRITTEN ONLY WHEN THE LATCH IS CONFIRMED IN PLACE (#3749
@@ -4015,9 +4130,9 @@ object_store_sweep() {
       obj_sweep_force_stamp_stale "$stamp"
     fi
     findings="$(printf '%s\n' "$out" | { grep -E '^OBJECT-STORE: (finding|object) ' || true; } | head -6 | tr '\n' ';' | cut -c1-600)"
-    notify "high" "worker-supervisor: SHARED OBJECT STORE CORRUPT" \
-      "git fsck reports damaged objects in this box's shared git object store — every lane here reads it, so NO gate verdict on this box can be trusted. Stopping. ${findings:-<no findings captured>}"
-    log "object-store: CORRUPT — stopping loudly; no worker may certify against a damaged shared store (#3749). ${findings:-<no findings captured>}"
+    notify "high" "$stop_title" \
+      "$stop_body ${findings:-<no findings captured>}"
+    log "object-store: $stop_headline ${findings:-<no findings captured>}"
     # THE REMEDY IS QUOTED FROM THE SWEEP, NEVER RESTATED (#3749 review round 9, item 2).
     # This lane HAS the sweep's output, and the sweep knows which damage class it found —
     # the repair differs by class, and it was measured there. Restating it here is how the
@@ -4041,7 +4156,7 @@ object_store_sweep() {
     else
       log "object-store: there is NO latch to clear (this verdict could not be recorded box-wide) — repair the store, then re-run the sweep and require its affirmative verdict before resuming any lane (#3749)."
     fi
-    finalize_exit "object-store-corrupt" 1
+    finalize_exit "$stop_reason" 1
   fi
 
   # THE STAMP IS WRITTEN FOR EVERY OUTCOME. It bounds how often this box SPENDS the
@@ -4077,8 +4192,8 @@ object_store_sweep() {
   # the other did not, so this run neither established damage nor ruled it out — and the
   # generic UNMEASURED line below would read as an ordinary "could not measure". Loud
   # enough to investigate, and still not a latch (see the CORRUPT branch for why).
-  if [[ "$rc" -eq 4 || "$verdict" == "CORRUPT" ]]; then
-    log "object-store: INCONSISTENT sweep result (rc=$rc verdict='${verdict:-<none>}') — exactly ONE of the exit status and the anchored verdict line says CORRUPT. Treated as UNMEASURED and NOT latched: an incomplete or unrecognised sweep must not stop every lane on this box (#3749). If the next sweep reproduces damage it will latch it; investigate the sweep itself."
+  if [[ "$rc" -eq 4 || "$rc" -eq 6 || "$verdict" == "CORRUPT" || "$verdict" == "UNSWEEPABLE" ]]; then
+    log "object-store: INCONSISTENT sweep result (rc=$rc verdict='${verdict:-<none>}') — exactly ONE of the exit status and the anchored verdict line reports a STOPPING verdict, or the two name different ones. Treated as UNMEASURED and NOT latched: an incomplete or unrecognised sweep must not stop every lane on this box (#3749). If the next sweep reproduces the finding it will latch it; investigate the sweep itself."
   fi
   log "object-store: UNMEASURED (rc=$rc verdict='${verdict:-<none>}') — the shared store was NOT rehashed, so its integrity is UNKNOWN, not clean. Continuing: a hygiene probe that cannot run must not stop the fleet (#3749)."
   printf '%s\n' "$out" | { grep '^OBJECT-STORE: unmeasured-cause ' || true; } | head -4 | while IFS= read -r obj_line; do

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -4064,8 +4064,10 @@ obj_sweep_latch_verdict() {
 # ANSWER IS AN AFFIRMATIVE "no". Returns 0 (carry on) only for `absent` and `unkeyed`;
 # never returns at all for `present` or `unknown`, because finalize_exit ends the process.
 #
-# IT IS CALLED AT THE TOP OF object_store_sweep, BEFORE EVERY BRANCH, AND AGAIN BEFORE
-# EVERY RETURN THAT LEADS TO A SPAWN (#3749 review rounds 3 and 5, item 1). Round 3 found
+# IT IS CALLED AT THE TOP OF object_store_sweep, BEFORE EVERY BRANCH, AGAIN BEFORE EVERY
+# RETURN THAT LEADS TO A SPAWN, AND ONCE MORE ON THE WAY OUT OF preflight_wait — which is
+# where the HOLD LOOP could otherwise carry a lane past a peer's verdict for up to an hour
+# (#3749 review rounds 3, 5 and 13, item 1). Round 3 found
 # THREE returns that reached a spawn without re-reading the latch and fixed all three;
 # round 5 found a FOURTH — the OBJ_SWEEP_INTERVAL_HOURS=0 opt-out, which returned before
 # any latch read at all, so the documented way to disable the sweep also disabled an
@@ -4181,6 +4183,35 @@ obj_sweep_stop_if_latched() {
   finalize_exit "$stop_reason" 1
 }
 
+# obj_sweep_script_path — THE ONE PLACE THAT NAMES THE SWEEP SCRIPT. Two call sites now
+# derive this box's latch path from it (object_store_sweep's entry gate and
+# obj_sweep_stop_if_latched_now), and the latch KEY is derived FROM this path, so two
+# spellings of it would key two different latches: one lane would record a stopping
+# verdict at a name the other never reads, which is the silent-permissive direction.
+obj_sweep_script_path() {
+  printf '%s' "$REPO_ROOT/scripts/check-object-store-integrity.sh"
+}
+
+# obj_sweep_stop_if_latched_now — ASK THE LATCH QUESTION FROM SCRATCH, for a caller that
+# holds no resolved paths of its own. It resolves script -> stamp -> latch through the
+# same three functions object_store_sweep uses and hands the answer to the same gate, so
+# `unknown` still STOPS and `unkeyed` is still the one permissive answer (see
+# obj_sweep_stop_if_latched for the reasoning at each branch — this wrapper adds no
+# policy of its own, deliberately: a second opinion about what a latch state means is a
+# second place for the permissive collapse to reappear).
+#
+# IT RESOLVES FRESH RATHER THAN READING A VALUE object_store_sweep LEFT BEHIND. A global
+# would save one `--print-store` (5 ms, measured) and would be EMPTY on any future path
+# that reaches this gate without having run the sweep first — and an empty latch path
+# answers `unkeyed`, which CARRIES ON. That is a silent fail-open bought for 5 ms of a
+# supervisor iteration measured in minutes.
+obj_sweep_stop_if_latched_now() {
+  local stamp latch
+  stamp="$(obj_sweep_stamp_path "$(obj_sweep_script_path)")"
+  latch="$(obj_sweep_latch_path "$stamp")"
+  obj_sweep_stop_if_latched "$latch"
+}
+
 object_store_sweep() {
   local script stamp latch claim claim_stale wait_until rc out verdict stop_verdict
   # ---------------------------------------------------------------------------
@@ -4217,7 +4248,7 @@ object_store_sweep() {
   # announces it once and carries on, with the reasoning — and the residual it leaves — at
   # that branch.
   # ---------------------------------------------------------------------------
-  script="$REPO_ROOT/scripts/check-object-store-integrity.sh"
+  script="$(obj_sweep_script_path)"
   stamp="$(obj_sweep_stamp_path "$script")"
   latch="$(obj_sweep_latch_path "$stamp")"
   obj_sweep_stop_if_latched "$latch"
@@ -4571,11 +4602,12 @@ object_store_sweep() {
 # what stops the next person looking. So the magnitudes below are stated PER PATH and each is
 # derived from a shipped default or from a measurement, never from the word "moments".
 #
-# WHAT THE ORDERING AND THE WAIT BUY. No lane advertises "this box has been swept" before a
-# stopping finding is durable; no lane returns from object_store_sweep toward a spawn without
-# having re-read the latch; and a lane that LOSES the sweep claim now waits for the peer's
-# verdict, re-reading the latch every OBJ_SWEEP_CLAIM_POLL_SECS, instead of walking off with
-# one stale read.
+# WHAT THE ORDERING, THE WAIT AND THE PREFLIGHT GATE BUY. No lane advertises "this box has
+# been swept" before a stopping finding is durable; no lane returns from object_store_sweep
+# toward a spawn without having re-read the latch; a lane that LOSES the sweep claim waits for
+# the peer's verdict, re-reading the latch every OBJ_SWEEP_CLAIM_POLL_SECS, instead of walking
+# off with one stale read; and no lane returns from preflight_wait — however long its hold
+# loop ran — without one more fresh read (round 13).
 #
 # PATH 1 — THE CLAIM LOSER. CLOSED as a distinct window (round 12). It WAS the peer's whole
 # sweep: 13-80s measured, 600s by construction. It is now bounded by the poll granularity —
@@ -4589,14 +4621,25 @@ object_store_sweep() {
 # post-sweep reads bracket it, so a peer latching the box during this lane's own walks (up to
 # 600s) is caught by the read on the way out.
 #
-# PATH 3 — THE LAST LATCH READ TO THE WORKER SPAWN. STILL OPEN, AND IT IS THE LARGEST OF THE
-# THREE. object_store_sweep returns, and the caller then runs the preflight hold loop, which
-# does NOT re-read the latch: on a clear box the gap is milliseconds, but every hold sleeps
-# HOLD_POLL_SECS and the loop tolerates up to BUILD_HOLD_MAX of them, so at the shipped
-# defaults the gap is up to 12 x 300s = 3600s — ONE HOUR, not "moments" (the leftover-worker
-# family is bounded at LEFTOVER_HOLD_MAX x HOLD_POLL_SECS = 900s). A peer's sweep completing
-# anywhere inside that stretch is unobserved by this lane, and ONE worker then starts on a
-# box that is already latched.
+# PATH 3 — THE LAST LATCH READ TO THE WORKER SPAWN. NARROWED FROM UP TO AN HOUR TO ONE
+# PRE-SPAWN PROLOGUE (round 13), AND IT IS NOT ZERO. It USED to be the largest of the three:
+# object_store_sweep returned, the caller ran the preflight hold loop, and that loop never
+# re-read the latch — every hold sleeps HOLD_POLL_SECS and the loop tolerates up to
+# BUILD_HOLD_MAX of them, so at the shipped defaults a lane could sit for 12 x 300s = 3600s,
+# ONE HOUR (the leftover-worker family is bounded at LEFTOVER_HOLD_MAX x HOLD_POLL_SECS =
+# 900s) and then spawn onto a box a peer had latched meanwhile. preflight_wait is now a
+# WRAPPER around preflight_wait_holds that re-reads the STOP latch on EVERY return out of the
+# loop, so the hold window is closed STRUCTURALLY — as a property of the function boundary,
+# not at an enumerated set of returns (see preflight_wait for why that shape was chosen).
+#
+# WHAT REMAINS IS run_iteration'S PRE-SPAWN PROLOGUE, AND IT IS A NETWORK ROUND-TRIP, NOT
+# "MILLISECONDS". Between that read and `bash -c "$WORKER_CMD"` sit an ITER bump, an `rm -f`,
+# a `mkdir -p`, some assignments — and stamp_claim, which runs CLAIM_CMD `stamp`: a ref PUSH
+# to origin (plus a best-effort delete push on a lane transition). Measured lower bound on
+# this fleet: a bare `git ls-remote origin HEAD` is 0.26-0.28s, and a push negotiates and
+# updates a ref on top of that. The supervisor puts NO timeout on it, so the window is
+# sub-second-to-seconds in practice and UNBOUNDED in principle if the network stalls. A lane
+# with CLAIM_CMD empty pays only the local prologue, which really is milliseconds.
 #
 # THE BOUND ON THE HARM, unchanged and still true for every path. It is not silent and not
 # durable: that lane's NEXT iteration begins with object_store_sweep, whose first act is the
@@ -4604,16 +4647,14 @@ object_store_sweep() {
 # Nothing certifies a merge inside that window without a full gate, and a full gate on a
 # latched box is exactly what the next iteration refuses.
 #
-# WHY PATH 3 IS NOT CLOSED HERE. An atomic "no worker may start after any peer latches"
+# WHY THE REMAINDER IS NOT CLOSED HERE. An atomic "no worker may start after any peer latches"
 # guarantee needs per-store synchronisation shared by the sweep and the spawn decision (a
-# lock held across both, or a spawn-time re-check inside whatever holds that lock) — a
-# redesign of the boundary between this function and the spawn path, not an ordering change.
-# It is split to its own issue, and so is the cheapest partial (a latch read inside the hold
-# loop, which would cut 3600s down to one HOLD_POLL_SECS): that read belongs with the
-# redesign rather than smuggled into a fix for path 1, where it would arrive untested and
-# would tempt exactly the "narrowed, so basically closed" reading this note was rewritten to
-# remove. PATH 1 IS CLOSED; PATH 3 IS OPEN AND ITS MAGNITUDE IS ABOVE. Do not describe the
-# race as gone.
+# lock held across both, with the spawn decision taken inside it) — a redesign of the boundary
+# between this function and the spawn path, not another read. It is split to its own issue. A
+# further latch read immediately before the spawn would shrink the window again and CANNOT
+# remove it: a read and a spawn are two operations, and putting the read after stamp_claim
+# only moves the network round-trip to the other side of it. PATH 1 AND THE HOLD WINDOW ARE
+# CLOSED; THE PRE-SPAWN WINDOW IS OPEN. Do not describe the race as gone.
 
 # ---------------------------------------------------------------------------
 # Preflight: fail-closed, wait-don't-spin. Returns a hold reason on stdout, or
@@ -4665,7 +4706,7 @@ preflight_stop_or_budget() {
   return 0
 }
 
-preflight_wait() {
+preflight_wait_holds() {
   local worker_holds=0 build_holds=0
   # ASKED IMMEDIATELY BEFORE THE SWEEP (#3749 review round 3, item 3). The sweep is the
   # longest uninterruptible step in an iteration, and it used to run BEFORE the hold
@@ -4742,6 +4783,50 @@ preflight_wait() {
     log "HOLD: $reason; sleeping ${HOLD_POLL_SECS}s"
     sleep "$HOLD_POLL_SECS"
   done
+}
+
+# preflight_wait — THE HOLD LOOP, PLUS A FRESH STOP-LATCH READ ON THE WAY OUT
+# (#3749 review round 13).
+#
+# THE DEFECT. The STOP latch was read at the top of object_store_sweep and again before
+# every return out of it — and then this function's hold loop ran, which does not read the
+# latch at all. Every hold sleeps HOLD_POLL_SECS and the loop tolerates up to
+# BUILD_HOLD_MAX of them, so at the shipped defaults a lane could sit here for up to
+# 12 x 300s = ONE HOUR after its last latch read and then spawn a worker on a box a PEER
+# had latched CORRUPT (or UNSWEEPABLE) in the meantime. It was declared as a residual for
+# a round and overruled: the read below is one stat plus one `--print-store`, and it
+# reduces that window from an hour to the code between here and the spawn.
+#
+# WHY A WRAPPER AND NOT A CALL BEFORE THE `return 0`. That is the shape round 3 and round 5
+# already paid for twice in object_store_sweep: "remember the check at every early return"
+# leaves a fifth door for the next reviewer. Splitting the loop into preflight_wait_holds
+# and gating it HERE makes the property structural — every RETURN out of the inner body,
+# including ones nobody has written yet, is followed by the latch read, because the caller
+# never sees the inner function at all. Asserted structurally in test_worker_supervisor.sh
+# (`preflight-latch-gate`), which also requires preflight_wait_holds to have exactly ONE
+# call site, so the gate cannot be bypassed by calling the inner body directly.
+#
+# THE OTHER EXITS ARE NOT RETURNS, AND THEY ARE DELIBERATELY UNTOUCHED. The stop-file,
+# wall-clock-budget and leftover-hold paths end in finalize_exit, which ends the PROCESS:
+# they never reach this gate, they never spawn, and their exit codes are unchanged.
+#
+# WHAT THIS DOES NOT CLOSE. The gap is now the code between this read and the spawn —
+# microseconds, not milliseconds of policy — and closing it entirely needs per-store
+# synchronisation shared by the sweep and the spawn decision (a lock held across both), not
+# another read. Do NOT describe the race as gone.
+preflight_wait() {
+  local rc=0
+  preflight_wait_holds || rc=$?
+  # UNCONDITIONAL, on every return the inner body can make. A non-zero return is not a
+  # reason to skip it: the caller does not test this function's status, so ANY return from
+  # it continues toward a spawn.
+  #
+  # NOT INSIDE A COMMAND SUBSTITUTION, and that is load-bearing (the trap
+  # obj_sweep_claim_wait documents): the gate stops this lane by calling finalize_exit, and
+  # inside `$( )` that would end a SUBSHELL — the wait would appear to return normally and
+  # the lane would spawn on a box it had just seen condemned.
+  obj_sweep_stop_if_latched_now
+  return "$rc"
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -3947,10 +3947,16 @@ obj_sweep_claim_wait() {
   elapsed=$(( $(date +%s) - started_at ))
   case "$OBJ_SWEEP_CLAIM_WAIT_STATE" in
     completed)
-      log "object-store sweep: the peer lane holding $claim FINISHED its sweep after ${elapsed}s of waiting and advertised it in the throttle stamp; this box is not latched (#3749)."
+      # WHAT THIS MAY CLAIM IS BOUNDED BY WHEN IT LOOKED. The pass that observed the fresh
+      # stamp read the latch first and found none, so what is true is that NO STOPPING
+      # VERDICT HAD BEEN RECORDED AS OF THAT READ — not that the box "is not latched" now,
+      # which is a claim about the present that a peer can falsify between this printf and
+      # the next statement. The caller re-reads the latch before it returns toward a spawn;
+      # this line is a journal entry, not a licence.
+      log "object-store sweep: the peer lane holding $claim FINISHED its sweep after ${elapsed}s of waiting and advertised it in the throttle stamp; no stopping verdict had been recorded for this box as of the read that observed it (#3749)."
       ;;
     vacated)
-      log "object-store sweep: the peer lane holding $claim GAVE THE CLAIM UP after ${elapsed}s without advertising a sweep — it was killed mid-sweep, or it stopped on a verdict it could not latch and forced the throttle stamp stale so every lane re-sweeps. This box is not latched; this lane will contend for the claim again (#3749)."
+      log "object-store sweep: the peer lane holding $claim GAVE THE CLAIM UP after ${elapsed}s without advertising a sweep — it was killed mid-sweep, or it stopped on a verdict it could not latch and forced the throttle stamp stale so every lane re-sweeps. No stopping verdict had been recorded for this box as of the read that observed it; this lane will contend for the claim again (#3749)."
       ;;
     expired)
       log "object-store sweep: the peer lane holding $claim has neither finished nor given it up in ${elapsed}s, and that claim is now older than the derived ${stale}s recovery bound, so the sweep it represents cannot still be running. This lane will RECOVER the claim and measure the store itself rather than carry on unmeasured (#3749)."

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -192,22 +192,30 @@ UNVERIFIED_MAX="${UNVERIFIED_MAX:-2}"
 # place for the verdict to drift.
 #
 # OBJ_SWEEP_INTERVAL_HOURS — minimum hours between sweeps, throttled by a stamp file.
-#   Measured cost: 19.83s per sweep on this fleet's 331M store, and a box runs up to 4
-#   lanes, so an UNTHROTTLED sweep would burn ~80s of every iteration cycle across the
-#   box for a property that changes on the timescale of disk faults, not minutes.
+#   MEASURED COST IS A RANGE WITH CONDITIONS, NOT A NUMBER (#3749 review): on this
+#   fleet's shared store (366M, git 2.43.0) two independent measurement sets give 13-24s
+#   warm and 47-80s cold or under concurrent gates — the sweep is I/O-bound, so cache
+#   state and box load dominate. An earlier revision of this comment quoted a single
+#   "19.83s" from one warm run and was wrong by 2.5-4x. A box runs up to 4 lanes, so an
+#   UNTHROTTLED sweep would burn ~50-320s of every iteration cycle across the box for a
+#   property that changes on the timescale of disk faults, not minutes.
 #   A value of 0 DISABLES the sweep (same `<=0 disables` semantics as BUILD_HOLD_MAX),
 #   which is ANNOUNCED ONCE in the journal rather than left silent: a disabled hygiene
 #   probe must be visible in the log, not inferred from the absence of its lines. It buys
 #   no green anywhere — this sweep certifies nothing, it only refuses to run workers over
 #   a store known to be damaged.
-# OBJ_SWEEP_TIMEOUT_SECS — passed through as the sweep's own `--timeout`. STRICTLY
-#   POSITIVE: the sweep rejects 0 as a usage error, which would turn the probe into a
-#   permanent UNMEASURED — a silently self-disabling bound, the shape validate_numeric_knobs
-#   exists for.
+# OBJ_SWEEP_TIMEOUT_SECS — passed through as the sweep's own `--timeout`, and it is the
+#   bound on EACH of the sweep's walks (a non-clean first walk is re-run once as a
+#   discriminator), so the worst-case wall time is twice it. 600s is ~7.5x the observed
+#   cold worst case above; the bound exists to stop a HANG, not to police duration, and a
+#   bound that expires on a healthy-but-busy box yields UNMEASURED noise nobody acts on.
+#   STRICTLY POSITIVE: the sweep rejects 0 as a usage error, which would turn the probe
+#   into a permanent UNMEASURED — a silently self-disabling bound, the shape
+#   validate_numeric_knobs exists for.
 OBJ_SWEEP_INTERVAL_HOURS="${OBJ_SWEEP_INTERVAL_HOURS:-6}"
-OBJ_SWEEP_TIMEOUT_SECS="${OBJ_SWEEP_TIMEOUT_SECS:-300}"
+OBJ_SWEEP_TIMEOUT_SECS="${OBJ_SWEEP_TIMEOUT_SECS:-600}"
 # Empty => derived per SHARED STORE in obj_sweep_stamp_path (below), so lanes sharing one
-# object store share one throttle.
+# object store share one throttle AND one cached verdict.
 OBJ_SWEEP_STAMP="${OBJ_SWEEP_STAMP:-}"
 # issue #2670 (roborev 1813): before escalating a non-merged PR state to a
 # mismatch, re-read gh a few times to absorb read-after-merge lag. Env-tunable so
@@ -3222,12 +3230,27 @@ acquire_lock() {
 OBJ_SWEEP_ANNOUNCED=0
 OBJ_SWEEP_UNMEASURED_NOTIFIED=0
 
-# obj_sweep_stamp_path — the throttle stamp. Keyed on the SHARED OBJECT STORE, not on
-# the lane, so four lanes of one box share one 6-hour cadence instead of sweeping four
-# times. An unresolvable store falls back to a fixed name: the stamp is a THROTTLE, and
-# every failure mode of it costs at most an extra sweep, never a missed one.
+# obj_sweep_stamp_path — the THROTTLE-AND-CACHED-VERDICT stamp. Keyed on the SHARED
+# OBJECT STORE, not on the lane, so four lanes of one box share one cadence instead of
+# sweeping four times — and, since #3749's review, so a CORRUPT verdict found by one lane
+# is seen by its peers instead of being throttled away.
+#
+# THE DIRECTORY IS DERIVED, NOT TAKEN FROM THE CALLER. Both facts this file records —
+# "this box swept recently" and "this box's shared store is damaged" — are BOX-wide facts
+# about a store every lane reads, so a per-lane `TMPDIR` would silently make them
+# per-lane: peers would keep their own cadence and, worse, never see a peer's CORRUPT.
+# `/tmp` when it is a writable directory, `${TMPDIR:-/tmp}` only as a fallback for a host
+# without one. OBJ_SWEEP_STAMP still overrides both (the self-suite pins it per case).
+#
+# AN UNRESOLVABLE STORE DOES NOT THROTTLE AT ALL — it prints the empty string, and the
+# caller then neither reads nor writes a stamp. The old fallback collapsed every
+# unresolvable store on a box onto ONE name, so two different checkouts shared a 6-hour
+# throttle and one suppressed the other's sweep: a MISSED sweep, not an extra one. Not
+# throttling costs nothing here, because the sweep resolves the same `--git-common-dir`
+# itself and fails FAST (a sub-second UNMEASURED) in exactly the states where this
+# resolution failed.
 obj_sweep_stamp_path() {
-  local common key
+  local common key dir
   if [[ -n "$OBJ_SWEEP_STAMP" ]]; then
     printf '%s' "$OBJ_SWEEP_STAMP"
     return 0
@@ -3236,16 +3259,34 @@ obj_sweep_stamp_path() {
   if [[ -n "$common" ]]; then
     common="$(cd "$REPO_ROOT" 2>/dev/null && cd "$common" 2>/dev/null && pwd -P)" || common=""
   fi
-  key="${common:-unresolved-store}"
+  [[ -n "$common" ]] || return 0
+  key="$common"
   # Flatten to one path component; keep only characters that cannot surprise a shell or
   # a filesystem.
   key="${key//\//_}"
   key="$(printf '%s' "$key" | tr -c 'A-Za-z0-9._-' '_')"
-  printf '%s' "${TMPDIR:-/tmp}/cqlite-object-store-sweep.${key}.stamp"
+  dir="/tmp"
+  [[ -d "$dir" && -w "$dir" ]] || dir="${TMPDIR:-/tmp}"
+  printf '%s' "${dir}/cqlite-object-store-sweep.${key}.stamp"
+}
+
+# obj_sweep_write_stamp <path> <verdict> — record WHEN this box last swept and WHAT it
+# found, as two lines: the epoch, then the verdict token.
+#
+# `2>/dev/null` PRECEDES the output redirection deliberately: bash applies redirections
+# LEFT TO RIGHT, so with the old order a failed `>"$stamp"` printed bash's own
+# UNANCHORED error before the suppression took effect, in addition to the intended log
+# line.
+obj_sweep_write_stamp() {
+  local path="$1" verdict="$2"
+  [[ -n "$path" ]] || return 0
+  printf '%s\n%s\n' "$(date +%s)" "$verdict" 2>/dev/null >"$path" ||
+    log "object-store sweep: could not write the throttle stamp $path — the sweep will re-run next iteration"
+  return 0
 }
 
 object_store_sweep() {
-  local script stamp now last rc out verdict
+  local script stamp now last rc out verdict cached stamp_ts stamp_verdict
   if [[ "$OBJ_SWEEP_INTERVAL_HOURS" -le 0 ]]; then
     # ANNOUNCED, never silent (the CLAIM_CMD-disabled precedent in main()): a hygiene
     # probe that is off must be visible in the journal rather than inferred from missing
@@ -3272,24 +3313,48 @@ object_store_sweep() {
   stamp="$(obj_sweep_stamp_path)"
   now="$(date +%s)"
   last=0
-  if [[ -r "$stamp" ]]; then
-    read -r last <"$stamp" 2>/dev/null || last=0
+  cached=""
+  if [[ -n "$stamp" && -r "$stamp" ]]; then
+    stamp_ts=""
+    stamp_verdict=""
+    { read -r stamp_ts || true; read -r stamp_verdict || true; } <"$stamp" 2>/dev/null || true
+    last="$stamp_ts"
+    cached="$stamp_verdict"
   fi
   [[ "$last" =~ ^[0-9]+$ ]] || last=0
-  # A stamp in the FUTURE (clock skew, a hand-edited file, a restored snapshot) must not
-  # park the sweep forever: treat it as never-swept.
-  [[ "$last" -gt "$now" ]] && last=0
-  if [[ $((now - last)) -lt $((OBJ_SWEEP_INTERVAL_HOURS * 3600)) ]]; then
+  # Only the exact token is honoured; anything else is treated as no cached verdict.
+  [[ "$cached" == "CORRUPT" ]] || cached=""
+
+  # A CACHED `CORRUPT` STOPS THIS LANE WITHOUT RE-SWEEPING, AND IT IGNORES THE INTERVAL.
+  #
+  # THE DEFECT THIS EXISTS FOR (#3749 review, BLOCKER A). The stamp is keyed on the
+  # SHARED store and lives in a box-wide directory, so it is genuinely box-wide. When it
+  # recorded only a timestamp, the lane that DETECTED corruption stopped — and its three
+  # peers then saw a FRESH stamp, skipped their own sweep for the whole interval, and kept
+  # spawning workers against a store known to be damaged. That is the exact harm this
+  # feature exists to prevent, delivered by the throttle.
+  #
+  # Persisting the VERDICT is the stronger fix of the two available: "don't stamp on
+  # CORRUPT" would merely make each peer re-run a 20-80s fsck to rediscover the same
+  # thing, and would leave a window between the write and the peer's next iteration.
+  #
+  # IT DOES NOT EXPIRE, and it is CLEARED BY HAND. Corruption is non-self-clearing, so an
+  # age-based expiry would resume workers over a still-damaged store; the operator who
+  # repairs the store removes the file, and the remedy line below NAMES the path and the
+  # command, because a latch nobody can clear bricks the box after the repair.
+  if [[ -n "$cached" ]]; then
+    notify "high" "worker-supervisor: SHARED OBJECT STORE CORRUPT (cached)" \
+      "a sweep on this box recorded CORRUPT for the shared git object store every lane here reads. Stopping without re-sweeping. Repair the store, then remove $stamp."
+    log "object-store: CORRUPT (cached at $last by a sweep on this box) — stopping; no worker may certify against a damaged shared store (#3749)."
+    log "object-store: REMEDY — stop every lane on this box and re-obtain the objects from the canonical remote; a local 'git gc'/'git repack' CANNOT repair it. THEN CLEAR THE LATCH: rm -f $stamp"
+    finalize_exit "object-store-corrupt" 1
+  fi
+
+  if [[ -n "$stamp" ]] && [[ $((now - last)) -lt $((OBJ_SWEEP_INTERVAL_HOURS * 3600)) ]]; then
     return 0
   fi
   rc=0
   out="$(bash "$script" --repo "$REPO_ROOT" --timeout "$OBJ_SWEEP_TIMEOUT_SECS" 2>&1)" || rc=$?
-  # The stamp is written for EVERY outcome, including UNMEASURED: the throttle bounds how
-  # often this box SPENDS the sweep, and a box that cannot measure (no timeout binary, say)
-  # must not re-attempt it every iteration. The verdict is journalled either way, so
-  # nothing is hidden by the stamp.
-  printf '%s\n' "$(date +%s)" >"$stamp" 2>/dev/null ||
-    log "object-store sweep: could not write the throttle stamp $stamp — the sweep will re-run next iteration"
   # Read the verdict from the sweep's OWN anchored control line, never from loose text:
   # its output prints repository-controlled paths verbatim, so an unanchored match could
   # land on one. Both the line AND the exit status are required to agree for the two
@@ -3297,14 +3362,39 @@ object_store_sweep() {
   # `{ grep || true; }` ON EVERY PIPELINE BELOW, AND IT IS LOAD-BEARING, NOT DEFENSIVE.
   # This file runs under `set -euo pipefail`: a `grep` that matches NOTHING exits 1, and
   # with `pipefail` that status becomes the pipeline's — so an ASSIGNMENT from such a
-  # substitution, or a bare pipeline, KILLS THE SUPERVISOR with rc=1. And "no match" is
-  # exactly the reachable case here: a sweep killed at its bound prints no `verdict ` line
-  # at all, and an UNMEASURED one need not print an `unmeasured-cause` line. Caught by
-  # scripts/tests/test_worker_supervisor.sh's obj-sweep(UNMEASURED) case, which planted a
-  # verdict with no cause line and observed the whole loop exit 1.
+  # substitution, or a bare pipeline, KILLS THE SUPERVISOR with rc=1. TWO REACHABLE
+  # CAUSES, and neither is a hypothetical (an earlier version of this comment named two
+  # that are NOT reachable, which is worse than no comment because it is what stops the
+  # next person looking):
+  #   * `$script` IS WHATEVER THIS CHECKOUT HOLDS. An older, newer or stubbed sweep, or
+  #     one killed from OUTSIDE this process (an operator, the OOM killer), prints no
+  #     `verdict ` line and no `unmeasured-cause` line at all. This supervisor must not
+  #     depend on the current output shape of a sibling script to stay alive.
+  #   * `head -1`/`head -4`/`head -6` CLOSE THE PIPE EARLY, so grep dies of SIGPIPE (141)
+  #     whenever there are more matching lines than the head takes — which is the ORDINARY
+  #     case for the finding and cause pipelines. `|| true` INSIDE the brace group is what
+  #     absorbs that status before `pipefail` can promote it.
+  # Caught by scripts/tests/test_worker_supervisor.sh's obj-sweep(UNMEASURED) case, which
+  # planted a verdict with no cause line and observed the whole loop exit 1.
   verdict="$(printf '%s\n' "$out" | { grep '^OBJECT-STORE: verdict ' || true; } | head -1)"
   verdict="${verdict#OBJECT-STORE: verdict }"
   verdict="${verdict%% *}"
+
+  # THE STAMP IS WRITTEN FOR EVERY OUTCOME, AND IT CARRIES THE VERDICT. The throttle
+  # bounds how often this box SPENDS the sweep (a box that cannot measure — no timeout
+  # binary, say — must not re-attempt it every iteration), and the recorded verdict is
+  # what stops a peer lane throttling past a CORRUPT this lane just found. Only the exact
+  # token is recorded; anything unrecognised is recorded as UNMEASURED, which grants no
+  # authority to anyone.
+  if [[ "$rc" -eq 0 && "$verdict" == "VERIFIED" ]]; then
+    stamp_verdict=VERIFIED
+  elif [[ "$rc" -eq 4 || "$verdict" == "CORRUPT" ]]; then
+    stamp_verdict=CORRUPT
+  else
+    stamp_verdict=UNMEASURED
+  fi
+  obj_sweep_write_stamp "$stamp" "$stamp_verdict"
+
   if [[ "$rc" -eq 0 && "$verdict" == "VERIFIED" ]]; then
     log "object-store: VERIFIED — $(printf '%s\n' "$out" | { grep '^OBJECT-STORE: measured ' || true; } | head -1)"
     return 0
@@ -3315,7 +3405,7 @@ object_store_sweep() {
     notify "high" "worker-supervisor: SHARED OBJECT STORE CORRUPT" \
       "git fsck reports damaged objects in this box's shared git object store — every lane here reads it, so NO gate verdict on this box can be trusted. Stopping. ${findings:-<no findings captured>}"
     log "object-store: CORRUPT — stopping loudly; no worker may certify against a damaged shared store (#3749). ${findings:-<no findings captured>}"
-    log "object-store: REMEDY — stop every lane on this box and re-obtain the objects from the canonical remote; a local 'git gc'/'git repack' CANNOT repair it."
+    log "object-store: REMEDY — stop every lane on this box and re-obtain the objects from the canonical remote; a local 'git gc'/'git repack' CANNOT repair it.${stamp:+ THEN CLEAR THE LATCH: rm -f $stamp}"
     finalize_exit "object-store-corrupt" 1
   fi
   # UNMEASURED (or no recognised verdict at all): REPORTED, and DELIBERATELY PERMISSIVE.

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -184,6 +184,31 @@ PROMPT_SIGNATURE_RE="${PROMPT_SIGNATURE_RE:-AskUserQuestion|Do you want to|waiti
 LEFTOVER_HOLD_MAX="${LEFTOVER_HOLD_MAX:-3}"
 BUILD_HOLD_MAX="${BUILD_HOLD_MAX:-12}"
 UNVERIFIED_MAX="${UNVERIFIED_MAX:-2}"
+# issue #3749: the SHARED git object store on this box (every lane here is a worktree of
+# ONE `.git`) is rehashed with `git fsck` on a THROTTLED cadence from the per-iteration
+# preflight path. This is the recurring half of #3749's control; the one-shot half is
+# scripts/bootstrap-agent-machine.sh section 5b-obj. Both go through the SAME script,
+# scripts/check-object-store-integrity.sh — a second implementation would be a second
+# place for the verdict to drift.
+#
+# OBJ_SWEEP_INTERVAL_HOURS — minimum hours between sweeps, throttled by a stamp file.
+#   Measured cost: 19.83s per sweep on this fleet's 331M store, and a box runs up to 4
+#   lanes, so an UNTHROTTLED sweep would burn ~80s of every iteration cycle across the
+#   box for a property that changes on the timescale of disk faults, not minutes.
+#   A value of 0 DISABLES the sweep (same `<=0 disables` semantics as BUILD_HOLD_MAX),
+#   which is ANNOUNCED ONCE in the journal rather than left silent: a disabled hygiene
+#   probe must be visible in the log, not inferred from the absence of its lines. It buys
+#   no green anywhere — this sweep certifies nothing, it only refuses to run workers over
+#   a store known to be damaged.
+# OBJ_SWEEP_TIMEOUT_SECS — passed through as the sweep's own `--timeout`. STRICTLY
+#   POSITIVE: the sweep rejects 0 as a usage error, which would turn the probe into a
+#   permanent UNMEASURED — a silently self-disabling bound, the shape validate_numeric_knobs
+#   exists for.
+OBJ_SWEEP_INTERVAL_HOURS="${OBJ_SWEEP_INTERVAL_HOURS:-6}"
+OBJ_SWEEP_TIMEOUT_SECS="${OBJ_SWEEP_TIMEOUT_SECS:-300}"
+# Empty => derived per SHARED STORE in obj_sweep_stamp_path (below), so lanes sharing one
+# object store share one throttle.
+OBJ_SWEEP_STAMP="${OBJ_SWEEP_STAMP:-}"
 # issue #2670 (roborev 1813): before escalating a non-merged PR state to a
 # mismatch, re-read gh a few times to absorb read-after-merge lag. Env-tunable so
 # the tooling tests set the wait to 0 (nothing sleeps in the suite).
@@ -3177,6 +3202,135 @@ acquire_lock() {
 }
 
 # ---------------------------------------------------------------------------
+# Shared-object-store integrity sweep (issue #3749) — THROTTLED, and deliberately
+# NOT a hold reason.
+#
+# WHY IT IS HERE. Every lane on this box reads ONE shared `.git`, and git does not
+# rehash an object against the id it was asked for on an ordinary read. A corrupt
+# shared store can therefore change ANY gate's verdict on this box, so no worker
+# should be allowed to certify against it. #3749's owner ruling scopes this to
+# ACCIDENTAL corruption (bit rot, a torn pack write, a SIGKILLed gc); DELIBERATE
+# peer forgery is invoker-class and out of model per the #3312 triage rule.
+#
+# WHY `CORRUPT` STOPS THE LOOP RATHER THAN HOLDING IT. Corruption is
+# NON-SELF-CLEARING: a HOLD-and-repoll loop would spin until the wall-clock budget
+# taking no useful action, which is precisely the latch #2670 bounded the leftover
+# families to avoid. So it uses the established "stop loudly" idiom — notify high,
+# journal, finalize_exit with its own reason — the same shape as leftover-worker
+# exceeding LEFTOVER_HOLD_MAX.
+# ---------------------------------------------------------------------------
+OBJ_SWEEP_ANNOUNCED=0
+OBJ_SWEEP_UNMEASURED_NOTIFIED=0
+
+# obj_sweep_stamp_path — the throttle stamp. Keyed on the SHARED OBJECT STORE, not on
+# the lane, so four lanes of one box share one 6-hour cadence instead of sweeping four
+# times. An unresolvable store falls back to a fixed name: the stamp is a THROTTLE, and
+# every failure mode of it costs at most an extra sweep, never a missed one.
+obj_sweep_stamp_path() {
+  local common key
+  if [[ -n "$OBJ_SWEEP_STAMP" ]]; then
+    printf '%s' "$OBJ_SWEEP_STAMP"
+    return 0
+  fi
+  common="$(git -C "$REPO_ROOT" rev-parse --git-common-dir 2>/dev/null)" || common=""
+  if [[ -n "$common" ]]; then
+    common="$(cd "$REPO_ROOT" 2>/dev/null && cd "$common" 2>/dev/null && pwd -P)" || common=""
+  fi
+  key="${common:-unresolved-store}"
+  # Flatten to one path component; keep only characters that cannot surprise a shell or
+  # a filesystem.
+  key="${key//\//_}"
+  key="$(printf '%s' "$key" | tr -c 'A-Za-z0-9._-' '_')"
+  printf '%s' "${TMPDIR:-/tmp}/cqlite-object-store-sweep.${key}.stamp"
+}
+
+object_store_sweep() {
+  local script stamp now last rc out verdict
+  if [[ "$OBJ_SWEEP_INTERVAL_HOURS" -le 0 ]]; then
+    # ANNOUNCED, never silent (the CLAIM_CMD-disabled precedent in main()): a hygiene
+    # probe that is off must be visible in the journal rather than inferred from missing
+    # lines.
+    if [[ "$OBJ_SWEEP_ANNOUNCED" -eq 0 ]]; then
+      log "object-store sweep DISABLED (OBJ_SWEEP_INTERVAL_HOURS=0) — this box's SHARED git object store is NOT being rehashed this run (#3749)"
+      OBJ_SWEEP_ANNOUNCED=1
+    fi
+    return 0
+  fi
+  script="$REPO_ROOT/scripts/check-object-store-integrity.sh"
+  if [[ ! -r "$script" ]]; then
+    # PERMISSIVE, AND HERE IS THE REASON, IN CODE (CLAUDE.md #3229: where a signal
+    # genuinely SHOULD be permissive, record the why at the branch). The sweep is absent
+    # from this checkout — an older branch, or a partial tree. Refusing to run any worker
+    # because a hygiene probe is missing is a self-DoS on the whole fleet, and the probe
+    # certifies nothing on the passing side either. Journalled once so it is visible.
+    if [[ "$OBJ_SWEEP_ANNOUNCED" -eq 0 ]]; then
+      log "object-store sweep UNAVAILABLE: no $script in this checkout — the shared store is NOT being rehashed (#3749). NOT treated as clean and NOT a stop reason."
+      OBJ_SWEEP_ANNOUNCED=1
+    fi
+    return 0
+  fi
+  stamp="$(obj_sweep_stamp_path)"
+  now="$(date +%s)"
+  last=0
+  if [[ -r "$stamp" ]]; then
+    read -r last <"$stamp" 2>/dev/null || last=0
+  fi
+  [[ "$last" =~ ^[0-9]+$ ]] || last=0
+  # A stamp in the FUTURE (clock skew, a hand-edited file, a restored snapshot) must not
+  # park the sweep forever: treat it as never-swept.
+  [[ "$last" -gt "$now" ]] && last=0
+  if [[ $((now - last)) -lt $((OBJ_SWEEP_INTERVAL_HOURS * 3600)) ]]; then
+    return 0
+  fi
+  rc=0
+  out="$(bash "$script" --repo "$REPO_ROOT" --timeout "$OBJ_SWEEP_TIMEOUT_SECS" 2>&1)" || rc=$?
+  # The stamp is written for EVERY outcome, including UNMEASURED: the throttle bounds how
+  # often this box SPENDS the sweep, and a box that cannot measure (no timeout binary, say)
+  # must not re-attempt it every iteration. The verdict is journalled either way, so
+  # nothing is hidden by the stamp.
+  printf '%s\n' "$(date +%s)" >"$stamp" 2>/dev/null ||
+    log "object-store sweep: could not write the throttle stamp $stamp — the sweep will re-run next iteration"
+  # Read the verdict from the sweep's OWN anchored control line, never from loose text:
+  # its output prints repository-controlled paths verbatim, so an unanchored match could
+  # land on one. Both the line AND the exit status are required to agree for the two
+  # actionable verdicts.
+  verdict="$(printf '%s\n' "$out" | grep '^OBJECT-STORE: verdict ' | head -1)"
+  verdict="${verdict#OBJECT-STORE: verdict }"
+  verdict="${verdict%% *}"
+  if [[ "$rc" -eq 0 && "$verdict" == "VERIFIED" ]]; then
+    log "object-store: VERIFIED — $(printf '%s\n' "$out" | grep '^OBJECT-STORE: measured ' | head -1)"
+    return 0
+  fi
+  if [[ "$rc" -eq 4 || "$verdict" == "CORRUPT" ]]; then
+    local findings
+    findings="$(printf '%s\n' "$out" | grep -E '^OBJECT-STORE: (finding|object) ' | head -6 | tr '\n' ';' | cut -c1-600)"
+    notify "high" "worker-supervisor: SHARED OBJECT STORE CORRUPT" \
+      "git fsck reports damaged objects in this box's shared git object store — every lane here reads it, so NO gate verdict on this box can be trusted. Stopping. ${findings:-<no findings captured>}"
+    log "object-store: CORRUPT — stopping loudly; no worker may certify against a damaged shared store (#3749). ${findings:-<no findings captured>}"
+    log "object-store: REMEDY — stop every lane on this box and re-obtain the objects from the canonical remote; a local 'git gc'/'git repack' CANNOT repair it."
+    finalize_exit "object-store-corrupt" 1
+  fi
+  # UNMEASURED (or no recognised verdict at all): REPORTED, and DELIBERATELY PERMISSIVE.
+  # THE WHY, IN CODE (CLAUDE.md #3229). An UNMEASURED sweep is not clean — nothing here
+  # reads it as clean, and it stops no worker from being spawned either, because refusing
+  # to run any worker on this box because a HYGIENE PROBE could not run is a self-DoS: the
+  # probe's failure modes are its own (no timeout binary, an unresolvable git dir, an
+  # expired bound on a loaded box), none of which is evidence about the store. So it is
+  # journalled every time and paged ONCE per run — loud enough to fix, never a silent
+  # swallow and never a latch.
+  log "object-store: UNMEASURED (rc=$rc verdict='${verdict:-<none>}') — the shared store was NOT rehashed, so its integrity is UNKNOWN, not clean. Continuing: a hygiene probe that cannot run must not stop the fleet (#3749)."
+  printf '%s\n' "$out" | grep '^OBJECT-STORE: unmeasured-cause ' | head -4 | while IFS= read -r obj_line; do
+    log "object-store: $obj_line"
+  done
+  if [[ "$OBJ_SWEEP_UNMEASURED_NOTIFIED" -eq 0 ]]; then
+    notify "high" "worker-supervisor: object-store sweep UNMEASURED" \
+      "the shared git object store could not be rehashed on this box (rc=$rc) — integrity is UNKNOWN, not clean. The loop continues; fix the cause so the sweep can run."
+    OBJ_SWEEP_UNMEASURED_NOTIFIED=1
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
 # Preflight: fail-closed, wait-don't-spin. Returns a hold reason on stdout, or
 # empty when clear. stop-file / budgets are handled by the caller (clean exit,
 # not a hold).
@@ -3219,6 +3373,11 @@ LAST_HOLD_REASON=""
 # allowed the LOOSE BUILD_HOLD_MAX so a legitimate concurrent full gate is waited out.
 preflight_wait() {
   local worker_holds=0 build_holds=0
+  # The throttled shared-object-store sweep (#3749) runs ONCE per iteration, HERE, before
+  # the hold loop: it is per-iteration box hygiene, not a hold reason, and it must not be
+  # re-run on every hold repoll. `CORRUPT` never returns — it stops the loop loudly from
+  # inside (see object_store_sweep).
+  object_store_sweep
   while true; do
     [[ -f "$STOP_FILE" ]] && finalize_exit "stop-file" 0
     [[ $(($(date +%s) - START_TS)) -ge "$MAX_HOURS_SECS" ]] && finalize_exit "budget-wallclock" 0
@@ -3884,10 +4043,15 @@ validate_numeric_knobs() {
   # silently break the bound (e.g. MAX_ISSUES=-1 ⇒ instant budget-issues rc=0, roborev
   # 1843). MAX_HOURS is here because its `$((MAX_HOURS * 3600))` derivation is integer
   # arithmetic (a bare-word MAX_HOURS would coerce to 0 → a broken wall-clock budget).
+  # OBJ_SWEEP_INTERVAL_HOURS is here, not in the signed group: 0 is its documented
+  # `disables` value and a NEGATIVE would be an operator typo whose meaning is undefined
+  # (the `-le 0` guard would treat it as disabled, which is not what a `-1` was trying to
+  # say). #3749.
   for name in MAX_HOURS MAX_ISSUES BREAKER_N BACKOFF_NOWORK_SECS HOLD_POLL_SECS \
               MAX_ITER_SECS STUCK_POLL_SECS STUCK_TAIL_LINES LEFTOVER_HOLD_MAX \
               UNVERIFIED_MAX MISMATCH_RETRIES MISMATCH_RETRY_WAIT_SECS \
-              PENDING_AUTOMERGE_MAX PENDING_AUTOMERGE_MIN_SECS; do
+              PENDING_AUTOMERGE_MAX PENDING_AUTOMERGE_MIN_SECS \
+              OBJ_SWEEP_INTERVAL_HOURS; do
     val="${!name}"
     [[ "$val" =~ ^[0-9]+$ ]] || _bad_knob "$name" "$val" "a non-negative integer"
   done
@@ -3902,6 +4066,15 @@ validate_numeric_knobs() {
     val="${!name}"
     [[ "$val" =~ ^[0-9]+$ ]] || _bad_knob "$name" "$val" "a positive integer"
     [[ "$val" -ge 1 ]] || _bad_knob "$name" "$val" "a positive integer (0 would silently skip the migration entirely)"
+  done
+  # OBJ_SWEEP_TIMEOUT_SECS is the same class (#3749): it is passed straight through as the
+  # sweep's `--timeout`, which REJECTS 0 as a usage error — so a 0 would make every sweep
+  # UNMEASURED forever, i.e. a bound that silently disables the probe rather than loosening
+  # it. Its own group because the message has to say that.
+  for name in OBJ_SWEEP_TIMEOUT_SECS; do
+    val="${!name}"
+    [[ "$val" =~ ^[0-9]+$ ]] || _bad_knob "$name" "$val" "a positive integer"
+    [[ "$val" -ge 1 ]] || _bad_knob "$name" "$val" "a positive integer (the sweep rejects 0, which would make every run UNMEASURED)"
   done
   # SIGNED integer knobs — the two with a documented `<=0 disables` contract.
   for name in BUILD_HOLD_MAX MISMATCH_GRACE_CAP_SECS; do

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -3709,7 +3709,13 @@ obj_sweep_claim_mark_owner() {
 obj_sweep_claim_owner_state() {
   local claim="$1" tok=""
   [[ -n "$claim" ]] || { printf 'gone'; return 0; }
-  { read -r tok || true; } <"$claim/owner" 2>/dev/null || tok=""
+  # `2>/dev/null` PRECEDES the input redirection, and the order is load-bearing: bash
+  # applies redirections left to right, so with it second an ABSENT owner file makes the
+  # shell print its own `No such file or directory` on the REAL stderr — an unanchored
+  # diagnostic from a function whose ordinary case (a double release: the sweep path, then
+  # the EXIT trap) has no file there at all. That is round 1's NIT 4, one file over, and a
+  # RED arm for item 2 is what surfaced it.
+  { read -r tok || true; } 2>/dev/null <"$claim/owner" || tok=""
   if [[ -n "$tok" && -n "$OBJ_SWEEP_CLAIM_TOKEN" && "$tok" == "$OBJ_SWEEP_CLAIM_TOKEN" ]]; then
     printf 'ours'
     return 0

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -3376,11 +3376,15 @@ obj_sweep_latch_path() {
 #   present — something is at that path. `-e || -L`, because a DANGLING symlink is
 #             `-e`-false and the fail-safe reading of "something is at the latch path" is
 #             LATCHED. Same idiom, same reason, as the supervisor lock's existence test.
-#   absent  — nothing is there AND the directory that would hold it was searchable and
-#             readable, so this is a MEASUREMENT and not a failure to look. A directory
-#             that does not exist yields `absent` too: no file can be inside it.
-#   unknown — the directory exists and this process cannot search or read it, so a latch
-#             may be sitting there unread. NEVER folded into `absent`.
+#   absent  — nothing is there AND the directory that would hold it was SEARCHABLE, so this
+#             is a MEASUREMENT and not a failure to look. A directory that does not exist
+#             yields `absent` too: no file can be inside one that is not there.
+#             SEARCH (`-x`) and not READ (`-r`) is the right test, deliberately: `-e` on a
+#             named path needs only search permission on the parent, so a searchable but
+#             unlistable directory gives a TRUE answer and requiring `-r` as well would
+#             refuse a probe that was in fact valid — a false stop bought for nothing.
+#   unknown — the directory exists and this process cannot search it, so a latch may be
+#             sitting there unread. NEVER folded into `absent`.
 #   unkeyed — there is no latch PATH at all, because the box-wide key could not be
 #             derived. A different statement from all three above: it is not that the file
 #             is unreadable, it is that no file was ever named. The caller decides, and
@@ -3398,7 +3402,7 @@ obj_sweep_latch_state() {
   dir="${latch%/*}"
   [[ "$dir" == "$latch" ]] && dir="."
   [[ -n "$dir" ]] || dir="/"
-  if [[ ! -d "$dir" ]] || { [[ -x "$dir" ]] && [[ -r "$dir" ]]; }; then
+  if [[ ! -d "$dir" ]] || [[ -x "$dir" ]]; then
     printf 'absent'
     return 0
   fi

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -229,8 +229,22 @@ UNVERIFIED_MAX="${UNVERIFIED_MAX:-2}"
 #   STRICTLY POSITIVE: the sweep rejects 0 as a usage error, which would turn the probe
 #   into a permanent UNMEASURED — a silently self-disabling bound, the shape
 #   validate_numeric_knobs exists for.
+# OBJ_SWEEP_CLAIM_POLL_SECS — the poll granularity of the WAIT a claim loser does on a peer
+#   lane's in-flight sweep (#3749 review round 12). NOT a bound: the bound is the claim's own
+#   DERIVED staleness threshold. This value is how often the waiting lane re-reads the STOP
+#   latch, the throttle stamp, the claim and the stop file, so it is also that lane's stop
+#   latency for as long as it waits — and, unlike the sweep itself, a wait IS interruptible
+#   because it runs in this shell rather than in the sweep's child process. STRICTLY POSITIVE
+#   for the opposite reason to the knobs above: a 0 does not disable the wait, it converts it
+#   into a busy spin over the whole derived budget.
 OBJ_SWEEP_INTERVAL_HOURS="${OBJ_SWEEP_INTERVAL_HOURS:-6}"
 OBJ_SWEEP_TIMEOUT_SECS="${OBJ_SWEEP_TIMEOUT_SECS:-200}"
+# POLL GRANULARITY for waiting on a PEER lane's in-flight sweep (#3749 review round 12) —
+# NOT a bound. The bound is derived (obj_sweep_claim_stale_secs); this is only how often the
+# waiting lane re-reads the latch, the throttle stamp, the claim and the stop file while it
+# waits, so it is also this lane's STOP LATENCY during a wait. STRICTLY POSITIVE: a 0 would
+# turn a bounded wait into a busy spin for up to the whole derived budget.
+OBJ_SWEEP_CLAIM_POLL_SECS="${OBJ_SWEEP_CLAIM_POLL_SECS:-5}"
 # Empty => derived per SHARED STORE in obj_sweep_stamp_path (below), so lanes sharing one
 # object store share one throttle. It also names the STOP latch (`<stamp>.STOP`), so
 # pinning it relocates both files together.
@@ -3272,11 +3286,29 @@ OBJ_SWEEP_CLAIM_OWNED=""
 # claim is created; empty until then, and an empty token can never match anything.
 OBJ_SWEEP_CLAIM_TOKEN=""
 OBJ_SWEEP_CLAIM_STATE=""
+# THE OUTCOME OF THE LAST WAIT ON A PEER'S IN-FLIGHT SWEEP (#3749 review round 12). A GLOBAL
+# and not stdout, for the same reason OBJ_SWEEP_CLAIM_STATE is one, plus a sharper one: the
+# wait STOPS THIS LANE from inside (obj_sweep_stop_if_latched -> finalize_exit) the moment a
+# peer latches the box, and a `$(...)` command substitution would confine that exit to a
+# SUBSHELL — the wait would appear to return normally and the lane would carry on to spawn a
+# worker on a box it had just seen condemned. That is the defect this wait exists to close,
+# reintroduced by the plumbing.
+OBJ_SWEEP_CLAIM_WAIT_STATE=""
+OBJ_SWEEP_CLAIM_WAIT_UNMEASURED_NOTIFIED=0
 # SLACK on the claim-staleness bound: what a sweep spends OUTSIDE its bounded fsck walks —
 # process startup, the `--print-store` resolution, output capture, and the notify/journal
 # writes. It is additive to a DERIVED product (see obj_sweep_claim_stale_secs) rather than
 # a bound in its own right, which is why it is a small constant and not a measurement.
-OBJ_SWEEP_CLAIM_SLACK_SECS=60
+# ENV-OVERRIDABLE SINCE #3749 REVIEW ROUND 12, AND THE REASON IS TESTABILITY, STATED HERE SO
+# IT IS NOT MISREAD AS AN OPERATOR TUNING KNOB. Round 12 made a claim LOSER wait out this
+# derived bound before giving up, so the "a peer holds a claim that never completes" state
+# now costs a real wait — and with a hard-coded 60s slack the shortest such wait expressible
+# in a test was ~61s, which is a minute of pure sleeping inside a suite that must stay fast.
+# The bound itself is still DERIVED (walks x per-walk + slack) and this term is still additive
+# slack rather than a bound in its own right; 0 is a legitimate value (no slack) and is
+# therefore validated in the NON-NEGATIVE group, not the strictly-positive one, with the trade
+# that a sweep whose overhead lands outside its walks could be taken over just as it finishes.
+OBJ_SWEEP_CLAIM_SLACK_SECS="${OBJ_SWEEP_CLAIM_SLACK_SECS:-60}"
 
 # obj_sweep_stamp_path <sweep-script> — the THROTTLE stamp: WHEN this box last SPENT a
 # sweep. Keyed on the SHARED OBJECT STORE, not on the lane, so four lanes of one box
@@ -3542,9 +3574,19 @@ obj_sweep_force_stamp_stale() {
 # SUPERVISOR_LOCK header), and a second locking mechanism in one file is a second set of
 # failure modes.
 #
-# A LOSER DOES NOT WAIT. It skips this iteration's sweep and carries on, after the usual
-# latch read: the sweep is a 6-hourly hygiene probe, so "a peer is doing it right now" is a
-# complete answer, and waiting would put the box's whole spawn path behind one fsck.
+# A LOSER *DOES* WAIT, AND THAT REVERSES THE ORIGINAL DESIGN (#3749 review round 12). It
+# used to skip its sweep and carry straight on to the spawn path after one latch read, on
+# the argument that "a peer is doing it right now" is a complete answer for a 6-hourly
+# hygiene probe. It is a complete answer about the SWEEP and it is not an answer about the
+# SPAWN: the loser knows a sweep is IN FLIGHT — that is precisely why its claim failed — and
+# the verdict of that sweep can be CORRUPT or UNSWEEPABLE, in which case the peer latches
+# the box. Skipping immediately spends the peer's whole sweep duration walking toward a
+# worker start on a box that is being condemned as it reads: MEASURED 13-80s of wall clock
+# on this fleet's 366M store, and up to MAX_SWEEP_WALKS x OBJ_SWEEP_TIMEOUT_SECS (600s at
+# the shipped defaults) by construction. So the loser waits for the peer, polling the latch,
+# the stamp and the claim — see obj_sweep_claim_wait for the bound and the four outcomes.
+# The cost is paid ONLY when a sweep is genuinely running, which the throttle makes at most
+# once per interval per lane.
 # ---------------------------------------------------------------------------
 
 # obj_sweep_claim_path <stamp-path> — the claim that belongs to that stamp. Derived from
@@ -3777,6 +3819,146 @@ obj_sweep_claim_release() {
   return 0
 }
 
+# obj_sweep_claim_wait <claim-dir> <stale-secs> <latch-path> <stamp-path> <overall-deadline>
+# — WAIT for the peer lane holding this claim to finish its sweep, and STOP THIS LANE from
+# inside the moment that peer latches the box. Sets OBJ_SWEEP_CLAIM_WAIT_STATE to exactly
+# one of:
+#
+#   completed — the throttle stamp went FRESH, so that peer finished a sweep and advertised
+#               it; the box is inside the interval again
+#   vacated   — the claim is GONE with no fresh stamp: the peer ended without advertising a
+#               sweep (killed mid-sweep, or it stopped on a verdict it could not latch and
+#               FORCED the stamp stale on purpose so that every lane re-sweeps)
+#   expired   — the claim outlived the DERIVED staleness bound while still present, so it is
+#               recoverable now and the caller's next acquire takes it over and sweeps
+#   exhausted — this ITERATION's whole wait budget is spent (or this lane cannot wait at
+#               all), so the caller must stop waiting
+#
+# THE DEFECT IT EXISTS FOR (#3749 review round 12). The `held` branch read the latch ONCE and
+# returned toward the spawn path while the peer's sweep was still running. The residual note
+# at the bottom of this file described the remaining race as the narrow gap between a lane's
+# last latch read and its worker start; for the claim loser that was wrong by orders of
+# magnitude — the gap was the peer's ENTIRE sweep. A comment that understates the window it
+# exists to disclose is worse than no comment, because it is what stops the next person
+# looking, so both the behaviour and the note were fixed together.
+#
+# THE BOUND IS NOT A NEW CONSTANT. It is the claim's OWN staleness bound, `stale`, the value
+# obj_sweep_claim_stale_secs derives from the shipped sweep's MAX_SWEEP_WALKS x this
+# supervisor's per-walk bound + slack. That is deliberate and it is the whole reason a dead
+# peer cannot wedge this wait: the same threshold that says "this claim can be TAKEN OVER"
+# says "stop waiting for it". A second, independently chosen wait bound could drift from the
+# sweep's real worst case in either direction — too short and a live peer is abandoned
+# mid-sweep, too long and a dead one is waited out past the point where the claim was already
+# recoverable — which is round 4's "a relation whose own constant is restated is two magic
+# numbers wearing a relation's clothes", one file over.
+#
+# TWO DEADLINES, AND THE CALLER OWNS THE OUTER ONE. Per PASS this function recomputes the
+# CLAIM's deadline from the `started` file, so a TAKEOVER by a third lane mid-wait extends
+# the wait to that lane's own bound instead of abandoning a sweep that has just begun. The
+# caller's `overall` deadline caps the sum of all of it at one `stale` from the top of the
+# iteration, which is what makes a chain of takeovers terminate.
+#
+# `expired` IS THE NON-PERMISSIVE OUTCOME, AND IT IS THE ONE THE REVIEW ASKED ABOUT. When the
+# peer neither finishes nor vacates, the claim it holds is by construction STALE at this
+# deadline — the bound above is exactly the age at which "the sweep it represents cannot
+# still be running" — so the answer is not "carry on unmeasured": the caller loops, the next
+# acquire RECOVERS that claim, and this lane MEASURES the store itself. The loser becomes the
+# sweeper.
+#
+# THE STOP FILE AND THE WALL-CLOCK BUDGET ARE RE-READ ON EVERY PASS. Unlike the sweep itself
+# — whose fsck walks run in a child process and are therefore not interruptible from here —
+# this wait executes in THIS shell, so it can and does honour a stop requested while it
+# waits. Stop latency during a wait is one OBJ_SWEEP_CLAIM_POLL_SECS.
+obj_sweep_claim_wait() {
+  local claim="$1" stale="$2" latch="$3" stamp="$4" overall="$5"
+  local now started deadline started_at elapsed
+  # DEFAULT `exhausted`: every early return here means "this lane did not, or could not,
+  # wait", and the caller must treat that as a spent budget rather than as progress. The
+  # permissive-looking states (`completed`, `vacated`, `expired`) are only ever reached by an
+  # AFFIRMATIVE observation below.
+  OBJ_SWEEP_CLAIM_WAIT_STATE=exhausted
+  [[ -n "$claim" ]] || return 0
+  [[ "$stale" =~ ^[0-9]+$ ]] || return 0
+  # NO OUTER DEADLINE MEANS NO WAIT, and it restores exactly the pre-round-12 behaviour for
+  # that box rather than inventing a budget: the caller could not derive one, which is the
+  # same condition under which no claim is taken at all.
+  [[ "$overall" =~ ^[0-9]+$ ]] || return 0
+  started_at="$(date +%s)"
+  log "object-store sweep: WAITING for the peer lane that holds the sweep claim ($claim) to finish its sweep before this lane goes anywhere near a worker spawn — a sweep in flight can end in a verdict that latches this box, and 13-80s is the measured range on this fleet. Polling every ${OBJ_SWEEP_CLAIM_POLL_SECS}s (stop file and wall-clock budget included), bounded by the claim's own derived staleness bound of ${stale}s (#3749)."
+  while true; do
+    # THE STOP FILE FIRST. An operator who touches it while this lane is parked behind a
+    # peer's fsck is entitled to be obeyed within one poll.
+    preflight_stop_or_budget
+    # THEN THE LATCH — THE ENTIRE POINT OF THIS FUNCTION. It never returns if the box has
+    # been latched; see the global's comment for why this must not be called in a subshell.
+    obj_sweep_stop_if_latched "$latch"
+    # THEN COMPLETION, IN THE PEER'S OWN WRITE ORDER. A stopping peer creates the LATCH,
+    # then writes the stamp, then exits (its EXIT trap releases the claim); a non-stopping
+    # one writes the stamp, then releases. So a fresh stamp or an absent claim observed
+    # AFTER the latch read above can only belong to a peer whose latch, if any, was already
+    # in place when that read happened — which is what makes these two checks safe to treat
+    # as "the sweep is over and this box is not latched".
+    if obj_sweep_stamp_is_fresh "$stamp"; then
+      OBJ_SWEEP_CLAIM_WAIT_STATE=completed
+      break
+    fi
+    if [[ ! -d "$claim" ]]; then
+      OBJ_SWEEP_CLAIM_WAIT_STATE=vacated
+      break
+    fi
+    now="$(date +%s)"
+    # THE CLAIM'S OWN DEADLINE, RE-READ EVERY PASS so a mid-wait takeover by a third lane is
+    # waited out on that lane's bound. `stat` is not used for the same GNU-vs-BSD reason
+    # obj_sweep_claim_acquire gives; an unreadable or future `started` falls back to the
+    # caller's outer deadline rather than to a made-up one, and the outer deadline is the
+    # ceiling in every case.
+    started=""
+    { read -r started || true; } 2>/dev/null <"$claim/started" || started=""
+    if [[ "$started" =~ ^[0-9]+$ ]] && [[ "$started" -le "$now" ]]; then
+      deadline=$((started + stale))
+    else
+      deadline="$overall"
+    fi
+    [[ "$deadline" -le "$overall" ]] || deadline="$overall"
+    # STRICTLY GREATER, AND IT MATCHES obj_sweep_claim_acquire'S TAKEOVER TEST EXACTLY. That
+    # function holds a claim while `age <= stale` and takes it over only when `age > stale`,
+    # so an expiry at `age >= stale` would return `expired` for one second during which the
+    # caller's re-acquire still answers `held` — a tight loop between the two, brief but real.
+    # The two comparisons are two halves of one threshold and they have to agree on the
+    # boundary, not merely on the number.
+    if [[ "$now" -gt "$deadline" ]]; then
+      if [[ "$now" -gt "$overall" ]]; then
+        OBJ_SWEEP_CLAIM_WAIT_STATE=exhausted
+      else
+        OBJ_SWEEP_CLAIM_WAIT_STATE=expired
+      fi
+      break
+    fi
+    # A FAILING `sleep` MUST NOT BECOME A BUSY SPIN over the whole derived budget, which is
+    # what `sleep ... || true` would buy on a host without it. It ends the wait instead, in
+    # the state that says the budget cannot be spent — announced, because a box that cannot
+    # wait has lost this protection and nothing else would say so.
+    if ! sleep "$OBJ_SWEEP_CLAIM_POLL_SECS" 2>/dev/null; then
+      log "object-store sweep: cannot WAIT for the peer lane's sweep — 'sleep $OBJ_SWEEP_CLAIM_POLL_SECS' failed on this host, so this lane will not poll for the peer's verdict and loses the protection that wait provides (#3749)."
+      OBJ_SWEEP_CLAIM_WAIT_STATE=exhausted
+      break
+    fi
+  done
+  elapsed=$(( $(date +%s) - started_at ))
+  case "$OBJ_SWEEP_CLAIM_WAIT_STATE" in
+    completed)
+      log "object-store sweep: the peer lane holding $claim FINISHED its sweep after ${elapsed}s of waiting and advertised it in the throttle stamp; this box is not latched (#3749)."
+      ;;
+    vacated)
+      log "object-store sweep: the peer lane holding $claim GAVE THE CLAIM UP after ${elapsed}s without advertising a sweep — it was killed mid-sweep, or it stopped on a verdict it could not latch and forced the throttle stamp stale so every lane re-sweeps. This box is not latched; this lane will contend for the claim again (#3749)."
+      ;;
+    expired)
+      log "object-store sweep: the peer lane holding $claim has neither finished nor given it up in ${elapsed}s, and that claim is now older than the derived ${stale}s recovery bound, so the sweep it represents cannot still be running. This lane will RECOVER the claim and measure the store itself rather than carry on unmeasured (#3749)."
+      ;;
+  esac
+  return 0
+}
+
 # obj_sweep_stamp_is_fresh <stamp-path> — 0 when this box swept inside the interval.
 #
 # ONE implementation, because the throttle is now read TWICE: once before contending for
@@ -3994,7 +4176,7 @@ obj_sweep_stop_if_latched() {
 }
 
 object_store_sweep() {
-  local script stamp latch claim claim_stale rc out verdict stop_verdict
+  local script stamp latch claim claim_stale wait_until rc out verdict stop_verdict
   # ---------------------------------------------------------------------------
   # THE ENTRY LATCH READ. IT IS ABOVE EVERY BRANCH IN THIS FUNCTION, AND THE LINES
   # BEFORE IT ARE ASSIGNMENTS ONLY — NO `if`, NO `return`, NOTHING THAT CAN LEAVE
@@ -4101,10 +4283,52 @@ object_store_sweep() {
   # loser skips instead of waiting.
   claim="$(obj_sweep_claim_path "$stamp")"
   claim_stale="$(obj_sweep_claim_stale_secs "$script" || true)"
-  obj_sweep_claim_acquire "$claim" "$claim_stale"
+  # THE ITERATION'S OVERALL WAIT BUDGET, AND IT IS THE SAME DERIVED VALUE AS THE STALENESS
+  # BOUND — not a second constant (#3749 review round 12). Any single claim can be at most
+  # `claim_stale` seconds from being recoverable, so one `claim_stale` from here is enough to
+  # outlast the claim this lane found AND to bound a chain of takeovers by peers. Where the
+  # bound could not be derived there is no budget and no wait, which is the same box on which
+  # no claim is taken at all.
+  wait_until=""
+  if [[ "$claim_stale" =~ ^[0-9]+$ ]]; then
+    wait_until=$(($(date +%s) + claim_stale))
+  fi
+  # ACQUIRE, AND IF A PEER IS SWEEPING, WAIT FOR IT — THEN CONTEND AGAIN.
+  #
+  # THE LOOP TERMINATES, and here is why rather than a hope. `held` is the only state that
+  # loops: every other one breaks immediately. A `held` costs a call to obj_sweep_claim_wait,
+  # which returns only on an affirmative observation (`completed`/`vacated`), on the claim
+  # having aged past its DERIVED recovery bound (`expired`, after which the very next acquire
+  # takes it over), or on the ITERATION's overall budget being spent (`exhausted`, which
+  # breaks out). It cannot spin: a claim that is present with no readable start time is waited
+  # out on the outer deadline rather than being read as instantly expired, and every pass of
+  # the wait sleeps.
+  #
+  # NOTHING BETWEEN THE WAIT AND THE RE-ACQUIRE NEEDS A LATCH READ: the wait itself reads the
+  # latch on every pass and does not return if the box is latched.
+  while true; do
+    obj_sweep_claim_acquire "$claim" "$claim_stale"
+    [[ "$OBJ_SWEEP_CLAIM_STATE" == held ]] || break
+    obj_sweep_claim_wait "$claim" "$claim_stale" "$latch" "$stamp" "$wait_until"
+    [[ "$OBJ_SWEEP_CLAIM_WAIT_STATE" != exhausted ]] || break
+  done
   case "$OBJ_SWEEP_CLAIM_STATE" in
     held)
-      log "object-store sweep: SKIPPED — a peer lane on this box holds the sweep claim ($claim), so the shared store is being rehashed by that lane right now. Not waiting, and not sweeping beside it: the sweep is a 6-hourly hygiene probe and one lane paying for it is the whole box's answer (#3749)."
+      # REACHED ONLY WITH THE WAIT BUDGET SPENT (or on a box that cannot wait at all): a peer
+      # lane is sweeping and this lane has already waited out one full derived staleness bound
+      # watching claims change hands. It is NOT a clean result and it is not reported as one —
+      # nothing here read the store, so its integrity is UNKNOWN, and the box gets a page once
+      # per run because a claim that keeps changing hands for that long is an anomaly, not a
+      # cadence. The lane does not stop: a peer sweeping is also the shape of a HEALTHY box
+      # recovering a wedged claim, and stopping four lanes on a hygiene probe's contention is
+      # the self-DoS this file refuses everywhere else. The residual this leaves is stated in
+      # full at the bottom of this file, per path, with its magnitude.
+      log "object-store sweep: NOT SWEPT AND NOT MEASURED — a peer lane still holds the sweep claim ($claim) after this lane waited out the whole derived ${claim_stale}s budget, so the claim has changed hands or overrun rather than completing. This box's store integrity is UNKNOWN, not clean, for this iteration (#3749)."
+      if [[ "$OBJ_SWEEP_CLAIM_WAIT_UNMEASURED_NOTIFIED" -eq 0 ]]; then
+        notify "high" "worker-supervisor: object-store sweep never got a turn" \
+          "a peer lane held the sweep claim for this box's shared object store for longer than the whole derived recovery bound (${claim_stale}s) — the store was NOT rehashed on this iteration and its integrity is UNKNOWN, not clean. Check for a wedged sweep on this box."
+        OBJ_SWEEP_CLAIM_WAIT_UNMEASURED_NOTIFIED=1
+      fi
       obj_sweep_stop_if_latched "$latch"
       return 0
       ;;
@@ -4328,35 +4552,62 @@ object_store_sweep() {
   return 0
 }
 
-# THE RESIDUAL WINDOW, STATED PRECISELY BECAUSE IT IS NOT CLOSED (#3749 review round 3,
-# item 1b — DELIBERATELY DEFERRED to its own issue, not papered over).
+# THE RESIDUAL WINDOWS, PER PATH, WITH THEIR REAL MAGNITUDES (#3749 review rounds 3 and 12).
 #
-# WHAT THE ORDERING ABOVE BUYS: no lane advertises "this box has been swept" before the
-# CORRUPT finding is durable, and no lane returns from this function toward a spawn
-# without having re-read the latch. That strictly shrinks the window; it does not remove
-# it.
+# THE PREVIOUS VERSION OF THIS NOTE WAS WRONG, AND IN THE DIRECTION THAT MATTERS. It gave
+# ONE figure for every path — "a peer can create the latch in the gap between this lane's
+# last latch read and the moment its worker actually starts", "ONE worker is spawned on a box
+# that was latched corrupt MOMENTS earlier" — and round 12's review found that for the
+# CLAIM-LOSER path this understated the window by orders of magnitude: it was never the
+# post-read gap, it was the peer's ENTIRE sweep — 13-80s measured on this fleet's 366M store
+# and up to MAX_SWEEP_WALKS x OBJ_SWEEP_TIMEOUT_SECS = 600s at the shipped defaults. A note
+# that understates the very window it exists to disclose is worse than no note, because it is
+# what stops the next person looking. So the magnitudes below are stated PER PATH and each is
+# derived from a shipped default or from a measurement, never from the word "moments".
 #
-# WHAT REMAINS RACY. The latch read and the worker spawn are two separate operations
-# with no synchronisation between them, so a peer can create the latch in the gap
-# between this lane's last `obj_sweep_stop_if_latched` and the moment its worker
-# actually starts — and that gap is not small: after this function returns, the caller
-# still runs the whole preflight hold loop (load, leftover processes, disk), which can
-# poll for minutes. A peer's sweep completing anywhere inside that stretch is
-# unobserved by this lane.
+# WHAT THE ORDERING AND THE WAIT BUY. No lane advertises "this box has been swept" before a
+# stopping finding is durable; no lane returns from object_store_sweep toward a spawn without
+# having re-read the latch; and a lane that LOSES the sweep claim now waits for the peer's
+# verdict, re-reading the latch every OBJ_SWEEP_CLAIM_POLL_SECS, instead of walking off with
+# one stale read.
 #
-# THE WORST OUTCOME, NAMED: ONE worker is spawned on a box that was latched corrupt
-# moments earlier. It is not silent and it is not durable — that lane's NEXT iteration
-# begins with `object_store_sweep`, whose first act is the latch read at the top, so it
-# stops there and its own worker exits at the end of its current issue. Nothing certifies
-# a merge in that window without a full gate, and a full gate on a latched box is exactly
-# what the next iteration refuses.
+# PATH 1 — THE CLAIM LOSER. CLOSED as a distinct window (round 12). It WAS the peer's whole
+# sweep: 13-80s measured, 600s by construction. It is now bounded by the poll granularity —
+# the waiting lane observes the latch within one OBJ_SWEEP_CLAIM_POLL_SECS (5s at the
+# shipped default) of its creation and stops there. One sub-case survives: if the derived
+# 660s wait budget is spent with peers still handing the claim around, the lane carries on
+# UNMEASURED — journalled and paged, never counted as clean — and from that point its
+# exposure is PATH 3's, below.
 #
-# WHY IT IS NOT CLOSED HERE. An atomic "no worker may start after any peer latches"
-# guarantee needs per-store synchronisation shared by the sweep and the spawn decision
-# (a lock held across both, or a spawn-time re-check inside whatever holds that lock) —
-# a redesign of the boundary between this function and the spawn path, not an ordering
-# change. It is split to its own issue. Do NOT describe the race as closed: it is
-# narrowed, and the residual above is what a reader is entitled to know.
+# PATH 2 — THIS LANE'S OWN SWEEP. Covered, not residual. The entry latch read and the
+# post-sweep reads bracket it, so a peer latching the box during this lane's own walks (up to
+# 600s) is caught by the read on the way out.
+#
+# PATH 3 — THE LAST LATCH READ TO THE WORKER SPAWN. STILL OPEN, AND IT IS THE LARGEST OF THE
+# THREE. object_store_sweep returns, and the caller then runs the preflight hold loop, which
+# does NOT re-read the latch: on a clear box the gap is milliseconds, but every hold sleeps
+# HOLD_POLL_SECS and the loop tolerates up to BUILD_HOLD_MAX of them, so at the shipped
+# defaults the gap is up to 12 x 300s = 3600s — ONE HOUR, not "moments" (the leftover-worker
+# family is bounded at LEFTOVER_HOLD_MAX x HOLD_POLL_SECS = 900s). A peer's sweep completing
+# anywhere inside that stretch is unobserved by this lane, and ONE worker then starts on a
+# box that is already latched.
+#
+# THE BOUND ON THE HARM, unchanged and still true for every path. It is not silent and not
+# durable: that lane's NEXT iteration begins with object_store_sweep, whose first act is the
+# entry latch read, so it stops there and its worker exits at the end of its current issue.
+# Nothing certifies a merge inside that window without a full gate, and a full gate on a
+# latched box is exactly what the next iteration refuses.
+#
+# WHY PATH 3 IS NOT CLOSED HERE. An atomic "no worker may start after any peer latches"
+# guarantee needs per-store synchronisation shared by the sweep and the spawn decision (a
+# lock held across both, or a spawn-time re-check inside whatever holds that lock) — a
+# redesign of the boundary between this function and the spawn path, not an ordering change.
+# It is split to its own issue, and so is the cheapest partial (a latch read inside the hold
+# loop, which would cut 3600s down to one HOLD_POLL_SECS): that read belongs with the
+# redesign rather than smuggled into a fix for path 1, where it would arrive untested and
+# would tempt exactly the "narrowed, so basically closed" reading this note was rewritten to
+# remove. PATH 1 IS CLOSED; PATH 3 IS OPEN AND ITS MAGNITUDE IS ABOVE. Do not describe the
+# race as gone.
 
 # ---------------------------------------------------------------------------
 # Preflight: fail-closed, wait-don't-spin. Returns a hold reason on stdout, or
@@ -4435,6 +4686,11 @@ preflight_wait() {
   # precisely so that every walk this caller can pay for still costs no more than ONE
   # walk at the script's bound. The stop file is re-read the moment
   # the sweep returns (the loop's first statement, below).
+  #
+  # ONE PART OF IT IS INTERRUPTIBLE, AND IT IS THE NEW PART (#3749 review round 12): when a
+  # PEER lane holds the sweep claim this lane now WAITS for that peer's verdict, and that
+  # wait runs in THIS shell rather than in the sweep's child, so it re-reads the stop file,
+  # the wall-clock budget and the STOP latch on every poll.
   object_store_sweep
   while true; do
     preflight_stop_or_budget
@@ -5108,7 +5364,7 @@ validate_numeric_knobs() {
               MAX_ITER_SECS STUCK_POLL_SECS STUCK_TAIL_LINES LEFTOVER_HOLD_MAX \
               UNVERIFIED_MAX MISMATCH_RETRIES MISMATCH_RETRY_WAIT_SECS \
               PENDING_AUTOMERGE_MAX PENDING_AUTOMERGE_MIN_SECS \
-              OBJ_SWEEP_INTERVAL_HOURS; do
+              OBJ_SWEEP_INTERVAL_HOURS OBJ_SWEEP_CLAIM_SLACK_SECS; do
     val="${!name}"
     [[ "$val" =~ ^[0-9]+$ ]] || _bad_knob "$name" "$val" "a non-negative integer"
   done
@@ -5132,6 +5388,16 @@ validate_numeric_knobs() {
     val="${!name}"
     [[ "$val" =~ ^[0-9]+$ ]] || _bad_knob "$name" "$val" "a positive integer"
     [[ "$val" -ge 1 ]] || _bad_knob "$name" "$val" "a positive integer (the sweep rejects 0, which would make every run UNMEASURED)"
+  done
+  # OBJ_SWEEP_CLAIM_POLL_SECS (#3749 review round 12) is the same class again, in the other
+  # direction: it is the sleep between passes of the wait on a PEER lane's in-flight sweep,
+  # so a 0 does not disable the wait — it turns a bounded wait into a BUSY SPIN for up to the
+  # whole derived staleness bound, on a box that is already spending an fsck. Its own group
+  # because the message has to say that.
+  for name in OBJ_SWEEP_CLAIM_POLL_SECS; do
+    val="${!name}"
+    [[ "$val" =~ ^[0-9]+$ ]] || _bad_knob "$name" "$val" "a positive integer"
+    [[ "$val" -ge 1 ]] || _bad_knob "$name" "$val" "a positive integer (0 would busy-spin the wait on a peer's sweep instead of polling it)"
   done
   # SIGNED integer knobs — the two with a documented `<=0 disables` contract.
   for name in BUILD_HOLD_MAX MISMATCH_GRACE_CAP_SECS; do

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -3373,6 +3373,28 @@ obj_sweep_set_latch() {
   obj_sweep_latch_present "$latch"
 }
 
+# obj_sweep_stop_if_latched <latch-path> — ASK THE LATCH QUESTION AND STOP IF THE ANSWER
+# IS YES. Returns 0 (carry on) when the box is not latched; never returns at all when it
+# is, because finalize_exit ends the process.
+#
+# WHY IT IS A FUNCTION CALLED FROM SEVERAL PLACES RATHER THAN ONE CHECK AT THE TOP
+# (#3749 review round 3, item 1a). The question has to be asked again IMMEDIATELY BEFORE
+# every path that lets this lane go on to spawn a worker, because a PEER can latch the
+# box at any moment — including while this lane's own sweep is in flight, which is up to
+# two fsck walks. A lane that swept CLEAN while a peer was recording CORRUPT would
+# otherwise return 0 from a sweep whose answer is already known to be superseded.
+obj_sweep_stop_if_latched() {
+  local latch="$1" latch_ts
+  obj_sweep_latch_present "$latch" || return 0
+  latch_ts="$(head -1 "$latch" 2>/dev/null || true)"
+  [[ "$latch_ts" =~ ^[0-9]+$ ]] || latch_ts="<unrecorded>"
+  notify "high" "worker-supervisor: SHARED OBJECT STORE CORRUPT (latched)" \
+    "a sweep on this box recorded CORRUPT for the shared git object store every lane here reads. Stopping without re-sweeping. Repair the store, then remove $latch."
+  log "object-store: CORRUPT (cached at $latch_ts by a sweep on this box) — stopping; no worker may certify against a damaged shared store (#3749)."
+  log "object-store: REMEDY — stop every lane on this box and re-obtain the objects from the canonical remote; a local 'git gc'/'git repack' CANNOT repair it. THEN CLEAR THE LATCH: rm -f $latch"
+  finalize_exit "object-store-corrupt" 1
+}
+
 object_store_sweep() {
   local script stamp latch latch_ts now last rc out verdict stamp_ts
   if [[ "$OBJ_SWEEP_INTERVAL_HOURS" -le 0 ]]; then
@@ -3432,17 +3454,13 @@ object_store_sweep() {
   # age-based expiry would resume workers over a still-damaged store; the operator who
   # repairs the store removes the file, and the remedy line below NAMES the path and the
   # command, because a latch nobody can clear bricks the box after the repair.
-  if obj_sweep_latch_present "$latch"; then
-    latch_ts="$(head -1 "$latch" 2>/dev/null || true)"
-    [[ "$latch_ts" =~ ^[0-9]+$ ]] || latch_ts="<unrecorded>"
-    notify "high" "worker-supervisor: SHARED OBJECT STORE CORRUPT (latched)" \
-      "a sweep on this box recorded CORRUPT for the shared git object store every lane here reads. Stopping without re-sweeping. Repair the store, then remove $latch."
-    log "object-store: CORRUPT (cached at $latch_ts by a sweep on this box) — stopping; no worker may certify against a damaged shared store (#3749)."
-    log "object-store: REMEDY — stop every lane on this box and re-obtain the objects from the canonical remote; a local 'git gc'/'git repack' CANNOT repair it. THEN CLEAR THE LATCH: rm -f $latch"
-    finalize_exit "object-store-corrupt" 1
-  fi
+  obj_sweep_stop_if_latched "$latch"
 
   if [[ -n "$stamp" ]] && [[ $((now - last)) -lt $((OBJ_SWEEP_INTERVAL_HOURS * 3600)) ]]; then
+    # RE-ASKED ON THE THROTTLED PATH TOO. Cheap (one stat), and it keeps ONE rule —
+    # "no return that leads to a spawn without a fresh latch read" — instead of a set of
+    # paths someone has to remember to audit individually.
+    obj_sweep_stop_if_latched "$latch"
     return 0
   fi
   rc=0
@@ -3472,33 +3490,53 @@ object_store_sweep() {
   verdict="${verdict#OBJECT-STORE: verdict }"
   verdict="${verdict%% *}"
 
-  # THE STAMP IS WRITTEN FOR EVERY OUTCOME. It bounds how often this box SPENDS the sweep
-  # — a box that cannot measure (no timeout binary, say) must not re-attempt it every
-  # iteration — and it says nothing about what was found. What a peer lane must not
-  # throttle past is recorded separately, and monotonically, by the latch below.
-  obj_sweep_write_stamp "$stamp"
-
-  if [[ "$rc" -eq 0 && "$verdict" == "VERIFIED" ]]; then
-    log "object-store: VERIFIED — $(printf '%s\n' "$out" | { grep '^OBJECT-STORE: measured ' || true; } | head -1)"
-    return 0
-  fi
+  # THE CORRUPT BRANCH IS TESTED FIRST, AND IT CREATES THE LATCH BEFORE THE THROTTLE
+  # STAMP IS WRITTEN (#3749 review round 3, item 1a).
+  #
+  # THE ORDERING DEFECT THIS FIXES. The stamp used to be written for every outcome
+  # BEFORE this branch ran, so between that write and the latch create there was a
+  # window in which a peer lane saw a FRESH, non-corrupt throttle stamp, skipped its own
+  # sweep for the whole interval, and went on spawning workers over a store this lane
+  # had already found damaged. The window was as long as it took to build the `findings`
+  # string and create a file; it is now empty in that direction, because the latch — the
+  # thing a peer must not throttle past — is in place before anything advertises that
+  # this box has been swept.
   if [[ "$rc" -eq 4 || "$verdict" == "CORRUPT" ]]; then
     local findings
-    findings="$(printf '%s\n' "$out" | { grep -E '^OBJECT-STORE: (finding|object) ' || true; } | head -6 | tr '\n' ';' | cut -c1-600)"
-    # LATCH FIRST, THEN STOP. A failure to persist it is REPORTED, never silent: this
-    # lane stops either way, but without the latch the peers on this box will re-run
-    # their own sweep and rediscover the damage rather than inheriting the verdict, and
-    # an operator reading only this journal would otherwise never learn that.
+    # LATCH FIRST, THEN EVERYTHING ELSE. A failure to persist it is REPORTED, never
+    # silent: this lane stops either way, but without the latch the peers on this box
+    # will re-run their own sweep and rediscover the damage rather than inheriting the
+    # verdict, and an operator reading only this journal would otherwise never learn that.
     if [[ -z "$latch" ]]; then
       log "object-store: the CORRUPT verdict could NOT be latched — this box's shared store could not be resolved, so there is no box-wide file to record it in. Peer lanes will re-sweep and rediscover it (#3749)."
     elif ! obj_sweep_set_latch "$latch"; then
       log "object-store: the CORRUPT verdict could NOT be latched at $latch (unwritable?) — peer lanes will re-sweep and rediscover it rather than inheriting this verdict (#3749)."
     fi
+    # ONLY NOW the throttle stamp: it says "this box paid for a sweep", and a peer
+    # reading it will also read the latch that is already there.
+    obj_sweep_write_stamp "$stamp"
+    findings="$(printf '%s\n' "$out" | { grep -E '^OBJECT-STORE: (finding|object) ' || true; } | head -6 | tr '\n' ';' | cut -c1-600)"
     notify "high" "worker-supervisor: SHARED OBJECT STORE CORRUPT" \
       "git fsck reports damaged objects in this box's shared git object store — every lane here reads it, so NO gate verdict on this box can be trusted. Stopping. ${findings:-<no findings captured>}"
     log "object-store: CORRUPT — stopping loudly; no worker may certify against a damaged shared store (#3749). ${findings:-<no findings captured>}"
     log "object-store: REMEDY — stop every lane on this box and re-obtain the objects from the canonical remote; a local 'git gc'/'git repack' CANNOT repair it.${latch:+ THEN CLEAR THE LATCH: rm -f $latch}"
     finalize_exit "object-store-corrupt" 1
+  fi
+
+  # THE STAMP IS WRITTEN FOR EVERY OUTCOME. It bounds how often this box SPENDS the
+  # sweep — a box that cannot measure (no timeout binary, say) must not re-attempt it
+  # every iteration — and it says nothing about what was found. What a peer lane must
+  # not throttle past is recorded separately, and monotonically, by the latch above.
+  obj_sweep_write_stamp "$stamp"
+
+  if [[ "$rc" -eq 0 && "$verdict" == "VERIFIED" ]]; then
+    log "object-store: VERIFIED — $(printf '%s\n' "$out" | { grep '^OBJECT-STORE: measured ' || true; } | head -1)"
+    # RE-ASKED AFTER THE SWEEP, BEFORE RETURNING TO THE SPAWN PATH. This lane's own walk
+    # said VERIFIED, but it took up to two fsck bounds to say it, and a PEER may have
+    # latched the box in the meantime. The peer's finding is about the same store and is
+    # strictly newer than this measurement, so it wins.
+    obj_sweep_stop_if_latched "$latch"
+    return 0
   fi
   # UNMEASURED (or no recognised verdict at all): REPORTED, and DELIBERATELY PERMISSIVE.
   # THE WHY, IN CODE (CLAUDE.md #3229). An UNMEASURED sweep is not clean — nothing here
@@ -3517,8 +3555,41 @@ object_store_sweep() {
       "the shared git object store could not be rehashed on this box (rc=$rc) — integrity is UNKNOWN, not clean. The loop continues; fix the cause so the sweep can run."
     OBJ_SWEEP_UNMEASURED_NOTIFIED=1
   fi
+  # Same re-check on the permissive path: UNMEASURED lets this lane carry on, so it is a
+  # return that leads to a spawn and it gets a fresh latch read like every other one.
+  obj_sweep_stop_if_latched "$latch"
   return 0
 }
+
+# THE RESIDUAL WINDOW, STATED PRECISELY BECAUSE IT IS NOT CLOSED (#3749 review round 3,
+# item 1b — DELIBERATELY DEFERRED to its own issue, not papered over).
+#
+# WHAT THE ORDERING ABOVE BUYS: no lane advertises "this box has been swept" before the
+# CORRUPT finding is durable, and no lane returns from this function toward a spawn
+# without having re-read the latch. That strictly shrinks the window; it does not remove
+# it.
+#
+# WHAT REMAINS RACY. The latch read and the worker spawn are two separate operations
+# with no synchronisation between them, so a peer can create the latch in the gap
+# between this lane's last `obj_sweep_stop_if_latched` and the moment its worker
+# actually starts — and that gap is not small: after this function returns, the caller
+# still runs the whole preflight hold loop (load, leftover processes, disk), which can
+# poll for minutes. A peer's sweep completing anywhere inside that stretch is
+# unobserved by this lane.
+#
+# THE WORST OUTCOME, NAMED: ONE worker is spawned on a box that was latched corrupt
+# moments earlier. It is not silent and it is not durable — that lane's NEXT iteration
+# begins with `object_store_sweep`, whose first act is the latch read at the top, so it
+# stops there and its own worker exits at the end of its current issue. Nothing certifies
+# a merge in that window without a full gate, and a full gate on a latched box is exactly
+# what the next iteration refuses.
+#
+# WHY IT IS NOT CLOSED HERE. An atomic "no worker may start after any peer latches"
+# guarantee needs per-store synchronisation shared by the sweep and the spawn decision
+# (a lock held across both, or a spawn-time re-check inside whatever holds that lock) —
+# a redesign of the boundary between this function and the spawn path, not an ordering
+# change. It is split to its own issue. Do NOT describe the race as closed: it is
+# narrowed, and the residual above is what a reader is entitled to know.
 
 # ---------------------------------------------------------------------------
 # Preflight: fail-closed, wait-don't-spin. Returns a hold reason on stdout, or

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -3825,7 +3825,14 @@ obj_sweep_claim_release() {
 # one of:
 #
 #   completed — the throttle stamp went FRESH, so that peer finished a sweep and advertised
-#               it; the box is inside the interval again
+#               it; the box is inside the interval again. THE CALLER MUST NOT CONTEND FOR
+#               THE CLAIM AGAIN ON THIS OUTCOME (#3749 review round 14): this state is
+#               reached WITHOUT SLEEPING, on the pass that observes the stamp, so a peer
+#               that advertised a sweep and then died holding its claim would answer
+#               `held` -> `completed` -> `held` -> `completed` at CPU speed forever. A
+#               fresh stamp says the store was measured inside the interval, which is all
+#               the caller needs: it skips, exactly as the throttle at the top of
+#               object_store_sweep would.
 #   vacated   — the claim is GONE with no fresh stamp: the peer ended without advertising a
 #               sweep (killed mid-sweep, or it stopped on a verdict it could not latch and
 #               FORCED the stamp stale on purpose so that every lane re-sweeps)
@@ -3954,6 +3961,10 @@ obj_sweep_claim_wait() {
       # the next statement. The caller re-reads the latch before it returns toward a spawn;
       # this line is a journal entry, not a licence.
       log "object-store sweep: the peer lane holding $claim FINISHED its sweep after ${elapsed}s of waiting and advertised it in the throttle stamp; no stopping verdict had been recorded for this box as of the read that observed it (#3749)."
+      # AND THE CALLER STOPS THERE. This line says nothing about whether that peer has
+      # RELEASED its claim — a peer killed between the stamp write and its EXIT trap has
+      # not — which is why the caller treats `completed` as a terminal skip rather than as
+      # a cue to contend again (round 14).
       ;;
     vacated)
       log "object-store sweep: the peer lane holding $claim GAVE THE CLAIM UP after ${elapsed}s without advertising a sweep — it was killed mid-sweep, or it stopped on a verdict it could not latch and forced the throttle stamp stale so every lane re-sweeps. No stopping verdict had been recorded for this box as of the read that observed it; this lane will contend for the claim again (#3749)."
@@ -4330,16 +4341,39 @@ object_store_sweep() {
   if [[ "$claim_stale" =~ ^[0-9]+$ ]]; then
     wait_until=$(($(date +%s) + claim_stale))
   fi
-  # ACQUIRE, AND IF A PEER IS SWEEPING, WAIT FOR IT — THEN CONTEND AGAIN.
+  # ACQUIRE, AND IF A PEER IS SWEEPING, WAIT FOR IT — THEN CONTEND AGAIN, EXCEPT WHERE
+  # CONTENDING AGAIN COULD NEVER ACHIEVE ANYTHING (#3749 review round 14).
   #
-  # THE LOOP TERMINATES, and here is why rather than a hope. `held` is the only state that
-  # loops: every other one breaks immediately. A `held` costs a call to obj_sweep_claim_wait,
-  # which returns only on an affirmative observation (`completed`/`vacated`), on the claim
-  # having aged past its DERIVED recovery bound (`expired`, after which the very next acquire
-  # takes it over), or on the ITERATION's overall budget being spent (`exhausted`, which
-  # breaks out). It cannot spin: a claim that is present with no readable start time is waited
-  # out on the outer deadline rather than being read as instantly expired, and every pass of
-  # the wait sleeps.
+  # THE DEFECT THIS LOOP HAD. `completed` — the throttle stamp went FRESH — was treated as
+  # "go round again", and the wait reaches it WITHOUT SLEEPING (it is tested on the pass that
+  # observes it). In the ordinary case that costs one harmless extra acquire: the peer
+  # released a moment earlier, so the re-acquire succeeds and the second throttle read below
+  # skips. But a peer that writes the stamp and then DIES before releasing leaves the claim
+  # PRESENT and the stamp FRESH — a state in which every acquire answers `held` and every
+  # wait answers `completed` in microseconds — so the lane spun CPU-hot, achieving nothing,
+  # until the supervisor's whole MAX_HOURS wall-clock budget expired. A liveness and CPU
+  # defect, not a wrong verdict, and on a four-lane box it is a burnt core that reads as
+  # "the fleet got slow" with no attributable cause.
+  #
+  # AND THE STALENESS RECOVERY COULD NOT SAVE IT, WHICH IS THE INTERESTING PART. Round 5 gave
+  # the claim an age-based bound precisely so a dead peer's claim becomes recoverable — but
+  # `completed` is tested BEFORE the claim's deadline on every pass, so on this path that
+  # recovery never ran. The fix does NOT add a second notion of "the peer is gone" (a second
+  # mechanism is a second thing to drift): a fresh stamp is the same answer the throttle at the
+  # top of this function gives, so the lane takes the same action it would have taken there —
+  # SKIP — and stops contending. See the `completed` branch below the loop.
+  #
+  # THE LOOP IS BOUNDED IN WALL TIME BY CONSTRUCTION, and by the value it already derived.
+  # `held` is the only state that continues, and after this round only `vacated` and `expired`
+  # reach the next pass: `exhausted` and `completed` break. Both survivors mean the claim this
+  # lane observed is gone or recoverable, so the next acquire normally ends the loop — but
+  # neither is REQUIRED to have slept (a claim that vanishes on the wait's first pass returns
+  # `vacated` immediately), so a peer flapping the claim could otherwise still spin. The
+  # `wait_until` test below is therefore over the ITERATION's own derived budget — the same
+  # `claim_stale` the wait and the recovery threshold use, never a second constant — which
+  # makes every path out of this loop bounded by ~claim_stale of wall clock rather than by
+  # MAX_HOURS. A break there leaves OBJ_SWEEP_CLAIM_STATE at `held`, i.e. the honest
+  # NOT-SWEPT-AND-NOT-MEASURED outcome below, which is exactly what `exhausted` reports.
   #
   # NOTHING BETWEEN THE WAIT AND THE RE-ACQUIRE NEEDS A LATCH READ: the wait itself reads the
   # latch on every pass and does not return if the box is latched.
@@ -4347,8 +4381,27 @@ object_store_sweep() {
     obj_sweep_claim_acquire "$claim" "$claim_stale"
     [[ "$OBJ_SWEEP_CLAIM_STATE" == held ]] || break
     obj_sweep_claim_wait "$claim" "$claim_stale" "$latch" "$stamp" "$wait_until"
-    [[ "$OBJ_SWEEP_CLAIM_WAIT_STATE" != exhausted ]] || break
+    case "$OBJ_SWEEP_CLAIM_WAIT_STATE" in
+      exhausted | completed) break ;;
+    esac
+    if [[ "$wait_until" =~ ^[0-9]+$ ]] && [[ "$(date +%s)" -gt "$wait_until" ]]; then
+      break
+    fi
   done
+  # THE PEER FINISHED AND ADVERTISED IT: SKIP, AND DO NOT CONTEND FOR THAT CLAIM AGAIN
+  # (#3749 review round 14). The stamp is fresh, so this box HAS been rehashed inside the
+  # interval — there is nothing for this lane to measure this iteration whether or not the
+  # peer ever gives its claim up. Returning here is not a new policy: it is the same skip the
+  # throttle at the top of this function performs on the same observation, and it is STRICTLY
+  # LESS work than the acquire-and-release round trip this path used to make in the ordinary
+  # case, so the common case (a peer that released a moment ago) gains no latency from the
+  # fix. The latch read is the one rule that governs every return from this function: no
+  # return that leads to a spawn without a fresh read.
+  if [[ "$OBJ_SWEEP_CLAIM_STATE" == held && "$OBJ_SWEEP_CLAIM_WAIT_STATE" == completed ]]; then
+    log "object-store sweep: SKIPPED — the peer lane holding $claim finished sweeping this store and advertised it in the throttle stamp while this lane waited, so the box is inside the interval again and this lane does not contend for that claim again (#3749)."
+    obj_sweep_stop_if_latched "$latch"
+    return 0
+  fi
   case "$OBJ_SWEEP_CLAIM_STATE" in
     held)
       # REACHED ONLY WITH THE WAIT BUDGET SPENT (or on a box that cannot wait at all): a peer
@@ -4606,8 +4659,9 @@ object_store_sweep() {
 # been swept" before a stopping finding is durable; no lane returns from object_store_sweep
 # toward a spawn without having re-read the latch; a lane that LOSES the sweep claim waits for
 # the peer's verdict, re-reading the latch every OBJ_SWEEP_CLAIM_POLL_SECS, instead of walking
-# off with one stale read; and no lane returns from preflight_wait — however long its hold
-# loop ran — without one more fresh read (round 13).
+# off with one stale read; that wait ends in bounded wall time whatever the peer does, rather
+# than spinning on a claim a dead peer will never give up (round 14); and no lane returns from
+# preflight_wait — however long its hold loop ran — without one more fresh read (round 13).
 #
 # PATH 1 — THE CLAIM LOSER. CLOSED as a distinct window (round 12). It WAS the peer's whole
 # sweep: 13-80s measured, 600s by construction. It is now bounded by the poll granularity —
@@ -4616,6 +4670,16 @@ object_store_sweep() {
 # 660s wait budget is spent with peers still handing the claim around, the lane carries on
 # UNMEASURED — journalled and paged, never counted as clean — and from that point its
 # exposure is PATH 3's, below.
+#
+# AND THE WAIT ITSELF IS BOUNDED IN WALL TIME BY CONSTRUCTION, NOT BY MAX_HOURS (round 14).
+# `completed` is reached WITHOUT SLEEPING, and the contention loop used to go round again on
+# it — so a peer that advertised its sweep and then DIED holding its claim (stamp FRESH,
+# claim PRESENT) made this lane spin CPU-hot until the supervisor's whole wall-clock budget
+# expired: 2165 observed completions in 20s, a burnt core on a four-lane box reading as "the
+# fleet got slow" with no attributable cause. `completed` now ENDS the wait and the lane
+# SKIPS (a fresh stamp is the same answer the throttle at the top of object_store_sweep
+# gives), and the loop carries its own deadline over the iteration's derived `claim_stale`
+# budget because neither remaining continuing state is required to have slept.
 #
 # PATH 2 — THIS LANE'S OWN SWEEP. Covered, not residual. The entry latch read and the
 # post-sweep reads bracket it, so a peer latching the box during this lane's own walks (up to

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -3376,21 +3376,33 @@ obj_sweep_latch_path() {
 #   present — something is at that path. `-e || -L`, because a DANGLING symlink is
 #             `-e`-false and the fail-safe reading of "something is at the latch path" is
 #             LATCHED. Same idiom, same reason, as the supervisor lock's existence test.
-#   absent  — nothing is there AND the directory that would hold it was SEARCHABLE, so this
-#             is a MEASUREMENT and not a failure to look. A directory that does not exist
-#             yields `absent` too: no file can be inside one that is not there.
+#   absent  — nothing is there AND the absence was ESTABLISHED THROUGH SEARCHABLE
+#             ANCESTORS, so it is a MEASUREMENT and not a failure to look.
 #             SEARCH (`-x`) and not READ (`-r`) is the right test, deliberately: `-e` on a
 #             named path needs only search permission on the parent, so a searchable but
 #             unlistable directory gives a TRUE answer and requiring `-r` as well would
 #             refuse a probe that was in fact valid — a false stop bought for nothing.
-#   unknown — the directory exists and this process cannot search it, so a latch may be
-#             sitting there unread. NEVER folded into `absent`.
+#   unknown — a latch may be sitting there unread, because some directory on the way to it
+#             exists and this process cannot search it. NEVER folded into `absent`.
+#
+# AND `-d` IS ITSELF A TWO-VALUED PREDICATE, WHICH IS THE SAME TRAP ONE LEVEL UP (#3749
+# review round 10, item 2). The first version answered `absent` whenever `[[ ! -d "$dir" ]]`
+# — reading "the holding directory does not exist" off a test that is ALSO false when an
+# ANCESTOR of that directory is not searchable. On a box where `/tmp/x` is mode 000 and the
+# latch would live at `/tmp/x/y/stamp.STOP`, `-d /tmp/x/y` is false, and a latch that may
+# well be sitting there was reported as an affirmative `absent` — bypassing the fail-closed
+# `unknown` state built for exactly this. So absence is established by WALKING UP to the
+# deepest ancestor this process can actually stat, and it counts only when that ancestor is
+# SEARCHABLE: with a searchable ancestor, a stat of its child gives a true answer (and so
+# does each stat below it, by induction), so a component that fails `-d` beneath one
+# genuinely is not there. With an UNSEARCHABLE one, nothing below it is observable and the
+# answer is `unknown`.
 #   unkeyed — there is no latch PATH at all, because the box-wide key could not be
 #             derived. A different statement from all three above: it is not that the file
 #             is unreadable, it is that no file was ever named. The caller decides, and
 #             says why at the branch.
 obj_sweep_latch_state() {
-  local latch="$1" dir
+  local latch="$1" dir probe parent
   [[ -n "$latch" ]] || {
     printf 'unkeyed'
     return 0
@@ -3400,9 +3412,29 @@ obj_sweep_latch_state() {
     return 0
   fi
   dir="${latch%/*}"
+  # No slash at all: the holding directory is the CWD, which is what a bare `-e` would
+  # have resolved the name against.
   [[ "$dir" == "$latch" ]] && dir="."
+  # A latch directly under the root: `${latch%/*}` strips to the empty string.
   [[ -n "$dir" ]] || dir="/"
-  if [[ ! -d "$dir" ]] || [[ -x "$dir" ]]; then
+  # Walk up to the deepest ancestor that can be STATTED. Each step strictly shortens the
+  # path or breaks, so this terminates; `.` is the implicit parent of a relative
+  # single-component path, and `/` is its own parent, which is where the walk ends.
+  probe="$dir"
+  while [[ ! -d "$probe" ]]; do
+    parent="${probe%/*}"
+    [[ -n "$parent" ]] || parent="/"
+    [[ "$parent" == "$probe" ]] && parent="."
+    [[ "$parent" != "$probe" ]] || break
+    probe="$parent"
+  done
+  # Not even the end of that walk is a statable directory: nothing was established, so the
+  # answer is `unknown` and not an absence.
+  if [[ ! -d "$probe" ]]; then
+    printf 'unknown'
+    return 0
+  fi
+  if [[ -x "$probe" ]]; then
     printf 'absent'
     return 0
   fi

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -206,14 +206,24 @@ UNVERIFIED_MAX="${UNVERIFIED_MAX:-2}"
 #   a store known to be damaged.
 # OBJ_SWEEP_TIMEOUT_SECS — passed through as the sweep's own `--timeout`, and it is the
 #   bound on EACH of the sweep's walks (a non-clean first walk is re-run once as a
-#   discriminator), so the worst-case wall time is twice it. 600s is ~7.5x the observed
-#   cold worst case above; the bound exists to stop a HANG, not to police duration, and a
-#   bound that expires on a healthy-but-busy box yields UNMEASURED noise nobody acts on.
+#   discriminator), so the worst-case wall time is TWICE it. The bound exists to stop a
+#   HANG, not to police duration, and a bound that expires on a healthy-but-busy box
+#   yields UNMEASURED noise nobody acts on.
+#   THE SUPERVISOR'S DEFAULT IS HALF THE SWEEP SCRIPT'S OWN (300 vs 600), AND THAT IS
+#   THIS CALLER'S LATENCY BUDGET RATHER THAN A DIFFERENT VIEW OF THE STORE (#3749 review
+#   round 3, item 3). The sweep runs inside a CHILD process, so nothing here can check
+#   the stop file or the wall-clock budget BETWEEN its two walks; the only lever this
+#   caller has is how long those two walks can take. At 300 the worst case is 600s — one
+#   walk at the script's own bound — instead of the 1200s that raising the per-walk bound
+#   to 600 in round 2 silently bought. 300s is still ~3.75x the observed COLD worst case
+#   (47-80s on this fleet's 366M store) and ~12x the warm one, so it costs no realistic
+#   sweep its verdict. The other caller, scripts/bootstrap-agent-machine.sh, keeps 600:
+#   machine onboarding is a one-shot step where nobody is waiting on a stop file.
 #   STRICTLY POSITIVE: the sweep rejects 0 as a usage error, which would turn the probe
 #   into a permanent UNMEASURED — a silently self-disabling bound, the shape
 #   validate_numeric_knobs exists for.
 OBJ_SWEEP_INTERVAL_HOURS="${OBJ_SWEEP_INTERVAL_HOURS:-6}"
-OBJ_SWEEP_TIMEOUT_SECS="${OBJ_SWEEP_TIMEOUT_SECS:-600}"
+OBJ_SWEEP_TIMEOUT_SECS="${OBJ_SWEEP_TIMEOUT_SECS:-300}"
 # Empty => derived per SHARED STORE in obj_sweep_stamp_path (below), so lanes sharing one
 # object store share one throttle. It also names the CORRUPT latch (`<stamp>.CORRUPT`),
 # so pinning it relocates both files together.
@@ -3632,16 +3642,43 @@ LAST_HOLD_REASON=""
 # leftover families are bounded SEPARATELY (roborev 1839): a non-self-clearing worker
 # orphan trips the TIGHT LEFTOVER_HOLD_MAX; a self-clearing build/gate process is
 # allowed the LOOSE BUILD_HOLD_MAX so a legitimate concurrent full gate is waited out.
+# preflight_stop_or_budget — the TWO clean-exit conditions, in one place so they can be
+# asked wherever this file is about to commit to something long and uninterruptible.
+# Never returns when either fires (finalize_exit ends the process).
+preflight_stop_or_budget() {
+  [[ -f "$STOP_FILE" ]] && finalize_exit "stop-file" 0
+  [[ $(($(date +%s) - START_TS)) -ge "$MAX_HOURS_SECS" ]] && finalize_exit "budget-wallclock" 0
+  return 0
+}
+
 preflight_wait() {
   local worker_holds=0 build_holds=0
+  # ASKED IMMEDIATELY BEFORE THE SWEEP (#3749 review round 3, item 3). The sweep is the
+  # longest uninterruptible step in an iteration, and it used to run BEFORE the hold
+  # loop's stop-file and wall-clock checks — so a stop requested just after the outer
+  # loop's own check was ignored for the whole sweep. An operator who touches the stop
+  # file is entitled to have it read before this process spends minutes on hygiene.
+  preflight_stop_or_budget
   # The throttled shared-object-store sweep (#3749) runs ONCE per iteration, HERE, before
   # the hold loop: it is per-iteration box hygiene, not a hold reason, and it must not be
   # re-run on every hold repoll. `CORRUPT` never returns — it stops the loop loudly from
   # inside (see object_store_sweep).
+  #
+  # THE IN-FLIGHT SWEEP IS STILL NOT INTERRUPTIBLE, AND THAT IS A DELIBERATE LIMIT, NOT
+  # AN OVERSIGHT. The sweep's two fsck walks happen inside a CHILD PROCESS
+  # (`bash scripts/check-object-store-integrity.sh`), so "check the stop file between the
+  # passes" is not something this function can do: there is no point between them that
+  # executes here. Making it interruptible means running the child in its own process
+  # group, polling, and signalling that group — a bounded-runner redesign whose own
+  # lifetime and process-ownership hazards this repo has already paid for once
+  # (CLAUDE.md: never signal a process group you no longer own), for a stop-latency win.
+  # So the exposure is BOUNDED IN WALL TIME INSTEAD: see OBJ_SWEEP_TIMEOUT_SECS, whose
+  # supervisor default is half the sweep script's own, precisely so that TWO walks here
+  # cost no more than ONE walk at the script's bound. The stop file is re-read the moment
+  # the sweep returns (the loop's first statement, below).
   object_store_sweep
   while true; do
-    [[ -f "$STOP_FILE" ]] && finalize_exit "stop-file" 0
-    [[ $(($(date +%s) - START_TS)) -ge "$MAX_HOURS_SECS" ]] && finalize_exit "budget-wallclock" 0
+    preflight_stop_or_budget
     local reason
     reason="$(preflight_reason)"
     if [[ -z "$reason" ]]; then

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -215,7 +215,8 @@ UNVERIFIED_MAX="${UNVERIFIED_MAX:-2}"
 OBJ_SWEEP_INTERVAL_HOURS="${OBJ_SWEEP_INTERVAL_HOURS:-6}"
 OBJ_SWEEP_TIMEOUT_SECS="${OBJ_SWEEP_TIMEOUT_SECS:-600}"
 # Empty => derived per SHARED STORE in obj_sweep_stamp_path (below), so lanes sharing one
-# object store share one throttle AND one cached verdict.
+# object store share one throttle. It also names the CORRUPT latch (`<stamp>.CORRUPT`),
+# so pinning it relocates both files together.
 OBJ_SWEEP_STAMP="${OBJ_SWEEP_STAMP:-}"
 # issue #2670 (roborev 1813): before escalating a non-merged PR state to a
 # mismatch, re-read gh a few times to absorb read-after-merge lag. Env-tunable so
@@ -3230,36 +3231,61 @@ acquire_lock() {
 OBJ_SWEEP_ANNOUNCED=0
 OBJ_SWEEP_UNMEASURED_NOTIFIED=0
 
-# obj_sweep_stamp_path — the THROTTLE-AND-CACHED-VERDICT stamp. Keyed on the SHARED
-# OBJECT STORE, not on the lane, so four lanes of one box share one cadence instead of
-# sweeping four times — and, since #3749's review, so a CORRUPT verdict found by one lane
-# is seen by its peers instead of being throttled away.
+# obj_sweep_stamp_path <sweep-script> — the THROTTLE stamp: WHEN this box last SPENT a
+# sweep. Keyed on the SHARED OBJECT STORE, not on the lane, so four lanes of one box
+# share one cadence instead of sweeping four times.
 #
-# THE DIRECTORY IS DERIVED, NOT TAKEN FROM THE CALLER. Both facts this file records —
-# "this box swept recently" and "this box's shared store is damaged" — are BOX-wide facts
-# about a store every lane reads, so a per-lane `TMPDIR` would silently make them
-# per-lane: peers would keep their own cadence and, worse, never see a peer's CORRUPT.
-# `/tmp` when it is a writable directory, `${TMPDIR:-/tmp}` only as a fallback for a host
-# without one. OBJ_SWEEP_STAMP still overrides both (the self-suite pins it per case).
+# IT HOLDS A TIMESTAMP AND NOTHING ELSE, AND THAT IS THE DESIGN, NOT AN OMISSION (#3749
+# review round 2, BLOCKER 1). The CORRUPT verdict lives in a SEPARATE, CREATE-ONLY file
+# — see obj_sweep_set_latch below for the reasoning. A timestamp is a cell it is
+# HARMLESS to move backwards: the worst a losing writer can do is buy the box one extra
+# sweep. A VERDICT is not, which is why it is not kept here.
+#
+# THE STORE IS RESOLVED BY THE SWEEP SCRIPT ITSELF (`--print-store`), NOT BY A `git`
+# CALL IN THIS FILE, AND THAT IS THE REVIEW'S OTHER CORRECTION (BLOCKER 2). This
+# function used to run a BARE `git -C "$REPO_ROOT" rev-parse --git-common-dir`,
+# inheriting the caller's environment, while the sweep it keys runs EVERY git call under
+# `env -i` + one allowlist. An inherited GIT_DIR/GIT_COMMON_DIR therefore selected
+# ANOTHER repository's stamp — so the real store's sweep is throttled away, or its
+# verdict recorded under the wrong key. That is the same defect class the sweep had just
+# closed, at a site the same round left behind, which is CLAUDE.md's roborev-job-276
+# ruling verbatim ("the migrated object reads ran under a bare `env` … the round-13 hole
+# re-opened at the NEW sites, not a new route"), and its remedy is the same: ONE
+# resolver, in the file that owns the allowlist. A future git call cannot be added
+# un-isolated HERE because there is no git call here at all — the un-isolated shape is
+# unavailable rather than discouraged.
+#
+# THE DIRECTORY IS DERIVED, NOT TAKEN FROM THE CALLER. Both facts this pair of files
+# records — "this box swept recently" and "this box's shared store is damaged" — are
+# BOX-wide facts about a store every lane reads, so a per-lane `TMPDIR` would silently
+# make them per-lane: peers would keep their own cadence and, worse, never see a peer's
+# CORRUPT. `/tmp` when it is a writable directory, `${TMPDIR:-/tmp}` only as a fallback
+# for a host without one. OBJ_SWEEP_STAMP still overrides both (the self-suite pins it
+# per case), and the latch follows it, so a pinned stamp relocates BOTH files together.
 #
 # AN UNRESOLVABLE STORE DOES NOT THROTTLE AT ALL — it prints the empty string, and the
 # caller then neither reads nor writes a stamp. The old fallback collapsed every
 # unresolvable store on a box onto ONE name, so two different checkouts shared a 6-hour
 # throttle and one suppressed the other's sweep: a MISSED sweep, not an extra one. Not
-# throttling costs nothing here, because the sweep resolves the same `--git-common-dir`
-# itself and fails FAST (a sub-second UNMEASURED) in exactly the states where this
-# resolution failed.
+# throttling costs nothing here, because the sweep resolves the same store itself and
+# fails FAST (a sub-second UNMEASURED) in exactly the states where this resolution
+# failed.
 obj_sweep_stamp_path() {
-  local common key dir
+  local script="$1" line common key dir
   if [[ -n "$OBJ_SWEEP_STAMP" ]]; then
     printf '%s' "$OBJ_SWEEP_STAMP"
     return 0
   fi
-  common="$(git -C "$REPO_ROOT" rev-parse --git-common-dir 2>/dev/null)" || common=""
-  if [[ -n "$common" ]]; then
-    common="$(cd "$REPO_ROOT" 2>/dev/null && cd "$common" 2>/dev/null && pwd -P)" || common=""
-  fi
-  [[ -n "$common" ]] || return 0
+  [[ -n "$script" && -r "$script" ]] || return 0
+  # `{ grep || true; }` for the reason spelled out in object_store_sweep below: this
+  # file runs under `set -euo pipefail`, so a grep that matches nothing (an older or
+  # stubbed sweep script that has no --print-store mode) would take the supervisor down.
+  line="$(bash "$script" --repo "$REPO_ROOT" --print-store 2>/dev/null |
+    { grep '^OBJECT-STORE: store ' || true; } | head -1)"
+  common="${line#OBJECT-STORE: store }"
+  # Both halves are required: an empty line yields an empty value, and a line the prefix
+  # did NOT strip is not the answer to this question.
+  [[ -n "$common" && "$common" != "$line" ]] || return 0
   key="$common"
   # Flatten to one path component; keep only characters that cannot surprise a shell or
   # a filesystem.
@@ -3270,23 +3296,85 @@ obj_sweep_stamp_path() {
   printf '%s' "${dir}/cqlite-object-store-sweep.${key}.stamp"
 }
 
-# obj_sweep_write_stamp <path> <verdict> — record WHEN this box last swept and WHAT it
-# found, as two lines: the epoch, then the verdict token.
+# obj_sweep_latch_path <stamp-path> — the CORRUPT latch that belongs to that stamp.
+# Derived from the stamp so the two always live in the same box-wide directory and a
+# pinned OBJ_SWEEP_STAMP relocates both.
+obj_sweep_latch_path() {
+  local stamp="$1"
+  [[ -n "$stamp" ]] || return 0
+  printf '%s.CORRUPT' "$stamp"
+}
+
+# obj_sweep_latch_present <latch-path> — is the latch in place?
+#
+# `-e || -L` rather than a bare `-e`: a DANGLING symlink at that name is `-e`-false, and
+# the fail-safe reading of "something is at the latch path" is that the box is latched.
+# Same idiom, same reason, as the supervisor lock's existence test above.
+obj_sweep_latch_present() {
+  local latch="$1"
+  [[ -n "$latch" ]] || return 1
+  [[ -e "$latch" || -L "$latch" ]]
+}
+
+# obj_sweep_write_stamp <path> — record WHEN this box last swept. One line, the epoch.
 #
 # `2>/dev/null` PRECEDES the output redirection deliberately: bash applies redirections
 # LEFT TO RIGHT, so with the old order a failed `>"$stamp"` printed bash's own
 # UNANCHORED error before the suppression took effect, in addition to the intended log
 # line.
 obj_sweep_write_stamp() {
-  local path="$1" verdict="$2"
+  local path="$1"
   [[ -n "$path" ]] || return 0
-  printf '%s\n%s\n' "$(date +%s)" "$verdict" 2>/dev/null >"$path" ||
+  printf '%s\n' "$(date +%s)" 2>/dev/null >"$path" ||
     log "object-store sweep: could not write the throttle stamp $path — the sweep will re-run next iteration"
   return 0
 }
 
+# obj_sweep_set_latch <latch-path> — record MONOTONICALLY that this box's shared object
+# store has been found damaged. Exits 0 when the latch is in place AFTERWARDS (whether
+# this call created it or found a peer's), 1 when it could not be persisted at all.
+#
+# WHY A SEPARATE CREATE-ONLY FILE AND NOT A VERDICT FIELD IN THE STAMP — THE DESIGN CALL
+# (#3749 review round 2, BLOCKER 1). Round 1 put the verdict IN the throttle stamp, and
+# the stamp is a mutable shared cell that every lane rewrites at the END of its own
+# sweep. Stamp writes are unsynchronised, so a peer whose sweep STARTED before this lane
+# detected corruption can finish AFTER it and overwrite `CORRUPT` with `VERIFIED` or
+# `UNMEASURED`; the other lanes then throttle on that fresh non-corrupt stamp and keep
+# working against a store already known to be damaged. That is round 1's own harm coming
+# back through a different door, and it is the SECOND consecutive review finding in this
+# one shared cell.
+#
+# A LOCK WAS THE OTHER OPTION AND WAS REJECTED. It makes the read-modify-write atomic,
+# but the value stays a mutable cell any writer can move BACKWARDS, so "CORRUPT is
+# sticky" would rest on every present and future writer remembering to honour it — plus
+# a lock has its own could-not-acquire path, which must then not silently skip the
+# latch. CLAUDE.md's standing ruling for this family is to REMOVE THE SHARED MUTABLE
+# CHANNEL rather than to serialise access to it, so the latch is its own file and its
+# only state transition is ABSENT -> PRESENT:
+#
+#   * `set -C` (noclobber) makes `>` FAIL on an existing path instead of truncating it,
+#     and create with O_EXCL on a missing one. The kernel arbitrates; a losing writer
+#     cannot overwrite the winner, and there is no read-modify-write to serialise.
+#   * It is set in a SUBSHELL so the option cannot leak into the rest of this script.
+#   * NOTHING HERE EVER REMOVES IT. Corruption is non-self-clearing, so it does not
+#     expire either; the operator who repairs the store removes the file, and every
+#     message that mentions the latch names that exact command.
+#
+# THE VERDICT IS THE FILE'S EXISTENCE, ASKED AFTERWARDS — never this call's own exit
+# status, which cannot tell "a peer got there first" (fine, the box is latched) from
+# "the directory is unwritable" (not fine, and the caller must say so out loud).
+obj_sweep_set_latch() {
+  local latch="$1"
+  [[ -n "$latch" ]] || return 1
+  (
+    set -C
+    printf '%s\nCORRUPT\n' "$(date +%s)" >"$latch"
+  ) 2>/dev/null || true
+  obj_sweep_latch_present "$latch"
+}
+
 object_store_sweep() {
-  local script stamp now last rc out verdict cached stamp_ts stamp_verdict
+  local script stamp latch latch_ts now last rc out verdict stamp_ts
   if [[ "$OBJ_SWEEP_INTERVAL_HOURS" -le 0 ]]; then
     # ANNOUNCED, never silent (the CLAIM_CMD-disabled precedent in main()): a hygiene
     # probe that is off must be visible in the journal rather than inferred from missing
@@ -3310,47 +3398,47 @@ object_store_sweep() {
     fi
     return 0
   fi
-  stamp="$(obj_sweep_stamp_path)"
+  stamp="$(obj_sweep_stamp_path "$script")"
+  latch="$(obj_sweep_latch_path "$stamp")"
   now="$(date +%s)"
   last=0
-  cached=""
   if [[ -n "$stamp" && -r "$stamp" ]]; then
     stamp_ts=""
-    stamp_verdict=""
-    { read -r stamp_ts || true; read -r stamp_verdict || true; } <"$stamp" 2>/dev/null || true
+    { read -r stamp_ts || true; } <"$stamp" 2>/dev/null || true
     last="$stamp_ts"
-    cached="$stamp_verdict"
   fi
   [[ "$last" =~ ^[0-9]+$ ]] || last=0
   # A stamp in the FUTURE (clock skew, a hand-edited file, a restored snapshot) must not
-  # park the sweep forever: treat it as never-swept. It does NOT clear a recorded CORRUPT,
-  # which is a fact about the store rather than about when it was last measured.
+  # park the sweep forever: treat it as never-swept. It does NOT clear the CORRUPT latch,
+  # which is a fact about the store rather than about when it was last measured — and,
+  # since round 2, is not even in this file.
   [[ "$last" -gt "$now" ]] && last=0
-  # Only the exact token is honoured; anything else is treated as no cached verdict.
-  [[ "$cached" == "CORRUPT" ]] || cached=""
 
-  # A CACHED `CORRUPT` STOPS THIS LANE WITHOUT RE-SWEEPING, AND IT IGNORES THE INTERVAL.
+  # A LATCHED BOX STOPS THIS LANE WITHOUT RE-SWEEPING, AND IT IGNORES THE INTERVAL.
   #
-  # THE DEFECT THIS EXISTS FOR (#3749 review, BLOCKER A). The stamp is keyed on the
+  # THE DEFECT THIS EXISTS FOR (#3749 review, BLOCKER A). The throttle is keyed on the
   # SHARED store and lives in a box-wide directory, so it is genuinely box-wide. When it
   # recorded only a timestamp, the lane that DETECTED corruption stopped — and its three
   # peers then saw a FRESH stamp, skipped their own sweep for the whole interval, and kept
   # spawning workers against a store known to be damaged. That is the exact harm this
   # feature exists to prevent, delivered by the throttle.
   #
-  # Persisting the VERDICT is the stronger fix of the two available: "don't stamp on
-  # CORRUPT" would merely make each peer re-run a 20-80s fsck to rediscover the same
-  # thing, and would leave a window between the write and the peer's next iteration.
+  # THE LATCH IS A DIFFERENT FILE FROM THE STAMP, ON PURPOSE (round 2, BLOCKER 1): see
+  # obj_sweep_set_latch for why a verdict field in the mutable stamp is not monotonic
+  # under concurrency and why a lock was rejected. Here the consequence is simply that
+  # this test is an EXISTENCE test, which no concurrent writer can undo.
   #
   # IT DOES NOT EXPIRE, and it is CLEARED BY HAND. Corruption is non-self-clearing, so an
   # age-based expiry would resume workers over a still-damaged store; the operator who
   # repairs the store removes the file, and the remedy line below NAMES the path and the
   # command, because a latch nobody can clear bricks the box after the repair.
-  if [[ -n "$cached" ]]; then
-    notify "high" "worker-supervisor: SHARED OBJECT STORE CORRUPT (cached)" \
-      "a sweep on this box recorded CORRUPT for the shared git object store every lane here reads. Stopping without re-sweeping. Repair the store, then remove $stamp."
-    log "object-store: CORRUPT (cached at $last by a sweep on this box) — stopping; no worker may certify against a damaged shared store (#3749)."
-    log "object-store: REMEDY — stop every lane on this box and re-obtain the objects from the canonical remote; a local 'git gc'/'git repack' CANNOT repair it. THEN CLEAR THE LATCH: rm -f $stamp"
+  if obj_sweep_latch_present "$latch"; then
+    latch_ts="$(head -1 "$latch" 2>/dev/null || true)"
+    [[ "$latch_ts" =~ ^[0-9]+$ ]] || latch_ts="<unrecorded>"
+    notify "high" "worker-supervisor: SHARED OBJECT STORE CORRUPT (latched)" \
+      "a sweep on this box recorded CORRUPT for the shared git object store every lane here reads. Stopping without re-sweeping. Repair the store, then remove $latch."
+    log "object-store: CORRUPT (cached at $latch_ts by a sweep on this box) — stopping; no worker may certify against a damaged shared store (#3749)."
+    log "object-store: REMEDY — stop every lane on this box and re-obtain the objects from the canonical remote; a local 'git gc'/'git repack' CANNOT repair it. THEN CLEAR THE LATCH: rm -f $latch"
     finalize_exit "object-store-corrupt" 1
   fi
 
@@ -3384,20 +3472,11 @@ object_store_sweep() {
   verdict="${verdict#OBJECT-STORE: verdict }"
   verdict="${verdict%% *}"
 
-  # THE STAMP IS WRITTEN FOR EVERY OUTCOME, AND IT CARRIES THE VERDICT. The throttle
-  # bounds how often this box SPENDS the sweep (a box that cannot measure — no timeout
-  # binary, say — must not re-attempt it every iteration), and the recorded verdict is
-  # what stops a peer lane throttling past a CORRUPT this lane just found. Only the exact
-  # token is recorded; anything unrecognised is recorded as UNMEASURED, which grants no
-  # authority to anyone.
-  if [[ "$rc" -eq 0 && "$verdict" == "VERIFIED" ]]; then
-    stamp_verdict=VERIFIED
-  elif [[ "$rc" -eq 4 || "$verdict" == "CORRUPT" ]]; then
-    stamp_verdict=CORRUPT
-  else
-    stamp_verdict=UNMEASURED
-  fi
-  obj_sweep_write_stamp "$stamp" "$stamp_verdict"
+  # THE STAMP IS WRITTEN FOR EVERY OUTCOME. It bounds how often this box SPENDS the sweep
+  # — a box that cannot measure (no timeout binary, say) must not re-attempt it every
+  # iteration — and it says nothing about what was found. What a peer lane must not
+  # throttle past is recorded separately, and monotonically, by the latch below.
+  obj_sweep_write_stamp "$stamp"
 
   if [[ "$rc" -eq 0 && "$verdict" == "VERIFIED" ]]; then
     log "object-store: VERIFIED — $(printf '%s\n' "$out" | { grep '^OBJECT-STORE: measured ' || true; } | head -1)"
@@ -3406,10 +3485,19 @@ object_store_sweep() {
   if [[ "$rc" -eq 4 || "$verdict" == "CORRUPT" ]]; then
     local findings
     findings="$(printf '%s\n' "$out" | { grep -E '^OBJECT-STORE: (finding|object) ' || true; } | head -6 | tr '\n' ';' | cut -c1-600)"
+    # LATCH FIRST, THEN STOP. A failure to persist it is REPORTED, never silent: this
+    # lane stops either way, but without the latch the peers on this box will re-run
+    # their own sweep and rediscover the damage rather than inheriting the verdict, and
+    # an operator reading only this journal would otherwise never learn that.
+    if [[ -z "$latch" ]]; then
+      log "object-store: the CORRUPT verdict could NOT be latched — this box's shared store could not be resolved, so there is no box-wide file to record it in. Peer lanes will re-sweep and rediscover it (#3749)."
+    elif ! obj_sweep_set_latch "$latch"; then
+      log "object-store: the CORRUPT verdict could NOT be latched at $latch (unwritable?) — peer lanes will re-sweep and rediscover it rather than inheriting this verdict (#3749)."
+    fi
     notify "high" "worker-supervisor: SHARED OBJECT STORE CORRUPT" \
       "git fsck reports damaged objects in this box's shared git object store — every lane here reads it, so NO gate verdict on this box can be trusted. Stopping. ${findings:-<no findings captured>}"
     log "object-store: CORRUPT — stopping loudly; no worker may certify against a damaged shared store (#3749). ${findings:-<no findings captured>}"
-    log "object-store: REMEDY — stop every lane on this box and re-obtain the objects from the canonical remote; a local 'git gc'/'git repack' CANNOT repair it.${stamp:+ THEN CLEAR THE LATCH: rm -f $stamp}"
+    log "object-store: REMEDY — stop every lane on this box and re-obtain the objects from the canonical remote; a local 'git gc'/'git repack' CANNOT repair it.${latch:+ THEN CLEAR THE LATCH: rm -f $latch}"
     finalize_exit "object-store-corrupt" 1
   fi
   # UNMEASURED (or no recognised verdict at all): REPORTED, and DELIBERATELY PERMISSIVE.

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -3484,8 +3484,10 @@ object_store_sweep() {
   out="$(bash "$script" --repo "$REPO_ROOT" --timeout "$OBJ_SWEEP_TIMEOUT_SECS" 2>&1)" || rc=$?
   # Read the verdict from the sweep's OWN anchored control line, never from loose text:
   # its output prints repository-controlled paths verbatim, so an unanchored match could
-  # land on one. Both the line AND the exit status are required to agree for the two
-  # actionable verdicts.
+  # land on one. Both the line AND the exit status are required to AGREE for the two
+  # actionable verdicts, and since #3749 review round 4 the CORRUPT branch really does
+  # require both (it was `||`, while this comment already claimed the conjunction — the
+  # false-rationale class, and the reason a reader would not have looked).
   # `{ grep || true; }` ON EVERY PIPELINE BELOW, AND IT IS LOAD-BEARING, NOT DEFENSIVE.
   # This file runs under `set -euo pipefail`: a `grep` that matches NOTHING exits 1, and
   # with `pipefail` that status becomes the pipeline's — so an ASSIGNMENT from such a
@@ -3518,7 +3520,17 @@ object_store_sweep() {
   # string and create a file; it is now empty in that direction, because the latch — the
   # thing a peer must not throttle past — is in place before anything advertises that
   # this box has been swept.
-  if [[ "$rc" -eq 4 || "$verdict" == "CORRUPT" ]]; then
+  #
+  # AND IT TAKES *BOTH*, WHICH IS ITEM 2 OF THE SAME REVIEW. With `||`, an exit 4 with no
+  # verdict line — or a `CORRUPT` line under any other status — created a PERSISTENT,
+  # BOX-WIDE latch that stops every lane on this box and can only be cleared by hand. An
+  # unrecognised or incomplete sweep must not be able to do that: the blast radius of a
+  # false latch (four lanes halted until someone notices) is worse than one more
+  # iteration of a store whose damage, if real, the NEXT sweep reproduces and latches
+  # properly. A disagreement therefore falls through to the UNMEASURED path below, which
+  # is non-passing, journalled, and paged once — and it is named explicitly there, so the
+  # signal is not swallowed on the way past.
+  if [[ "$rc" -eq 4 && "$verdict" == "CORRUPT" ]]; then
     local findings
     # LATCH FIRST, THEN EVERYTHING ELSE. A failure to persist it is REPORTED, never
     # silent: this lane stops either way, but without the latch the peers on this box
@@ -3563,6 +3575,13 @@ object_store_sweep() {
   # expired bound on a loaded box), none of which is evidence about the store. So it is
   # journalled every time and paged ONCE per run — loud enough to fix, never a silent
   # swallow and never a latch.
+  # A DISAGREEMENT IS NAMED, NOT MERELY DEMOTED. One of the two channels said CORRUPT and
+  # the other did not, so this run neither established damage nor ruled it out — and the
+  # generic UNMEASURED line below would read as an ordinary "could not measure". Loud
+  # enough to investigate, and still not a latch (see the CORRUPT branch for why).
+  if [[ "$rc" -eq 4 || "$verdict" == "CORRUPT" ]]; then
+    log "object-store: INCONSISTENT sweep result (rc=$rc verdict='${verdict:-<none>}') — exactly ONE of the exit status and the anchored verdict line says CORRUPT. Treated as UNMEASURED and NOT latched: an incomplete or unrecognised sweep must not stop every lane on this box (#3749). If the next sweep reproduces damage it will latch it; investigate the sweep itself."
+  fi
   log "object-store: UNMEASURED (rc=$rc verdict='${verdict:-<none>}') — the shared store was NOT rehashed, so its integrity is UNKNOWN, not clean. Continuing: a hygiene probe that cannot run must not stop the fleet (#3749)."
   printf '%s\n' "$out" | { grep '^OBJECT-STORE: unmeasured-cause ' || true; } | head -4 | while IFS= read -r obj_line; do
     log "object-store: $obj_line"

--- a/scripts/tests/test_agent_gate_component_set.sh
+++ b/scripts/tests/test_agent_gate_component_set.sh
@@ -2074,7 +2074,7 @@ n_components=$( fx "$same" && bash scripts/agent-gate.sh --list 2>/dev/null | wc
 # of the exact match, because a PASS whose baseline source is unstated cannot be audited: the
 # transitional TEXT path is format-brittle and becomes unreachable once the manifest is on main.
 # _cs_pass_line_ok <line> <expected-head>: the PASS line equals <expected-head> followed by EXACTLY
-# ONE of the three legal object-provenance clauses (#3746 / roborev job 311). Pinned as a CLOSED SET
+# ONE of the three legal object-provenance clauses (#3749 / roborev job 311). Pinned as a CLOSED SET
 # rather than one literal because which clause is emitted is ENVIRONMENT-DEPENDENT — it says whether
 # this box's shared object store already held the fixture's baseline commit, which a peer lane's
 # fetch can change between runs. Pinning one literal would red on correct input; pinning nothing
@@ -2085,9 +2085,9 @@ _cs_pass_line_ok() {
   local l="$1" h="$2" tail
   case "$l" in "$h"*) tail="${l#"$h"}" ;; *) return 1 ;; esac
   case "$tail" in
-    "; objects: baseline REUSED from this lane's SHARED store — store TRUSTED, not verified (#3746)") return 0 ;;
-    "; objects: baseline FETCHED from the canonical remote, HEAD's own from this lane's SHARED store — store TRUSTED, not verified (#3746)") return 0 ;;
-    "; objects: provenance NOT RECORDED — treat the store as TRUSTED, not verified (#3746)") return 0 ;;
+    "; objects: baseline REUSED from this lane's SHARED store — store TRUSTED, not verified (#3749)") return 0 ;;
+    "; objects: baseline FETCHED from the canonical remote, HEAD's own from this lane's SHARED store — store TRUSTED, not verified (#3749)") return 0 ;;
+    "; objects: provenance NOT RECORDED — treat the store as TRUSTED, not verified (#3749)") return 0 ;;
   esac
   return 1
 }
@@ -2102,7 +2102,7 @@ if [ "$(field VERDICT "$s_out")" = PASS ] \
    && _cs_pass_line_ok "$s_line" "component-set: PASS ($n_components/$n_components names vs origin/main $s_sha; NAMES ONLY — not implementations, and no component is run here) — baseline read via the committed manifest"; then
   ok "3544-no-skew: an in-sync tree stamps an affirmative PASS naming its baseline sha, the read path AND the object-store trust boundary"
 else
-  bad "3544-no-skew: expected 'component-set: PASS ($n_components/$n_components names vs origin/main $s_sha; NAMES ONLY — not implementations, and no component is run here) — baseline read via the committed manifest' + one of the three legal '; objects: …(#3746)' clauses"
+  bad "3544-no-skew: expected 'component-set: PASS ($n_components/$n_components names vs origin/main $s_sha; NAMES ONLY — not implementations, and no component is run here) — baseline read via the committed manifest' + one of the three legal '; objects: …(#3749)' clauses"
   printf '%s\n' "$s_out"
 fi
 

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -1500,6 +1500,63 @@ else
   bad "obj: CORRUPT lacks a remedy line or the summary restatement"
 fi
 
+# 7o-e/f. THE TWO CHANNELS MUST AGREE BEFORE CORRUPT IS CLAIMED (#3749 review round 4,
+#   item 2). This reader used to accept `rc == 4 || verdict == CORRUPT` while its own
+#   comment asserted the conjunction, so an exit 4 with NO verdict line — or a stray
+#   `CORRUPT` line under any other status — produced the CORRUPT report here and, in the
+#   sibling supervisor, a persistent BOX-WIDE latch that halts every lane until an
+#   operator clears it by hand. An unrecognised or incomplete sweep must not be able to do
+#   that: a false latch is worse than one more iteration over a store whose damage, if
+#   real, the next sweep reproduces.
+#
+#   THE ARTIFACT IS SUBSTITUTED, not a variable set: the sandbox's own copy of the sweep
+#   script is replaced by a stub, because a test-only seam is one more thing a real
+#   invoker can set (CLAUDE.md #3312 corollary). Two arms, one property apart — WHICH of
+#   the two channels says CORRUPT.
+mk_sweep_stub() {
+  # mk_sweep_stub <sandbox> <verdict-or-NONE> <exit>
+  local sandbox="$1" verdict="$2" rc="$3" f="$1/scripts/check-object-store-integrity.sh"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'for a in "$@"; do [ "$a" = --print-store ] && exit 0; done\n'
+    printf 'printf "OBJECT-STORE: measured stub\\n"\n'
+    [ "$verdict" = NONE ] || printf 'printf "OBJECT-STORE: verdict %s\\n"\n' "$verdict"
+    printf 'exit %s\n' "$rc"
+  } >"$f"
+  chmod +x "$f"
+}
+for _arm in "NONE:4:status-only" "CORRUPT:5:line-only"; do
+  # Parsed by expansion rather than `set --`: this is top-level script code, and `set --`
+  # would overwrite the suite's own positional parameters.
+  _av="${_arm%%:*}"
+  _rest="${_arm#*:}"
+  _ar="${_rest%%:*}"
+  _an="${_rest#*:}"
+  repo7oe="$tmp/repo7oe-$_an"; mk_push_repo "$repo7oe" "file://$bare7pa"
+  mk_sweep_stub "$repo7oe" "$_av" "$_ar"
+  _src=0
+  _sout=$(bash "$repo7oe/scripts/check-object-store-integrity.sh" --repo "$repo7oe" 2>&1) || _src=$?
+  _sline=no
+  printf '%s' "$_sout" | grep -q 'OBJECT-STORE: verdict ' && _sline=yes
+  _swant=yes
+  [ "$_av" = NONE ] && _swant=no
+  if [ "$_src" -eq "$_ar" ] && [ "$_sline" = "$_swant" ]; then
+    ok "obj: the inconsistency plant IS the shape described ($_an: the stub exits $_ar, verdict line present=$_sline)"
+  else
+    bad "obj: the inconsistency plant ($_an) exited $_src with verdict-line=$_sline (wanted $_ar/$_swant) — the case below would prove nothing"
+  fi
+  run_push "$repo7oe" "$bin7pa" "$gc7pa" --skip-push-probe --strict
+  if printf '%s' "$push_out" | grep -q '\[warn\].*object-store: UNMEASURED — INCONSISTENT' &&
+    ! printf '%s' "$push_out" | grep -q '\[warn\].*object-store: CORRUPT' &&
+    ! printf '%s' "$push_out" | grep -q 'SHARED OBJECT STORE CORRUPT' &&
+    ! push_green "$push_out"; then
+    ok "obj: $_an — exactly ONE channel saying CORRUPT is reported UNMEASURED/INCONSISTENT, never the CORRUPT verdict, and never certified"
+  else
+    bad "obj: $_an — an inconsistent sweep result was not handled as UNMEASURED/INCONSISTENT (rc=$push_rc)"
+    push_plain "$push_out" | grep -F 'object-store:' | head -4
+  fi
+done
+
 # 7o-d. UNMEASURABLE: the sweep script absent from the checkout. Must be a [warn] naming
 #   what could not be measured — never an [ok], because an [ok] is what --strict reads.
 repo7od="$tmp/repo7od"; mk_push_repo "$repo7od" "file://$bare7pa"

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -1803,7 +1803,17 @@ if push_plain "$out7pk" | grep -q "git ls-remote .* refs/claims/smoke-"; then
   ok "push: the quoted verdict reaches the operator with the ls-remote check for the possibly-stranded ref"
 else
   bad "push: cleanup-unverified verdict lost its stray-ref guidance in transit"
-  push_plain "$out7pk" | grep -E 'CLAIM:|git-push' | head -3
+  # THE DIAGNOSTIC CARRIES THE rc AND A COUNT, NOT JUST THE FIRST THREE MATCHES (#3749
+  # review round 4). This pair has failed twice on this branch and the captured evidence
+  # could not tell the candidate causes apart: a different reason code, a probe KILLED at
+  # its 60s bound under load (which prints the UNMEASURED verdict and no CLAIM line at
+  # all), or a sandbox missing claim.sh. All three look the same when only the first three
+  # matching lines are shown — one observed log printed a single line and left it
+  # ambiguous whether a CLAIM verdict was quoted at ALL, which is precisely the fact that
+  # separates them. So: the probe's exit status, how many CLAIM lines reached the output,
+  # and then the lines.
+  printf '  rc=%s claim-lines=%s\n' "$rc7pk" "$(push_plain "$out7pk" | grep -cE 'CLAIM: ' || true)"
+  push_plain "$out7pk" | grep -E 'CLAIM: |git-push:' | head -6 | sed 's/^/    /'
 fi
 # NO CAUSE MAY BE ATTRIBUTED (#3369 review). One nonzero exit cannot tell a deletion
 # policy from a network drop from a post-readback auth failure, so neither claim.sh nor

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -36,8 +36,8 @@ $1"; }
 # instead, by the base_warns assertion in block 7p.
 skip() { printf 'skip - %s\n' "$1"; SKIPS=$((SKIPS + 1)); }
 
-# --- SECTION 5b-obj IS OPTED OUT SUITE-WIDE, AND THE PUSH SANDBOXES OPT BACK IN (#3749) -
-# 5b-obj rehashes the SHARED git object store with a full `git fsck`. Against the REAL
+# --- SECTION 5d IS OPTED OUT SUITE-WIDE, AND THE PUSH SANDBOXES OPT BACK IN (#3749) -
+# 5d rehashes the SHARED git object store with a full `git fsck`. Against the REAL
 # checkout that is 19.83s per invocation (measured on this fleet's 331M store) and this
 # suite drives bootstrap dozens of times — ~12 minutes added to a MANDATORY gate
 # component for a property most of these cases are not about. So the env opt-out is set
@@ -48,7 +48,7 @@ skip() { printf 'skip - %s\n' "$1"; SKIPS=$((SKIPS + 1)); }
 # skips — the exact drift the comments in that block record happening FOUR times. Hence
 # `run_push` sets it back to 0 and `mk_push_repo` stages the sweep script: in those
 # sandboxes the subject is the sandbox's OWN tiny repo, so the sweep runs in milliseconds,
-# reports VERIFIED, and contributes ZERO warnings. The dedicated 5b-obj cases below then
+# reports VERIFIED, and contributes ZERO warnings. The dedicated 5d cases below then
 # get a real end-to-end verdict instead of a mocked one.
 export CQLITE_BOOTSTRAP_SKIP_OBJECT_STORE_SWEEP=1
 
@@ -1222,7 +1222,7 @@ mk_push_repo() {
   # running. Staging it here plus the pinned `sudo` shim in mk_push_bin makes 5b contribute
   # ZERO warnings deterministically — on a pinned host and an unpinned one alike.
   cp "$SCRIPT_DIR/../agent-gate.sh" "$dir/scripts/agent-gate.sh"
-  # Staged for SECTION 5b-obj (#3749), for the same reason agent-gate.sh is staged above:
+  # Staged for SECTION 5d (#3749), for the same reason agent-gate.sh is staged above:
   # without it the section reports `object-store: UNMEASURED (no
   # scripts/check-object-store-integrity.sh ...)` — one extra [warn] in EVERY case built on
   # this helper, which is precisely how base_warns has drifted before. With it staged, the
@@ -1422,7 +1422,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 7o. SECTION 5b-obj — the SHARED OBJECT-STORE INTEGRITY SWEEP (issue #3749)
+# 7o. SECTION 5d — the SHARED OBJECT-STORE INTEGRITY SWEEP (issue #3749)
 #
 # Four cases, all end-to-end through the real section: the affirmative verdict, the
 # opt-out, a PLANTED CORRUPTION, and the unmeasurable case. The sweep script's own
@@ -1437,7 +1437,7 @@ if printf '%s' "$out7pa" | grep -q '\[ok\].*object-store: VERIFIED' &&
   printf '%s' "$out7pa" | grep -q 'point-in-time'; then
   ok "obj: a clean store is reported VERIFIED as [ok], declared as a POINT-IN-TIME sweep (not a per-read guarantee)"
 else
-  bad "obj: section 5b-obj did not report VERIFIED as [ok] on a clean sandbox"
+  bad "obj: section 5d did not report VERIFIED as [ok] on a clean sandbox"
   push_plain "$out7pa" | grep -F 'object-store:' | head -4
 fi
 

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -1552,6 +1552,53 @@ else
   bad "obj: UNSWEEPABLE either lacks its banner restatement or claims damage nothing established"
   push_plain "$push_out" | grep -F 'OBJECT STORE' | head -4
 fi
+# 7o-d3. THE SAME [warn] FOR THE VERDICT'S OTHER CAUSE, ON A STORE WITH NO DAMAGE AT ALL
+#   (#3749 review round 11, item 1). UNSWEEPABLE now also fires when the store's OWN
+#   configuration sets `fsck.*` keys, which can suppress or downgrade the very diagnostics
+#   the sweep reads its verdict from — so no walk is run and no affirmative verdict is
+#   obtainable. ONE PROPERTY from 7o-d2: the fixture is UNDAMAGED, and the refusal comes
+#   from the config alone.
+#
+#   WHY IT IS WORTH A CASE HERE when the branch is shared: this reader's text is derived
+#   from the TOKEN, and until this round it named the fatal mechanism ("git fsck RAN and
+#   reproducibly DIED") as though it were the only cause. A fixture that reaches the same
+#   branch by the other route is what stops that text drifting back.
+repo7od3="$tmp/repo7od3"; mk_push_repo "$repo7od3" "file://$bare7pa"
+(
+  cd "$repo7od3" || exit 1
+  printf 'bbb\n' >objf4
+  git -c user.email=t@t -c user.name=t add objf4 >/dev/null 2>&1
+  git -c user.email=t@t -c user.name=t commit -q -m obj-policy-fixture >/dev/null 2>&1
+  git config fsck.missingEmail ignore >/dev/null 2>&1
+) || true
+od3_rc=0
+git -C "$repo7od3" fsck --no-progress --no-dangling >/dev/null 2>&1 || od3_rc=$?
+od3_key=$(git -C "$repo7od3" config --get fsck.missingEmail 2>/dev/null)
+if [ "$od3_rc" -eq 0 ] && [ "$od3_key" = ignore ]; then
+  ok "obj: the plant IS the shape described (an UNDAMAGED store — plain fsck exits 0 — whose own config sets an fsck.* key)"
+else
+  bad "obj: fsck-status=$od3_rc key='$od3_key' — not the undamaged-with-policy shape; the case below would prove nothing"
+fi
+run_push "$repo7od3" "$bin7pa" "$gc7pa" --skip-push-probe --strict
+if printf '%s' "$push_out" | grep -q '\[warn\].*object-store: UNSWEEPABLE' &&
+  printf '%s' "$push_out" | grep -q 'COULD NOT BE SWEPT' &&
+  ! push_green "$push_out" && [ "$push_rc" -ne 0 ]; then
+  ok "obj: a store whose own fsck policy could suppress the diagnostics reaches the SAME stopping verdict, withholds green and fails --strict — the verdict is about what can be measured, not about what was found"
+else
+  bad "obj: an fsck-policy refusal did not produce an UNSWEEPABLE verdict (rc=$push_rc)"
+  push_plain "$push_out" | grep -F 'object-store:' | head -4
+fi
+# AND IT STILL CLAIMS NO DAMAGE — nothing was rehashed on this path either, so the damage
+# text and its measured repairs would be as wrong here as on the fatal path.
+if ! printf '%s' "$push_out" | grep -q '\[warn\].*object-store: CORRUPT' &&
+  ! printf '%s' "$push_out" | grep -q 'SHARED OBJECT STORE CORRUPT' &&
+  printf '%s' "$push_out" | grep -qi 'no damage was established'; then
+  ok "obj: the fsck-policy refusal claims NO damage and is not folded into the CORRUPT banner"
+else
+  bad "obj: the fsck-policy refusal claims damage nothing established, or lost its no-damage statement"
+  push_plain "$push_out" | grep -F 'OBJECT STORE' | head -4
+fi
+
 # 7o-e/f. THE TWO CHANNELS MUST AGREE BEFORE CORRUPT IS CLAIMED (#3749 review round 4,
 #   item 2). This reader used to accept `rc == 4 || verdict == CORRUPT` while its own
 #   comment asserted the conjunction, so an exit 4 with NO verdict line — or a stray

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -1500,6 +1500,58 @@ else
   bad "obj: CORRUPT lacks a remedy line or the summary restatement"
 fi
 
+# 7o-d2. A SWEEP THAT RAN AND REPRODUCIBLY DIED IS ITS OWN [warn], AND IT CLAIMS NO CAUSE
+#   (#3749 review round 10, item 1). Real commit-object corruption makes `git fsck` DIE
+#   (exit 128 on git 2.43.0) rather than report a bit, and that status used to land on
+#   UNMEASURED — which in the sibling supervisor means "write a fresh throttle stamp and
+#   keep spawning workers". A false negative on genuine corruption of the shared store.
+#
+#   A REAL FIXTURE, one property apart from 7o-c above: the damaged object is the COMMIT
+#   the ref names rather than a blob. The construction is asserted with git — the type,
+#   and the fatal status — because a case that could not tell a broken fixture from a
+#   broken subject proves nothing.
+repo7od2="$tmp/repo7od2"; mk_push_repo "$repo7od2" "file://$bare7pa"
+# The sandbox repo is deliberately OBJECTLESS (see mk_push_repo), so the fixture makes its
+# own commit first — exactly as 7o-c above does.
+(
+  cd "$repo7od2" || exit 1
+  printf 'aaa\n' >objf3
+  git -c user.email=t@t -c user.name=t add objf3 >/dev/null 2>&1
+  git -c user.email=t@t -c user.name=t commit -q -m obj-fatal-fixture >/dev/null 2>&1
+) || true
+od2_sha=$(git -C "$repo7od2" rev-parse HEAD 2>/dev/null)
+od2_type=$(git -C "$repo7od2" cat-file -t "$od2_sha" 2>/dev/null)
+if [ -n "$od2_sha" ]; then
+  od2_p="$repo7od2/.git/objects/${od2_sha:0:2}/${od2_sha:2}"
+  chmod u+w "$od2_p" 2>/dev/null
+  printf 'not zlib at all, definitely garbage bytes' >"$od2_p" 2>/dev/null
+fi
+od2_rc=0
+git -C "$repo7od2" fsck --no-progress --no-dangling >/dev/null 2>&1 || od2_rc=$?
+if [ "$od2_type" = commit ] && [ "$od2_rc" -ge 128 ]; then
+  ok "obj: the plant IS the shape described (the COMMIT object the ref names is unparseable, and git exits $od2_rc — a fatal death, not a bitmask status)"
+else
+  bad "obj: type='$od2_type' fsck-status=$od2_rc — not the fatal-death shape; the case below would prove nothing"
+fi
+run_push "$repo7od2" "$bin7pa" "$gc7pa" --skip-push-probe --strict
+if printf '%s' "$push_out" | grep -q '\[warn\].*object-store: UNSWEEPABLE' &&
+  ! push_green "$push_out" && [ "$push_rc" -ne 0 ]; then
+  ok "obj: a store whose sweep RUNS and reproducibly DIES is reported UNSWEEPABLE, withholds green and fails --strict — never the permissive 'not measured' that let every lane carry on"
+else
+  bad "obj: a fatal sweep did not produce an UNSWEEPABLE verdict (rc=$push_rc)"
+  push_plain "$push_out" | grep -F 'object-store:' | head -4
+fi
+# IT MUST NOT CLAIM DAMAGE, and it must be restated in the banner under its OWN wording:
+# nothing here established a cause, so the CORRUPT text and its measured re-clone remedy
+# would be a confidently-wrong instruction (round 9's class).
+if printf '%s' "$push_out" | grep -q 'COULD NOT BE SWEPT' &&
+  ! printf '%s' "$push_out" | grep -q '\[warn\].*object-store: CORRUPT' &&
+  ! printf '%s' "$push_out" | grep -q 'SHARED OBJECT STORE CORRUPT'; then
+  ok "obj: UNSWEEPABLE is restated in the summary banner under its own wording and claims NO damage — a different fact from CORRUPT, with a different remedy"
+else
+  bad "obj: UNSWEEPABLE either lacks its banner restatement or claims damage nothing established"
+  push_plain "$push_out" | grep -F 'OBJECT STORE' | head -4
+fi
 # 7o-e/f. THE TWO CHANNELS MUST AGREE BEFORE CORRUPT IS CLAIMED (#3749 review round 4,
 #   item 2). This reader used to accept `rc == 4 || verdict == CORRUPT` while its own
 #   comment asserted the conjunction, so an exit 4 with NO verdict line — or a stray

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -1514,12 +1514,16 @@ fi
 #   invoker can set (CLAUDE.md #3312 corollary). Two arms, one property apart — WHICH of
 #   the two channels says CORRUPT.
 mk_sweep_stub() {
-  # mk_sweep_stub <sandbox> <verdict-or-NONE> <exit>
-  local sandbox="$1" verdict="$2" rc="$3" f="$1/scripts/check-object-store-integrity.sh"
+  # mk_sweep_stub <sandbox> <verdict-or-NONE> <exit> [verdict-detail-line]
+  # The 4th argument is optional and exists for ONE property (#3749 review round 9, item
+  # 2): this section must QUOTE the sweep's operator remedy rather than restate it, and a
+  # planted token is the only way to measure a pass-through end to end.
+  local sandbox="$1" verdict="$2" rc="$3" detail="${4:-}" f="$1/scripts/check-object-store-integrity.sh"
   {
     printf '#!/usr/bin/env bash\n'
     printf 'for a in "$@"; do [ "$a" = --print-store ] && exit 0; done\n'
     printf 'printf "OBJECT-STORE: measured stub\\n"\n'
+    [ -z "$detail" ] || printf 'printf "OBJECT-STORE: verdict-detail %%s\\n" %s\n' "$(printf '%q' "$detail")"
     [ "$verdict" = NONE ] || printf 'printf "OBJECT-STORE: verdict %s\\n"\n' "$verdict"
     printf 'exit %s\n' "$rc"
   } >"$f"
@@ -1573,6 +1577,50 @@ if printf '%s' "$push_out" | grep -q '\[warn\].*object-store: UNMEASURED' &&
   ok "obj: an unmeasurable store is a [warn] UNMEASURED with no [ok] anywhere — unmeasured is never certified"
 else
   bad "obj: an unmeasurable store did not warn, or produced an [ok]"
+  push_plain "$push_out" | grep -F 'object-store:' | head -4
+fi
+
+# 7o-e. THE REMEDY IS QUOTED FROM THE SWEEP, NOT RESTATED HERE (#3749 review round 9,
+#   item 2). This section used to carry its own copy of the repair instruction, and it
+#   said `git fetch --force origin` — measured to repair NOTHING (`--force` only permits
+#   non-fast-forward REF updates; it re-downloads no objects), so an operator who followed
+#   it exactly kept the corruption and believed it fixed. The measurements live beside the
+#   text in check-object-store-integrity.sh; what this case pins is that ONE correction
+#   there reaches the operator here.
+#
+#   NOT A STRING TAUTOLOGY: it asserts nothing about what the remedy SAYS. It plants a
+#   token this file could not otherwise produce and requires the section to have passed it
+#   through, so deleting the quote — or writing a fresh paraphrase — reds this case
+#   whatever the paraphrase says.
+repo7oe2="$tmp/repo7oe-remedy"; mk_push_repo "$repo7oe2" "file://$bare7pa"
+_rtok="REMEDY: PLANTED-REPAIR-TEXT-7oe-$$"
+mk_sweep_stub "$repo7oe2" CORRUPT 4 "$_rtok"
+_rout=$(bash "$repo7oe2/scripts/check-object-store-integrity.sh" --repo "$repo7oe2" 2>&1 || true)
+if printf '%s' "$_rout" | grep -qF "OBJECT-STORE: verdict-detail $_rtok"; then
+  ok "obj: the remedy plant IS the shape described (the stub sweep prints that verdict-detail line)"
+else
+  bad "obj: the remedy plant did not take — the case below would prove nothing (stub said: $(printf '%s' "$_rout" | tr '\n' ';'))"
+fi
+run_push "$repo7oe2" "$bin7pa" "$gc7pa" --skip-push-probe --strict
+if printf '%s' "$push_out" | grep -qF "$_rtok" &&
+  printf '%s' "$push_out" | grep -q '\[warn\].*object-store: CORRUPT' &&
+  ! push_green "$push_out"; then
+  ok "obj: the CORRUPT report QUOTES the sweep's own operator remedy verbatim — the guidance is owned by the file that measured it"
+else
+  bad "obj: the sweep's remedy text did not reach the bootstrap output"
+  push_plain "$push_out" | grep -F 'object-store:' | head -4
+fi
+# THE FALLBACK, one property apart: a sweep that prints NO guidance (an older or stubbed
+# script). A stopped box must never be left with no remedy at all.
+repo7oe3="$tmp/repo7oe-remedy-none"; mk_push_repo "$repo7oe3" "file://$bare7pa"
+mk_sweep_stub "$repo7oe3" CORRUPT 4
+run_push "$repo7oe3" "$bin7pa" "$gc7pa" --skip-push-probe --strict
+if printf '%s' "$push_out" | grep -q 'REMEDY' &&
+  printf '%s' "$push_out" | grep -q 'check-object-store-integrity.sh' &&
+  ! push_green "$push_out"; then
+  ok "obj: with nothing to quote, CORRUPT still carries a remedy naming the sweep to run by hand — the diagnostic fails closed"
+else
+  bad "obj: a CORRUPT verdict with no quotable guidance left the operator with no remedy"
   push_plain "$push_out" | grep -F 'object-store:' | head -4
 fi
 

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -36,6 +36,22 @@ $1"; }
 # instead, by the base_warns assertion in block 7p.
 skip() { printf 'skip - %s\n' "$1"; SKIPS=$((SKIPS + 1)); }
 
+# --- SECTION 5b-obj IS OPTED OUT SUITE-WIDE, AND THE PUSH SANDBOXES OPT BACK IN (#3749) -
+# 5b-obj rehashes the SHARED git object store with a full `git fsck`. Against the REAL
+# checkout that is 19.83s per invocation (measured on this fleet's 331M store) and this
+# suite drives bootstrap dozens of times — ~12 minutes added to a MANDATORY gate
+# component for a property most of these cases are not about. So the env opt-out is set
+# ONCE here.
+#
+# THE OPT-OUT IS A [warn] BY DESIGN (it can never buy a vacuous green), so it would push
+# `base_warns` from 1 to 2 and silently turn block 7p's three end-to-end assertions into
+# skips — the exact drift the comments in that block record happening FOUR times. Hence
+# `run_push` sets it back to 0 and `mk_push_repo` stages the sweep script: in those
+# sandboxes the subject is the sandbox's OWN tiny repo, so the sweep runs in milliseconds,
+# reports VERIFIED, and contributes ZERO warnings. The dedicated 5b-obj cases below then
+# get a real end-to-end verdict instead of a mocked one.
+export CQLITE_BOOTSTRAP_SKIP_OBJECT_STORE_SWEEP=1
+
 # --- THIS SUITE IS NOT RUNNABLE AS ROOT, AND SAYS SO UP FRONT (#3414 roborev round 7) --
 # OUR OWN REGRESSION, and the second time these three cases have been silently disabled.
 # Round 5 made the test seam refuse under EUID 0 (finding S, a real privilege-escalation
@@ -1206,6 +1222,13 @@ mk_push_repo() {
   # running. Staging it here plus the pinned `sudo` shim in mk_push_bin makes 5b contribute
   # ZERO warnings deterministically — on a pinned host and an unpinned one alike.
   cp "$SCRIPT_DIR/../agent-gate.sh" "$dir/scripts/agent-gate.sh"
+  # Staged for SECTION 5b-obj (#3749), for the same reason agent-gate.sh is staged above:
+  # without it the section reports `object-store: UNMEASURED (no
+  # scripts/check-object-store-integrity.sh ...)` — one extra [warn] in EVERY case built on
+  # this helper, which is precisely how base_warns has drifted before. With it staged, the
+  # subject is this sandbox's own (objectless, therefore trivially intact) repo, so the
+  # section contributes ZERO warnings deterministically.
+  cp "$SCRIPT_DIR/../check-object-store-integrity.sh" "$dir/scripts/check-object-store-integrity.sh"
   # A PER-SANDBOX system env file carrying the pin, pointed at by run_push. Section 5b's
   # VERIFIED now requires BOTH the file line and a session that sees it (roborev round 2),
   # so without this the sandboxes would take the new NOT-SYSTEM-WIDE branch, base_warns
@@ -1317,6 +1340,7 @@ run_push() {
   push_rc=0
   push_out=$(PATH="$bin:$PATH" HOME="$repo/.home" CARGO_HOME="$repo/.home/.cargo" \
     CQLITE_BOOTSTRAP_ENV_FILE="$repo/etc-environment" \
+    CQLITE_BOOTSTRAP_SKIP_OBJECT_STORE_SWEEP=0 \
     GIT_CONFIG_GLOBAL="$gc" GIT_CONFIG_NOSYSTEM=1 CLAIM_MACHINE=push-probe-test \
     CODEX_NOTIFY_WEBHOOK='https://ntfy.example.com/t' \
     CQLITE_PROJECT_OWNER=pmcfadin CQLITE_PROJECT_NUMBER=1 \
@@ -1395,6 +1419,102 @@ if [ "$base_warns" -eq 1 ]; then
 else
   skip "push: absolute-green assertions need an otherwise-clean sandbox (baseline=$base_warns warnings)"
   printf '%s' "$out7pd" | grep -F '[warn]' | sed 's/\x1b\[[0-9;]*m//g' | head -5
+fi
+
+# ---------------------------------------------------------------------------
+# 7o. SECTION 5b-obj — the SHARED OBJECT-STORE INTEGRITY SWEEP (issue #3749)
+#
+# Four cases, all end-to-end through the real section: the affirmative verdict, the
+# opt-out, a PLANTED CORRUPTION, and the unmeasurable case. The sweep script's own
+# behaviour is covered by scripts/tests/test_check_object_store_integrity.sh; what these
+# assert is BOOTSTRAP's half — that VERIFIED is the only [ok], that CORRUPT is loud, and
+# that neither the opt-out nor an unmeasured host can buy a green.
+# ---------------------------------------------------------------------------
+# 7o-a. THE AFFIRMATIVE VERDICT, on the same run block 7p just proved goes fully green.
+#   Its zero-warning baseline is the second half of the assertion: a section that reported
+#   ok while warning would have shown up as base_warns drift.
+if printf '%s' "$out7pa" | grep -q '\[ok\].*object-store: VERIFIED' &&
+  printf '%s' "$out7pa" | grep -q 'point-in-time'; then
+  ok "obj: a clean store is reported VERIFIED as [ok], declared as a POINT-IN-TIME sweep (not a per-read guarantee)"
+else
+  bad "obj: section 5b-obj did not report VERIFIED as [ok] on a clean sandbox"
+  push_plain "$out7pa" | grep -F 'object-store:' | head -4
+fi
+
+# 7o-b. THE OPT-OUT: loud, non-passing, and it names WHICH spelling was used. One property
+#   apart from 7o-a — the flag.
+run_push "$repo7pa" "$bin7pa" "$gc7pa" --skip-push-probe --skip-object-store-sweep --strict
+if printf '%s' "$push_out" | grep -q '\[warn\].*object-store: OPT-OUT (--skip-object-store-sweep)' &&
+  ! push_green "$push_out" && [ "$push_rc" -ne 0 ]; then
+  ok "obj: --skip-object-store-sweep is a LOUD [warn] OPT-OUT that withholds green and fails --strict"
+else
+  bad "obj: the opt-out was silent, reported ok, or bought a green (rc=$push_rc)"
+  push_plain "$push_out" | grep -F 'object-store:' | head -4
+fi
+
+# 7o-c. PLANTED CORRUPTION, one property apart from a clean sandbox: a hash-path mismatch
+#   in the sandbox's OWN object store. The construction is ASSERTED with git before
+#   bootstrap runs — `cat-file` must hand back the WRONG content without complaint — so
+#   this cannot pass against an intact fixture, and the [warn] cannot be attributed to
+#   some unrelated breakage.
+repo7oc="$tmp/repo7oc"; mk_push_repo "$repo7oc" "file://$bare7pa"
+(
+  cd "$repo7oc" || exit 1
+  printf 'aaa\n' >objf1
+  printf 'bbb\n' >objf2
+  git -c user.email=t@t -c user.name=t add objf1 objf2 >/dev/null 2>&1
+  git -c user.email=t@t -c user.name=t commit -q -m obj-fixture >/dev/null 2>&1
+) || true
+oc_a=$(git -C "$repo7oc" rev-parse HEAD:objf1 2>/dev/null)
+oc_b=$(git -C "$repo7oc" rev-parse HEAD:objf2 2>/dev/null)
+if [ -n "$oc_a" ] && [ -n "$oc_b" ] && [ "$oc_a" != "$oc_b" ]; then
+  oc_pa="$repo7oc/.git/objects/${oc_a:0:2}/${oc_a:2}"
+  oc_pb="$repo7oc/.git/objects/${oc_b:0:2}/${oc_b:2}"
+  chmod 644 "$oc_pa" 2>/dev/null
+  cp "$oc_pb" "$oc_pa" 2>/dev/null
+fi
+if [ -n "$oc_a" ] && [ "$(git -C "$repo7oc" cat-file -p "$oc_a" 2>/dev/null)" = "bbb" ]; then
+  ok "obj: the plant IS the defect described (git returns objf2's content for objf1's sha, no error)"
+else
+  bad "obj: the corruption plant did not take — the case below would prove nothing"
+fi
+run_push "$repo7oc" "$bin7pa" "$gc7pa" --skip-push-probe --strict
+if printf '%s' "$push_out" | grep -q '\[warn\].*object-store: CORRUPT' &&
+  ! push_green "$push_out" && [ "$push_rc" -ne 0 ]; then
+  ok "obj: a corrupt shared store is reported CORRUPT, withholds green and fails --strict"
+else
+  bad "obj: a corrupt store did not produce a CORRUPT verdict (rc=$push_rc)"
+  push_plain "$push_out" | grep -F 'object-store:' | head -4
+fi
+if [ -n "$oc_a" ] && printf '%s' "$push_out" | grep -q "object $oc_a"; then
+  ok "obj: the CORRUPT report NAMES the affected object id ($oc_a)"
+else
+  bad "obj: the affected object id is not named in the bootstrap output"
+fi
+if printf '%s' "$push_out" | grep -q 'REMEDY' &&
+  printf '%s' "$push_out" | grep -q 'SHARED OBJECT STORE CORRUPT'; then
+  ok "obj: CORRUPT carries a remedy AND is restated in the summary banner (one [warn] among many is missable)"
+else
+  bad "obj: CORRUPT lacks a remedy line or the summary restatement"
+fi
+
+# 7o-d. UNMEASURABLE: the sweep script absent from the checkout. Must be a [warn] naming
+#   what could not be measured — never an [ok], because an [ok] is what --strict reads.
+repo7od="$tmp/repo7od"; mk_push_repo "$repo7od" "file://$bare7pa"
+rm -f "$repo7od/scripts/check-object-store-integrity.sh"
+if [ ! -e "$repo7od/scripts/check-object-store-integrity.sh" ]; then
+  ok "obj: the unmeasurable plant IS the property described (the sweep script is absent from that checkout)"
+else
+  bad "obj: could not remove the sweep script from the sandbox"
+fi
+run_push "$repo7od" "$bin7pa" "$gc7pa" --skip-push-probe --strict
+if printf '%s' "$push_out" | grep -q '\[warn\].*object-store: UNMEASURED' &&
+  ! printf '%s' "$push_out" | grep -q '\[ok\].*object-store:' &&
+  ! push_green "$push_out"; then
+  ok "obj: an unmeasurable store is a [warn] UNMEASURED with no [ok] anywhere — unmeasured is never certified"
+else
+  bad "obj: an unmeasurable store did not warn, or produced an [ok]"
+  push_plain "$push_out" | grep -F 'object-store:' | head -4
 fi
 
 # 7p-b. PUSH FAILS, credential-shaped. The bare repo's pre-receive hook speaks the

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -38,10 +38,12 @@ skip() { printf 'skip - %s\n' "$1"; SKIPS=$((SKIPS + 1)); }
 
 # --- SECTION 5d IS OPTED OUT SUITE-WIDE, AND THE PUSH SANDBOXES OPT BACK IN (#3749) -
 # 5d rehashes the SHARED git object store with a full `git fsck`. Against the REAL
-# checkout that is 19.83s per invocation (measured on this fleet's 331M store) and this
-# suite drives bootstrap dozens of times — ~12 minutes added to a MANDATORY gate
-# component for a property most of these cases are not about. So the env opt-out is set
-# ONCE here.
+# checkout that is 13-24s per invocation warm and 47-80s cold or under concurrent gates
+# (two independent measurement sets on this fleet's 366M store, git 2.43.0), and this
+# suite drives bootstrap dozens of times — roughly 8 to 45 MINUTES added to a MANDATORY
+# gate component for a property most of these cases are not about. (An earlier revision
+# quoted a single "19.83s" from one warm run; a single number was what made that claim
+# wrong.) So the env opt-out is set ONCE here.
 #
 # THE OPT-OUT IS A [warn] BY DESIGN (it can never buy a vacuous green), so it would push
 # `base_warns` from 1 to 2 and silently turn block 7p's three end-to-end assertions into

--- a/scripts/tests/test_check_object_store_integrity.sh
+++ b/scripts/tests/test_check_object_store_integrity.sh
@@ -411,7 +411,7 @@ mk_bin() {
   local dir="$1" t p
   shift
   mkdir -p "$dir"
-  for t in bash printf mktemp rm cat sed awk grep tr sort head wc date nice chmod mkdir cmp "$@"; do
+  for t in bash env printf mktemp rm cat sed awk grep tr sort head wc date nice chmod mkdir cmp "$@"; do
     p=$(type -P "$t" 2>/dev/null) || continue
     [ -n "$p" ] && ln -sf "$p" "$dir/$t" 2>/dev/null
   done

--- a/scripts/tests/test_check_object_store_integrity.sh
+++ b/scripts/tests/test_check_object_store_integrity.sh
@@ -88,7 +88,7 @@ record_out() {
         tok=${line#'OBJECT-STORE: verdict '}
         tok=${tok%% *}
         case "$tok" in
-          VERIFIED | CORRUPT | UNMEASURED) ;;
+          VERIFIED | CORRUPT | UNMEASURED | UNSWEEPABLE) ;;
           *) printf '%s\t%s\n' "$tag" "$line" >>"$VERDICT_BAD" ;;
         esac
         ;;
@@ -122,11 +122,11 @@ whole_suite_checks() {
     ok "anchor: the whole-suite assertion inspects $nonempty output lines from every run"
   fi
   cov_missing=""
-  for needle in 'verdict VERIFIED' 'verdict CORRUPT' 'verdict UNMEASURED' 'USAGE'; do
+  for needle in 'verdict VERIFIED' 'verdict CORRUPT' 'verdict UNMEASURED' 'verdict UNSWEEPABLE' 'USAGE'; do
     grep -q "$needle" "$ALL_OUT" || cov_missing="$cov_missing '$needle'"
   done
   if [ -z "$cov_missing" ]; then
-    ok "anchor: the accumulated output covers all THREE verdicts AND the usage path"
+    ok "anchor: the accumulated output covers all FOUR verdicts AND the usage path"
   else
     bad "anchor: accumulated output missing:$cov_missing — narrower than the suite claims"
   fi
@@ -138,7 +138,7 @@ whole_suite_checks() {
   if [ -s "$VERDICT_BAD" ]; then
     bad "anchor: a 'verdict ' line carries a token outside the closed set; first: $(head -1 "$VERDICT_BAD")"
   else
-    ok "anchor: every 'verdict ' token is from {VERIFIED, CORRUPT, UNMEASURED}"
+    ok "anchor: every 'verdict ' token is from {VERIFIED, CORRUPT, UNMEASURED, UNSWEEPABLE}"
   fi
   [ "$INSPECTED_RECORDS" -lt 0 ] && INSPECTED_RECORDS=$RECORD_CALLS
 }
@@ -158,7 +158,7 @@ whole_suite_checks() {
 # restated constant is a magic number wearing a relation's clothes. RAISE IT when you add
 # cases; LOWER IT when you deliberately remove them, never "for safety" — a floor above
 # the real count is a permanently red suite.
-CASE_FLOOR=120
+CASE_FLOOR=128
 
 finish() {
   local rc=$?
@@ -609,7 +609,8 @@ all_lines=$(grep -c . "$SUBJECT" | tr -d ' ')
 if [ "$code_lines" -lt "$all_lines" ] && [ "$code_lines" -gt 60 ] &&
   grep -q 'verdict VERIFIED' "$T/subject-code.txt" &&
   grep -q 'verdict CORRUPT' "$T/subject-code.txt" &&
-  grep -q 'verdict UNMEASURED' "$T/subject-code.txt"; then
+  grep -q 'verdict UNMEASURED' "$T/subject-code.txt" &&
+  grep -q 'verdict UNSWEEPABLE' "$T/subject-code.txt"; then
   ok "template: the comment-stripped source ($code_lines of $all_lines lines) still holds the output templates"
 else
   bad "template: the comment strip left no usable template text ($code_lines of $all_lines) — the case would be vacuous"
@@ -623,7 +624,7 @@ for tok in PASS 'RESULT:' OK; do
 done
 [ "$tmpl_bad" -eq 0 ] &&
   ok "template: the static text carries none of PASS, OK, RESULT: — its output can never be pasted as a gate/roborev block"
-own_bad=$(grep -nE 'VERIFIED|CORRUPT|UNMEASURED' "$T/subject-code.txt" | grep -v 'verdict ' | head -1)
+own_bad=$(grep -nE 'VERIFIED|CORRUPT|UNMEASURED|UNSWEEPABLE' "$T/subject-code.txt" | grep -v 'verdict ' | head -1)
 if [ -z "$own_bad" ]; then
   ok "template: its OWN verdict tokens appear only on 'verdict ' templates (structural)"
 else
@@ -1128,12 +1129,23 @@ if [ -n "${REAL_GIT:-}" ]; then
     fi
   done
 
-  # --- Case 23: AND THE NON-BITMASK PATH STILL REFUSES ---------------------
+  # --- Case 23: AND THE NON-BITMASK PATH STILL REFUSES TO BIT-TEST ---------
   # The control for Case 22, and the half of the round-1 reasoning that was RIGHT: 128 is
-  # git's `die()` and 127 a missing binary, and `127 & 1` is 1. Neither may be bit-tested.
-  # ONE property from the arms above: the status, which is at or above the floor where
-  # shell and `die()` conventions live.
-  for _nb in 127 128; do
+  # git's `die()` and 127 a missing binary, and `127 & 1` is 1. NEITHER MAY BE
+  # BIT-TESTED, and that has not changed.
+  #
+  # WHAT DID CHANGE (#3749 review round 10, item 1): they no longer share a VERDICT. Both
+  # arms used to assert exit 5 / UNMEASURED — and UNMEASURED means the supervisor writes a
+  # fresh throttle stamp and keeps spawning workers, so this case was pinning a false
+  # negative on real commit-object corruption (Case 32 builds that fixture). "The probe
+  # could not START" and "the probe RAN, twice, and reproducibly DIED" are different
+  # facts, so each arm now asserts the verdict that belongs to it, and each is ONE
+  # PROPERTY — the status — from the others.
+  #   127 -> the exec convention: nothing ran, permissive UNMEASURED with its own cause.
+  #   128 -> git's own die(): it RAN and did not finish, so the stopping verdict.
+  #    64 -> a bit outside the supported mask: still the "cannot read as its error
+  #          bitmask" cause, which is the text this case has always pinned.
+  for _nb in 127 128 64; do
     SH_NB="$T/shim-nonmask$_nb"
     LOG_NB="$T/shim-nonmask$_nb-calls.txt"
     : >"$LOG_NB"
@@ -1141,13 +1153,34 @@ if [ -n "${REAL_GIT:-}" ]; then
     OUT=$(PATH="$SH_NB:$PATH" bash "$SUBJECT" --repo "$R_CLEAN" 2>&1)
     RC=$?
     record_out "nonmask-$_nb"
-    if [ "$RC" -eq 5 ] && [ "$(verdict_of)" = UNMEASURED ] &&
-      printf '%s\n' "$OUT" | grep -q 'cannot read as its error'; then
-      ok "non-bitmask($_nb): a status outside the mask is UNMEASURED with its OWN cause — never bit-tested into CORRUPT, and never described as a reachability problem it never reported"
+    case "$_nb" in
+      127) NB_RC=5 NB_V=UNMEASURED NB_TXT='could not be RUN' ;;
+      128) NB_RC=6 NB_V=UNSWEEPABLE NB_TXT='RAN and DIED without finishing' ;;
+      *) NB_RC=5 NB_V=UNMEASURED NB_TXT='cannot read as its error' ;;
+    esac
+    if [ "$RC" -eq "$NB_RC" ] && [ "$(verdict_of)" = "$NB_V" ] &&
+      printf '%s\n' "$OUT" | grep -q "$NB_TXT"; then
+      ok "non-bitmask($_nb): a status outside the mask is $NB_V with its OWN cause naming what happened — never bit-tested into CORRUPT, and never described as a reachability problem it never reported"
     else
-      bad "non-bitmask($_nb): rc=$RC verdict='$(verdict_of)' (wanted 5/UNMEASURED naming the unreadable status)"
+      bad "non-bitmask($_nb): rc=$RC verdict='$(verdict_of)' (wanted $NB_RC/$NB_V naming '$NB_TXT')"
     fi
   done
+  # AND THE STOPPING VERDICT STILL NEEDS THE CLASS TO REPRODUCE. ONE property from the
+  # 128 arm above: the shim dies fatally on its FIRST call only. A fatal death that does
+  # not survive a second independent walk is not an established fact about the store.
+  SH_NB1="$T/shim-nonmask-once"
+  LOG_NB1="$T/shim-nonmask-once-calls.txt"
+  : >"$LOG_NB1"
+  mk_fsck_shim "$SH_NB1" once 128 "$DMG_MSG2" "$LOG_NB1"
+  OUT=$(PATH="$SH_NB1:$PATH" bash "$SUBJECT" --repo "$R_CLEAN" 2>&1)
+  RC=$?
+  record_out "nonmask-once"
+  if [ "$(grep -c . "$LOG_NB1" | tr -d ' ')" -ge 2 ] && [ "$RC" -eq 5 ] &&
+    [ "$(verdict_of)" = UNMEASURED ]; then
+    ok "non-bitmask(once): a fatal death in ONE of two walks is UNMEASURED, not the stopping verdict — reproduction is required for it too, and the shim really was called twice"
+  else
+    bad "non-bitmask(once): rc=$RC verdict='$(verdict_of)' calls=$(grep -c . "$LOG_NB1" | tr -d ' ') (wanted 5/UNMEASURED after two calls)"
+  fi
 fi
 
 # --- Case 24: `--print-store` IS THE ONE ISOLATED RESOLVER ------------------
@@ -1801,4 +1834,102 @@ if [ -z "$DG_VEST" ]; then
   ok "declared-gap(no-vestige): neither the sweep nor its two consumers carry a private-root probe mode, flag or census key — the gap is declared in ONE place and claimed nowhere"
 else
   bad "declared-gap(no-vestige): probe remnants in$DG_VEST — if the gap has been CLOSED, change this case and the declaration together; if not, the remnant is dead code claiming coverage the declaration denies"
+fi
+
+# --- Case 32: A CORRUPT **COMMIT** OBJECT IS UNSWEEPABLE, NOT "NOT MEASURED" -
+# THE FALSE NEGATIVE THIS CASE EXISTS FOR (#3749 review round 10, item 1). Real
+# commit-object corruption makes `git fsck` DIE rather than report a bit. Case 21's own
+# comment records the fact ("corrupting the COMMIT object instead makes git `die()`, exit
+# 128") and Case 23 then ASSERTED that 128 is UNMEASURED — so the fixture recipe below
+# produced, on the previous version, a false negative on genuine corruption of the shared
+# store: exit 5, the supervisor writes a fresh throttle stamp, and every lane on the box
+# carries on. The same class as round 4's missing-live-object High, one status range over.
+#
+# WHAT THE VERDICT MAY AND MAY NOT SAY. UNSWEEPABLE is a STOPPING verdict that claims NO
+# cause: what was established is that the walk RAN and reproducibly DIED without
+# finishing, which is not the same fact as "the probe could not start" (UNMEASURED, and
+# deliberately permissive — a hygiene probe that cannot run must not stop the fleet). So
+# this case asserts BOTH halves: that it stops, and that it names no repair.
+#
+# A REAL FIXTURE, NOT A SHIM. Case 23's arms stage statuses with a git shim, which can
+# show the classifier maps 128 somewhere but cannot show that REAL corruption produces
+# 128 on the git in use. This one damages a real commit object in a real store and
+# MEASURES the status with git before the subject runs.
+mk_corrupt_commit_repo() {
+  local r
+  r=$(newrepo "$1")
+  local sha p
+  # The commit a live ref points AT, named explicitly. The distinction is load-bearing
+  # and measured (git 2.43.0): unparseable bytes under the HEAD commit's name exit 128
+  # (`fatal: loose object ... is corrupt`), while the same damage to a BLOB, or a VALID
+  # object stored under the commit's name, exits 3 (bits 2|1) and is Cases 3/4's subject.
+  sha=$(g "$r" rev-parse HEAD 2>/dev/null)
+  [ -n "$sha" ] || { printf '%s' "$r"; return 0; }
+  p=$(loose_path "$r" "$sha")
+  chmod u+w "$p" 2>/dev/null
+  printf 'not zlib at all, definitely garbage bytes' >"$p"
+  printf '%s' "$r"
+}
+R_CC_TWIN=$(newrepo corrupt-commit-twin)
+CC_SHA=$(g "$R_CC_TWIN" rev-parse HEAD 2>/dev/null)
+CC_TYPE=$(g "$R_CC_TWIN" cat-file -t "$CC_SHA" 2>/dev/null)
+CC_REF=$(g "$R_CC_TWIN" rev-parse HEAD 2>/dev/null)
+R_CC=$(mk_corrupt_commit_repo corrupt-commit)
+S_CC=$(fsck_status "$R_CC")
+S_CC_TWIN=$(fsck_status "$R_CC_TWIN")
+# CONSTRUCTION, THREE THINGS, because each one is a way this case could pass while
+# measuring something else: the damaged object really is a COMMIT, it really is the one a
+# live ref names, and on THIS git that damage really does produce a status at or above
+# the fatal floor (and NOT a bitmask status, which would make it Case 3's subject).
+if [ "$CC_TYPE" = commit ] && [ -n "$CC_REF" ] && [ "$CC_SHA" = "$CC_REF" ] &&
+  [ "$S_CC" -ge 128 ] && [ "$S_CC_TWIN" -eq 0 ]; then
+  ok "corrupt-commit-plant: the damaged object is the COMMIT object HEAD names ($CC_TYPE), git 2.43 exits $S_CC on it (at or above the fatal floor, so NOT a bitmask status), and the byte-identical twin exits $S_CC_TWIN"
+else
+  bad "corrupt-commit-plant: type='$CC_TYPE' sha='$CC_SHA' ref='$CC_REF' damaged-status=$S_CC twin-status=$S_CC_TWIN — not the shape this case is about; the asserts below would prove nothing"
+fi
+if run 6 "corrupt commit: UNSWEEPABLE, not UNMEASURED" --repo "$R_CC"; then
+  if [ "$(verdict_of)" = UNSWEEPABLE ] && [ "$(verdict_lines)" -eq 1 ]; then
+    ok "corrupt-commit: a store whose fsck RUNS and reproducibly DIES yields exactly one 'verdict UNSWEEPABLE' line and exit 6 — a STOPPING verdict, where the previous classifier said 'not measured' and let every lane carry on"
+  else
+    bad "corrupt-commit: verdict='$(verdict_of)' on $(verdict_lines) verdict line(s), wanted UNSWEEPABLE"
+  fi
+  # IT RAN TWICE. A stopping verdict on ONE observation is what the reproduction
+  # discriminator exists to prevent, so the two measured passes are required to be there.
+  if printf '%s\n' "$OUT" | grep -q "^OBJECT-STORE: measured pass 1: fsck rc=$S_CC " &&
+    printf '%s\n' "$OUT" | grep -q "^OBJECT-STORE: measured pass 2: fsck rc=$S_CC "; then
+    ok "corrupt-commit: the verdict rests on TWO independent walks, both reported with the status they returned ($S_CC)"
+  else
+    bad "corrupt-commit: the two walks are not both reported — a stopping verdict on one observation cannot separate a transient from a durable fact"
+  fi
+  # THE OPERATOR GETS git's OWN LAST WORD. `fatal:` matches none of the other recognised
+  # diagnostic shapes, and a stopping verdict that leaves a human with no text is round
+  # 9's defect in a new place.
+  if printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: finding fatal: '; then
+    ok "corrupt-commit: git's own 'fatal:' line — the only account of why it stopped — reaches the operator as a finding"
+  else
+    bad "corrupt-commit: the fatal diagnostic was dropped: $(printf '%s\n' "$OUT" | grep -c '^OBJECT-STORE: finding ') finding line(s)"
+  fi
+  # AND IT CLAIMS NO CAUSE. No cause was established, so no repair may be printed: the
+  # re-clone/--refetch instructions belong to the damage verdict, which measured its
+  # class. It must still tell the operator what to DO (run the walk by hand).
+  CC_BAD=""
+  for CC_TOK in refetch 'clone' 'reflog expire' 'multi-pack-index write'; do
+    printf '%s\n' "$OUT" | grep -qi -- "$CC_TOK" && CC_BAD="$CC_BAD [$CC_TOK]"
+  done
+  if [ -z "$CC_BAD" ] && printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: verdict-detail REMEDY' &&
+    printf '%s\n' "$OUT" | grep -q 'fsck --no-progress --no-dangling'; then
+    ok "corrupt-commit: the remedy names the walk to run BY HAND and carries NONE of the class-specific repairs (no re-clone, no --refetch, no reflog expire) — the printed text matches what was established"
+  else
+    bad "corrupt-commit: forbidden repair token(s)$CC_BAD, or no hand-run instruction — a repair chosen for a cause nobody established is worse than none"
+  fi
+fi
+# ONE PROPERTY APART: the BYTE-IDENTICAL twin, built by the same `newrepo` with the same
+# pinned clock and NOT damaged. It must be VERIFIED, so the verdict above is attributable
+# to the planted damage and not to the fixture recipe.
+if run 0 "corrupt-commit twin: still VERIFIED" --repo "$R_CC_TWIN"; then
+  if [ "$(verdict_of)" = VERIFIED ]; then
+    ok "corrupt-commit-control: the undamaged twin of that fixture is VERIFIED — the stopping verdict is the planted commit damage, not the recipe"
+  else
+    bad "corrupt-commit-control: verdict='$(verdict_of)' on the CLEAN twin, wanted VERIFIED"
+  fi
 fi

--- a/scripts/tests/test_check_object_store_integrity.sh
+++ b/scripts/tests/test_check_object_store_integrity.sh
@@ -158,7 +158,7 @@ whole_suite_checks() {
 # restated constant is a magic number wearing a relation's clothes. RAISE IT when you add
 # cases; LOWER IT when you deliberately remove them, never "for safety" — a floor above
 # the real count is a permanently red suite.
-CASE_FLOOR=128
+CASE_FLOOR=151
 
 finish() {
   local rc=$?
@@ -1932,4 +1932,253 @@ if run 0 "corrupt-commit twin: still VERIFIED" --repo "$R_CC_TWIN"; then
   else
     bad "corrupt-commit-control: verdict='$(verdict_of)' on the CLEAN twin, wanted VERIFIED"
   fi
+fi
+
+# --- Case 33: THE STORE'S OWN `fsck.*` CONFIG CANNOT PRODUCE A FALSE VERDICT -
+#
+# THE FINDING (#3749 review round 11, item 1). Round 3 put every git call under `env -i`
+# plus one allowlist, which closes the ENVIRONMENT sources of git config. It cannot close
+# the repository's OWN config, because that is a FILE in the store and not a variable —
+# and `git fsck` is configurable: `fsck.skipList` drops the validation messages of the
+# objects it names, and `fsck.<msg-id>=ignore` downgrades an individual diagnostic. Both
+# change the EXIT STATUS this script reads its verdict from, so a DAMAGED store reported
+# `VERIFIED`, exit 0. The shared `/data/lanes/repo/.git/config` is written by peer lanes
+# and by accident (someone works around one known-bad object in history), so this is in
+# model, and it produces the one failure this whole control exists to prevent.
+#
+# THE PLANT, MEASURED FIRST AND ASSERTED WITH GIT (git 2.43.0, 2026-09-02): a commit
+# object whose author line carries no email is an ERROR-severity fsck message, so a plain
+# `git fsck` exits 1 — ERROR_OBJECT, this script's own damage bit. That is the CONTROL
+# arm. Add either fsck.* form and the SAME repository exits 0.
+#
+# THREE ARMS, EACH ONE PROPERTY FROM THE FIRST:
+#   (a) damage, no fsck config          -> CORRUPT   (the plant is detected at all)
+#   (b) damage + fsck.<msg-id>=ignore   -> not VERIFIED
+#   (c) damage + fsck.skipList          -> not VERIFIED
+# and a CLEAN store carrying only the config, to show the refusal is the config and not
+# the damage.
+mk_missingemail_repo() {
+  # A repo whose ref names a commit with no author email. Built from `newrepo` so the
+  # fixture recipe is the suite's one path, then given a second ref to the bad commit —
+  # the object must be REACHABLE or fsck never looks at it.
+  local name="$1" r tree bad
+  r=$(newrepo "$name")
+  tree=$(git -C "$r" rev-parse 'HEAD^{tree}' 2>/dev/null)
+  [ -n "$tree" ] || { printf '%s' "$r"; return 0; }
+  bad=$(printf 'tree %s\nauthor NoEmail 1700000000 +0000\ncommitter t <t@t> 1700000000 +0000\n\nbad\n' "$tree" |
+    git -C "$r" hash-object -t commit -w --stdin --literally 2>/dev/null)
+  [ -n "$bad" ] && git -C "$r" update-ref refs/heads/bad "$bad" >/dev/null 2>&1
+  printf '%s' "$r"
+}
+
+R_FP_A=$(mk_missingemail_repo fsckpolicy-a)
+R_FP_B=$(mk_missingemail_repo fsckpolicy-b)
+R_FP_C=$(mk_missingemail_repo fsckpolicy-c)
+FP_SKIP="$T/fsckpolicy-skip.txt"
+FP_BAD_SHA=$(git -C "$R_FP_C" rev-parse refs/heads/bad 2>/dev/null)
+printf '%s\n' "$FP_BAD_SHA" >"$FP_SKIP"
+git -C "$R_FP_B" config fsck.missingEmail ignore >/dev/null 2>&1
+git -C "$R_FP_C" config fsck.skipList "$FP_SKIP" >/dev/null 2>&1
+
+# CONSTRUCTION, with git and not with the subject: the damage must be REAL (rc 1, the
+# damage bit) and each suppression must ACTUALLY SUPPRESS (rc 0 on the same repository).
+# Without this the arms below could pass against a plant that no longer plants, or a
+# config form git has stopped honouring — in which case the case would be about nothing.
+FP_RC_A=0; git -C "$R_FP_A" fsck --no-progress --no-dangling >/dev/null 2>&1 || FP_RC_A=$?
+FP_RC_B=0; git -C "$R_FP_B" fsck --no-progress --no-dangling >/dev/null 2>&1 || FP_RC_B=$?
+FP_RC_C=0; git -C "$R_FP_C" fsck --no-progress --no-dangling >/dev/null 2>&1 || FP_RC_C=$?
+if [ -n "$FP_BAD_SHA" ] && [ "$((FP_RC_A & 1))" -eq 1 ] && [ "$FP_RC_B" -eq 0 ] && [ "$FP_RC_C" -eq 0 ]; then
+  ok "fsck-policy-plant: the damage is real (plain fsck rc=$FP_RC_A, carrying ERROR_OBJECT) and BOTH config forms genuinely suppress it to rc=0 on the same repository — the arms below are about a live suppression route"
+else
+  bad "fsck-policy-plant: plain=$FP_RC_A msgid=$FP_RC_B skiplist=$FP_RC_C sha='$FP_BAD_SHA' — the arms below would prove nothing"
+fi
+
+# (a) THE CONTROL: the same damage with NO fsck config is detected. This is what makes
+#     (b) and (c) attributable to the configuration rather than to the fixture.
+if run 4 "fsck-policy(control): damage with no fsck config is CORRUPT" --repo "$R_FP_A"; then
+  if [ "$(verdict_of)" = CORRUPT ] &&
+    printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: measured fsck-policy: no fsck\.\* key'; then
+    ok "fsck-policy(control): with no fsck.* key the sweep WALKS, reports the affirmative policy measurement, and calls the planted damage CORRUPT"
+  else
+    bad "fsck-policy(control): verdict='$(verdict_of)' — the plant is not otherwise detected, so the refusal arms below are unattributable"
+  fi
+fi
+
+# (b) and (c): the SAME damage under each suppression form. The property asserted first is
+#     the one the finding is about — NOT VERIFIED, NOT exit 0 — and only then the verdict
+#     it does produce.
+for FP_ARM in msgid skiplist; do
+  case "$FP_ARM" in
+    msgid) FP_REPO="$R_FP_B"; FP_KEY='fsck.missingemail' ;;
+    *)     FP_REPO="$R_FP_C"; FP_KEY='fsck.skiplist' ;;
+  esac
+  OUT=$(bash "$SUBJECT" --repo "$FP_REPO" 2>&1)
+  RC=$?
+  record_out "fsck-policy-$FP_ARM"
+  if [ "$RC" -ne 0 ] && [ "$(verdict_of)" != VERIFIED ]; then
+    ok "fsck-policy($FP_ARM): a store whose own config can suppress the damage it holds does NOT report VERIFIED (rc=$RC) — the false affirmative verdict this item exists to remove"
+  else
+    bad "fsck-policy($FP_ARM): rc=$RC verdict='$(verdict_of)' — a DAMAGED store reported clean because its own configuration suppressed the diagnostic"
+  fi
+  if [ "$RC" -eq 6 ] && [ "$(verdict_of)" = UNSWEEPABLE ]; then
+    ok "fsck-policy($FP_ARM): it is the STOPPING verdict (exit 6/UNSWEEPABLE), not the permissive one — an fsck policy is a persistent property of the repository, so 'measure again in 6h' would mean detection is off on this box until somebody reads a journal line"
+  else
+    bad "fsck-policy($FP_ARM): rc=$RC verdict='$(verdict_of)' (wanted 6/UNSWEEPABLE)"
+  fi
+  if printf '%s\n' "$OUT" | grep -q "^OBJECT-STORE: finding fsck policy key(s): .*$FP_KEY"; then
+    ok "fsck-policy($FP_ARM): the offending key is NAMED ($FP_KEY) — an operator cannot act on 'something in your config'"
+  else
+    bad "fsck-policy($FP_ARM): the key is not named: [$(printf '%s\n' "$OUT" | grep '^OBJECT-STORE: finding ' | tr '\n' '|')]"
+  fi
+  # IT MUST NOT CLAIM DAMAGE, and it must say how to INSPECT. Nothing was rehashed here —
+  # no walk ran at all — so the damage verdict's measured repairs would be round 9's
+  # confidently-wrong text, and the class-specific tokens are asserted ABSENT.
+  FP_FORBID=""
+  for FP_TOK in refetch 'git clone' 'reflog expire' 'multi-pack-index write'; do
+    printf '%s\n' "$OUT" | grep -qi -- "$FP_TOK" && FP_FORBID="$FP_FORBID [$FP_TOK]"
+  done
+  if [ -z "$FP_FORBID" ] &&
+    printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: verdict-detail NO DAMAGE IS CLAIMED' &&
+    printf '%s\n' "$OUT" | grep -q 'config --list --show-origin --name-only'; then
+    ok "fsck-policy($FP_ARM): it claims NO damage, carries none of the repair instructions that belong to a measured damage class, and names the command that lists the keys with the scopes this sweep reads"
+  else
+    bad "fsck-policy($FP_ARM): forbidden repair token(s)$FP_FORBID, or no no-damage statement, or no inspection command"
+  fi
+  # AND NO WALK RAN. The refusal is BEFORE the sweep, so there must be no pass
+  # measurement at all — a run that walked and then refused would have spent two fsck
+  # bounds and could have printed a measurement nobody may trust.
+  if ! printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: measured pass '; then
+    ok "fsck-policy($FP_ARM): NO walk was run (no 'measured pass' line) — the refusal is a precondition, not a post-hoc downgrade of a measurement"
+  else
+    bad "fsck-policy($FP_ARM): a walk ran under an fsck policy this script cannot trust"
+  fi
+done
+
+# (d) A CLEAN store carrying ONLY the config. One property from the control in the other
+#     direction: no damage at all, and it still refuses — because the refusal is about
+#     what the sweep can TRUST, not about what it found. Without this arm the verdict
+#     above could be read as a damage finding wearing a different token.
+R_FP_D=$(newrepo fsckpolicy-d)
+git -C "$R_FP_D" config fsck.missingEmail ignore >/dev/null 2>&1
+OUT=$(bash "$SUBJECT" --repo "$R_FP_D" 2>&1)
+RC=$?
+record_out "fsck-policy-clean-store"
+if [ "$RC" -eq 6 ] && [ "$(verdict_of)" = UNSWEEPABLE ]; then
+  ok "fsck-policy(clean-store): an UNDAMAGED store whose config sets fsck.* also refuses — the verdict is about the trustworthiness of the measurement, not about a finding"
+else
+  bad "fsck-policy(clean-store): rc=$RC verdict='$(verdict_of)' (wanted 6/UNSWEEPABLE)"
+fi
+
+# (e) `--print-store` MUST STILL WORK ON SUCH A STORE, and this is not cosmetic: the
+#     supervisor asks for the store KEY to find the very latch that records the stop. A
+#     refusal here would leave a stopped box unable to name the file recording why.
+OUT=$(bash "$SUBJECT" --repo "$R_FP_D" --print-store 2>&1)
+RC=$?
+record_out "fsck-policy-print-store"
+if [ "$RC" -eq 0 ] && printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: store ' &&
+  ! printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: verdict '; then
+  ok "fsck-policy(print-store): the resolver still answers for a store the sweep refuses — it runs no fsck, and the caller needs the key to read the latch that records the stop"
+else
+  bad "fsck-policy(print-store): rc=$RC output=[$(printf '%s\n' "$OUT" | tr '\n' '|')]"
+fi
+
+# --- Case 34: "COULD NOT ASK" IS PERMISSIVE, AND IT IS NOT `VERIFIED` -------
+#
+# The probe is the sole oracle for the policy, so a probe that fails leaves the policy
+# UNREAD — and CLAUDE.md's standing rule is that a verdict may never be derived from the
+# absence of a bad signal. Two shapes, each with its own cause text, and BOTH must be
+# non-passing while NEITHER stops the box: an unreadable policy is a "could not measure"
+# fact of the same kind as the `unrunnable` class, not a persistent property of the store.
+#
+# A `git config` SHIM is the lever. The store cannot be made to fail that call without
+# also breaking the `rev-parse` that resolves it (an unparseable config fails both), which
+# would refuse one step earlier and prove nothing about this branch.
+if [ -n "${REAL_GIT:-}" ]; then
+  for FP_U in fails empty; do
+    SH_FP="$T/shim-cfg-$FP_U"
+    mk_bin "$SH_FP" timeout gtimeout
+    rm -f "$SH_FP/git"
+    {
+      printf '#!/usr/bin/env bash\n'
+      printf '# Test shim: `config --list` %s; everything else delegates to the real git.\n' "$FP_U"
+      printf 'for a in "$@"; do\n'
+      printf '  if [ "$a" = config ]; then\n'
+      if [ "$FP_U" = fails ]; then
+        printf '    printf "shim: config unavailable\\n" >&2\n'
+        printf '    exit 128\n'
+      else
+        printf '    exit 0\n'
+      fi
+      printf '  fi\n'
+      printf 'done\n'
+      printf 'exec %s "$@"\n' "$(printf '%q' "$REAL_GIT")"
+    } >"$SH_FP/git"
+    chmod +x "$SH_FP/git"
+    # CONSTRUCTION: the shim really does what the arm needs, and it really does NOT break
+    # the resolution the sweep does first — otherwise the refusal below would be the
+    # store-resolution branch and not this one.
+    FP_CFG_RC=0
+    PATH="$SH_FP:$PATH" "$SH_FP/git" --git-dir="$R_CLEAN/.git" config --list --name-only >"$T/cfg-$FP_U.out" 2>/dev/null || FP_CFG_RC=$?
+    FP_RP=$(PATH="$SH_FP:$PATH" "$SH_FP/git" -C "$R_CLEAN" rev-parse --git-common-dir 2>/dev/null)
+    if [ "$FP_U" = fails ]; then FP_WANT_RC=128; else FP_WANT_RC=0; fi
+    if [ "$FP_CFG_RC" -eq "$FP_WANT_RC" ] && [ ! -s "$T/cfg-$FP_U.out" ] && [ -n "$FP_RP" ]; then
+      ok "fsck-policy-unknown-plant($FP_U): the shim answers 'config --list' with rc=$FP_CFG_RC and no keys while 'rev-parse --git-common-dir' still resolves — the arm below is about the policy probe and not about store resolution"
+    else
+      bad "fsck-policy-unknown-plant($FP_U): cfg-rc=$FP_CFG_RC keys=$(wc -c <"$T/cfg-$FP_U.out" | tr -d ' ') rev-parse='$FP_RP' — the arm below would prove nothing"
+    fi
+    OUT=$(PATH="$SH_FP:$PATH" bash "$SUBJECT" --repo "$R_CLEAN" 2>&1)
+    RC=$?
+    record_out "fsck-policy-unknown-$FP_U"
+    if [ "$RC" -eq 5 ] && [ "$(verdict_of)" = UNMEASURED ] &&
+      printf '%s\n' "$OUT" | grep -q 'fsck POLICY of this store'; then
+      ok "fsck-policy-unknown($FP_U): an unread policy is UNMEASURED with its own cause — non-passing (it can never be VERIFIED) and permissive (it does not stop the box), because 'could not ask' is a fact about this run, not about the store"
+    else
+      bad "fsck-policy-unknown($FP_U): rc=$RC verdict='$(verdict_of)' (wanted 5/UNMEASURED naming the policy)"
+    fi
+    if ! printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: measured pass '; then
+      ok "fsck-policy-unknown($FP_U): no walk was run — an affirmative verdict is unobtainable under an unread policy, so spending two fsck bounds to reach one would be waste"
+    else
+      bad "fsck-policy-unknown($FP_U): a walk ran under a policy this run could not read"
+    fi
+  done
+fi
+
+# --- Case 35: THE PROBE ASKS ABOUT THE CONFIG THE WALK WILL ACTUALLY READ ---
+#
+# STRUCTURAL, over the shipped source, and it is the one property behaviour cannot show:
+# a probe that read a DIFFERENT git dir, or ran a BARE `git` (inheriting the caller's
+# GIT_CONFIG_* and so a different policy), would answer correctly on every fixture in this
+# suite and be wrong in production. Round 2's BLOCKER 2 was exactly that shape one
+# function over — the supervisor resolving the store with an un-isolated git — so the
+# invariant is asserted rather than believed.
+FP_PROBE=$(sed -n '/^fsck_policy_probe() {/,/^}/p' "$SUBJECT")
+if [ -n "$FP_PROBE" ] &&
+  printf '%s\n' "$FP_PROBE" | grep -q 'git_isolated git --git-dir="\$dir" config --list --name-only'; then
+  ok "fsck-policy(structure): the probe runs under git_isolated, with --git-dir, on the same store the walks use — so it reads the configuration the fsck will read"
+else
+  bad "fsck-policy(structure): the probe's git call is not the isolated --git-dir form: [$(printf '%s\n' "$FP_PROBE" | grep -n 'git ' | tr '\n' '|')]"
+fi
+# COMMENT LINES ARE STRIPPED FIRST: this file's own prose says `git` repeatedly, and a
+# census that counted it would answer about the documentation rather than the code.
+FP_CODE=$(printf '%s\n' "$FP_PROBE" | sed -e 's/[[:space:]]*#.*$//' -e '/^[[:space:]]*$/d')
+# AND THE CENSUS IS OVER COMMAND POSITIONS, NOT OVER THE TOKEN `git`: two of the probe's
+# lines carry `git ...` inside a DIAGNOSTIC STRING (the cause text an operator reads), and
+# counting those would make this assert answer about prose. A command position is a line
+# start, a command substitution, a pipe, a `&&` or a `;` — the shapes that EXECUTE.
+FP_GIT_ALL=$(printf '%s\n' "$FP_CODE" | grep -c -E '(^[[:space:]]*|\$\(|\|[[:space:]]*|&&[[:space:]]*|;[[:space:]]*)git[ _]' | tr -d ' ')
+FP_GIT_ISO=$(printf '%s\n' "$FP_CODE" | grep -c 'git_isolated git ' | tr -d ' ')
+if [ "$FP_GIT_ALL" -ge 1 ] && [ "$FP_GIT_ALL" -eq "$FP_GIT_ISO" ]; then
+  ok "fsck-policy(structure): EVERY git call in the probe is isolated ($FP_GIT_ISO of $FP_GIT_ALL) — an un-isolated one would read another policy than the walk does (round 2's BLOCKER 2, one function over)"
+else
+  bad "fsck-policy(structure): $FP_GIT_ALL git line(s) in the probe body, $FP_GIT_ISO of them isolated"
+fi
+# AND THE AFFIRMATIVE STATE IS THE ONLY ONE THAT PROCEEDS. `none` must be set only after
+# keys were actually read: an rc-0 answer with an empty listing is `unknown`, not an empty
+# policy, because every git repository's own config declares core.repositoryformatversion.
+if printf '%s\n' "$FP_PROBE" | grep -q 'FSCK_POLICY_STATE=unknown' &&
+  printf '%s\n' "$FP_PROBE" | grep -B4 'FSCK_POLICY_STATE=none' | grep -q 'hits' &&
+  printf '%s\n' "$FP_PROBE" | grep -q 'if \[ -z "\$out" \]'; then
+  ok "fsck-policy(structure): the probe starts at 'unknown' and reaches 'none' only by having COUNTED keys — an empty listing is an unread policy, never an empty one"
+else
+  bad "fsck-policy(structure): the probe's default state or its empty-listing branch is not the affirmative shape"
 fi

--- a/scripts/tests/test_check_object_store_integrity.sh
+++ b/scripts/tests/test_check_object_store_integrity.sh
@@ -154,7 +154,7 @@ whole_suite_checks() {
 # assertions (the two `command -v` guards and the fixture-construction asserts), so a
 # green run is 81 on any host that can run it at all; a green run BELOW this number
 # means cases were removed or the run was truncated. RAISE IT when you add cases.
-CASE_FLOOR=103
+CASE_FLOOR=104
 
 finish() {
   local rc=$?
@@ -201,8 +201,31 @@ trap 'exit 143' TERM
 # --- fixtures ---------------------------------------------------------------
 g() { local r="$1"; shift; git -C "$r" "$@"; }
 
+# THE FIXTURE CLOCK IS PINNED, AND THE SUITE'S VALIDITY RESTS ON IT — DO NOT REMOVE.
+# A commit's sha is a function of its author/committer DATES as well as its tree, so an
+# unpinned builder makes every fixture's object ids a function of THE WALL-CLOCK SECOND
+# THE FIXTURE WAS BUILT IN. Two `newrepo` calls landing either side of a second boundary
+# then produce DIFFERENT commit shas, which is a wall-clock race in a correctness test
+# (CLAUDE.md pre-roborev self-check; scripts/tests/check-no-wallclock-asserts.sh, #2642).
+#
+# It is not hypothetical and it is not cosmetic: Case 18's POSITIVE CONTROL runs a plain
+# git with `GIT_OBJECT_DIRECTORY=<clean>/.git/objects --git-dir=<mismatch>/.git` and
+# requires exit 0 — which holds ONLY while the two fixtures share object ids, because
+# otherwise <mismatch>'s refs name objects absent from <clean>'s store and fsck raises
+# ERROR_REACHABLE (exit 2). Measured with this exact recipe: same second =>
+# b1d2aeee4db43bcb41f647c78430314a2d0a5a58 twice; 1.2s later =>
+# 7efdf0e1453622b5bc6ff818e508f4857ce89455. Observed intermittently as
+# "env-plant: a plain git was not redirected by GIT_OBJECT_DIRECTORY (rc=2)" on a loaded
+# box, which would red `tooling-tests` in the gate of record for every lane, forever.
+#
+# The control was RIGHT to fail-close there; the fixture construction was what was wrong.
+# The fixed epoch is arbitrary (matching the 1700000000 used elsewhere in this file) and
+# carries an explicit `+0000` so the value does not depend on the box's TZ either.
+FIXTURE_DATE='1700000000 +0000'
+
 # newrepo <name> -> path. Two blobs, one commit. THE ONE CODE PATH every fixture is
-# built by, so a corruption case's CLEAN TWIN is identical but for the planted damage.
+# built by, so a corruption case's CLEAN TWIN is identical but for the planted damage —
+# BYTE-IDENTICAL, object ids included, which is what the pin above buys.
 newrepo() {
   local r="$T/$1"
   mkdir -p "$r"
@@ -212,7 +235,8 @@ newrepo() {
   printf 'content aaa\n' >"$r/f1"
   printf 'content bbb\n' >"$r/f2"
   g "$r" add f1 f2 >/dev/null
-  g "$r" -c user.email=t@t -c user.name=t commit -q -m c1 >/dev/null
+  GIT_AUTHOR_DATE="$FIXTURE_DATE" GIT_COMMITTER_DATE="$FIXTURE_DATE" \
+    g "$r" -c user.email=t@t -c user.name=t commit -q -m c1 >/dev/null
   printf '%s' "$r"
 }
 
@@ -861,6 +885,20 @@ fi
 # THE CONSTRUCTION IS ASSERTED FIRST, and it is what makes this case non-vacuous: a
 # PLAIN (non-isolated) git really is redirected by the variable, so a green below is
 # the isolation and not an inert variable.
+# THE PRECONDITION OF THE CONTROL BELOW, MEASURED RATHER THAN ASSUMED. The redirect can
+# only make <mismatch>'s refs resolve inside <clean>'s object store while the two
+# fixtures share object ids; if they do not, fsck raises ERROR_REACHABLE and the control
+# fails for a reason that has nothing to do with the injection. That identity is what
+# FIXTURE_DATE buys (see the builder's header) — unpinned it held only when both builds
+# happened to land in the same wall-clock second. Asserted HERE, at the one case that
+# depends on it, so removing the pin reds with the cause named instead of intermittently.
+CLEAN_HEAD=$(git -C "$R_CLEAN" rev-parse HEAD 2>/dev/null)
+MIS_HEAD=$(git -C "$R_MIS" rev-parse HEAD 2>/dev/null)
+if [ -n "$CLEAN_HEAD" ] && [ "$CLEAN_HEAD" = "$MIS_HEAD" ]; then
+  ok "env-plant: the clean and mismatch fixtures share a HEAD sha — the builder's clock is pinned, so the control below cannot turn on when the suite ran"
+else
+  bad "env-plant: clean HEAD '$CLEAN_HEAD' != mismatch HEAD '$MIS_HEAD' — the fixture clock is NOT pinned and the control below is a wall-clock race"
+fi
 plain_rc=0
 GIT_OBJECT_DIRECTORY="$R_CLEAN/.git/objects" \
   git --git-dir="$R_MIS/.git" fsck --no-progress --no-dangling >/dev/null 2>&1 || plain_rc=$?

--- a/scripts/tests/test_check_object_store_integrity.sh
+++ b/scripts/tests/test_check_object_store_integrity.sh
@@ -152,9 +152,13 @@ whole_suite_checks() {
 # suite could vanish — or be cut short by a signal — and still report green. Every
 # host-dependent branch in this file emits a `bad` rather than silently running fewer
 # assertions (the two `command -v` guards and the fixture-construction asserts), so a
-# green run is 81 on any host that can run it at all; a green run BELOW this number
-# means cases were removed or the run was truncated. RAISE IT when you add cases.
-CASE_FLOOR=123
+# green run hits exactly the number below on any host that can run it at all; a green run
+# BELOW it means cases were removed or the run was truncated. The count is written ONCE,
+# as the value: a second copy of it in this comment went stale for three rounds and a
+# restated constant is a magic number wearing a relation's clothes. RAISE IT when you add
+# cases; LOWER IT when you deliberately remove them, never "for safety" — a floor above
+# the real count is a permanently red suite.
+CASE_FLOOR=120
 
 finish() {
   local rc=$?
@@ -1711,164 +1715,90 @@ for WTR_MODE in head index prunable; do
   fi
 done
 
-# --- Case 31: THE ROOT A COMMON-DIR fsck DOES **NOT** WALK ------------------
-# THE REAL HOLE, and it is narrower and sharper than the review finding that led to it.
-# A LINKED worktree's per-worktree refs (`refs/worktree/*`, `refs/bisect/*`,
-# `refs/rewritten/*`) are roots only for an fsck run with THAT worktree's git dir. Delete
-# an object named only by one and a common-dir fsck exits **0**: the worktree's HEAD
-# reflog echoes the id, and that echo CLEARS under `--no-reflogs`, so even the round-4
-# attribution walk reads it as reflog-scoped. The MAIN worktree's per-worktree refs live
-# in the common dir and ARE walked, which is why this fixture uses a LINKED one.
-mk_wt_privateref_repo() {
-  # mk_wt_privateref_repo <name> <delete|keep> -> path; the victim id is published to
-  # "$T/<name>.victim" for the same subshell reason as mk_wt_root_repo above.
-  local r="$T/$1" act="$2" wt="$T/$1-wt" WTP_VICTIM=""
-  : >"$T/$1.victim"
-  mkdir -p "$r"
-  git init -q "$r" >/dev/null 2>&1
-  g "$r" config user.email t@t
-  g "$r" config user.name t
-  printf 'content aaa\n' >"$r/f1"
-  g "$r" add f1 >/dev/null
-  GIT_AUTHOR_DATE="$FIXTURE_DATE" GIT_COMMITTER_DATE="$FIXTURE_DATE" \
-    g "$r" -c user.email=t@t -c user.name=t commit -q -m c1 >/dev/null
-  g "$r" worktree add -q --detach "$wt" HEAD >/dev/null 2>&1 || { printf '%s' "$r"; return 0; }
-  printf 'private-ref-only\n' >"$wt/u"
-  g "$wt" add u >/dev/null
-  GIT_AUTHOR_DATE="$FIXTURE_DATE" GIT_COMMITTER_DATE="$FIXTURE_DATE" \
-    g "$wt" -c user.email=t@t -c user.name=t commit -q -m private-ref >/dev/null
-  WTP_VICTIM=$(g "$wt" rev-parse HEAD 2>/dev/null)
-  g "$wt" update-ref refs/worktree/private "$WTP_VICTIM" >/dev/null 2>&1
-  # Move HEAD off it, and drop the reflogs, so the per-worktree REF is the ONLY thing
-  # left naming the object — which is the whole point of the case.
-  g "$wt" checkout -q --detach HEAD~1 >/dev/null 2>&1
-  rm -f "$r/.git/worktrees/$(basename "$wt")/logs/HEAD" "$r/.git/logs/HEAD" 2>/dev/null
-  rm -rf "$r/.git/logs/refs" 2>/dev/null
-  printf '%s' "$WTP_VICTIM" >"$T/$1.victim"
-  if [ "$act" = delete ] && [ -n "$WTP_VICTIM" ]; then
-    chmod u+w "$(loose_path "$r" "$WTP_VICTIM")" 2>/dev/null
-    rm -f "$(loose_path "$r" "$WTP_VICTIM")"
-  fi
-  printf '%s' "$r"
-}
-R_WTP=$(mk_wt_privateref_repo wtpriv delete)
-WTP_DEAD=$(cat "$T/wtpriv.victim" 2>/dev/null || true)
-R_WTP_OK=$(mk_wt_privateref_repo wtpriv-ctl keep)
-WTP_ALIVE=$(cat "$T/wtpriv-ctl.victim" 2>/dev/null || true)
-WTP_RAW=$(fsck_status_mode "$R_WTP")
-WTP_RAW_NR=0
-git -C "$R_WTP" fsck --no-progress --no-dangling --no-reflogs >/dev/null 2>&1 || WTP_RAW_NR=$?
-# THE CONSTRUCTION ASSERT IS ALSO THE EVIDENCE THAT THE PROBE IS LOAD-BEARING: raw git,
-# in exactly the configuration the sweep's walks use, calls this store CLEAN. Without
-# that, a green below could not distinguish "the probe found it" from "fsck found it".
-if [ -n "$WTP_DEAD" ] && [ "$WTP_DEAD" = "$WTP_ALIVE" ] &&
-  ! git -C "$R_WTP" cat-file -e "$WTP_DEAD" 2>/dev/null &&
-  git -C "$R_WTP_OK" cat-file -e "$WTP_ALIVE" 2>/dev/null &&
-  [ "$(git --git-dir="$R_WTP/.git" rev-parse --verify -q refs/worktree/private 2>/dev/null)" != "$WTP_DEAD" ] &&
-  [ "$(git --git-dir="$R_WTP/.git/worktrees/wtpriv-wt" rev-parse --verify -q refs/worktree/private 2>/dev/null)" = "$WTP_DEAD" ] &&
-  [ "$WTP_RAW" -eq 0 ] && [ "$WTP_RAW_NR" -eq 0 ]; then
-  ok "wt-privateref-plant: $WTP_DEAD is named ONLY by the LINKED worktree's refs/worktree/private (invisible from the common dir), it is absent, the control still holds it, and a raw common-dir fsck calls this store CLEAN with and without reflogs — so anything found below is found by the probe"
-else
-  bad "wt-privateref-plant: dead='$WTP_DEAD' alive='$WTP_ALIVE' raw-fsck=$WTP_RAW/$WTP_RAW_NR — not the shape this case is about; the arms below would prove nothing"
-fi
-if run 4 "wt-privateref: CORRUPT" --repo "$R_WTP"; then
-  if [ "$(verdict_of)" = CORRUPT ] &&
-    printf '%s\n' "$OUT" | grep -q "^OBJECT-STORE: private-root ABSENT $WTP_DEAD .* refs/worktree/private$"; then
-    ok "wt-privateref: an object named only by a LINKED worktree's per-worktree ref is CORRUPT (exit 4) and the missing root is NAMED — the store a raw fsck called clean"
+# --- Case 31: THE GAP IS DECLARED, ON EVERY RUN, IN THE OUTPUT --------------
+# WHAT THIS CASE IS FOR (#3749 review round 8). A common-dir fsck does NOT use a LINKED
+# worktree's per-worktree refs (`refs/worktree/*`, `refs/bisect/*`, `refs/rewritten/*`)
+# as reachability roots, so an object named ONLY by one of them is not detected. A probe
+# for that WAS built and REMOVED: it produced three false-clean routes of its own (a
+# missing CHILD of a present root; a per-worktree ref whose NAME collides with a common
+# one; a failed `awk`/`sort`/`comm` degrading to a zero-root census), and CLAUDE.md's
+# ruling is that a guard with known false-PASSes is worse than no guard. What replaces it
+# is a DECLARATION — and a declaration nobody can see is worth nothing, so the property
+# under test is that it is EMITTED, on every verdict class, in the anchored stream.
+#
+# THIS CASE AND THE GAP ARE ONE FACT. If the gap is ever genuinely CLOSED, this case must
+# change in the SAME diff as the declaration it pins: a stale declaration claiming a hole
+# that no longer exists is as misleading as a silent hole.
+dg_lines() { printf '%s\n' "$OUT" | grep '^OBJECT-STORE: declared-gap '; }
+for DG_ARM in "clean:0:$R_CLEAN" "corrupt:4:$R_ROT" "unmeasured:5:$R_REFLOG_MISS"; do
+  DG_NAME=${DG_ARM%%:*}
+  DG_REST=${DG_ARM#*:}
+  DG_WANT=${DG_REST%%:*}
+  DG_REPO=${DG_REST#*:}
+  OUT=$(bash "$SUBJECT" --repo "$DG_REPO" 2>&1)
+  RC=$?
+  record_out "declared-gap-$DG_NAME"
+  # THE POINT OF RUNNING ALL THREE CLASSES: what a run did NOT walk does not depend on
+  # what it found, so a declaration printed only beside the affirmative verdict would be
+  # absent from exactly the logs an operator reads most carefully.
+  if [ "$RC" -eq "$DG_WANT" ] && [ -n "$(dg_lines)" ]; then
+    ok "declared-gap($DG_NAME): the run-time declaration is present on a $DG_NAME run (exit $RC, verdict $(verdict_of)) — it is not conditional on the verdict"
   else
-    bad "wt-privateref: verdict='$(verdict_of)' — wanted CORRUPT naming $WTP_DEAD: $(printf '%s\n' "$OUT" | grep 'private-root' | head -2 | tr '\n' ' ')"
+    bad "declared-gap($DG_NAME): exit $RC (wanted $DG_WANT) verdict='$(verdict_of)' declaration-lines=$(dg_lines | grep -c .) — a run that omits the declaration is indistinguishable from one that covers the gap"
   fi
-fi
-if run 0 "wt-privateref-control: VERIFIED" --repo "$R_WTP_OK"; then
-  if [ "$(verdict_of)" = VERIFIED ] &&
-    printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: measured private-roots checked=1 .* absent=0 '; then
-    ok "wt-privateref(control): the SAME fixture with the object present is VERIFIED, and the affirmative branch reports that it CHECKED the private root — so VERIFIED is an affirmative statement about it, not silence"
-  else
-    bad "wt-privateref(control): verdict='$(verdict_of)' census='$(printf '%s\n' "$OUT" | grep 'measured private-roots')' — the control must pass AND must show the root was checked"
-  fi
-fi
-
-# --- Case 32: A WORKTREE THAT CANNOT BE INSPECTED IS NOT A CLEAN ONE --------
-# The permissive direction here would be silent and total: a worktree whose refs cannot
-# be listed contributes ZERO roots, so the probe would report `absent=0` and the sweep
-# would go on to VERIFIED — the exact shape CLAUDE.md names (a multi-state signal whose
-# unmeasured state inherits the permissive branch). It is UNMEASURED instead, and the
-# worktree is NAMED.
-R_WTU=$(mk_wt_root_repo wtunread head keep)
-WTU_ADMIN="$R_WTU/.git/worktrees/wtunread-wt"
-if [ "$(id -u)" = 0 ]; then
-  skipped=1
-  ok "wt-unreadable: SKIPPED as root — permission bits are advisory for uid 0, so a chmod plant would not make the admin dir unreadable and a green would prove nothing"
-elif [ -d "$WTU_ADMIN" ] && chmod 000 "$WTU_ADMIN" 2>/dev/null &&
-  ! git --git-dir="$WTU_ADMIN" for-each-ref >/dev/null 2>&1; then
-  ok "wt-unreadable-plant: the linked worktree's admin dir really is unreadable to this process (git cannot list its refs)"
-  if run 5 "wt-unreadable: UNMEASURED" --repo "$R_WTU"; then
-    if [ "$(verdict_of)" = UNMEASURED ] &&
-      printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: private-root UNREADABLE wtunread-wt ' &&
-      ! printf '%s\n' "$OUT" | grep -q 'verdict VERIFIED'; then
-      ok "wt-unreadable: a registered worktree whose refs cannot be listed is UNMEASURED and is NAMED — never a silent zero-root contribution to VERIFIED"
-    else
-      bad "wt-unreadable: verdict='$(verdict_of)' lines='$(printf '%s\n' "$OUT" | grep 'private-root' | head -2 | tr '\n' ' ')'"
-    fi
-  fi
-  chmod 755 "$WTU_ADMIN" 2>/dev/null
-  # ONE PROPERTY BACK: with the permissions restored the same fixture is VERIFIED, so the
-  # UNMEASURED above is the unreadable admin dir and not the fixture.
-  if run 0 "wt-unreadable-control: VERIFIED" --repo "$R_WTU"; then
-    if [ "$(verdict_of)" = VERIFIED ]; then
-      ok "wt-unreadable(control): restoring ONLY the permission bits makes the same fixture VERIFIED"
-    else
-      bad "wt-unreadable(control): verdict='$(verdict_of)' after restoring permissions"
-    fi
-  fi
-else
-  bad "wt-unreadable-plant: could not make the linked worktree's admin dir unreadable ($WTU_ADMIN) — the case below would prove nothing"
-fi
-
-# --- Case 33: THE PROBE MODE'S OWN CONTRACT --------------------------------
-# The caller requires EXACTLY ONE terminal census line and reads the exit status and that
-# line as a CONJUNCTION (the round-4 two-channel rule, applied to the channel this round
-# adds). If the mode stopped printing the census, or printed two, the caller would report
-# UNMEASURED — so the contract is pinned here, where the failure is attributable.
-OUT=$(bash "$SUBJECT" --repo "$R_WTP_OK" --probe-private-roots 2>&1)
-RC=$?
-record_out "probe-mode"
-PRP_CENSUS_N=$(printf '%s\n' "$OUT" | grep -c '^OBJECT-STORE: private-roots checked=')
-if [ "$RC" -eq 0 ] && [ "$PRP_CENSUS_N" -eq 1 ] &&
-  ! printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: verdict '; then
-  ok "probe-mode: --probe-private-roots exits 0, prints exactly one terminal census line, and emits NO verdict — it is a measurement the sweep consumes, not a certification"
-else
-  bad "probe-mode: rc=$RC census-lines=$PRP_CENSUS_N verdict='$(verdict_of)' — the contract the sweep's caller-side conjunction depends on is broken"
-fi
-if bash "$SUBJECT" --repo "$R_WTP_OK" --probe-private-roots --print-store >/dev/null 2>&1; then
-  bad "probe-mode: --probe-private-roots and --print-store were accepted together — two early-exit modes in one run have no defined output"
-else
-  ok "probe-mode: --probe-private-roots and --print-store are mutually exclusive (usage error, no verdict)"
-fi
-
-# --- Case 34: THE PROBE IS THE THIRD STAGE, NEVER A FOURTH (placement) ------
-# WHY THIS IS A CORRECTNESS CASE AND NOT BOOKKEEPING. Every caller derives its own
-# uninterruptible-block bound from the sweep's declared MAX_SWEEP_WALKS, and that number
-# stayed at 3 only because the reachability-attribution path (3 fsck walks) TERMINATES
-# before the probe can run. That is a property of WHERE the call sits, so no arithmetic
-# can check it: it is measured against the fixture that actually spends three walks.
-OUT=$(bash "$SUBJECT" --repo "$R_LIVE_MISS" 2>&1)
-RC=$?
-record_out "probe-placement-3walk"
-if [ "$RC" -eq 4 ] &&
-  printf '%s\n' "$OUT" | grep -q 'pass 3: fsck --no-reflogs' &&
-  ! printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: private-root'; then
-  ok "probe-placement: the 3-fsck-walk path (reachability attribution) terminates BEFORE the private-root probe, so the worst case is still MAX_SWEEP_WALKS bounded stages and no caller's derived bound moved"
-else
-  bad "probe-placement: rc=$RC — a run that spent THREE fsck walks also ran the probe, which makes every caller's uninterruptible window one stage wider than its bound assumes: $(printf '%s\n' "$OUT" | grep -cE 'measured pass|private-root') marker(s)"
-fi
-# And the complementary half: a run that reaches the affirmative branch DID pay for it,
-# so the stage is real and the case above is not passing because the probe never runs.
+done
+# THE COUNT CARRIES `RECOGNISED`, NEVER A BARE NUMBER: a bare `1` in a log reads as a
+# complete census, and this list states its own non-exhaustiveness. Asserted in both
+# directions — the affirmative form is present, and no `declared-gap <digits>` line
+# exists without it.
 OUT=$(bash "$SUBJECT" --repo "$R_CLEAN" 2>&1)
 RC=$?
-record_out "probe-placement-clean"
-if [ "$RC" -eq 0 ] && printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: measured private-roots '; then
-  ok "probe-placement(control): a run that reaches VERIFIED DOES run the probe — the case above is a placement property, not a probe that never fires"
+record_out "declared-gap-form"
+DG_BARE=$(dg_lines | grep -E '^OBJECT-STORE: declared-gap [0-9]+$' | head -1)
+if dg_lines | grep -q '^OBJECT-STORE: declared-gap 1 RECOGNISED' && [ -z "$DG_BARE" ]; then
+  ok "declared-gap(form): the count is emitted as '1 RECOGNISED' and no bare-count line exists — the declaration cannot be read as a completed census"
 else
-  bad "probe-placement(control): rc=$RC — a VERIFIED run did not run the private-root probe at all"
+  bad "declared-gap(form): recognised-line='$(dg_lines | grep -m1 RECOGNISED)' bare='$DG_BARE'"
+fi
+# IT MUST NAME WHAT IS NOT WALKED, WHAT *IS* WALKED, AND THE MEASUREMENT WITH ITS DATE.
+# The middle one is what keeps the declaration honest: "an fsck misses some worktree
+# state" would be true and useless, and the round-7 measurement (private HEAD, INDEX and
+# prunable HEADs ARE walked — pinned by Case 30 above) is what narrows it to one
+# namespace. The date is required because "zero instances" is a measurement that expires.
+DG_MISS=""
+for DG_TOK in 'refs/worktree/\*' 'refs/bisect/\*' 'refs/rewritten/\*' 'NOT in the gap' \
+  'private HEAD and INDEX' 'prunable' '2026-09-02' '0 such refs' '#3749'; do
+  dg_lines | grep -q -- "$DG_TOK" || DG_MISS="$DG_MISS [$DG_TOK]"
+done
+if [ -z "$DG_MISS" ]; then
+  ok "declared-gap(content): the declaration names all three un-walked namespaces, the coverage that is NOT in the gap, the fleet measurement and its date, and the issue"
+else
+  bad "declared-gap(content): the declaration is missing$DG_MISS — a declaration that does not say what IS covered cannot be checked by a reader"
+fi
+# ANCHORED, AND BEFORE THE VERDICT. Property (a) of this script's output is that every
+# line carries the prefix; and the declaration is printed BEFORE the walk, so it survives
+# in a log truncated at the point a long fsck was killed.
+DG_TOTAL=$(printf '%s\n' "$OUT" | grep -c 'declared-gap')
+DG_ANCH=$(dg_lines | grep -c .)
+DG_FIRST=$(printf '%s\n' "$OUT" | grep -nE '^OBJECT-STORE: (declared-gap|verdict) ' | head -1)
+if [ "$DG_TOTAL" -eq "$DG_ANCH" ] && [ "$DG_ANCH" -gt 1 ] &&
+  printf '%s' "$DG_FIRST" | grep -q 'declared-gap'; then
+  ok "declared-gap(anchoring): all $DG_ANCH declaration lines are anchored and the declaration precedes the verdict — it survives a log truncated mid-walk"
+else
+  bad "declared-gap(anchoring): total=$DG_TOTAL anchored=$DG_ANCH first-of(declared-gap|verdict)='$DG_FIRST'"
+fi
+# AND THE REMOVAL IS COMPLETE: no vestigial mode, flag or census key anywhere in the
+# shipped script or its two consumers. A half-removed probe is the worst of both — the
+# declaration would say the gap is open while a dead code path claimed to check it.
+DG_VEST=""
+for DG_F in "$SUBJECT" "$(dirname "$SUBJECT")/../local/worker-supervisor.sh" \
+  "$(dirname "$SUBJECT")/../bootstrap-agent-machine.sh"; do
+  [ -r "$DG_F" ] || continue
+  grep -qE 'probe-private-roots|PROBE_PRIVATE_ROOTS|private-root' "$DG_F" &&
+    DG_VEST="$DG_VEST $(basename "$DG_F")"
+done
+if [ -z "$DG_VEST" ]; then
+  ok "declared-gap(no-vestige): neither the sweep nor its two consumers carry a private-root probe mode, flag or census key — the gap is declared in ONE place and claimed nowhere"
+else
+  bad "declared-gap(no-vestige): probe remnants in$DG_VEST — if the gap has been CLOSED, change this case and the declaration together; if not, the remnant is dead code claiming coverage the declaration denies"
 fi

--- a/scripts/tests/test_check_object_store_integrity.sh
+++ b/scripts/tests/test_check_object_store_integrity.sh
@@ -879,3 +879,184 @@ if [ "$RC" -eq 5 ] && [ "$(verdict_of)" = UNMEASURED ] &&
 else
   bad "no-env: rc=$RC verdict='$(verdict_of)' (wanted 5/UNMEASURED)"
 fi
+
+# --- Case 21: THE BITMASK DOES NOT END AT 31 (real fixtures) ----------------
+# THE DEFECT THIS CASE EXISTS FOR (#3749 review round 2, BLOCKER 3). The first bitmask
+# classifier only bit-tested statuses in 1..31, on the reasoning that 128 is git's
+# `die()` and `127 & 1` would read as object damage. But git's own mask is wider: 2.43
+# defines 32 ERROR_MULTI_PACK_INDEX. So a store with BOTH a multi-pack-index complaint
+# and real object damage exits 33/35/36, fell outside the range, was called
+# `unclassified` and became UNMEASURED — a FALSE NEGATIVE on genuine object corruption,
+# which is the one direction this control exists to prevent.
+#
+# TWO REAL FIXTURES, ONE PROPERTY APART: both carry a truncated `multi-pack-index`; only
+# the second also carries a corrupted loose object. The exit statuses are MEASURED with
+# git before the subject runs, and the assertion is on the BITS rather than on a literal
+# number, so a git that numbers its bits differently fails the construction assert
+# (attributable) instead of silently passing the case (not).
+mk_midx_repo() {
+  local r="$T/$1"
+  mkdir -p "$r"
+  git init -q "$r" >/dev/null 2>&1
+  g "$r" config user.email t@t
+  g "$r" config user.name t
+  printf 'content aaa\n' >"$r/f1"
+  g "$r" add f1 >/dev/null
+  g "$r" -c user.email=t@t -c user.name=t commit -q -m c1 >/dev/null
+  g "$r" repack -q -ad >/dev/null 2>&1
+  g "$r" multi-pack-index write >/dev/null 2>&1
+  # A second commit AFTER the repack, so the store also holds loose objects to damage.
+  printf 'content bbb\n' >"$r/f2"
+  g "$r" add f2 >/dev/null
+  g "$r" -c user.email=t@t -c user.name=t commit -q -m c2 >/dev/null
+  # The plant: a multi-pack-index too short to parse.
+  printf 'MIDX\001' >"$r/.git/objects/pack/multi-pack-index"
+  printf '%s' "$r"
+}
+fsck_status() {
+  local rc=0
+  git -C "$1" fsck --no-progress --no-dangling >/dev/null 2>&1 || rc=$?
+  printf '%s' "$rc"
+}
+R_MIDX=$(mk_midx_repo midx)
+R_MIDX_DMG=$(mk_midx_repo midx-damaged)
+# The BLOB of the post-repack commit, named explicitly rather than "whatever `find`
+# returns first": corrupting the COMMIT object instead makes git `die()` (exit 128, a
+# NON-bitmask status), which is Case 23's subject and not this one. Measured both ways on
+# git 2.43.0 — blob 35, commit 128 — so the choice is load-bearing, not incidental.
+MIDX_BLOB=$(g "$R_MIDX_DMG" rev-parse HEAD:f2 2>/dev/null)
+MIDX_LOOSE=""
+if [ -n "$MIDX_BLOB" ]; then
+  MIDX_LOOSE=$(loose_path "$R_MIDX_DMG" "$MIDX_BLOB")
+  chmod u+w "$MIDX_LOOSE" 2>/dev/null
+  printf 'garbagegarbagegarbage' >"$MIDX_LOOSE"
+fi
+S_MIDX=$(fsck_status "$R_MIDX")
+S_MIDX_DMG=$(fsck_status "$R_MIDX_DMG")
+if [ "$((S_MIDX & 32))" -ne 0 ] && [ "$((S_MIDX & 5))" -eq 0 ] &&
+  [ "$((S_MIDX_DMG & 32))" -ne 0 ] && [ "$((S_MIDX_DMG & 1))" -ne 0 ]; then
+  ok "midx-plant: the fixtures ARE what the case claims (git 2.43 exits $S_MIDX for the midx alone = bit 32 and no damage bit, $S_MIDX_DMG with a corrupted loose object = 32 PLUS bit 1) — the status the old 1..31 range check dropped"
+else
+  bad "midx-plant: fsck exited $S_MIDX (midx only) and $S_MIDX_DMG (midx+damage) — not the 32/32|1 shapes the case is about; the cases below would prove nothing"
+fi
+if run 4 "midx+damage: CORRUPT, not UNMEASURED" --repo "$R_MIDX_DMG"; then
+  if [ "$(verdict_of)" = CORRUPT ]; then
+    ok "midx+damage: object damage ALONGSIDE a multi-pack-index complaint (exit $S_MIDX_DMG) is CORRUPT — an unrelated high bit cannot mask the damage bits"
+  else
+    bad "midx+damage: verdict='$(verdict_of)', wanted CORRUPT — real object corruption was dropped because of an unrelated bit"
+  fi
+fi
+# ONE PROPERTY APART: the same fixture WITHOUT the damaged object. Non-passing, and NOT
+# the fatal branch — so the CORRUPT above is attributable to the damage bit and not to
+# the multi-pack-index complaint the two fixtures share.
+if run 5 "midx alone: UNMEASURED, not CORRUPT" --repo "$R_MIDX"; then
+  if [ "$(verdict_of)" = UNMEASURED ] &&
+    printf '%s\n' "$OUT" | grep -q 'multi-pack-index'; then
+    ok "midx alone: a multi-pack-index complaint with NO damage bit is UNMEASURED and the cause names the class — never CORRUPT, and never clean"
+  else
+    bad "midx alone: verdict='$(verdict_of)' — wanted UNMEASURED naming the multi-pack-index class"
+  fi
+fi
+
+# --- Case 22: THE TWO STATUSES THE FINDING NAMES, EXACTLY -------------------
+# 33 (32|1) and 36 (32|4) are the statuses the review named. They are staged with the
+# shim rather than with a fixture, because a real store cannot be made to exit a chosen
+# status on demand — and 36 in particular needs pack damage that does not also set other
+# bits. Each arm is ONE PROPERTY from the reproduced-damage arm of Case 17 (rc=3): the
+# added bit 32.
+if [ -n "${REAL_GIT:-}" ]; then
+  DMG_MSG2='error: f761ec192d9f0dca3329044b96ebdb12839dbff6: object corrupt or missing: /somewhere'
+  for _bm in 33 36; do
+    SH_BM="$T/shim-bit$_bm"
+    LOG_BM="$T/shim-bit$_bm-calls.txt"
+    : >"$LOG_BM"
+    mk_fsck_shim "$SH_BM" always "$_bm" "$DMG_MSG2" "$LOG_BM"
+    bm_c=0
+    PATH="$SH_BM:$PATH" "$SH_BM/git" -C "$R_CLEAN" fsck --no-progress >/dev/null 2>&1 || bm_c=$?
+    if [ "$bm_c" -eq "$_bm" ]; then
+      ok "bitmask-plant($_bm): the shim really exits $_bm, so the case below measures the classifier and not the shim"
+    else
+      bad "bitmask-plant($_bm): the shim exited $bm_c — the case below would prove nothing"
+    fi
+    : >"$LOG_BM"
+    OUT=$(PATH="$SH_BM:$PATH" bash "$SUBJECT" --repo "$R_CLEAN" 2>&1)
+    RC=$?
+    record_out "bitmask-$_bm"
+    if [ "$RC" -eq 4 ] && [ "$(verdict_of)" = CORRUPT ]; then
+      ok "bitmask($_bm): a damage bit travelling with ERROR_MULTI_PACK_INDEX is CORRUPT — the status the 1..31 range check turned into a false UNMEASURED"
+    else
+      bad "bitmask($_bm): rc=$RC verdict='$(verdict_of)' (wanted 4/CORRUPT)"
+    fi
+  done
+
+  # --- Case 23: AND THE NON-BITMASK PATH STILL REFUSES ---------------------
+  # The control for Case 22, and the half of the round-1 reasoning that was RIGHT: 128 is
+  # git's `die()` and 127 a missing binary, and `127 & 1` is 1. Neither may be bit-tested.
+  # ONE property from the arms above: the status, which is at or above the floor where
+  # shell and `die()` conventions live.
+  for _nb in 127 128; do
+    SH_NB="$T/shim-nonmask$_nb"
+    LOG_NB="$T/shim-nonmask$_nb-calls.txt"
+    : >"$LOG_NB"
+    mk_fsck_shim "$SH_NB" always "$_nb" "$DMG_MSG2" "$LOG_NB"
+    OUT=$(PATH="$SH_NB:$PATH" bash "$SUBJECT" --repo "$R_CLEAN" 2>&1)
+    RC=$?
+    record_out "nonmask-$_nb"
+    if [ "$RC" -eq 5 ] && [ "$(verdict_of)" = UNMEASURED ] &&
+      printf '%s\n' "$OUT" | grep -q 'cannot read as its error'; then
+      ok "non-bitmask($_nb): a status outside the mask is UNMEASURED with its OWN cause — never bit-tested into CORRUPT, and never described as a reachability problem it never reported"
+    else
+      bad "non-bitmask($_nb): rc=$RC verdict='$(verdict_of)' (wanted 5/UNMEASURED naming the unreadable status)"
+    fi
+  done
+fi
+
+# --- Case 24: `--print-store` IS THE ONE ISOLATED RESOLVER ------------------
+# WHY IT EXISTS (#3749 review round 2, BLOCKER 2). A caller that throttles or latches on
+# the shared store has to NAME it, and naming it means resolving `--git-common-dir`.
+# `scripts/local/worker-supervisor.sh` was doing that with a BARE `git`, inheriting the
+# caller's environment, while this script had just moved every one of its own git calls
+# under `env -i` + one allowlist — so an inherited `GIT_DIR` keyed the supervisor's stamp
+# on ANOTHER repository. This mode is the shared resolver that removes the second
+# implementation, so it must be isolated exactly like the sweep is.
+if run 0 "print-store: resolves and exits without sweeping" --repo "$R_CLEAN" --print-store; then
+  if [ "$(printf '%s\n' "$OUT" | grep -c '^OBJECT-STORE: store ')" -eq 1 ] &&
+    printf '%s\n' "$OUT" | grep -q "^OBJECT-STORE: store $R_CLEAN/\.git/objects$" &&
+    ! printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: verdict '; then
+    ok "print-store: prints exactly one anchored 'store' line naming the resolved store, and NO verdict — it measures nothing and must not look like it did"
+  else
+    bad "print-store: output was [$(printf '%s\n' "$OUT" | tr '\n' '|')]"
+  fi
+fi
+# THE ISOLATION, with its construction asserted first: a PLAIN git IS redirected by
+# GIT_COMMON_DIR, so a green here is the allowlist and not an inert variable. This is the
+# exact injection that mis-keyed the supervisor's stamp.
+plain_common=$(GIT_COMMON_DIR="$R_MIS/.git" git -C "$R_CLEAN" rev-parse --git-common-dir 2>/dev/null || true)
+if [ "$plain_common" = "$R_MIS/.git" ]; then
+  ok "print-store-plant: the injection IS effective against a non-isolated git (GIT_COMMON_DIR repoints rev-parse at another repository)"
+else
+  bad "print-store-plant: a plain git was not repointed by GIT_COMMON_DIR (got '$plain_common') — the case below would prove nothing"
+fi
+OUT=$(GIT_COMMON_DIR="$R_MIS/.git" bash "$SUBJECT" --repo "$R_CLEAN" --print-store 2>&1)
+RC=$?
+record_out "print-store-env"
+if [ "$RC" -eq 0 ] &&
+  printf '%s\n' "$OUT" | grep -q "^OBJECT-STORE: store $R_CLEAN/\.git/objects$"; then
+  ok "print-store: an inherited GIT_COMMON_DIR cannot make the resolver name a DIFFERENT store — a caller keying a throttle on it cannot be pointed at another repository"
+else
+  bad "print-store: rc=$RC out=[$(printf '%s\n' "$OUT" | tr '\n' '|')] — the resolver was repointed by the caller's environment"
+fi
+# A HOST WITHOUT `timeout` can still be ASKED THE QUESTION: this mode runs one rev-parse,
+# not an fsck, so refusing for want of a bound would leave a caller keying its throttle on
+# nothing exactly where the sweep is already UNMEASURED. ONE property from Case 11.
+BIN_NOTO="$T/bin-notimeout-print"
+mk_bin "$BIN_NOTO" git
+rm -f "$BIN_NOTO/timeout" "$BIN_NOTO/gtimeout"
+OUT=$(PATH="$BIN_NOTO" bash "$SUBJECT" --repo "$R_CLEAN" --print-store 2>&1)
+RC=$?
+record_out "print-store-no-timeout"
+if [ "$RC" -eq 0 ] && printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: store '; then
+  ok "print-store: a host with no timeout binary can still NAME the store (the bound is the sweep's requirement, not the resolver's)"
+else
+  bad "print-store(no-timeout): rc=$RC out=[$(printf '%s\n' "$OUT" | tr '\n' '|')]"
+fi

--- a/scripts/tests/test_check_object_store_integrity.sh
+++ b/scripts/tests/test_check_object_store_integrity.sh
@@ -154,7 +154,7 @@ whole_suite_checks() {
 # assertions (the two `command -v` guards and the fixture-construction asserts), so a
 # green run is 81 on any host that can run it at all; a green run BELOW this number
 # means cases were removed or the run was truncated. RAISE IT when you add cases.
-CASE_FLOOR=94
+CASE_FLOOR=103
 
 finish() {
   local rc=$?
@@ -1124,6 +1124,17 @@ if run 0 "print-store: resolves and exits without sweeping" --repo "$R_CLEAN" --
   else
     bad "print-store: output was [$(printf '%s\n' "$OUT" | tr '\n' '|')]"
   fi
+  # AND THE KEY LINE, which is what a caller actually keys its throttle and CORRUPT latch
+  # on (#3749 review round 5, item 3). Exactly one, and of the shape the caller validates:
+  # a readable tail plus 16 hex of sha256 over the RAW path. Case 29 below is the property;
+  # this is the CONTRACT — a caller that stopped receiving it would silently lose its
+  # box-wide key.
+  if [ "$(printf '%s\n' "$OUT" | grep -c '^OBJECT-STORE: store-key ')" -eq 1 ] &&
+    printf '%s\n' "$OUT" | grep -qE '^OBJECT-STORE: store-key [A-Za-z0-9._-]{1,64}\.[0-9a-f]{16}$'; then
+    ok "print-store: prints exactly one anchored 'store-key' line of the shape the caller validates (readable tail + 16 hex digest)"
+  else
+    bad "print-store: no usable store-key line in [$(printf '%s\n' "$OUT" | tr '\n' '|')]"
+  fi
 fi
 # THE ISOLATION, with its construction asserted first: a PLAIN git IS redirected by
 # GIT_COMMON_DIR, so a green here is the allowlist and not an inert variable. This is the
@@ -1463,4 +1474,83 @@ if [ -z "$p12_bad" ]; then
   ok "no-reflogs: passes 1 and 2 — the sweep proper — carry no --no-reflogs, so the flag cannot become a suppressor of the very class it exists to attribute (structural)"
 else
   bad "no-reflogs: a SWEEP walk carries --no-reflogs: $p12_bad"
+fi
+
+# --- Case 29: THE STORE KEY IS INJECTIVE OVER THE **RAW** PATH --------------
+# THE DEFECT (#3749 review round 5, item 3). Round 4 made the caller's throttle/latch key
+# injective over the FLATTENING and then computed the digest from the value this script had
+# already passed through `sane()` — a DISPLAY encoding, and a lossy one. A store path
+# holding a REAL newline and one holding the two literal characters `\n` render to the same
+# text, so two different stores shared a throttle stamp AND a CORRUPT latch: one suppressing
+# the other's sweep for the whole interval, or one store's damage stopping every lane
+# working on the other. The identity now comes from the raw bytes, in this script, and the
+# caller receives a finished key.
+#
+# The construction assert measures the COLLISION FIRST — the two values really do render
+# identically — so a green below is injectivity and not two arbitrary distinct strings.
+KEYFN="$T/keyfn.sh"
+sed -n '/^sane() {/,/^}/p;/^store_digest() {/,/^}/p;/^store_key() {/,/^}/p' "$SUBJECT" >"$KEYFN"
+if grep -q '^store_key() {' "$KEYFN" && grep -q '^store_digest() {' "$KEYFN" &&
+  grep -q '^sane() {' "$KEYFN"; then
+  ok "store-key-plant: sane/store_digest/store_key were extracted from the shipped script at run time — the case measures the shipped derivation, not a restatement of it"
+else
+  bad "store-key-plant: the extraction from $SUBJECT did not yield the three functions — everything below would be vacuous"
+fi
+RAW_NL=$(printf '/tmp/objstore-a\nb/objects')
+RAW_LIT='/tmp/objstore-a\nb/objects'
+SANE_NL=$(bash -c '. "$1"; sane "$2"' _ "$KEYFN" "$RAW_NL" 2>/dev/null)
+SANE_LIT=$(bash -c '. "$1"; sane "$2"' _ "$KEYFN" "$RAW_LIT" 2>/dev/null)
+if [ -n "$SANE_NL" ] && [ "$SANE_NL" = "$SANE_LIT" ]; then
+  ok "store-key-plant: the two store paths RENDER identically through sane() ('$SANE_NL') — the collision this case is about is really available"
+else
+  bad "store-key-plant: the two paths render differently ('$SANE_NL' vs '$SANE_LIT') — the assert below would prove nothing"
+fi
+KEY_NL=$(bash -c '. "$1"; store_key "$2"' _ "$KEYFN" "$RAW_NL" 2>/dev/null)
+KEY_LIT=$(bash -c '. "$1"; store_key "$2"' _ "$KEYFN" "$RAW_LIT" 2>/dev/null)
+if [ -n "$KEY_NL" ] && [ -n "$KEY_LIT" ] && [ "$KEY_NL" != "$KEY_LIT" ]; then
+  ok "store-key: two stores whose paths RENDER identically get DIFFERENT keys — the identity is the raw bytes, not the display encoding"
+else
+  bad "store-key: nl='$KEY_NL' lit='$KEY_LIT' — the key is computed from the rendering, so two different stores share a throttle stamp and a CORRUPT latch"
+fi
+# ROUND 4'S PROPERTY, PRESERVED: the flattening collision is still separated.
+KEY_A=$(bash -c '. "$1"; store_key "$2"' _ "$KEYFN" '/tmp/objstore-collide/a/b/objects' 2>/dev/null)
+KEY_B=$(bash -c '. "$1"; store_key "$2"' _ "$KEYFN" '/tmp/objstore-collide/a_b/objects' 2>/dev/null)
+KEY_A2=$(bash -c '. "$1"; store_key "$2"' _ "$KEYFN" '/tmp/objstore-collide/a/b/objects' 2>/dev/null)
+if [ -n "$KEY_A" ] && [ "$KEY_A" != "$KEY_B" ] && [ "$KEY_A" = "$KEY_A2" ]; then
+  ok "store-key: two paths that FLATTEN to one name still get different keys, and the same path gets the SAME key twice (a digest, not a nonce)"
+else
+  bad "store-key: a='$KEY_A' b='$KEY_B' a2='$KEY_A2'"
+fi
+case "$KEY_A" in
+  *objects.[0-9a-f]*) ok "store-key: the key keeps a readable tail naming the store and ends in the digest, so an operator reading 'ls /tmp' can still tell which store a stamp belongs to" ;;
+  *) bad "store-key: '$KEY_A' is not operator-readable" ;;
+esac
+# END TO END, and this is the arm that pins the WIRING rather than the function: a real
+# repository under a newline-bearing path. The printed key must NOT equal the key of the
+# printed `store` line — which is exactly what it would equal if the caller (or this mode)
+# digested the rendering.
+NLDIR=$(printf '%s/nl-a\nb' "$T")
+if mkdir -p "$NLDIR" 2>/dev/null && git init -q "$NLDIR/repo" >/dev/null 2>&1; then
+  ok "store-key-plant: a repository really can be created under a newline-bearing path on this filesystem — the end-to-end arm below has a subject"
+else
+  bad "store-key-plant: could not create a repository under a newline-bearing path; the end-to-end arm below would prove nothing"
+fi
+OUT=$(bash "$SUBJECT" --repo "$NLDIR/repo" --print-store 2>&1)
+RC=$?
+record_out "print-store-newline"
+PRINTED_STORE=$(printf '%s\n' "$OUT" | sed -n 's/^OBJECT-STORE: store //p' | head -1)
+PRINTED_KEY=$(printf '%s\n' "$OUT" | sed -n 's/^OBJECT-STORE: store-key //p' | head -1)
+KEY_OF_DISPLAY=$(bash -c '. "$1"; store_key "$2"' _ "$KEYFN" "$PRINTED_STORE" 2>/dev/null)
+if [ "$RC" -eq 0 ] && [ -n "$PRINTED_KEY" ] && [ -n "$KEY_OF_DISPLAY" ] &&
+  [ "$PRINTED_KEY" != "$KEY_OF_DISPLAY" ]; then
+  ok "store-key: --print-store on a repository under a newline-bearing path prints a key that is NOT the key of its own rendered 'store' line — the digest is taken from the raw canonical path (rc=$RC)"
+else
+  bad "store-key(end-to-end): rc=$RC printed-key='$PRINTED_KEY' key-of-display='$KEY_OF_DISPLAY' store='$PRINTED_STORE' — the key is derived from the display rendering"
+fi
+# AND THE RENDERED LINE IS STILL SAFE: one line, with the newline escaped, so the anchored
+# output invariant survives a path that could otherwise inject a prefix-less line.
+if [ "$(printf '%s\n' "$OUT" | grep -c '^OBJECT-STORE: ')" = "$(printf '%s\n' "$OUT" | grep -c .)" ]; then
+  ok "store-key: every line of the newline-path run is still anchored — sane() keeps doing the job it exists for, and the key does the job sane() cannot"
+else
+  bad "store-key: an unanchored line appeared for a newline-bearing store path: [$(printf '%s\n' "$OUT" | tr '\n' '|')]"
 fi

--- a/scripts/tests/test_check_object_store_integrity.sh
+++ b/scripts/tests/test_check_object_store_integrity.sh
@@ -364,12 +364,18 @@ fi
 # administrative directory, and sweeping that would audit the wrong thing while reporting
 # a verdict about "the store".
 R_WT_MAIN=$(newrepo wtmain)
+# CANONICALISED, NOT THE LITERAL PATH: the subject reports `pwd -P`, and on macOS
+# `${TMPDIR}` resolves through `/private`, so pinning `$R_WT_MAIN/.git/objects`
+# false-REDS on correct input on a platform this script's own header claims to
+# support (#3749 review NIT 9). A guard that reds on correct input is the guard
+# agents learn to waive.
+R_WT_MAIN_P=$(cd "$R_WT_MAIN" && pwd -P)
 R_WT="$T/wt-linked"
 if g "$R_WT_MAIN" worktree add -q --detach "$R_WT" >/dev/null 2>&1 && [ -d "$R_WT" ]; then
   WT_PRIVATE=$(git -C "$R_WT" rev-parse --absolute-git-dir 2>/dev/null)
   if run 0 "worktree: VERIFIED" --repo "$R_WT"; then
-    if printf '%s\n' "$OUT" | grep -q "^OBJECT-STORE: store $R_WT_MAIN/\.git/objects$"; then
-      ok "worktree: a linked worktree sweeps the SHARED common store ($R_WT_MAIN/.git/objects)"
+    if printf '%s\n' "$OUT" | grep -q "^OBJECT-STORE: store $R_WT_MAIN_P/\.git/objects$"; then
+      ok "worktree: a linked worktree sweeps the SHARED common store ($R_WT_MAIN_P/.git/objects)"
     else
       bad "worktree: the swept store is not the shared one: $(printf '%s\n' "$OUT" | grep '^OBJECT-STORE: store ')"
     fi
@@ -583,4 +589,270 @@ if [ "$before" = "$after" ] && [ -n "$before" ]; then
   ok "no-mutation: a full sweep leaves the repository byte-identical (no ref, no pack, no rewrite)"
 else
   bad "no-mutation: the sweep changed the repository"
+fi
+
+# --- Case 16: REACHABILITY IS NOT CORRUPT (the #3749 review's BLOCKER B) ----
+# THE DEFECT THIS CASE EXISTS FOR, MEASURED ON THE REAL FLEET STORE: `git fsck`
+# prints `error: <ref>: invalid reflog entry <sha>` when a reflog names an object a
+# peer lane's gc has pruned, and on a store eight lanes are concurrently writing that
+# happened on roughly a quarter to a half of all runs — on a store nothing is wrong
+# with. The first classifier recognised damage from `/^error/p`, so every one of
+# those was a CORRUPT that pages high, stops the supervisor and fails `--strict`
+# bootstrap. The class now comes from fsck's exit BITMASK (1/4 = object/pack damage,
+# 2/8/16 = reachability/refs/commit-graph).
+#
+# IT IS NOT DEMOTED TO CLEAN EITHER, and that is the other half: a genuinely MISSING
+# object reports the same ERROR_REACHABLE bit, so this lands on its own NON-PASSING
+# state with its own cause.
+R_REFLOG=$(newrepo reflog)
+RL_BR=$(git -C "$R_REFLOG" symbolic-ref --short HEAD 2>/dev/null)
+RL_LOG="$R_REFLOG/.git/logs/refs/heads/$RL_BR"
+if [ -n "$RL_BR" ] && [ -f "$RL_LOG" ]; then
+  printf '%s %s t <t@t> 1700000000 +0000\tbogus\n' \
+    "$(git -C "$R_REFLOG" rev-parse HEAD)" \
+    "1111111111111111111111111111111111111111" >>"$RL_LOG"
+fi
+RL_RC=0
+git -C "$R_REFLOG" fsck --no-progress --no-dangling >/dev/null 2>"$T/reflog-fsck.err" || RL_RC=$?
+if [ "$RL_RC" -eq 2 ] && grep -q 'invalid reflog entry' "$T/reflog-fsck.err" &&
+  git -C "$R_REFLOG" cat-file -p "$(git -C "$R_REFLOG" rev-parse HEAD:f1)" >/dev/null 2>&1; then
+  # ONE property: the fixture differs from its clean twin only by a reflog line, and
+  # the assertion is on the BITMASK (2 = ERROR_REACHABLE, no 1/4) rather than on the
+  # message — that is the signal the subject now classifies on.
+  ok "reflog-plant: the plant IS the defect described (fsck exits 2 = ERROR_REACHABLE with an 'invalid reflog entry', objects readable)"
+else
+  bad "reflog-plant: fsck rc=$RL_RC on the reflog fixture (wanted 2) — the case below would prove nothing"
+fi
+if run 5 "reflog: UNMEASURED not CORRUPT" --repo "$R_REFLOG"; then
+  if [ "$(verdict_of)" = UNMEASURED ]; then
+    ok "reflog: a stale reflog entry on a busy shared store is UNMEASURED, NOT CORRUPT (it stops no supervisor)"
+  else
+    bad "reflog: verdict was '$(verdict_of)', wanted UNMEASURED — a healthy store must not read as corrupt"
+  fi
+  if printf '%s\n' "$OUT" | grep -q 'reachability/ref/commit-graph' &&
+    printf '%s\n' "$OUT" | grep -q 'reflog expire'; then
+    ok "reflog: the cause NAMES the class and gives the remedy for it (not the re-clone remedy, which is for damage)"
+  else
+    bad "reflog: the UNMEASURED cause does not name the reachability class"
+  fi
+  if ! printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: object '; then
+    ok "reflog: NO 'object' lines — the 40-hex tokens in a reflog diagnostic name INTACT objects, not damaged ones"
+  else
+    bad "reflog: intact object ids were reported as affected objects"
+  fi
+fi
+
+# --- Case 17: THE DISCRIMINATOR — a non-clean walk must REPRODUCE ----------
+# The store this sweep audits is mutated by up to 8 peer lanes WHILE fsck walks it,
+# so a diagnostic can be a concurrency artefact. No fixture can hold a concurrent
+# writer, so the discriminator is exercised with a git shim whose FIRST fsck reports
+# and whose SECOND does not — the sequence a transient produces.
+#
+# THREE ARMS, EACH ONE PROPERTY APART: report-once vs report-always (the condition),
+# and reachability vs damage (the exit bits).
+mk_fsck_shim() {
+  # mk_fsck_shim <dir> <always|once> <rc> <message> <log>
+  local d="$1" when="$2" rc="$3" msg="$4" log="$5"
+  mk_bin "$d" timeout gtimeout
+  rm -f "$d/git"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf '# Test shim: on `fsck`, report %s and exit %s; delegate everything else.\n' "$when" "$rc"
+    printf 'for a in "$@"; do\n'
+    printf '  if [ "$a" = fsck ]; then\n'
+    printf '    printf "call\\n" >>%s\n' "$(printf '%q' "$log")"
+    printf '    n=$(grep -c . %s 2>/dev/null || printf 0)\n' "$(printf '%q' "$log")"
+    if [ "$when" = always ]; then
+      printf '    if [ 1 -eq 1 ]; then\n'
+    else
+      printf '    if [ "$n" -le 1 ]; then\n'
+    fi
+    printf '      printf "%%s\\n" %s >&2\n' "$(printf '%q' "$msg")"
+    printf '      exit %s\n' "$rc"
+    printf '    fi\n'
+    printf '    break\n'
+    printf '  fi\n'
+    printf 'done\n'
+    printf 'exec %s "$@"\n' "$(printf '%q' "$REAL_GIT")"
+  } >"$d/git"
+  chmod +x "$d/git"
+}
+if [ -z "${REAL_GIT:-}" ]; then
+  bad "discriminator: no real git on PATH — the shim arms cannot be built"
+else
+  RL_MSG='error: refs/heads/x: invalid reflog entry 1111111111111111111111111111111111111111'
+  DMG_MSG='error: f761ec192d9f0dca3329044b96ebdb12839dbff6: hash-path mismatch, found at: /somewhere'
+  # (a) CONSTRUCTION, asserted before the subject runs: the once-shim really does
+  #     report on its first fsck and not on its second.
+  SH_ONCE="$T/shim-once"
+  LOG_ONCE="$T/shim-once-calls.txt"
+  : >"$LOG_ONCE"
+  mk_fsck_shim "$SH_ONCE" once 2 "$RL_MSG" "$LOG_ONCE"
+  c1=0; PATH="$SH_ONCE:$PATH" "$SH_ONCE/git" -C "$R_CLEAN" fsck --no-progress >/dev/null 2>&1 || c1=$?
+  c2=0; PATH="$SH_ONCE:$PATH" "$SH_ONCE/git" -C "$R_CLEAN" fsck --no-progress >/dev/null 2>&1 || c2=$?
+  if [ "$c1" -eq 2 ] && [ "$c2" -eq 0 ] && [ "$(grep -c . "$LOG_ONCE" | tr -d ' ')" -eq 2 ]; then
+    ok "discriminator-plant: the once-shim IS the sequence described (first fsck rc=2, second rc=0, both logged)"
+  else
+    bad "discriminator-plant: first=$c1 second=$c2 calls=$(grep -c . "$LOG_ONCE" | tr -d ' ') — the cases below would prove nothing"
+  fi
+  : >"$LOG_ONCE"
+  OUT=$(PATH="$SH_ONCE:$PATH" bash "$SUBJECT" --repo "$R_CLEAN" 2>&1)
+  RC=$?
+  record_out "discriminator-transient"
+  if [ "$RC" -eq 0 ] && [ "$(verdict_of)" = VERIFIED ] &&
+    [ "$(grep -c . "$LOG_ONCE" | tr -d ' ')" -eq 2 ] &&
+    printf '%s\n' "$OUT" | grep -q 'did NOT reproduce'; then
+    ok "discriminator: a diagnostic that does not survive a SECOND walk is VERIFIED — and the run says so, having really walked twice"
+  else
+    bad "discriminator(transient): rc=$RC verdict='$(verdict_of)' walks=$(grep -c . "$LOG_ONCE" | tr -d ' ') (wanted 0/VERIFIED/2)"
+  fi
+  # (b) ONE PROPERTY APART: the same message on EVERY walk. It reproduces, so it is
+  #     non-passing — and still not CORRUPT, because it is the reachability class.
+  SH_ALWAYS="$T/shim-always"
+  LOG_ALWAYS="$T/shim-always-calls.txt"
+  : >"$LOG_ALWAYS"
+  mk_fsck_shim "$SH_ALWAYS" always 2 "$RL_MSG" "$LOG_ALWAYS"
+  OUT=$(PATH="$SH_ALWAYS:$PATH" bash "$SUBJECT" --repo "$R_CLEAN" 2>&1)
+  RC=$?
+  record_out "discriminator-persistent"
+  if [ "$RC" -eq 5 ] && [ "$(verdict_of)" = UNMEASURED ] &&
+    [ "$(grep -c . "$LOG_ALWAYS" | tr -d ' ')" -eq 2 ]; then
+    ok "discriminator: the SAME diagnostic on BOTH walks does not reach VERIFIED — the re-run is a discriminator, not a retry-until-clean"
+  else
+    bad "discriminator(persistent): rc=$RC verdict='$(verdict_of)' walks=$(grep -c . "$LOG_ALWAYS" | tr -d ' ') (wanted 5/UNMEASURED/2)"
+  fi
+  # (c) A DAMAGE class (fsck exit bit 1) seen ONCE and not the second time is
+  #     UNMEASURED: neither established damage nor a clean store. One property apart
+  #     from (a) — the exit bits.
+  SH_FLICK="$T/shim-flicker"
+  LOG_FLICK="$T/shim-flicker-calls.txt"
+  : >"$LOG_FLICK"
+  mk_fsck_shim "$SH_FLICK" once 3 "$DMG_MSG" "$LOG_FLICK"
+  OUT=$(PATH="$SH_FLICK:$PATH" bash "$SUBJECT" --repo "$R_CLEAN" 2>&1)
+  RC=$?
+  record_out "discriminator-flicker"
+  if [ "$RC" -eq 5 ] && [ "$(verdict_of)" = UNMEASURED ] &&
+    printf '%s\n' "$OUT" | grep -q 'did not reproduce'; then
+    ok "discriminator: a DAMAGE class seen once and not twice is UNMEASURED — a flickering corruption signal is certified as neither"
+  else
+    bad "discriminator(flicker): rc=$RC verdict='$(verdict_of)' (wanted 5/UNMEASURED)"
+  fi
+  # (d) AND THE FATAL BRANCH STILL FIRES when it reproduces: same shim, always-arm,
+  #     damage bits. Without this the three arms above could all be a subject that
+  #     simply never reports CORRUPT.
+  SH_DMG="$T/shim-damage"
+  LOG_DMG="$T/shim-damage-calls.txt"
+  : >"$LOG_DMG"
+  mk_fsck_shim "$SH_DMG" always 3 "$DMG_MSG" "$LOG_DMG"
+  OUT=$(PATH="$SH_DMG:$PATH" bash "$SUBJECT" --repo "$R_CLEAN" 2>&1)
+  RC=$?
+  record_out "discriminator-reproduced-damage"
+  if [ "$RC" -eq 4 ] && [ "$(verdict_of)" = CORRUPT ] &&
+    [ "$(grep -c . "$LOG_DMG" | tr -d ' ')" -eq 2 ]; then
+    ok "discriminator: a damage class on BOTH walks IS CORRUPT (exit 4) — the discriminator did not defang the fatal branch"
+  else
+    bad "discriminator(reproduced): rc=$RC verdict='$(verdict_of)' walks=$(grep -c . "$LOG_DMG" | tr -d ' ') (wanted 4/CORRUPT/2)"
+  fi
+fi
+
+# --- Case 18: THE INHERITED GIT ENVIRONMENT CANNOT BEND THE VERDICT --------
+# Reproduced against the first version of this script: `GIT_OBJECT_DIRECTORY=<good>`
+# with `--repo <bad>` printed `store <bad>/.git/objects` and `verdict VERIFIED`,
+# exit 0 — every emitted line affirmatively false, with no signal to either consumer.
+# The script pinned two ambient variables and inherited the rest of the family.
+#
+# THE CONSTRUCTION IS ASSERTED FIRST, and it is what makes this case non-vacuous: a
+# PLAIN (non-isolated) git really is redirected by the variable, so a green below is
+# the isolation and not an inert variable.
+plain_rc=0
+GIT_OBJECT_DIRECTORY="$R_CLEAN/.git/objects" \
+  git --git-dir="$R_MIS/.git" fsck --no-progress --no-dangling >/dev/null 2>&1 || plain_rc=$?
+if [ "$plain_rc" -eq 0 ]; then
+  ok "env-plant: the injection IS effective against a non-isolated git (GIT_OBJECT_DIRECTORY makes the CORRUPT store fsck clean)"
+else
+  bad "env-plant: a plain git was not redirected by GIT_OBJECT_DIRECTORY (rc=$plain_rc) — the cases below would prove nothing"
+fi
+OUT=$(GIT_OBJECT_DIRECTORY="$R_CLEAN/.git/objects" bash "$SUBJECT" --repo "$R_MIS" 2>&1)
+RC=$?
+record_out "env-object-directory"
+if [ "$RC" -eq 4 ] && [ "$(verdict_of)" = CORRUPT ] &&
+  printf '%s\n' "$OUT" | grep -q "^OBJECT-STORE: store $R_MIS/\.git/objects$"; then
+  ok "env: an inherited GIT_OBJECT_DIRECTORY cannot make the sweep read a store OTHER than the one it names"
+else
+  bad "env(GIT_OBJECT_DIRECTORY): rc=$RC verdict='$(verdict_of)' — a false verdict about the named store"
+fi
+OUT=$(GIT_DIR="$R_CLEAN/.git" bash "$SUBJECT" --repo "$R_MIS" 2>&1)
+RC=$?
+record_out "env-git-dir"
+if [ "$RC" -eq 4 ] && [ "$(verdict_of)" = CORRUPT ] &&
+  printf '%s\n' "$OUT" | grep -q "^OBJECT-STORE: store $R_MIS/\.git/objects$"; then
+  ok "env: an inherited GIT_DIR does not repoint the sweep (the subject is --repo, resolved under isolation)"
+else
+  bad "env(GIT_DIR): rc=$RC verdict='$(verdict_of)' store=$(printf '%s\n' "$OUT" | grep '^OBJECT-STORE: store ')"
+fi
+OUT=$(GIT_ALTERNATE_OBJECT_DIRECTORIES="$R_MIS/.git/objects" bash "$SUBJECT" --repo "$R_CLEAN" 2>&1)
+RC=$?
+record_out "env-alternates"
+if [ "$RC" -eq 0 ] && [ "$(verdict_of)" = VERIFIED ]; then
+  ok "env: an inherited GIT_ALTERNATE_OBJECT_DIRECTORIES cannot import a CORRUPT store into a healthy one's verdict"
+else
+  bad "env(alternates): rc=$RC verdict='$(verdict_of)' — a false verdict about the named store"
+fi
+
+# --- Case 19: A MULTI-LINE fsck DIAGNOSTIC SURVIVES WHOLE, AND sane() RUNS -
+# git PERMITS NEWLINES IN PATHS and fsck quotes the path verbatim, so a diagnostic
+# can be two physical lines. The first version split findings with `sed`, so the
+# CONTINUATION — which carries the rest of the path the operator has to act on —
+# matched no pattern and was DROPPED SILENTLY: the anchor invariant held, but by
+# truncation, and the header's "fields are otherwise kept VERBATIM" was false.
+#
+# This is also the ONLY case that puts a control character into a field, so it is
+# what exercises sane()'s escape loop at all.
+NL=$'\n'
+R_NLDIR="$T/nl${NL}dir"
+if mkdir -p "$R_NLDIR" 2>/dev/null && [ -d "$R_NLDIR" ]; then
+  R_NL="$R_NLDIR/repo"
+  mkdir -p "$R_NL"
+  git init -q "$R_NL" >/dev/null 2>&1
+  g "$R_NL" config user.email t@t
+  g "$R_NL" config user.name t
+  printf 'content aaa\n' >"$R_NL/f1"
+  printf 'content bbb\n' >"$R_NL/f2"
+  g "$R_NL" add f1 f2 >/dev/null 2>&1
+  g "$R_NL" -c user.email=t@t -c user.name=t commit -q -m c1 >/dev/null 2>&1
+  NL_A=$(git -C "$R_NL" rev-parse HEAD:f1 2>/dev/null)
+  NL_B=$(git -C "$R_NL" rev-parse HEAD:f2 2>/dev/null)
+  if [ -n "$NL_A" ] && [ -n "$NL_B" ] && [ "$NL_A" != "$NL_B" ]; then
+    chmod 644 "$(loose_path "$R_NL" "$NL_A")" 2>/dev/null
+    cp "$(loose_path "$R_NL" "$NL_B")" "$(loose_path "$R_NL" "$NL_A")"
+  fi
+  # ABSOLUTE --git-dir, deliberately: with `-C <repo>` git prints the object path
+  # RELATIVE to the repo, which does not contain the newline-bearing directory at all
+  # — so the construction would be asserted against a diagnostic of a different shape
+  # than the one the subject (which passes an absolute --git-dir) actually receives.
+  nl_lines=$(git --git-dir="$R_NL/.git" fsck --no-progress --no-dangling 2>&1 | grep -c . | tr -d ' ')
+  if [ "$(git -C "$R_NL" cat-file -p "$NL_A" 2>/dev/null)" = "content bbb" ] && [ "$nl_lines" -ge 3 ]; then
+    ok "newline-plant: the plant IS the shape described (a hash-path mismatch whose quoted path contains a NEWLINE, so fsck emits a multi-line diagnostic)"
+  else
+    bad "newline-plant: content='$(git -C "$R_NL" cat-file -p "$NL_A" 2>/dev/null | head -1)' fsck-lines=$nl_lines — the case below would prove nothing"
+  fi
+  OUT=$(bash "$SUBJECT" --repo "$R_NL" 2>&1)
+  RC=$?
+  record_out "newline-path"
+  if [ "$RC" -eq 4 ] && [ "$(verdict_of)" = CORRUPT ]; then
+    ok "newline-path: a store under a newline-bearing path is still classified (exit 4)"
+  else
+    bad "newline-path: rc=$RC verdict='$(verdict_of)' (wanted 4/CORRUPT)"
+  fi
+  # THE TRUNCATION HALF: the continuation must be PRESENT, on the SAME anchored line,
+  # with the newline rendered as a visible escape. `nl${NL}dir` is the containing
+  # directory, so `dir/repo/.git/objects` is exactly the text `sed` used to drop.
+  if printf '%s\n' "$OUT" | grep -q 'finding .*hash-path mismatch' &&
+    printf '%s\n' "$OUT" | grep -q 'nl\\ndir/repo/\.git/objects'; then
+    ok "newline-path: the CONTINUATION of a multi-line diagnostic survives on the same anchored line, newline escaped as \\n (sane()'s escape loop, unexercised before)"
+  else
+    bad "newline-path: the diagnostic was truncated — the operator is handed a path that does not exist: $(printf '%s\n' "$OUT" | grep 'finding ' | head -1)"
+  fi
+else
+  bad "newline-path: could not create a newline-bearing directory (the case cannot run on this filesystem)"
 fi

--- a/scripts/tests/test_check_object_store_integrity.sh
+++ b/scripts/tests/test_check_object_store_integrity.sh
@@ -856,3 +856,26 @@ if mkdir -p "$R_NLDIR" 2>/dev/null && [ -d "$R_NLDIR" ]; then
 else
   bad "newline-path: could not create a newline-bearing directory (the case cannot run on this filesystem)"
 fi
+
+# --- Case 20: NO `env` REFUSES rather than measuring un-isolated ------------
+# `env -i` is how every git call here gets its allowlisted environment (Case 18), so a
+# host without `env` cannot isolate — and the alternative to refusing is running fsck
+# under the caller's environment, which is exactly the false-VERIFIED Case 18 covers.
+# ONE property against Case 11's control: the same hermetic PATH, minus `env`.
+BIN_NOENV="$T/bin-noenv"
+mk_bin "$BIN_NOENV" git timeout gtimeout
+rm -f "$BIN_NOENV/env"
+if [ ! -e "$BIN_NOENV/env" ] && [ -e "$BIN_NOENV/git" ] && [ -e "$BIN_NOENV/timeout" ]; then
+  ok "no-env-plant: the plant IS the property described (git and timeout present, env absent)"
+else
+  bad "no-env-plant: the hermetic PATH is not the shape the case claims"
+fi
+OUT=$(PATH="$BIN_NOENV" bash "$SUBJECT" --repo "$R_CLEAN" 2>&1)
+RC=$?
+record_out "no-env"
+if [ "$RC" -eq 5 ] && [ "$(verdict_of)" = UNMEASURED ] &&
+  printf '%s\n' "$OUT" | grep -q 'cannot ISOLATE'; then
+  ok "no-env: a host that cannot isolate git's environment is UNMEASURED, never a measurement taken un-isolated"
+else
+  bad "no-env: rc=$RC verdict='$(verdict_of)' (wanted 5/UNMEASURED)"
+fi

--- a/scripts/tests/test_check_object_store_integrity.sh
+++ b/scripts/tests/test_check_object_store_integrity.sh
@@ -146,7 +146,15 @@ whole_suite_checks() {
 # THE CASE FLOOR is a MINIMUM, not an equality: adding cases must not require editing it,
 # while a span-replacing edit that DELETES cases reds the suite instead of reporting a
 # green tally over a shrunken suite (#3544's own subject, inside its own test file).
-CASE_FLOOR=34
+#
+# IT IS SET TO THE EXACT CURRENT COUNT, and the slack it used to carry was itself a
+# defect (#3749 review round 3, item 4): a floor of 34 against 74 actual meant HALF the
+# suite could vanish — or be cut short by a signal — and still report green. Every
+# host-dependent branch in this file emits a `bad` rather than silently running fewer
+# assertions (the two `command -v` guards and the fixture-construction asserts), so a
+# green run is 81 on any host that can run it at all; a green run BELOW this number
+# means cases were removed or the run was truncated. RAISE IT when you add cases.
+CASE_FLOOR=84
 
 finish() {
   local rc=$?
@@ -176,8 +184,19 @@ finish() {
 }
 # EXIT *and* the signals: bash runs no EXIT trap for a signal left at its default
 # disposition, so an interrupted run would strand the scratch tree.
+# THE SIGNAL TRAPS SET AN EXPLICIT NONZERO STATUS AND LET **EXIT** DO THE CLEANUP
+# (#3749 review round 3, item 4). They used to call `finish` directly, and `finish`
+# derives its exit status from `$?` — which at trap time is the status of whatever
+# command was interrupted, routinely **0**. So a signal arriving mid-suite ran the
+# cleanup, reported the cases that had passed SO FAR, and **exited 0** with every later
+# case never run: a green tally over a shrunken suite, which is this repository's own
+# recorded incident class (#3544) inside a file whose header claims to guard against it.
+# `exit <128+signo>` makes the EXIT trap run with a nonzero `$?`, so `finish` reports
+# FAIL, and the shell's conventional status for the signal is preserved.
 trap finish EXIT
-trap 'finish' INT TERM HUP
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 # --- fixtures ---------------------------------------------------------------
 g() { local r="$1"; shift; git -C "$r" "$@"; }
@@ -1059,4 +1078,193 @@ if [ "$RC" -eq 0 ] && printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: store '; th
   ok "print-store: a host with no timeout binary can still NAME the store (the bound is the sweep's requirement, not the resolver's)"
 else
   bad "print-store(no-timeout): rc=$RC out=[$(printf '%s\n' "$OUT" | tr '\n' '|')]"
+fi
+
+# --- Case 25: A FAILED LAUNCH/CAPTURE IS UNMEASURED, NEVER CORRUPT ----------
+# THE DEFECT (#3749 review round 3, item 2). The two capture redirections are part of
+# the fsck command, so if opening the scratch output file FAILS bash never execs
+# anything and the status is 1 — which is also fsck's ERROR_OBJECT bit. Both passes
+# then fail identically, both "reproduce", and the sweep emitted **CORRUPT** about a
+# store it never opened. That is a false CORRUPT on a healthy box: the same class as
+# round 1's BLOCKER B, arriving through the shell instead of through a concurrent
+# writer, and it pages high + stops the supervisor + fails --strict bootstrap.
+#
+# THE LEVER IS A `mktemp` SHIM, and it is WHITE-BOX ON PURPOSE. The failure has to be
+# staged at the exact place the subject writes, so the shim plants a DIRECTORY at the
+# capture paths the subject uses for its two passes: `> <dir>` fails with EISDIR for
+# EVERY uid, so this case does not depend on permission bits (a chmod-based plant is
+# inert as root, and this suite must not silently skip there). The coupling to the
+# `p1.out`/`p2.out` names is deliberate and is asserted: if fsck_pass renames its
+# capture files the CONSTRUCTION assert below reds, which is attributable, rather than
+# the case passing against a plant that no longer plants anything.
+if [ -z "${REAL_GIT:-}" ]; then
+  bad "launch-capture: no real git on PATH — the shim arms cannot be built"
+else
+  REAL_MKTEMP=$(command -v mktemp 2>/dev/null) || REAL_MKTEMP=""
+  # mk_mktemp_shim <dir> <entry...> — a `mktemp` that delegates, then creates <entry...>
+  # inside the directory it just made. With no entries it is a pure pass-through, which
+  # is the CONTROL arm.
+  mk_mktemp_shim() {
+    local d="$1"
+    shift
+    mkdir -p "$d"
+    {
+      printf '#!/usr/bin/env bash\n'
+      printf '# Test shim: delegate to the real mktemp, then plant entries in the result.\n'
+      printf 'out=$(%s "$@") || exit $?\n' "$(printf '%q' "$REAL_MKTEMP")"
+      printf 'if [ -d "$out" ]; then\n'
+      local e
+      for e in "$@"; do
+        printf '  mkdir -p "$out"/%s 2>/dev/null || true\n' "$(printf '%q' "$e")"
+      done
+      printf 'fi\n'
+      printf 'printf "%%s\\n" "$out"\n'
+    } >"$d/mktemp"
+    chmod +x "$d/mktemp"
+  }
+  if [ -z "$REAL_MKTEMP" ]; then
+    bad "launch-capture: no mktemp on PATH — the shim arms cannot be built"
+  else
+    # (a) CONSTRUCTION, asserted before the subject runs, in THREE parts. The shim must
+    #     really plant the directory; a redirection into it must really FAIL; and that
+    #     failure's status must really be 1 — the value that carries ERROR_OBJECT. If
+    #     the third stopped being true the whole case would be about nothing.
+    SH_CAP="$T/shim-capture"
+    mk_mktemp_shim "$SH_CAP" p1.out p2.out
+    PROBE_D=$(PATH="$SH_CAP:$PATH" mktemp -d "$T/capture-probe.XXXXXX" 2>/dev/null || true)
+    probe_rc=0
+    if [ -n "$PROBE_D" ] && [ -d "$PROBE_D" ]; then
+      (true >"$PROBE_D/p1.out") 2>/dev/null || probe_rc=$?
+    fi
+    if [ -n "$PROBE_D" ] && [ -d "$PROBE_D/p1.out" ] && [ -d "$PROBE_D/p2.out" ] &&
+      [ "$probe_rc" -eq 1 ]; then
+      ok "launch-capture-plant: the shim IS the defect described (a DIRECTORY at both capture paths; redirecting into it fails with status 1 — fsck's ERROR_OBJECT bit)"
+    else
+      bad "launch-capture-plant: dir='$PROBE_D' p1=$([ -d "$PROBE_D/p1.out" ] && echo dir || echo no) redirect-rc=$probe_rc — the case below would prove nothing"
+    fi
+    # (b) THE SUBJECT: a CLEAN store, an unopenable capture path. UNMEASURED (exit 5),
+    #     and the cause must say the fsck was never launched/captured rather than
+    #     describing the store.
+    OUT=$(PATH="$SH_CAP:$PATH" bash "$SUBJECT" --repo "$R_CLEAN" 2>&1)
+    RC=$?
+    record_out "launch-capture-failed"
+    if [ "$RC" -eq 5 ] && [ "$(verdict_of)" = UNMEASURED ]; then
+      ok "launch-capture: a failed capture redirection is UNMEASURED (exit 5) — the shell's status 1 is NOT read as fsck's ERROR_OBJECT bit"
+    else
+      bad "launch-capture: rc=$RC verdict='$(verdict_of)' (wanted 5/UNMEASURED) — a launch failure is being classified as object damage"
+    fi
+    if [ "$(verdict_of)" != CORRUPT ] && [ "$RC" -ne 4 ]; then
+      ok "launch-capture: the healthy store is NOT reported CORRUPT — the false-CORRUPT class (round 1 BLOCKER B) does not return through the shell"
+    else
+      bad "launch-capture: a HEALTHY store was reported CORRUPT because the capture failed"
+    fi
+    if printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: unmeasured-cause .*could not be LAUNCHED'; then
+      ok "launch-capture: the cause NAMES the launch/capture failure, so an operator is sent to the scratch filesystem and not to a re-clone"
+    else
+      bad "launch-capture: no launch/capture cause line — the operator gets UNMEASURED with the wrong or no explanation"
+    fi
+    if ! printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: object '; then
+      ok "launch-capture: NO 'object' lines — nothing was rehashed, so naming object ids would be a fabricated finding"
+    else
+      bad "launch-capture: object ids reported for a walk that never ran"
+    fi
+    # (c) THE CONTROL, ONE PROPERTY APART: the same shim mechanism, planting a name the
+    #     subject never opens. Without this, (b) could be passing because ANY mktemp
+    #     shim breaks the run.
+    SH_CAP_OK="$T/shim-capture-control"
+    mk_mktemp_shim "$SH_CAP_OK" unused-by-the-subject
+    OUT=$(PATH="$SH_CAP_OK:$PATH" bash "$SUBJECT" --repo "$R_CLEAN" 2>&1)
+    RC=$?
+    record_out "launch-capture-control"
+    if [ "$RC" -eq 0 ] && [ "$(verdict_of)" = VERIFIED ]; then
+      ok "launch-capture-control: the SAME shim planting a name the subject never opens is VERIFIED — the UNMEASURED above is the capture failure, not the shim"
+    else
+      bad "launch-capture-control: rc=$RC verdict='$(verdict_of)' (wanted 0/VERIFIED) — the shim itself is breaking the run"
+    fi
+    # (d) THE CONFIRMING PASS has the same rule. Plant ONLY the second pass's capture
+    #     path and make the first walk non-clean (the reflog shim), so pass 1 runs and
+    #     pass 2 cannot be launched: neither confirmed nor dismissed => UNMEASURED, and
+    #     never the fatal branch on a status the shell produced.
+    SH_CAP_P2="$T/shim-capture-p2"
+    mk_mktemp_shim "$SH_CAP_P2" p2.out
+    LOG_CAP="$T/shim-capture-calls.txt"
+    : >"$LOG_CAP"
+    mk_fsck_shim "$T/shim-capture-git" always 2 "$RL_MSG" "$LOG_CAP"
+    # mk_bin populated that dir with SYMLINKS to the real tools, so the shim must
+    # REPLACE the link rather than be copied through it (a `cp` onto a symlink writes
+    # the TARGET — /usr/bin/mktemp — which fails, loudly and unanchored).
+    rm -f "$T/shim-capture-git/mktemp"
+    cp "$SH_CAP_P2/mktemp" "$T/shim-capture-git/mktemp"
+    OUT=$(PATH="$T/shim-capture-git:$PATH" bash "$SUBJECT" --repo "$R_CLEAN" 2>&1)
+    RC=$?
+    record_out "launch-capture-pass2"
+    if [ "$RC" -eq 5 ] && [ "$(verdict_of)" = UNMEASURED ] &&
+      printf '%s\n' "$OUT" | grep -q 'confirming pass could not'; then
+      ok "launch-capture: an unlaunchable CONFIRMING pass is UNMEASURED naming itself — the discriminator cannot be satisfied by a walk that never ran"
+    else
+      bad "launch-capture(pass2): rc=$RC verdict='$(verdict_of)' (wanted 5/UNMEASURED naming the confirming pass)"
+    fi
+  fi
+fi
+
+# --- Case 26: A SIGNALLED RUN OF **THIS SUITE** CANNOT EXIT GREEN -----------
+# THE DEFECT (#3749 review round 3, item 4). The signal traps used to be
+# `trap 'finish' INT TERM HUP`. `finish` takes its exit status from `$?`, and at trap
+# time `$?` is the status of whatever was interrupted — routinely **0** — so a signal
+# arriving mid-suite ran the cleanup, printed the tally of the cases that had run SO
+# FAR, and **exited 0**, with every later case never executed. Combined with a case
+# floor of 34 against 74 actual, half this suite could be silently skipped and the run
+# still read as a pass. That is precisely the "green tally over a shrunken suite" class
+# this file's own header claims to guard against.
+#
+# THE TRAP DECLARATIONS ARE EXTRACTED FROM THIS FILE AT RUN TIME, never restated: a
+# case that re-typed them would go on passing after someone changed the real ones. The
+# harness supplies only the `$?`-derived exit rule that `finish` itself applies, and
+# busy-waits on a command whose status is 0 so the trap fires with `$? == 0` — the
+# condition under which the defect is silent.
+TRAP_SRC="$T/trap-lines.txt"
+grep -n '^trap ' "${BASH_SOURCE[0]}" | sed 's/^[0-9]*://' >"$TRAP_SRC"
+trap_n=$(grep -c . "$TRAP_SRC" | tr -d ' ')
+if [ "$trap_n" -ge 4 ] && grep -qx 'trap finish EXIT' "$TRAP_SRC" &&
+  ! grep -q "^trap 'finish'" "$TRAP_SRC"; then
+  ok "signal-trap-plant: this file declares $trap_n top-level traps including 'trap finish EXIT', and none delegates a SIGNAL straight to finish"
+else
+  bad "signal-trap-plant: extracted $trap_n trap line(s) [$(tr '\n' ';' <"$TRAP_SRC")] — the case below would prove nothing"
+fi
+# mk_trap_harness <path> <trap-file> — the real `finish`'s status rule plus <trap-file>'s
+# declarations, then a loop whose last command exits 0.
+mk_trap_harness() {
+  local path="$1" traps="$2"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'finish() { local rc=$?; if [ "$rc" -ne 0 ]; then exit 1; fi; exit 0; }\n'
+    cat "$traps"
+    printf 'while :; do :; done\n'
+  } >"$path"
+  chmod +x "$path"
+}
+# term_status <harness> -> the exit status after a SIGTERM 0.3s in.
+term_status() {
+  local h="$1" pid st=0
+  bash "$h" >/dev/null 2>&1 &
+  pid=$!
+  sleep 0.3
+  kill -TERM "$pid" 2>/dev/null
+  wait "$pid" 2>/dev/null || st=$?
+  printf '%s' "$st"
+}
+mk_trap_harness "$T/trap-green.sh" "$TRAP_SRC"
+printf 'trap finish EXIT\ntrap %s INT TERM HUP\n' "'finish'" >"$T/trap-red-lines.txt"
+mk_trap_harness "$T/trap-red.sh" "$T/trap-red-lines.txt"
+green_st=$(term_status "$T/trap-green.sh")
+red_st=$(term_status "$T/trap-red.sh")
+if [ "$red_st" -eq 0 ]; then
+  ok "signal-trap-control: the OLD form (a signal delegating straight to finish) really does exit 0 on SIGTERM — the harness can see the defect"
+else
+  bad "signal-trap-control: the old form exited $red_st, not 0 — a green below would prove nothing"
+fi
+if [ "$green_st" -ne 0 ]; then
+  ok "signal-trap: THIS suite's own trap declarations exit NONZERO ($green_st) on SIGTERM — a signalled run can never be read as a pass with cases unrun"
+else
+  bad "signal-trap: this suite's traps exit 0 on SIGTERM — a truncated run reports green"
 fi

--- a/scripts/tests/test_check_object_store_integrity.sh
+++ b/scripts/tests/test_check_object_store_integrity.sh
@@ -154,7 +154,7 @@ whole_suite_checks() {
 # assertions (the two `command -v` guards and the fixture-construction asserts), so a
 # green run is 81 on any host that can run it at all; a green run BELOW this number
 # means cases were removed or the run was truncated. RAISE IT when you add cases.
-CASE_FLOOR=104
+CASE_FLOOR=123
 
 finish() {
   local rc=$?
@@ -1619,4 +1619,256 @@ if [ "$(printf '%s\n' "$OUT" | grep -c '^OBJECT-STORE: ')" = "$(printf '%s\n' "$
   ok "store-key: every line of the newline-path run is still anchored — sane() keeps doing the job it exists for, and the key does the job sane() cannot"
 else
   bad "store-key: an unanchored line appeared for a newline-bearing store path: [$(printf '%s\n' "$OUT" | tr '\n' '|')]"
+fi
+
+# --- Case 30: THE LINKED-WORKTREE ROOTS A COMMON-DIR fsck **DOES** WALK ------
+# THE REVIEW FINDING THIS CASE ANSWERS (#3749 review round 7) claimed that running fsck
+# with `--git-dir=<common>` discards linked worktrees' private administrative context, so
+# an object needed only by a lane's private HEAD or index could be overlooked and the
+# store reported VERIFIED. MEASURED ON git 2.43.0, THAT IS FALSE — and the reason this
+# case exists is that "false today" is not a property anybody had checked: the coverage
+# was BELIEVED, and a future git that narrowed fsck's worktree enumeration would have
+# shrunk this control silently. Now it reds a case.
+#
+# THREE ROOTS, EACH WITH A ONE-PROPERTY CONTROL. Each fixture is built by ONE code path
+# and the arms differ only in whether the object is deleted, and the construction is
+# asserted with git before the subject runs: the object really is gone, and the ONLY
+# thing that names it is the linked worktree.
+mk_wt_root_repo() {
+  # mk_wt_root_repo <name> <head|index|prunable> <delete|keep> -> path
+  # The victim object id is published to "$T/<name>.victim" and NOT to a variable: the
+  # caller uses $( ), which runs this in a SUBSHELL, so an assignment would never be seen
+  # (measured the hard way — it read as an unbound variable under set -u).
+  local r="$T/$1" mode="$2" act="$3" wt="$T/$1-wt" WTR_VICTIM=""
+  : >"$T/$1.victim"
+  mkdir -p "$r"
+  git init -q "$r" >/dev/null 2>&1
+  g "$r" config user.email t@t
+  g "$r" config user.name t
+  printf 'content aaa\n' >"$r/f1"
+  g "$r" add f1 >/dev/null
+  GIT_AUTHOR_DATE="$FIXTURE_DATE" GIT_COMMITTER_DATE="$FIXTURE_DATE" \
+    g "$r" -c user.email=t@t -c user.name=t commit -q -m c1 >/dev/null
+  g "$r" worktree add -q --detach "$wt" HEAD >/dev/null 2>&1 || { printf '%s' "$r"; return 0; }
+  case "$mode" in
+    head | prunable)
+      # A commit that exists ONLY as this linked worktree's detached HEAD.
+      printf 'lane-private\n' >"$wt/u"
+      g "$wt" add u >/dev/null
+      GIT_AUTHOR_DATE="$FIXTURE_DATE" GIT_COMMITTER_DATE="$FIXTURE_DATE" \
+        g "$wt" -c user.email=t@t -c user.name=t commit -q -m lane-only >/dev/null
+      WTR_VICTIM=$(g "$wt" rev-parse HEAD 2>/dev/null)
+      [ "$mode" = prunable ] && rm -rf "$wt"
+      ;;
+    index)
+      # A blob STAGED in the linked worktree and in no commit anywhere.
+      printf 'staged-only\n' >"$wt/s"
+      g "$wt" add s >/dev/null
+      WTR_VICTIM=$(g "$wt" rev-parse :s 2>/dev/null)
+      ;;
+  esac
+  printf '%s' "$WTR_VICTIM" >"$T/$1.victim"
+  if [ "$act" = delete ] && [ -n "$WTR_VICTIM" ]; then
+    chmod u+w "$(loose_path "$r" "$WTR_VICTIM")" 2>/dev/null
+    rm -f "$(loose_path "$r" "$WTR_VICTIM")"
+  fi
+  printf '%s' "$r"
+}
+for WTR_MODE in head index prunable; do
+  R_WTR=$(mk_wt_root_repo "wtroot-$WTR_MODE" "$WTR_MODE" delete)
+  WTR_DEAD=$(cat "$T/wtroot-$WTR_MODE.victim" 2>/dev/null || true)
+  R_WTR_OK=$(mk_wt_root_repo "wtroot-$WTR_MODE-ctl" "$WTR_MODE" keep)
+  WTR_ALIVE=$(cat "$T/wtroot-$WTR_MODE-ctl.victim" 2>/dev/null || true)
+  # CONSTRUCTION, ASSERTED WITH git AND NOT WITH THE SUBJECT: the two arms name the SAME
+  # object (so they differ in one property), the subject arm really has lost it, and the
+  # control really still has it.
+  if [ -n "$WTR_DEAD" ] && [ "$WTR_DEAD" = "$WTR_ALIVE" ] &&
+    ! git -C "$R_WTR" cat-file -e "$WTR_DEAD" 2>/dev/null &&
+    git -C "$R_WTR_OK" cat-file -e "$WTR_ALIVE" 2>/dev/null; then
+    ok "wt-root-plant($WTR_MODE): both arms name the same object $WTR_DEAD, the subject has lost it and the one-property control still holds it"
+  else
+    bad "wt-root-plant($WTR_MODE): dead='$WTR_DEAD' alive='$WTR_ALIVE' — the arms are not one property apart; the two cases below would prove nothing"
+  fi
+  # THE SUBJECT: non-passing, and never VERIFIED. `head` and `prunable` reach the fatal
+  # branch (the complaint survives --no-reflogs); `index` is asserted only as non-clean,
+  # because WHICH non-passing verdict it earns is git's business and not this control's
+  # claim — pinning the stronger one would red on a git that words it differently.
+  OUT=$(bash "$SUBJECT" --repo "$R_WTR" 2>&1)
+  RC=$?
+  record_out "wt-root-$WTR_MODE"
+  if [ "$RC" -ne 0 ] && [ "$(verdict_of)" != VERIFIED ]; then
+    ok "wt-root($WTR_MODE): a common-dir fsck DOES walk a linked worktree's private $WTR_MODE root — an object needed only by it is not reported clean (exit $RC, verdict $(verdict_of))"
+  else
+    bad "wt-root($WTR_MODE): exit $RC verdict='$(verdict_of)' — the sweep called a store VERIFIED while an object a linked worktree's $WTR_MODE root needs is absent"
+  fi
+  OUT=$(bash "$SUBJECT" --repo "$R_WTR_OK" 2>&1)
+  RC=$?
+  record_out "wt-root-$WTR_MODE-control"
+  if [ "$RC" -eq 0 ] && [ "$(verdict_of)" = VERIFIED ]; then
+    ok "wt-root($WTR_MODE-control): the same fixture with the object PRESENT is VERIFIED, so the non-pass above is the missing object and not the worktree"
+  else
+    bad "wt-root($WTR_MODE-control): exit $RC verdict='$(verdict_of)' — the control does not pass, so the subject arm attributes nothing"
+  fi
+done
+
+# --- Case 31: THE ROOT A COMMON-DIR fsck DOES **NOT** WALK ------------------
+# THE REAL HOLE, and it is narrower and sharper than the review finding that led to it.
+# A LINKED worktree's per-worktree refs (`refs/worktree/*`, `refs/bisect/*`,
+# `refs/rewritten/*`) are roots only for an fsck run with THAT worktree's git dir. Delete
+# an object named only by one and a common-dir fsck exits **0**: the worktree's HEAD
+# reflog echoes the id, and that echo CLEARS under `--no-reflogs`, so even the round-4
+# attribution walk reads it as reflog-scoped. The MAIN worktree's per-worktree refs live
+# in the common dir and ARE walked, which is why this fixture uses a LINKED one.
+mk_wt_privateref_repo() {
+  # mk_wt_privateref_repo <name> <delete|keep> -> path; the victim id is published to
+  # "$T/<name>.victim" for the same subshell reason as mk_wt_root_repo above.
+  local r="$T/$1" act="$2" wt="$T/$1-wt" WTP_VICTIM=""
+  : >"$T/$1.victim"
+  mkdir -p "$r"
+  git init -q "$r" >/dev/null 2>&1
+  g "$r" config user.email t@t
+  g "$r" config user.name t
+  printf 'content aaa\n' >"$r/f1"
+  g "$r" add f1 >/dev/null
+  GIT_AUTHOR_DATE="$FIXTURE_DATE" GIT_COMMITTER_DATE="$FIXTURE_DATE" \
+    g "$r" -c user.email=t@t -c user.name=t commit -q -m c1 >/dev/null
+  g "$r" worktree add -q --detach "$wt" HEAD >/dev/null 2>&1 || { printf '%s' "$r"; return 0; }
+  printf 'private-ref-only\n' >"$wt/u"
+  g "$wt" add u >/dev/null
+  GIT_AUTHOR_DATE="$FIXTURE_DATE" GIT_COMMITTER_DATE="$FIXTURE_DATE" \
+    g "$wt" -c user.email=t@t -c user.name=t commit -q -m private-ref >/dev/null
+  WTP_VICTIM=$(g "$wt" rev-parse HEAD 2>/dev/null)
+  g "$wt" update-ref refs/worktree/private "$WTP_VICTIM" >/dev/null 2>&1
+  # Move HEAD off it, and drop the reflogs, so the per-worktree REF is the ONLY thing
+  # left naming the object — which is the whole point of the case.
+  g "$wt" checkout -q --detach HEAD~1 >/dev/null 2>&1
+  rm -f "$r/.git/worktrees/$(basename "$wt")/logs/HEAD" "$r/.git/logs/HEAD" 2>/dev/null
+  rm -rf "$r/.git/logs/refs" 2>/dev/null
+  printf '%s' "$WTP_VICTIM" >"$T/$1.victim"
+  if [ "$act" = delete ] && [ -n "$WTP_VICTIM" ]; then
+    chmod u+w "$(loose_path "$r" "$WTP_VICTIM")" 2>/dev/null
+    rm -f "$(loose_path "$r" "$WTP_VICTIM")"
+  fi
+  printf '%s' "$r"
+}
+R_WTP=$(mk_wt_privateref_repo wtpriv delete)
+WTP_DEAD=$(cat "$T/wtpriv.victim" 2>/dev/null || true)
+R_WTP_OK=$(mk_wt_privateref_repo wtpriv-ctl keep)
+WTP_ALIVE=$(cat "$T/wtpriv-ctl.victim" 2>/dev/null || true)
+WTP_RAW=$(fsck_status_mode "$R_WTP")
+WTP_RAW_NR=0
+git -C "$R_WTP" fsck --no-progress --no-dangling --no-reflogs >/dev/null 2>&1 || WTP_RAW_NR=$?
+# THE CONSTRUCTION ASSERT IS ALSO THE EVIDENCE THAT THE PROBE IS LOAD-BEARING: raw git,
+# in exactly the configuration the sweep's walks use, calls this store CLEAN. Without
+# that, a green below could not distinguish "the probe found it" from "fsck found it".
+if [ -n "$WTP_DEAD" ] && [ "$WTP_DEAD" = "$WTP_ALIVE" ] &&
+  ! git -C "$R_WTP" cat-file -e "$WTP_DEAD" 2>/dev/null &&
+  git -C "$R_WTP_OK" cat-file -e "$WTP_ALIVE" 2>/dev/null &&
+  [ "$(git --git-dir="$R_WTP/.git" rev-parse --verify -q refs/worktree/private 2>/dev/null)" != "$WTP_DEAD" ] &&
+  [ "$(git --git-dir="$R_WTP/.git/worktrees/wtpriv-wt" rev-parse --verify -q refs/worktree/private 2>/dev/null)" = "$WTP_DEAD" ] &&
+  [ "$WTP_RAW" -eq 0 ] && [ "$WTP_RAW_NR" -eq 0 ]; then
+  ok "wt-privateref-plant: $WTP_DEAD is named ONLY by the LINKED worktree's refs/worktree/private (invisible from the common dir), it is absent, the control still holds it, and a raw common-dir fsck calls this store CLEAN with and without reflogs — so anything found below is found by the probe"
+else
+  bad "wt-privateref-plant: dead='$WTP_DEAD' alive='$WTP_ALIVE' raw-fsck=$WTP_RAW/$WTP_RAW_NR — not the shape this case is about; the arms below would prove nothing"
+fi
+if run 4 "wt-privateref: CORRUPT" --repo "$R_WTP"; then
+  if [ "$(verdict_of)" = CORRUPT ] &&
+    printf '%s\n' "$OUT" | grep -q "^OBJECT-STORE: private-root ABSENT $WTP_DEAD .* refs/worktree/private$"; then
+    ok "wt-privateref: an object named only by a LINKED worktree's per-worktree ref is CORRUPT (exit 4) and the missing root is NAMED — the store a raw fsck called clean"
+  else
+    bad "wt-privateref: verdict='$(verdict_of)' — wanted CORRUPT naming $WTP_DEAD: $(printf '%s\n' "$OUT" | grep 'private-root' | head -2 | tr '\n' ' ')"
+  fi
+fi
+if run 0 "wt-privateref-control: VERIFIED" --repo "$R_WTP_OK"; then
+  if [ "$(verdict_of)" = VERIFIED ] &&
+    printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: measured private-roots checked=1 .* absent=0 '; then
+    ok "wt-privateref(control): the SAME fixture with the object present is VERIFIED, and the affirmative branch reports that it CHECKED the private root — so VERIFIED is an affirmative statement about it, not silence"
+  else
+    bad "wt-privateref(control): verdict='$(verdict_of)' census='$(printf '%s\n' "$OUT" | grep 'measured private-roots')' — the control must pass AND must show the root was checked"
+  fi
+fi
+
+# --- Case 32: A WORKTREE THAT CANNOT BE INSPECTED IS NOT A CLEAN ONE --------
+# The permissive direction here would be silent and total: a worktree whose refs cannot
+# be listed contributes ZERO roots, so the probe would report `absent=0` and the sweep
+# would go on to VERIFIED — the exact shape CLAUDE.md names (a multi-state signal whose
+# unmeasured state inherits the permissive branch). It is UNMEASURED instead, and the
+# worktree is NAMED.
+R_WTU=$(mk_wt_root_repo wtunread head keep)
+WTU_ADMIN="$R_WTU/.git/worktrees/wtunread-wt"
+if [ "$(id -u)" = 0 ]; then
+  skipped=1
+  ok "wt-unreadable: SKIPPED as root — permission bits are advisory for uid 0, so a chmod plant would not make the admin dir unreadable and a green would prove nothing"
+elif [ -d "$WTU_ADMIN" ] && chmod 000 "$WTU_ADMIN" 2>/dev/null &&
+  ! git --git-dir="$WTU_ADMIN" for-each-ref >/dev/null 2>&1; then
+  ok "wt-unreadable-plant: the linked worktree's admin dir really is unreadable to this process (git cannot list its refs)"
+  if run 5 "wt-unreadable: UNMEASURED" --repo "$R_WTU"; then
+    if [ "$(verdict_of)" = UNMEASURED ] &&
+      printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: private-root UNREADABLE wtunread-wt ' &&
+      ! printf '%s\n' "$OUT" | grep -q 'verdict VERIFIED'; then
+      ok "wt-unreadable: a registered worktree whose refs cannot be listed is UNMEASURED and is NAMED — never a silent zero-root contribution to VERIFIED"
+    else
+      bad "wt-unreadable: verdict='$(verdict_of)' lines='$(printf '%s\n' "$OUT" | grep 'private-root' | head -2 | tr '\n' ' ')'"
+    fi
+  fi
+  chmod 755 "$WTU_ADMIN" 2>/dev/null
+  # ONE PROPERTY BACK: with the permissions restored the same fixture is VERIFIED, so the
+  # UNMEASURED above is the unreadable admin dir and not the fixture.
+  if run 0 "wt-unreadable-control: VERIFIED" --repo "$R_WTU"; then
+    if [ "$(verdict_of)" = VERIFIED ]; then
+      ok "wt-unreadable(control): restoring ONLY the permission bits makes the same fixture VERIFIED"
+    else
+      bad "wt-unreadable(control): verdict='$(verdict_of)' after restoring permissions"
+    fi
+  fi
+else
+  bad "wt-unreadable-plant: could not make the linked worktree's admin dir unreadable ($WTU_ADMIN) — the case below would prove nothing"
+fi
+
+# --- Case 33: THE PROBE MODE'S OWN CONTRACT --------------------------------
+# The caller requires EXACTLY ONE terminal census line and reads the exit status and that
+# line as a CONJUNCTION (the round-4 two-channel rule, applied to the channel this round
+# adds). If the mode stopped printing the census, or printed two, the caller would report
+# UNMEASURED — so the contract is pinned here, where the failure is attributable.
+OUT=$(bash "$SUBJECT" --repo "$R_WTP_OK" --probe-private-roots 2>&1)
+RC=$?
+record_out "probe-mode"
+PRP_CENSUS_N=$(printf '%s\n' "$OUT" | grep -c '^OBJECT-STORE: private-roots checked=')
+if [ "$RC" -eq 0 ] && [ "$PRP_CENSUS_N" -eq 1 ] &&
+  ! printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: verdict '; then
+  ok "probe-mode: --probe-private-roots exits 0, prints exactly one terminal census line, and emits NO verdict — it is a measurement the sweep consumes, not a certification"
+else
+  bad "probe-mode: rc=$RC census-lines=$PRP_CENSUS_N verdict='$(verdict_of)' — the contract the sweep's caller-side conjunction depends on is broken"
+fi
+if bash "$SUBJECT" --repo "$R_WTP_OK" --probe-private-roots --print-store >/dev/null 2>&1; then
+  bad "probe-mode: --probe-private-roots and --print-store were accepted together — two early-exit modes in one run have no defined output"
+else
+  ok "probe-mode: --probe-private-roots and --print-store are mutually exclusive (usage error, no verdict)"
+fi
+
+# --- Case 34: THE PROBE IS THE THIRD STAGE, NEVER A FOURTH (placement) ------
+# WHY THIS IS A CORRECTNESS CASE AND NOT BOOKKEEPING. Every caller derives its own
+# uninterruptible-block bound from the sweep's declared MAX_SWEEP_WALKS, and that number
+# stayed at 3 only because the reachability-attribution path (3 fsck walks) TERMINATES
+# before the probe can run. That is a property of WHERE the call sits, so no arithmetic
+# can check it: it is measured against the fixture that actually spends three walks.
+OUT=$(bash "$SUBJECT" --repo "$R_LIVE_MISS" 2>&1)
+RC=$?
+record_out "probe-placement-3walk"
+if [ "$RC" -eq 4 ] &&
+  printf '%s\n' "$OUT" | grep -q 'pass 3: fsck --no-reflogs' &&
+  ! printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: private-root'; then
+  ok "probe-placement: the 3-fsck-walk path (reachability attribution) terminates BEFORE the private-root probe, so the worst case is still MAX_SWEEP_WALKS bounded stages and no caller's derived bound moved"
+else
+  bad "probe-placement: rc=$RC — a run that spent THREE fsck walks also ran the probe, which makes every caller's uninterruptible window one stage wider than its bound assumes: $(printf '%s\n' "$OUT" | grep -cE 'measured pass|private-root') marker(s)"
+fi
+# And the complementary half: a run that reaches the affirmative branch DID pay for it,
+# so the stage is real and the case above is not passing because the probe never runs.
+OUT=$(bash "$SUBJECT" --repo "$R_CLEAN" 2>&1)
+RC=$?
+record_out "probe-placement-clean"
+if [ "$RC" -eq 0 ] && printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: measured private-roots '; then
+  ok "probe-placement(control): a run that reaches VERIFIED DOES run the probe — the case above is a placement property, not a probe that never fires"
+else
+  bad "probe-placement(control): rc=$RC — a VERIFIED run did not run the private-root probe at all"
 fi

--- a/scripts/tests/test_check_object_store_integrity.sh
+++ b/scripts/tests/test_check_object_store_integrity.sh
@@ -1,0 +1,586 @@
+#!/usr/bin/env bash
+#
+# Regression tests for scripts/check-object-store-integrity.sh (issue #3749).
+#
+# Fast + HERMETIC: every case builds a synthetic git repo under one `mktemp -d`, and
+# nothing here reads THIS box's shared object store — a suite whose verdict depended on
+# the health of the machine running it would be untestable and unattributable. No
+# network, no `gh`, no cargo.
+#
+# The suite carries five things beyond ordinary cases, because a guard here can be
+# SATISFIED AND WRONG:
+#
+#   1. RED-ARM DISCIPLINE, EXPLICIT (CLAUDE.md: "a bare red is not evidence"). Every
+#      corruption case differs from a CLEAN TWIN built by the same code path in EXACTLY
+#      ONE property — the planted damage — and the construction is ASSERTED with git
+#      before the subject is run, so a case cannot pass against a fixture that never had
+#      the property under test. An unrelated breakage produces an identical exit code.
+#   2. A PLANTED MUTANT proving the FULL REHASH is load-bearing (Case 6). A copy of the
+#      script with `--connectivity-only` added must (a) genuinely carry that defect and
+#      nothing else, and (b) report VERIFIED on a store the real script calls CORRUPT.
+#      Measured on git 2.43.0: `git fsck --connectivity-only` exits 0 on a hash-path
+#      mismatch. That is why the script's header forbids the flag, and this is the case
+#      that stops someone "optimising" it in.
+#   3. THE ANCHORED OUTPUT GUARANTEE, whole-suite: every nonempty line of EVERY run,
+#      stdout AND stderr, begins with `OBJECT-STORE: `, and every `verdict ` line carries
+#      a token from the CLOSED set. Violations ACCUMULATE to files and are reported once,
+#      from the EXIT trap — never from a position in this file, which is maintained by
+#      hand and would silently shrink as cases are appended (the #3650 R6 F3 lesson).
+#   4. THE STATIC-TEMPLATE ASSERTION (Case 13), structural over the source: the script's
+#      own literal text carries no FOREIGN verdict vocabulary (`PASS`, `OK`, `RESULT:`) so
+#      its output can never be mistaken for an AGENT-GATE/ROBOREV/PREMERGE block, and its
+#      OWN verdict tokens appear only on `verdict ` templates. Provable, unlike a claim
+#      about one sample run.
+#   5. A CASE FLOOR. A span-replacing edit that silently deletes cases while the suite
+#      reports green is a recorded incident in this repo (#3544 deleted four).
+#
+# Run standalone:   bash scripts/tests/test_check_object_store_integrity.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUBJECT="$SCRIPT_DIR/../check-object-store-integrity.sh"
+
+PASS=0
+FAIL=0
+ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+if [ ! -r "$SUBJECT" ]; then
+  printf 'FAIL - the subject %s is not readable\n' "$SUBJECT" >&2
+  exit 1
+fi
+
+# THE SCRATCH DIR IS VALIDATED BEFORE ANY PATH IS BUILT FROM IT. An unchecked `mktemp`
+# leaves $T empty, after which every "$T/..." resolves at the filesystem ROOT — and the
+# trap would run `rm -rf ""`.
+if ! T=$(mktemp -d "${TMPDIR:-/tmp}/object-store-integrity-test.XXXXXX" 2>/dev/null) ||
+  [ -z "$T" ] || [ ! -d "$T" ]; then
+  printf 'FAIL - could not create a scratch directory under %s\n' "${TMPDIR:-/tmp}" >&2
+  exit 1
+fi
+
+ALL_OUT="$T/all-output.txt"
+ANCHOR_BAD="$T/anchor-violations.txt"
+VERDICT_BAD="$T/verdict-violations.txt"
+: >"$ALL_OUT"
+: >"$ANCHOR_BAD"
+: >"$VERDICT_BAD"
+
+RECORD_CALLS=0
+INSPECTED_RECORDS=-1
+WHOLE_SUITE_RUNS=0
+FINISHED=0
+
+# record_out <tag> — accumulate $OUT and check the anchored invariants on it. Called from
+# run() so no case can forget it.
+record_out() {
+  local tag="$1" line tok
+  RECORD_CALLS=$((RECORD_CALLS + 1))
+  printf '%s\n' "$OUT" >>"$ALL_OUT"
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    case "$line" in
+      'OBJECT-STORE: '*) ;;
+      *) printf '%s\t%s\n' "$tag" "$line" >>"$ANCHOR_BAD" ;;
+    esac
+    case "$line" in
+      'OBJECT-STORE: verdict '*)
+        tok=${line#'OBJECT-STORE: verdict '}
+        tok=${tok%% *}
+        case "$tok" in
+          VERIFIED | CORRUPT | UNMEASURED) ;;
+          *) printf '%s\t%s\n' "$tag" "$line" >>"$VERDICT_BAD" ;;
+        esac
+        ;;
+    esac
+  done <<RECORD_OUT
+$OUT
+RECORD_OUT
+}
+
+# verdict_of — the token on $OUT's single `verdict ` line, or the empty string.
+verdict_of() {
+  local v
+  v=$(printf '%s\n' "$OUT" | grep '^OBJECT-STORE: verdict ' | head -1)
+  v=${v#'OBJECT-STORE: verdict '}
+  printf '%s' "${v%% *}"
+}
+verdict_lines() { printf '%s\n' "$OUT" | grep -c '^OBJECT-STORE: verdict ' | tr -d ' '; }
+
+# whole_suite_checks — invoked ONLY from finish (the EXIT trap), so a case appended
+# anywhere in this file is inspected. DO NOT CALL IT ANYWHERE ELSE: the count
+# reconciliation below reds the suite if it runs more than once or inspects fewer runs
+# than the suite recorded.
+whole_suite_checks() {
+  local nonempty cov_missing needle
+  WHOLE_SUITE_RUNS=$((WHOLE_SUITE_RUNS + 1))
+
+  nonempty=$(grep -c . "$ALL_OUT" | tr -d ' ')
+  if [ "$nonempty" -lt 80 ]; then
+    bad "anchor: only $nonempty accumulated lines — the whole-suite assertion would be weak"
+  else
+    ok "anchor: the whole-suite assertion inspects $nonempty output lines from every run"
+  fi
+  cov_missing=""
+  for needle in 'verdict VERIFIED' 'verdict CORRUPT' 'verdict UNMEASURED' 'USAGE'; do
+    grep -q "$needle" "$ALL_OUT" || cov_missing="$cov_missing '$needle'"
+  done
+  if [ -z "$cov_missing" ]; then
+    ok "anchor: the accumulated output covers all THREE verdicts AND the usage path"
+  else
+    bad "anchor: accumulated output missing:$cov_missing — narrower than the suite claims"
+  fi
+  if [ -s "$ANCHOR_BAD" ]; then
+    bad "anchor: $(grep -c . "$ANCHOR_BAD" | tr -d ' ') line(s) lack the 'OBJECT-STORE: ' prefix; first: $(head -1 "$ANCHOR_BAD")"
+  else
+    ok "anchor: EVERY nonempty line of EVERY run, stdout AND stderr, begins with 'OBJECT-STORE: '"
+  fi
+  if [ -s "$VERDICT_BAD" ]; then
+    bad "anchor: a 'verdict ' line carries a token outside the closed set; first: $(head -1 "$VERDICT_BAD")"
+  else
+    ok "anchor: every 'verdict ' token is from {VERIFIED, CORRUPT, UNMEASURED}"
+  fi
+  [ "$INSPECTED_RECORDS" -lt 0 ] && INSPECTED_RECORDS=$RECORD_CALLS
+}
+
+# THE CASE FLOOR is a MINIMUM, not an equality: adding cases must not require editing it,
+# while a span-replacing edit that DELETES cases reds the suite instead of reporting a
+# green tally over a shrunken suite (#3544's own subject, inside its own test file).
+CASE_FLOOR=34
+
+finish() {
+  local rc=$?
+  if [ "$FINISHED" -eq 1 ]; then
+    rm -rf "$T"
+    return
+  fi
+  FINISHED=1
+  whole_suite_checks
+  if [ "$WHOLE_SUITE_RUNS" -ne 1 ]; then
+    bad "whole-suite: the accumulated-output assertions ran $WHOLE_SUITE_RUNS times, not once — they belong to finish() alone"
+  elif [ "$INSPECTED_RECORDS" -ne "$RECORD_CALLS" ]; then
+    bad "whole-suite: they inspected $INSPECTED_RECORDS recorded runs but the suite recorded $RECORD_CALLS — do NOT reposition the check, it must run from finish()"
+  else
+    ok "whole-suite: the assertions inspected EVERY one of the $RECORD_CALLS recorded runs"
+  fi
+  if [ "$PASS" -lt "$CASE_FLOOR" ] && [ "$FAIL" -eq 0 ]; then
+    printf 'FAIL - case-floor: %d cases ran but this suite declares a floor of %d — cases were REMOVED (or are skipping) without the floor being lowered deliberately.\n' "$PASS" "$CASE_FLOOR"
+    FAIL=$((FAIL + 1))
+  fi
+  printf '\n=== object-store-integrity: %d passed, %d failed (floor %d) ===\n' "$PASS" "$FAIL" "$CASE_FLOOR"
+  rm -rf "$T"
+  if [ "$FAIL" -ne 0 ] || [ "$rc" -ne 0 ]; then
+    exit 1
+  fi
+  exit 0
+}
+# EXIT *and* the signals: bash runs no EXIT trap for a signal left at its default
+# disposition, so an interrupted run would strand the scratch tree.
+trap finish EXIT
+trap 'finish' INT TERM HUP
+
+# --- fixtures ---------------------------------------------------------------
+g() { local r="$1"; shift; git -C "$r" "$@"; }
+
+# newrepo <name> -> path. Two blobs, one commit. THE ONE CODE PATH every fixture is
+# built by, so a corruption case's CLEAN TWIN is identical but for the planted damage.
+newrepo() {
+  local r="$T/$1"
+  mkdir -p "$r"
+  git init -q "$r" >/dev/null 2>&1
+  g "$r" config user.email t@t
+  g "$r" config user.name t
+  printf 'content aaa\n' >"$r/f1"
+  printf 'content bbb\n' >"$r/f2"
+  g "$r" add f1 f2 >/dev/null
+  g "$r" -c user.email=t@t -c user.name=t commit -q -m c1 >/dev/null
+  printf '%s' "$r"
+}
+
+loose_path() {
+  local r="$1" sha="$2"
+  printf '%s' "$r/.git/objects/${sha:0:2}/${sha:2}"
+}
+
+# run <expected-exit> <desc> [args...] — run the subject, set $OUT/$RC, accumulate.
+run() {
+  local want="$1" desc="$2"
+  shift 2
+  # The subject is resolved from THIS FILE'S OWN location, with no settable path
+  # variable: a case needing a different script SUBSTITUTES the artifact (the mutant
+  # case writes its own copy and calls it directly), because a test-only seam is one
+  # more thing a real invoker can set (CLAUDE.md #3312 corollary).
+  OUT=$(bash "$SUBJECT" "$@" 2>&1)
+  RC=$?
+  record_out "$desc"
+  if [ "$RC" -eq "$want" ]; then
+    return 0
+  fi
+  bad "$desc (exit $RC, wanted $want)"
+  printf '%s\n' "$OUT" | head -6
+  return 1
+}
+
+# --- Case 1: FIXTURE SELF-CONSISTENCY ---------------------------------------
+# Asserted with git, not with the subject: a case that used the subject to validate its
+# own fixture could not distinguish a broken fixture from a broken subject.
+R_CLEAN=$(newrepo clean)
+if git -C "$R_CLEAN" rev-parse HEAD >/dev/null 2>&1 &&
+  [ -n "$(git -C "$R_CLEAN" rev-parse HEAD:f1 2>/dev/null)" ] &&
+  git -C "$R_CLEAN" fsck --no-progress --no-dangling >/dev/null 2>&1; then
+  ok "fixture: the clean repo really is a repo with objects, and git itself calls it intact"
+else
+  bad "fixture: the clean repo is not the shape this suite claims"
+fi
+
+# --- Case 2: a clean store is VERIFIED, exit 0 ------------------------------
+if run 0 "clean: VERIFIED" --repo "$R_CLEAN"; then
+  if [ "$(verdict_of)" = VERIFIED ] && [ "$(verdict_lines)" -eq 1 ]; then
+    ok "clean: a clean store yields exactly one 'verdict VERIFIED' line and exit 0"
+  else
+    bad "clean: verdict was '$(verdict_of)' on $(verdict_lines) verdict line(s)"
+  fi
+  if printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: measured fsck rc=0 '; then
+    ok "clean: the affirmative branch reports its MEASUREMENT (fsck rc=0), not just a verdict"
+  else
+    bad "clean: no 'measured' line — VERIFIED must be an affirmative measurement"
+  fi
+  if printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: store .*/\.git/objects$'; then
+    ok "clean: the run NAMES the object store it swept"
+  else
+    bad "clean: the run does not name the store it swept"
+  fi
+fi
+
+# --- Case 3: a ZLIB-DAMAGED loose object is CORRUPT, exit 4 -----------------
+# RED ARM, ONE PROPERTY: built by the same `newrepo` as the clean twin above, then ONE
+# loose object's bytes are overwritten. The construction is asserted with git first —
+# `cat-file` must FAIL on that object — so this case cannot pass against an intact
+# fixture, and the exit code alone is never taken as evidence.
+R_ROT=$(newrepo rotted)
+ROT_SHA=$(git -C "$R_ROT" rev-parse HEAD:f1)
+ROT_PATH=$(loose_path "$R_ROT" "$ROT_SHA")
+chmod 644 "$ROT_PATH" 2>/dev/null
+printf 'not a zlib stream at all' >"$ROT_PATH"
+if [ -n "$ROT_SHA" ] && ! git -C "$R_ROT" cat-file -p "$ROT_SHA" >/dev/null 2>&1 &&
+  git -C "$R_CLEAN" cat-file -p "$(git -C "$R_CLEAN" rev-parse HEAD:f1)" >/dev/null 2>&1; then
+  ok "rot-plant: the plant IS the defect described (that object is unreadable here, readable in the clean twin)"
+else
+  bad "rot-plant: the fixture is not corrupt (or the clean twin is) — the case below would prove nothing"
+fi
+if run 4 "rotted: CORRUPT" --repo "$R_ROT"; then
+  if [ "$(verdict_of)" = CORRUPT ]; then
+    ok "rotted: a zlib-damaged loose object yields 'verdict CORRUPT' and exit 4"
+  else
+    bad "rotted: verdict was '$(verdict_of)', wanted CORRUPT"
+  fi
+  if printf '%s\n' "$OUT" | grep -q "^OBJECT-STORE: object $ROT_SHA$"; then
+    ok "rotted: the output NAMES the affected object id on its own 'object' line"
+  else
+    bad "rotted: the affected object id $ROT_SHA is not named on an 'object' line"
+  fi
+  if printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: finding '; then
+    ok "rotted: fsck's own diagnostic is quoted verbatim on a 'finding' line (not re-worded)"
+  else
+    bad "rotted: no 'finding' line — the operator gets a verdict with no evidence"
+  fi
+  if printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: verdict-detail REMEDY'; then
+    ok "rotted: the CORRUPT verdict carries an operator REMEDY"
+  else
+    bad "rotted: CORRUPT with no remedy line"
+  fi
+fi
+
+# --- Case 4: a HASH-PATH MISMATCH is CORRUPT --------------------------------
+# THE CLASS THIS SCRIPT EXISTS FOR: a whole, well-formed, zlib-valid object whose CONTENT
+# does not hash to its own name. An ordinary git read does not notice (no rehash); fsck
+# does. One property again: f1's loose object file is replaced by f2's, byte for byte.
+R_MIS=$(newrepo mismatch)
+MIS_A=$(git -C "$R_MIS" rev-parse HEAD:f1)
+MIS_B=$(git -C "$R_MIS" rev-parse HEAD:f2)
+MIS_PA=$(loose_path "$R_MIS" "$MIS_A")
+MIS_PB=$(loose_path "$R_MIS" "$MIS_B")
+chmod 644 "$MIS_PA" 2>/dev/null
+cp "$MIS_PB" "$MIS_PA"
+if [ -n "$MIS_A" ] && [ -n "$MIS_B" ] && [ "$MIS_A" != "$MIS_B" ] &&
+  cmp -s "$MIS_PA" "$MIS_PB" &&
+  [ "$(git -C "$R_MIS" cat-file -p "$MIS_A" 2>/dev/null)" = "content bbb" ]; then
+  # `cat-file` HANDS BACK THE WRONG CONTENT WITHOUT COMPLAINT — that is the measurement
+  # the whole trust boundary rests on, made here rather than asserted from prose.
+  ok "mismatch-plant: the plant IS the defect described (git returns f2's content for f1's sha, no error)"
+else
+  bad "mismatch-plant: the fixture does not carry a hash-path mismatch — the case below would prove nothing"
+fi
+if run 4 "mismatch: CORRUPT" --repo "$R_MIS"; then
+  if [ "$(verdict_of)" = CORRUPT ]; then
+    ok "mismatch: a content/name mismatch (the class an ordinary read cannot see) is CORRUPT, exit 4"
+  else
+    bad "mismatch: verdict was '$(verdict_of)', wanted CORRUPT"
+  fi
+  if printf '%s\n' "$OUT" | grep -q "^OBJECT-STORE: object $MIS_A$" &&
+    printf '%s\n' "$OUT" | grep -q "^OBJECT-STORE: object $MIS_B$"; then
+    ok "mismatch: BOTH object ids fsck named are reported"
+  else
+    bad "mismatch: the reported ids do not include both $MIS_A and $MIS_B"
+  fi
+fi
+
+# --- Case 5: the CLEAN TWIN of the corruption cases is still VERIFIED -------
+# The other half of the one-property discipline: the fixture builder does not itself
+# produce something fsck dislikes, so CORRUPT above is attributable to the plant.
+R_TWIN=$(newrepo twin)
+if run 0 "twin: VERIFIED" --repo "$R_TWIN"; then
+  [ "$(verdict_of)" = VERIFIED ] &&
+    ok "twin: an UNplanted repo from the same builder is VERIFIED — the plants are what CORRUPT reports" ||
+    bad "twin: an unplanted repo reported '$(verdict_of)'"
+fi
+
+# --- Case 6 (PLANTED MUTANT): the FULL REHASH is load-bearing --------------
+# A copy of the script with `--connectivity-only` added to the fsck call. Measured on git
+# 2.43.0: that flag walks reachability WITHOUT rehashing content, so it exits 0 on the
+# Case 4 fixture. Two halves: the plant IS the defect described, and it gets Case 4 wrong.
+MUT="$T/mutant-connectivity-only.sh"
+sed 's/fsck --no-progress --no-dangling/fsck --no-progress --no-dangling --connectivity-only/' \
+  "$SUBJECT" >"$MUT"
+if bash -n "$MUT" 2>/dev/null &&
+  grep -q -- '--connectivity-only' "$MUT" &&
+  ! grep -q -- 'fsck --no-progress --no-dangling --connectivity-only' "$SUBJECT" &&
+  [ "$(grep -c -- '--connectivity-only' "$MUT")" -gt "$(grep -c -- '--connectivity-only' "$SUBJECT")" ]; then
+  ok "connectivity-mutant: the plant IS the defect described (--connectivity-only on the fsck call, absent from the subject)"
+else
+  bad "connectivity-mutant: the plant is not the defect described"
+fi
+MUT_OUT=$(bash "$MUT" --repo "$R_MIS" 2>&1)
+MUT_RC=$?
+# DELIBERATELY NOT recorded into $ALL_OUT: it is the violation the suite exists to forbid.
+if [ "$MUT_RC" -eq 0 ] && printf '%s\n' "$MUT_OUT" | grep -q '^OBJECT-STORE: verdict VERIFIED'; then
+  ok "connectivity-mutant: WITHOUT the full rehash the SAME corrupt store reports VERIFIED — the flag would make this vacuous"
+else
+  bad "connectivity-mutant: expected a vacuous VERIFIED from the mutant (rc=$MUT_RC) — the case proves nothing otherwise"
+fi
+
+# --- Case 7: a linked WORKTREE reports the SHARED (common) store ------------
+# `--git-common-dir`, not `--git-dir`: in a worktree the latter names the lane's private
+# administrative directory, and sweeping that would audit the wrong thing while reporting
+# a verdict about "the store".
+R_WT_MAIN=$(newrepo wtmain)
+R_WT="$T/wt-linked"
+if g "$R_WT_MAIN" worktree add -q --detach "$R_WT" >/dev/null 2>&1 && [ -d "$R_WT" ]; then
+  WT_PRIVATE=$(git -C "$R_WT" rev-parse --absolute-git-dir 2>/dev/null)
+  if run 0 "worktree: VERIFIED" --repo "$R_WT"; then
+    if printf '%s\n' "$OUT" | grep -q "^OBJECT-STORE: store $R_WT_MAIN/\.git/objects$"; then
+      ok "worktree: a linked worktree sweeps the SHARED common store ($R_WT_MAIN/.git/objects)"
+    else
+      bad "worktree: the swept store is not the shared one: $(printf '%s\n' "$OUT" | grep '^OBJECT-STORE: store ')"
+    fi
+    if [ -n "$WT_PRIVATE" ] && ! printf '%s\n' "$OUT" | grep -q "^OBJECT-STORE: store $WT_PRIVATE/objects$"; then
+      ok "worktree: it does NOT sweep the worktree's private git dir ($WT_PRIVATE)"
+    else
+      bad "worktree: the private per-worktree dir was swept instead of the shared store"
+    fi
+  fi
+else
+  bad "worktree: could not create a linked worktree fixture (git worktree add failed)"
+fi
+
+# --- Case 8: NOT A GIT REPOSITORY is UNMEASURED, and never VERIFIED --------
+mkdir -p "$T/plain-dir"
+if run 5 "not-a-repo: UNMEASURED" --repo "$T/plain-dir"; then
+  if [ "$(verdict_of)" = UNMEASURED ] &&
+    ! printf '%s\n' "$OUT" | grep -q 'verdict VERIFIED'; then
+    ok "not-a-repo: an unresolvable store is UNMEASURED (exit 5) and emits NO clean signal"
+  else
+    bad "not-a-repo: verdict was '$(verdict_of)'"
+  fi
+  if printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: unmeasured-cause '; then
+    ok "not-a-repo: the run NAMES what could not be measured"
+  else
+    bad "not-a-repo: UNMEASURED with no cause line"
+  fi
+  if printf '%s\n' "$OUT" | grep -q 'MUST NOT READ THIS'; then
+    ok "not-a-repo: the verdict detail states the consumer contract (unmeasured is not clean)"
+  else
+    bad "not-a-repo: the consumer contract is not stated in the output"
+  fi
+fi
+
+# --- hermetic PATH dirs for the tool-absence cases -------------------------
+# Symlinked coreutils only; each case adds exactly the tools it intends to be present, so
+# the verdict cannot depend on what this host happens to have installed.
+mk_bin() {
+  local dir="$1" t p
+  shift
+  mkdir -p "$dir"
+  for t in bash printf mktemp rm cat sed awk grep tr sort head wc date nice chmod mkdir cmp "$@"; do
+    p=$(type -P "$t" 2>/dev/null) || continue
+    [ -n "$p" ] && ln -sf "$p" "$dir/$t" 2>/dev/null
+  done
+}
+
+# --- Case 9: NO GIT is UNMEASURED ------------------------------------------
+BIN_NOGIT="$T/bin-nogit"
+mk_bin "$BIN_NOGIT" timeout
+OUT=$(PATH="$BIN_NOGIT" bash "$SUBJECT" --repo "$R_CLEAN" 2>&1)
+RC=$?
+record_out "no-git"
+if [ "$RC" -eq 5 ] && [ "$(verdict_of)" = UNMEASURED ] &&
+  printf '%s\n' "$OUT" | grep -q 'git is not on PATH'; then
+  ok "no-git: without git the sweep is UNMEASURED (exit 5) naming the missing tool"
+else
+  bad "no-git: rc=$RC verdict='$(verdict_of)' (wanted 5/UNMEASURED)"
+fi
+
+# --- Case 10: NO TIMEOUT BINARY refuses to run UNBOUNDED -------------------
+# The RED ARM is one property against Case 11's control: the same hermetic PATH, with and
+# without a `timeout`.
+BIN_NOTO="$T/bin-notimeout"
+mk_bin "$BIN_NOTO" git
+rm -f "$BIN_NOTO/timeout" "$BIN_NOTO/gtimeout"
+if [ ! -e "$BIN_NOTO/timeout" ] && [ ! -e "$BIN_NOTO/gtimeout" ] && [ -e "$BIN_NOTO/git" ]; then
+  ok "no-timeout-plant: the plant IS the property described (git present, neither timeout nor gtimeout)"
+else
+  bad "no-timeout-plant: the hermetic PATH is not the shape the case claims"
+fi
+OUT=$(PATH="$BIN_NOTO" bash "$SUBJECT" --repo "$R_CLEAN" 2>&1)
+RC=$?
+record_out "no-timeout"
+if [ "$RC" -eq 5 ] && [ "$(verdict_of)" = UNMEASURED ] &&
+  printf '%s\n' "$OUT" | grep -q 'UNBOUNDED'; then
+  ok "no-timeout: an unboundable host REFUSES to sweep and is UNMEASURED, never VERIFIED"
+else
+  bad "no-timeout: rc=$RC verdict='$(verdict_of)' (wanted 5/UNMEASURED)"
+fi
+
+# --- Case 11: the CONTROL for Case 10 --------------------------------------
+BIN_TO="$T/bin-timeout"
+mk_bin "$BIN_TO" git timeout gtimeout
+OUT=$(PATH="$BIN_TO" bash "$SUBJECT" --repo "$R_CLEAN" 2>&1)
+RC=$?
+record_out "hermetic-control"
+if [ "$RC" -eq 0 ] && [ "$(verdict_of)" = VERIFIED ]; then
+  ok "hermetic-control: the SAME hermetic PATH plus a timeout binary reaches VERIFIED — Case 10's refusal is the bound, not the sandbox"
+else
+  bad "hermetic-control: rc=$RC verdict='$(verdict_of)' — Case 10 proves nothing without this"
+fi
+
+# --- Case 12: an EXPIRED BOUND is UNMEASURED, never VERIFIED ---------------
+# A git shim that SLEEPS on `fsck` and delegates everything else to the real git, so the
+# only difference from the control below is the sleep. Two halves: the shim records its
+# invocations (so the degrade is attributed to a call that really happened), and the same
+# fixture with a NON-sleeping shim still reaches VERIFIED.
+REAL_GIT=$(command -v git 2>/dev/null) || REAL_GIT=""
+if [ -z "$REAL_GIT" ]; then
+  bad "bound-expired: no git on PATH — the bound cannot be exercised"
+else
+  SHIM_SLOW="$T/shim-slow"
+  SHIM_FAST="$T/shim-fast"
+  SHIM_LOG="$T/shim-calls.txt"
+  : >"$SHIM_LOG"
+  mk_bin "$SHIM_SLOW" timeout gtimeout sleep
+  mk_bin "$SHIM_FAST" timeout gtimeout sleep
+  for _pair in "$SHIM_SLOW:yes" "$SHIM_FAST:no"; do
+    _d=${_pair%:*}
+    _slow=${_pair#*:}
+    rm -f "$_d/git"
+    {
+      printf '#!/usr/bin/env bash\n'
+      printf '# Test shim: log fsck calls; %s; delegate everything else to the real git.\n' \
+        "$([ "$_slow" = yes ] && echo 'SLEEP past the bound on fsck' || echo 'run fsck normally')"
+      printf 'for a in "$@"; do if [ "$a" = fsck ]; then printf %%s\\\\n "$*" >>"%s"; ' "$SHIM_LOG"
+      if [ "$_slow" = yes ]; then printf 'sleep 30; exit 0; '; fi
+      printf 'break; fi; done\n'
+      printf 'exec %s "$@"\n' "$REAL_GIT"
+    } >"$_d/git"
+    chmod +x "$_d/git"
+  done
+  if grep -q 'sleep 30' "$SHIM_SLOW/git" && ! grep -q 'sleep 30' "$SHIM_FAST/git"; then
+    ok "bound-plant: the two shims differ in EXACTLY one property (the sleep past the bound)"
+  else
+    bad "bound-plant: the shims are not the pair described"
+  fi
+  OUT=$(PATH="$SHIM_SLOW:$PATH" bash "$SUBJECT" --repo "$R_CLEAN" --timeout 1 2>&1)
+  RC=$?
+  record_out "bound-expired"
+  if [ "$RC" -eq 5 ] && [ "$(verdict_of)" = UNMEASURED ] &&
+    printf '%s\n' "$OUT" | grep -q 'exceeded its 1s bound' &&
+    [ -s "$SHIM_LOG" ]; then
+    ok "bound-expired: a sweep killed at its bound is UNMEASURED (exit 5), and the fsck really was invoked"
+  else
+    bad "bound-expired: rc=$RC verdict='$(verdict_of)' shim-invoked=$([ -s "$SHIM_LOG" ] && echo yes || echo no)"
+  fi
+  OUT=$(PATH="$SHIM_FAST:$PATH" bash "$SUBJECT" --repo "$R_CLEAN" --timeout 1 2>&1)
+  RC=$?
+  record_out "bound-control"
+  if [ "$RC" -eq 0 ] && [ "$(verdict_of)" = VERIFIED ]; then
+    ok "bound-control: the NON-sleeping shim at the SAME 1s bound reaches VERIFIED — the sleep is what expired it"
+  else
+    bad "bound-control: rc=$RC verdict='$(verdict_of)' — the expired-bound case proves nothing without this"
+  fi
+fi
+
+# --- Case 13: usage errors are exit 2 and emit NO verdict ------------------
+usage_case() {
+  local desc="$1"
+  shift
+  OUT=$(bash "$SUBJECT" "$@" 2>&1)
+  RC=$?
+  record_out "usage $desc"
+  if [ "$RC" -eq 2 ] && [ "$(verdict_lines)" -eq 0 ]; then
+    ok "usage: $desc -> exit 2 with NO verdict line (exit 0 means VERIFIED here)"
+  else
+    bad "usage: $desc -> rc=$RC with $(verdict_lines) verdict line(s), wanted 2 and 0"
+  fi
+}
+usage_case "an unrecognised flag" --bogus
+usage_case "a bare positional" somewhere
+usage_case "--timeout with a non-numeric value" --timeout abc
+usage_case "--timeout 0 (which would kill every sweep instantly)" --timeout 0
+usage_case "--repo with no value" --repo
+usage_case "a repeated --repo" --repo "$R_CLEAN" --repo "$R_TWIN"
+usage_case "--help (a run that measured nothing must not exit 0)" --help
+
+# --- Case 14: the STATIC TEMPLATE TEXT, structurally ----------------------
+# Only WHOLE-LINE comments are stripped: this file's `#` characters live inside printf
+# formats (`(#3749)`) and parameter expansions (`${s//...}`), so a trailing-comment strip
+# could TRUNCATE a template and HIDE a token. Keeping too much text can only produce a
+# false FAIL, never a false PASS.
+grep -v '^[[:space:]]*#' "$SUBJECT" >"$T/subject-code.txt"
+code_lines=$(grep -c . "$T/subject-code.txt" | tr -d ' ')
+all_lines=$(grep -c . "$SUBJECT" | tr -d ' ')
+if [ "$code_lines" -lt "$all_lines" ] && [ "$code_lines" -gt 60 ] &&
+  grep -q 'verdict VERIFIED' "$T/subject-code.txt" &&
+  grep -q 'verdict CORRUPT' "$T/subject-code.txt" &&
+  grep -q 'verdict UNMEASURED' "$T/subject-code.txt"; then
+  ok "template: the comment-stripped source ($code_lines of $all_lines lines) still holds the output templates"
+else
+  bad "template: the comment strip left no usable template text ($code_lines of $all_lines) — the case would be vacuous"
+fi
+tmpl_bad=0
+for tok in PASS 'RESULT:' OK; do
+  if grep -q -- "$tok" "$T/subject-code.txt"; then
+    bad "template: the script's own static text contains the FOREIGN verdict token '$tok': $(grep -m1 -- "$tok" "$T/subject-code.txt")"
+    tmpl_bad=1
+  fi
+done
+[ "$tmpl_bad" -eq 0 ] &&
+  ok "template: the static text carries none of PASS, OK, RESULT: — its output can never be pasted as a gate/roborev block"
+own_bad=$(grep -nE 'VERIFIED|CORRUPT|UNMEASURED' "$T/subject-code.txt" | grep -v 'verdict ' | head -1)
+if [ -z "$own_bad" ]; then
+  ok "template: its OWN verdict tokens appear only on 'verdict ' templates (structural)"
+else
+  bad "template: a verdict token appears off the verdict line: $own_bad"
+fi
+
+# --- Case 15: it MUTATES NOTHING ------------------------------------------
+# A verifier with a side effect is a worse verifier, and this one is run from a hygiene
+# path on a box other lanes share. Compared as a sorted listing of the whole repo
+# (paths + sizes), which catches a new ref, a new pack and a rewritten object alike.
+snap() { (cd "$1" && find . -type f -exec ls -ld {} + 2>/dev/null | awk '{print $5, $NF}' | sort); }
+before=$(snap "$R_CLEAN")
+run 0 "no-mutation sweep" --repo "$R_CLEAN" >/dev/null
+after=$(snap "$R_CLEAN")
+if [ "$before" = "$after" ] && [ -n "$before" ]; then
+  ok "no-mutation: a full sweep leaves the repository byte-identical (no ref, no pack, no rewrite)"
+else
+  bad "no-mutation: the sweep changed the repository"
+fi

--- a/scripts/tests/test_check_object_store_integrity.sh
+++ b/scripts/tests/test_check_object_store_integrity.sh
@@ -154,7 +154,7 @@ whole_suite_checks() {
 # assertions (the two `command -v` guards and the fixture-construction asserts), so a
 # green run is 81 on any host that can run it at all; a green run BELOW this number
 # means cases were removed or the run was truncated. RAISE IT when you add cases.
-CASE_FLOOR=84
+CASE_FLOOR=94
 
 finish() {
   local rc=$?
@@ -358,12 +358,18 @@ fi
 # A copy of the script with `--connectivity-only` added to the fsck call. Measured on git
 # 2.43.0: that flag walks reachability WITHOUT rehashing content, so it exits 0 on the
 # Case 4 fixture. Two halves: the plant IS the defect described, and it gets Case 4 wrong.
+#
+# THE PLANT IS ON THE ARGV ARRAY, which is where the flags live since round 4 gave the
+# third walk its own mode. The previous plant sed'ed the literal `fsck --no-progress
+# --no-dangling`; when that text moved into `fargs=(...)` the sed matched NOTHING, the
+# mutant became a byte-identical copy of the subject, and the construction assert caught
+# it — which is what a construction assert is for.
 MUT="$T/mutant-connectivity-only.sh"
-sed 's/fsck --no-progress --no-dangling/fsck --no-progress --no-dangling --connectivity-only/' \
+sed 's/^  fargs=(--no-progress --no-dangling)$/  fargs=(--no-progress --no-dangling --connectivity-only)/' \
   "$SUBJECT" >"$MUT"
 if bash -n "$MUT" 2>/dev/null &&
-  grep -q -- '--connectivity-only' "$MUT" &&
-  ! grep -q -- 'fsck --no-progress --no-dangling --connectivity-only' "$SUBJECT" &&
+  grep -q -- 'fargs=(--no-progress --no-dangling --connectivity-only)' "$MUT" &&
+  ! grep -q -- 'fargs=(--no-progress --no-dangling --connectivity-only)' "$SUBJECT" &&
   [ "$(grep -c -- '--connectivity-only' "$MUT")" -gt "$(grep -c -- '--connectivity-only' "$SUBJECT")" ]; then
   ok "connectivity-mutant: the plant IS the defect described (--connectivity-only on the fsck call, absent from the subject)"
 else
@@ -648,11 +654,12 @@ if run 5 "reflog: UNMEASURED not CORRUPT" --repo "$R_REFLOG"; then
   else
     bad "reflog: verdict was '$(verdict_of)', wanted UNMEASURED — a healthy store must not read as corrupt"
   fi
-  if printf '%s\n' "$OUT" | grep -q 'reachability/ref/commit-graph' &&
-    printf '%s\n' "$OUT" | grep -q 'reflog expire'; then
-    ok "reflog: the cause NAMES the class and gives the remedy for it (not the re-clone remedy, which is for damage)"
+  if printf '%s\n' "$OUT" | grep -q 'REFLOG-SCOPED' &&
+    printf '%s\n' "$OUT" | grep -q 'reflog expire' &&
+    printf '%s\n' "$OUT" | grep -q 'pass 3: fsck --no-reflogs'; then
+    ok "reflog: the cause ATTRIBUTES the complaint (a third --no-reflogs walk cleared it => REFLOG-SCOPED) and gives that class's remedy, not the re-clone one"
   else
-    bad "reflog: the UNMEASURED cause does not name the reachability class"
+    bad "reflog: the UNMEASURED cause does not attribute the reachability complaint: $(printf '%s\n' "$OUT" | grep 'unmeasured-cause' | tail -2 | tr '\n' ' ')"
   fi
   if ! printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: object '; then
     ok "reflog: NO 'object' lines — the 40-hex tokens in a reflog diagnostic name INTACT objects, not damaged ones"
@@ -670,17 +677,29 @@ fi
 # THREE ARMS, EACH ONE PROPERTY APART: report-once vs report-always (the condition),
 # and reachability vs damage (the exit bits).
 mk_fsck_shim() {
-  # mk_fsck_shim <dir> <always|once> <rc> <message> <log>
-  local d="$1" when="$2" rc="$3" msg="$4" log="$5"
+  # mk_fsck_shim <dir> <always|once> <rc> <message> <log> [rc-when---no-reflogs]
+  #
+  # THE SIXTH ARGUMENT IS WHAT MAKES THE REACHABILITY-CAUSE ARMS POSSIBLE (#3749 review
+  # round 4). The subject's third walk carries `--no-reflogs`, and the whole question it
+  # asks is whether the complaint SURVIVES that flag — so a shim that answered the same
+  # way to both configurations could not stage either outcome. It defaults to <rc>, which
+  # is what every pre-round-4 arm wants (a shim that has no opinion about reflogs).
+  local d="$1" when="$2" rc="$3" msg="$4" log="$5" nrl_rc="${6:-$3}"
   mk_bin "$d" timeout gtimeout
   rm -f "$d/git"
   {
     printf '#!/usr/bin/env bash\n'
-    printf '# Test shim: on `fsck`, report %s and exit %s; delegate everything else.\n' "$when" "$rc"
+    printf '# Test shim: on `fsck`, report %s and exit %s (%s with --no-reflogs); delegate everything else.\n' "$when" "$rc" "$nrl_rc"
+    printf 'nrl=0\n'
+    printf 'for a in "$@"; do [ "$a" = --no-reflogs ] && nrl=1; done\n'
     printf 'for a in "$@"; do\n'
     printf '  if [ "$a" = fsck ]; then\n'
     printf '    printf "call\\n" >>%s\n' "$(printf '%q' "$log")"
     printf '    n=$(grep -c . %s 2>/dev/null || printf 0)\n' "$(printf '%q' "$log")"
+    printf '    if [ "$nrl" = 1 ]; then\n'
+    printf '      if [ %s -ne 0 ]; then printf "%%s\\n" %s >&2; fi\n' "$(printf '%q' "$nrl_rc")" "$(printf '%q' "$msg")"
+    printf '      exit %s\n' "$nrl_rc"
+    printf '    fi\n'
     if [ "$when" = always ]; then
       printf '    if [ 1 -eq 1 ]; then\n'
     else
@@ -726,19 +745,78 @@ else
     bad "discriminator(transient): rc=$RC verdict='$(verdict_of)' walks=$(grep -c . "$LOG_ONCE" | tr -d ' ') (wanted 0/VERIFIED/2)"
   fi
   # (b) ONE PROPERTY APART: the same message on EVERY walk. It reproduces, so it is
-  #     non-passing — and still not CORRUPT, because it is the reachability class.
+  #     non-passing — and still not CORRUPT, because with the reflogs EXCLUDED it clears
+  #     (the shim's 6th argument), which is what makes it reflog-scoped rather than
+  #     damage. THREE walks now: sweep, reproduction, attribution.
   SH_ALWAYS="$T/shim-always"
   LOG_ALWAYS="$T/shim-always-calls.txt"
   : >"$LOG_ALWAYS"
-  mk_fsck_shim "$SH_ALWAYS" always 2 "$RL_MSG" "$LOG_ALWAYS"
+  mk_fsck_shim "$SH_ALWAYS" always 2 "$RL_MSG" "$LOG_ALWAYS" 0
   OUT=$(PATH="$SH_ALWAYS:$PATH" bash "$SUBJECT" --repo "$R_CLEAN" 2>&1)
   RC=$?
   record_out "discriminator-persistent"
   if [ "$RC" -eq 5 ] && [ "$(verdict_of)" = UNMEASURED ] &&
-    [ "$(grep -c . "$LOG_ALWAYS" | tr -d ' ')" -eq 2 ]; then
-    ok "discriminator: the SAME diagnostic on BOTH walks does not reach VERIFIED — the re-run is a discriminator, not a retry-until-clean"
+    [ "$(grep -c . "$LOG_ALWAYS" | tr -d ' ')" -eq 3 ] &&
+    printf '%s\n' "$OUT" | grep -q 'REFLOG-SCOPED'; then
+    ok "discriminator: the SAME reachability diagnostic on BOTH walks does not reach VERIFIED — and having cleared with --no-reflogs it is attributed REFLOG-SCOPED, not damage (3 walks)"
   else
-    bad "discriminator(persistent): rc=$RC verdict='$(verdict_of)' walks=$(grep -c . "$LOG_ALWAYS" | tr -d ' ') (wanted 5/UNMEASURED/2)"
+    bad "discriminator(persistent): rc=$RC verdict='$(verdict_of)' walks=$(grep -c . "$LOG_ALWAYS" | tr -d ' ') (wanted 5/UNMEASURED/3 naming REFLOG-SCOPED)"
+  fi
+  # (b2) THE ITEM-1 DEFECT, STAGED: one property from (b) — the complaint SURVIVES the
+  #      reflog-excluded walk. Before round 4 this reached UNMEASURED, which the
+  #      supervisor deliberately continues past, so workers kept running against a store
+  #      with an object missing from under a live ref.
+  SH_LIVE="$T/shim-live-reachable"
+  LOG_LIVE="$T/shim-live-reachable-calls.txt"
+  : >"$LOG_LIVE"
+  mk_fsck_shim "$SH_LIVE" always 2 'missing blob 1111111111111111111111111111111111111111' "$LOG_LIVE" 2
+  OUT=$(PATH="$SH_LIVE:$PATH" bash "$SUBJECT" --repo "$R_CLEAN" 2>&1)
+  RC=$?
+  record_out "discriminator-live-reachable"
+  if [ "$RC" -eq 4 ] && [ "$(verdict_of)" = CORRUPT ] &&
+    [ "$(grep -c . "$LOG_LIVE" | tr -d ' ')" -eq 3 ]; then
+    ok "reachability-attribution: a reachability complaint that SURVIVES --no-reflogs is CORRUPT (exit 4) — the false negative round 4 fixed, staged one property from (b)"
+  else
+    bad "reachability-attribution(live): rc=$RC verdict='$(verdict_of)' walks=$(grep -c . "$LOG_LIVE" | tr -d ' ') (wanted 4/CORRUPT/3)"
+  fi
+  if printf '%s\n' "$OUT" | grep -q 'is the remedy for the OTHER cause' &&
+    ! printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: object '; then
+    ok "reachability-attribution: the CORRUPT remedy says the reflog remedy does NOT apply, and no 40-hex token is labelled an affected 'object' (a broken-link diagnostic names the intact source too)"
+  else
+    bad "reachability-attribution: the CORRUPT branch's remedy/labelling is wrong: $(printf '%s\n' "$OUT" | grep 'verdict-detail' | head -3 | tr '\n' ' ')"
+  fi
+  # (b3) THE ATTRIBUTION ITSELF FAILING is not a licence to pick either verdict: a third
+  #      walk that returns a status this script cannot read leaves the reproduced
+  #      complaint UNATTRIBUTED, which is neither CORRUPT nor clean. One property from
+  #      (b2): the third walk's status.
+  SH_UNATTR="$T/shim-unattributable"
+  LOG_UNATTR="$T/shim-unattributable-calls.txt"
+  : >"$LOG_UNATTR"
+  mk_fsck_shim "$SH_UNATTR" always 2 "$RL_MSG" "$LOG_UNATTR" 128
+  OUT=$(PATH="$SH_UNATTR:$PATH" bash "$SUBJECT" --repo "$R_CLEAN" 2>&1)
+  RC=$?
+  record_out "discriminator-unattributable"
+  if [ "$RC" -eq 5 ] && [ "$(verdict_of)" = UNMEASURED ] &&
+    printf '%s\n' "$OUT" | grep -q 'could NOT be attributed'; then
+    ok "reachability-attribution: a third walk that produces no usable answer leaves the complaint UNATTRIBUTED and non-passing — never CORRUPT on an unreadable status, never clean"
+  else
+    bad "reachability-attribution(unattributable): rc=$RC verdict='$(verdict_of)' (wanted 5/UNMEASURED naming the failed attribution)"
+  fi
+  # (b4) AND A DAMAGE BIT SEEN ONLY IN THE THIRD WALK has not reproduced across the two
+  #      sweep walks, so it is UNMEASURED too — the third walk can strengthen the
+  #      reachability verdict, it cannot introduce a damage verdict of its own.
+  SH_L8="$T/shim-late-damage"
+  LOG_L8="$T/shim-late-damage-calls.txt"
+  : >"$LOG_L8"
+  mk_fsck_shim "$SH_L8" always 2 "$RL_MSG" "$LOG_L8" 1
+  OUT=$(PATH="$SH_L8:$PATH" bash "$SUBJECT" --repo "$R_CLEAN" 2>&1)
+  RC=$?
+  record_out "discriminator-late-damage"
+  if [ "$RC" -eq 5 ] && [ "$(verdict_of)" = UNMEASURED ] &&
+    printf '%s\n' "$OUT" | grep -q 'appeared ONLY in the'; then
+    ok "reachability-attribution: a damage bit appearing ONLY in the third walk is UNMEASURED — the attribution walk cannot manufacture a damage verdict the sweep walks never saw"
+  else
+    bad "reachability-attribution(late-damage): rc=$RC verdict='$(verdict_of)' (wanted 5/UNMEASURED naming the third-walk-only damage)"
   fi
   # (c) A DAMAGE class (fsck exit bit 1) seen ONCE and not the second time is
   #     UNMEASURED: neither established damage nor a clean store. One property apart
@@ -1267,4 +1345,122 @@ if [ "$green_st" -ne 0 ]; then
   ok "signal-trap: THIS suite's own trap declarations exit NONZERO ($green_st) on SIGTERM — a signalled run can never be read as a pass with cases unrun"
 else
   bad "signal-trap: this suite's traps exit 0 on SIGTERM — a truncated run reports green"
+fi
+
+# --- Case 27: A MISSING LIVE-REACHABLE OBJECT IS CORRUPT (real fixtures) ----
+# THE DEFECT THIS CASE EXISTS FOR (#3749 review round 4, item 1). fsck raises
+# ERROR_REACHABLE (exit bit 2) for BOTH a stale reflog entry — routine on a store eight
+# lanes write — and an object that is genuinely ABSENT while a live ref still needs it.
+# The round-2/3 classifier put both on UNMEASURED, which is deliberately NON-FATAL to the
+# supervisor's loop, so a demonstrably damaged store went on spawning workers and the
+# journal called it "not measured". That is a false negative on real corruption, the one
+# direction this whole control exists to prevent.
+#
+# TWO REAL FIXTURES, ONE PROPERTY APART, AND THE PROPERTY IS *WHAT STILL NEEDS THE
+# OBJECT*. Both are built by the same code path and both have exactly one loose object
+# deleted; in the first, HEAD's tree names it, and in the second only the reflog does.
+# No shim: the round-4 arms in Case 17 stage the same two outcomes with a shim, which
+# proves the classifier reacts to the flag, while these prove that REAL GIT answers the
+# two configurations differently in the way the classifier depends on.
+mk_missing_obj_repo() {
+  # mk_missing_obj_repo <name> <live|reflog> -> path
+  local r="$T/$1" mode="$2" victim=""
+  mkdir -p "$r"
+  git init -q "$r" >/dev/null 2>&1
+  g "$r" config user.email t@t
+  g "$r" config user.name t
+  printf 'content aaa\n' >"$r/f1"
+  g "$r" add f1 >/dev/null
+  g "$r" -c user.email=t@t -c user.name=t commit -q -m c1 >/dev/null
+  printf 'content bbb\n' >"$r/f2"
+  g "$r" add f2 >/dev/null
+  g "$r" -c user.email=t@t -c user.name=t commit -q -m c2 >/dev/null
+  if [ "$mode" = live ]; then
+    # The blob HEAD's tree still names.
+    victim=$(g "$r" rev-parse HEAD:f2 2>/dev/null)
+  else
+    # A commit that ONLY the reflog names: created, then reset away.
+    victim=$(g "$r" rev-parse HEAD 2>/dev/null)
+    g "$r" reset -q --hard HEAD~1 >/dev/null 2>&1
+  fi
+  if [ -n "$victim" ]; then
+    chmod u+w "$(loose_path "$r" "$victim")" 2>/dev/null
+    rm -f "$(loose_path "$r" "$victim")"
+  fi
+  printf '%s' "$r"
+}
+# fsck_status_mode <repo> [--no-reflogs] -> the exit status
+fsck_status_mode() {
+  local r="$1" rc=0
+  if [ "${2:-}" = --no-reflogs ]; then
+    git -C "$r" fsck --no-progress --no-dangling --no-reflogs >/dev/null 2>&1 || rc=$?
+  else
+    git -C "$r" fsck --no-progress --no-dangling >/dev/null 2>&1 || rc=$?
+  fi
+  printf '%s' "$rc"
+}
+R_LIVE_MISS=$(mk_missing_obj_repo missing-live live)
+R_REFLOG_MISS=$(mk_missing_obj_repo missing-reflog reflog)
+LM_WITH=$(fsck_status_mode "$R_LIVE_MISS")
+LM_WITHOUT=$(fsck_status_mode "$R_LIVE_MISS" --no-reflogs)
+RM_WITH=$(fsck_status_mode "$R_REFLOG_MISS")
+RM_WITHOUT=$(fsck_status_mode "$R_REFLOG_MISS" --no-reflogs)
+# THE CONSTRUCTION ASSERT IS ON THE BITS, not on literal numbers, and it asserts the
+# DISCRIMINATING OBSERVABLE: this is what makes the fixtures the two things the case
+# claims. A git that answered the two configurations the same way would red HERE
+# (attributable) rather than passing the cases below (not).
+if [ "$((LM_WITH & 2))" -ne 0 ] && [ "$((LM_WITH & 5))" -eq 0 ] &&
+  [ "$((LM_WITHOUT & 2))" -ne 0 ] &&
+  [ "$((RM_WITH & 2))" -ne 0 ] && [ "$((RM_WITH & 5))" -eq 0 ] &&
+  [ "$RM_WITHOUT" -eq 0 ]; then
+  ok "missing-object-plant: the two fixtures ARE what the case claims (live-reachable: fsck $LM_WITH with reflogs and $LM_WITHOUT without, both ERROR_REACHABLE and no damage bit; reflog-only: $RM_WITH with reflogs and $RM_WITHOUT without)"
+else
+  bad "missing-object-plant: live=$LM_WITH/$LM_WITHOUT reflog-only=$RM_WITH/$RM_WITHOUT — not the two shapes the case is about; the cases below would prove nothing"
+fi
+if run 4 "missing live-reachable object: CORRUPT" --repo "$R_LIVE_MISS"; then
+  if [ "$(verdict_of)" = CORRUPT ]; then
+    ok "missing-live: an object MISSING while HEAD's tree still names it is CORRUPT (exit 4) — it stops the supervisor, where the pre-round-4 UNMEASURED did not"
+  else
+    bad "missing-live: verdict='$(verdict_of)', wanted CORRUPT — real corruption reported as something a consumer continues past"
+  fi
+  if printf '%s\n' "$OUT" | grep -q 'pass 3: fsck --no-reflogs' &&
+    printf '%s\n' "$OUT" | grep -q 'live ref, the index or HEAD' &&
+    printf '%s\n' "$OUT" | grep -q '^OBJECT-STORE: finding missing '; then
+    ok "missing-live: the verdict is attributed by a THIRD --no-reflogs walk, says which roots still need the object, and names the diagnostic"
+  else
+    bad "missing-live: the CORRUPT verdict does not show the attribution: $(printf '%s\n' "$OUT" | grep -E 'measured pass|verdict-detail' | head -4 | tr '\n' ' ')"
+  fi
+fi
+# ONE PROPERTY APART: the same deletion, reachable only from the reflog. Non-passing and
+# NOT the fatal branch — so the CORRUPT above is attributable to the LIVE reachability and
+# not merely to "an object is missing".
+if run 5 "missing reflog-only object: UNMEASURED" --repo "$R_REFLOG_MISS"; then
+  if [ "$(verdict_of)" = UNMEASURED ] &&
+    printf '%s\n' "$OUT" | grep -q 'REFLOG-SCOPED'; then
+    ok "missing-reflog-only: an object only the REFLOG names clears with --no-reflogs, so it stays REFLOG-SCOPED and non-passing — never the fatal branch, and never clean"
+  else
+    bad "missing-reflog-only: verdict='$(verdict_of)' — wanted UNMEASURED attributed REFLOG-SCOPED"
+  fi
+fi
+
+# --- Case 28: THE SWEEP WALKS NEVER CARRY `--no-reflogs` (structural) -------
+# `--no-reflogs` belongs to the reachability-CAUSE discriminator and to nothing else.
+# Round 1 proposed it as a way to SUPPRESS the intermittent reflog false positive, the
+# lead measured it and rejected it, and the two uses are one edit apart: put it on the
+# sweep and a real missing object on a store with reflogs stops being reported at all.
+# Behaviour cannot see the difference (both configurations exit 0 on a healthy store), so
+# the guard is structural over the shipped call sites.
+sweep_calls=$(grep -n '^[[:space:]]*fsck_pass ' "$SUBJECT")
+p12_bad=$(printf '%s\n' "$sweep_calls" | grep -E 'fsck_pass p[12]\b' | grep -- '--no-reflogs' | head -1)
+p3_ok=$(printf '%s\n' "$sweep_calls" | grep -cE 'fsck_pass p3 --no-reflogs$' | tr -d ' ')
+n_calls=$(printf '%s\n' "$sweep_calls" | grep -c . | tr -d ' ')
+if [ "$n_calls" -ge 3 ] && [ "$p3_ok" -eq 1 ]; then
+  ok "no-reflogs-plant: the shipped script has $n_calls fsck_pass call sites and exactly one is the p3 --no-reflogs attribution walk — the assert below has a subject"
+else
+  bad "no-reflogs-plant: $n_calls fsck_pass call site(s), p3-with-flag=$p3_ok — the call sites moved; the assert below would be vacuous"
+fi
+if [ -z "$p12_bad" ]; then
+  ok "no-reflogs: passes 1 and 2 — the sweep proper — carry no --no-reflogs, so the flag cannot become a suppressor of the very class it exists to attribute (structural)"
+else
+  bad "no-reflogs: a SWEEP walk carries --no-reflogs: $p12_bad"
 fi

--- a/scripts/tests/test_check_object_store_integrity.sh
+++ b/scripts/tests/test_check_object_store_integrity.sh
@@ -1358,41 +1358,69 @@ if [ "$trap_n" -ge 4 ] && grep -qx 'trap finish EXIT' "$TRAP_SRC" &&
 else
   bad "signal-trap-plant: extracted $trap_n trap line(s) [$(tr '\n' ';' <"$TRAP_SRC")] — the case below would prove nothing"
 fi
-# mk_trap_harness <path> <trap-file> — the real `finish`'s status rule plus <trap-file>'s
-# declarations, then a loop whose last command exits 0.
+# mk_trap_harness <path> <trap-file> <ready-file> — the real `finish`'s status rule plus
+# <trap-file>'s declarations, a READINESS STAMP, then a loop whose last command exits 0.
 mk_trap_harness() {
-  local path="$1" traps="$2"
+  local path="$1" traps="$2" ready="$3"
   {
     printf '#!/usr/bin/env bash\n'
     printf 'finish() { local rc=$?; if [ "$rc" -ne 0 ]; then exit 1; fi; exit 0; }\n'
     cat "$traps"
+    # THE SIGNAL IS ORDERED BY THIS STAMP, NEVER BY A SLEEP. A fixed delay would be a
+    # wall-clock race of exactly the class this file's fixture pin removes: on a loaded
+    # box bash can take longer than the delay to start, parse and INSTALL ITS TRAPS, and
+    # a SIGTERM arriving before them is handled by the DEFAULT disposition (exit 143).
+    # That makes the RED arm below — which requires the old form to exit 0 — fail-close
+    # for a reason that has nothing to do with the trap form under test, while the GREEN
+    # arm would still pass, for the wrong reason. The stamp is written only after every
+    # trap declaration has executed, so the kill below cannot outrun them.
+    printf 'printf r >%q\n' "$ready"
     printf 'while :; do :; done\n'
   } >"$path"
   chmod +x "$path"
 }
-# term_status <harness> -> the exit status after a SIGTERM 0.3s in.
+# term_status <harness> <ready-file> -> the exit status after a SIGTERM delivered once the
+# harness has AFFIRMATIVELY installed its traps, or `not-ready` if it never got there
+# (bounded: a wedged harness fails the run rather than hanging it).
 term_status() {
-  local h="$1" pid st=0
+  local h="$1" ready="$2" pid st=0 waited=0
+  rm -f "$ready"
   bash "$h" >/dev/null 2>&1 &
   pid=$!
-  sleep 0.3
+  while [ ! -e "$ready" ] && [ "$waited" -lt 200 ]; do
+    sleep 0.05
+    waited=$((waited + 1))
+  done
+  if [ ! -e "$ready" ]; then
+    kill -KILL "$pid" 2>/dev/null
+    wait "$pid" 2>/dev/null
+    printf 'not-ready'
+    return
+  fi
   kill -TERM "$pid" 2>/dev/null
   wait "$pid" 2>/dev/null || st=$?
   printf '%s' "$st"
 }
-mk_trap_harness "$T/trap-green.sh" "$TRAP_SRC"
+mk_trap_harness "$T/trap-green.sh" "$TRAP_SRC" "$T/trap-green.ready"
 printf 'trap finish EXIT\ntrap %s INT TERM HUP\n' "'finish'" >"$T/trap-red-lines.txt"
-mk_trap_harness "$T/trap-red.sh" "$T/trap-red-lines.txt"
-green_st=$(term_status "$T/trap-green.sh")
-red_st=$(term_status "$T/trap-red.sh")
-if [ "$red_st" -eq 0 ]; then
+mk_trap_harness "$T/trap-red.sh" "$T/trap-red-lines.txt" "$T/trap-red.ready"
+green_st=$(term_status "$T/trap-green.sh" "$T/trap-green.ready")
+red_st=$(term_status "$T/trap-red.sh" "$T/trap-red.ready")
+# A NON-NUMERIC STATUS IS ITS OWN REFUSAL, never fed to `[ ... -eq ]`: an unmeasured
+# harness must not be read as either verdict.
+trap_measured=yes
+case "$green_st" in '' | *[!0-9]*) trap_measured=no ;; esac
+case "$red_st" in '' | *[!0-9]*) trap_measured=no ;; esac
+if [ "$trap_measured" = no ]; then
+  bad "signal-trap-harness: a harness never reported its traps installed (green='$green_st' red='$red_st') — the two cases here would prove nothing"
+elif [ "$red_st" -eq 0 ]; then
   ok "signal-trap-control: the OLD form (a signal delegating straight to finish) really does exit 0 on SIGTERM — the harness can see the defect"
 else
   bad "signal-trap-control: the old form exited $red_st, not 0 — a green below would prove nothing"
 fi
-if [ "$green_st" -ne 0 ]; then
+if [ "$trap_measured" = yes ] && [ "$green_st" -ne 0 ]; then
   ok "signal-trap: THIS suite's own trap declarations exit NONZERO ($green_st) on SIGTERM — a signalled run can never be read as a pass with cases unrun"
-else
+elif [ "$trap_measured" = yes ]; then
   bad "signal-trap: this suite's traps exit 0 on SIGTERM — a truncated run reports green"
 fi
 

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -9360,8 +9360,11 @@ t test_lane_lock_failure_cause_is_not_inferred_from_later_state
 # `FATAL: lane-identity-unprovable` when it cannot derive a per-lane identity, and a
 # plain scratch repo is not a lane worktree. Supplying the identity is what the refusal
 # itself recommends, and it keeps the fixture a one-`git init` tree.
+# The optional 5th argument is a shell line the stub runs BEFORE printing its verdict —
+# used by the monotonicity case to have a PEER LANE latch the box while this lane's sweep
+# is still in flight, which is the only way to stage the stale-writer race in one process.
 obj_sweep_tree() {
-  local d="$1" verdict="$2" rc="$3" calllog="${4:-}" root="$d/root"
+  local d="$1" verdict="$2" rc="$3" calllog="${4:-}" during="${5:-}" root="$d/root"
   mkdir -p "$root/scripts/local" "$root/scripts/lib"
   git -C "$root" init -q 2>/dev/null
   git -C "$root" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init 2>/dev/null
@@ -9373,6 +9376,7 @@ obj_sweep_tree() {
     printf '#!/usr/bin/env bash\n'
     printf '# STUB sweep: record the invocation, print one anchored verdict, exit with its code.\n'
     [[ -n "$calllog" ]] && printf 'printf "called\\n" >>%s\n' "$(printf '%q' "$calllog")"
+    [[ -n "$during" ]] && printf '%s\n' "$during"
     printf 'printf "OBJECT-STORE: measured stub\\n"\n'
     printf 'printf "OBJECT-STORE: object deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\\n"\n'
     printf 'printf "OBJECT-STORE: verdict %s\\n"\n' "$verdict"
@@ -9566,21 +9570,32 @@ t test_object_store_sweep_verdicts
 t test_object_store_sweep_throttle_and_disable
 t test_object_store_sweep_knobs
 
-# THE THROTTLE MUST NOT SUPPRESS A PEER LANE'S CORRUPT (#3749 review, BLOCKER A).
+# THE THROTTLE MUST NOT SUPPRESS A PEER LANE'S CORRUPT, AND NOTHING MAY UN-RECORD ONE
+# (#3749 review, BLOCKER A of round 1 and BLOCKER 1 of round 2).
 #
-# THE DEFECT: the stamp is keyed on the SHARED object store and lives in a box-wide
-# directory, and it used to record only a TIMESTAMP — written for every outcome. So the
-# lane that DETECTED corruption stopped, and its three peers then saw a fresh stamp,
-# skipped their own sweep for the whole 6-hour interval, and kept spawning workers against
-# a store known to be damaged: the exact harm the feature exists to prevent, delivered by
-# its own throttle.
+# THE ROUND-1 DEFECT: the stamp is keyed on the SHARED object store and lives in a
+# box-wide directory, and it used to record only a TIMESTAMP — written for every outcome.
+# So the lane that DETECTED corruption stopped, and its three peers then saw a fresh
+# stamp, skipped their own sweep for the whole 6-hour interval, and kept spawning workers
+# against a store known to be damaged: the exact harm the feature exists to prevent,
+# delivered by its own throttle.
 #
-# The two halves are asserted separately, because either alone can pass while the box is
-# still unprotected: (1) a CORRUPT run RECORDS the verdict, and (2) a later lane reading
-# that record STOPS — without re-sweeping, and while the interval is still fresh.
+# THE ROUND-2 DEFECT, WHICH IS THE SAME HARM THROUGH A DIFFERENT DOOR: round 1 fixed it by
+# putting the VERDICT in that same stamp. A stamp write is an unsynchronised overwrite, so
+# a lane whose sweep STARTED before the detection could finish AFTER it and replace
+# `CORRUPT` with `VERIFIED`. Peers then throttle on the fresh non-corrupt stamp and keep
+# working. The verdict therefore no longer lives in a mutable cell at all: it is a
+# SEPARATE CREATE-ONLY file, `<stamp>.CORRUPT`, whose only transition is ABSENT -> PRESENT.
+#
+# The halves are asserted separately, because each can pass while the box is unprotected:
+# (1) a CORRUPT run RECORDS the verdict, (2) a later lane reading that record STOPS,
+# (3) the record NAMES how to clear it, (4) the control shows the stop is the record and
+# not the file's mere presence, (5) A WRITER FINISHING AFTER THE RECORD CANNOT UNDO IT,
+# and (6) the create-only primitive itself is create-only, extracted from the shipped
+# script rather than restated here.
 test_object_store_corrupt_verdict_outlives_the_throttle() {
-  local d root counter calls rc stamp
-  # (1) A CORRUPT sweep records the VERDICT beside the timestamp.
+  local d root counter calls rc stamp latch
+  # (1) A CORRUPT sweep records the verdict in the LATCH, beside a plain-epoch stamp.
   d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-corrupt"
   common_env "$d"
   write_finalize_stub "$d/bin/worker.sh" "$counter"
@@ -9588,20 +9603,21 @@ test_object_store_corrupt_verdict_outlives_the_throttle() {
   export MAX_ISSUES=1
   export OBJ_SWEEP_INTERVAL_HOURS=6
   export OBJ_SWEEP_STAMP="$d/sweep.stamp"
-  stamp="$OBJ_SWEEP_STAMP"
+  stamp="$OBJ_SWEEP_STAMP"; latch="$stamp.CORRUPT"
   root="$(obj_sweep_tree "$d" CORRUPT 4 "$calls")"
   env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/detect.log" 2>&1
   rc=$?
-  if [[ "$rc" -eq 1 ]] && [[ "$(sed -n 2p "$stamp" 2>/dev/null)" == "CORRUPT" ]] &&
-     grep -qE '^[0-9]+$' <(sed -n 1p "$stamp" 2>/dev/null); then
-    pass "obj-sweep(corrupt-latch): the detecting lane RECORDS 'CORRUPT' in the shared stamp, not just an epoch"
+  if [[ "$rc" -eq 1 && -e "$latch" ]] && grep -q '^CORRUPT$' "$latch" &&
+     grep -qE '^[0-9]+$' <(sed -n 1p "$stamp" 2>/dev/null) &&
+     [[ "$(wc -l <"$stamp" | tr -d ' ')" -eq 1 ]]; then
+    pass "obj-sweep(corrupt-latch): the detecting lane creates the box-wide CORRUPT latch, and the throttle stamp stays a plain epoch"
   else
-    fail "obj-sweep(corrupt-latch): rc=$rc stamp='$(tr '\n' '/' <"$stamp" 2>/dev/null)' (wanted an epoch then CORRUPT)"
+    fail "obj-sweep(corrupt-latch): rc=$rc latch='$(tr '\n' '/' <"$latch" 2>/dev/null)' stamp='$(tr '\n' '/' <"$stamp" 2>/dev/null)'"
   fi
   # (2) THE PEER LANE. Same box, same stamp, INSIDE the interval — and ONE property
   #     different from the run above: its sweep stub would report VERIFIED. It must still
   #     stop, and it must NOT re-sweep (the stub records its invocations, so this is
-  #     measured, not inferred) and must name how to clear the latch.
+  #     measured, not inferred).
   calls="$d/calls-peer"
   root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
   env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/peer.log" 2>&1
@@ -9609,18 +9625,18 @@ test_object_store_corrupt_verdict_outlives_the_throttle() {
   if [[ "$rc" -eq 1 && ! -s "$calls" ]] &&
      grep -q '"reason":"object-store-corrupt"' "$JOURNAL_FILE" &&
      grep -q 'object-store: CORRUPT (cached' "$d/peer.log"; then
-    pass "obj-sweep(corrupt-latch): a PEER lane inside the interval STOPS on the cached verdict instead of throttling past it — without re-sweeping"
+    pass "obj-sweep(corrupt-latch): a PEER lane inside the interval STOPS on the latch instead of throttling past it — without re-sweeping"
   else
     fail "obj-sweep(corrupt-latch-peer): rc=$rc reswept=$([[ -s "$calls" ]] && echo yes || echo no) (see $d/peer.log)"
   fi
-  if grep -q "rm -f $stamp" "$d/peer.log"; then
-    pass "obj-sweep(corrupt-latch): the remedy NAMES the file to remove — a latch nobody can clear bricks the box after the repair"
+  if grep -q "rm -f $latch" "$d/peer.log"; then
+    pass "obj-sweep(corrupt-latch): the remedy NAMES the LATCH file to remove — a latch nobody can clear bricks the box after the repair"
   else
     fail "obj-sweep(corrupt-latch): the stop gives no way to clear the latch (see $d/peer.log)"
   fi
-  # (3) THE CONTROL, one property apart from (2): the SAME fresh stamp carrying VERIFIED.
-  #     The lane must proceed and, being inside the interval, must NOT sweep — so (2)'s
-  #     stop is attributable to the recorded verdict and not to the stamp's mere presence.
+  # (3) THE CONTROL, one property apart from (2): the SAME fresh stamp with NO latch
+  #     beside it. The lane must proceed and, being inside the interval, must NOT sweep —
+  #     so (2)'s stop is attributable to the latch and not to the stamp's mere presence.
   d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-control"
   common_env "$d"
   write_finalize_stub "$d/bin/worker.sh" "$counter"
@@ -9628,18 +9644,160 @@ test_object_store_corrupt_verdict_outlives_the_throttle() {
   export MAX_ISSUES=1
   export OBJ_SWEEP_INTERVAL_HOURS=6
   export OBJ_SWEEP_STAMP="$d/sweep.stamp"
-  printf '%s\nVERIFIED\n' "$(date +%s)" >"$OBJ_SWEEP_STAMP"
+  printf '%s\n' "$(date +%s)" >"$OBJ_SWEEP_STAMP"
   root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
   env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/control.log" 2>&1
   rc=$?
   if [[ "$rc" -eq 0 && ! -s "$calls" && -f "$counter" ]]; then
-    pass "obj-sweep(corrupt-latch): the SAME stamp carrying VERIFIED throttles normally and the worker runs — the stop above is the recorded verdict, not the file"
+    pass "obj-sweep(corrupt-latch): the SAME fresh stamp WITHOUT a latch throttles normally and the worker runs — the stop above is the latch, not the file"
   else
     fail "obj-sweep(corrupt-latch-control): rc=$rc swept=$([[ -s "$calls" ]] && echo yes || echo no) spawned=$([[ -f "$counter" ]] && echo yes || echo no) (see $d)"
   fi
 }
 
 t test_object_store_corrupt_verdict_outlives_the_throttle
+
+# THE STALE WRITER (#3749 review round 2, BLOCKER 1). This is the case round 1 did not
+# have, and the one its design could not have passed.
+#
+# THE RACE, STAGED IN ONE PROCESS. Lane B reads no latch and starts a sweep. WHILE it is
+# running, peer lane A finds the store damaged and records CORRUPT. Lane B's sweep then
+# finishes and writes its own result. Under round 1 that write was an overwrite of the one
+# shared cell holding the verdict, so `VERIFIED` replaced `CORRUPT` and every lane on the
+# box — including A's successor — throttled on a fresh, non-corrupt stamp.
+#
+# The sweep stub creates the latch itself, which IS lane A's write: what matters is that
+# it lands after lane B's read and before lane B's write, and a side effect inside the
+# stub is the only way to place it there deterministically (a real second supervisor
+# would race the assertion, not the code).
+test_object_store_latch_survives_a_writer_that_finishes_after_it() {
+  local d root counter calls rc stamp latch after stamp_ts
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-late"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  stamp="$OBJ_SWEEP_STAMP"; latch="$stamp.CORRUPT"
+  # The peer's bytes are DISTINCTIVE, so "unchanged" below is a comparison and not an
+  # existence test: a re-created latch would carry the supervisor's own two lines.
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls" \
+    "printf '1700000000\nCORRUPT\nplanted-by-peer-lane-A\n' >$(printf '%q' "$latch")")"
+  # CONSTRUCTION, asserted before the subject runs: no latch exists yet, so lane B really
+  # does start its sweep unlatched and take the write path at the end.
+  if [[ ! -e "$latch" ]]; then
+    pass "obj-sweep(stale-writer-plant): the box starts UNLATCHED, so the run below really reaches the post-sweep write path"
+  else
+    fail "obj-sweep(stale-writer-plant): a latch already exists at $latch — the case below would prove nothing"
+  fi
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/late.log" 2>&1
+  rc=$?
+  after="$(cat "$latch" 2>/dev/null || true)"
+  stamp_ts="$(sed -n 1p "$stamp" 2>/dev/null || true)"
+  # CONSTRUCTION, second half: the stub really ran (so the write path really executed) and
+  # the latch really appeared DURING it.
+  if [[ "$(obj_sweep_calls "$calls")" -eq 1 && -e "$latch" ]]; then
+    pass "obj-sweep(stale-writer-plant): the sweep ran exactly once and the peer's latch appeared while it was in flight"
+  else
+    fail "obj-sweep(stale-writer-plant): calls=$(obj_sweep_calls "$calls") latch=$([[ -e "$latch" ]] && echo yes || echo no) — the assertions below would prove nothing"
+  fi
+  # THE SUBJECT: the VERIFIED writer that finished after the record did not un-record it.
+  if [[ "$after" == $'1700000000\nCORRUPT\nplanted-by-peer-lane-A' ]]; then
+    pass "obj-sweep(stale-writer): a sweep that FINISHES after a peer recorded CORRUPT cannot overwrite it — the peer's bytes are intact"
+  else
+    fail "obj-sweep(stale-writer): the latch was rewritten by the finishing VERIFIED sweep: '$(printf '%s' "$after" | tr '\n' '/')'"
+  fi
+  # ...and it is not that the writer wrote NOTHING: the throttle cell, which is harmless
+  # to move, DID move. One writer, two cells, exactly one of them mutable — that pairing is
+  # the design, and asserting only the first half would also pass a supervisor that had
+  # simply stopped recording anything.
+  if [[ "$stamp_ts" =~ ^[0-9]+$ ]] && [[ "$stamp_ts" -ge 1700000001 ]]; then
+    pass "obj-sweep(stale-writer): the same writer DID advance the throttle timestamp — the immutability is the latch's, not a supervisor that wrote nothing"
+  else
+    fail "obj-sweep(stale-writer): the throttle stamp reads '$stamp_ts' — the writer never completed its write path, so the case above is vacuous"
+  fi
+  # ...and the harm is prevented END TO END: the next lane on this box stops.
+  calls="$d/calls-successor"
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/successor.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 1 && ! -s "$calls" ]] && grep -q 'object-store: CORRUPT (cached' "$d/successor.log"; then
+    pass "obj-sweep(stale-writer): the NEXT lane on the box still stops — the peer's CORRUPT survived a later VERIFIED writer end to end"
+  else
+    fail "obj-sweep(stale-writer-successor): rc=$rc reswept=$([[ -s "$calls" ]] && echo yes || echo no) (see $d/successor.log)"
+  fi
+}
+
+t test_object_store_latch_survives_a_writer_that_finishes_after_it
+
+# THE CREATE-ONLY PRIMITIVE ITSELF (#3749 review round 2, BLOCKER 1).
+#
+# The case above proves the harm is prevented on the path the supervisor takes. This one
+# asks the narrower question the design rests on — can `obj_sweep_set_latch` ever
+# OVERWRITE — and it asks it of the SHIPPED function, extracted from
+# scripts/local/worker-supervisor.sh at run time, so restating the implementation here
+# could not make it pass. Two reachable states are then covered that the supervisor path
+# cannot stage: a latch that already exists (a peer won the race), and one that cannot be
+# created at all (an unwritable directory), which must be reported and never silently read
+# as "latched".
+test_object_store_set_latch_is_create_only() {
+  local d fns rc out latch
+  d="$(new_case_dir)"
+  fns="$d/extracted.sh"
+  sed -n '/^obj_sweep_latch_present() {/,/^}/p;/^obj_sweep_set_latch() {/,/^}/p' \
+    "$SUPERVISOR" >"$fns"
+  # CONSTRUCTION: the extraction really got both functions, and the create-only mechanism
+  # really is in the extracted text. Without this the cases below could be measuring an
+  # empty file (every one of which would `command not found` and be reported as a failure,
+  # but with a cause nobody could attribute).
+  if grep -q '^obj_sweep_set_latch() {' "$fns" && grep -q '^obj_sweep_latch_present() {' "$fns" &&
+     grep -q 'set -C' "$fns"; then
+    pass "obj-sweep(set-latch-plant): both functions were extracted from the shipped supervisor, noclobber included"
+  else
+    fail "obj-sweep(set-latch-plant): the extraction from $SUPERVISOR did not yield the functions — the cases below would prove nothing"
+    return 0
+  fi
+  # (a) ABSENT -> PRESENT: it creates, and reports success.
+  latch="$d/a.CORRUPT"
+  rc=0
+  out="$(bash -c 'set -euo pipefail; . "$1"; obj_sweep_set_latch "$2"' _ "$fns" "$latch" 2>&1)" || rc=$?
+  if [[ "$rc" -eq 0 && -e "$latch" ]] && grep -q '^CORRUPT$' "$latch"; then
+    pass "obj-sweep(set-latch): an absent latch is created and the call reports success"
+  else
+    fail "obj-sweep(set-latch-create): rc=$rc out=[$out] content='$(tr '\n' '/' <"$latch" 2>/dev/null)'"
+  fi
+  # (b) PRESENT -> PRESENT, ONE property apart from (a): the file already exists. It must
+  #     report success (the box IS latched) and leave the incumbent's bytes ALONE.
+  latch="$d/b.CORRUPT"
+  printf 'incumbent\n' >"$latch"
+  rc=0
+  out="$(bash -c 'set -euo pipefail; . "$1"; obj_sweep_set_latch "$2"' _ "$fns" "$latch" 2>&1)" || rc=$?
+  if [[ "$rc" -eq 0 && "$(cat "$latch")" == "incumbent" ]]; then
+    pass "obj-sweep(set-latch): an EXISTING latch is left byte-for-byte alone and still reports latched — the transition is ABSENT -> PRESENT only"
+  else
+    fail "obj-sweep(set-latch-existing): rc=$rc content='$(tr '\n' '/' <"$latch")' out=[$out]"
+  fi
+  # (c) CANNOT PERSIST: an unwritable directory. The call must report FAILURE, because the
+  #     caller has to say so out loud — a create that could not happen must never be read
+  #     as a latched box.
+  if [[ "$(id -u)" == "0" ]]; then
+    skip "obj-sweep(set-latch): running as root, where an unwritable directory is not unwritable — the could-not-persist direction cannot be staged"
+    return 0
+  fi
+  mkdir -p "$d/ro"
+  chmod 500 "$d/ro"
+  rc=0
+  out="$(bash -c 'set -euo pipefail; . "$1"; obj_sweep_set_latch "$2"' _ "$fns" "$d/ro/c.CORRUPT" 2>&1)" || rc=$?
+  chmod 700 "$d/ro"
+  if [[ "$rc" -ne 0 && "$out" != *"No such file"* ]]; then
+    pass "obj-sweep(set-latch): a latch that CANNOT be created reports failure rather than a silently latched box"
+  else
+    fail "obj-sweep(set-latch-unwritable): rc=$rc out=[$out] — a failed create was reported as success"
+  fi
+}
+
+t test_object_store_set_latch_is_create_only
 
 # ---------------------------------------------------------------------------
 # Test 48 (#3549, roborev job 196 F2): THE SUITE LEAVES NO FIXTURE PROCESS BEHIND.

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -968,6 +968,15 @@ common_env() {
   # supervisor at their own scratch tree with a stub sweep, so the branch coverage is real
   # rather than mocked away.
   export OBJ_SWEEP_INTERVAL_HOURS=0
+  # AND THE STAMP KEY IS PINNED PER CASE, for two reasons. (1) Isolation: the throttle stamp and
+  # the STOP latch are BOX-WIDE files derived from that key, and preflight_wait now re-reads the
+  # latch on its way out (round 13) — so a case inheriting an earlier case's exported stamp
+  # inherits its LATCH too, and a lane that should spawn stops on another case's planted
+  # corruption. Exports persist across cases in this one shell, so "the previous case set it" is
+  # the default, not the exception. (2) Cost: an unset key sends every latch read through the
+  # sweep script's `--print-store` (a subprocess, ~5-9 ms). The cases that are ABOUT the
+  # resolver unset it again on purpose.
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
   # roborev 1839: preflight bounds the two leftover families separately, so it reads
   # per-family probes (the old combined PROC_PROBE_CMD is gone). Default both to clear;
   # leftover-hold tests override the family they exercise.
@@ -10951,6 +10960,14 @@ test_preflight_reads_the_stop_file_before_the_object_store_sweep() {
   local d obs drv
   d="$(new_case_dir)"; obs="$d/obs.txt"; drv="$d/drv.sh"
   sv_preflight_order_driver "$drv" "$obs"
+  # PINNED PER CASE, and it is not cosmetic: preflight_wait re-reads the STOP latch on the way
+  # out (round 13), the latch path is derived from OBJ_SWEEP_STAMP, and this case supplies its
+  # environment on the command line rather than through common_env — so without a pin it
+  # inherits whatever an EARLIER case exported, and the obj-sweep cases leave a LATCHED stamp
+  # behind. The control arm then "failed" by stopping on a real latch from another case. The
+  # gate itself is deliberately left in the path: the control arm is what shows it does not
+  # stop a lane that should proceed.
+  export OBJ_SWEEP_STAMP="$d/order.stamp"
   if ! bash -n "$drv" 2>/dev/null; then
     fail "preflight-order-plant: the scratch driver does not parse — the arms below would prove nothing"
     return
@@ -10991,6 +11008,171 @@ test_preflight_reads_the_stop_file_before_the_object_store_sweep() {
 }
 
 t test_preflight_reads_the_stop_file_before_the_object_store_sweep
+
+# THE HOLD LOOP MUST NOT CARRY A LANE PAST A PEER'S STOPPING VERDICT (#3749 review round 13).
+#
+# THE DEFECT. object_store_sweep reads the STOP latch at entry and again before every return
+# that leads to a spawn — and then preflight_wait's HOLD LOOP ran, which read the latch not at
+# all. Every hold sleeps HOLD_POLL_SECS and the loop tolerates up to BUILD_HOLD_MAX of them, so
+# at the shipped defaults a lane could sit here for 12 x 300s = ONE HOUR after its last latch
+# read and then spawn a worker onto a box a PEER had latched CORRUPT in the meantime.
+#
+# THE STRUCTURAL HALF, and why it is not an enumeration. Round 3 fixed three returns that
+# reached a spawn without a latch read and round 5 found a fourth: "remember the check at every
+# return" leaves a door for the next reviewer. The loop is therefore in preflight_wait_holds and
+# the gate is in the WRAPPER, so a return added to the inner body TOMORROW is gated too — the
+# caller never sees the inner function. This case asserts exactly that shape: the gate sits
+# after the one inner call and before every return of the wrapper, the inner body has exactly
+# one call site, and the gate is not inside a command substitution (where finalize_exit would
+# end a SUBSHELL and the lane would spawn anyway — the trap obj_sweep_claim_wait documents).
+test_preflight_wait_gates_every_return_on_the_latch() {
+  local body gate call_line ret_before inner_refs n line subshell=""
+  body="$(awk '/^preflight_wait\(\) \{$/,/^\}$/' "$SUPERVISOR")"
+  gate="$(grep -n '^[[:space:]]*obj_sweep_stop_if_latched_now$' <<<"$body" | head -1 | cut -d: -f1)"
+  call_line="$(grep -n '^[[:space:]]*preflight_wait_holds ' <<<"$body" | head -1 | cut -d: -f1)"
+  # PLANT: the wrapper was really extracted and really contains both halves. A body of ""
+  # has no ungated return either, so every assert below would be vacuous without this.
+  if [[ -n "$body" && "$gate" =~ ^[0-9]+$ && "$call_line" =~ ^[0-9]+$ ]]; then
+    pass "preflight-latch-gate-plant: preflight_wait was extracted from the shipped supervisor and carries both the inner call and the latch gate"
+  else
+    fail "preflight-latch-gate-plant: body=${#body} bytes gate='$gate' inner-call='$call_line' — the asserts below would prove nothing"
+    return
+  fi
+  # (1) THE GATE IS AFTER THE INNER CALL AND BEFORE EVERY return/exit IN THE WRAPPER.
+  ret_before=""
+  n=0
+  while IFS= read -r line; do
+    n=$((n + 1))
+    [[ "$n" -lt "$gate" ]] || break
+    [[ "$line" =~ ^[[:space:]]*(return|exit)([[:space:]]|$) ]] && ret_before="${ret_before}${ret_before:+ | }line $n: $line"
+  done <<<"$body"
+  if [[ "$call_line" -lt "$gate" && -z "$ret_before" ]]; then
+    pass "preflight-latch-gate: the latch read is at wrapper line $gate, after the single preflight_wait_holds call at $call_line, and NOTHING returns before it — every return out of the hold loop, including ones not yet written, is followed by a fresh latch read [STRUCTURAL]"
+  else
+    fail "preflight-latch-gate: inner call at '$call_line', gate at '$gate', return(s) before the gate: ${ret_before:-none} — a hold can end in a spawn without asking the latch question"
+  fi
+  # (2) THE INNER BODY HAS EXACTLY ONE CALL SITE. Without this the property is bypassable by
+  #     calling preflight_wait_holds directly from main(), which is the same defect wearing a
+  #     different name.
+  inner_refs="$(grep -c '^[[:space:]]*preflight_wait_holds\b' "$SUPERVISOR" 2>/dev/null || true)"
+  [[ "$inner_refs" =~ ^[0-9]+$ ]] || inner_refs=-1
+  if [[ "$inner_refs" -eq 2 ]]; then
+    pass "preflight-latch-gate: preflight_wait_holds appears exactly twice at the start of a line (its definition and the ONE gated call) — the hold loop has no ungated caller [STRUCTURAL]"
+  else
+    fail "preflight-latch-gate(callers): $inner_refs line-initial references to preflight_wait_holds, wanted 2 (definition + one call) — a second caller would bypass the gate"
+  fi
+  # (3) AND THE GATE IS NOT INSIDE A COMMAND SUBSTITUTION anywhere in the file: it stops the
+  #     lane through finalize_exit, which inside `$( )` ends a subshell and returns.
+  subshell="$(grep -n '\$(.*obj_sweep_stop_if_latched_now' "$SUPERVISOR" 2>/dev/null || true)"
+  if [[ -z "$subshell" ]]; then
+    pass "preflight-latch-gate: no call site puts the gate in a command substitution — its finalize_exit ends the PROCESS, not a subshell [STRUCTURAL]"
+  else
+    fail "preflight-latch-gate(subshell): $subshell — finalize_exit there would end a subshell and the lane would spawn anyway"
+  fi
+}
+
+t test_preflight_wait_gates_every_return_on_the_latch
+
+# THE BEHAVIOURAL HALF: A LATCH THAT APPEARS **DURING** A HOLD (#3749 review round 13).
+#
+# The latch is created by the leftover-worker probe on its FIRST call, which the supervisor
+# reaches only after object_store_sweep has already returned — so the entry read and the
+# post-sweep reads provably could not have seen it, and the HOLD line in the journal is the
+# construction assert that the loop really ran between them.
+#
+# ARM (b) IS LOAD-BEARING, NOT DECORATION. "The lane did not spawn" is also what a broken
+# fixture produces, so the control is the SAME staging one property apart — the probe creates a
+# harmless file instead of the latch — where the lane MUST hold and then run its worker.
+test_preflight_latch_during_a_hold_stops_the_lane() {
+  local d root counter calls rc latch probe holds
+  # ---- (a) THE SUBJECT: the peer's latch lands while this lane is holding ---------------
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-hold-latch"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  latch="$OBJ_SWEEP_STAMP.STOP"
+  probe="$d/bin/probe.sh"
+  # HOLD ONCE, THEN CLEAR — so the loop returns normally and the gate on the way out is the
+  # only thing that can stop this lane. The side effect is the peer's latch, written with the
+  # supervisor's own two-line shape (epoch, verdict).
+  cat >"$probe" <<EOF
+#!/usr/bin/env bash
+n=0
+[[ -f "$d/probe.n" ]] && n=\$(cat "$d/probe.n")
+n=\$((n + 1)); printf '%s' "\$n" >"$d/probe.n"
+if [[ "\$n" -le 1 ]]; then
+  printf '1700000000\nCORRUPT\nplanted-by-peer-lane-during-hold\n' >"$latch"
+  echo 1
+else
+  echo 0
+fi
+EOF
+  chmod +x "$probe"
+  export PROC_PROBE_WORKER_CMD="bash $probe"
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
+  if [[ ! -e "$latch" ]]; then
+    pass "preflight-hold-latch-plant: the box starts UNLATCHED, so the run below reaches the hold loop with nothing for the entry read to find"
+  else
+    fail "preflight-hold-latch-plant: a latch already exists at $latch — the arm below would prove nothing"
+    return
+  fi
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/hold.log" 2>&1
+  rc=$?
+  holds="$(grep -c 'HOLD: leftover-worker' "$d/hold.log" 2>/dev/null || true)"
+  [[ "$holds" =~ ^[0-9]+$ ]] || holds=0
+  # CONSTRUCTION FIRST, AND IT NAMES WHICH THING WENT WRONG: a hold really happened (so the
+  # latch really appeared after every pre-existing read) and the sweep really ran.
+  if [[ "$holds" -ge 1 && -s "$calls" && -e "$latch" ]]; then
+    pass "preflight-hold-latch-plant: the lane swept, then HELD $holds time(s), and the peer's latch was created during that hold — after every latch read the pre-round-13 code performed"
+  else
+    fail "preflight-hold-latch-plant: STAGING — holds=$holds swept=$([[ -s "$calls" ]] && echo yes || echo no) latch=$([[ -e "$latch" ]] && echo present || echo absent) (see $d/hold.log)"
+    return
+  fi
+  if [[ "$rc" -eq 1 && ! -f "$counter" ]] && grep -q 'object-store: CORRUPT' "$d/hold.log"; then
+    pass "preflight-hold-latch: a latch recorded by a peer DURING the hold stops the lane on the way out of preflight_wait — no worker is spawned onto a box latched while this lane was waiting"
+  else
+    fail "preflight-hold-latch: THE DEFECT — rc=$rc spawned=$([[ -f "$counter" ]] && echo yes || echo no): the lane held for $holds poll(s) with a peer's CORRUPT latch already on disk and carried straight on to its worker (see $d/hold.log)"
+  fi
+  # ---- (b) THE CONTROL, one property apart: the hold ends with NO latch ----------------
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-hold-clean"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  latch="$OBJ_SWEEP_STAMP.STOP"
+  probe="$d/bin/probe.sh"
+  cat >"$probe" <<EOF
+#!/usr/bin/env bash
+n=0
+[[ -f "$d/probe.n" ]] && n=\$(cat "$d/probe.n")
+n=\$((n + 1)); printf '%s' "\$n" >"$d/probe.n"
+if [[ "\$n" -le 1 ]]; then
+  printf 'not-a-latch\n' >"$d/harmless"
+  echo 1
+else
+  echo 0
+fi
+EOF
+  chmod +x "$probe"
+  export PROC_PROBE_WORKER_CMD="bash $probe"
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/clean.log" 2>&1
+  rc=$?
+  holds="$(grep -c 'HOLD: leftover-worker' "$d/clean.log" 2>/dev/null || true)"
+  [[ "$holds" =~ ^[0-9]+$ ]] || holds=0
+  if [[ "$rc" -eq 0 && -f "$counter" && "$holds" -ge 1 && ! -e "$latch" && -f "$d/harmless" ]]; then
+    pass "preflight-hold-latch-control: the SAME hold with no latch created still spawns the worker — the arm above is the latch, not a lane that stopped holding"
+  else
+    fail "preflight-hold-latch-control: rc=$rc spawned=$([[ -f "$counter" ]] && echo yes || echo no) holds=$holds latch=$([[ -e "$latch" ]] && echo present || echo absent) (see $d/clean.log)"
+  fi
+}
+
+t test_preflight_latch_during_a_hold_stops_the_lane
 
 # AND THE EXPOSURE IS BOUNDED IN WALL TIME, because the in-flight sweep is NOT
 # interruptible (#3749 review round 3, item 3). Its walks run in a CHILD process, so no

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -10597,11 +10597,20 @@ test_object_store_sweep_claim_wait_completed_stops_contending() {
     fi
     # THE PROPERTY: ONE completion, no re-contention, the worker runs, and NO fsck was spent
     # (the box is inside the interval — that is what a fresh stamp means).
-    if [[ "$rc" == 0 && "$completed_n" -eq 1 && "$skipped_n" -eq 1 && -f "$counter" && ! -s "$calls" ]]; then
+    #
+    # THE CONTROL ARM DELIBERATELY DOES **NOT** REQUIRE THE NEW SKIP LINE, and that is what
+    # keeps it a one-property control. Its job is to show that the dead-peer arm's verdict is
+    # the PERSISTENT CLAIM and not a lane that has stopped working, so it must stay passable
+    # under a mutant that removes the fix (round 13's lesson: a control that reds under the
+    # subject's own mutant proves nothing about the subject). A released peer lets the lane
+    # proceed by EITHER route — the new skip, or the acquire-and-release round trip the old
+    # code took — and both are "it proceeded, promptly, having swept nothing".
+    if [[ "$rc" == 0 && "$completed_n" -eq 1 && -f "$counter" && ! -s "$calls" ]] &&
+      { [[ "$arm" != dead-peer ]] || [[ "$skipped_n" -eq 1 ]]; }; then
       if [[ "$arm" == dead-peer ]]; then
         pass "obj-sweep(claim-wait-completed/dead-peer): a peer that advertises a sweep and then never releases its claim ends this lane's wait ONCE — the lane skips the interval and runs its worker instead of re-contending for a claim nobody will give up"
       else
-        pass "obj-sweep(claim-wait-completed/released-control): the SAME staging with the peer RELEASING normally also ends in one completion and one skip, inside the same cap — so the dead-peer arm is the persistent claim and not a lane that stopped working"
+        pass "obj-sweep(claim-wait-completed/released-control): the SAME staging with the peer RELEASING normally also ends in one completion, inside the same cap, with no fsck spent — so the dead-peer arm is the persistent claim and not a lane that stopped working"
       fi
     elif [[ "$rc" == timeout ]]; then
       fail "obj-sweep(claim-wait-completed/$arm): THE DEFECT — the lane did NOT exit within 20s (the derived wait budget is 63s, so this is not the wait expiring): it observed the peer's completion $completed_n time(s), i.e. it went back and contended for the still-present claim after every one of them, spinning until the wall-clock budget (see $d/sup.log)"

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -9912,6 +9912,218 @@ test_object_store_latch_is_written_before_the_throttle_stamp() {
 
 t test_object_store_latch_is_written_before_the_throttle_stamp
 
+# THE ENTRY LATCH READ — THE STRUCTURAL INVARIANT, NOT THE FOUR KNOWN SITES (#3749 review
+# round 5, item 1).
+#
+# THE DEFECT, AND WHY THIS CASE IS SHAPED THE WAY IT IS. Round 3 found "a return path that
+# reaches a spawn without re-reading the CORRUPT latch" at THREE sites and fixed all three
+# with a shared helper; round 5 found a FOURTH — the OBJ_SWEEP_INTERVAL_HOURS=0 opt-out,
+# which returned before any latch read, so the documented way to disable the sweep also
+# disabled an already-recorded verdict. A case that enumerated the four sites would leave a
+# fifth for the next reviewer, so this one asserts the PROPERTY THAT MAKES A FIFTH
+# UNEXPRESSIBLE: the latch read is at the TOP of object_store_sweep, and the lines before it
+# are declarations and assignments ONLY — no `if`, no `return`, nothing that can leave the
+# function. Since the FIRST control-flow line in the body comes after the gate call, EVERY
+# `return` in it does too, including ones nobody has written yet.
+#
+# LABELLED [STRUCTURAL] IN THE MESSAGE, because that is what it is: a claim about the
+# shipped source, not a measurement of a run. The behavioural half — the four return paths,
+# each with a control — is the case that follows.
+test_object_store_sweep_reads_the_latch_at_entry() {
+  local body gate_line first_cf line i n bad prologue_bad=""
+  body="$(awk '/^object_store_sweep\(\) \{$/,/^\}$/' "$SUPERVISOR")"
+  gate_line="$(grep -n '^[[:space:]]*obj_sweep_stop_if_latched ' <<<"$body" | head -1 | cut -d: -f1)"
+  # PLANT ASSERT: the body was really extracted, it really contains a gate call, and it
+  # really contains the branches this invariant is about — otherwise the comparison below
+  # would be vacuous (a body of "" has no control flow either).
+  if [[ -n "$body" && "$gate_line" =~ ^[0-9]+$ ]] &&
+    grep -q 'OBJ_SWEEP_INTERVAL_HOURS" -le 0' <<<"$body" &&
+    grep -q '! -r "\$script"' <<<"$body"; then
+    pass "obj-sweep(entry-latch-plant): object_store_sweep was extracted from the shipped supervisor and carries both early-return branches plus a latch gate"
+  else
+    fail "obj-sweep(entry-latch-plant): body=${#body} bytes gate_line='$gate_line' — the asserts below would be vacuous"
+    return
+  fi
+  # (1) THE FIRST CONTROL-FLOW LINE COMES AFTER THE GATE. `#`-comment lines cannot match:
+  # every pattern here is anchored on a keyword at the start of the line.
+  first_cf="$(grep -nE '^[[:space:]]*(if|while|until|for|case|return|exit|\[\[|\{)([[:space:]]|\()' <<<"$body" | head -1 | cut -d: -f1)"
+  if [[ "$first_cf" =~ ^[0-9]+$ && "$gate_line" -lt "$first_cf" ]]; then
+    pass "obj-sweep(entry-latch-read): the latch gate is at body line $gate_line and the FIRST control-flow line is $first_cf — every return in object_store_sweep, including ones not yet written, is preceded by a latch read [STRUCTURAL]"
+  else
+    fail "obj-sweep(entry-latch-read): gate at '$gate_line', first control flow at '$first_cf' — a branch can leave this function without asking the latch question"
+  fi
+  # (2) AND THE PROLOGUE IS DECLARATIONS AND ASSIGNMENTS ONLY. (1) is keyword-anchored, so
+  # it cannot see `some_helper || return 0` or a bare call that exits; this half requires
+  # every line before the gate to be a comment, a blank, a `local`, or a plain assignment.
+  n=0
+  while IFS= read -r line; do
+    n=$((n + 1))
+    [[ "$n" -lt "$gate_line" ]] || break
+    [[ "$n" -eq 1 ]] && continue
+    if [[ "$line" =~ ^[[:space:]]*# ]] ||
+      [[ -z "${line//[[:space:]]/}" ]] ||
+      [[ "$line" =~ ^[[:space:]]*local[[:space:]] ]] ||
+      [[ "$line" =~ ^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=[^\;\&\|]*$ ]]; then
+      continue
+    fi
+    prologue_bad="${prologue_bad}${prologue_bad:+ | }${line}"
+  done <<<"$body"
+  if [[ -z "$prologue_bad" ]]; then
+    pass "obj-sweep(entry-latch-prologue): every line before the latch gate is a comment, a declaration or a plain assignment — nothing before it can branch, call out or return [STRUCTURAL]"
+  else
+    fail "obj-sweep(entry-latch-prologue): executable non-assignment line(s) before the latch gate: $prologue_bad"
+  fi
+}
+
+t test_object_store_sweep_reads_the_latch_at_entry
+
+# THE BEHAVIOURAL HALF: THE TWO RETURN PATHS THAT USED TO PRECEDE ANY LATCH READ (#3749
+# review round 5, item 1). Each arm has a CONTROL one property apart, because "the lane
+# stopped" is also what a broken fixture produces.
+test_object_store_sweep_latch_beats_the_opt_out() {
+  local d root counter calls rc latch
+  # (a) THE FINDING ITSELF: OBJ_SWEEP_INTERVAL_HOURS=0 — the documented opt-out — on a box
+  #     whose latch is already set. The lane must STOP, must NOT sweep (the opt-out still
+  #     opts out of spending fsck walks), and must not spawn.
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-optout"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=0
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  latch="$OBJ_SWEEP_STAMP.CORRUPT"
+  printf '%s\nCORRUPT\n' "$(date +%s)" >"$latch"
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/optout.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 1 && ! -f "$counter" && ! -s "$calls" ]] &&
+    grep -q 'object-store: CORRUPT (cached' "$d/optout.log" &&
+    grep -q '"reason":"object-store-corrupt"' "$JOURNAL_FILE"; then
+    pass "obj-sweep(opt-out-latched): with the sweep DISABLED, an existing CORRUPT latch still stops the lane — a latch is a fact about the store, not a schedule"
+  else
+    fail "obj-sweep(opt-out-latched): rc=$rc spawned=$([[ -f "$counter" ]] && echo yes || echo no) swept=$([[ -s "$calls" ]] && echo yes || echo no) (see $d/optout.log)"
+  fi
+  # (b) CONTROL, one property apart: the same disabled sweep with NO latch. The worker must
+  #     run and the sweep must still not be spent — so (a) is the latch, not the opt-out
+  #     having been broken into a stop.
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-optout-control"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=0
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/optout-control.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 0 && -f "$counter" && ! -s "$calls" ]] &&
+    grep -q 'object-store sweep DISABLED' "$d/optout-control.log"; then
+    pass "obj-sweep(opt-out-control): the SAME disabled sweep with no latch still announces DISABLED, still spends no walk, and the worker runs"
+  else
+    fail "obj-sweep(opt-out-control): rc=$rc spawned=$([[ -f "$counter" ]] && echo yes || echo no) swept=$([[ -s "$calls" ]] && echo yes || echo no) (see $d/optout-control.log)"
+  fi
+  # (c) THE OTHER PRE-GATE RETURN: the sweep script is ABSENT from this checkout (an older
+  #     branch, a partial tree). With the key pinned the latch is still NAMEABLE, so it is
+  #     still read — the lane stops instead of running because a hygiene probe is missing.
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-unavail"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  latch="$OBJ_SWEEP_STAMP.CORRUPT"
+  printf '%s\nCORRUPT\n' "$(date +%s)" >"$latch"
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
+  rm -f "$root/scripts/check-object-store-integrity.sh"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/unavail.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 1 && ! -f "$counter" ]] &&
+    grep -q 'object-store: CORRUPT (cached' "$d/unavail.log"; then
+    pass "obj-sweep(unavailable-latched): with the sweep script absent but the key pinned, the latch is still read and still stops the lane"
+  else
+    fail "obj-sweep(unavailable-latched): rc=$rc spawned=$([[ -f "$counter" ]] && echo yes || echo no) (see $d/unavail.log)"
+  fi
+  # (d) CONTROL for (c): same absent script, no latch. The lane must announce UNAVAILABLE
+  #     and RUN — refusing to work because a hygiene probe is missing is the self-DoS the
+  #     code rules out at that branch, and this arm is what keeps (c) from having quietly
+  #     become one.
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-unavail-control"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
+  rm -f "$root/scripts/check-object-store-integrity.sh"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/unavail-control.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 0 && -f "$counter" ]] &&
+    grep -q 'object-store sweep UNAVAILABLE' "$d/unavail-control.log"; then
+    pass "obj-sweep(unavailable-control): the same absent sweep script with NO latch announces UNAVAILABLE and the worker runs — the stop above is the latch, not the missing probe"
+  else
+    fail "obj-sweep(unavailable-control): rc=$rc spawned=$([[ -f "$counter" ]] && echo yes || echo no) (see $d/unavail-control.log)"
+  fi
+}
+
+t test_object_store_sweep_latch_beats_the_opt_out
+
+# AN UNREADABLE LATCH IS NOT AN ABSENT ONE (#3749 review round 5, item 1's second half).
+#
+# `[[ -e "$latch" ]]` is FALSE both for a latch that is not there and for one this process
+# cannot look at — the two-valued file predicate CLAUDE.md warns about, on the single file
+# whose job is to stop the box. The supervisor answers the latch question in four values,
+# and `unknown` must STOP, under its OWN reason: nothing observed damage, so calling it
+# CORRUPT would send an operator to re-clone a healthy store.
+test_object_store_latch_unreadable_is_not_absent() {
+  local d root counter calls rc dir
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-unreadable"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  dir="$d/latchdir"
+  mkdir -p "$dir"
+  export OBJ_SWEEP_STAMP="$dir/sweep.stamp"
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
+  # CONTROL FIRST, so the stop below is attributable to the permissions and not to the
+  # subdirectory: a searchable directory with no latch in it runs the sweep and the worker.
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/readable.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 0 && -f "$counter" && -s "$calls" ]]; then
+    pass "obj-sweep(latch-unreadable-control): a SEARCHABLE latch directory with no latch in it is an affirmative 'absent' — the sweep runs and so does the worker"
+  else
+    fail "obj-sweep(latch-unreadable-control): rc=$rc spawned=$([[ -f "$counter" ]] && echo yes || echo no) swept=$([[ -s "$calls" ]] && echo yes || echo no) (see $d/readable.log)"
+  fi
+  chmod 000 "$dir" 2>/dev/null || true
+  # CONSTRUCTION ASSERT: as root the permission bits are advisory, so the plant does not
+  # plant. Skipped explicitly rather than passing against a directory this process can
+  # still read.
+  if [[ -x "$dir" || -r "$dir" ]]; then
+    chmod 755 "$dir" 2>/dev/null || true
+    skip "obj-sweep(latch-unreadable): this process can still search a 000 directory (root?) — the unknown-latch state cannot be planted here"
+    return
+  fi
+  rm -f "$counter"
+  : >"$calls"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/unreadable.log" 2>&1
+  rc=$?
+  chmod 755 "$dir" 2>/dev/null || true
+  if [[ "$rc" -eq 1 && ! -f "$counter" ]] &&
+    grep -q 'could NOT be read' "$d/unreadable.log" &&
+    grep -q '"reason":"object-store-latch-unreadable"' "$JOURNAL_FILE" &&
+    ! grep -q '"reason":"object-store-corrupt"' "$JOURNAL_FILE"; then
+    pass "obj-sweep(latch-unreadable): a latch this process cannot look at STOPS the lane under its own reason — UNKNOWN is not 'absent', and it is not reported as a corruption finding either"
+  else
+    fail "obj-sweep(latch-unreadable): rc=$rc spawned=$([[ -f "$counter" ]] && echo yes || echo no) reason=$(grep -o '"reason":"[a-z-]*"' "$JOURNAL_FILE" | tail -1) (see $d/unreadable.log)"
+  fi
+}
+
+t test_object_store_latch_unreadable_is_not_absent
+
 # AND THE BEHAVIOURAL HALF THE ORDERING SERVES: on the CORRUPT path BOTH files exist
 # when the lane stops, so the state a peer inherits is complete rather than half-written.
 test_object_store_corrupt_leaves_both_the_latch_and_the_stamp() {
@@ -10065,15 +10277,20 @@ test_object_store_set_latch_is_create_only() {
   local d fns rc out latch
   d="$(new_case_dir)"
   fns="$d/extracted.sh"
-  sed -n '/^obj_sweep_latch_present() {/,/^}/p;/^obj_sweep_set_latch() {/,/^}/p' \
+  # THREE functions, because the create's verdict is the file's EXISTENCE asked afterwards
+  # and that question is now answered in four values (round 5, item 1):
+  # obj_sweep_latch_present delegates to obj_sweep_latch_state, so extracting only the
+  # first two yields a `command not found` — a real failure, but one whose cause is the
+  # extraction rather than the subject.
+  sed -n '/^obj_sweep_latch_state() {/,/^}/p;/^obj_sweep_latch_present() {/,/^}/p;/^obj_sweep_set_latch() {/,/^}/p' \
     "$SUPERVISOR" >"$fns"
-  # CONSTRUCTION: the extraction really got both functions, and the create-only mechanism
-  # really is in the extracted text. Without this the cases below could be measuring an
-  # empty file (every one of which would `command not found` and be reported as a failure,
-  # but with a cause nobody could attribute).
+  # CONSTRUCTION: the extraction really got all three functions, and the create-only
+  # mechanism really is in the extracted text. Without this the cases below could be
+  # measuring an empty file (every one of which would `command not found` and be reported
+  # as a failure, but with a cause nobody could attribute).
   if grep -q '^obj_sweep_set_latch() {' "$fns" && grep -q '^obj_sweep_latch_present() {' "$fns" &&
-     grep -q 'set -C' "$fns"; then
-    pass "obj-sweep(set-latch-plant): both functions were extracted from the shipped supervisor, noclobber included"
+     grep -q '^obj_sweep_latch_state() {' "$fns" && grep -q 'set -C' "$fns"; then
+    pass "obj-sweep(set-latch-plant): all three latch functions were extracted from the shipped supervisor, noclobber included"
   else
     fail "obj-sweep(set-latch-plant): the extraction from $SUPERVISOR did not yield the functions — the cases below would prove nothing"
     return 0

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -11030,12 +11030,31 @@ test_preflight_wait_gates_every_return_on_the_latch() {
   body="$(awk '/^preflight_wait\(\) \{$/,/^\}$/' "$SUPERVISOR")"
   gate="$(grep -n '^[[:space:]]*obj_sweep_stop_if_latched_now$' <<<"$body" | head -1 | cut -d: -f1)"
   call_line="$(grep -n '^[[:space:]]*preflight_wait_holds ' <<<"$body" | head -1 | cut -d: -f1)"
-  # PLANT: the wrapper was really extracted and really contains both halves. A body of ""
-  # has no ungated return either, so every assert below would be vacuous without this.
-  if [[ -n "$body" && "$gate" =~ ^[0-9]+$ && "$call_line" =~ ^[0-9]+$ ]]; then
-    pass "preflight-latch-gate-plant: preflight_wait was extracted from the shipped supervisor and carries both the inner call and the latch gate"
+  # (3) FIRST, BECAUSE IT DOES NOT DEPEND ON THE EXTRACTION and must not be skipped by the
+  #     plant's early return: the gate is nowhere inside a command substitution. It stops the
+  #     lane through finalize_exit, and inside `$( )` that ends a SUBSHELL.
+  #     MEASURED NUANCE, recorded so nobody reads more into this than it says: with the shipped
+  #     `set -e` an `x="$(gate)"` whose finalize_exit exits 1 still takes the process down, so
+  #     the behavioural arm below does NOT catch that mutant — this assert is the only thing
+  #     that does. The protection evaporates the moment the status is tested (`if x="$(gate)"`)
+  #     or the verdict exits 0, which is why the shape is banned rather than tolerated.
+  subshell="$(grep -n '\$(.*obj_sweep_stop_if_latched_now' "$SUPERVISOR" 2>/dev/null || true)"
+  if [[ -z "$subshell" ]]; then
+    pass "preflight-latch-gate: no call site puts the gate in a command substitution — its finalize_exit ends the PROCESS, not a subshell [STRUCTURAL]"
   else
-    fail "preflight-latch-gate-plant: body=${#body} bytes gate='$gate' inner-call='$call_line' — the asserts below would prove nothing"
+    fail "preflight-latch-gate(subshell): $subshell — finalize_exit there would end a subshell and the lane would spawn anyway"
+  fi
+  # PLANT: the wrapper was really extracted and really carries both halves. A body of "" has no
+  # ungated return either, so the asserts below would be vacuous without this — and a body that
+  # extracted fine while carrying NO plain gate call is not a staging failure, it is the defect
+  # itself, so it is named as one.
+  if [[ -n "$body" && "$call_line" =~ ^[0-9]+$ && "$gate" =~ ^[0-9]+$ ]]; then
+    pass "preflight-latch-gate-plant: preflight_wait was extracted from the shipped supervisor and carries both the inner call and the latch gate"
+  elif [[ -n "$body" && "$call_line" =~ ^[0-9]+$ ]]; then
+    fail "preflight-latch-gate: THE DEFECT — preflight_wait calls the hold loop at line $call_line and then reads the STOP latch NOWHERE (no plain 'obj_sweep_stop_if_latched_now' call in its body), so a hold of up to BUILD_HOLD_MAX x HOLD_POLL_SECS ends in a spawn on whatever a peer recorded meanwhile"
+    return
+  else
+    fail "preflight-latch-gate-plant: STAGING — body=${#body} bytes gate='$gate' inner-call='$call_line'; preflight_wait could not be read from $SUPERVISOR and the asserts below would prove nothing"
     return
   fi
   # (1) THE GATE IS AFTER THE INNER CALL AND BEFORE EVERY return/exit IN THE WRAPPER.
@@ -11060,14 +11079,6 @@ test_preflight_wait_gates_every_return_on_the_latch() {
     pass "preflight-latch-gate: preflight_wait_holds appears exactly twice at the start of a line (its definition and the ONE gated call) — the hold loop has no ungated caller [STRUCTURAL]"
   else
     fail "preflight-latch-gate(callers): $inner_refs line-initial references to preflight_wait_holds, wanted 2 (definition + one call) — a second caller would bypass the gate"
-  fi
-  # (3) AND THE GATE IS NOT INSIDE A COMMAND SUBSTITUTION anywhere in the file: it stops the
-  #     lane through finalize_exit, which inside `$( )` ends a subshell and returns.
-  subshell="$(grep -n '\$(.*obj_sweep_stop_if_latched_now' "$SUPERVISOR" 2>/dev/null || true)"
-  if [[ -z "$subshell" ]]; then
-    pass "preflight-latch-gate: no call site puts the gate in a command substitution — its finalize_exit ends the PROCESS, not a subshell [STRUCTURAL]"
-  else
-    fail "preflight-latch-gate(subshell): $subshell — finalize_exit there would end a subshell and the lane would spawn anyway"
   fi
 }
 

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -11004,11 +11004,20 @@ test_object_store_unsweepable_stops_the_box_without_claiming_a_cause() {
   else
     fail "obj-sweep(unsweepable): reason=$(grep -o '"reason":"[a-z-]*"' "$JOURNAL_FILE" | tail -1) (see $d/detect.log)"
   fi
-  # NO CAUSE IS CLAIMED. The damage remedy was MEASURED for a damage class this run never
+  # NO DAMAGE IS CLAIMED. The damage remedy was MEASURED for a damage class this run never
   # established, so printing it here would be round 9's defect: the text a human gets when
   # the box has stopped must match what was measured.
+  #
+  # THE WORDING MOVED FROM "NO cause was established" TO "NO damage was established" (#3749
+  # review round 11, item 1), and the change is not cosmetic: UNSWEEPABLE now has TWO
+  # causes, and for one of them a cause IS established and named (the store's own `fsck.*`
+  # config keys). The claim that must hold for EVERY cause of this verdict — and that this
+  # reader, which knows only the token, may therefore make — is that no DAMAGE was
+  # established. The sibling case
+  # test_object_store_unsweepable_text_asserts_no_mechanism asserts the other half: that
+  # the token-derived text names no mechanism at all.
   if ! grep -qi 'refetch\|damaged shared store' "$d/detect.log" &&
-     grep -q 'NO cause was established' "$d/detect.log"; then
+     grep -q 'NO damage was established' "$d/detect.log"; then
     pass "obj-sweep(unsweepable): the stop names NO repair and says so — the store's integrity is UNKNOWN, which is not the same claim as damage"
   else
     fail "obj-sweep(unsweepable): the stop claims a cause it did not establish (see $d/detect.log)"
@@ -11252,6 +11261,191 @@ test_object_store_stamp_key_is_injective() {
 }
 
 t test_object_store_stamp_key_is_injective
+
+# A RELEASE MUST NOT DELETE A SUCCESSOR'S CLAIM (#3749 review round 11, item 2).
+#
+# THE DEFECT. `obj_sweep_claim_release` removed the claim PATH unconditionally, and a path
+# is not an identity. Round 5 gave the claim a stale-recovery route, so by the time an
+# original owner releases, the directory at that path may be a DIFFERENT lane's claim — one
+# that legitimately took over after this lane's sweep overran the recovery bound. Deleting
+# it permits a second concurrent full-store fsck, which is the herd the claim exists to
+# prevent. A second route reaches the same place: a lane on the `unavailable` path never
+# owned the claim at all (no derivable recovery bound) and still ran the release at the end
+# of its own sweep.
+#
+# ASKED OF THE SHIPPED FUNCTIONS, extracted at run time — the takeover sequence cannot be
+# staged through a whole supervisor run (it needs two lanes' claims at one path in a
+# controlled order), and a test that re-typed the release would keep passing after the real
+# one changed.
+test_object_store_sweep_claim_release_requires_ownership() {
+  local d fns claim out tok_a tok_b
+  d="$(new_case_dir)"
+  fns="$d/extracted-claim.sh"
+  sed -n '/^obj_sweep_claim_mark_owner() {/,/^}/p;/^obj_sweep_claim_owner_state() {/,/^}/p;/^obj_sweep_claim_release() {/,/^}/p;/^obj_sweep_claim_mark_started() {/,/^}/p;/^obj_sweep_claim_acquire() {/,/^}/p' \
+    "$SUPERVISOR" >"$fns"
+  # CONSTRUCTION: all five functions were extracted, and the release really does consult
+  # ownership. Without this the arms below could be measuring an empty file.
+  if grep -q '^obj_sweep_claim_release() {' "$fns" && grep -q '^obj_sweep_claim_acquire() {' "$fns" &&
+    grep -q '^obj_sweep_claim_owner_state() {' "$fns" && grep -q '^obj_sweep_claim_mark_owner() {' "$fns" &&
+    grep -q 'obj_sweep_claim_owner_state' "$(printf '%s' "$fns")"; then
+    pass "obj-sweep(claim-owner-plant): the claim functions were extracted from the shipped supervisor and the release consults an ownership state"
+  else
+    fail "obj-sweep(claim-owner-plant): the extraction from $SUPERVISOR did not yield the functions — the cases below would prove nothing"
+    return 0
+  fi
+
+  # (a) CONTROL, one property from (b): a lane releasing a claim it STILL owns removes it.
+  #     A fix that simply stopped releasing would pass (b) and fail here, which is why the
+  #     control comes first.
+  claim="$d/a.sweeping"
+  out="$(bash -c 'set -uo pipefail; log() { printf "LOG %s\n" "$1"; }; OBJ_SWEEP_CLAIM_OWNED=""; OBJ_SWEEP_CLAIM_TOKEN=""; OBJ_SWEEP_CLAIM_STATE=""; OBJ_SWEEP_TIMEOUT_SECS=200; OBJ_SWEEP_CLAIM_SLACK_SECS=60; . "$1"; obj_sweep_claim_acquire "$2" 660; printf "state=%s\n" "$OBJ_SWEEP_CLAIM_STATE"; obj_sweep_claim_release "$2"; [[ -e "$2" ]] && printf "SURVIVED\n" || printf "REMOVED\n"' _ "$fns" "$claim" 2>&1)"
+  if printf '%s' "$out" | grep -q 'state=acquired' && printf '%s' "$out" | grep -q 'REMOVED'; then
+    pass "obj-sweep(claim-release-control): a lane that still owns its claim DOES remove it on release — the next interval is contended honestly, so the ownership test has not simply disabled the release"
+  else
+    fail "obj-sweep(claim-release-control): [$(printf '%s' "$out" | tr '\n' '|')]"
+  fi
+
+  # (b) THE FINDING: takeover, then the ORIGINAL owner releases. Lane A acquires; its
+  #     `started` is rewritten to an old epoch (round 5's recovery condition — a lane
+  #     killed mid-sweep, or one whose sweep overran the bound); lane B takes it over and
+  #     writes its own token; lane A then releases. B's claim must SURVIVE.
+  #
+  #     Two PROCESSES, because the token lives in a process global: one shell could not
+  #     hold two lanes' tokens at once, and faking that would be testing the fake.
+  claim="$d/b.sweeping"
+  tok_a="$(bash -c 'set -uo pipefail; log() { :; }; OBJ_SWEEP_CLAIM_OWNED=""; OBJ_SWEEP_CLAIM_TOKEN=""; OBJ_SWEEP_CLAIM_STATE=""; OBJ_SWEEP_TIMEOUT_SECS=200; OBJ_SWEEP_CLAIM_SLACK_SECS=60; . "$1"; obj_sweep_claim_acquire "$2" 660; printf "%s" "$OBJ_SWEEP_CLAIM_TOKEN"' _ "$fns" "$claim" 2>&1)"
+  printf '%s\n' 1 >"$claim/started"
+  tok_b="$(bash -c 'set -uo pipefail; log() { :; }; OBJ_SWEEP_CLAIM_OWNED=""; OBJ_SWEEP_CLAIM_TOKEN=""; OBJ_SWEEP_CLAIM_STATE=""; OBJ_SWEEP_TIMEOUT_SECS=200; OBJ_SWEEP_CLAIM_SLACK_SECS=60; . "$1"; obj_sweep_claim_acquire "$2" 660; printf "%s:%s" "$OBJ_SWEEP_CLAIM_STATE" "$OBJ_SWEEP_CLAIM_TOKEN"' _ "$fns" "$claim" 2>&1)"
+  # CONSTRUCTION: the takeover really happened (state `taken`), and the two tokens really
+  # differ — if they collided the arm below would pass for the wrong reason.
+  if [[ "$tok_b" == taken:* && -n "$tok_a" && "${tok_b#taken:}" != "$tok_a" ]]; then
+    pass "obj-sweep(claim-takeover-plant): lane B RECOVERED lane A's stale claim (state=taken) and the two ownership tokens differ — the sequence the finding describes"
+  else
+    fail "obj-sweep(claim-takeover-plant): A='$tok_a' B='$tok_b' — no takeover, or colliding tokens; the arm below would prove nothing"
+    return 0
+  fi
+  # Lane A releases, with A's token restored into a fresh process (a release from the sweep
+  # path or from the EXIT trap — both call the same function with the same global).
+  out="$(bash -c 'set -uo pipefail; log() { printf "LOG %s\n" "$1"; }; OBJ_SWEEP_CLAIM_OWNED="$2"; OBJ_SWEEP_CLAIM_TOKEN="$3"; . "$1"; obj_sweep_claim_release "$2"; [[ -e "$2" ]] && printf "SURVIVED\n" || printf "REMOVED\n"' _ "$fns" "$claim" "$tok_a" 2>&1)"
+  if printf '%s' "$out" | grep -q 'SURVIVED'; then
+    pass "obj-sweep(claim-takeover): the SUCCESSOR's claim survives a release by the original owner — round 5's serialisation is not defeated by a lane finishing late"
+  else
+    fail "obj-sweep(claim-takeover): the original owner deleted the successor's claim: [$(printf '%s' "$out" | tr '\n' '|')]"
+  fi
+  if printf '%s' "$out" | grep -q "LOG .*NOT removing"; then
+    pass "obj-sweep(claim-takeover): and it SAYS so — a claim left in place for a reason nobody can see is indistinguishable from a release that silently failed"
+  else
+    fail "obj-sweep(claim-takeover): the refusal is silent: [$(printf '%s' "$out" | tr '\n' '|')]"
+  fi
+  # AND B's TOKEN IS STILL THE ONE IN THE FILE, so what survived is B's claim and not a
+  # husk A left behind.
+  if [[ "$({ read -r x || true; } <"$claim/owner" 2>/dev/null; printf '%s' "${x:-}")" == "${tok_b#taken:}" ]]; then
+    pass "obj-sweep(claim-takeover): the surviving claim still carries B's token — B remains the owner, so its own release will work"
+  else
+    fail "obj-sweep(claim-takeover): the surviving claim's token is not B's"
+  fi
+
+  # (c) THE `unavailable` ROUTE, one property from (b): a lane that NEVER owned the claim
+  #     (no token at all — the shape of the no-derivable-bound path) must not delete a
+  #     peer's live claim either. This is the second way the old code reached the same harm.
+  out="$(bash -c 'set -uo pipefail; log() { printf "LOG %s\n" "$1"; }; OBJ_SWEEP_CLAIM_OWNED=""; OBJ_SWEEP_CLAIM_TOKEN=""; . "$1"; obj_sweep_claim_release "$2"; [[ -e "$2" ]] && printf "SURVIVED\n" || printf "REMOVED\n"' _ "$fns" "$claim" 2>&1)"
+  if printf '%s' "$out" | grep -q 'SURVIVED'; then
+    pass "obj-sweep(claim-never-owned): a lane with NO token of its own leaves a peer's claim alone — the `unavailable` path used to delete it at the end of its own sweep"
+  else
+    fail "obj-sweep(claim-never-owned): a lane that never owned the claim deleted it: [$(printf '%s' "$out" | tr '\n' '|')]"
+  fi
+
+  # (d) AN UNREADABLE TOKEN IS NOT AN ABSENT ONE. The ownership question is four-valued and
+  #     only the affirmative answer deletes, so a claim whose token cannot be read is LEFT
+  #     for the staleness bound to recover — the fail-closed direction, since the harm of
+  #     deleting is a concurrent sweep and the harm of keeping is one skipped 6-hourly probe.
+  rm -f "$claim/owner"
+  out="$(bash -c 'set -uo pipefail; log() { printf "LOG %s\n" "$1"; }; OBJ_SWEEP_CLAIM_OWNED="$2"; OBJ_SWEEP_CLAIM_TOKEN="$3"; . "$1"; printf "state=%s\n" "$(obj_sweep_claim_owner_state "$2")"; obj_sweep_claim_release "$2"; [[ -e "$2" ]] && printf "SURVIVED\n" || printf "REMOVED\n"' _ "$fns" "$claim" "$tok_a" 2>&1)"
+  if printf '%s' "$out" | grep -q 'state=unknown' && printf '%s' "$out" | grep -q 'SURVIVED' &&
+    printf '%s' "$out" | grep -q 'LOG .*could not be read'; then
+    pass "obj-sweep(claim-unreadable): a claim whose ownership token cannot be read reads 'unknown', is NOT removed, and says why — a failed probe may not destroy a peer's claim"
+  else
+    fail "obj-sweep(claim-unreadable): [$(printf '%s' "$out" | tr '\n' '|')]"
+  fi
+
+  # (e) AND A CLAIM THAT IS SIMPLY GONE is not an anomaly: no delete, and no journal line,
+  #     because a double release (sweep path then EXIT trap) is ordinary.
+  rm -rf "$claim"
+  out="$(bash -c 'set -uo pipefail; log() { printf "LOG %s\n" "$1"; }; OBJ_SWEEP_CLAIM_OWNED="$2"; OBJ_SWEEP_CLAIM_TOKEN="$3"; . "$1"; printf "state=%s\n" "$(obj_sweep_claim_owner_state "$2")"; obj_sweep_claim_release "$2"' _ "$fns" "$claim" "$tok_a" 2>&1)"
+  if printf '%s' "$out" | grep -q 'state=gone' && ! printf '%s' "$out" | grep -q 'LOG '; then
+    pass "obj-sweep(claim-gone): an already-released claim reads 'gone' and is reported as nothing — a double release is the ordinary case (the sweep path and then the EXIT trap), not a fault to page about"
+  else
+    fail "obj-sweep(claim-gone): [$(printf '%s' "$out" | tr '\n' '|')]"
+  fi
+}
+
+t test_object_store_sweep_claim_release_requires_ownership
+
+# THE OWNER TOKEN IS WRITTEN BEFORE `started`, AND THAT ORDER IS THE PROPERTY (#3749 review
+# round 11, item 2). `started` is what makes a claim AGEABLE by a peer, so a claim a peer
+# can age must already name its owner; the reverse order leaves a window in which a peer
+# takes over a claim whose owner is unrecorded, and the original owner then reads its own
+# live claim as `unknown` forever. STRUCTURAL over the shipped acquire body, and labelled
+# as such: both writes are inside one function with nothing a fixture can interpose on, so
+# whoever looks afterwards sees both files whichever order they were written in.
+test_object_store_sweep_claim_records_its_owner_before_started() {
+  local body owner_line started_line arm
+  body="$(sed -n '/^obj_sweep_claim_acquire() {/,/^}/p' "$SUPERVISOR")"
+  if [[ -z "$body" ]]; then
+    fail "obj-sweep(claim-order): obj_sweep_claim_acquire could not be extracted from $SUPERVISOR"
+    return 0
+  fi
+  # BOTH create paths — `acquired` and the round-5 `taken` recovery — are asserted, because
+  # a recovered claim is exactly the one a late original owner is about to release.
+  for arm in acquired taken; do
+    owner_line="$(printf '%s\n' "$body" | grep -n 'obj_sweep_claim_mark_owner' | sed -n "$([[ $arm == acquired ]] && echo 1 || echo 2)p" | cut -d: -f1)"
+    started_line="$(printf '%s\n' "$body" | grep -n 'obj_sweep_claim_mark_started' | sed -n "$([[ $arm == acquired ]] && echo 1 || echo 2)p" | cut -d: -f1)"
+    if [[ -n "$owner_line" && -n "$started_line" && "$owner_line" -lt "$started_line" ]]; then
+      pass "obj-sweep(claim-order/$arm): [STRUCTURAL] the ownership token is recorded (line $owner_line) BEFORE the start time (line $started_line) — a claim a peer can age already names its owner"
+    else
+      fail "obj-sweep(claim-order/$arm): [STRUCTURAL] owner='$owner_line' started='$started_line' — a claim can become ageable before it names an owner"
+    fi
+  done
+}
+
+t test_object_store_sweep_claim_records_its_owner_before_started
+
+# THE STOPPING TEXT MAY ONLY ASSERT WHAT IS TRUE OF EVERY CAUSE OF ITS VERDICT (#3749
+# review round 11, item 1).
+#
+# UNSWEEPABLE now has TWO causes — git fsck ran and reproducibly died, and a store whose
+# own config sets `fsck.*` keys (so no walk runs at all) — while the LATCH records only the
+# TOKEN. So a consumer reading that latch cannot know which cause fired, and its text used
+# to say "git fsck RAN and reproducibly DIED", which on the second cause is a
+# confidently-wrong sentence in the one place an operator reads when the box has stopped.
+# That is this issue's own false-rationale class, in a journal line.
+test_object_store_unsweepable_text_asserts_no_mechanism() {
+  local body needle bad_tokens=""
+  # The two texts derived from the token alone: the live stop branch's `case` arm and the
+  # cached-latch reader. Both are extracted from the shipped supervisor.
+  body="$(sed -n '/stop_headline="UNSWEEPABLE/,+3p;/UNSWEEPABLE)$/,+4p' "$SUPERVISOR" | grep -E 'stop_headline=|stop_body=|notify |log ')"
+  if [[ -z "$body" ]]; then
+    fail "obj-sweep(unsweepable-text): the UNSWEEPABLE operator text could not be extracted from $SUPERVISOR"
+    return 0
+  fi
+  for needle in 'DIED' 'died' 'fatal line' "fatal:"; do
+    printf '%s\n' "$body" | grep -qF -- "$needle" && bad_tokens="$bad_tokens [$needle]"
+  done
+  if [[ -z "$bad_tokens" ]]; then
+    pass "obj-sweep(unsweepable-text): neither the live stop text nor the cached-latch text names a MECHANISM — both are derived from the verdict token, which is all either reader knows, and the sweep's own quoted lines carry the cause"
+  else
+    fail "obj-sweep(unsweepable-text): mechanism claim(s)$bad_tokens in text derived from the token alone — true for one cause of UNSWEEPABLE and false for the other"
+  fi
+  # AND IT STILL SAYS THE TWO THINGS IT MUST: this is not clean, and no damage was
+  # established. A fix that emptied the text would pass the assert above.
+  if printf '%s\n' "$body" | grep -qi 'UNKNOWN' && printf '%s\n' "$body" | grep -qi 'NO damage'; then
+    pass "obj-sweep(unsweepable-text): it still states the two facts that ARE true of every cause — the store's content is UNKNOWN, and no damage was established"
+  else
+    fail "obj-sweep(unsweepable-text): the generalised text lost the UNKNOWN or the no-damage statement: [$(printf '%s\n' "$body" | tr '\n' '|' | cut -c1-300)]"
+  fi
+}
+
+t test_object_store_unsweepable_text_asserts_no_mechanism
 
 # ---------------------------------------------------------------------------
 # Test 48 (#3549, roborev job 196 F2): THE SUITE LEAVES NO FIXTURE PROCESS BEHIND.

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -10515,6 +10515,22 @@ test_object_store_unlatchable_corrupt_does_not_refresh_the_throttle() {
   else
     fail "obj-sweep(unlatchable): stamp='$(tr '\n' '/' <"$stamp" 2>/dev/null)' — a peer reading it can throttle past a confirmed-corrupt store (see $d/unlatchable.log)"
   fi
+  # AND THE ARM THAT MAKES *FORCING* NECESSARY RATHER THAN MERELY LEAVING THE STAMP ALONE:
+  # a PEER whose own sweep started earlier finishes DURING this one and writes a FRESH
+  # timestamp. Staged with the `during` hook (a side effect inside the sweep stub — the
+  # only way to place that write between this lane's read and its own write
+  # deterministically), which is the round-2 stale-writer idiom. "Leave the stamp alone"
+  # passes the arm above and FAILS here: the peer's fresh stamp survives and every lane on
+  # the box throttles for the interval over a store confirmed damaged.
+  calls="$d/calls-unlatchable-during"
+  root="$(obj_sweep_tree "$d" CORRUPT 4 "$calls" "printf '%s\\n' \"\$(date +%s)\" >$(printf '%q' "$stamp")")"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/during.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 1 && ! -e "$latch" ]] && [[ "$(sed -n 1p "$stamp" 2>/dev/null)" == 0 ]]; then
+    pass "obj-sweep(unlatchable): a peer's FRESH stamp written mid-sweep is overwritten to expired — an unlatchable finding is not undone by a concurrent writer"
+  else
+    fail "obj-sweep(unlatchable-during): rc=$rc latch=$([[ -e "$latch" ]] && echo yes || echo no) stamp='$(sed -n 1p "$stamp" 2>/dev/null)' — a peer's mid-sweep stamp survived an unlatchable CORRUPT verdict (see $d/during.log)"
+  fi
   # AND THE CONSEQUENCE, MEASURED ON A PEER: same box, same stamp, INSIDE the interval.
   # It must re-sweep (the stub records its invocations) and stop on its own finding.
   calls="$d/calls-unlatchable-peer"

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -10340,7 +10340,15 @@ test_object_store_sweep_claim_loser_waits_for_the_peer_verdict() {
       touch "$d/go"
       fixture_wait "$lane_a" >/dev/null 2>&1 || true
       fixture_wait "$lane_b" >/dev/null 2>&1 || true
-      fail "obj-sweep(loser-wait-parked/$arm): waiting=$(grep -c 'WAITING for the peer lane' "$d/b.log" 2>/dev/null || true) latch=$([[ -e "$OBJ_SWEEP_STAMP.STOP" ]] && echo present || echo absent) spawned=$([[ -f "$counter2" ]] && echo yes || echo no) after $waited polls (see $d/b.log)"
+      # NAME WHICH OF THE TWO THINGS WENT WRONG, because they are different findings and a
+      # single message for both is what makes a RED arm unattributable: a loser that never
+      # parked AND ALREADY RAN ITS WORKER is the round-12 defect itself, observed, while
+      # anything else here is a staging failure and proves nothing either way.
+      if [[ -f "$counter2" ]]; then
+        fail "obj-sweep(loser-wait-parked/$arm): THE DEFECT — the claim loser never waited (waiting=$(grep -c 'WAITING for the peer lane' "$d/b.log" 2>/dev/null || true)) and has ALREADY SPAWNED its worker while the peer's sweep was in flight (latch=$([[ -e "$OBJ_SWEEP_STAMP.STOP" ]] && echo present || echo absent) after $waited polls) — see $d/b.log"
+      else
+        fail "obj-sweep(loser-wait-parked/$arm): STAGING — waiting=$(grep -c 'WAITING for the peer lane' "$d/b.log" 2>/dev/null || true) latch=$([[ -e "$OBJ_SWEEP_STAMP.STOP" ]] && echo present || echo absent) spawned=no after $waited polls; the arm below could not be staged (see $d/b.log)"
+      fi
       continue
     fi
     # RELEASE LANE A: its sweep now prints its verdict and lane A acts on it.

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -9371,6 +9371,10 @@ t test_lane_lock_failure_cause_is_not_inferred_from_later_state
 # that count sweeps must not be made to count resolutions.
 obj_sweep_tree() {
   local d="$1" verdict="$2" rc="$3" calllog="${4:-}" during="${5:-}" storeline="${6:-}" root="$d/root"
+  # $7 (optional) — one `verdict-detail` line for the stub to print. The consumers are
+  # required to QUOTE the sweep's operator guidance rather than restate it (#3749 review
+  # round 9, item 2), and a planted token is the only way to measure that end to end.
+  local detail="${7:-}"
   mkdir -p "$root/scripts/local" "$root/scripts/lib"
   git -C "$root" init -q 2>/dev/null
   git -C "$root" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init 2>/dev/null
@@ -9408,6 +9412,7 @@ obj_sweep_tree() {
     # between its verdict print and its exit, or an older/stubbed script, leaves behind.
     # An empty string would print `verdict ` with an empty token, which is a DIFFERENT
     # (and unreachable) shape.
+    [[ -z "$detail" ]] || printf 'printf "OBJECT-STORE: verdict-detail %%s\\n" %s\n' "$(printf '%q' "$detail")"
     [[ "$verdict" == NONE ]] || printf 'printf "OBJECT-STORE: verdict %s\\n"\n' "$verdict"
     printf 'exit %s\n' "$rc"
   } >"$root/scripts/check-object-store-integrity.sh"
@@ -10559,6 +10564,89 @@ test_object_store_unlatchable_corrupt_does_not_refresh_the_throttle() {
 }
 
 t test_object_store_unlatchable_corrupt_does_not_refresh_the_throttle
+
+# THE OPERATOR REMEDY IS QUOTED FROM THE SWEEP, NOT RESTATED HERE (#3749 review round 9,
+# item 2).
+#
+# THE DEFECT. Three files carried their own copy of the repair instruction and all three
+# said `git fetch --force origin`, which repairs nothing — `--force` only permits
+# non-fast-forward REF updates and re-downloads no objects, so with the advertised tips
+# unchanged the negotiation can transfer nothing at all. An operator following it exactly
+# kept the corruption and gained the impression of a repair. The measurements are recorded
+# beside the text in check-object-store-integrity.sh; what THIS case pins is the plumbing
+# that makes one correction enough: the sweep owns the words, and this consumer prints them.
+#
+# WHY THIS IS NOT A STRING TAUTOLOGY. It does not assert what the remedy SAYS (which would
+# be a test of its own fixture). It plants a token no consumer could know and requires the
+# consumer to have PASSED IT THROUGH — so deleting the quote, or replacing it with a fresh
+# paraphrase, reds this case whatever the paraphrase happens to say.
+test_object_store_corrupt_quotes_the_sweeps_own_remedy() {
+  local d root counter calls rc token detail_out
+  token="REMEDY: PLANTED-REPAIR-TEXT-item2-$$"
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-remedy"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  root="$(obj_sweep_tree "$d" CORRUPT 4 "$calls" "" "" "$token")"
+  # CONSTRUCTION: the stub really does print that line, and the supervisor cannot have
+  # obtained the token any other way.
+  # CAPTURED FIRST, NOT PIPED: this suite runs with `pipefail` and the stub sweep EXITS 4
+  # by design, so a pipeline's status would be the stub's and not grep's — which decides
+  # the construction assert the wrong way (and, for its negated sibling below, decides it
+  # the wrong way in the PERMISSIVE direction).
+  detail_out="$(bash "$root/scripts/check-object-store-integrity.sh" 2>/dev/null || true)"
+  if printf '%s\n' "$detail_out" | grep -qF "OBJECT-STORE: verdict-detail $token"; then
+    pass "obj-sweep(remedy-plant): the stub sweep really prints the planted verdict-detail remedy line"
+  else
+    fail "obj-sweep(remedy-plant): the stub prints no such line — the assert below would be vacuous"
+    return
+  fi
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/remedy.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 1 ]] && grep -qF "$token" "$d/remedy.log"; then
+    pass "obj-sweep(remedy): the stopping lane QUOTES the sweep's own operator remedy verbatim — one correction, in the file that measured it, reaches the journal"
+  else
+    fail "obj-sweep(remedy): rc=$rc — the sweep's remedy text did not reach the journal (see $d/remedy.log)"
+  fi
+  # AND IT NAMES THE CONDITION FOR CLEARING THE LATCH: a successful re-run, not a belief.
+  if grep -q 'CLEAR THE LATCH ONLY AFTER' "$d/remedy.log"; then
+    pass "obj-sweep(remedy): clearing the latch is gated on a re-run of the sweep reporting its affirmative verdict"
+  else
+    fail "obj-sweep(remedy): the stop does not say what must be true before the latch is cleared (see $d/remedy.log)"
+  fi
+  # THE FALLBACK ARM, one property apart: a sweep that prints NO guidance at all (an older
+  # or stubbed script — the ordinary state on any branch cut before #3749). A stopping lane
+  # must never leave an operator with no remedy, so the consumer supplies one naming the
+  # sweep to run by hand.
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-remedy-none"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  root="$(obj_sweep_tree "$d" CORRUPT 4 "$calls")"
+  detail_out="$(bash "$root/scripts/check-object-store-integrity.sh" 2>/dev/null || true)"
+  if ! printf '%s\n' "$detail_out" | grep -q 'verdict-detail'; then
+    pass "obj-sweep(remedy-fallback-plant): this stub really prints no verdict-detail guidance at all"
+  else
+    fail "obj-sweep(remedy-fallback-plant): the stub does print guidance — the arm below is not the fallback"
+    return
+  fi
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/remedy-none.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 1 ]] && grep -q 'object-store: REMEDY' "$d/remedy-none.log" &&
+    grep -q 'check-object-store-integrity.sh' "$d/remedy-none.log"; then
+    pass "obj-sweep(remedy-fallback): with nothing to quote the lane still prints a remedy that names the sweep to run by hand — the diagnostic fails closed"
+  else
+    fail "obj-sweep(remedy-fallback): rc=$rc — a stopping lane was left with no remedy (see $d/remedy-none.log)"
+  fi
+}
+
+t test_object_store_corrupt_quotes_the_sweeps_own_remedy
 
 # THE STOP FILE AND THE WALL-CLOCK BUDGET ARE READ BEFORE THE SWEEP, NOT AFTER IT
 # (#3749 review round 3, item 3).

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -9391,7 +9391,11 @@ obj_sweep_tree() {
     [[ -n "$during" ]] && printf '%s\n' "$during"
     printf 'printf "OBJECT-STORE: measured stub\\n"\n'
     printf 'printf "OBJECT-STORE: object deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\\n"\n'
-    printf 'printf "OBJECT-STORE: verdict %s\\n"\n' "$verdict"
+    # The verdict `NONE` means PRINT NO VERDICT LINE AT ALL — the state a sweep killed
+    # between its verdict print and its exit, or an older/stubbed script, leaves behind.
+    # An empty string would print `verdict ` with an empty token, which is a DIFFERENT
+    # (and unreachable) shape.
+    [[ "$verdict" == NONE ]] || printf 'printf "OBJECT-STORE: verdict %s\\n"\n' "$verdict"
     printf 'exit %s\n' "$rc"
   } >"$root/scripts/check-object-store-integrity.sh"
   chmod +x "$root/scripts/check-object-store-integrity.sh"
@@ -9579,6 +9583,70 @@ test_object_store_sweep_knobs() {
 }
 
 t test_object_store_sweep_verdicts
+
+# BOTH CHANNELS MUST AGREE BEFORE A BOX-WIDE LATCH IS CREATED (#3749 review round 4,
+# item 2). The CORRUPT branch used to be `rc == 4 || verdict == CORRUPT` while the comment
+# above it already asserted the conjunction — the false-rationale class, and the reason
+# nobody looked. The harm is not a wrong log line: the latch is STICKY, BOX-WIDE and
+# operator-cleared, so an exit 4 with no verdict line, or a stray `CORRUPT` line under any
+# other status, HALTS EVERY LANE ON THE BOX until a human notices.
+#
+# Two arms, ONE PROPERTY APART — which of the two channels says CORRUPT — plus the control
+# that the conjunction still fires when they DO agree (without it, both arms would pass
+# against a supervisor that had simply lost the ability to latch at all).
+test_object_store_sweep_requires_both_channels_to_agree() {
+  local d root counter rc calls stamp latch arm verdict code
+  for arm in "status-only:NONE:4" "line-only:CORRUPT:5"; do
+    verdict="${arm#*:}"; code="${verdict#*:}"; verdict="${verdict%%:*}"
+    d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls"
+    common_env "$d"
+    write_finalize_stub "$d/bin/worker.sh" "$counter"
+    export WORKER_CMD="$d/bin/worker.sh"
+    export MAX_ISSUES=1
+    export OBJ_SWEEP_INTERVAL_HOURS=6
+    export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+    stamp="$OBJ_SWEEP_STAMP"; latch="$stamp.CORRUPT"
+    root="$(obj_sweep_tree "$d" "$verdict" "$code" "$calls")"
+    env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/stdout.log" 2>&1
+    rc=$?
+    if [[ "$rc" -eq 0 && -f "$counter" ]] && [[ ! -e "$latch" ]] &&
+      ! grep -q '"reason":"object-store-corrupt"' "$JOURNAL_FILE"; then
+      pass "obj-sweep(disagreement/${arm%%:*}): exactly ONE channel saying CORRUPT creates NO box-wide latch and stops no lane — an unrecognised or incomplete sweep cannot halt four lanes until an operator clears a file"
+    else
+      fail "obj-sweep(disagreement/${arm%%:*}): rc=$rc latched=$([[ -e "$latch" ]] && echo yes || echo no) spawned=$([[ -f "$counter" ]] && echo yes || echo no) (see $d/stdout.log)"
+    fi
+    # AND IT IS NAMED, not silently demoted: the generic UNMEASURED line would read as an
+    # ordinary "could not measure" for a run in which one channel reported damage.
+    if grep -q 'INCONSISTENT sweep result' "$d/stdout.log" &&
+      grep -q 'object-store: UNMEASURED' "$d/stdout.log"; then
+      pass "obj-sweep(disagreement/${arm%%:*}): the disagreement is journalled by name AND as UNMEASURED — the signal is not swallowed on the way past"
+    else
+      fail "obj-sweep(disagreement/${arm%%:*}): the run does not name the inconsistency: $(grep -c 'object-store' "$d/stdout.log") object-store line(s) (see $d/stdout.log)"
+    fi
+  done
+  # THE CONTROL: the two channels AGREEING still latches and still stops. One property
+  # from each arm above.
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  stamp="$OBJ_SWEEP_STAMP"; latch="$stamp.CORRUPT"
+  root="$(obj_sweep_tree "$d" CORRUPT 4 "$calls")"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/stdout.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 1 && ! -f "$counter" && -e "$latch" ]] &&
+    ! grep -q 'INCONSISTENT sweep result' "$d/stdout.log"; then
+    pass "obj-sweep(disagreement-control): rc=4 AND verdict CORRUPT together still latch the box and stop the lane, with no inconsistency claimed — the two arms above are the disagreement, not a lost ability to latch"
+  else
+    fail "obj-sweep(disagreement-control): rc=$rc latched=$([[ -e "$latch" ]] && echo yes || echo no) spawned=$([[ -f "$counter" ]] && echo yes || echo no) (see $d/stdout.log)"
+  fi
+}
+
+t test_object_store_sweep_requires_both_channels_to_agree
+
 t test_object_store_sweep_throttle_and_disable
 t test_object_store_sweep_knobs
 

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -10188,6 +10188,10 @@ test_object_store_sweep_claim_prevents_the_herd() {
   export MAX_ISSUES=1
   export OBJ_SWEEP_INTERVAL_HOURS=6
   export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  # POLL EVERY SECOND, because since #3749 review round 12 the loser WAITS for the peer's
+  # verdict instead of skipping immediately: the poll is what bounds how quickly it notices
+  # the peer finished. It is granularity, not the wait BOUND (which stays derived).
+  export OBJ_SWEEP_CLAIM_POLL_SECS=1
   # The `during` hook: announce that the sweep is IN FLIGHT, then block until this case
   # says go (bounded, so a wedged fixture fails the run rather than hanging it).
   root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls" \
@@ -10219,11 +10223,17 @@ test_object_store_sweep_claim_prevents_the_herd() {
   WORKER_CMD="$d/bin/worker2.sh" env LANE_ID=objsweep-b SUPERVISOR_LOCK="$d/lock-b" \
     bash "$root/scripts/local/worker-supervisor.sh" >"$d/b.log" 2>&1
   rc=$?
+  # SINCE #3749 REVIEW ROUND 12 THE LOSER WAITS, so what this asserts changed with the
+  # behaviour: lane B must NAME the claim, WAIT for that peer's verdict rather than walking
+  # off toward a spawn while an fsck is in flight, observe the peer's completion, and only
+  # then run its worker. The old assert required the opposite ("does not wait"), which is the
+  # very defect round 12 fixed — a peer's sweep can end in a verdict that latches this box.
   if [[ "$rc" -eq 0 && -f "$counter2" ]] &&
-    grep -q 'object-store sweep: SKIPPED — a peer lane on this box holds the sweep claim' "$d/b.log"; then
-    pass "obj-sweep(herd): a second lane whose peer is MID-SWEEP skips the sweep, names the claim, does not wait, and still runs its worker"
+    grep -q 'object-store sweep: WAITING for the peer lane that holds the sweep claim' "$d/b.log" &&
+    grep -q 'FINISHED its sweep after' "$d/b.log"; then
+    pass "obj-sweep(herd): a second lane whose peer is MID-SWEEP does not sweep beside it — it names the claim, WAITS for that peer's verdict, observes the completion, and then runs its worker"
   else
-    fail "obj-sweep(herd): rc=$rc spawned=$([[ -f "$counter2" ]] && echo yes || echo no) (see $d/b.log)"
+    fail "obj-sweep(herd): rc=$rc spawned=$([[ -f "$counter2" ]] && echo yes || echo no) waited=$(grep -c 'WAITING for the peer lane' "$d/b.log" 2>/dev/null || true) (see $d/b.log)"
   fi
   touch "$d/go"
   fixture_wait "$lane_a" >/dev/null 2>&1 || true
@@ -10262,6 +10272,176 @@ test_object_store_sweep_claim_prevents_the_herd() {
 
 t test_object_store_sweep_claim_prevents_the_herd
 
+# THE CLAIM LOSER MUST NOT SPAWN A WORKER WHILE THE PEER'S SWEEP IS STILL IN FLIGHT (#3749
+# review round 12).
+#
+# THE DEFECT. `held` read the STOP latch once and returned toward the spawn path. The lane
+# therefore committed to spawning at a moment when the only thing it knew was that a
+# full-store fsck was RUNNING — and if that fsck ends in CORRUPT or UNSWEEPABLE, the peer
+# latches the box and the loser has already started a worker on it. The window was the peer's
+# ENTIRE sweep (13-80s measured on this fleet, up to MAX_SWEEP_WALKS x OBJ_SWEEP_TIMEOUT_SECS
+# by construction), not the narrow post-read gap the residual note used to describe.
+#
+# TWO ARMS, ONE PROPERTY APART, AND THE CONTROL IS LOAD-BEARING. Arm (a) has the peer latch
+# the box mid-sweep and requires the loser NOT to spawn. On its own that arm is also passed by
+# a lane that never spawns at all, so arm (b) is the same staging with the peer finishing
+# CLEAN, where the loser MUST proceed and run its worker. Only the peer's verdict differs.
+test_object_store_sweep_claim_loser_waits_for_the_peer_verdict() {
+  local d root calls counter1 counter2 rc waited lane_a lane_b verdict rcode arm
+  for arm in corrupt clean; do
+    if [[ "$arm" == corrupt ]]; then verdict=CORRUPT; rcode=4; else verdict=VERIFIED; rcode=0; fi
+    d="$(new_case_dir)"; calls="$d/calls"; counter1="$d/counter1"; counter2="$d/counter2"
+    common_env "$d"
+    write_finalize_stub "$d/bin/worker1.sh" "$counter1"
+    write_finalize_stub "$d/bin/worker2.sh" "$counter2"
+    export MAX_ISSUES=1
+    export OBJ_SWEEP_INTERVAL_HOURS=6
+    export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+    # POLL EVERY SECOND so the arm is seconds rather than tens of seconds; the WAIT BOUND is
+    # still the derived one (3 x 1 + 60 = 63s here), which is what has to comfortably exceed
+    # the staging below — if it did not, the wait would expire and the loser would carry on
+    # for a reason that has nothing to do with the property under test.
+    export OBJ_SWEEP_CLAIM_POLL_SECS=1
+    export OBJ_SWEEP_TIMEOUT_SECS=1
+    root="$(obj_sweep_tree "$d" "$verdict" "$rcode" "$calls" \
+      "printf in >$(printf '%q' "$d/sweeping"); i=0; while [ ! -f $(printf '%q' "$d/go") ] && [ \$i -lt 400 ]; do sleep 0.05; i=\$((i+1)); done")"
+    # LANE A: takes the claim and parks INSIDE its sweep until this case says go. Through
+    # fixture_bg (never a bare `&`) so the harness owns the process group, and with its own
+    # single-instance lock, which is what two lanes of one box legitimately have.
+    fixture_bg env WORKER_CMD="$d/bin/worker1.sh" LANE_ID=objsweep-wait-a \
+      SUPERVISOR_LOCK="$d/lock-a" \
+      bash "$root/scripts/local/worker-supervisor.sh" >"$d/a.log" 2>&1
+    lane_a="$FIXTURE_LAST_PID"
+    waited=0
+    while [[ ! -f "$d/sweeping" && "$waited" -lt 400 ]]; do sleep 0.05; waited=$((waited + 1)); done
+    if [[ -f "$d/sweeping" && -d "$OBJ_SWEEP_STAMP.sweeping" && ! -e "$OBJ_SWEEP_STAMP.STOP" ]]; then
+      pass "obj-sweep(loser-wait-plant/$arm): lane A is INSIDE its sweep, holds the claim, and the box is NOT yet latched — so lane B below meets a genuinely in-flight sweep"
+    else
+      touch "$d/go"; fixture_wait "$lane_a" >/dev/null 2>&1 || true
+      fail "obj-sweep(loser-wait-plant/$arm): in-sweep=$([[ -f "$d/sweeping" ]] && echo yes || echo no) claim=$([[ -d "$OBJ_SWEEP_STAMP.sweeping" ]] && echo yes || echo no) latch=$([[ -e "$OBJ_SWEEP_STAMP.STOP" ]] && echo present || echo absent) after $waited polls"
+      continue
+    fi
+    # LANE B: the claim LOSER. Backgrounded, because the whole point is that it now BLOCKS.
+    fixture_bg env WORKER_CMD="$d/bin/worker2.sh" LANE_ID=objsweep-wait-b \
+      SUPERVISOR_LOCK="$d/lock-b" \
+      bash "$root/scripts/local/worker-supervisor.sh" >"$d/b.log" 2>&1
+    lane_b="$FIXTURE_LAST_PID"
+    waited=0
+    while ! grep -q 'WAITING for the peer lane that holds the sweep claim' "$d/b.log" 2>/dev/null &&
+      [[ "$waited" -lt 600 ]]; do sleep 0.05; waited=$((waited + 1)); done
+    # CONSTRUCTION ASSERT, AND IT IS THE ONE THAT MAKES THE ARM MEAN ANYTHING: B is parked on
+    # the peer BEFORE any verdict exists — no latch, no worker of its own. Without this, arm
+    # (a) would also be passed by a lane that simply read an ALREADY-latched box, which is
+    # the pre-existing behaviour and not the fix.
+    if grep -q 'WAITING for the peer lane that holds the sweep claim' "$d/b.log" 2>/dev/null &&
+      [[ ! -e "$OBJ_SWEEP_STAMP.STOP" && ! -f "$counter2" ]]; then
+      pass "obj-sweep(loser-wait-parked/$arm): lane B is WAITING on the peer's in-flight sweep with no latch yet recorded and no worker of its own started"
+    else
+      touch "$d/go"
+      fixture_wait "$lane_a" >/dev/null 2>&1 || true
+      fixture_wait "$lane_b" >/dev/null 2>&1 || true
+      fail "obj-sweep(loser-wait-parked/$arm): waiting=$(grep -c 'WAITING for the peer lane' "$d/b.log" 2>/dev/null || true) latch=$([[ -e "$OBJ_SWEEP_STAMP.STOP" ]] && echo present || echo absent) spawned=$([[ -f "$counter2" ]] && echo yes || echo no) after $waited polls (see $d/b.log)"
+      continue
+    fi
+    # RELEASE LANE A: its sweep now prints its verdict and lane A acts on it.
+    touch "$d/go"
+    fixture_wait "$lane_a" >/dev/null 2>&1 || true
+    fixture_wait "$lane_b" >/dev/null 2>&1
+    # FIXTURE_WAIT_STATUS, NEVER `$?`: fixture_wait ALWAYS returns 0 (it goes on to release
+    # ownership of the group), and reading `$?` here made the corrupt arm assert `rc -ne 0`
+    # against a constant 0 — a case that could never pass, found by running it.
+    rc="$FIXTURE_WAIT_STATUS"
+    if [[ "$arm" == corrupt ]]; then
+      # `CORRUPT (cached at` IS THE ATTRIBUTION. That wording is printed only by
+      # obj_sweep_stop_if_latched — i.e. only by a lane that READ a latch a peer recorded —
+      # while the sweeping lane prints "CORRUPT — stopping loudly". The journal and the
+      # notify log are shared by both lanes of this case, so a bare reason grep could not
+      # tell lane B's stop from lane A's.
+      if [[ "$rc" -ne 0 && ! -f "$counter2" ]] &&
+        grep -q 'object-store: CORRUPT (cached at' "$d/b.log"; then
+        pass "obj-sweep(loser-wait/corrupt): a lane parked on a peer's sweep that ends in CORRUPT STOPS on the latch and never spawns a worker — the window that was the peer's whole sweep"
+      else
+        fail "obj-sweep(loser-wait/corrupt): rc=$rc spawned=$([[ -f "$counter2" ]] && echo yes || echo no) latch=$([[ -e "$OBJ_SWEEP_STAMP.STOP" ]] && echo present || echo absent) (see $d/b.log, $d/a.log)"
+      fi
+      # AND IT IS THE PEER'S LATCH IT STOPPED ON: the verdict was recorded box-wide, and the
+      # page lane B raised is the LATCHED-box one, which only the latch reader emits.
+      if [[ -e "$OBJ_SWEEP_STAMP.STOP" ]] &&
+        grep -q 'SHARED OBJECT STORE CORRUPT (latched)' "$NOTIFY_LOG" 2>/dev/null; then
+        pass "obj-sweep(loser-wait/corrupt): the peer's verdict was recorded box-wide and the waiting lane paged for a LATCHED store rather than for one it swept itself"
+      else
+        fail "obj-sweep(loser-wait/corrupt-page): latch=$([[ -e "$OBJ_SWEEP_STAMP.STOP" ]] && echo present || echo absent) notify=$(grep -c 'latched' "$NOTIFY_LOG" 2>/dev/null || true)"
+      fi
+    else
+      if [[ "$rc" -eq 0 && -f "$counter2" ]] &&
+        grep -q 'FINISHED its sweep after' "$d/b.log" &&
+        [[ "$(obj_sweep_calls "$calls")" -eq 1 ]]; then
+        pass "obj-sweep(loser-wait/clean-control): the SAME staging with a peer that finishes CLEAN lets the loser proceed and run its worker after ONE sweep across both lanes — so the corrupt arm is the verdict, not a lane that stopped spawning"
+      else
+        fail "obj-sweep(loser-wait/clean-control): rc=$rc spawned=$([[ -f "$counter2" ]] && echo yes || echo no) calls=$(obj_sweep_calls "$calls") (see $d/b.log)"
+      fi
+    fi
+    unset OBJ_SWEEP_CLAIM_POLL_SECS OBJ_SWEEP_TIMEOUT_SECS
+  done
+}
+
+t test_object_store_sweep_claim_loser_waits_for_the_peer_verdict
+
+# TWO STRUCTURAL PROPERTIES OF THE WAIT THAT NO BEHAVIOURAL CASE CAN SEE (#3749 review round
+# 12). Both are about how the wait is WIRED, and each has a specific way of failing silently.
+#
+# 1. IT MUST NOT BE CALLED IN A COMMAND SUBSTITUTION. The wait stops the lane from inside
+#    (obj_sweep_stop_if_latched -> finalize_exit) the moment a peer latches the box. Inside
+#    `$(...)` that exit is confined to a SUBSHELL: the wait would appear to return normally
+#    and the lane would carry on to spawn a worker on a box it had just seen condemned — the
+#    exact defect the wait exists to close, reintroduced by the plumbing, and INVISIBLE to a
+#    test that stages a latch, because the state would look right in every log line. It is
+#    the same trap obj_sweep_claim_acquire documents for OBJ_SWEEP_CLAIM_OWNED.
+# 2. THE WAIT BOUND MUST BE THE CLAIM'S OWN DERIVED STALENESS BOUND, not a second constant.
+#    A wait bound that drifts from the sweep's real worst case is wrong in both directions
+#    (too short abandons a live peer mid-sweep; too long waits out a claim that was already
+#    recoverable), and a literal would still pass every behavioural case here because the
+#    fixtures pin the knobs anyway.
+test_object_store_sweep_claim_wait_is_wired_correctly() {
+  local body call_line wait_line subst
+  body="$(awk '/^object_store_sweep\(\) \{$/,/^\}$/' "$SUPERVISOR")"
+  if [[ -n "$body" ]] && grep -q 'obj_sweep_claim_wait ' <<<"$body" &&
+    grep -q 'obj_sweep_claim_stale_secs ' <<<"$body"; then
+    pass "obj-sweep(wait-wiring-plant): object_store_sweep was extracted from the shipped supervisor and calls both obj_sweep_claim_wait and obj_sweep_claim_stale_secs"
+  else
+    fail "obj-sweep(wait-wiring-plant): the extracted body is $(wc -l <<<"$body") lines and does not carry both calls — the asserts below would be vacuous"
+    return
+  fi
+  # (1) EVERY call site, and the test is over COMMAND POSITIONS: a mention inside a comment
+  #     or a log string is prose, not a call.
+  subst="$(grep -n 'obj_sweep_claim_wait' <<<"$body" | grep -v '^\s*[0-9]*:\s*#' |
+    { grep -E '\$\(\s*obj_sweep_claim_wait|`obj_sweep_claim_wait' || true; })"
+  if [[ -z "$subst" ]]; then
+    pass "obj-sweep(wait-no-subshell): obj_sweep_claim_wait is never called in a command substitution, so the stop it performs on a peer's latch cannot be confined to a subshell [STRUCTURAL]"
+  else
+    fail "obj-sweep(wait-no-subshell): called inside a command substitution — its finalize_exit would only exit that subshell: $subst"
+  fi
+  # AND THE FUNCTION ITSELF MUST NOT PUBLISH ITS OUTCOME ON STDOUT, which is what would
+  # invite such a call site in the first place.
+  if ! sed -n '/^obj_sweep_claim_wait() {/,/^}/p' "$SUPERVISOR" |
+    { grep -E '^\s*(printf|echo) ' || true; } | grep -q .; then
+    pass "obj-sweep(wait-no-stdout): obj_sweep_claim_wait publishes its outcome in a GLOBAL and prints nothing, so there is no reason for a caller to reach for a command substitution [STRUCTURAL]"
+  else
+    fail "obj-sweep(wait-no-stdout): it writes to stdout, which invites the command-substitution call site the assert above forbids"
+  fi
+  # (2) THE BOUND'S PROVENANCE. The call must pass the DERIVED value, and the iteration's
+  #     outer budget must be computed FROM that same value — neither may be a literal.
+  wait_line="$({ grep -E '^\s*obj_sweep_claim_wait ' <<<"$body" || true; } | head -1)"
+  call_line="$({ grep -E '^\s*wait_until=\$\(\(' <<<"$body" || true; } | head -1)"
+  if [[ "$wait_line" == *'"$claim_stale"'* ]] && [[ "$call_line" == *'claim_stale'* ]] &&
+    [[ ! "$wait_line" =~ [0-9]{2,} ]]; then
+    pass "obj-sweep(wait-bound-derived): the wait is bounded by the claim's OWN derived staleness value (obj_sweep_claim_stale_secs), and the iteration's outer budget is computed from it — no second, driftable constant [STRUCTURAL]"
+  else
+    fail "obj-sweep(wait-bound-derived): call='$wait_line' budget='$call_line' — the wait bound must be the derived claim_stale, never a literal"
+  fi
+}
+
+t test_object_store_sweep_claim_wait_is_wired_correctly
+
 # THE OTHER HALF, AND THE HAZARD THE CLAIM INTRODUCES: A STALE CLAIM MUST NOT WEDGE THE BOX
 # (#3749 review round 5, item 2). A lane killed mid-sweep leaves its claim behind, and
 # without recovery no lane on the box ever sweeps again — strictly worse than the herd.
@@ -10280,8 +10460,12 @@ test_object_store_sweep_claim_recovers_when_stale() {
   walks="${walks#MAX_SWEEP_WALKS=}"
   per_walk="$({ grep -m1 '^OBJ_SWEEP_TIMEOUT_SECS=' "$SUPERVISOR" || true; } 2>/dev/null)"
   per_walk="${per_walk#*:-}"; per_walk="${per_walk%%\}*}"
+  # PARSED THE SAME WAY AS THE PER-WALK BOUND ABOVE, because since #3749 review round 12 the
+  # slack term is an env-overridable default (`"${VAR:-60}"`) rather than a bare literal — it
+  # is what lets the wait cases below compress this derived bound instead of sleeping a
+  # minute. Read the SHIPPED default out of the declaration, never re-typed here.
   bound="$({ grep -m1 '^OBJ_SWEEP_CLAIM_SLACK_SECS=' "$SUPERVISOR" || true; } 2>/dev/null)"
-  bound="${bound#OBJ_SWEEP_CLAIM_SLACK_SECS=}"
+  bound="${bound#*:-}"; bound="${bound%%\}*}"
   if grep -q '^obj_sweep_claim_stale_secs() {' "$fns" &&
     [[ "$walks" =~ ^[0-9]+$ && "$per_walk" =~ ^[0-9]+$ && "$bound" =~ ^[0-9]+$ ]]; then
     pass "obj-sweep(claim-bound-plant): all three declarations were read from the shipped files (MAX_SWEEP_WALKS $walks, per-walk bound $per_walk s, slack $bound s)"
@@ -10318,6 +10502,14 @@ test_object_store_sweep_claim_recovers_when_stale() {
   fi
   # (c) CONTROL, one property apart: the same claim with a FRESH start time. It must be
   #     respected — so (b) is the AGE and not the recovery firing unconditionally.
+  #
+  #     WHAT ROUND 12 CHANGED HERE, AND WHY THE BOUND IS COMPRESSED. A fresh claim is no
+  #     longer skipped past: the lane WAITS for the peer that holds it, and this plant is a
+  #     claim NOBODY WILL EVER FINISH, so the wait can only end by exhausting the whole
+  #     derived budget. At the shipped defaults that is 660s of sleeping, so this case pins
+  #     OBJ_SWEEP_TIMEOUT_SECS and the (now env-overridable) slack term to make the SAME
+  #     derived relation come out at a few seconds. The property under test is unchanged;
+  #     only its price is.
   d="$(new_case_dir)"; calls="$d/calls-fresh"; counter="$d/counter"
   common_env "$d"
   write_finalize_stub "$d/bin/worker.sh" "$counter"
@@ -10325,6 +10517,9 @@ test_object_store_sweep_claim_recovers_when_stale() {
   export MAX_ISSUES=1
   export OBJ_SWEEP_INTERVAL_HOURS=6
   export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  export OBJ_SWEEP_TIMEOUT_SECS=1
+  export OBJ_SWEEP_CLAIM_SLACK_SECS=2
+  export OBJ_SWEEP_CLAIM_POLL_SECS=1
   claim="$OBJ_SWEEP_STAMP.sweeping"
   mkdir -p "$claim"
   printf '%s\n' "$(date +%s)" >"$claim/started"
@@ -10332,11 +10527,47 @@ test_object_store_sweep_claim_recovers_when_stale() {
   env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/fresh.log" 2>&1
   rc=$?
   if [[ "$rc" -eq 0 && ! -s "$calls" && -f "$counter" ]] &&
-    grep -q 'holds the sweep claim' "$d/fresh.log"; then
-    pass "obj-sweep(claim-fresh-control): a claim younger than the bound is respected — the recovery is age-driven, not unconditional"
+    grep -q 'WAITING for the peer lane that holds the sweep claim' "$d/fresh.log" &&
+    grep -q 'NOT SWEPT AND NOT MEASURED' "$d/fresh.log"; then
+    pass "obj-sweep(claim-fresh-control): a claim younger than the bound is respected — the lane WAITS for it instead of sweeping beside it, and a peer that never finishes ends the wait as NOT MEASURED rather than as a clean skip"
   else
-    fail "obj-sweep(claim-fresh-control): rc=$rc calls=$(obj_sweep_calls "$calls") (see $d/fresh.log)"
+    fail "obj-sweep(claim-fresh-control): rc=$rc calls=$(obj_sweep_calls "$calls") waited=$(grep -c 'WAITING for the peer lane' "$d/fresh.log" 2>/dev/null || true) (see $d/fresh.log)"
   fi
+  unset OBJ_SWEEP_TIMEOUT_SECS OBJ_SWEEP_CLAIM_SLACK_SECS OBJ_SWEEP_CLAIM_POLL_SECS
+  # (c2) THE `expired` PATH, WHICH IS ROUND 12'S NON-PERMISSIVE OUTCOME AND ONE PROPERTY
+  #      FROM (c): the same never-finishing claim, planted OLD ENOUGH that its own derived
+  #      deadline falls INSIDE the wait. The lane must not carry on unmeasured — it recovers
+  #      the claim the moment that deadline passes and MEASURES the store itself. The loser
+  #      becomes the sweeper.
+  d="$(new_case_dir)"; calls="$d/calls-expired"; counter="$d/counter"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  export OBJ_SWEEP_TIMEOUT_SECS=1
+  export OBJ_SWEEP_CLAIM_SLACK_SECS=4
+  export OBJ_SWEEP_CLAIM_POLL_SECS=1
+  claim="$OBJ_SWEEP_STAMP.sweeping"
+  mkdir -p "$claim"
+  # Derived from the pinned knobs, never re-typed: MAX_SWEEP_WALKS(3) x 1 + 4 = 7s, planted
+  # 4s old, so the claim's own deadline is ~3s out while the outer budget is ~7s — the one
+  # arrangement in which `expired` and not `exhausted` is the outcome.
+  printf '%s\n' "$(( $(date +%s) - 4 ))" >"$claim/started"
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/expired.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 0 && "$(obj_sweep_calls "$calls")" -eq 1 && -f "$counter" ]] &&
+    grep -q 'WAITING for the peer lane that holds the sweep claim' "$d/expired.log" &&
+    grep -q 'will RECOVER the claim and measure the store itself' "$d/expired.log" &&
+    grep -q 'RECOVERED a stale sweep claim' "$d/expired.log" &&
+    ! grep -q 'NOT SWEPT AND NOT MEASURED' "$d/expired.log"; then
+    pass "obj-sweep(claim-wait-expired): when the peer neither finishes nor gives the claim up, the waiting lane RECOVERS it at the derived deadline and measures the store itself — the non-permissive outcome, not a carry-on"
+  else
+    fail "obj-sweep(claim-wait-expired): rc=$rc calls=$(obj_sweep_calls "$calls") (see $d/expired.log)"
+  fi
+  unset OBJ_SWEEP_TIMEOUT_SECS OBJ_SWEEP_CLAIM_SLACK_SECS OBJ_SWEEP_CLAIM_POLL_SECS
   # (d) A CLAIM WITH NO PARSEABLE START TIME is treated as STALE — the deliberate
   #     direction, because its cause is a lane killed between the mkdir and the `started`
   #     write, and the other reading wedges the sweep forever on a file nobody can age.

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -9842,6 +9842,113 @@ test_object_store_corrupt_leaves_both_the_latch_and_the_stamp() {
 
 t test_object_store_corrupt_leaves_both_the_latch_and_the_stamp
 
+# THE STOP FILE AND THE WALL-CLOCK BUDGET ARE READ BEFORE THE SWEEP, NOT AFTER IT
+# (#3749 review round 3, item 3).
+#
+# THE DEFECT. `preflight_wait` ran `object_store_sweep` BEFORE the hold loop, whose first
+# statement is the stop-file and budget check — so a stop requested after the outer
+# loop's own check (during `credit_merged_pending_prs`' gh calls, or the claim
+# migration's bounded retry burst, both of which sit between them) was ignored for the
+# whole sweep. Round 2 raised the per-walk bound to 600s and the sweep takes two walks on
+# the non-clean path, so that ignore-window had just grown to ~20 minutes.
+#
+# DRIVEN THROUGH THE SHIPPED FUNCTION, SOURCED (the sv_scratch_head idiom): the ordering
+# inside `preflight_wait` is the whole subject, and a full supervisor run cannot stage it
+# — the outer loop checks the stop file first, so a stop file present at startup never
+# reaches this function at all. Sourcing means the function under test is the shipped
+# one, and the stubs below only OBSERVE.
+sv_preflight_order_driver() {
+  local out="$1" obs="$2"
+  {
+    sv_scratch_head
+    printf 'OBS=%s\n' "$(printf '%q' "$obs")"
+    printf ': >"$OBS"\n'
+    # The supervisor assigns START_TS unconditionally at source time, so the budget arm
+    # has to move it AFTERWARDS; an env value alone is silently overwritten (which is how
+    # that arm first passed the sweep it was meant to skip).
+    printf 'START_TS="${DRV_START_TS:-$START_TS}"\n'
+    # Defined AFTER the source, so they replace the shipped definitions. Each records and
+    # nothing else; finalize_exit ends the driver as the real one ends the process.
+    printf 'object_store_sweep() { printf "sweep\\n" >>"$OBS"; return 0; }\n'
+    printf 'finalize_exit() { printf "finalize:%%s:%%s\\n" "$1" "$2" >>"$OBS"; exit 0; }\n'
+    printf 'preflight_reason() { printf "preflight-probe\\n" >>"$OBS"; printf ""; }\n'
+    printf 'preflight_wait\n'
+    printf 'printf "returned\\n" >>"$OBS"\n'
+  } >"$out"
+}
+test_preflight_reads_the_stop_file_before_the_object_store_sweep() {
+  local d obs drv
+  d="$(new_case_dir)"; obs="$d/obs.txt"; drv="$d/drv.sh"
+  sv_preflight_order_driver "$drv" "$obs"
+  if ! bash -n "$drv" 2>/dev/null; then
+    fail "preflight-order-plant: the scratch driver does not parse — the arms below would prove nothing"
+    return
+  fi
+  # (a) CONTROL FIRST, so a green in (b) cannot come from a driver that never reaches the
+  #     sweep at all: no stop file, budget not exhausted => the sweep runs and the function
+  #     returns normally.
+  # MAX_HOURS_SECS is DERIVED inside main(), which a sourced driver never runs, so it is
+  # supplied explicitly here rather than left empty (an empty value compares as 0 and
+  # would fire the budget in every arm — which is how the control arm first failed).
+  env STOP_FILE="$d/absent-stop" START_TS="$(date +%s)" MAX_HOURS_SECS=99999 \
+    bash "$drv" >"$d/ctl.log" 2>&1
+  if grep -qx 'sweep' "$obs" && grep -qx 'returned' "$obs" && ! grep -q '^finalize:' "$obs"; then
+    pass "preflight-order-control: with no stop file the sweep RUNS and preflight_wait returns — the arms below are not passing because the driver never gets there"
+  else
+    fail "preflight-order-control: obs=[$(tr '\n' ';' <"$obs")] (see $d/ctl.log)"
+  fi
+  # (b) THE SUBJECT: a stop file present when preflight_wait is entered. The loop must
+  #     exit `stop-file` and the sweep must NOT have run.
+  : >"$d/stop"
+  env STOP_FILE="$d/stop" START_TS="$(date +%s)" MAX_HOURS_SECS=99999 \
+    bash "$drv" >"$d/stop.log" 2>&1
+  if grep -qx 'finalize:stop-file:0' "$obs" && ! grep -qx 'sweep' "$obs"; then
+    pass "preflight-order: a stop file present on entry exits the loop BEFORE the object-store sweep — an operator's stop is not held for up to two fsck bounds"
+  else
+    fail "preflight-order(stop): obs=[$(tr '\n' ';' <"$obs")] — the sweep ran (or the stop was not read) ahead of the stop file (see $d/stop.log)"
+  fi
+  # (c) THE SAME FOR THE WALL-CLOCK BUDGET, one property apart from (b): no stop file,
+  #     an exhausted budget. Both conditions are checked at the same point, and asserting
+  #     only one would let the other regress.
+  env STOP_FILE="$d/absent-stop" DRV_START_TS=0 MAX_HOURS_SECS=1 \
+    bash "$drv" >"$d/budget.log" 2>&1
+  if grep -qx 'finalize:budget-wallclock:0' "$obs" && ! grep -qx 'sweep' "$obs"; then
+    pass "preflight-order: an exhausted wall-clock budget also exits BEFORE the sweep — the run does not spend minutes of hygiene past its own deadline"
+  else
+    fail "preflight-order(budget): obs=[$(tr '\n' ';' <"$obs")] (see $d/budget.log)"
+  fi
+}
+
+t test_preflight_reads_the_stop_file_before_the_object_store_sweep
+
+# AND THE EXPOSURE IS BOUNDED IN WALL TIME, because the in-flight sweep is NOT
+# interruptible (#3749 review round 3, item 3). Its two walks run in a CHILD process, so
+# no check between them can execute here; the only lever this caller has is how long the
+# two of them may take. The supervisor's default per-walk bound is therefore HALF the
+# sweep script's own, so 2 walks here cost no more than 1 walk at the script's bound.
+# Asserted as a RELATION between the two defaults, read from both shipped files, rather
+# than as two magic numbers that could drift apart silently.
+test_supervisor_sweep_bound_is_half_the_sweep_scripts_own() {
+  local sup_default script_default sweep_sh
+  sweep_sh="$REPO_ROOT/scripts/check-object-store-integrity.sh"
+  sup_default="$(sed -n 's/^OBJ_SWEEP_TIMEOUT_SECS="\${OBJ_SWEEP_TIMEOUT_SECS:-\([0-9]*\)}"$/\1/p' "$SUPERVISOR" | head -1)"
+  script_default="$(sed -n 's/^BOUND_SECS=\([0-9]*\)$/\1/p' "$sweep_sh" | head -1)"
+  if [[ "$sup_default" =~ ^[0-9]+$ ]] && [[ "$script_default" =~ ^[0-9]+$ ]] &&
+    [[ "$sup_default" -gt 0 ]] && [[ "$script_default" -gt 0 ]]; then
+    pass "sweep-bound-plant: both defaults were read from the shipped files (supervisor $sup_default, sweep script $script_default)"
+  else
+    fail "sweep-bound-plant: supervisor='$sup_default' script='$script_default' — one of the declarations moved; the assert below would be vacuous"
+    return
+  fi
+  if [[ $((sup_default * 2)) -le "$script_default" ]]; then
+    pass "sweep-bound: the supervisor's per-walk bound ($sup_default s) is at most HALF the sweep script's own ($script_default s), so its worst case of TWO walks costs no more than ONE walk at the script's bound — the uninterruptible window did not double when the script's bound was raised"
+  else
+    fail "sweep-bound: 2 x $sup_default > $script_default — the supervisor can block uninterruptibly for longer than one of the sweep script's own bounds"
+  fi
+}
+
+t test_supervisor_sweep_bound_is_half_the_sweep_scripts_own
+
 # THE CREATE-ONLY PRIMITIVE ITSELF (#3749 review round 2, BLOCKER 1).
 #
 # The case above proves the harm is prevented on the path the supervisor takes. This one

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -961,8 +961,9 @@ common_env() {
   export LOAD_PROBE_CMD="echo 0"
   export DISK_PROBE_CMD="echo 999999"
   # The #3749 shared-object-store sweep OFF by default: `REPO_ROOT` is the REAL lane
-  # checkout in these cases, so a sweep here would `git fsck` this box's 331M shared store
-  # (19.83s measured) once per case — minutes added to a MANDATORY gate component for a
+  # checkout in these cases, so a sweep here would `git fsck` this box's 366M shared store
+  # once per case — 13-24s warm and 47-80s cold or under concurrent gates (two independent
+  # measurement sets), i.e. MANY minutes added to a MANDATORY gate component for a
   # property these cases are not about. The dedicated cases below override it and point the
   # supervisor at their own scratch tree with a stub sweep, so the branch coverage is real
   # rather than mocked away.
@@ -9338,24 +9339,6 @@ t test_lane_lock_failure_cause_is_not_inferred_from_later_state
 
 
 # ---------------------------------------------------------------------------
-# Test 48 (#3549, roborev job 196 F2): THE SUITE LEAVES NO FIXTURE PROCESS BEHIND.
-#
-# This is the assert the leak had no equivalent of: the fixtures were reaped per case, by pid, and
-# nothing ever CHECKED, so five-minute orphans accumulated invisibly behind a green summary on a
-# four-lane box. Cleanup that is not asserted is a comment.
-#
-# WHAT IT MEASURES. Every `fixture_bg` registers its pgid as OWNED; this runs the same reap the EXIT trap
-# runs and then asks each STILL-OWNED group whether any member is still alive (`kill -0` on a negative
-# pid). A group is the right unit: it sees an ORPHANED CHILD whose parent shell is already gone, which is
-# exactly the leak — a `sleep 300` inside `bash <script>`.
-#
-# THE COUNT AND THE SUBJECT SET ARE NOW DIFFERENT THINGS (#3549, roborev job 198 F2). `FIXTURE_OWNED`
-# SHRINKS: a group is released the moment it is proven gone, which is what stops a later reap signalling
-# a recycled pgid. So the non-vacuity floor is taken from `FIXTURE_STAGED`, the monotone count of groups
-# ever staged, and the leak set is what remains OWNED after the reap. A group released as `foreign`
-# (existing but unsignallable — the number now belongs to another user) is NOT a leak of ours and is
-# reported separately if it ever happens, because calling it a leak would blame this suite for a pid
-# ---------------------------------------------------------------------------
 # Tests (#3749): the THROTTLED shared-object-store sweep in the preflight path.
 #
 # Every case runs the supervisor from a SCRATCH TREE carrying a STUB sweep script — the
@@ -9397,6 +9380,18 @@ obj_sweep_tree() {
   } >"$root/scripts/check-object-store-integrity.sh"
   chmod +x "$root/scripts/check-object-store-integrity.sh"
   printf '%s' "$root"
+}
+
+# obj_sweep_calls <file> -> the number of recorded invocations, ALWAYS one integer.
+# `grep -c .` prints `0` AND EXITS 1 on an existing-but-empty file, so the idiom
+# `n=$(grep -c . f || echo 0)` yields the two-line value `0\n0` and the `[[ -eq ]]`
+# that follows ERRORS instead of comparing — a diagnostic garbled exactly on the
+# failing path, and the two-valued collapse this repo lints for elsewhere.
+obj_sweep_calls() {
+  local n
+  n="$(grep -c . "$1" 2>/dev/null || true)"
+  [[ "$n" =~ ^[0-9]+$ ]] || n=0
+  printf '%s' "$n"
 }
 
 test_object_store_sweep_verdicts() {
@@ -9496,7 +9491,7 @@ test_object_store_sweep_throttle_and_disable() {
   root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
   env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/run1.log" 2>&1
   env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/run2.log" 2>&1
-  n=$(grep -c . "$calls" 2>/dev/null || echo 0)
+  n=$(obj_sweep_calls "$calls")
   if [[ "$n" -eq 1 ]]; then
     pass "obj-sweep(throttle): two runs inside the interval sweep exactly ONCE (measured invocations, not inferred)"
   else
@@ -9506,7 +9501,7 @@ test_object_store_sweep_throttle_and_disable() {
   # snapshot, a hand-edited file). ONE property apart from (a): the stamp's value.
   printf '%s\n' "$(( $(date +%s) + 86400 ))" >"$OBJ_SWEEP_STAMP"
   env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/run3.log" 2>&1
-  n=$(grep -c . "$calls" 2>/dev/null || echo 0)
+  n=$(obj_sweep_calls "$calls")
   if [[ "$n" -eq 2 ]]; then
     pass "obj-sweep(throttle): a stamp in the FUTURE is treated as never-swept, not as a permanent skip"
   else
@@ -9571,6 +9566,99 @@ t test_object_store_sweep_verdicts
 t test_object_store_sweep_throttle_and_disable
 t test_object_store_sweep_knobs
 
+# THE THROTTLE MUST NOT SUPPRESS A PEER LANE'S CORRUPT (#3749 review, BLOCKER A).
+#
+# THE DEFECT: the stamp is keyed on the SHARED object store and lives in a box-wide
+# directory, and it used to record only a TIMESTAMP — written for every outcome. So the
+# lane that DETECTED corruption stopped, and its three peers then saw a fresh stamp,
+# skipped their own sweep for the whole 6-hour interval, and kept spawning workers against
+# a store known to be damaged: the exact harm the feature exists to prevent, delivered by
+# its own throttle.
+#
+# The two halves are asserted separately, because either alone can pass while the box is
+# still unprotected: (1) a CORRUPT run RECORDS the verdict, and (2) a later lane reading
+# that record STOPS — without re-sweeping, and while the interval is still fresh.
+test_object_store_corrupt_verdict_outlives_the_throttle() {
+  local d root counter calls rc stamp
+  # (1) A CORRUPT sweep records the VERDICT beside the timestamp.
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-corrupt"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  stamp="$OBJ_SWEEP_STAMP"
+  root="$(obj_sweep_tree "$d" CORRUPT 4 "$calls")"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/detect.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 1 ]] && [[ "$(sed -n 2p "$stamp" 2>/dev/null)" == "CORRUPT" ]] &&
+     grep -qE '^[0-9]+$' <(sed -n 1p "$stamp" 2>/dev/null); then
+    pass "obj-sweep(corrupt-latch): the detecting lane RECORDS 'CORRUPT' in the shared stamp, not just an epoch"
+  else
+    fail "obj-sweep(corrupt-latch): rc=$rc stamp='$(tr '\n' '/' <"$stamp" 2>/dev/null)' (wanted an epoch then CORRUPT)"
+  fi
+  # (2) THE PEER LANE. Same box, same stamp, INSIDE the interval — and ONE property
+  #     different from the run above: its sweep stub would report VERIFIED. It must still
+  #     stop, and it must NOT re-sweep (the stub records its invocations, so this is
+  #     measured, not inferred) and must name how to clear the latch.
+  calls="$d/calls-peer"
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/peer.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 1 && ! -s "$calls" ]] &&
+     grep -q '"reason":"object-store-corrupt"' "$JOURNAL_FILE" &&
+     grep -q 'object-store: CORRUPT (cached' "$d/peer.log"; then
+    pass "obj-sweep(corrupt-latch): a PEER lane inside the interval STOPS on the cached verdict instead of throttling past it — without re-sweeping"
+  else
+    fail "obj-sweep(corrupt-latch-peer): rc=$rc reswept=$([[ -s "$calls" ]] && echo yes || echo no) (see $d/peer.log)"
+  fi
+  if grep -q "rm -f $stamp" "$d/peer.log"; then
+    pass "obj-sweep(corrupt-latch): the remedy NAMES the file to remove — a latch nobody can clear bricks the box after the repair"
+  else
+    fail "obj-sweep(corrupt-latch): the stop gives no way to clear the latch (see $d/peer.log)"
+  fi
+  # (3) THE CONTROL, one property apart from (2): the SAME fresh stamp carrying VERIFIED.
+  #     The lane must proceed and, being inside the interval, must NOT sweep — so (2)'s
+  #     stop is attributable to the recorded verdict and not to the stamp's mere presence.
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-control"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  printf '%s\nVERIFIED\n' "$(date +%s)" >"$OBJ_SWEEP_STAMP"
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/control.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 0 && ! -s "$calls" && -f "$counter" ]]; then
+    pass "obj-sweep(corrupt-latch): the SAME stamp carrying VERIFIED throttles normally and the worker runs — the stop above is the recorded verdict, not the file"
+  else
+    fail "obj-sweep(corrupt-latch-control): rc=$rc swept=$([[ -s "$calls" ]] && echo yes || echo no) spawned=$([[ -f "$counter" ]] && echo yes || echo no) (see $d)"
+  fi
+}
+
+t test_object_store_corrupt_verdict_outlives_the_throttle
+
+# ---------------------------------------------------------------------------
+# Test 48 (#3549, roborev job 196 F2): THE SUITE LEAVES NO FIXTURE PROCESS BEHIND.
+#
+# This is the assert the leak had no equivalent of: the fixtures were reaped per case, by pid, and
+# nothing ever CHECKED, so five-minute orphans accumulated invisibly behind a green summary on a
+# four-lane box. Cleanup that is not asserted is a comment.
+#
+# WHAT IT MEASURES. Every `fixture_bg` registers its pgid as OWNED; this runs the same reap the EXIT trap
+# runs and then asks each STILL-OWNED group whether any member is still alive (`kill -0` on a negative
+# pid). A group is the right unit: it sees an ORPHANED CHILD whose parent shell is already gone, which is
+# exactly the leak — a `sleep 300` inside `bash <script>`.
+#
+# THE COUNT AND THE SUBJECT SET ARE NOW DIFFERENT THINGS (#3549, roborev job 198 F2). `FIXTURE_OWNED`
+# SHRINKS: a group is released the moment it is proven gone, which is what stops a later reap signalling
+# a recycled pgid. So the non-vacuity floor is taken from `FIXTURE_STAGED`, the monotone count of groups
+# ever staged, and the leak set is what remains OWNED after the reap. A group released as `foreign`
+# (existing but unsignallable — the number now belongs to another user) is NOT a leak of ours and is
+# reported separately if it ever happens, because calling it a leak would blame this suite for a pid
 # number the kernel reassigned.
 #
 # IT MUST BE THE LAST `t`: a case running after it would register groups nobody checks.

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -9414,6 +9414,33 @@ obj_sweep_calls() {
   printf '%s' "$n"
 }
 
+# obj_sweep_expected_stamp <scratch-dir> <store-path> -> the stamp path THE SHIPPED
+# SUPERVISOR derives for that store.
+#
+# THE DERIVATION IS EXTRACTED FROM THE SHIPPED FILE AT RUN TIME, never restated: a test
+# that re-typed the key formula would keep passing after the real one changed (and, worse,
+# would fail attributing the difference to whatever the case is really about — which is
+# exactly what happened when round 4 replaced the flattened key with a digest). The two
+# functions are lifted verbatim into a driver, with a stub sweep script for the
+# `--print-store` resolution they ask for.
+obj_sweep_expected_stamp() {
+  local d="$1" store="$2"
+  mkdir -p "$d"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'printf "OBJECT-STORE: store %%s\\n" %s\n' "$(printf '%q' "$store")"
+  } >"$d/sweep-stub.sh"
+  {
+    printf 'set -uo pipefail\n'
+    printf 'OBJ_SWEEP_STAMP=""\n'
+    printf 'REPO_ROOT=%s\n' "$(printf '%q' "$d")"
+    awk '/^obj_sweep_digest\(\) \{$/,/^\}$/' "$SUPERVISOR"
+    awk '/^obj_sweep_stamp_path\(\) \{$/,/^\}$/' "$SUPERVISOR"
+    printf 'obj_sweep_stamp_path %s\n' "$(printf '%q' "$d/sweep-stub.sh")"
+  } >"$d/driver.sh"
+  bash "$d/driver.sh" 2>/dev/null
+}
+
 test_object_store_sweep_verdicts() {
   local d root counter rc calls
   # (a) VERIFIED: the sweep runs, is journalled, and the iteration proceeds normally.
@@ -10125,10 +10152,12 @@ test_object_store_stamp_key_comes_from_the_resolver() {
   # The stamp names both files (`<stamp>` and `<stamp>.CORRUPT`), derived exactly as
   # obj_sweep_stamp_path derives them, so the assertions below name a path rather than
   # globbing a shared /tmp that peer lanes are also writing.
-  key_fake="$(printf '%s' "${fake//\//_}" | tr -c 'A-Za-z0-9._-' '_')"
-  key_other="$(printf '%s' "${other//\//_}" | tr -c 'A-Za-z0-9._-' '_')"
-  stamp_fake="/tmp/cqlite-object-store-sweep.${key_fake}.stamp"
-  stamp_other="/tmp/cqlite-object-store-sweep.${key_other}.stamp"
+  # DERIVED BY CALLING THE SHIPPED FUNCTIONS, never restated here. This case used to
+  # re-type the flattening (`${x//\//_} | tr -c ...`), so when round 4 replaced the key
+  # with a digest the expectation and the implementation were two different formulas and
+  # the case failed for a reason that had nothing to do with the resolver.
+  stamp_fake="$(obj_sweep_expected_stamp "$d/expect-fake" "$fake")"
+  stamp_other="$(obj_sweep_expected_stamp "$d/expect-other" "$other")"
   rm -f "$stamp_fake" "$stamp_other"
   # CONSTRUCTION: a BARE git in this environment really does answer with the INJECTED
   # directory, so a green below is the resolver and not an inert variable. This is the
@@ -10173,6 +10202,86 @@ test_object_store_stamp_key_comes_from_the_resolver() {
 }
 
 t test_object_store_stamp_key_comes_from_the_resolver
+
+# THE KEY MUST BE INJECTIVE, AND FLATTENING IS NOT (#3749 review round 4, item 3).
+# Replacing `/` and every unsupported character with `_` maps `/tmp/a/b/objects` and
+# `/tmp/a_b/objects` to the SAME name, so two different repositories on one box shared a
+# throttle stamp and a CORRUPT latch: one store could suppress the other's sweep for the
+# whole interval, or stop every lane on the box with the other store's damage. The key is
+# now a sha256 digest of the canonical path, with a sanitised tail kept for readability.
+test_object_store_stamp_key_is_injective() {
+  local d a b flat_a flat_b sa sb sa2 root_a root_b calls_a calls_b rc bin_ok bin_no with without
+  d="$(new_case_dir)"
+  a="/tmp/objstore-collide/a/b/objects"
+  b="/tmp/objstore-collide/a_b/objects"
+  # CONSTRUCTION: the two paths really do FLATTEN to one name, so the case has a subject.
+  # Without this the assertion below would pass for any two distinct paths.
+  flat_a="$(printf '%s' "${a//\//_}" | tr -c 'A-Za-z0-9._-' '_')"
+  flat_b="$(printf '%s' "${b//\//_}" | tr -c 'A-Za-z0-9._-' '_')"
+  if [[ "$flat_a" == "$flat_b" ]]; then
+    pass "obj-sweep(injective-plant): the two store paths collide under the OLD flattening ('$flat_a') — the collision the case is about is really available"
+  else
+    fail "obj-sweep(injective-plant): '$flat_a' != '$flat_b' — the paths do not collide; the assertions below would prove nothing"
+    return
+  fi
+  sa="$(obj_sweep_expected_stamp "$d/key-a" "$a")"
+  sb="$(obj_sweep_expected_stamp "$d/key-b" "$b")"
+  sa2="$(obj_sweep_expected_stamp "$d/key-a2" "$a")"
+  if [[ -n "$sa" && -n "$sb" && "$sa" != "$sb" ]]; then
+    pass "obj-sweep(injective): two stores that flatten to ONE name get DIFFERENT keys — neither can suppress the other's sweep or latch it corrupt"
+  else
+    fail "obj-sweep(injective): a='$sa' b='$sb' — the key is not injective"
+  fi
+  if [[ -n "$sa2" && "$sa2" == "$sa" ]]; then
+    pass "obj-sweep(injective): the same store yields the SAME key on a second call — it is a digest, not a nonce (a nonce would defeat the throttle AND the latch entirely)"
+  else
+    fail "obj-sweep(injective): the key is not stable ('$sa' then '$sa2')"
+  fi
+  if [[ "$sa" == *objects* && "$sa" == *cqlite-object-store-sweep* && "$sa" == *.stamp ]]; then
+    pass "obj-sweep(injective): the key keeps a readable tail and the shared prefix/suffix, so an operator reading /tmp can still tell which store a stamp belongs to"
+  else
+    fail "obj-sweep(injective): the key is not operator-readable: '$sa'"
+  fi
+
+  # FAIL CLOSED WITH NO DIGEST TOOL: the empty path (no throttle, no latch), never a
+  # silent fall back to the non-injective form on exactly the hosts nobody tested. ONE
+  # PROPERTY between the two arms — whether sha256sum is on PATH — and the CONTROL comes
+  # first, so an empty answer cannot be attributed to the hermetic PATH itself.
+  bin_ok="$d/bin-with-digest"
+  bin_no="$d/bin-without-digest"
+  mkdir -p "$bin_ok" "$bin_no"
+  # `mkdir` is in the list because the DERIVATION HELPER needs it to build its own
+  # driver — the first version omitted it, the control arm produced no key, and the
+  # missing-digest arm would have passed for the wrong reason. That is what a control arm
+  # is for.
+  for tool in bash grep head tr awk mkdir cat sed; do
+    ln -sf "$(command -v "$tool")" "$bin_ok/$tool" 2>/dev/null
+    ln -sf "$(command -v "$tool")" "$bin_no/$tool" 2>/dev/null
+  done
+  ln -sf "$(command -v sha256sum || command -v shasum)" "$bin_ok/" 2>/dev/null
+  if [[ -x "$bin_ok/sha256sum" || -x "$bin_ok/shasum" ]] &&
+    [[ ! -e "$bin_no/sha256sum" && ! -e "$bin_no/shasum" && ! -e "$bin_no/openssl" ]] &&
+    [[ -x "$bin_no/tr" && -x "$bin_no/grep" && -x "$bin_no/mkdir" ]]; then
+    pass "obj-sweep(no-digest-plant): the two hermetic PATHs differ in ONE property — a sha256 tool — and both carry the tr/grep/head the derivation itself needs"
+  else
+    fail "obj-sweep(no-digest-plant): the hermetic PATHs are not the shape the case claims; the arms below would prove nothing"
+    return
+  fi
+  with="$(PATH="$bin_ok" obj_sweep_expected_stamp "$d/key-with" "$a")"
+  without="$(PATH="$bin_no" obj_sweep_expected_stamp "$d/key-without" "$a")"
+  if [[ -n "$with" ]]; then
+    pass "obj-sweep(no-digest-control): with a digest tool on the hermetic PATH the derivation still answers ('$with')"
+  else
+    fail "obj-sweep(no-digest-control): the control produced no key — the arm below cannot be attributed to the missing digest tool"
+  fi
+  if [[ -z "$without" ]]; then
+    pass "obj-sweep(no-digest): a host with NO sha256 tool yields the EMPTY key — the caller then neither throttles nor latches, instead of silently sharing a name between two stores"
+  else
+    fail "obj-sweep(no-digest): a host with no digest tool still produced a key ('$without') — the non-injective fallback is back"
+  fi
+}
+
+t test_object_store_stamp_key_is_injective
 
 # ---------------------------------------------------------------------------
 # Test 48 (#3549, roborev job 196 F2): THE SUITE LEAVES NO FIXTURE PROCESS BEHIND.

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -9389,7 +9389,14 @@ obj_sweep_tree() {
     printf 'MAX_SWEEP_WALKS=3\n'
     printf 'for a in "$@"; do\n'
     printf '  if [ "$a" = --print-store ]; then\n'
-    [[ -n "$storeline" ]] && printf '    printf "OBJECT-STORE: store %%s\\n" %s\n' "$(printf '%q' "$storeline")"
+    if [[ -n "$storeline" ]]; then
+      printf '    printf "OBJECT-STORE: store %%s\\n" %s\n' "$(printf '%q' "$storeline")"
+      # AND THE KEY, which is what the supervisor actually reads (round 5, item 3). It is
+      # the SHIPPED derivation's answer for that path, so this stub and the real resolver
+      # cannot disagree about the same store.
+      printf '    printf "OBJECT-STORE: store-key %%s\\n" %s\n' \
+        "$(printf '%q' "$(obj_sweep_store_key "$storeline")")"
+    fi
     printf '    exit 0\n'
     printf '  fi\n'
     printf 'done\n'
@@ -9432,19 +9439,42 @@ obj_sweep_calls() {
 obj_sweep_expected_stamp() {
   local d="$1" store="$2"
   mkdir -p "$d"
+  # THE STUB SWEEP SCRIPT COMPUTES THE KEY WITH THE SHIPPED `store_key`, EXTRACTED FROM
+  # check-object-store-integrity.sh AT RUN TIME (#3749 review round 5, item 3: the key is
+  # derived from the RAW path by the resolver, because the `store` line is a lossy display
+  # rendering). It is computed INSIDE the stub rather than baked in as a literal, so a
+  # caller that restricts PATH — the no-digest-tool arms below — restricts the derivation
+  # too, which is the whole point of those arms.
   {
     printf '#!/usr/bin/env bash\n'
+    sed -n '/^store_digest() {/,/^}/p;/^store_key() {/,/^}/p' \
+      "$REPO_ROOT/scripts/check-object-store-integrity.sh"
     printf 'printf "OBJECT-STORE: store %%s\\n" %s\n' "$(printf '%q' "$store")"
+    printf 'if k=$(store_key %s); then printf "OBJECT-STORE: store-key %%s\\n" "$k"; fi\n' \
+      "$(printf '%q' "$store")"
   } >"$d/sweep-stub.sh"
   {
     printf 'set -uo pipefail\n'
     printf 'OBJ_SWEEP_STAMP=""\n'
     printf 'REPO_ROOT=%s\n' "$(printf '%q' "$d")"
-    awk '/^obj_sweep_digest\(\) \{$/,/^\}$/' "$SUPERVISOR"
     awk '/^obj_sweep_stamp_path\(\) \{$/,/^\}$/' "$SUPERVISOR"
     printf 'obj_sweep_stamp_path %s\n' "$(printf '%q' "$d/sweep-stub.sh")"
   } >"$d/driver.sh"
   bash "$d/driver.sh" 2>/dev/null
+}
+
+# obj_sweep_store_key <store-path> -> the key the SHIPPED sweep script derives for it,
+# extracted at run time for the same reason as everything else in this section: a test that
+# re-typed the formula would keep passing after the real one changed.
+obj_sweep_store_key() {
+  local d
+  d="$(mktemp -d "$TMP_ROOT/storekey.XXXXXX")" || return 1
+  {
+    sed -n '/^store_digest() {/,/^}/p;/^store_key() {/,/^}/p' \
+      "$REPO_ROOT/scripts/check-object-store-integrity.sh"
+    printf 'store_key %s\n' "$(printf '%q' "$1")"
+  } >"$d/key.sh"
+  bash "$d/key.sh" 2>/dev/null
 }
 
 test_object_store_sweep_verdicts() {
@@ -10674,6 +10704,43 @@ test_object_store_stamp_key_comes_from_the_resolver() {
     pass "obj-sweep(resolver): a store the resolver cannot name does NOT throttle — both runs swept, so no unresolvable store can suppress another's sweep through a shared fallback name"
   else
     fail "obj-sweep(resolver-unresolvable): rc=$rc sweeps=$(obj_sweep_calls "$calls") (wanted 2)"
+  fi
+
+  # AND ONE PROPERTY APART AGAIN: a resolver that names the store but produces NO
+  # `store-key` line — a host with no digest tool (#3749 review round 5, item 3: the key is
+  # derived from the RAW path by the resolver, so its absence is now the resolver's answer
+  # and no longer something this file can compute for itself). The `store` line is present
+  # and MUST NOT be used as a key: it is a `sane()`-rendered display value, and keying on it
+  # is exactly the non-injective form this round removed.
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-nokey"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  unset OBJ_SWEEP_STAMP
+  fake="$d/resolved-store/objects"
+  mkdir -p "$fake"
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls" "" "$fake")"
+  sed -i '/OBJECT-STORE: store-key/d' "$root/scripts/check-object-store-integrity.sh"
+  # CONSTRUCTION: the stub really does still name the store and really does not name a key.
+  if bash "$root/scripts/check-object-store-integrity.sh" --print-store 2>/dev/null |
+    grep -q '^OBJECT-STORE: store ' &&
+    ! bash "$root/scripts/check-object-store-integrity.sh" --print-store 2>/dev/null |
+      grep -q '^OBJECT-STORE: store-key '; then
+    pass "obj-sweep(nokey-plant): the resolver names the store and produces NO key — the state a host with no digest tool is in"
+  else
+    fail "obj-sweep(nokey-plant): the stub is not the shape the arm below claims"
+    return
+  fi
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/nokey1.log" 2>&1
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/nokey2.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 0 && "$(obj_sweep_calls "$calls")" -eq 2 ]] &&
+    grep -q 'no box-wide key for this store' "$d/nokey1.log"; then
+    pass "obj-sweep(nokey): a resolver that names a store but no KEY yields no throttle and no latch, announced — the display-only `store` line is never used as an identity"
+  else
+    fail "obj-sweep(nokey): rc=$rc sweeps=$(obj_sweep_calls "$calls") (wanted 2) (see $d/nokey1.log)"
   fi
 }
 

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -9381,6 +9381,12 @@ obj_sweep_tree() {
   {
     printf '#!/usr/bin/env bash\n'
     printf '# STUB sweep: record the invocation, print one anchored verdict, exit with its code.\n'
+    # THE STUB DECLARES MAX_SWEEP_WALKS BECAUSE THE REAL SCRIPT DOES, and the supervisor
+    # READS it out of whatever sweep script the checkout holds to derive the recovery bound
+    # for the in-progress claim (#3749 review round 5, item 2). A stub without it is a
+    # different, also-real state — no derivable bound, therefore no claim — and the case
+    # that covers THAT deletes this line rather than the stub omitting it silently here.
+    printf 'MAX_SWEEP_WALKS=3\n'
     printf 'for a in "$@"; do\n'
     printf '  if [ "$a" = --print-store ]; then\n'
     [[ -n "$storeline" ]] && printf '    printf "OBJECT-STORE: store %%s\\n" %s\n' "$(printf '%q' "$storeline")"
@@ -10123,6 +10129,259 @@ test_object_store_latch_unreadable_is_not_absent() {
 }
 
 t test_object_store_latch_unreadable_is_not_absent
+
+# THE THUNDERING HERD: ONE SWEEP PER BOX AT A TIME (#3749 review round 5, item 2 — a Low in
+# round 1, "not disposed of" in round 2, a Medium with a consequence in round 5).
+#
+# THE DEFECT. The throttle stamp is written at the END of a sweep, so when the interval
+# expires every lane on the box reads the same stale stamp and starts its own full-store
+# fsck. The consequence is not only CPU: the walks are I/O-bound, so contention pushes them
+# toward the per-walk bound, and an expired bound is UNMEASURED — a CORRELATED loss of the
+# measurement on every lane at once.
+#
+# THIS IS A GENUINELY CONCURRENT TEST, NOT A STAGED ONE. The first supervisor's sweep stub
+# BLOCKS until this case releases it, so the second supervisor provably runs while the first
+# is inside its sweep — a fixture that merely started two processes and counted would pass
+# just as well when the second happened to start after the first had finished and written
+# the stamp, i.e. for the throttle's reason and not the claim's.
+test_object_store_sweep_claim_prevents_the_herd() {
+  local d root calls counter1 counter2 rc waited lane_a
+  d="$(new_case_dir)"; calls="$d/calls"; counter1="$d/counter1"; counter2="$d/counter2"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker1.sh" "$counter1"
+  write_finalize_stub "$d/bin/worker2.sh" "$counter2"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  # The `during` hook: announce that the sweep is IN FLIGHT, then block until this case
+  # says go (bounded, so a wedged fixture fails the run rather than hanging it).
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls" \
+    "printf in >$(printf '%q' "$d/sweeping"); i=0; while [ ! -f $(printf '%q' "$d/go") ] && [ \$i -lt 200 ]; do sleep 0.05; i=\$((i+1)); done")"
+  # THROUGH `fixture_bg`, never a bare `&`: it makes the job a process-group leader and
+  # REGISTERS the group, which is what lets the harness reap whatever the supervisor forks
+  # (its sweep stub sits in a bounded wait loop). A bare `&` would leak that tree onto a
+  # four-lane box, and the suite's own leak assert would catch it as an unattributable
+  # failure at the very end of the run.
+  # EACH LANE GETS ITS OWN SINGLE-INSTANCE LOCK, which is what two lanes on one box
+  # legitimately have (per lane since #3467). `common_env` pins ONE SUPERVISOR_LOCK for the
+  # case, and inheriting it would make lane B refuse to start as "another instance" — a
+  # refusal about the LOCK, not about the sweep claim this case is measuring.
+  fixture_bg env WORKER_CMD="$d/bin/worker1.sh" LANE_ID=objsweep-a \
+    SUPERVISOR_LOCK="$d/lock-a" \
+    bash "$root/scripts/local/worker-supervisor.sh" >"$d/a.log" 2>&1
+  lane_a="$FIXTURE_LAST_PID"
+  waited=0
+  while [[ ! -f "$d/sweeping" && "$waited" -lt 200 ]]; do sleep 0.05; waited=$((waited + 1)); done
+  # CONSTRUCTION ASSERT: lane A really is inside its sweep, and it really is holding the
+  # claim. Without both, the assert below would be about a sequential pair of runs.
+  if [[ -f "$d/sweeping" && -d "$OBJ_SWEEP_STAMP.sweeping" ]]; then
+    pass "obj-sweep(herd-plant): lane A is INSIDE its sweep and holds the claim $OBJ_SWEEP_STAMP.sweeping — lane B below runs genuinely concurrently"
+  else
+    touch "$d/go"; fixture_wait "$lane_a" >/dev/null 2>&1 || true
+    fail "obj-sweep(herd-plant): in-sweep=$([[ -f "$d/sweeping" ]] && echo yes || echo no) claim=$([[ -d "$OBJ_SWEEP_STAMP.sweeping" ]] && echo yes || echo no) after ${waited} polls — the concurrency could not be staged"
+    return
+  fi
+  WORKER_CMD="$d/bin/worker2.sh" env LANE_ID=objsweep-b SUPERVISOR_LOCK="$d/lock-b" \
+    bash "$root/scripts/local/worker-supervisor.sh" >"$d/b.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 0 && -f "$counter2" ]] &&
+    grep -q 'object-store sweep: SKIPPED — a peer lane on this box holds the sweep claim' "$d/b.log"; then
+    pass "obj-sweep(herd): a second lane whose peer is MID-SWEEP skips the sweep, names the claim, does not wait, and still runs its worker"
+  else
+    fail "obj-sweep(herd): rc=$rc spawned=$([[ -f "$counter2" ]] && echo yes || echo no) (see $d/b.log)"
+  fi
+  touch "$d/go"
+  fixture_wait "$lane_a" >/dev/null 2>&1 || true
+  if [[ "$(obj_sweep_calls "$calls")" -eq 1 ]]; then
+    pass "obj-sweep(herd): exactly ONE fsck sweep was spent across the two concurrent lanes (measured invocations, not inferred)"
+  else
+    fail "obj-sweep(herd): $(obj_sweep_calls "$calls") sweeps across two concurrent lanes, wanted 1 (see $calls)"
+  fi
+  # AND THE CLAIM IS GIVEN UP, so the NEXT interval is contended honestly rather than
+  # inherited by whoever swept last.
+  if [[ ! -e "$OBJ_SWEEP_STAMP.sweeping" ]]; then
+    pass "obj-sweep(herd): the sweeping lane RELEASED its claim on the way out"
+  else
+    fail "obj-sweep(herd-release): the claim $OBJ_SWEEP_STAMP.sweeping outlived the sweep that took it"
+  fi
+  # THE CONTROL, ONE PROPERTY APART: the same lane B, same stub, with NO peer holding a
+  # claim and a stale stamp. It must SWEEP — so the skip above is the claim and not lane B
+  # having lost the ability to sweep at all.
+  d="$(new_case_dir)"; calls="$d/calls-control"; counter1="$d/counter"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter1"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/control.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 0 && "$(obj_sweep_calls "$calls")" -eq 1 ]] &&
+    ! grep -q 'holds the sweep claim' "$d/control.log"; then
+    pass "obj-sweep(herd-control): with no peer holding the claim the same lane sweeps normally"
+  else
+    fail "obj-sweep(herd-control): rc=$rc calls=$(obj_sweep_calls "$calls") (see $d/control.log)"
+  fi
+}
+
+t test_object_store_sweep_claim_prevents_the_herd
+
+# THE OTHER HALF, AND THE HAZARD THE CLAIM INTRODUCES: A STALE CLAIM MUST NOT WEDGE THE BOX
+# (#3749 review round 5, item 2). A lane killed mid-sweep leaves its claim behind, and
+# without recovery no lane on the box ever sweeps again — strictly worse than the herd.
+#
+# The recovery bound is DERIVED (see obj_sweep_claim_stale_secs) and the derivation itself
+# is asserted below, from the shipped files, so this case does not re-type it either.
+test_object_store_sweep_claim_recovers_when_stale() {
+  local d root calls counter rc claim bound fns walks per_walk want got
+  # (a) THE BOUND'S DERIVATION, read out of the two shipped files. A test that re-typed
+  #     `3 x 200 + 60` would keep passing after either declaration moved — round 4's
+  #     MAX_SWEEP_WALKS lesson, one function over.
+  d="$(new_case_dir)"
+  fns="$d/extracted.sh"
+  sed -n '/^obj_sweep_claim_stale_secs() {/,/^}/p' "$SUPERVISOR" >"$fns"
+  walks="$({ grep -m1 '^MAX_SWEEP_WALKS=' "$REPO_ROOT/scripts/check-object-store-integrity.sh" || true; } 2>/dev/null)"
+  walks="${walks#MAX_SWEEP_WALKS=}"
+  per_walk="$({ grep -m1 '^OBJ_SWEEP_TIMEOUT_SECS=' "$SUPERVISOR" || true; } 2>/dev/null)"
+  per_walk="${per_walk#*:-}"; per_walk="${per_walk%%\}*}"
+  bound="$({ grep -m1 '^OBJ_SWEEP_CLAIM_SLACK_SECS=' "$SUPERVISOR" || true; } 2>/dev/null)"
+  bound="${bound#OBJ_SWEEP_CLAIM_SLACK_SECS=}"
+  if grep -q '^obj_sweep_claim_stale_secs() {' "$fns" &&
+    [[ "$walks" =~ ^[0-9]+$ && "$per_walk" =~ ^[0-9]+$ && "$bound" =~ ^[0-9]+$ ]]; then
+    pass "obj-sweep(claim-bound-plant): all three declarations were read from the shipped files (MAX_SWEEP_WALKS $walks, per-walk bound $per_walk s, slack $bound s)"
+  else
+    fail "obj-sweep(claim-bound-plant): walks='$walks' per_walk='$per_walk' slack='$bound' — the assert below would be vacuous"
+    return
+  fi
+  want=$((walks * per_walk + bound))
+  got="$(bash -c 'set -uo pipefail; OBJ_SWEEP_TIMEOUT_SECS="'"$per_walk"'"; OBJ_SWEEP_CLAIM_SLACK_SECS="'"$bound"'"; . "$1"; obj_sweep_claim_stale_secs "$2"' _ "$fns" "$REPO_ROOT/scripts/check-object-store-integrity.sh" 2>&1)"
+  if [[ "$got" == "$want" ]]; then
+    pass "obj-sweep(claim-bound): the recovery bound is the sweep's own MAX_SWEEP_WALKS x this supervisor's per-walk bound + slack (${want}s) — a claim cannot be called stale while the sweep it represents could still be running"
+  else
+    fail "obj-sweep(claim-bound): the shipped function answered '$got', the shipped declarations give '$want'"
+  fi
+  # (b) A CLAIM OLDER THAN THE BOUND IS RECOVERED and the sweep runs.
+  d="$(new_case_dir)"; calls="$d/calls-stale"; counter="$d/counter"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  claim="$OBJ_SWEEP_STAMP.sweeping"
+  mkdir -p "$claim"
+  printf '%s\n' "$(( $(date +%s) - want - 10 ))" >"$claim/started"
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/stale.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 0 && "$(obj_sweep_calls "$calls")" -eq 1 && -f "$counter" ]] &&
+    grep -q 'RECOVERED a stale sweep claim' "$d/stale.log"; then
+    pass "obj-sweep(claim-stale): a claim left behind by a lane killed mid-sweep is RECOVERED and the box sweeps again — a stale claim is a delay, never a wedge"
+  else
+    fail "obj-sweep(claim-stale): rc=$rc calls=$(obj_sweep_calls "$calls") (see $d/stale.log)"
+  fi
+  # (c) CONTROL, one property apart: the same claim with a FRESH start time. It must be
+  #     respected — so (b) is the AGE and not the recovery firing unconditionally.
+  d="$(new_case_dir)"; calls="$d/calls-fresh"; counter="$d/counter"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  claim="$OBJ_SWEEP_STAMP.sweeping"
+  mkdir -p "$claim"
+  printf '%s\n' "$(date +%s)" >"$claim/started"
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/fresh.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 0 && ! -s "$calls" && -f "$counter" ]] &&
+    grep -q 'holds the sweep claim' "$d/fresh.log"; then
+    pass "obj-sweep(claim-fresh-control): a claim younger than the bound is respected — the recovery is age-driven, not unconditional"
+  else
+    fail "obj-sweep(claim-fresh-control): rc=$rc calls=$(obj_sweep_calls "$calls") (see $d/fresh.log)"
+  fi
+  # (d) A CLAIM WITH NO PARSEABLE START TIME is treated as STALE — the deliberate
+  #     direction, because its cause is a lane killed between the mkdir and the `started`
+  #     write, and the other reading wedges the sweep forever on a file nobody can age.
+  d="$(new_case_dir)"; calls="$d/calls-unaged"; counter="$d/counter"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  claim="$OBJ_SWEEP_STAMP.sweeping"
+  mkdir -p "$claim"
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/unaged.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 0 && "$(obj_sweep_calls "$calls")" -eq 1 ]] &&
+    grep -q 'RECOVERED a stale sweep claim' "$d/unaged.log"; then
+    pass "obj-sweep(claim-unaged): a claim carrying no start time is recovered rather than trusted — an unageable claim must not be able to wedge the box"
+  else
+    fail "obj-sweep(claim-unaged): rc=$rc calls=$(obj_sweep_calls "$calls") (see $d/unaged.log)"
+  fi
+  # (e) NO DERIVABLE BOUND ⇒ NO CLAIM AT ALL, announced. One property apart from (b): the
+  #     sweep script carries no MAX_SWEEP_WALKS declaration, so the recovery bound cannot
+  #     be derived — and a claim that could never be recovered is worse than the herd it
+  #     prevents, so none is taken and the previous behaviour is restored explicitly.
+  d="$(new_case_dir)"; calls="$d/calls-nobound"; counter="$d/counter"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
+  sed -i '/^MAX_SWEEP_WALKS=/d' "$root/scripts/check-object-store-integrity.sh"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/nobound.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 0 && "$(obj_sweep_calls "$calls")" -eq 1 && ! -e "$OBJ_SWEEP_STAMP.sweeping" ]] &&
+    grep -q 'NO in-progress claim is being taken' "$d/nobound.log"; then
+    pass "obj-sweep(claim-nobound): a sweep script whose MAX_SWEEP_WALKS cannot be read yields NO claim, announced in the journal, and the sweep still runs"
+  else
+    fail "obj-sweep(claim-nobound): rc=$rc calls=$(obj_sweep_calls "$calls") claim=$([[ -e "$OBJ_SWEEP_STAMP.sweeping" ]] && echo present || echo absent) (see $d/nobound.log)"
+  fi
+}
+
+t test_object_store_sweep_claim_recovers_when_stale
+
+# THE CLAIM IS A REGISTERED RESOURCE, NOT ONE WHOSE LIFETIME NOBODY OWNS (#3749 review
+# round 5, item 2; CLAUDE.md's roborev-job-282 ruling that a fix which ADDS a resource
+# inherits that resource's lifetime bugs). The CORRUPT path ends the process instead of
+# returning, so the claim it took has to be released by the EXIT trap — otherwise the
+# detecting lane's peers would wait out the staleness bound before they could sweep.
+test_object_store_sweep_claim_is_released_on_the_exit_path() {
+  local d root calls counter rc claim
+  d="$(new_case_dir)"; calls="$d/calls-corrupt"; counter="$d/counter"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  claim="$OBJ_SWEEP_STAMP.sweeping"
+  root="$(obj_sweep_tree "$d" CORRUPT 4 "$calls")"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/corrupt.log" 2>&1
+  rc=$?
+  # CONSTRUCTION: the run really took the CORRUPT exit path (so the claim really was taken
+  # and really was NOT released by the normal post-sweep release, which that path skips).
+  if [[ "$rc" -eq 1 && -e "$OBJ_SWEEP_STAMP.CORRUPT" && -s "$calls" ]]; then
+    pass "obj-sweep(claim-exit-plant): the run swept, found CORRUPT and left via finalize_exit — the path that never reaches the post-sweep release"
+  else
+    fail "obj-sweep(claim-exit-plant): rc=$rc latched=$([[ -e "$OBJ_SWEEP_STAMP.CORRUPT" ]] && echo yes || echo no) — the assert below would be vacuous"
+    return
+  fi
+  if [[ ! -e "$claim" ]]; then
+    pass "obj-sweep(claim-exit): the EXIT trap released the sweep claim even though that path ends the process — a stopping lane does not make its peers wait out the staleness bound"
+  else
+    fail "obj-sweep(claim-exit): the claim $claim outlived a lane that exited through finalize_exit"
+  fi
+}
+
+t test_object_store_sweep_claim_is_released_on_the_exit_path
 
 # AND THE BEHAVIOURAL HALF THE ORDERING SERVES: on the CORRUPT path BOTH files exist
 # when the lane stops, so the state a peer inherits is complete rather than half-written.

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -10515,6 +10515,16 @@ test_object_store_unlatchable_corrupt_does_not_refresh_the_throttle() {
   else
     fail "obj-sweep(unlatchable): stamp='$(tr '\n' '/' <"$stamp" 2>/dev/null)' — a peer reading it can throttle past a confirmed-corrupt store (see $d/unlatchable.log)"
   fi
+  # AND THE DIAGNOSTIC DOES NOT NAME A LATCH THAT IS NOT THERE. Printing "rm -f <latch>"
+  # here would be a second confidently-wrong instruction of exactly the class round 9 item
+  # 2 removed: the file does not exist, so an operator sent to delete it learns nothing and
+  # may conclude the box was latched.
+  if ! grep -q "rm -f $latch" "$d/unlatchable.log" &&
+    grep -q 'NO latch to clear' "$d/unlatchable.log"; then
+    pass "obj-sweep(unlatchable): the stop says there is NO latch to clear instead of naming a file that was never created"
+  else
+    fail "obj-sweep(unlatchable-remedy): the diagnostic points at a latch that does not exist (see $d/unlatchable.log)"
+  fi
   # AND THE ARM THAT MAKES *FORCING* NECESSARY RATHER THAN MERELY LEAVING THE STAMP ALONE:
   # a PEER whose own sweep started earlier finishes DURING this one and writes a FRESH
   # timestamp. Staged with the `during` hook (a side effect inside the sweep stub — the

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -9729,6 +9729,41 @@ test_object_store_latch_survives_a_writer_that_finishes_after_it() {
   else
     fail "obj-sweep(stale-writer): the throttle stamp reads '$stamp_ts' — the writer never completed its write path, so the case above is vacuous"
   fi
+  # AND LANE B ITSELF MUST STOP, WHICH IS THE ROUND-3 HALF (#3749 review round 3, item
+  # 1a). Its own walk said VERIFIED, but a peer latched the box WHILE that walk was in
+  # flight, so the peer's finding is strictly newer than lane B's measurement and is
+  # about the same store. Before the re-check on the VERIFIED path, lane B returned 0
+  # from the sweep and went on to SPAWN A WORKER over a store already recorded damaged —
+  # the sweep having "passed" was exactly what made it silent. Both halves are asserted,
+  # because a supervisor that crashed would also spawn nothing.
+  if [[ "$rc" -eq 1 && ! -f "$counter" ]] &&
+    grep -q 'object-store: CORRUPT (cached' "$d/late.log"; then
+    pass "obj-sweep(stale-writer): the lane whose OWN sweep said VERIFIED still STOPS on the latch a peer created mid-sweep — it re-reads it before returning toward a spawn"
+  else
+    fail "obj-sweep(stale-writer-recheck): rc=$rc spawned=$([[ -f "$counter" ]] && echo yes || echo no) — a worker was started on a box latched CORRUPT while this lane was sweeping (see $d/late.log)"
+  fi
+  # ...and the control that keeps it one property apart: the SAME fixture with the peer
+  # side effect creating a harmless file instead of the latch runs the worker normally.
+  # Without it, the stop above could be any post-sweep failure.
+  local d2 counter2 calls2 rc2
+  d2="$(new_case_dir)"; counter2="$d2/counter"; calls2="$d2/calls-nolatch"
+  common_env "$d2"
+  write_finalize_stub "$d2/bin/worker.sh" "$counter2"
+  export WORKER_CMD="$d2/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d2/sweep.stamp"
+  local root2
+  root2="$(obj_sweep_tree "$d2" VERIFIED 0 "$calls2" \
+    "printf 'peer wrote something harmless\n' >$(printf '%q' "$d2/peer-note.txt")")"
+  env LANE_ID=objsweep-test bash "$root2/scripts/local/worker-supervisor.sh" >"$d2/nolatch.log" 2>&1
+  rc2=$?
+  if [[ "$rc2" -eq 0 && -f "$counter2" && -f "$d2/peer-note.txt" ]]; then
+    pass "obj-sweep(stale-writer-control): the same mid-sweep peer write that is NOT a latch leaves the worker running — the stop above is the latch, not the side effect"
+  else
+    fail "obj-sweep(stale-writer-control): rc=$rc2 spawned=$([[ -f "$counter2" ]] && echo yes || echo no) peer-ran=$([[ -f "$d2/peer-note.txt" ]] && echo yes || echo no) (see $d2/nolatch.log)"
+  fi
+  export OBJ_SWEEP_STAMP="$stamp"
   # ...and the harm is prevented END TO END: the next lane on this box stops.
   calls="$d/calls-successor"
   root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
@@ -9742,6 +9777,70 @@ test_object_store_latch_survives_a_writer_that_finishes_after_it() {
 }
 
 t test_object_store_latch_survives_a_writer_that_finishes_after_it
+
+# THE ORDER OF THE TWO WRITES, ASSERTED STRUCTURALLY — AND LABELLED AS SUCH (#3749
+# review round 3, item 1a; CLAUDE.md's precedent: where the race itself cannot be
+# staged, the coverage is the observable before/after difference plus a STRUCTURAL
+# assert of the invariant, never a structural assert dressed up as behavioural).
+#
+# THE DEFECT. The throttle stamp used to be written for EVERY outcome BEFORE the CORRUPT
+# branch ran, so between that write and the latch create a peer could read a fresh,
+# non-corrupt stamp, skip its own sweep for the whole 6h interval, and keep spawning
+# workers over a store this lane had already found damaged.
+#
+# WHY STRUCTURAL. Both writes happen inside one function with nothing in between that a
+# fixture can interpose on — no subprocess, no notify hook, no sleep — so the ordering
+# has no observable consequence in a single-process test: whoever looks afterwards sees
+# both files whichever order they were written in. The invariant is therefore read off
+# the SHIPPED source, and it is a claim about the source, not a measurement of a race.
+test_object_store_latch_is_written_before_the_throttle_stamp() {
+  local body first_stamp latch_line
+  body="$(awk '/^object_store_sweep\(\) \{$/,/^\}$/' "$SUPERVISOR")"
+  if [[ -n "$body" ]] && grep -q 'obj_sweep_set_latch' <<<"$body" &&
+    grep -q 'obj_sweep_write_stamp' <<<"$body"; then
+    pass "obj-sweep(write-order-plant): object_store_sweep was extracted from the shipped supervisor and contains both writes"
+  else
+    fail "obj-sweep(write-order-plant): could not extract a body containing both calls — the assert below would be vacuous"
+    return
+  fi
+  # The FIRST write_stamp call, whatever branch it is in, must come AFTER the latch
+  # create. Taking the first (not the one in the CORRUPT branch) is deliberate: a stamp
+  # written anywhere earlier reopens the window, wherever it lives.
+  latch_line="$(grep -n 'obj_sweep_set_latch "\$latch"' <<<"$body" | head -1 | cut -d: -f1)"
+  first_stamp="$(grep -n 'obj_sweep_write_stamp "\$stamp"' <<<"$body" | head -1 | cut -d: -f1)"
+  if [[ "$latch_line" =~ ^[0-9]+$ && "$first_stamp" =~ ^[0-9]+$ && "$latch_line" -lt "$first_stamp" ]]; then
+    pass "obj-sweep(write-order): the CORRUPT latch is created (line $latch_line) BEFORE any throttle stamp is written (line $first_stamp) — no peer can read a fresh non-corrupt stamp for a box already found damaged [STRUCTURAL]"
+  else
+    fail "obj-sweep(write-order): set_latch at line '$latch_line', first write_stamp at line '$first_stamp' — the stamp advertises a swept box before the finding is durable"
+  fi
+}
+
+t test_object_store_latch_is_written_before_the_throttle_stamp
+
+# AND THE BEHAVIOURAL HALF THE ORDERING SERVES: on the CORRUPT path BOTH files exist
+# when the lane stops, so the state a peer inherits is complete rather than half-written.
+test_object_store_corrupt_leaves_both_the_latch_and_the_stamp() {
+  local d root counter calls rc stamp latch
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-both"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  stamp="$OBJ_SWEEP_STAMP"; latch="$stamp.CORRUPT"
+  root="$(obj_sweep_tree "$d" CORRUPT 4 "$calls")"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/both.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 1 && ! -f "$counter" ]] && [[ -e "$latch" ]] &&
+    [[ "$(sed -n 1p "$stamp" 2>/dev/null)" =~ ^[0-9]+$ ]]; then
+    pass "obj-sweep(corrupt-both): the detecting lane leaves BOTH the latch and a throttle stamp — reordering the writes did not drop the stamp, so a latched box still bounds how often it re-sweeps"
+  else
+    fail "obj-sweep(corrupt-both): rc=$rc latch=$([[ -e "$latch" ]] && echo yes || echo no) stamp='$(sed -n 1p "$stamp" 2>/dev/null)' spawned=$([[ -f "$counter" ]] && echo yes || echo no) (see $d/both.log)"
+  fi
+}
+
+t test_object_store_corrupt_leaves_both_the_latch_and_the_stamp
 
 # THE CREATE-ONLY PRIMITIVE ITSELF (#3749 review round 2, BLOCKER 1).
 #

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -9922,32 +9922,39 @@ test_preflight_reads_the_stop_file_before_the_object_store_sweep() {
 t test_preflight_reads_the_stop_file_before_the_object_store_sweep
 
 # AND THE EXPOSURE IS BOUNDED IN WALL TIME, because the in-flight sweep is NOT
-# interruptible (#3749 review round 3, item 3). Its two walks run in a CHILD process, so
-# no check between them can execute here; the only lever this caller has is how long the
-# two of them may take. The supervisor's default per-walk bound is therefore HALF the
-# sweep script's own, so 2 walks here cost no more than 1 walk at the script's bound.
-# Asserted as a RELATION between the two defaults, read from both shipped files, rather
-# than as two magic numbers that could drift apart silently.
-test_supervisor_sweep_bound_is_half_the_sweep_scripts_own() {
-  local sup_default script_default sweep_sh
+# interruptible (#3749 review round 3, item 3). Its walks run in a CHILD process, so no
+# check between them can execute here; the only lever this caller has is how long they
+# may take in total. The supervisor's default per-walk bound is therefore the sweep
+# script's own bound DIVIDED BY MAX_SWEEP_WALKS, so every walk this caller can pay for
+# still costs no more than 1 walk at the script's bound.
+#
+# ALL THREE NUMBERS ARE READ FROM THE SHIPPED FILES, INCLUDING THE WALK COUNT (#3749
+# review round 4). Round 3 hard-coded the factor 2 in this test, so ADDING A THIRD WALK
+# to the sweep — which is exactly what round 4 did — would have kept this assert green
+# while the supervisor's real worst case rose to 900s. A relation whose own constant is
+# re-typed here is two magic numbers wearing a relation's clothes.
+test_supervisor_sweep_bound_covers_every_walk_the_script_can_take() {
+  local sup_default script_default max_walks sweep_sh
   sweep_sh="$REPO_ROOT/scripts/check-object-store-integrity.sh"
   sup_default="$(sed -n 's/^OBJ_SWEEP_TIMEOUT_SECS="\${OBJ_SWEEP_TIMEOUT_SECS:-\([0-9]*\)}"$/\1/p' "$SUPERVISOR" | head -1)"
   script_default="$(sed -n 's/^BOUND_SECS=\([0-9]*\)$/\1/p' "$sweep_sh" | head -1)"
+  max_walks="$(sed -n 's/^MAX_SWEEP_WALKS=\([0-9]*\)$/\1/p' "$sweep_sh" | head -1)"
   if [[ "$sup_default" =~ ^[0-9]+$ ]] && [[ "$script_default" =~ ^[0-9]+$ ]] &&
-    [[ "$sup_default" -gt 0 ]] && [[ "$script_default" -gt 0 ]]; then
-    pass "sweep-bound-plant: both defaults were read from the shipped files (supervisor $sup_default, sweep script $script_default)"
+    [[ "$max_walks" =~ ^[0-9]+$ ]] &&
+    [[ "$sup_default" -gt 0 ]] && [[ "$script_default" -gt 0 ]] && [[ "$max_walks" -ge 2 ]]; then
+    pass "sweep-bound-plant: all three numbers were read from the shipped files (supervisor $sup_default, sweep script $script_default, MAX_SWEEP_WALKS $max_walks)"
   else
-    fail "sweep-bound-plant: supervisor='$sup_default' script='$script_default' — one of the declarations moved; the assert below would be vacuous"
+    fail "sweep-bound-plant: supervisor='$sup_default' script='$script_default' walks='$max_walks' — one of the declarations moved; the assert below would be vacuous"
     return
   fi
-  if [[ $((sup_default * 2)) -le "$script_default" ]]; then
-    pass "sweep-bound: the supervisor's per-walk bound ($sup_default s) is at most HALF the sweep script's own ($script_default s), so its worst case of TWO walks costs no more than ONE walk at the script's bound — the uninterruptible window did not double when the script's bound was raised"
+  if [[ $((sup_default * max_walks)) -le "$script_default" ]]; then
+    pass "sweep-bound: the supervisor's per-walk bound ($sup_default s) x the sweep's own MAX_SWEEP_WALKS ($max_walks) is at most the script's bound ($script_default s), so its worst case costs no more than ONE walk at the script's bound — adding a walk to the sweep cannot silently widen this caller's uninterruptible window"
   else
-    fail "sweep-bound: 2 x $sup_default > $script_default — the supervisor can block uninterruptibly for longer than one of the sweep script's own bounds"
+    fail "sweep-bound: $max_walks x $sup_default > $script_default — the supervisor can block uninterruptibly for longer than one of the sweep script's own bounds"
   fi
 }
 
-t test_supervisor_sweep_bound_is_half_the_sweep_scripts_own
+t test_supervisor_sweep_bound_covers_every_walk_the_script_can_take
 
 # THE CREATE-ONLY PRIMITIVE ITSELF (#3749 review round 2, BLOCKER 1).
 #

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -10419,7 +10419,7 @@ t test_object_store_sweep_claim_loser_waits_for_the_peer_verdict
 #    recoverable), and a literal would still pass every behavioural case here because the
 #    fixtures pin the knobs anyway.
 test_object_store_sweep_claim_wait_is_wired_correctly() {
-  local body call_line wait_line subst
+  local body call_line wait_line subst loop_body loop_break loop_bound
   body="$(awk '/^object_store_sweep\(\) \{$/,/^\}$/' "$SUPERVISOR")"
   if [[ -n "$body" ]] && grep -q 'obj_sweep_claim_wait ' <<<"$body" &&
     grep -q 'obj_sweep_claim_stale_secs ' <<<"$body"; then
@@ -10455,9 +10455,164 @@ test_object_store_sweep_claim_wait_is_wired_correctly() {
   else
     fail "obj-sweep(wait-bound-derived): call='$wait_line' budget='$call_line' — the wait bound must be the derived claim_stale, never a literal"
   fi
+  # (3) THE CALLER'S LOOP MUST BREAK ON `completed`, AND ITS OWN BOUND MUST BE THE DERIVED
+  #     BUDGET (#3749 review round 14). `completed` is reached WITHOUT SLEEPING, so a loop
+  #     that contends again on it spins at CPU speed for as long as the peer's claim stays
+  #     put — until MAX_HOURS. There IS behavioural coverage
+  #     (obj-sweep(claim-wait-completed/*)) and it necessarily costs a 20s liveness cap,
+  #     because the symptom is a lane that never returns; this assert reds INSTANTLY if the
+  #     break is dropped again, and it also pins the loop-level deadline to `wait_until`
+  #     rather than to a number somebody typed.
+  loop_body="$(awk '/^  while true; do$/,/^  done$/' <<<"$body" | head -20)"
+  loop_break="$({ grep -E '^\s*exhausted \| completed\)' <<<"$loop_body" || true; } | head -1)"
+  loop_bound="$({ grep -E '^\s*if \[\[ "\$wait_until"' <<<"$loop_body" || true; } | head -1)"
+  if [[ "$loop_break" == *break* ]] && [[ "$loop_bound" == *'wait_until'* ]] &&
+    [[ ! "$loop_bound" =~ [0-9]{2,} ]]; then
+    pass "obj-sweep(wait-completed-breaks): the caller's contention loop BREAKS on \`completed\` (a state the wait reaches without sleeping) and bounds itself on the iteration's own derived \`wait_until\` budget — so a peer that advertises a sweep and dies holding its claim cannot make this lane spin [STRUCTURAL]"
+  else
+    fail "obj-sweep(wait-completed-breaks): break-arm='$loop_break' loop-bound='$loop_bound' — \`completed\` must end the loop and the loop's own deadline must be the derived wait_until, never a literal"
+  fi
 }
 
 t test_object_store_sweep_claim_wait_is_wired_correctly
+
+# A PEER THAT ADVERTISES A SWEEP AND THEN NEVER RELEASES ITS CLAIM MUST NOT MAKE THIS LANE
+# SPIN (#3749 review round 14).
+#
+# THE DEFECT. `obj_sweep_claim_wait` returns `completed` the instant the throttle stamp goes
+# FRESH — and it does so on the pass that observes it, WITHOUT sleeping. The caller's loop
+# then treated `completed` as "go round and contend again". In the ordinary case that is
+# harmless (the peer released a moment earlier, so the re-acquire succeeds and the second
+# throttle read skips), but a peer that writes the stamp and DIES before releasing leaves the
+# claim present and the stamp fresh — and in that state every acquire answers `held`, every
+# wait answers `completed` in microseconds, and the loop spins CPU-hot with nothing to do
+# until the supervisor's whole MAX_HOURS wall-clock budget expires. It is a liveness and CPU
+# defect, not a wrong verdict: on a four-lane box it burns a core and reads as "the fleet got
+# slow" with no obvious cause.
+#
+# WHY THE STALENESS RECOVERY DID NOT SAVE IT. Round 5 gave the claim an age-based bound
+# precisely so a dead peer's claim is recoverable. This path never reached it: `completed` is
+# tested BEFORE the claim's deadline on every pass, so the recovery the design relies on never
+# ran. The fix does not add a second notion of "the peer is gone" — a fresh stamp means the
+# box has been measured inside the interval, which is the SAME answer the throttle at the top
+# of object_store_sweep gives, so the lane skips exactly as it would have and stops contending.
+#
+# TWO ARMS, ONE PROPERTY APART. Arm `dead-peer`: the peer writes the stamp and NEVER releases.
+# Arm `released-peer`: the same peer releases normally — the common case, which must still
+# fall straight through with no added latency. And the CONSTRUCTION is asserted in both, since
+# without it these arms could pass because nothing ever happened: the stamp really did go
+# FRESH while the lane was parked, and in the dead-peer arm the claim really is still present
+# when the lane finishes.
+#
+# THE BOUND IS DISCRIMINATING, NOT ARBITRARY. The derived wait budget here is
+# MAX_SWEEP_WALKS(3) x OBJ_SWEEP_TIMEOUT_SECS(1) + OBJ_SWEEP_CLAIM_SLACK_SECS(60) = 63s, so a
+# lane that merely waited the claim out could not finish inside this case's 20s cap: a pass
+# inside it is the skip, never an `exhausted` in disguise.
+test_object_store_sweep_claim_wait_completed_stops_contending() {
+  local d root calls counter rc claim stamp sup_pid waited finished arm
+  local completed_n release stamp_ts now_ts skipped_n
+  for arm in dead-peer released-peer; do
+    d="$(new_case_dir)"; calls="$d/calls"; counter="$d/counter"
+    common_env "$d"
+    write_finalize_stub "$d/bin/worker.sh" "$counter"
+    export WORKER_CMD="$d/bin/worker.sh"
+    export MAX_ISSUES=1
+    export OBJ_SWEEP_INTERVAL_HOURS=6
+    export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+    export OBJ_SWEEP_TIMEOUT_SECS=1
+    export OBJ_SWEEP_CLAIM_SLACK_SECS=60
+    export OBJ_SWEEP_CLAIM_POLL_SECS=1
+    stamp="$OBJ_SWEEP_STAMP"
+    claim="$stamp.sweeping"
+    # NO STAMP YET: the lane must find the box outside the interval, or it would take the
+    # throttled path at the top of object_store_sweep and never reach the claim at all.
+    mkdir -p "$claim"
+    printf '%s\n' "$(date +%s)" >"$claim/started"
+    root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
+    # THE PEER, as a separate process, so the stamp goes fresh WHILE the lane is parked
+    # inside the wait rather than before it starts. It waits for the lane's own WAITING line
+    # — the only observable that says the lane is in the wait — then advertises the sweep.
+    if [[ "$arm" == released-peer ]]; then
+      release="rm -rf -- $(printf '%q' "$claim")"
+    else
+      release=": # dead peer: the claim is deliberately left behind"
+    fi
+    {
+      printf '#!/usr/bin/env bash\n'
+      printf 'i=0\n'
+      printf 'while [ "$i" -lt 600 ]; do\n'
+      printf '  if grep -q %s %s 2>/dev/null; then\n' \
+        "$(printf '%q' 'WAITING for the peer lane that holds the sweep claim')" \
+        "$(printf '%q' "$d/sup.log")"
+      printf '    printf "%%s\\n" "$(date +%%s)" >%s\n' "$(printf '%q' "$stamp")"
+      printf '    %s\n' "$release"
+      printf '    exit 0\n'
+      printf '  fi\n'
+      printf '  sleep 0.05\n'
+      printf '  i=$((i + 1))\n'
+      printf 'done\n'
+      printf 'exit 1\n'
+    } >"$d/bin/peer.sh"
+    chmod +x "$d/bin/peer.sh"
+    env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/sup.log" 2>&1 &
+    sup_pid=$!
+    bash "$d/bin/peer.sh" >"$d/peer.log" 2>&1 &
+    # BOUNDED, background+poll+kill (macOS has no `timeout(1)`), and the cap is what makes the
+    # spin observable: under the defect this lane never exits at all until MAX_HOURS.
+    waited=0; finished=no
+    while [[ "$waited" -lt 200 ]]; do   # 200 x 0.1s = 20s, well inside the derived 63s budget
+      kill -0 "$sup_pid" 2>/dev/null || { finished=yes; break; }
+      sleep 0.1
+      waited=$((waited + 1))
+    done
+    rc=0
+    if [[ "$finished" == yes ]]; then
+      wait "$sup_pid" || rc=$?
+    else
+      kill -KILL "$sup_pid" 2>/dev/null || true
+      wait "$sup_pid" 2>/dev/null || true
+      rc=timeout
+    fi
+    wait >/dev/null 2>&1 || true
+    completed_n="$({ grep -c 'FINISHED its sweep after' "$d/sup.log" 2>/dev/null || true; } | head -1)"
+    [[ "$completed_n" =~ ^[0-9]+$ ]] || completed_n=0
+    skipped_n="$({ grep -c 'does not contend for that claim again' "$d/sup.log" 2>/dev/null || true; } | head -1)"
+    [[ "$skipped_n" =~ ^[0-9]+$ ]] || skipped_n=0
+    # CONSTRUCTION FIRST, AND IT IS NOT THE PROPERTY UNDER TEST: the stamp must really have
+    # gone FRESH (so the lane really did observe `completed`), and in the dead-peer arm the
+    # claim must really still be there (so the lane really was in the fresh-stamp +
+    # persistent-claim state). Without this both arms are passed by a run in which the peer
+    # never fired.
+    stamp_ts=""
+    { read -r stamp_ts || true; } <"$stamp" 2>/dev/null || true
+    now_ts="$(date +%s)"
+    if [[ "$stamp_ts" =~ ^[0-9]+$ ]] && [[ "$stamp_ts" -le "$now_ts" ]] &&
+      [[ "$completed_n" -ge 1 ]] &&
+      { [[ "$arm" == released-peer ]] || [[ -d "$claim" ]]; }; then
+      pass "obj-sweep(claim-wait-completed-plant/$arm): the peer advertised its sweep in the throttle stamp WHILE this lane was parked in the wait (the lane logged the completion), and the claim is $([[ -d "$claim" ]] && echo 'still present' || echo 'released') exactly as this arm stages it"
+    else
+      fail "obj-sweep(claim-wait-completed-plant/$arm): STAGING — stamp='$stamp_ts' completions=$completed_n claim=$([[ -d "$claim" ]] && echo present || echo absent) peer-rc=$(cat "$d/peer.log" 2>/dev/null | head -1) (see $d/sup.log); the assert below would prove nothing"
+      unset OBJ_SWEEP_TIMEOUT_SECS OBJ_SWEEP_CLAIM_SLACK_SECS OBJ_SWEEP_CLAIM_POLL_SECS
+      continue
+    fi
+    # THE PROPERTY: ONE completion, no re-contention, the worker runs, and NO fsck was spent
+    # (the box is inside the interval — that is what a fresh stamp means).
+    if [[ "$rc" == 0 && "$completed_n" -eq 1 && "$skipped_n" -eq 1 && -f "$counter" && ! -s "$calls" ]]; then
+      if [[ "$arm" == dead-peer ]]; then
+        pass "obj-sweep(claim-wait-completed/dead-peer): a peer that advertises a sweep and then never releases its claim ends this lane's wait ONCE — the lane skips the interval and runs its worker instead of re-contending for a claim nobody will give up"
+      else
+        pass "obj-sweep(claim-wait-completed/released-control): the SAME staging with the peer RELEASING normally also ends in one completion and one skip, inside the same cap — so the dead-peer arm is the persistent claim and not a lane that stopped working"
+      fi
+    elif [[ "$rc" == timeout ]]; then
+      fail "obj-sweep(claim-wait-completed/$arm): THE DEFECT — the lane did NOT exit within 20s (the derived wait budget is 63s, so this is not the wait expiring): it observed the peer's completion $completed_n time(s), i.e. it went back and contended for the still-present claim after every one of them, spinning until the wall-clock budget (see $d/sup.log)"
+    else
+      fail "obj-sweep(claim-wait-completed/$arm): rc=$rc completions=$completed_n skips=$skipped_n spawned=$([[ -f "$counter" ]] && echo yes || echo no) sweeps=$(obj_sweep_calls "$calls") (see $d/sup.log)"
+    fi
+    unset OBJ_SWEEP_TIMEOUT_SECS OBJ_SWEEP_CLAIM_SLACK_SECS OBJ_SWEEP_CLAIM_POLL_SECS
+  done
+}
+
+t test_object_store_sweep_claim_wait_completed_stops_contending
 
 # THE OTHER HALF, AND THE HAZARD THE CLAIM INTRODUCES: A STALE CLAIM MUST NOT WEDGE THE BOX
 # (#3749 review round 5, item 2). A lane killed mid-sweep leaves its claim behind, and

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -9363,8 +9363,14 @@ t test_lane_lock_failure_cause_is_not_inferred_from_later_state
 # The optional 5th argument is a shell line the stub runs BEFORE printing its verdict —
 # used by the monotonicity case to have a PEER LANE latch the box while this lane's sweep
 # is still in flight, which is the only way to stage the stale-writer race in one process.
+#
+# The optional 6th is the store path the stub answers `--print-store` with, i.e. the ONE
+# isolated resolver the supervisor now keys its stamp on. Empty (the default) means the
+# stub answers NOTHING, which is the unresolvable-store state. A `--print-store` call is
+# deliberately NOT written to the call log: it resolves, it does not sweep, and the cases
+# that count sweeps must not be made to count resolutions.
 obj_sweep_tree() {
-  local d="$1" verdict="$2" rc="$3" calllog="${4:-}" during="${5:-}" root="$d/root"
+  local d="$1" verdict="$2" rc="$3" calllog="${4:-}" during="${5:-}" storeline="${6:-}" root="$d/root"
   mkdir -p "$root/scripts/local" "$root/scripts/lib"
   git -C "$root" init -q 2>/dev/null
   git -C "$root" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init 2>/dev/null
@@ -9375,6 +9381,12 @@ obj_sweep_tree() {
   {
     printf '#!/usr/bin/env bash\n'
     printf '# STUB sweep: record the invocation, print one anchored verdict, exit with its code.\n'
+    printf 'for a in "$@"; do\n'
+    printf '  if [ "$a" = --print-store ]; then\n'
+    [[ -n "$storeline" ]] && printf '    printf "OBJECT-STORE: store %%s\\n" %s\n' "$(printf '%q' "$storeline")"
+    printf '    exit 0\n'
+    printf '  fi\n'
+    printf 'done\n'
     [[ -n "$calllog" ]] && printf 'printf "called\\n" >>%s\n' "$(printf '%q' "$calllog")"
     [[ -n "$during" ]] && printf '%s\n' "$during"
     printf 'printf "OBJECT-STORE: measured stub\\n"\n'
@@ -9798,6 +9810,88 @@ test_object_store_set_latch_is_create_only() {
 }
 
 t test_object_store_set_latch_is_create_only
+
+# THE STAMP KEY COMES FROM THE ISOLATED RESOLVER, NOT FROM AN AMBIENT `git`
+# (#3749 review round 2, BLOCKER 2).
+#
+# THE DEFECT: obj_sweep_stamp_path resolved `--git-common-dir` with a BARE `git`,
+# inheriting the caller's environment, while the sweep it keys runs every git call under
+# `env -i` + one allowlist. An inherited `GIT_DIR`/`GIT_COMMON_DIR` therefore selected
+# ANOTHER repository's stamp — so the real store's sweep is throttled away, or its verdict
+# recorded under the wrong key, on a box where the key is also what a peer lane's CORRUPT
+# is found by. The resolution now has ONE implementation, in the file that owns the
+# allowlist, and this supervisor ASKS for it.
+#
+# The cases above all pin OBJ_SWEEP_STAMP, so none of them exercises the resolver at all.
+# This one unsets it, which is the production shape.
+test_object_store_stamp_key_comes_from_the_resolver() {
+  local d root counter calls rc fake other key_fake key_other stamp_fake stamp_other bare
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-resolver"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  unset OBJ_SWEEP_STAMP
+  fake="$d/resolved-store/objects"
+  mkdir -p "$fake"
+  # A REAL repository: git refuses an empty directory as a common dir and answers with
+  # nothing at all, which would make the construction assert below unfalsifiable rather
+  # than false.
+  git init -q "$d/injected-store" >/dev/null 2>&1
+  other="$d/injected-store/.git"
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls" "" "$fake")"
+  # The stamp names both files (`<stamp>` and `<stamp>.CORRUPT`), derived exactly as
+  # obj_sweep_stamp_path derives them, so the assertions below name a path rather than
+  # globbing a shared /tmp that peer lanes are also writing.
+  key_fake="$(printf '%s' "${fake//\//_}" | tr -c 'A-Za-z0-9._-' '_')"
+  key_other="$(printf '%s' "${other//\//_}" | tr -c 'A-Za-z0-9._-' '_')"
+  stamp_fake="/tmp/cqlite-object-store-sweep.${key_fake}.stamp"
+  stamp_other="/tmp/cqlite-object-store-sweep.${key_other}.stamp"
+  rm -f "$stamp_fake" "$stamp_other"
+  # CONSTRUCTION: a BARE git in this environment really does answer with the INJECTED
+  # directory, so a green below is the resolver and not an inert variable. This is the
+  # exact call the supervisor used to make.
+  bare="$(GIT_COMMON_DIR="$other" git -C "$root" rev-parse --git-common-dir 2>/dev/null || true)"
+  if [[ "$bare" == "$other" ]]; then
+    pass "obj-sweep(resolver-plant): a BARE git in this environment resolves to the INJECTED repository — the mis-keying the case is about is really available here"
+  else
+    fail "obj-sweep(resolver-plant): a bare git answered '$bare', not the injected '$other' — the case below would prove nothing"
+  fi
+  env LANE_ID=objsweep-test GIT_COMMON_DIR="$other" \
+    bash "$root/scripts/local/worker-supervisor.sh" >"$d/resolver.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 0 && -e "$stamp_fake" && ! -e "$stamp_other" ]]; then
+    pass "obj-sweep(resolver): the stamp is keyed on the store the SWEEP SCRIPT resolved, and an inherited GIT_COMMON_DIR cannot move it to another repository's key"
+  else
+    fail "obj-sweep(resolver): rc=$rc resolved-key=$([[ -e "$stamp_fake" ]] && echo yes || echo no) injected-key=$([[ -e "$stamp_other" ]] && echo yes || echo no) (see $d/resolver.log)"
+  fi
+  rm -f "$stamp_fake" "$stamp_other" "$stamp_fake.CORRUPT" "$stamp_other.CORRUPT"
+
+  # ONE PROPERTY APART: the resolver answers NOTHING (an unresolvable store). The lane
+  # must NOT throttle at all — the old fallback collapsed every unresolvable store on a
+  # box onto ONE name, so two checkouts shared a 6-hour throttle and one suppressed the
+  # other's sweep, which is a MISSED sweep. Measured as two consecutive runs BOTH
+  # sweeping, which is the observable that distinguishes "no throttle" from "throttled".
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-unresolvable"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  unset OBJ_SWEEP_STAMP
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/unres1.log" 2>&1
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/unres2.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 0 && "$(obj_sweep_calls "$calls")" -eq 2 ]]; then
+    pass "obj-sweep(resolver): a store the resolver cannot name does NOT throttle — both runs swept, so no unresolvable store can suppress another's sweep through a shared fallback name"
+  else
+    fail "obj-sweep(resolver-unresolvable): rc=$rc sweeps=$(obj_sweep_calls "$calls") (wanted 2)"
+  fi
+}
+
+t test_object_store_stamp_key_comes_from_the_resolver
 
 # ---------------------------------------------------------------------------
 # Test 48 (#3549, roborev job 196 F2): THE SUITE LEAVES NO FIXTURE PROCESS BEHIND.

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -9371,6 +9371,12 @@ t test_lane_lock_failure_cause_is_not_inferred_from_later_state
 # invocations, so a case cannot pass against a sweep that never ran.
 # ---------------------------------------------------------------------------
 # obj_sweep_tree <dir> <verdict-line> <exit> [call-log] -> scratch repo root
+#
+# The runs below pass `LANE_ID` EXPLICITLY (per invocation, never exported, so nothing
+# leaks into a later case): the supervisor refuses to start with
+# `FATAL: lane-identity-unprovable` when it cannot derive a per-lane identity, and a
+# plain scratch repo is not a lane worktree. Supplying the identity is what the refusal
+# itself recommends, and it keeps the fixture a one-`git init` tree.
 obj_sweep_tree() {
   local d="$1" verdict="$2" rc="$3" calllog="${4:-}" root="$d/root"
   mkdir -p "$root/scripts/local" "$root/scripts/lib"
@@ -9404,7 +9410,7 @@ test_object_store_sweep_verdicts() {
   export OBJ_SWEEP_INTERVAL_HOURS=6
   export OBJ_SWEEP_STAMP="$d/sweep.stamp"
   root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
-  bash "$root/scripts/local/worker-supervisor.sh" >"$d/stdout.log" 2>&1
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/stdout.log" 2>&1
   rc=$?
   if [[ "$rc" -eq 0 && -s "$calls" && -f "$counter" ]] &&
      grep -q 'object-store: VERIFIED' "$d/stdout.log"; then
@@ -9430,7 +9436,7 @@ test_object_store_sweep_verdicts() {
   export OBJ_SWEEP_INTERVAL_HOURS=6
   export OBJ_SWEEP_STAMP="$d/sweep.stamp"
   root="$(obj_sweep_tree "$d" CORRUPT 4 "$calls")"
-  bash "$root/scripts/local/worker-supervisor.sh" >"$d/stdout.log" 2>&1
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/stdout.log" 2>&1
   rc=$?
   if [[ "$rc" -eq 1 && -s "$calls" && ! -f "$counter" ]] &&
      grep -q '"reason":"object-store-corrupt"' "$JOURNAL_FILE" &&
@@ -9465,7 +9471,7 @@ test_object_store_sweep_verdicts() {
   export OBJ_SWEEP_INTERVAL_HOURS=6
   export OBJ_SWEEP_STAMP="$d/sweep.stamp"
   root="$(obj_sweep_tree "$d" UNMEASURED 5 "$calls")"
-  bash "$root/scripts/local/worker-supervisor.sh" >"$d/stdout.log" 2>&1
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/stdout.log" 2>&1
   rc=$?
   if [[ "$rc" -eq 0 && -s "$calls" && -f "$counter" ]] &&
      grep -q 'object-store: UNMEASURED' "$d/stdout.log" &&
@@ -9488,8 +9494,8 @@ test_object_store_sweep_throttle_and_disable() {
   export OBJ_SWEEP_INTERVAL_HOURS=6
   export OBJ_SWEEP_STAMP="$d/sweep.stamp"
   root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
-  bash "$root/scripts/local/worker-supervisor.sh" >"$d/run1.log" 2>&1
-  bash "$root/scripts/local/worker-supervisor.sh" >"$d/run2.log" 2>&1
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/run1.log" 2>&1
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/run2.log" 2>&1
   n=$(grep -c . "$calls" 2>/dev/null || echo 0)
   if [[ "$n" -eq 1 ]]; then
     pass "obj-sweep(throttle): two runs inside the interval sweep exactly ONCE (measured invocations, not inferred)"
@@ -9499,7 +9505,7 @@ test_object_store_sweep_throttle_and_disable() {
   # (b) A STAMP IN THE FUTURE must not park the sweep forever (clock skew, a restored
   # snapshot, a hand-edited file). ONE property apart from (a): the stamp's value.
   printf '%s\n' "$(( $(date +%s) + 86400 ))" >"$OBJ_SWEEP_STAMP"
-  bash "$root/scripts/local/worker-supervisor.sh" >"$d/run3.log" 2>&1
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/run3.log" 2>&1
   n=$(grep -c . "$calls" 2>/dev/null || echo 0)
   if [[ "$n" -eq 2 ]]; then
     pass "obj-sweep(throttle): a stamp in the FUTURE is treated as never-swept, not as a permanent skip"
@@ -9515,7 +9521,7 @@ test_object_store_sweep_throttle_and_disable() {
   export OBJ_SWEEP_INTERVAL_HOURS=0
   export OBJ_SWEEP_STAMP="$d/sweep.stamp"
   root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
-  bash "$root/scripts/local/worker-supervisor.sh" >"$d/stdout.log" 2>&1
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/stdout.log" 2>&1
   rc=$?
   if [[ "$rc" -eq 0 && ! -s "$calls" ]] &&
      grep -q 'object-store sweep DISABLED' "$d/stdout.log"; then

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -960,6 +960,13 @@ common_env() {
   export LOCK_CMD=""
   export LOAD_PROBE_CMD="echo 0"
   export DISK_PROBE_CMD="echo 999999"
+  # The #3749 shared-object-store sweep OFF by default: `REPO_ROOT` is the REAL lane
+  # checkout in these cases, so a sweep here would `git fsck` this box's 331M shared store
+  # (19.83s measured) once per case — minutes added to a MANDATORY gate component for a
+  # property these cases are not about. The dedicated cases below override it and point the
+  # supervisor at their own scratch tree with a stub sweep, so the branch coverage is real
+  # rather than mocked away.
+  export OBJ_SWEEP_INTERVAL_HOURS=0
   # roborev 1839: preflight bounds the two leftover families separately, so it reads
   # per-family probes (the old combined PROC_PROBE_CMD is gone). Default both to clear;
   # leftover-hold tests override the family they exercise.
@@ -987,7 +994,8 @@ common_env() {
   # next test in this shared shell and cause a spurious pass/fail.
   unset MAX_HOURS_SECS DISK_FLOOR_GB PENDING_AUTOMERGE_MAX PENDING_AUTOMERGE_MIN_SECS \
         BUILD_HOLD_MAX LEFTOVER_HOLD_MAX UNVERIFIED_MAX MISMATCH_RETRIES \
-        MISMATCH_GRACE_CAP_SECS PROC_LIST_WORKER_CMD PROC_LIST_BUILD_CMD 2>/dev/null || true
+        MISMATCH_GRACE_CAP_SECS PROC_LIST_WORKER_CMD PROC_LIST_BUILD_CMD \
+        OBJ_SWEEP_STAMP OBJ_SWEEP_TIMEOUT_SECS 2>/dev/null || true
   # Claim stamping (issue #2655) OFF by default so most tests stay focused; the
   # dedicated claim tests set a hermetic CLAIM_CMD stub that logs its args.
   export CLAIM_CMD=""
@@ -9347,6 +9355,216 @@ t test_lane_lock_failure_cause_is_not_inferred_from_later_state
 # ever staged, and the leak set is what remains OWNED after the reap. A group released as `foreign`
 # (existing but unsignallable — the number now belongs to another user) is NOT a leak of ours and is
 # reported separately if it ever happens, because calling it a leak would blame this suite for a pid
+# ---------------------------------------------------------------------------
+# Tests (#3749): the THROTTLED shared-object-store sweep in the preflight path.
+#
+# Every case runs the supervisor from a SCRATCH TREE carrying a STUB sweep script — the
+# artifact is SUBSTITUTED rather than reached through a path variable, because a test-only
+# seam is one more thing a real invoker can set (CLAUDE.md's #3312 corollary), and because
+# the real sweep's own behaviour belongs to
+# scripts/tests/test_check_object_store_integrity.sh. What these assert is the
+# SUPERVISOR's half: which verdict stops the loop, which one does not, and that the
+# throttle throttles.
+#
+# RED-ARM DISCIPLINE: the three verdict cases differ from one another in EXACTLY ONE
+# property — the stub's verdict line and exit status — and each stub RECORDS its
+# invocations, so a case cannot pass against a sweep that never ran.
+# ---------------------------------------------------------------------------
+# obj_sweep_tree <dir> <verdict-line> <exit> [call-log] -> scratch repo root
+obj_sweep_tree() {
+  local d="$1" verdict="$2" rc="$3" calllog="${4:-}" root="$d/root"
+  mkdir -p "$root/scripts/local" "$root/scripts/lib"
+  git -C "$root" init -q 2>/dev/null
+  git -C "$root" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init 2>/dev/null
+  cp "$SUPERVISOR" "$root/scripts/local/worker-supervisor.sh"
+  # scripts/lib is needed by the default notify path (an incomplete scratch tree produces
+  # an unattributable failure — learned by the lane-identity cases above).
+  cp "$REPO_ROOT/scripts/lib/gate-notify.sh" "$root/scripts/lib/" 2>/dev/null || true
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf '# STUB sweep: record the invocation, print one anchored verdict, exit with its code.\n'
+    [[ -n "$calllog" ]] && printf 'printf "called\\n" >>%s\n' "$(printf '%q' "$calllog")"
+    printf 'printf "OBJECT-STORE: measured stub\\n"\n'
+    printf 'printf "OBJECT-STORE: object deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\\n"\n'
+    printf 'printf "OBJECT-STORE: verdict %s\\n"\n' "$verdict"
+    printf 'exit %s\n' "$rc"
+  } >"$root/scripts/check-object-store-integrity.sh"
+  chmod +x "$root/scripts/check-object-store-integrity.sh"
+  printf '%s' "$root"
+}
+
+test_object_store_sweep_verdicts() {
+  local d root counter rc calls
+  # (a) VERIFIED: the sweep runs, is journalled, and the iteration proceeds normally.
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-verified"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
+  bash "$root/scripts/local/worker-supervisor.sh" >"$d/stdout.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 0 && -s "$calls" && -f "$counter" ]] &&
+     grep -q 'object-store: VERIFIED' "$d/stdout.log"; then
+    pass "obj-sweep(VERIFIED): the sweep ran, was journalled, and the worker still ran"
+  else
+    fail "obj-sweep(VERIFIED): rc=$rc swept=$([[ -s "$calls" ]] && echo yes || echo no) spawned=$([[ -f "$counter" ]] && echo yes || echo no) (see $d)"
+  fi
+  # The stamp is written, which is what the throttle reads.
+  if [[ -s "$OBJ_SWEEP_STAMP" ]] && grep -qE '^[0-9]+$' "$OBJ_SWEEP_STAMP"; then
+    pass "obj-sweep(VERIFIED): the throttle stamp records an epoch"
+  else
+    fail "obj-sweep(stamp): no usable stamp at $OBJ_SWEEP_STAMP"
+  fi
+
+  # (b) CORRUPT: ONE property different from (a) — the stub's verdict. It must STOP the
+  # loop (corruption is non-self-clearing, so a HOLD would spin to the budget) and NO
+  # worker may run: a worker must never certify against a damaged shared store.
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-corrupt"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  root="$(obj_sweep_tree "$d" CORRUPT 4 "$calls")"
+  bash "$root/scripts/local/worker-supervisor.sh" >"$d/stdout.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 1 && -s "$calls" && ! -f "$counter" ]] &&
+     grep -q '"reason":"object-store-corrupt"' "$JOURNAL_FILE" &&
+     grep -q 'object-store: CORRUPT' "$d/stdout.log"; then
+    pass "obj-sweep(CORRUPT): stops the loop loudly (rc=1, own reason) and spawns NO worker"
+  else
+    fail "obj-sweep(CORRUPT): rc=$rc swept=$([[ -s "$calls" ]] && echo yes || echo no) spawned=$([[ -f "$counter" ]] && echo yes || echo no) (see $d)"
+  fi
+  if grep -q 'OBJECT STORE CORRUPT' "$NOTIFY_LOG" 2>/dev/null &&
+     grep -q 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' "$d/stdout.log"; then
+    pass "obj-sweep(CORRUPT): pages high AND carries the sweep's own findings (object ids) into the journal"
+  else
+    fail "obj-sweep(CORRUPT): no high page, or the findings were dropped (see $NOTIFY_LOG)"
+  fi
+  # AND IT IS NOT A HOLD REASON. A HOLD would have logged `HOLD:` and repolled until the
+  # wall-clock budget with no useful action — the latch #2670 bounded the leftover families
+  # to avoid. Asserted directly, because "it stopped" alone cannot distinguish the two.
+  if ! grep -q 'HOLD: object-store' "$d/stdout.log"; then
+    pass "obj-sweep(CORRUPT): it is NOT a hold reason (non-self-clearing: a repoll loop would spin to the budget)"
+  else
+    fail "obj-sweep(CORRUPT): corruption was treated as a HOLD"
+  fi
+
+  # (c) UNMEASURED: again ONE property different — reported, paged once, and DELIBERATELY
+  # NOT a stop: refusing to run any worker because a hygiene probe could not run is a
+  # self-DoS. The permissive branch is asserted here so a future "tighten it" edit reds.
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-unmeasured"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  root="$(obj_sweep_tree "$d" UNMEASURED 5 "$calls")"
+  bash "$root/scripts/local/worker-supervisor.sh" >"$d/stdout.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 0 && -s "$calls" && -f "$counter" ]] &&
+     grep -q 'object-store: UNMEASURED' "$d/stdout.log" &&
+     grep -q 'UNKNOWN, not clean' "$d/stdout.log"; then
+    pass "obj-sweep(UNMEASURED): reported as UNKNOWN-not-clean, paged, and the loop CONTINUES (a hygiene probe must not stop the fleet)"
+  else
+    fail "obj-sweep(UNMEASURED): rc=$rc swept=$([[ -s "$calls" ]] && echo yes || echo no) spawned=$([[ -f "$counter" ]] && echo yes || echo no) (see $d)"
+  fi
+}
+
+test_object_store_sweep_throttle_and_disable() {
+  local d root counter calls rc n
+  # (a) THE THROTTLE: two runs sharing one stamp sweep ONCE. The stub counts invocations,
+  # so this measures the throttle rather than inferring it from absent log lines.
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
+  bash "$root/scripts/local/worker-supervisor.sh" >"$d/run1.log" 2>&1
+  bash "$root/scripts/local/worker-supervisor.sh" >"$d/run2.log" 2>&1
+  n=$(grep -c . "$calls" 2>/dev/null || echo 0)
+  if [[ "$n" -eq 1 ]]; then
+    pass "obj-sweep(throttle): two runs inside the interval sweep exactly ONCE (measured invocations, not inferred)"
+  else
+    fail "obj-sweep(throttle): the sweep ran $n time(s) across two runs, wanted 1 (see $calls)"
+  fi
+  # (b) A STAMP IN THE FUTURE must not park the sweep forever (clock skew, a restored
+  # snapshot, a hand-edited file). ONE property apart from (a): the stamp's value.
+  printf '%s\n' "$(( $(date +%s) + 86400 ))" >"$OBJ_SWEEP_STAMP"
+  bash "$root/scripts/local/worker-supervisor.sh" >"$d/run3.log" 2>&1
+  n=$(grep -c . "$calls" 2>/dev/null || echo 0)
+  if [[ "$n" -eq 2 ]]; then
+    pass "obj-sweep(throttle): a stamp in the FUTURE is treated as never-swept, not as a permanent skip"
+  else
+    fail "obj-sweep(future-stamp): invocations=$n, wanted 2"
+  fi
+  # (c) DISABLED (interval 0) — announced in the journal, and the sweep really does not run.
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-off"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=0
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
+  bash "$root/scripts/local/worker-supervisor.sh" >"$d/stdout.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 0 && ! -s "$calls" ]] &&
+     grep -q 'object-store sweep DISABLED' "$d/stdout.log"; then
+    pass "obj-sweep(disabled): interval 0 skips the sweep and ANNOUNCES it (a disabled hygiene probe must be visible, not inferred)"
+  else
+    fail "obj-sweep(disabled): rc=$rc swept=$([[ -s "$calls" ]] && echo yes || echo no) (see $d)"
+  fi
+}
+
+test_object_store_sweep_knobs() {
+  local d rc page
+  # A malformed interval must FAIL CLOSED like its siblings: a bare word would evaluate to
+  # 0 in `-le 0` and SILENTLY DISABLE the sweep — the `MAX_HOURS=abc → 0` hazard, one knob
+  # over.
+  d="$(new_case_dir)"
+  common_env "$d"
+  export WORKER_CMD="$d/bin/worker.sh"
+  write_finalize_stub "$d/bin/worker.sh" "$d/counter"
+  export OBJ_SWEEP_INTERVAL_HOURS="abc"
+  bash "$SUPERVISOR" >"$d/stdout.log" 2>&1
+  rc=$?
+  page=$(grep -c 'bad config' "$NOTIFY_LOG" 2>/dev/null || true)
+  if [[ "$rc" -eq 2 && ! -f "$d/counter" && "$page" -ge 1 ]]; then
+    pass "obj-sweep(knob): a malformed OBJ_SWEEP_INTERVAL_HOURS pages and exits 2 (never a silently-disabled sweep)"
+  else
+    fail "obj-sweep(knob-interval): rc=$rc page=$page spawned=$([[ -f "$d/counter" ]] && echo yes || echo no)"
+  fi
+  # ZERO is not a lax bound for the TIMEOUT: the sweep REJECTS 0 as a usage error, so a 0
+  # would make every run UNMEASURED forever — a bound that disables the probe rather than
+  # loosening it. Strictly positive, and the message has to say so.
+  d="$(new_case_dir)"
+  common_env "$d"
+  export WORKER_CMD="$d/bin/worker.sh"
+  write_finalize_stub "$d/bin/worker.sh" "$d/counter"
+  export OBJ_SWEEP_TIMEOUT_SECS=0
+  bash "$SUPERVISOR" >"$d/stdout.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 2 && ! -f "$d/counter" ]] &&
+     grep -q 'OBJ_SWEEP_TIMEOUT_SECS' "$d/stdout.log"; then
+    pass "obj-sweep(knob): OBJ_SWEEP_TIMEOUT_SECS=0 fails closed naming the knob (0 would make every sweep UNMEASURED)"
+  else
+    fail "obj-sweep(knob-timeout): rc=$rc spawned=$([[ -f "$d/counter" ]] && echo yes || echo no) (see $d/stdout.log)"
+  fi
+}
+
+t test_object_store_sweep_verdicts
+t test_object_store_sweep_throttle_and_disable
+t test_object_store_sweep_knobs
+
 # number the kernel reassigned.
 #
 # IT MUST BE THE LAST `t`: a case running after it would register groups nobody checks.

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -9673,7 +9673,7 @@ test_object_store_sweep_requires_both_channels_to_agree() {
     export MAX_ISSUES=1
     export OBJ_SWEEP_INTERVAL_HOURS=6
     export OBJ_SWEEP_STAMP="$d/sweep.stamp"
-    stamp="$OBJ_SWEEP_STAMP"; latch="$stamp.CORRUPT"
+    stamp="$OBJ_SWEEP_STAMP"; latch="$stamp.STOP"
     root="$(obj_sweep_tree "$d" "$verdict" "$code" "$calls")"
     env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/stdout.log" 2>&1
     rc=$?
@@ -9701,7 +9701,7 @@ test_object_store_sweep_requires_both_channels_to_agree() {
   export MAX_ISSUES=1
   export OBJ_SWEEP_INTERVAL_HOURS=6
   export OBJ_SWEEP_STAMP="$d/sweep.stamp"
-  stamp="$OBJ_SWEEP_STAMP"; latch="$stamp.CORRUPT"
+  stamp="$OBJ_SWEEP_STAMP"; latch="$stamp.STOP"
   root="$(obj_sweep_tree "$d" CORRUPT 4 "$calls")"
   env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/stdout.log" 2>&1
   rc=$?
@@ -9733,7 +9733,7 @@ t test_object_store_sweep_knobs
 # a lane whose sweep STARTED before the detection could finish AFTER it and replace
 # `CORRUPT` with `VERIFIED`. Peers then throttle on the fresh non-corrupt stamp and keep
 # working. The verdict therefore no longer lives in a mutable cell at all: it is a
-# SEPARATE CREATE-ONLY file, `<stamp>.CORRUPT`, whose only transition is ABSENT -> PRESENT.
+# SEPARATE CREATE-ONLY file, `<stamp>.STOP`, whose only transition is ABSENT -> PRESENT.
 #
 # The halves are asserted separately, because each can pass while the box is unprotected:
 # (1) a CORRUPT run RECORDS the verdict, (2) a later lane reading that record STOPS,
@@ -9751,7 +9751,7 @@ test_object_store_corrupt_verdict_outlives_the_throttle() {
   export MAX_ISSUES=1
   export OBJ_SWEEP_INTERVAL_HOURS=6
   export OBJ_SWEEP_STAMP="$d/sweep.stamp"
-  stamp="$OBJ_SWEEP_STAMP"; latch="$stamp.CORRUPT"
+  stamp="$OBJ_SWEEP_STAMP"; latch="$stamp.STOP"
   root="$(obj_sweep_tree "$d" CORRUPT 4 "$calls")"
   env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/detect.log" 2>&1
   rc=$?
@@ -9827,7 +9827,7 @@ test_object_store_latch_survives_a_writer_that_finishes_after_it() {
   export MAX_ISSUES=1
   export OBJ_SWEEP_INTERVAL_HOURS=6
   export OBJ_SWEEP_STAMP="$d/sweep.stamp"
-  stamp="$OBJ_SWEEP_STAMP"; latch="$stamp.CORRUPT"
+  stamp="$OBJ_SWEEP_STAMP"; latch="$stamp.STOP"
   # The peer's bytes are DISTINCTIVE, so "unchanged" below is a comparison and not an
   # existence test: a re-created latch would carry the supervisor's own two lines.
   root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls" \
@@ -10033,7 +10033,7 @@ test_object_store_sweep_latch_beats_the_opt_out() {
   export MAX_ISSUES=1
   export OBJ_SWEEP_INTERVAL_HOURS=0
   export OBJ_SWEEP_STAMP="$d/sweep.stamp"
-  latch="$OBJ_SWEEP_STAMP.CORRUPT"
+  latch="$OBJ_SWEEP_STAMP.STOP"
   printf '%s\nCORRUPT\n' "$(date +%s)" >"$latch"
   root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
   env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/optout.log" 2>&1
@@ -10074,7 +10074,7 @@ test_object_store_sweep_latch_beats_the_opt_out() {
   export MAX_ISSUES=1
   export OBJ_SWEEP_INTERVAL_HOURS=6
   export OBJ_SWEEP_STAMP="$d/sweep.stamp"
-  latch="$OBJ_SWEEP_STAMP.CORRUPT"
+  latch="$OBJ_SWEEP_STAMP.STOP"
   printf '%s\nCORRUPT\n' "$(date +%s)" >"$latch"
   root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
   rm -f "$root/scripts/check-object-store-integrity.sh"
@@ -10403,10 +10403,10 @@ test_object_store_sweep_claim_is_released_on_the_exit_path() {
   rc=$?
   # CONSTRUCTION: the run really took the CORRUPT exit path (so the claim really was taken
   # and really was NOT released by the normal post-sweep release, which that path skips).
-  if [[ "$rc" -eq 1 && -e "$OBJ_SWEEP_STAMP.CORRUPT" && -s "$calls" ]]; then
+  if [[ "$rc" -eq 1 && -e "$OBJ_SWEEP_STAMP.STOP" && -s "$calls" ]]; then
     pass "obj-sweep(claim-exit-plant): the run swept, found CORRUPT and left via finalize_exit — the path that never reaches the post-sweep release"
   else
-    fail "obj-sweep(claim-exit-plant): rc=$rc latched=$([[ -e "$OBJ_SWEEP_STAMP.CORRUPT" ]] && echo yes || echo no) — the assert below would be vacuous"
+    fail "obj-sweep(claim-exit-plant): rc=$rc latched=$([[ -e "$OBJ_SWEEP_STAMP.STOP" ]] && echo yes || echo no) — the assert below would be vacuous"
     return
   fi
   if [[ ! -e "$claim" ]]; then
@@ -10429,7 +10429,7 @@ test_object_store_corrupt_leaves_both_the_latch_and_the_stamp() {
   export MAX_ISSUES=1
   export OBJ_SWEEP_INTERVAL_HOURS=6
   export OBJ_SWEEP_STAMP="$d/sweep.stamp"
-  stamp="$OBJ_SWEEP_STAMP"; latch="$stamp.CORRUPT"
+  stamp="$OBJ_SWEEP_STAMP"; latch="$stamp.STOP"
   root="$(obj_sweep_tree "$d" CORRUPT 4 "$calls")"
   env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/both.log" 2>&1
   rc=$?
@@ -10449,7 +10449,7 @@ t test_object_store_corrupt_leaves_both_the_latch_and_the_stamp
 #
 # THE DEFECT. The CORRUPT branch wrote the throttle stamp unconditionally. On the path
 # where the latch could NOT be persisted but the stamp COULD — a writable stamp inside a
-# directory that is not writable, so creating `<stamp>.CORRUPT` fails while rewriting
+# directory that is not writable, so creating `<stamp>.STOP` fails while rewriting
 # `<stamp>` succeeds — the detecting lane stopped (correct) and advertised a freshly swept
 # box to its peers (not correct). Those peers then read a fresh stamp, skipped their own
 # sweep for the whole interval, and kept spawning workers over a store already confirmed
@@ -10475,7 +10475,7 @@ test_object_store_unlatchable_corrupt_does_not_refresh_the_throttle() {
   export OBJ_SWEEP_INTERVAL_HOURS=6
   box="$d/box"; mkdir -p "$box"
   export OBJ_SWEEP_STAMP="$box/sweep.stamp"
-  stamp="$OBJ_SWEEP_STAMP"; latch="$stamp.CORRUPT"
+  stamp="$OBJ_SWEEP_STAMP"; latch="$stamp.STOP"
   # An EXPIRED stamp, so this lane sweeps; then close the directory for writing.
   printf '1\n' >"$stamp"
   chmod 0500 "$box"
@@ -10565,7 +10565,7 @@ test_object_store_unlatchable_corrupt_does_not_refresh_the_throttle() {
   export OBJ_SWEEP_INTERVAL_HOURS=6
   box="$d/box"; mkdir -p "$box"
   export OBJ_SWEEP_STAMP="$box/sweep.stamp"
-  stamp="$OBJ_SWEEP_STAMP"; latch="$stamp.CORRUPT"
+  stamp="$OBJ_SWEEP_STAMP"; latch="$stamp.STOP"
   printf '1\n' >"$stamp"
   root="$(obj_sweep_tree "$d" CORRUPT 4 "$calls")"
   env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/control-latchable.log" 2>&1
@@ -10799,7 +10799,7 @@ t test_supervisor_sweep_bound_covers_every_walk_the_script_can_take
 # created at all (an unwritable directory), which must be reported and never silently read
 # as "latched".
 test_object_store_set_latch_is_create_only() {
-  local d fns rc out latch
+  local d fns rc out latch latch_v latch_bad latch_arm
   d="$(new_case_dir)"
   fns="$d/extracted.sh"
   # THREE functions, because the create's verdict is the file's EXISTENCE asked afterwards
@@ -10807,39 +10807,80 @@ test_object_store_set_latch_is_create_only() {
   # obj_sweep_latch_present delegates to obj_sweep_latch_state, so extracting only the
   # first two yields a `command not found` — a real failure, but one whose cause is the
   # extraction rather than the subject.
-  sed -n '/^obj_sweep_latch_state() {/,/^}/p;/^obj_sweep_latch_present() {/,/^}/p;/^obj_sweep_set_latch() {/,/^}/p' \
+  sed -n '/^obj_sweep_latch_state() {/,/^}/p;/^obj_sweep_latch_present() {/,/^}/p;/^obj_sweep_set_latch() {/,/^}/p;/^obj_sweep_latch_verdict() {/,/^}/p' \
     "$SUPERVISOR" >"$fns"
   # CONSTRUCTION: the extraction really got all three functions, and the create-only
   # mechanism really is in the extracted text. Without this the cases below could be
   # measuring an empty file (every one of which would `command not found` and be reported
   # as a failure, but with a cause nobody could attribute).
   if grep -q '^obj_sweep_set_latch() {' "$fns" && grep -q '^obj_sweep_latch_present() {' "$fns" &&
-     grep -q '^obj_sweep_latch_state() {' "$fns" && grep -q 'set -C' "$fns"; then
-    pass "obj-sweep(set-latch-plant): all three latch functions were extracted from the shipped supervisor, noclobber included"
+     grep -q '^obj_sweep_latch_state() {' "$fns" && grep -q '^obj_sweep_latch_verdict() {' "$fns" &&
+     grep -q 'set -C' "$fns"; then
+    pass "obj-sweep(set-latch-plant): all four latch functions were extracted from the shipped supervisor, noclobber included"
   else
     fail "obj-sweep(set-latch-plant): the extraction from $SUPERVISOR did not yield the functions — the cases below would prove nothing"
     return 0
   fi
-  # (a) ABSENT -> PRESENT: it creates, and reports success.
-  latch="$d/a.CORRUPT"
-  rc=0
-  out="$(bash -c 'set -euo pipefail; . "$1"; obj_sweep_set_latch "$2"' _ "$fns" "$latch" 2>&1)" || rc=$?
-  if [[ "$rc" -eq 0 && -e "$latch" ]] && grep -q '^CORRUPT$' "$latch"; then
-    pass "obj-sweep(set-latch): an absent latch is created and the call reports success"
-  else
-    fail "obj-sweep(set-latch-create): rc=$rc out=[$out] content='$(tr '\n' '/' <"$latch" 2>/dev/null)'"
-  fi
+  # (a) ABSENT -> PRESENT, ONCE PER STOPPING VERDICT: it creates, records WHICH verdict,
+  #     and reports success. Both tokens are exercised because the latch is one file for
+  #     two verdicts now (#3749 review round 10, item 1) and the reader branches on the
+  #     content, so a create that wrote the wrong token would send a peer lane to the
+  #     wrong text.
+  for latch_v in CORRUPT UNSWEEPABLE; do
+    latch="$d/a-$latch_v.STOP"
+    rc=0
+    out="$(bash -c 'set -euo pipefail; . "$1"; obj_sweep_set_latch "$2" "$3"' _ "$fns" "$latch" "$latch_v" 2>&1)" || rc=$?
+    if [[ "$rc" -eq 0 && -e "$latch" ]] && grep -q "^$latch_v\$" "$latch"; then
+      pass "obj-sweep(set-latch/$latch_v): an absent latch is created recording $latch_v, and the call reports success"
+    else
+      fail "obj-sweep(set-latch-create/$latch_v): rc=$rc out=[$out] content='$(tr '\n' '/' <"$latch" 2>/dev/null)'"
+    fi
+  done
   # (b) PRESENT -> PRESENT, ONE property apart from (a): the file already exists. It must
   #     report success (the box IS latched) and leave the incumbent's bytes ALONE.
-  latch="$d/b.CORRUPT"
+  latch="$d/b.STOP"
   printf 'incumbent\n' >"$latch"
   rc=0
-  out="$(bash -c 'set -euo pipefail; . "$1"; obj_sweep_set_latch "$2"' _ "$fns" "$latch" 2>&1)" || rc=$?
+  out="$(bash -c 'set -euo pipefail; . "$1"; obj_sweep_set_latch "$2" CORRUPT' _ "$fns" "$latch" 2>&1)" || rc=$?
   if [[ "$rc" -eq 0 && "$(cat "$latch")" == "incumbent" ]]; then
     pass "obj-sweep(set-latch): an EXISTING latch is left byte-for-byte alone and still reports latched — the transition is ABSENT -> PRESENT only"
   else
     fail "obj-sweep(set-latch-existing): rc=$rc content='$(tr '\n' '/' <"$latch")' out=[$out]"
   fi
+  # (b2) THE VERDICT IS A CLOSED SET OF TWO, AND AN UNRECOGNISED ONE CREATES NOTHING. A
+  #      latch whose content no reader can recognise could only be reported as a
+  #      cause-free stop, so writing one would record a fact nobody can act on; refusing
+  #      sends the caller down its journalled could-not-persist path instead. Two arms,
+  #      one property apart from (a): the token, and its absence.
+  for latch_bad in WRONGVERDICT ''; do
+    latch="$d/bad-${latch_bad:-empty}.STOP"
+    rc=0
+    out="$(bash -c 'set -euo pipefail; . "$1"; obj_sweep_set_latch "$2" "$3"' _ "$fns" "$latch" "$latch_bad" 2>&1)" || rc=$?
+    if [[ "$rc" -ne 0 && ! -e "$latch" ]]; then
+      pass "obj-sweep(set-latch-closed/${latch_bad:-<empty>}): an unrecognised stopping verdict creates NO latch and reports failure — the caller must say so out loud rather than record a token nobody can read"
+    else
+      fail "obj-sweep(set-latch-closed/${latch_bad:-<empty>}): rc=$rc created=$([[ -e "$latch" ]] && echo yes || echo no) out=[$out]"
+    fi
+  done
+  # (c) WHICH VERDICT THE LATCH RECORDS, READ AFFIRMATIVELY. Only a second line that IS
+  #     one of the two tokens may be reported as that token; everything else is
+  #     UNRECOGNISED, and never defaulted to the damage verdict — that would name a cause
+  #     the box may not have, which is why the file is no longer called `.CORRUPT`.
+  for latch_arm in "CORRUPT:CORRUPT" "UNSWEEPABLE:UNSWEEPABLE" "SOMETHINGELSE:UNRECOGNISED" \
+    ":UNRECOGNISED" "MISSING:UNRECOGNISED"; do
+    latch="$d/rd-${latch_arm%%:*}.STOP"
+    if [[ "${latch_arm%%:*}" == MISSING ]]; then
+      rm -f "$latch"
+    else
+      printf '%s\n%s\n' "$(date +%s)" "${latch_arm%%:*}" >"$latch"
+    fi
+    out="$(bash -c 'set -euo pipefail; . "$1"; obj_sweep_latch_verdict "$2"' _ "$fns" "$latch" 2>&1)" || true
+    if [[ "$out" == "${latch_arm#*:}" ]]; then
+      pass "obj-sweep(latch-verdict/${latch_arm%%:*}): a latch recording '${latch_arm%%:*}' reads as ${latch_arm#*:}"
+    else
+      fail "obj-sweep(latch-verdict/${latch_arm%%:*}): read '$out', wanted '${latch_arm#*:}'"
+    fi
+  done
   # (c) CANNOT PERSIST: an unwritable directory. The call must report FAILURE, because the
   #     caller has to say so out loud — a create that could not happen must never be read
   #     as a latched box.
@@ -10850,7 +10891,7 @@ test_object_store_set_latch_is_create_only() {
   mkdir -p "$d/ro"
   chmod 500 "$d/ro"
   rc=0
-  out="$(bash -c 'set -euo pipefail; . "$1"; obj_sweep_set_latch "$2"' _ "$fns" "$d/ro/c.CORRUPT" 2>&1)" || rc=$?
+  out="$(bash -c 'set -euo pipefail; . "$1"; obj_sweep_set_latch "$2"' _ "$fns" "$d/ro/c.STOP" 2>&1)" || rc=$?
   chmod 700 "$d/ro"
   if [[ "$rc" -ne 0 && "$out" != *"No such file"* ]]; then
     pass "obj-sweep(set-latch): a latch that CANNOT be created reports failure rather than a silently latched box"
@@ -10860,6 +10901,156 @@ test_object_store_set_latch_is_create_only() {
 }
 
 t test_object_store_set_latch_is_create_only
+
+# ABSENCE MUST BE ESTABLISHED THROUGH SEARCHABLE ANCESTORS (#3749 review round 10, item 2).
+#
+# THE DEFECT. The four-valued probe decided `absent` on `[[ ! -d "$dir" ]]` — and `-d` is
+# ITSELF a two-valued predicate: it is false both for a holding directory that does not
+# exist and for one whose ANCESTOR this process cannot search. So a latch sitting under an
+# unsearchable ancestor was reported as an affirmative `absent`, the PERMISSIVE value,
+# bypassing the fail-closed `unknown` state built for exactly this case. It is CLAUDE.md's
+# standing predicate rule landing one level up from where round 5 fixed it, in the single
+# probe whose whole job is to be fail-closed.
+#
+# ASKED OF THE SHIPPED FUNCTION, extracted at run time, and every arm is ONE PROPERTY from
+# its neighbour: the same tree, the same latch path, only the permission bits move.
+test_object_store_latch_absence_needs_searchable_ancestors() {
+  local d fns out latch
+  d="$(new_case_dir)"
+  fns="$d/extracted-state.sh"
+  sed -n '/^obj_sweep_latch_state() {/,/^}/p' "$SUPERVISOR" >"$fns"
+  if grep -q '^obj_sweep_latch_state() {' "$fns" && grep -q 'unknown' "$fns"; then
+    pass "obj-sweep(ancestor-plant): obj_sweep_latch_state was extracted from the shipped supervisor and carries the four-valued vocabulary"
+  else
+    fail "obj-sweep(ancestor-plant): the extraction from $SUPERVISOR did not yield the function — the cases below would prove nothing"
+    return 0
+  fi
+  mkdir -p "$d/anc/inner"
+  latch="$d/anc/inner/sweep.stamp.STOP"
+  # CONTROL FIRST, one property from the case below: the same missing latch under the same
+  # two directories, both searchable. This is a real measurement of absence and must stay
+  # `absent` — a fix that answered `unknown` here would stop every healthy lane.
+  out="$(bash -c 'set -euo pipefail; . "$1"; obj_sweep_latch_state "$2"' _ "$fns" "$latch" 2>&1)" || true
+  if [[ "$out" == absent ]]; then
+    pass "obj-sweep(ancestor-control): a missing latch under SEARCHABLE ancestors is an affirmative 'absent' — the fail-closed answer below is the permissions, not the walk"
+  else
+    fail "obj-sweep(ancestor-control): read '$out', wanted 'absent' — a healthy box would be stopped by this"
+  fi
+  chmod 000 "$d/anc" 2>/dev/null || true
+  # CONSTRUCTION ASSERT: as root the permission bits are advisory, so the plant does not
+  # plant. Skipped explicitly rather than passing against a directory this process can
+  # still search (the idiom the latch-unreadable case already uses).
+  if [[ -x "$d/anc" || -r "$d/anc" ]]; then
+    chmod 755 "$d/anc" 2>/dev/null || true
+    skip "obj-sweep(ancestor): this process can still search a 000 directory (root?) — an inaccessible ancestor cannot be planted here"
+    return 0
+  fi
+  out="$(bash -c 'set -euo pipefail; . "$1"; obj_sweep_latch_state "$2"' _ "$fns" "$latch" 2>&1)" || true
+  chmod 755 "$d/anc" 2>/dev/null || true
+  if [[ "$out" == unknown ]]; then
+    pass "obj-sweep(ancestor): a latch beneath an INACCESSIBLE ANCESTOR reads 'unknown', not 'absent' — a stopping verdict may be sitting there unread, and `-d` on the holding directory cannot tell the two apart"
+  else
+    fail "obj-sweep(ancestor): read '$out', wanted 'unknown' — an unstatable ancestor was collapsed onto the permissive answer"
+  fi
+  # AND THE CONSEQUENCE, so this is not only a string comparison: `unknown` is what
+  # obj_sweep_stop_if_latched refuses to carry on from, and `absent` is what it returns 0
+  # for. The behavioural half of that is the latch-unreadable case above; here the two
+  # readings are simply required to differ, which is the whole content of the finding.
+  if [[ "$out" != absent ]]; then
+    pass "obj-sweep(ancestor): the two readings DIFFER, so the fail-closed branch is reachable for this shape at all"
+  else
+    fail "obj-sweep(ancestor): the inaccessible-ancestor shape reads the same as a measured absence"
+  fi
+}
+
+t test_object_store_latch_absence_needs_searchable_ancestors
+
+# A REPRODUCIBLE FATAL SWEEP STOPS THE BOX WITHOUT CLAIMING A CAUSE (#3749 review round
+# 10, item 1).
+#
+# THE DEFECT. `git fsck` DIES (exit 128) on real commit-object corruption in the shared
+# store — measured, and pinned by Case 32 of test_check_object_store_integrity.sh. That
+# status used to be `unclassified` -> UNMEASURED, and UNMEASURED is deliberately
+# permissive: this supervisor writes a fresh throttle stamp and keeps spawning workers. So
+# a demonstrably unreadable store carried on being certified against, reported as "not
+# measured".
+#
+# WHAT IS ASSERTED HERE IS THE SUPERVISOR'S HALF: the new stopping verdict stops this lane,
+# latches the box so peers cannot throttle past it, records WHICH verdict, and says nothing
+# about damage — no re-clone remedy, no corruption claim — because the sweep established no
+# cause. Its journal reason is its own, so an operator can tell the two stops apart.
+test_object_store_unsweepable_stops_the_box_without_claiming_a_cause() {
+  local d root counter calls rc stamp latch
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-unsweepable"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  stamp="$OBJ_SWEEP_STAMP"; latch="$stamp.STOP"
+  root="$(obj_sweep_tree "$d" UNSWEEPABLE 6 "$calls")"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/detect.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 1 && ! -f "$counter" && -s "$calls" && -e "$latch" ]] &&
+     grep -q '^UNSWEEPABLE$' "$latch"; then
+    pass "obj-sweep(unsweepable): a sweep that RAN and reproducibly DIED stops the lane (rc=1), spawns NO worker, and latches the box recording UNSWEEPABLE"
+  else
+    fail "obj-sweep(unsweepable): rc=$rc spawned=$([[ -f "$counter" ]] && echo yes || echo no) swept=$([[ -s "$calls" ]] && echo yes || echo no) latch='$(tr '\n' '/' <"$latch" 2>/dev/null)' (see $d/detect.log)"
+  fi
+  if grep -q '"reason":"object-store-unsweepable"' "$JOURNAL_FILE" &&
+     ! grep -q '"reason":"object-store-corrupt"' "$JOURNAL_FILE"; then
+    pass "obj-sweep(unsweepable): the journal reason is its OWN — an operator can tell 'could not be swept' from 'damage was found', which are different facts and different remedies"
+  else
+    fail "obj-sweep(unsweepable): reason=$(grep -o '"reason":"[a-z-]*"' "$JOURNAL_FILE" | tail -1) (see $d/detect.log)"
+  fi
+  # NO CAUSE IS CLAIMED. The damage remedy was MEASURED for a damage class this run never
+  # established, so printing it here would be round 9's defect: the text a human gets when
+  # the box has stopped must match what was measured.
+  if ! grep -qi 'refetch\|damaged shared store' "$d/detect.log" &&
+     grep -q 'NO cause was established' "$d/detect.log"; then
+    pass "obj-sweep(unsweepable): the stop names NO repair and says so — the store's integrity is UNKNOWN, which is not the same claim as damage"
+  else
+    fail "obj-sweep(unsweepable): the stop claims a cause it did not establish (see $d/detect.log)"
+  fi
+  # THE PEER LANE, one property different from the run above: its own sweep stub would say
+  # VERIFIED. It must still stop on the latch, without re-sweeping, and it must report the
+  # verdict THE FILE records rather than the damage text.
+  calls="$d/calls-peer"
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/peer.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 1 && ! -s "$calls" ]] &&
+     grep -q 'object-store: UNSWEEPABLE (cached' "$d/peer.log" &&
+     ! grep -q 'object-store: CORRUPT (cached' "$d/peer.log" &&
+     grep -q "rm -f $latch" "$d/peer.log"; then
+    pass "obj-sweep(unsweepable): a PEER lane stops on the latch without re-sweeping, reports the verdict the FILE records (not the damage text), and names the latch to clear"
+  else
+    fail "obj-sweep(unsweepable-peer): rc=$rc reswept=$([[ -s "$calls" ]] && echo yes || echo no) (see $d/peer.log)"
+  fi
+  # AND THE DISAGREEMENT ARM, one property from the detecting run: exit 6 with a verdict
+  # line naming the OTHER verdict. Neither channel may act alone, so this is UNMEASURED,
+  # NOT latched, and the worker runs — the same rule round 4 established for CORRUPT.
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-mixed"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  export OBJ_SWEEP_STAMP="$d/sweep.stamp"
+  latch="$OBJ_SWEEP_STAMP.STOP"
+  root="$(obj_sweep_tree "$d" CORRUPT 6 "$calls")"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/mixed.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 0 && -f "$counter" && ! -e "$latch" ]] &&
+     grep -q 'INCONSISTENT sweep result' "$d/mixed.log"; then
+    pass "obj-sweep(unsweepable-disagreement): an exit 6 whose verdict line names a DIFFERENT verdict creates no latch and stops no lane — it is named as inconsistent instead, so an incomplete sweep cannot halt four lanes"
+  else
+    fail "obj-sweep(unsweepable-disagreement): rc=$rc latched=$([[ -e "$latch" ]] && echo yes || echo no) spawned=$([[ -f "$counter" ]] && echo yes || echo no) (see $d/mixed.log)"
+  fi
+}
+
+t test_object_store_unsweepable_stops_the_box_without_claiming_a_cause
 
 # THE STAMP KEY COMES FROM THE ISOLATED RESOLVER, NOT FROM AN AMBIENT `git`
 # (#3749 review round 2, BLOCKER 2).
@@ -10891,7 +11082,7 @@ test_object_store_stamp_key_comes_from_the_resolver() {
   git init -q "$d/injected-store" >/dev/null 2>&1
   other="$d/injected-store/.git"
   root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls" "" "$fake")"
-  # The stamp names both files (`<stamp>` and `<stamp>.CORRUPT`), derived exactly as
+  # The stamp names both files (`<stamp>` and `<stamp>.STOP`), derived exactly as
   # obj_sweep_stamp_path derives them, so the assertions below name a path rather than
   # globbing a shared /tmp that peer lanes are also writing.
   # DERIVED BY CALLING THE SHIPPED FUNCTIONS, never restated here. This case used to
@@ -10918,7 +11109,7 @@ test_object_store_stamp_key_comes_from_the_resolver() {
   else
     fail "obj-sweep(resolver): rc=$rc resolved-key=$([[ -e "$stamp_fake" ]] && echo yes || echo no) injected-key=$([[ -e "$stamp_other" ]] && echo yes || echo no) (see $d/resolver.log)"
   fi
-  rm -f "$stamp_fake" "$stamp_other" "$stamp_fake.CORRUPT" "$stamp_other.CORRUPT"
+  rm -f "$stamp_fake" "$stamp_other" "$stamp_fake.STOP" "$stamp_other.STOP"
 
   # ONE PROPERTY APART: the resolver answers NOTHING (an unresolvable store). The lane
   # must NOT throttle at all — the old fallback collapsed every unresolvable store on a

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -10438,6 +10438,128 @@ test_object_store_corrupt_leaves_both_the_latch_and_the_stamp() {
 
 t test_object_store_corrupt_leaves_both_the_latch_and_the_stamp
 
+# AN UNLATCHABLE CORRUPT VERDICT MUST NOT REFRESH THE THROTTLE STAMP (#3749 review round
+# 9, item 1) — the round-1 harm surviving in the ONE branch that never got round 1's
+# treatment.
+#
+# THE DEFECT. The CORRUPT branch wrote the throttle stamp unconditionally. On the path
+# where the latch could NOT be persisted but the stamp COULD — a writable stamp inside a
+# directory that is not writable, so creating `<stamp>.CORRUPT` fails while rewriting
+# `<stamp>` succeeds — the detecting lane stopped (correct) and advertised a freshly swept
+# box to its peers (not correct). Those peers then read a fresh stamp, skipped their own
+# sweep for the whole interval, and kept spawning workers over a store already confirmed
+# damaged. Round 2's note that an unpersistable latch is "journalled and this lane still
+# stops" is true and says nothing about the peers, which is the half that matters.
+#
+# THE FIXTURE IS THE SCENARIO, not a stub of it: a real directory whose write bit is off
+# with a real stamp file inside it, and the two construction asserts prove BOTH halves of
+# the premise (the latch create really fails, the stamp rewrite really succeeds) before
+# anything is asserted about the supervisor. Permission bits are advisory for root, so the
+# case skips there rather than passing vacuously.
+test_object_store_unlatchable_corrupt_does_not_refresh_the_throttle() {
+  local d root counter calls rc box stamp latch
+  if [[ "$(id -u)" -eq 0 ]]; then
+    skip "obj-sweep(unlatchable): needs a directory this process cannot write to; permission bits are advisory for root"
+    return
+  fi
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-unlatchable"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  box="$d/box"; mkdir -p "$box"
+  export OBJ_SWEEP_STAMP="$box/sweep.stamp"
+  stamp="$OBJ_SWEEP_STAMP"; latch="$stamp.CORRUPT"
+  # An EXPIRED stamp, so this lane sweeps; then close the directory for writing.
+  printf '1\n' >"$stamp"
+  chmod 0500 "$box"
+  # CONSTRUCTION (a): the latch really cannot be created here.
+  if ! (printf 'x\n' >"$latch") 2>/dev/null && [[ ! -e "$latch" ]]; then
+    pass "obj-sweep(unlatchable-plant): the latch path really cannot be created in this directory"
+  else
+    chmod 0700 "$box"
+    fail "obj-sweep(unlatchable-plant): a latch WAS creatable at $latch — the case would be about nothing"
+    return
+  fi
+  # CONSTRUCTION (b): the stamp really can still be rewritten — this is what made the
+  # defect reachable, and without it the assert below would pass for the wrong reason.
+  if (printf '1\n' >"$stamp") 2>/dev/null && [[ "$(cat "$stamp")" == 1 ]]; then
+    pass "obj-sweep(unlatchable-plant): the stamp inside it really IS still writable — the defect's precondition holds"
+  else
+    chmod 0700 "$box"
+    fail "obj-sweep(unlatchable-plant): the stamp was not writable either — the case would not reach the branch"
+    return
+  fi
+  root="$(obj_sweep_tree "$d" CORRUPT 4 "$calls")"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/unlatchable.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 1 && ! -f "$counter" && ! -e "$latch" ]] &&
+    grep -q 'could NOT be latched' "$d/unlatchable.log"; then
+    pass "obj-sweep(unlatchable-plant): the run detected CORRUPT, stopped, and really did fail to latch — the state the assert below is about"
+  else
+    chmod 0700 "$box"
+    fail "obj-sweep(unlatchable-plant): rc=$rc latch=$([[ -e "$latch" ]] && echo yes || echo no) spawned=$([[ -f "$counter" ]] && echo yes || echo no) (see $d/unlatchable.log)"
+    return
+  fi
+  # THE PROPERTY: the stamp does NOT read as freshly swept. It is forced to `0`, which
+  # obj_sweep_stamp_is_fresh reads as expired for any plausible clock.
+  if [[ "$(sed -n 1p "$stamp" 2>/dev/null)" == 0 ]] &&
+    grep -q 'FORCED STALE' "$d/unlatchable.log"; then
+    pass "obj-sweep(unlatchable): an unlatchable CORRUPT verdict FORCES the throttle stamp stale instead of advertising a freshly swept box"
+  else
+    fail "obj-sweep(unlatchable): stamp='$(tr '\n' '/' <"$stamp" 2>/dev/null)' — a peer reading it can throttle past a confirmed-corrupt store (see $d/unlatchable.log)"
+  fi
+  # AND THE CONSEQUENCE, MEASURED ON A PEER: same box, same stamp, INSIDE the interval.
+  # It must re-sweep (the stub records its invocations) and stop on its own finding.
+  calls="$d/calls-unlatchable-peer"
+  root="$(obj_sweep_tree "$d" CORRUPT 4 "$calls")"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/unlatchable-peer.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 1 && -s "$calls" && ! -f "$counter" ]]; then
+    pass "obj-sweep(unlatchable): a PEER lane inside the interval RE-SWEEPS, reproduces the damage and stops — it does not inherit six hours of silence from the stamp"
+  else
+    fail "obj-sweep(unlatchable-peer): rc=$rc reswept=$([[ -s "$calls" ]] && echo yes || echo no) spawned=$([[ -f "$counter" ]] && echo yes || echo no) (see $d/unlatchable-peer.log)"
+  fi
+  chmod 0700 "$box"
+  # THE CONTROL, ONE PROPERTY APART: the same fixture with the directory WRITABLE. The
+  # latch is created, the stamp carries a real epoch (NOT 0), and a peer then stops
+  # WITHOUT re-sweeping. So the forced-stale stamp above is attributable to the failed
+  # latch and not to the CORRUPT verdict alone.
+  d="$(new_case_dir)"; counter="$d/counter"; calls="$d/calls-unlatchable-control"
+  common_env "$d"
+  write_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  export OBJ_SWEEP_INTERVAL_HOURS=6
+  box="$d/box"; mkdir -p "$box"
+  export OBJ_SWEEP_STAMP="$box/sweep.stamp"
+  stamp="$OBJ_SWEEP_STAMP"; latch="$stamp.CORRUPT"
+  printf '1\n' >"$stamp"
+  root="$(obj_sweep_tree "$d" CORRUPT 4 "$calls")"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/control-latchable.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 1 && -e "$latch" ]] &&
+    [[ "$(sed -n 1p "$stamp" 2>/dev/null)" =~ ^[0-9]+$ ]] &&
+    [[ "$(sed -n 1p "$stamp" 2>/dev/null)" -gt 1 ]] &&
+    ! grep -q 'FORCED STALE' "$d/control-latchable.log"; then
+    pass "obj-sweep(unlatchable-control): with the latch WRITABLE the same CORRUPT run advances the stamp normally and forces nothing — the stale-forcing is the missing latch, not the verdict"
+  else
+    fail "obj-sweep(unlatchable-control): latch=$([[ -e "$latch" ]] && echo yes || echo no) stamp='$(tr '\n' '/' <"$stamp" 2>/dev/null)' (see $d/control-latchable.log)"
+  fi
+  calls="$d/calls-unlatchable-control-peer"
+  root="$(obj_sweep_tree "$d" VERIFIED 0 "$calls")"
+  env LANE_ID=objsweep-test bash "$root/scripts/local/worker-supervisor.sh" >"$d/control-peer.log" 2>&1
+  rc=$?
+  if [[ "$rc" -eq 1 && ! -s "$calls" ]]; then
+    pass "obj-sweep(unlatchable-control): and its peer stops on the LATCH without re-sweeping — the two arms differ in one property, the write bit on one directory"
+  else
+    fail "obj-sweep(unlatchable-control-peer): rc=$rc reswept=$([[ -s "$calls" ]] && echo yes || echo no) (see $d/control-peer.log)"
+  fi
+}
+
+t test_object_store_unlatchable_corrupt_does_not_refresh_the_throttle
+
 # THE STOP FILE AND THE WALL-CLOCK BUDGET ARE READ BEFORE THE SWEEP, NOT AFTER IT
 # (#3749 review round 3, item 3).
 #

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -11372,8 +11372,13 @@ test_object_store_sweep_claim_release_requires_ownership() {
   #     because a double release (sweep path then EXIT trap) is ordinary.
   rm -rf "$claim"
   out="$(bash -c 'set -uo pipefail; log() { printf "LOG %s\n" "$1"; }; OBJ_SWEEP_CLAIM_OWNED="$2"; OBJ_SWEEP_CLAIM_TOKEN="$3"; . "$1"; printf "state=%s\n" "$(obj_sweep_claim_owner_state "$2")"; obj_sweep_claim_release "$2"' _ "$fns" "$claim" "$tok_a" 2>&1)"
-  if printf '%s' "$out" | grep -q 'state=gone' && ! printf '%s' "$out" | grep -q 'LOG '; then
-    pass "obj-sweep(claim-gone): an already-released claim reads 'gone' and is reported as nothing — a double release is the ordinary case (the sweep path and then the EXIT trap), not a fault to page about"
+  # THE WHOLE OUTPUT IS COMPARED, not just the absence of a LOG line: with the input
+  # redirection ordered before `2>/dev/null` the shell itself printed `No such file or
+  # directory` on the real stderr for exactly this (ordinary) shape — an UNANCHORED
+  # diagnostic in the supervisor's journal, round 1's NIT 4 one file over, which a
+  # `grep -q 'LOG '` test could not see. A RED arm for this item is what surfaced it.
+  if [[ "$out" == "state=gone" ]]; then
+    pass "obj-sweep(claim-gone): an already-released claim reads 'gone' and produces NO output at all — neither a journal line nor an unanchored shell error; a double release is the ordinary case (the sweep path and then the EXIT trap), not a fault to page about"
   else
     fail "obj-sweep(claim-gone): [$(printf '%s' "$out" | tr '\n' '|')]"
   fi

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -682,6 +682,21 @@ paged once and deliberately does **not** stop the loop, because refusing to run 
 hygiene probe that could not run is a self-DoS. **That sweep is periodic, not per-read, which is why
 the emitted clause still says `TRUSTED, not verified`.**
 
+**The fatal verdict is affirmative, and it had to be made so.** A `git fsck` over a store up to
+eight peer lanes are concurrently writing prints `error:` lines on a **healthy** store (measured on
+this fleet: `invalid reflog entry` naming a different branch each run, on a quarter to a half of all
+runs), so recognising damage from the *text shape* of a diagnostic made a healthy box page high, stop
+its supervisor and fail `--strict` bootstrap. The class comes from fsck's exit **bitmask** — bits
+`1 ERROR_OBJECT`/`4 ERROR_PACK` are the subject; `2 ERROR_REACHABLE`/`8 ERROR_REFS`/
+`16 ERROR_COMMIT_GRAPH` are *not* demoted to clean (a genuinely missing object reports bit 2) but get
+their own non-passing `UNMEASURED` cause; a status outside `1..31` is not a bitmask at all. And no
+non-clean walk is fatal on one observation: it is re-run **once** as a discriminator — a concurrency
+artefact does not survive a second independent walk, damage does — never a retry-until-clean loop.
+The `CORRUPT` verdict is **persisted** in the box-wide throttle stamp, because a timestamp-only stamp
+let the detecting lane stop while its peers skipped their own sweep for the interval and kept
+spawning workers over the damaged store; the latch does not expire and is cleared by hand
+(`rm -f <stamp>`, named in the remedy).
+
 Three alternatives were **rejected** by the same ruling, recorded so they are not re-derived:
 per-lane full clones (a permanent multi-GB tax for an out-of-model threat); per-read rehashing (the
 fourth carve into one pre-flight, charged to every `--lite` round); and removing the reuse

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -654,22 +654,45 @@ baseline source (`— baseline read via the committed manifest` / `— baseline 
 FALLBACK: … VERIFIED ABSENT at that sha`), so use of the fallback is visible rather than inferred.
 
 **And it ends by naming the OBJECT provenance too, because the shared object store is TRUSTED, not
-verified** (`; objects: baseline REUSED from this lane's SHARED store` / `baseline FETCHED from the
-canonical remote, HEAD's own from this lane's SHARED store` / `provenance NOT RECORDED` — each
-followed by `store TRUSTED, not verified (#3746)`). Git does not rehash a packed object against the
-id it was asked for on an ordinary read, and on this fleet **every lane on a box is a worktree of
-one shared `.git`**, so a peer lane planting a forged pack/index can make a canonical sha resolve to
-a shortened manifest — a false `PASS`, and a non-invoker route, hence a defect.
+verified per-read** (`; objects: baseline REUSED from this lane's SHARED store` / `baseline FETCHED
+from the canonical remote, HEAD's own from this lane's SHARED store` / `provenance NOT RECORDED` —
+each followed by `store TRUSTED, not verified (#3749)`). Git does not rehash a packed object against
+the id it was asked for on an ordinary read, and on this fleet **every lane on a box is a worktree of
+one shared `.git`**, so a planted pack/index can make a canonical sha resolve to a shortened
+manifest — a false `PASS`. What an ordinary read *does* verify is the pack CRC and the zlib stream,
+which catch **accidental** damage (bit rot, a torn or truncated write) but never rehash content
+against its own name.
 
-It is **declared rather than closed** because removal does not close it. The ancestry walk and the
-provenance leg read HEAD's **committed** content, which has no source other than that store — the
-working tree cannot substitute, since the `UNCOMMITTED` verdict exists precisely to compare against
-what is committed — so a forged HEAD object still turns `UNCOMMITTED` (fatal) into `DECLARED`
-(non-fatal) after removal, while charging every `--lite` round for a half-closure (measured
-3.41 s / 93 MB full, 3.58 s / 45 MB at `--depth=1`; shallow is *not* cheaper — it still ships the
-tip's whole tree). A check that claims nothing false is worth more than one claiming a closure it
-does not deliver. Closing it properly — including the possibility that the real subject is the
-infrastructure decision that lanes share an object store at all — is **#3746**.
+**#3749's owner ruling split that into two subjects, and overturned the earlier framing.** This page
+used to call a peer lane planting objects "a non-invoker route, hence a defect"; that is
+**retracted**. *Deliberate* forgery by a same-host peer is **invoker-class and out of model** — the
+#3312 triage rule already says same-host actors able to write these scripts are invoker-class, and a
+peer wanting a false `PASS` can simply edit `scripts/agent-gate.sh`, which is cheaper than forging
+pack data; no check inside a process defends against the party that controls the process.
+*Accidental* corruption **is** in model, and its control is a periodic full-rehash sweep:
+`scripts/check-object-store-integrity.sh` runs a full `git fsck` (never `--connectivity-only`, which
+does not rehash content) over the shared store and emits an anchored three-valued
+`VERIFIED`/`CORRUPT`/`UNMEASURED` verdict — exit 0/4/5, and **a consumer must not read `UNMEASURED`
+as clean**. It runs at machine onboarding (`bootstrap-agent-machine.sh` section 5b-obj, where
+`VERIFIED` is the only `[ok]`, so an unmeasured host cannot pass `--strict`) and on the worker
+supervisor's throttled per-iteration cadence (default every 6h). There, `CORRUPT` **stops the
+supervisor loudly** instead of holding — corruption is non-self-clearing, so a hold-and-repoll loop
+would spin to the wall-clock budget taking no useful action — while `UNMEASURED` is journalled and
+paged once and deliberately does **not** stop the loop, because refusing to run any worker over a
+hygiene probe that could not run is a self-DoS. **That sweep is periodic, not per-read, which is why
+the emitted clause still says `TRUSTED, not verified`.**
+
+Three alternatives were **rejected** by the same ruling, recorded so they are not re-derived:
+per-lane full clones (a permanent multi-GB tax for an out-of-model threat); per-read rehashing (the
+fourth carve into one pre-flight, charged to every `--lite` round); and removing the reuse
+optimisation — whose original argument still stands, because removal does not close it. The ancestry
+walk and the provenance leg read HEAD's **committed** content, which has no source other than that
+store — the working tree cannot substitute, since the `UNCOMMITTED` verdict exists precisely to
+compare against what is committed — so a forged HEAD object still turns `UNCOMMITTED` (fatal) into
+`DECLARED` (non-fatal) after removal, while charging every `--lite` round for a half-closure
+(measured 3.41 s / 93 MB full, 3.58 s / 45 MB at `--depth=1`; shallow is *not* cheaper — it still
+ships the tip's whole tree). A check that claims nothing false is worth more than one claiming a
+closure it does not deliver.
 
 **The baseline's identity is validated before the fetch.** Trusting a remote merely *named*
 `origin` made `git remote set-url origin <anything>` a git-config-shaped opt-out — and it fires

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -825,6 +825,33 @@ said `VERIFIED` returned toward a spawn without re-reading the latch, so a peer 
 *during* that lane's two fsck walks was never seen. Both are ordering fixes, neither needs a lock:
 latch first, stamp second, and one `obj_sweep_stop_if_latched` helper before the throttled,
 `VERIFIED` and `UNMEASURED` returns alike — one rule instead of a set of paths to audit.
+**And ordering was not enough: the stamp is written only if the latch is CONFIRMED present, else it
+is forced stale (round 9, item 1).** "Latch first, stamp second" left the stamp unconditional, so on
+the one branch where the latch could not be *persisted* — a writable stamp inside a directory that is
+not writable, so creating `<stamp>.CORRUPT` fails while rewriting `<stamp>` succeeds — the detecting
+lane stopped (correct) and still advertised a freshly swept box (not correct): its peers read the
+fresh stamp, skipped their own sweep for the whole interval, and kept working against a store already
+confirmed damaged. The stamp write is now gated on `obj_sweep_latch_present`, the afterwards-existence
+check and never the create's exit status (which cannot tell "a peer got there first" from "the
+directory is unwritable"); where the latch is missing the stamp is forced to epoch `0`, because a peer
+whose sweep started earlier can finish *during* this one and write a fresh timestamp. Forcing can only
+cause MORE sweeping, so it cannot manufacture a false clean.
+
+**And the printed remedy has to work, which it did not (round 9, item 2).** All three copies of the
+repair instruction said `git fetch --force origin`, which repairs nothing: `--force` only permits
+non-fast-forward *ref* updates and re-downloads no objects, so with the advertised tips unchanged the
+negotiation can transfer nothing — an operator following it exactly kept the corruption and gained the
+impression of a repair. Measured on git 2.43.0 against planted damage, by the sweep's own verdict:
+`--force` leaves a corrupt loose object, a flipped pack byte and a missing object untouched;
+`git fetch --refetch origin` (git 2.36+) restores a MISSING object but not damaged content, whose bytes
+stay in the object directory where fsck still finds them — so content damage needs the pack or loose
+object deleted first, after which `--refetch` verifies clean. A fresh clone works, but only **from the
+canonical remote over the network**: `git clone <local path>` hardlinks the object files, so a clone of
+the damaged repository is damaged too. Hence the sweep owns the text (it knows the damage class, and
+the measurements live beside it) and both consumers QUOTE its `verdict-detail` lines instead of
+paraphrasing, with a fail-closed fallback so a stopped box is never left with no remedy — and clearing
+the latch is gated on a re-run of the sweep reporting its affirmative verdict.
+
 **That rule was still a set of SITES, and round 5 found the fourth — so the read is now at ENTRY,
 above every branch.** The documented opt-out `OBJ_SWEEP_INTERVAL_HOURS=0` returned before any latch
 read, so switching the sweep off also switched off an already-recorded `CORRUPT` verdict. Patching

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -707,7 +707,31 @@ the verdict stronger. Passes 1 and 2 never carry the flag (asserted structurally
 call sites), an attribution walk that is killed, unlaunchable or unclassifiable leaves the complaint
 `UNATTRIBUTED` and non-passing, and a damage bit appearing only in the third walk has not reproduced
 across the sweep walks. The verdict set stays closed at three: the split is in the *cause* text, not
-in a fourth token two readers and a structural assert would have to learn. **The mask does not end at
+in a fourth token two readers and a structural assert would have to learn. **And "the roots the walk
+has" was itself an unchecked assumption, wrong in both directions.** A review finding held that
+`--git-dir=<common>` discards linked worktrees' private administrative context, so a missing object
+needed only by a lane's private HEAD or index would be overlooked. Measured on git 2.43.0, that is
+**false**: a common-dir fsck *does* walk every registered worktree's private `HEAD`, its private
+index, and the HEAD of a *prunable* worktree — all three surviving `--no-reflogs`, hence already
+`CORRUPT`. What it does *not* walk is a **linked** worktree's per-worktree refs (`refs/worktree/*`,
+`refs/bisect/*`, `refs/rewritten/*`; the main worktree's live in the common dir and are walked):
+delete an object named only by one and the sweep exits **0 VERIFIED**, because the HEAD reflog echoes
+the id and that echo clears under `--no-reflogs`. Both halves are now measured rather than believed —
+the covered roots are pinned by fixtures, and the gap is closed by a **private-root probe**: not an
+fsck (`git fsck <sha>` *replaces* the default heads, an explicit-head fsck still costs a full rehash,
+and `rev-list <missing-root>` dies 128) but an O(refs) question — list each linked worktree's refs,
+subtract the common ones, ask `cat-file --batch-check` whether the remainder's targets are present
+(0.22 s against the live 15-worktree store). Its enumeration is **filesystem-first because the git
+command is fail-open**: `git worktree list --porcelain` silently drops a worktree whose admin
+`gitdir` file is missing, so `$GIT_COMMON_DIR/worktrees/*` — git's own administrative directory, not
+a guess about lane layout — is the subject set, with the command kept as a cross-check in the
+direction it can fail. A worktree that cannot be inspected is *not* a clean one (a named
+`UNREADABLE` record, never a silent zero-root contribution to `VERIFIED`). And it widens no caller's
+window, **by placement rather than arithmetic**: one bounded child stage immediately before the
+single affirmative branch, and every branch of the reachability block exits, so a run that spent a
+third fsck walk never reaches it — asserted behaviourally against the fixture that really spends
+three walks. Declared residual: it asks whether each private ref's *target* is present, not whether
+its whole closure is. **The mask does not end at
 31, and assuming it did dropped real damage.** A range check over `1..31` — reasoned from 128 being
 `die()` and `127 & 1` being 1 — classified 33 (`32|1`) and 36 (`32|4`) as unclassified and therefore
 `UNMEASURED`, a false negative on genuine object corruption. Measured on git 2.43.0: a truncated

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -929,9 +929,26 @@ merely a CPU cost: the walks are I/O-bound, so contention pushes them toward the
 an expired bound is `UNMEASURED`, a correlated loss of the measurement on every lane at once. The
 serialiser is a per-store claim **directory** created with `mkdir` (the latch's kernel-arbitrated
 create-only primitive, and deliberately not `flock`, since this file's single-instance lock is
-mkdir-based precisely because macOS ships no `flock(1)`). A loser does not wait — it skips that
-iteration's probe and carries on after the usual latch read — and the throttle is **re-read after
-acquiring**, which is what stops the claim converting a herd into a queue of redundant sweeps. A
+mkdir-based precisely because macOS ships no `flock(1)`). **A loser *does* wait, which reverses the
+original design.** It used to skip that iteration's probe and carry straight on to the spawn path
+after one latch read, on the argument that "a peer is doing it right now" is a complete answer for a
+6-hourly hygiene sweep — a complete answer about the SWEEP and no answer at all about the SPAWN,
+because the loser knows a full-store fsck is in flight (that is why its claim failed) and that fsck
+can end in `CORRUPT` or `UNSWEEPABLE`, latching the box. The window it discarded was the peer's
+**entire sweep**: 13-80s measured on this fleet, up to `MAX_SWEEP_WALKS` × `OBJ_SWEEP_TIMEOUT_SECS`
+(600s at the shipped defaults) by construction — not the narrow post-read spawn gap the residual
+note described. The loser now waits, re-reading the latch, the stamp, the claim and the stop file
+every `OBJ_SWEEP_CLAIM_POLL_SECS` (granularity, not a bound), **bounded by the claim's own derived
+staleness value**: the same 660s that says "this claim may be taken over" says "stop waiting for
+it", so a dead peer cannot wedge the wait and there is no second, driftable constant. A timeout is
+not a clean result and does not carry on — when the peer neither finishes nor vacates, that claim is
+stale by construction at the deadline, so the next acquire recovers it and **the loser becomes the
+sweeper**; only where peers keep handing the claim around for the whole budget does the lane skip,
+journalled and paged as `NOT SWEPT AND NOT MEASURED`, never as clean, and never as a stop (a peer
+sweeping is also the shape of a healthy box recovering a wedged claim, and stopping four lanes over a
+hygiene probe's contention is the self-DoS that file refuses everywhere else). The throttle is
+**re-read after acquiring**, which is what stops the claim converting a herd into a queue of
+redundant sweeps. A
 stale claim must not wedge the box, which would be worse than the herd, so the recovery threshold is
 **derived**: a claim cannot be stale while the sweep it represents could still be running, so it is
 the sweep's own `MAX_SWEEP_WALKS` (read from that script) × this supervisor's per-walk bound + slack
@@ -941,12 +958,22 @@ and where the bound cannot be derived **no claim is taken at all** and the previ
 restored, announced. The claim is a registered resource released by the EXIT trap, so the `CORRUPT`
 path — which ends the process — does not leave peers waiting out the bound. Not closed, and
 pre-existing: this file installs no INT/TERM handlers, so a signalled supervisor releases neither
-its claim nor its lock; for the claim that is a delay, not a wedge. **What is
-not closed:** the latch read and the worker spawn are still unsynchronised, and the preflight hold
-loop can poll for minutes between them, so one worker can still start on a box latched moments
-earlier. It is bounded (that lane's next iteration reads the latch at the top of its sweep and
-stops) and the atomic guarantee needs per-store synchronisation shared by the sweep and the spawn
-decision, which is split to its own issue. The sweep is also **not interruptible** — its two walks
+its claim nor its lock; for the claim that is a delay, not a wedge. **What is not closed, per path
+and with its real magnitude** — the earlier version of this text gave one figure for every path
+("one worker can still start on a box latched *moments* earlier") and it was wrong twice. **Path 1,
+the claim loser: closed** — it was the peer's whole sweep (13-80s measured, 600s by construction),
+now bounded by one `OBJ_SWEEP_CLAIM_POLL_SECS`. **Path 2, a lane's own sweep: covered** by the entry
+read plus the post-sweep reads. **Path 3, the last latch read to the worker spawn: open, and the
+largest of the three** — `object_store_sweep` returns and the caller then runs the preflight hold
+loop, which does *not* re-read the latch: milliseconds on a clear box, but every hold sleeps
+`HOLD_POLL_SECS` and the loop tolerates up to `BUILD_HOLD_MAX` of them, so at the shipped defaults
+the gap is up to 12 × 300s = **3600s, one hour** (the leftover-worker family bounds at
+`LEFTOVER_HOLD_MAX` × `HOLD_POLL_SECS` = 900s), and "minutes" understated it by 12x. It is bounded
+in harm (that lane's next iteration reads the latch at the top of its sweep and stops, and nothing
+certifies a merge in that window without a full gate, which a latched box refuses), and the atomic
+guarantee needs per-store synchronisation shared by the sweep and the spawn decision, which is split
+to its own issue — as is the cheapest partial, a latch read inside the hold loop that would cut
+3600s to one `HOLD_POLL_SECS`. Path 1 is closed; path 3 is open; the race is not gone. The sweep is also **not interruptible** — its two walks
 run in a child process — so the supervisor checks the stop file and the wall-clock budget
 immediately *before* the sweep, and bounds the exposure in wall time: its per-walk default is the
 sweep script's own bound **divided by `MAX_SWEEP_WALKS`** (200 vs 600/3), so every walk it can pay

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -688,14 +688,36 @@ this fleet: `invalid reflog entry` naming a different branch each run, on a quar
 runs), so recognising damage from the *text shape* of a diagnostic made a healthy box page high, stop
 its supervisor and fail `--strict` bootstrap. The class comes from fsck's exit **bitmask** — bits
 `1 ERROR_OBJECT`/`4 ERROR_PACK` are the subject; `2 ERROR_REACHABLE`/`8 ERROR_REFS`/
-`16 ERROR_COMMIT_GRAPH` are *not* demoted to clean (a genuinely missing object reports bit 2) but get
-their own non-passing `UNMEASURED` cause; a status outside `1..31` is not a bitmask at all. And no
-non-clean walk is fatal on one observation: it is re-run **once** as a discriminator — a concurrency
-artefact does not survive a second independent walk, damage does — never a retry-until-clean loop.
-The `CORRUPT` verdict is **persisted** in the box-wide throttle stamp, because a timestamp-only stamp
-let the detecting lane stop while its peers skipped their own sweep for the interval and kept
-spawning workers over the damaged store; the latch does not expire and is cleared by hand
-(`rm -f <stamp>`, named in the remedy).
+`16 ERROR_COMMIT_GRAPH`/`32 ERROR_MULTI_PACK_INDEX` are *not* demoted to clean (a genuinely missing
+object reports bit 2) but get their own non-passing `UNMEASURED` cause. **The mask does not end at
+31, and assuming it did dropped real damage.** A range check over `1..31` — reasoned from 128 being
+`die()` and `127 & 1` being 1 — classified 33 (`32|1`) and 36 (`32|4`) as unclassified and therefore
+`UNMEASURED`, a false negative on genuine object corruption. Measured on git 2.43.0: a truncated
+`multi-pack-index` exits 32, and that store with one corrupted blob exits 35. So the damage bits are
+tested **independently, and first**, and an unrelated bit can never mask them; only a status at or
+above 124 (timeout/shell conventions, `die()` and signal deaths above them) is refused bit-testing
+outright, and a status carrying a bit outside the supported mask is unclassified rather than folded
+into a class whose remedy would be wrong — which is how it degrades safely as git adds bits.
+
+And no non-clean walk is fatal on one observation: it is re-run **once** as a discriminator — a
+concurrency artefact does not survive a second independent walk, damage does — never a
+retry-until-clean loop. The `CORRUPT` verdict is **persisted for the box in its own create-only
+file** (`<stamp>.CORRUPT`), because a timestamp-only stamp let the detecting lane stop while its
+peers skipped their own sweep for the interval and kept spawning workers over the damaged store.
+Putting the verdict *in* that stamp was the first fix and was itself a defect: stamp writes are
+unsynchronised overwrites, so a lane whose sweep started before the detection could finish after it
+and replace `CORRUPT` with `VERIFIED`. Two consecutive review rounds found a defect in that one
+shared mutable cell, so the channel is **removed rather than serialised** — the latch's only
+transition is ABSENT → PRESENT, created under `set -C` so the kernel arbitrates and a losing writer
+cannot overwrite the winner, while the timestamp stays freely overwritable because moving a
+timestamp backwards costs one extra sweep. A lock was considered and rejected: it makes the
+read-modify-write atomic but leaves a value any writer can move backwards, so "CORRUPT is sticky"
+would rest on every future writer remembering to honour it. The latch does not expire and is cleared
+by hand (`rm -f <latch>`, named in every message that mentions it); a create that could not happen
+is reported, never read as a latched box. The stamp's **key** is resolved by the sweep script itself
+(`--print-store`), never by a `git` call in the supervisor — a bare `git rev-parse
+--git-common-dir` inherits the caller's environment, so an inherited `GIT_DIR` keyed the stamp on
+another repository.
 
 Three alternatives were **rejected** by the same ruling, recorded so they are not re-derived:
 per-lane full clones (a permanent multi-GB tax for an out-of-model threat); per-read rehashing (the

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -959,21 +959,27 @@ restored, announced. The claim is a registered resource released by the EXIT tra
 path — which ends the process — does not leave peers waiting out the bound. Not closed, and
 pre-existing: this file installs no INT/TERM handlers, so a signalled supervisor releases neither
 its claim nor its lock; for the claim that is a delay, not a wedge. **What is not closed, per path
-and with its real magnitude** — the earlier version of this text gave one figure for every path
-("one worker can still start on a box latched *moments* earlier") and it was wrong twice. **Path 1,
+and with its real magnitude** — a residual whose size is understated is worse than one described
+honestly, and a residual left standing when it could be closed is the other half of that. **Path 1,
 the claim loser: closed** — it was the peer's whole sweep (13-80s measured, 600s by construction),
 now bounded by one `OBJ_SWEEP_CLAIM_POLL_SECS`. **Path 2, a lane's own sweep: covered** by the entry
-read plus the post-sweep reads. **Path 3, the last latch read to the worker spawn: open, and the
-largest of the three** — `object_store_sweep` returns and the caller then runs the preflight hold
-loop, which does *not* re-read the latch: milliseconds on a clear box, but every hold sleeps
-`HOLD_POLL_SECS` and the loop tolerates up to `BUILD_HOLD_MAX` of them, so at the shipped defaults
-the gap is up to 12 × 300s = **3600s, one hour** (the leftover-worker family bounds at
-`LEFTOVER_HOLD_MAX` × `HOLD_POLL_SECS` = 900s), and "minutes" understated it by 12x. It is bounded
-in harm (that lane's next iteration reads the latch at the top of its sweep and stops, and nothing
-certifies a merge in that window without a full gate, which a latched box refuses), and the atomic
-guarantee needs per-store synchronisation shared by the sweep and the spawn decision, which is split
-to its own issue — as is the cheapest partial, a latch read inside the hold loop that would cut
-3600s to one `HOLD_POLL_SECS`. Path 1 is closed; path 3 is open; the race is not gone. The sweep is also **not interruptible** — its two walks
+read plus the post-sweep reads. **Path 3, the last latch read to the worker spawn: narrowed from up
+to an hour to one pre-spawn prologue, and it is not zero.** The hold loop used to run after the last
+latch read and never re-read it, so at the shipped defaults a lane could sit for `BUILD_HOLD_MAX` ×
+`HOLD_POLL_SECS` = 12 × 300s = **3600s** (leftover-worker family: `LEFTOVER_HOLD_MAX` ×
+`HOLD_POLL_SECS` = 900s) and then spawn onto a box a peer had latched meanwhile. `preflight_wait` is
+now a **wrapper**: the loop lives in `preflight_wait_holds` and the STOP latch is re-read on *every*
+return out of it, so the hold window is closed structurally — a property of the function boundary,
+not an enumerated set of returns (round 3 fixed three such returns and round 5 found a fourth; that
+shape does not converge). What remains is `run_iteration`'s pre-spawn prologue: `stamp_claim`, i.e.
+one `claim-heartbeat.sh stamp` ref push to `origin`, around an `rm`/`mkdir`/assignments — a measured
+lower bound of **0.26-0.28s** for a bare `git ls-remote origin HEAD` on this fleet, unbounded in
+principle since the supervisor puts no timeout on that push, and **not** the "milliseconds" a purely
+local prologue would give. It is bounded in harm (that lane's next iteration reads the latch at the
+top of its sweep and stops, and nothing certifies a merge in that window without a full gate, which
+a latched box refuses), and closing it entirely still needs per-store synchronisation shared by the
+sweep and the spawn decision, which is split to its own issue. Path 1 and the hold window are
+closed; the pre-spawn window is open; the race is not gone. The sweep is also **not interruptible** — its two walks
 run in a child process — so the supervisor checks the stop file and the wall-clock budget
 immediately *before* the sweep, and bounds the exposure in wall time: its per-walk default is the
 sweep script's own bound **divided by `MAX_SWEEP_WALKS`** (200 vs 600/3), so every walk it can pay

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -763,7 +763,17 @@ another repository — and it is a **digest** of that canonical path, because fl
 injective: replacing `/` and every unsupported character with `_` maps `/tmp/a/b/objects` and
 `/tmp/a_b/objects` to one name, so two repositories on a box shared a throttle stamp *and* a
 `CORRUPT` latch. The form is `<sanitised tail>.<16 hex of sha256>`, where the tail is readability
-only and carries no identity; three digest tools (`sha256sum`, `shasum -a 256`,
+only and carries no identity. **The digest is taken from the RAW path, in the resolver — digesting
+the RENDERED value was itself the next defect (round 5).** Round 4 made the key injective over the
+flattening and then fed the digest the value `--print-store` had already passed through the sweep
+script's `sane()` escaper, which is a *display* encoding and a lossy one: a path holding a real
+newline and one holding the two literal characters `\n` produced ONE key, which is the same
+shared-stamp-and-latch harm arriving through the fix for it. So `store_key` lives in the sweep
+script — the only process holding the raw bytes — and publishes a second anchored `store-key` line
+that the caller validates and uses verbatim, while the supervisor's own digest helper is gone, so no
+lossy value is left for a future caller to digest. The transferable rule: **a value sanitised for
+DISPLAY is not an IDENTITY; derive a comparison key before any rendering, and where both are needed
+publish two fields rather than deriving one from the other.** Three digest tools (`sha256sum`, `shasum -a 256`,
 `openssl dgst -sha256`) cover both platforms, the output is parsed from both ends and then validated
 as hex, and a host with none fails closed to the **empty** key — no throttle, no latch, announced
 once naming both causes — never a silent fall back to the colliding form. `cksum` is present
@@ -777,7 +787,42 @@ non-corrupt stamp and throttled past a corruption about to be recorded; and a la
 said `VERIFIED` returned toward a spawn without re-reading the latch, so a peer latching the box
 *during* that lane's two fsck walks was never seen. Both are ordering fixes, neither needs a lock:
 latch first, stamp second, and one `obj_sweep_stop_if_latched` helper before the throttled,
-`VERIFIED` and `UNMEASURED` returns alike — one rule instead of a set of paths to audit. **What is
+`VERIFIED` and `UNMEASURED` returns alike — one rule instead of a set of paths to audit.
+**That rule was still a set of SITES, and round 5 found the fourth — so the read is now at ENTRY,
+above every branch.** The documented opt-out `OBJ_SWEEP_INTERVAL_HOURS=0` returned before any latch
+read, so switching the sweep off also switched off an already-recorded `CORRUPT` verdict. Patching
+the fourth site would have left a fifth, because the design required every early return to remember
+the check; the read is therefore hoisted to the top of `object_store_sweep`, whose prologue is now
+declarations and assignments only, and the invariant is a property of the FUNCTION ("it cannot be
+entered without a latch read") that holds for branches nobody has written yet — asserted
+structurally. The post-sweep reads stay: a peer can latch the box while this lane spends up to
+`MAX_SWEEP_WALKS` walks. Cost: one `--print-store` resolution per iteration (measured 5 ms) on a
+path that previously paid none. The latch question is also **four-valued**, because `[[ -e ]]` is
+false both for an absent latch and for one the process cannot look at: `unknown` STOPS under its own
+reason (`object-store-latch-unreadable`, never as `CORRUPT` — nothing observed damage), and
+`unkeyed` is the one permissive answer, announced once, because no key means no latch was ever named
+and stopping would make a missing sweep script halt every lane for want of a hygiene probe.
+
+**The thundering herd is closed, with the hazard its fix introduces.** The throttle read and the
+sweep invocation were unsynchronised and the stamp is written at the END of a sweep, so when the
+interval expired every lane read the same stale stamp and started its own full-store fsck — not
+merely a CPU cost: the walks are I/O-bound, so contention pushes them toward the per-walk bound, and
+an expired bound is `UNMEASURED`, a correlated loss of the measurement on every lane at once. The
+serialiser is a per-store claim **directory** created with `mkdir` (the latch's kernel-arbitrated
+create-only primitive, and deliberately not `flock`, since this file's single-instance lock is
+mkdir-based precisely because macOS ships no `flock(1)`). A loser does not wait — it skips that
+iteration's probe and carries on after the usual latch read — and the throttle is **re-read after
+acquiring**, which is what stops the claim converting a herd into a queue of redundant sweeps. A
+stale claim must not wedge the box, which would be worse than the herd, so the recovery threshold is
+**derived**: a claim cannot be stale while the sweep it represents could still be running, so it is
+the sweep's own `MAX_SWEEP_WALKS` (read from that script) × this supervisor's per-walk bound + slack
+= 3 × 200 + 60 = 660s; a claim with no parseable start time reads as stale on purpose (its cause is
+a lane killed between the `mkdir` and the write, and the other reading wedges the sweep forever),
+and where the bound cannot be derived **no claim is taken at all** and the previous behaviour is
+restored, announced. The claim is a registered resource released by the EXIT trap, so the `CORRUPT`
+path — which ends the process — does not leave peers waiting out the bound. Not closed, and
+pre-existing: this file installs no INT/TERM handlers, so a signalled supervisor releases neither
+its claim nor its lock; for the claim that is a delay, not a wedge. **What is
 not closed:** the latch read and the worker spawn are still unsynchronised, and the preflight hold
 loop can poll for minutes between them, so one worker can still start on a box latched moments
 earlier. It is bounded (that lane's next iteration reads the latch at the top of its sweep and

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -673,7 +673,7 @@ pack data; no check inside a process defends against the party that controls the
 `scripts/check-object-store-integrity.sh` runs a full `git fsck` (never `--connectivity-only`, which
 does not rehash content) over the shared store and emits an anchored three-valued
 `VERIFIED`/`CORRUPT`/`UNMEASURED` verdict — exit 0/4/5, and **a consumer must not read `UNMEASURED`
-as clean**. It runs at machine onboarding (`bootstrap-agent-machine.sh` section 5b-obj, where
+as clean**. It runs at machine onboarding (`bootstrap-agent-machine.sh` section 5d, where
 `VERIFIED` is the only `[ok]`, so an unmeasured host cannot pass `--strict`) and on the worker
 supervisor's throttled per-iteration cadence (default every 6h). There, `CORRUPT` **stops the
 supervisor loudly** instead of holding — corruption is non-self-clearing, so a hold-and-repoll loop

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -716,22 +716,35 @@ index, and the HEAD of a *prunable* worktree — all three surviving `--no-reflo
 `CORRUPT`. What it does *not* walk is a **linked** worktree's per-worktree refs (`refs/worktree/*`,
 `refs/bisect/*`, `refs/rewritten/*`; the main worktree's live in the common dir and are walked):
 delete an object named only by one and the sweep exits **0 VERIFIED**, because the HEAD reflog echoes
-the id and that echo clears under `--no-reflogs`. Both halves are now measured rather than believed —
-the covered roots are pinned by fixtures, and the gap is closed by a **private-root probe**: not an
-fsck (`git fsck <sha>` *replaces* the default heads, an explicit-head fsck still costs a full rehash,
-and `rev-list <missing-root>` dies 128) but an O(refs) question — list each linked worktree's refs,
-subtract the common ones, ask `cat-file --batch-check` whether the remainder's targets are present
-(0.22 s against the live 15-worktree store). Its enumeration is **filesystem-first because the git
-command is fail-open**: `git worktree list --porcelain` silently drops a worktree whose admin
-`gitdir` file is missing, so `$GIT_COMMON_DIR/worktrees/*` — git's own administrative directory, not
-a guess about lane layout — is the subject set, with the command kept as a cross-check in the
-direction it can fail. A worktree that cannot be inspected is *not* a clean one (a named
-`UNREADABLE` record, never a silent zero-root contribution to `VERIFIED`). And it widens no caller's
-window, **by placement rather than arithmetic**: one bounded child stage immediately before the
-single affirmative branch, and every branch of the reachability block exits, so a run that spent a
-third fsck walk never reaches it — asserted behaviourally against the fixture that really spends
-three walks. Declared residual: it asks whether each private ref's *target* is present, not whether
-its whole closure is. **The mask does not end at
+the id and that echo clears under `--no-reflogs`. The covered roots are pinned by fixtures; **the
+hole is a DECLARED GAP, and the probe built to close it was removed.** Three measurements rule out
+the fsck-shaped fixes and are recorded so nobody re-derives them: `git fsck <sha>` *replaces* the
+default heads (so private roots can never be appended to the sweep walk), an explicit-head fsck
+still scans the whole object directory and so costs a full rehash, and `rev-list <missing-root>`
+dies 128 (so `--missing=print` cannot answer the case that fires). What was built instead was an
+O(refs) question — enumerate each linked worktree's refs, subtract the common ones, ask
+`cat-file --batch-check` whether the remainder's targets are present — and **its first review
+returned three false-`VERIFIED` routes of its own, two of them High**: a present root whose
+reachable *child* is missing is invisible to a target-presence check; a per-worktree ref is
+discarded by the name subtraction when a common ref shares its name, even pointing at a different,
+missing object; and a failed `awk`/`sort`/`comm` degrades to a zero-root census and then permits
+`VERIFIED`. A mechanism added to prevent one false clean produced three new ways to reach one, in
+one review — so #3229's ruling (*a guard with known documented false-PASSes is worse than no guard*),
+its companion (*subtraction cannot introduce a false PASS*) and #3544's own posture (*a check that
+claims nothing false is worth more than one claiming a closure it does not deliver*) all point the
+same way. **The class also has zero instances on this fleet**, measured twice independently on
+2026-09-02: 14 registered worktrees, all three namespaces absent from every linked worktree's admin
+dir and from the common dir, 0 mentions in `packed-refs` — live per-worktree refs would have made
+removal leave a live hole, and the right answer would then have been to fix the three findings.
+**The declaration is emitted on every run**: `declared-gap` lines, on all three verdict classes
+(what a run did not walk does not depend on what it found), in **`1 RECOGNISED`** form rather than a
+bare count, naming the un-walked namespaces, the coverage that is *not* in the gap (the measurement
+above, which is what keeps the gap one namespace wide) and the fleet measurement with its date,
+since "zero instances" expires. One measurement is kept for whoever revisits this:
+**`git worktree list --porcelain` is fail-open** — it silently drops a worktree whose admin `gitdir`
+file is missing (rc 0, no diagnostic) — so any future enumeration must be filesystem-first over
+`$GIT_COMMON_DIR/worktrees/*`, git's own administrative directory, with the command only as a
+cross-check in the direction it can fail. **The mask does not end at
 31, and assuming it did dropped real damage.** A range check over `1..31` — reasoned from 128 being
 `die()` and `127 & 1` being 1 — classified 33 (`32|1`) and 36 (`32|4`) as unclassified and therefore
 `UNMEASURED`, a false negative on genuine object corruption. Measured on git 2.43.0: a truncated

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -943,7 +943,23 @@ staleness value**: the same 660s that says "this claim may be taken over" says "
 it", so a dead peer cannot wedge the wait and there is no second, driftable constant. A timeout is
 not a clean result and does not carry on — when the peer neither finishes nor vacates, that claim is
 stale by construction at the deadline, so the next acquire recovers it and **the loser becomes the
-sweeper**; only where peers keep handing the claim around for the whole budget does the lane skip,
+sweeper**. **And a completed peer ends the wait — it does not send the loser back to contend.** The
+wait's `completed` (the throttle stamp went fresh) was treated as "go round and acquire again", and
+it is reached *without sleeping*, on the pass that observes the stamp — so a peer that writes the
+stamp and then dies before releasing leaves the claim present and the stamp fresh, every acquire
+answers `held`, every wait answers `completed` in microseconds, and the lane spun CPU-hot until the
+supervisor's whole `MAX_HOURS` budget expired (measured: 2165 completions in 20s). The age-based
+recovery built for exactly that dead peer could not save it, which is the transferable part:
+`completed` was tested *before* the claim's deadline on every pass, so the recovery the design
+relies on never ran. The fix adds no second notion of "the peer is gone" — a fresh stamp is the same
+answer the throttle at the top of the sweep gives, so the lane skips exactly as it would have there,
+which is strictly less work than the acquire-and-release round trip the ordinary case used to make.
+The loop is now bounded in wall time **by construction** and by a value it already derived
+(`exhausted` and `completed` break; neither surviving state is required to have slept, so the loop
+itself is bounded by the iteration's own `claim_stale` budget), never by `MAX_HOURS`. The general
+rule: **a state a loop can reach without sleeping must not be a loop-continuing state**, and a bound
+placed after a fast-path test is not a bound at all.
+Otherwise, only where peers keep handing the claim around for the whole budget does the lane skip,
 journalled and paged as `NOT SWEPT AND NOT MEASURED`, never as clean, and never as a stop (a peer
 sweeping is also the shape of a healthy box recovering a wedged claim, and stopping four lanes over a
 hygiene probe's contention is the self-DoS that file refuses everywhere else). The throttle is

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -671,13 +671,14 @@ peer wanting a false `PASS` can simply edit `scripts/agent-gate.sh`, which is ch
 pack data; no check inside a process defends against the party that controls the process.
 *Accidental* corruption **is** in model, and its control is a periodic full-rehash sweep:
 `scripts/check-object-store-integrity.sh` runs a full `git fsck` (never `--connectivity-only`, which
-does not rehash content) over the shared store and emits an anchored three-valued
-`VERIFIED`/`CORRUPT`/`UNMEASURED` verdict — exit 0/4/5, and **a consumer must not read `UNMEASURED`
-as clean**. It runs at machine onboarding (`bootstrap-agent-machine.sh` section 5d, where
+does not rehash content) over the shared store and emits an anchored four-valued
+`VERIFIED`/`CORRUPT`/`UNSWEEPABLE`/`UNMEASURED` verdict — exit 0/4/6/5, and **a consumer must not
+read `UNMEASURED` as clean**. It runs at machine onboarding (`bootstrap-agent-machine.sh` section 5d, where
 `VERIFIED` is the only `[ok]`, so an unmeasured host cannot pass `--strict`) and on the worker
 supervisor's throttled per-iteration cadence (default every 6h). There, `CORRUPT` **stops the
 supervisor loudly** instead of holding — corruption is non-self-clearing, so a hold-and-repoll loop
-would spin to the wall-clock budget taking no useful action — while `UNMEASURED` is journalled and
+would spin to the wall-clock budget taking no useful action — and so does `UNSWEEPABLE` (below),
+while `UNMEASURED` is journalled and
 paged once and deliberately does **not** stop the loop, because refusing to run any worker over a
 hygiene probe that could not run is a self-DoS. **That sweep is periodic, not per-read, which is why
 the emitted clause still says `TRUSTED, not verified`.**
@@ -754,6 +755,27 @@ above 124 (timeout/shell conventions, `die()` and signal deaths above them) is r
 outright, and a status carrying a bit outside the supported mask is unclassified rather than folded
 into a class whose remedy would be wrong — which is how it degrades safely as git adds bits.
 
+**And that range has two halves, which sharing one verdict made a false negative on real
+commit-object corruption.** Measured on git 2.43.0: overwrite the loose object a live ref points *at*
+with unparseable bytes and fsck prints `fatal: loose object <sha> … is corrupt` and exits **128**,
+while the same damage to a *blob* — or a valid object stored under the commit's name — exits 3
+(`2|1`) and is caught. So the exact damage this control exists for lands outside the mask, where
+`unclassified` ⇒ `UNMEASURED` ⇒ the supervisor writes a fresh throttle stamp and keeps spawning
+workers. `124..127` is the timeout/exec convention — the fsck **never ran**, a fact about the box's
+tooling, and it stays permissive; `128`+ is git's own `die()` or a signal death — it **ran and did
+not finish**, and reproduced on *both* walks it is the stopping verdict `UNSWEEPABLE` (exit 6). The
+boundary is argued from the exec chain rather than assumed: `env`/`nice`/`timeout` each report their
+own failures inside `125..127`, so a status at or above 128 is the innermost command having actually
+started, which together with the launch marker below makes "fsck ran and died" an *affirmative*
+observation. **`UNSWEEPABLE` claims no cause and prints no repair** — the alternative was to read the
+`fatal:` text for a damage signature, i.e. the text-shape classifier again, narrower, with every
+wording nobody enumerated falling back to the same permissive state. It tells the operator to run the
+walk by hand and act on what the `fatal:` line names (that line is kept in the findings **for display
+only**; it reaches no branch), and it makes a completed sweep the condition for resuming. The
+verdict set is closed at **four**, and the closure is over *dispositions*, not over a count: a token
+is what every consumer keys its behaviour on, so a state that stops the box cannot be expressed as
+another verdict's cause text, while two causes that both continue (the reflog split above) must be.
+
 **And a status is only a bitmask if the command that produced it actually ran.** fsck's status space
 is shared with the shell's, so the classifier had a precondition it never checked: the two capture
 redirections are part of the fsck command, and a failure to open the scratch output file (a full or
@@ -781,7 +803,11 @@ reproduces it and latches it properly. A disagreement is therefore routed to `UN
 (`INCONSISTENT sweep result`), never folded into the generic "could not measure" line; the
 `UNMEASURED` tests stay disjunctive on purpose, because a disjunction that can only reach a
 non-passing branch cannot manufacture a verdict. The `CORRUPT` verdict is **persisted for the box in its own create-only
-file** (`<stamp>.CORRUPT`), because a timestamp-only stamp let the detecting lane stop while its
+file** (`<stamp>.STOP`, which records *which* stopping verdict it is, read affirmatively — it was
+`.CORRUPT` until a second stopping verdict existed, and a file whose *name* asserts damage is a
+confidently-wrong claim on disk for a verdict that establishes no cause; an unrecognised second line
+is a cause-free stop and is never defaulted to the damage text), because a timestamp-only stamp let
+the detecting lane stop while its
 peers skipped their own sweep for the interval and kept spawning workers over the damaged store.
 Putting the verdict *in* that stamp was the first fix and was itself a defect: stamp writes are
 unsynchronised overwrites, so a lane whose sweep started before the detection could finish after it
@@ -828,7 +854,7 @@ latch first, stamp second, and one `obj_sweep_stop_if_latched` helper before the
 **And ordering was not enough: the stamp is written only if the latch is CONFIRMED present, else it
 is forced stale (round 9, item 1).** "Latch first, stamp second" left the stamp unconditional, so on
 the one branch where the latch could not be *persisted* — a writable stamp inside a directory that is
-not writable, so creating `<stamp>.CORRUPT` fails while rewriting `<stamp>` succeeds — the detecting
+not writable, so creating `<stamp>.STOP` fails while rewriting `<stamp>` succeeds — the detecting
 lane stopped (correct) and still advertised a freshly swept box (not correct): its peers read the
 fresh stamp, skipped their own sweep for the whole interval, and kept working against a store already
 confirmed damaged. The stamp write is now gated on `obj_sweep_latch_present`, the afterwards-existence
@@ -864,6 +890,10 @@ structurally. The post-sweep reads stay: a peer can latch the box while this lan
 path that previously paid none. The latch question is also **four-valued**, because `[[ -e ]]` is
 false both for an absent latch and for one the process cannot look at: `unknown` STOPS under its own
 reason (`object-store-latch-unreadable`, never as `CORRUPT` — nothing observed damage), and
+`absent` requires the absence to be **established through searchable ancestors** — `-d` on the
+holding directory is itself two-valued (false both for a directory that does not exist and for one
+whose *ancestor* cannot be searched), so the probe walks up to the deepest ancestor it can stat and
+counts the absence only when that one is searchable, and
 `unkeyed` is the one permissive answer, announced once, because no key means no latch was ever named
 and stopping would make a missing sweep script halt every lane for want of a hygiene probe.
 

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -688,8 +688,26 @@ this fleet: `invalid reflog entry` naming a different branch each run, on a quar
 runs), so recognising damage from the *text shape* of a diagnostic made a healthy box page high, stop
 its supervisor and fail `--strict` bootstrap. The class comes from fsck's exit **bitmask** — bits
 `1 ERROR_OBJECT`/`4 ERROR_PACK` are the subject; `2 ERROR_REACHABLE`/`8 ERROR_REFS`/
-`16 ERROR_COMMIT_GRAPH`/`32 ERROR_MULTI_PACK_INDEX` are *not* demoted to clean (a genuinely missing
-object reports bit 2) but get their own non-passing `UNMEASURED` cause. **The mask does not end at
+`16 ERROR_COMMIT_GRAPH`/`32 ERROR_MULTI_PACK_INDEX` are *not* demoted to clean but get their own
+non-passing `UNMEASURED` cause. **Except that `2 ERROR_REACHABLE` has two causes, and routing both
+to `UNMEASURED` was a false negative on real corruption.** That bit fires for a stale reflog entry
+naming an object a peer's gc pruned (routine, not the subject) *and* for an object genuinely absent
+while a live ref, the index or HEAD still needs it (corruption). Both reproduce, so the reproduction
+discriminator cannot separate them, and `UNMEASURED` is deliberately non-fatal to the supervisor's
+loop — so workers kept running against a demonstrably damaged store, reported as "not measured".
+They are separated by a **third walk with `--no-reflogs`**, which drops the reflogs from the
+reachability roots and keeps everything else: a complaint that *survives* it is reachable from a live
+root and is `CORRUPT`, with a remedy that says the reflog remedy does not apply; one that *clears* is
+`REFLOG-SCOPED` and stays `UNMEASURED`. Measured on git 2.43.0 on real fixtures, both directions: a
+blob deleted while HEAD's tree names it exits 2 with and without reflogs; a commit deleted after
+`reset --hard`, named only by the reflog, exits 2 with and **0** without. This is **not** the
+`--no-reflogs` *suppression* rejected earlier — that decided whether to report and was measured not
+to help; this decides which cause, on a class that has already reproduced twice, and can only make
+the verdict stronger. Passes 1 and 2 never carry the flag (asserted structurally over the shipped
+call sites), an attribution walk that is killed, unlaunchable or unclassifiable leaves the complaint
+`UNATTRIBUTED` and non-passing, and a damage bit appearing only in the third walk has not reproduced
+across the sweep walks. The verdict set stays closed at three: the split is in the *cause* text, not
+in a fourth token two readers and a structural assert would have to learn. **The mask does not end at
 31, and assuming it did dropped real damage.** A range check over `1..31` — reasoned from 128 being
 `die()` and `127 & 1` being 1 — classified 33 (`32|1`) and 36 (`32|4`) as unclassified and therefore
 `UNMEASURED`, a false negative on genuine object corruption. Measured on git 2.43.0: a truncated
@@ -714,7 +732,18 @@ process whose convention you are applying is the process that produced it.**
 
 And no non-clean walk is fatal on one observation: it is re-run **once** as a discriminator — a
 concurrency artefact does not survive a second independent walk, damage does — never a
-retry-until-clean loop. The `CORRUPT` verdict is **persisted for the box in its own create-only
+retry-until-clean loop (the reachability attribution above is a third walk answering a different
+question; `MAX_SWEEP_WALKS` in the sweep script is the declared ceiling, and every caller's bound is
+derived from it). **The two channels must also agree before the fatal verdict is acted on.** Both
+consumers read the exit status *and* the anchored `verdict ` line, and both tested them with `||`
+while the comment above each asserted the conjunction — so an exit 4 with no verdict line, or a stray
+`CORRUPT` line under any other status, was enough to create a sticky, box-wide, operator-cleared
+latch that halts every lane. Blast radius decides the direction: a false latch stops four lanes until
+a human notices, while one more iteration over a genuinely damaged store costs the next sweep, which
+reproduces it and latches it properly. A disagreement is therefore routed to `UNMEASURED` and *named*
+(`INCONSISTENT sweep result`), never folded into the generic "could not measure" line; the
+`UNMEASURED` tests stay disjunctive on purpose, because a disjunction that can only reach a
+non-passing branch cannot manufacture a verdict. The `CORRUPT` verdict is **persisted for the box in its own create-only
 file** (`<stamp>.CORRUPT`), because a timestamp-only stamp let the detecting lane stop while its
 peers skipped their own sweep for the interval and kept spawning workers over the damaged store.
 Putting the verdict *in* that stamp was the first fix and was itself a defect: stamp writes are
@@ -730,7 +759,16 @@ by hand (`rm -f <latch>`, named in every message that mentions it); a create tha
 is reported, never read as a latched box. The stamp's **key** is resolved by the sweep script itself
 (`--print-store`), never by a `git` call in the supervisor — a bare `git rev-parse
 --git-common-dir` inherits the caller's environment, so an inherited `GIT_DIR` keyed the stamp on
-another repository.
+another repository — and it is a **digest** of that canonical path, because flattening is not
+injective: replacing `/` and every unsupported character with `_` maps `/tmp/a/b/objects` and
+`/tmp/a_b/objects` to one name, so two repositories on a box shared a throttle stamp *and* a
+`CORRUPT` latch. The form is `<sanitised tail>.<16 hex of sha256>`, where the tail is readability
+only and carries no identity; three digest tools (`sha256sum`, `shasum -a 256`,
+`openssl dgst -sha256`) cover both platforms, the output is parsed from both ends and then validated
+as hex, and a host with none fails closed to the **empty** key — no throttle, no latch, announced
+once naming both causes — never a silent fall back to the colliding form. `cksum` is present
+everywhere and deliberately unused: CRC32 is not collision-resistant, and a colliding key is the
+defect being removed.
 
 **The latch is created before the throttle stamp, re-read before every return that leads to a spawn,
 and the remaining race is declared rather than closed.** The stamp used to be written for every
@@ -746,9 +784,13 @@ earlier. It is bounded (that lane's next iteration reads the latch at the top of
 stops) and the atomic guarantee needs per-store synchronisation shared by the sweep and the spawn
 decision, which is split to its own issue. The sweep is also **not interruptible** — its two walks
 run in a child process — so the supervisor checks the stop file and the wall-clock budget
-immediately *before* the sweep, and bounds the exposure in wall time: its per-walk default is
-**half** the sweep script's own (300 vs 600), so two walks cost no more than one walk at the
-script's bound. Raising a bound is a change to somebody's stop latency.
+immediately *before* the sweep, and bounds the exposure in wall time: its per-walk default is the
+sweep script's own bound **divided by `MAX_SWEEP_WALKS`** (200 vs 600/3), so every walk it can pay
+for still costs no more than one walk at the script's bound. The walk count is **read from the
+shipped script**, not re-typed in the test: the relation was asserted with a hard-coded factor 2, so
+adding the third walk would have kept it green while the supervisor's real worst case rose to 900s —
+a relation whose own constant is restated is two magic numbers wearing a relation's clothes. Raising
+a bound, or the walk count, is a change to somebody's stop latency.
 
 Three alternatives were **rejected** by the same ruling, recorded so they are not re-derived:
 per-lane full clones (a permanent multi-GB tax for an out-of-model threat); per-read rehashing (the

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -699,6 +699,19 @@ above 124 (timeout/shell conventions, `die()` and signal deaths above them) is r
 outright, and a status carrying a bit outside the supported mask is unclassified rather than folded
 into a class whose remedy would be wrong — which is how it degrades safely as git adds bits.
 
+**And a status is only a bitmask if the command that produced it actually ran.** fsck's status space
+is shared with the shell's, so the classifier had a precondition it never checked: the two capture
+redirections are part of the fsck command, and a failure to open the scratch output file (a full or
+reaped `TMPDIR`) means bash execs nothing and exits **1** — `ERROR_OBJECT`. Both passes then fail
+identically, both "reproduce", and the sweep emitted `CORRUPT` **about a store it never opened** —
+the same false-`CORRUPT` harm as the text-shape classifier, arriving through the shell instead of
+through a concurrent writer. It cannot be inferred from the status, which is the point; the evidence
+is **affirmative** — a marker written inside the redirected group as its first statement (a
+redirection failure on a compound command means the body does not execute at all) plus both capture
+files existing afterwards — and its absence is a `launchfail` class routed to `UNMEASURED`, never
+bit-tested. Generalise it: **before reading a status as a structured value, establish that the
+process whose convention you are applying is the process that produced it.**
+
 And no non-clean walk is fatal on one observation: it is re-run **once** as a discriminator — a
 concurrency artefact does not survive a second independent walk, damage does — never a
 retry-until-clean loop. The `CORRUPT` verdict is **persisted for the box in its own create-only
@@ -718,6 +731,24 @@ is reported, never read as a latched box. The stamp's **key** is resolved by the
 (`--print-store`), never by a `git` call in the supervisor — a bare `git rev-parse
 --git-common-dir` inherits the caller's environment, so an inherited `GIT_DIR` keyed the stamp on
 another repository.
+
+**The latch is created before the throttle stamp, re-read before every return that leads to a spawn,
+and the remaining race is declared rather than closed.** The stamp used to be written for every
+outcome *before* the `CORRUPT` branch ran, so between those two writes a peer read a fresh
+non-corrupt stamp and throttled past a corruption about to be recorded; and a lane whose own sweep
+said `VERIFIED` returned toward a spawn without re-reading the latch, so a peer latching the box
+*during* that lane's two fsck walks was never seen. Both are ordering fixes, neither needs a lock:
+latch first, stamp second, and one `obj_sweep_stop_if_latched` helper before the throttled,
+`VERIFIED` and `UNMEASURED` returns alike — one rule instead of a set of paths to audit. **What is
+not closed:** the latch read and the worker spawn are still unsynchronised, and the preflight hold
+loop can poll for minutes between them, so one worker can still start on a box latched moments
+earlier. It is bounded (that lane's next iteration reads the latch at the top of its sweep and
+stops) and the atomic guarantee needs per-store synchronisation shared by the sweep and the spawn
+decision, which is split to its own issue. The sweep is also **not interruptible** — its two walks
+run in a child process — so the supervisor checks the stop file and the wall-clock budget
+immediately *before* the sweep, and bounds the exposure in wall time: its per-walk default is
+**half** the sweep script's own (300 vs 600), so two walks cost no more than one walk at the
+script's bound. Raising a bound is a change to somebody's stop latency.
 
 Three alternatives were **rejected** by the same ruling, recorded so they are not re-derived:
 per-lane full clones (a permanent multi-GB tax for an out-of-model threat); per-read rehashing (the

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -767,7 +767,8 @@ not finish**, and reproduced on *both* walks it is the stopping verdict `UNSWEEP
 boundary is argued from the exec chain rather than assumed: `env`/`nice`/`timeout` each report their
 own failures inside `125..127`, so a status at or above 128 is the innermost command having actually
 started, which together with the launch marker below makes "fsck ran and died" an *affirmative*
-observation. **`UNSWEEPABLE` claims no cause and prints no repair** — the alternative was to read the
+observation. **On that cause `UNSWEEPABLE` claims no cause and prints no repair** (scoped to the
+*fatal* cause: the verdict gained a second one, below, which does name its cause) — the alternative was to read the
 `fatal:` text for a damage signature, i.e. the text-shape classifier again, narrower, with every
 wording nobody enumerated falling back to the same permissive state. It tells the operator to run the
 walk by hand and act on what the `fatal:` line names (that line is kept in the findings **for display
@@ -775,6 +776,30 @@ only**; it reaches no branch), and it makes a completed sweep the condition for 
 verdict set is closed at **four**, and the closure is over *dispositions*, not over a count: a token
 is what every consumer keys its behaviour on, so a state that stops the box cannot be expressed as
 another verdict's cause text, while two causes that both continue (the reflog split above) must be.
+
+**`UNSWEEPABLE` has a second cause: the store's own `fsck.*` config, which the environment allowlist
+cannot reach.** `env -i` plus the allowlist closes git's *environment* config sources; a **local
+config is a file in the repository, not an environment variable**, and `git fsck` is configurable.
+Measured on git 2.43.0 against a real fixture (a commit object with no author email — an
+ERROR-severity message, exit bit 1, the sweep's own damage class): plain fsck exits **1**, while both
+`fsck.<msg-id>=ignore` and a `fsck.skipList` naming that object exit **0** — so the sweep reported
+`VERIFIED` **about a damaged store**, the exact false affirmative this control exists to prevent. It
+is in model because the file is the *shared* `.git/config` a peer lane, or an accident, writes. It is
+**refused, not overridden**: `fsck.<msg-id>` is an open-ended key space (one key per message id, new
+ids with new git versions), so a `-c` per key is a list that is wrong the moment git adds a message,
+and a partial override is the "one axis closed, space declared done" shape this issue has hit five
+times. So any `fsck.*` key in the configuration the walk would read means **no walk at all** and
+`UNSWEEPABLE`, naming the keys and the `config --list --show-origin --name-only` that lists them, and
+claiming **no damage** — nothing was rehashed. It *stops* rather than reporting, because the policy is
+a persistent property of the repository and because an `fsck.<msg-id>` naming an id this git does not
+know **already** stops the box through the fatal cause, so the permissive reading would stop a box
+whose config merely breaks fsck while letting one that suppresses real damage carry on. "Could not
+**ask**" stays permissive and is its own state: a failed probe, or an rc-0 answer listing no key at
+all (an *unread* policy, not an empty one — every repository's config declares
+`core.repositoryformatversion`), is `UNMEASURED` with its own cause and no walk, so `VERIFIED` is
+reachable only from a policy that was read and found empty. And both consumers' text is now derived
+from the **token** alone — the latch records only the verdict, so a reader naming the fatal mechanism
+was affirmatively false on the other cause.
 
 **And a status is only a bitmask if the command that produced it actually ran.** fsck's status space
 is shared with the shell's, so the classifier had a precondition it never checked: the two capture


### PR DESCRIPTION
Closes #3749.

Scoped by the **owner ruling of 2026-09-01** on the issue thread: deliberate peer forgery of the shared lane object store is **invoker-class and out of model** (recorded, not patched — every lane on a box runs as one user and can edit `agent-gate.sh` itself, so a peer wanting a false PASS has cheaper paths than forging pack data). The in-model subject is **accidental corruption**.

## What lands

1. **`scripts/check-object-store-integrity.sh`** — a `git fsck` sweep of the SHARED store (every lane on a box is a worktree of one `/data/lanes/repo/.git`), with an anchored three-valued verdict `VERIFIED` / `CORRUPT` / `UNMEASURED` (exit 0 / 4 / 5). Consumers must not read `UNMEASURED` as clean.
2. **Bootstrap** — a new section in `bootstrap-agent-machine.sh`. `VERIFIED` is the only `[ok]`; `CORRUPT` fails loudly with the affected object ids; `UNMEASURED` warns and withholds green, so `--strict` cannot certify an unmeasured host.
3. **Periodic hook** — a throttled sweep in `worker-supervisor.sh`'s per-iteration preflight. This box has no crontab and no bootstrap-installed timer (measured), so the supervisor's preflight *is* the box's existing recurring cadence.
4. **Fast-path documentation** in `agent-gate.sh` — what the object-reuse path relies on (git's pack CRC + zlib checks on an ordinary read), why deliberate forgery is out of scope, the sweep as the in-model control, and the three rejected alternatives recorded so they are not re-derived.
5. **`#3746` → `#3749`** repointing across `agent-gate.sh`, its pinned closed-set self-test, `CLAUDE.md` and the `gate-contract` page (ruling item 4).

## Verification

`--lite` PASS. Suites: `test_check_object_store_integrity.sh` **104/0** (floor 104), `test_worker_supervisor.sh` **512/0/0**, `test_bootstrap_agent_machine.sh` **217/0/0**. Every round's result was re-run independently by the coordinating lane, not accepted on the implementer's report — which is how the wall-clock race below was caught.

The sweep returns `VERIFIED` against the real 366M shared store.

## Review history — six rounds, and what they changed

| round | job | findings | the High |
|---|---|---|---|
| 1 | 365 | 2 | `CORRUPT` wrote the throttle stamp, so peer lanes skipped the sweep for 6h |
| 2 | 377 | 3 | a stale writer could overwrite a cached `CORRUPT` with `VERIFIED` |
| 3 | 386 | 4 | the latch was checked only *before* sweeping |
| 4 | 394 | 3 | a missing **live-reachable** object was `UNMEASURED`, and the supervisor continues past that |
| 5 | 398 | 3 | the `INTERVAL_HOURS=0` opt-out returned before the latch check |
| 6 | 404 | 1 | — (one Medium) |

Two of these are worth calling out because they were false verdicts in a merge-relevant control:

- **A healthy store intermittently reported `CORRUPT`.** Corruption was recognised from the *text shape* of fsck's diagnostics, and `git fsck` walking a store that up to 8 peer lanes are concurrently mutating emits `error:` lines on a healthy store — measured at roughly **1 run in 4**, unprompted. That would have paged `high`, stopped the supervisor and failed `--strict` bootstrap on good boxes. Now: classify on fsck's **exit bitmask** (damage bits tested independently, so an unrelated high bit cannot mask `ERROR_OBJECT`/`ERROR_PACK`), and require a non-clean walk to **reproduce** before it may mean `CORRUPT` — a transient does not survive a second walk, real damage does.
- **A false `VERIFIED`.** `GIT_OBJECT_DIRECTORY=<good>` with `--repo <bad>` named the corrupt store and reported `VERIFIED`, exit 0. Every git call now runs under `env -i` + one allowlist.

The concurrency work converged by **removing the shared mutable channel** rather than locking it: the `CORRUPT` verdict is a create-only latch file, monotonic by construction, read once at *entry* to the sweep above every branch — so "an early return that forgets the latch", found at four separate sites across rounds 3 and 5, became unexpressible rather than fixed a fifth time.

## Known residuals, all deliberate

- **The latch/spawn race, per path, with real magnitudes.** **PATH 1, the claim loser: CLOSED** — it was the peer's entire sweep (13-80s measured on this fleet's 366M store; 600s by construction), and a waiting lane now observes a latch within one `OBJ_SWEEP_CLAIM_POLL_SECS` (5s default). **PATH 2, a lane's own sweep: COVERED** by the entry read plus the post-sweep reads. **PATH 3, last latch read to worker spawn: NARROWED FROM UP TO AN HOUR TO ONE PRE-SPAWN PROLOGUE, AND IT IS NOT ZERO.** The hold loop used to run after the last latch read and never re-read it, so at shipped defaults a lane could sit `BUILD_HOLD_MAX` x `HOLD_POLL_SECS` = 12 x 300s = **3600s** and then spawn onto a box a peer had latched meanwhile. `preflight_wait` is now a wrapper around `preflight_wait_holds`, and the latch is re-read on **every** return out of it — closed **structurally**, at the function boundary, not as an enumerated set of returns (round 3 fixed three such returns; round 5 found a fourth — that shape does not converge). What remains is `run_iteration`'s pre-spawn prologue, which performs a `claim-heartbeat.sh stamp` ref push to origin with no timeout: measured lower bound on this fleet is **0.26-0.28s** for a bare `git ls-remote`, so the real window is sub-second-to-seconds, and unbounded in principle if the network stalls — **not the "milliseconds" a purely local prologue would give.** The harm bound is unchanged and is why this is a declared residual rather than a blocker: not silent, not durable — that lane's next iteration reads the latch at the top of its sweep and stops, and nothing certifies a merge in that window without a full gate, which a latched box refuses. Closing it entirely still needs per-store synchronisation shared by the sweep and the spawn decision; split to its own issue.
- **The sweep is wired to neither path that produces a gate of record.** Attended lanes and `flow-closer` never trigger it and nothing at gate time reads a sweep result. The ruling asked for bootstrap + a periodic hook, which is what this delivers; whether that is the right target is a product question, raised on the issue.
- Unpinned fixture clocks remain in two standalone fixtures (safe today, deliberately not pinned so a future cross-comparison must think about it), and consumer-side branch coverage gaps — batched into one follow-up issue.

## Notes for the closer

- **`prompt-content: FAIL` on rounds 4-6 is SNAPSHOT DELIVERY, not a vacuous review.** The diff is ~6000 lines, so roborev ships it by transient snapshot rather than inline. Token accounting on job 404: **input 1,304,492 / cached 1,182,720 / output 14,804**, against the documented vacuous baseline of ~18.7k input / 0 cached. An absence waiver will be needed at the final sha.
- `test_bootstrap_agent_machine.sh` has a flake at `push: cleanup-unverified verdict lost its stray-ref guidance in transit`. Attribution was measured — **0/5 at HEAD vs 0/5 on `origin/main`, interleaved** — and the verdict is **UNDERPOWERED**, not "pre-existing": the flake did not reproduce at all, and this branch touches both bootstrap files, so it stays presumed ours. **Do not waive it.** If the gate reds there, check whether the *preceding* assertion in the same block also failed: both ⇒ the 60s probe bound timed out; only `:1805` ⇒ the ls-remote hint genuinely did not survive, a different defect with a different owner.
- The `gate-contract.md` change is not published from this lane; the served-page grep is owed after merge.


