### PR TITLE
fix(#3940): position the flight cancel test structurally, not with a calibrated sleep

### DIFF
--- a/cqlite-flight/src/warm/rebuild.rs
+++ b/cqlite-flight/src/warm/rebuild.rs
@@ -349,10 +349,10 @@ impl WarmTableRegistry {
                 return Err(WarmError::Cancelled);
             }
             let (reader, real) = self.coalescer.open(entry.id, cancel, || {
-                // Test-only rendezvous (issue #3940): fires on the LEADER's own
-                // thread, downstream of every flight-side cancel gate above and
-                // of the coalescer's own follower poll, immediately before the
-                // Index.db open+parse. A cancel tripped here is therefore
+                // Test-only rendezvous (issue #3940): fires on the OPENING
+                // thread (whichever role reaches a real open), downstream of
+                // every flight-side cancel gate above and of the coalescer's own
+                // follower poll, immediately before the Index.db open+parse. A cancel tripped here is therefore
                 // observable ONLY by the parse's `ScanCancel` polling (fix C),
                 // which is what makes the mid-parse-cancel repro deterministic
                 // instead of sleep-calibrated. No-op in production.

--- a/cqlite-flight/src/warm/rebuild.rs
+++ b/cqlite-flight/src/warm/rebuild.rs
@@ -349,6 +349,15 @@ impl WarmTableRegistry {
                 return Err(WarmError::Cancelled);
             }
             let (reader, real) = self.coalescer.open(entry.id, cancel, || {
+                // Test-only rendezvous (issue #3940): fires on the LEADER's own
+                // thread, downstream of every flight-side cancel gate above and
+                // of the coalescer's own follower poll, immediately before the
+                // Index.db open+parse. A cancel tripped here is therefore
+                // observable ONLY by the parse's `ScanCancel` polling (fix C),
+                // which is what makes the mid-parse-cancel repro deterministic
+                // instead of sleep-calibrated. No-op in production.
+                #[cfg(test)]
+                self.run_open_parse_barrier();
                 open_one_reader(
                     &runtime,
                     &entry.path,

--- a/cqlite-flight/src/warm/registry.rs
+++ b/cqlite-flight/src/warm/registry.rs
@@ -187,6 +187,17 @@ pub struct WarmTableRegistry {
     /// production. `pub(super)` for [`super::rebuild`] (campsite split).
     #[cfg(test)]
     pub(super) open_barrier: Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
+    /// Test-only hook invoked INSIDE the coalesced real-open closure, on the
+    /// leader's own thread, immediately BEFORE `open_one_reader` runs the
+    /// Index.db open+parse — i.e. downstream of EVERY flight-side cancel gate
+    /// (`rebuild`'s pre-rebuild + pre-open checks, `open_added`'s per-iteration
+    /// check, and the coalescer's follower-wait poll), so a cancellation tripped
+    /// from here can only be observed by the parse's own `ScanCancel` polling
+    /// (issue #2383 fix C). That is what lets the mid-parse-cancel test position
+    /// its cancel STRUCTURALLY instead of with a calibrated sleep (issue #3940).
+    /// `None` (a no-op) in production. `pub(super)` for [`super::rebuild`].
+    #[cfg(test)]
+    pub(super) open_parse_barrier: Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
 }
 
 impl Default for WarmTableRegistry {
@@ -214,6 +225,8 @@ impl WarmTableRegistry {
             swap_barrier: Mutex::new(None),
             #[cfg(test)]
             open_barrier: Mutex::new(None),
+            #[cfg(test)]
+            open_parse_barrier: Mutex::new(None),
         }
     }
 
@@ -801,6 +814,31 @@ impl WarmTableRegistry {
     pub(super) fn run_open_barrier(&self) {
         let hook = self
             .open_barrier
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone();
+        if let Some(f) = hook {
+            f();
+        }
+    }
+
+    /// Install the test-only pre-parse rendezvous (see the field doc).
+    #[cfg(test)]
+    pub(crate) fn set_open_parse_barrier(&self, f: Arc<dyn Fn() + Send + Sync>) {
+        *self
+            .open_parse_barrier
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner) = Some(f);
+    }
+
+    /// Invoke the pre-parse rendezvous if one is installed. The `Arc` is cloned
+    /// out first so the hook runs WITHOUT holding the `open_parse_barrier` lock
+    /// (same discipline as [`Self::run_swap_barrier`]). `pub(super)` for
+    /// [`super::rebuild::WarmTableRegistry::open_added`] (campsite split).
+    #[cfg(test)]
+    pub(super) fn run_open_parse_barrier(&self) {
+        let hook = self
+            .open_parse_barrier
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .clone();

--- a/cqlite-flight/src/warm/registry.rs
+++ b/cqlite-flight/src/warm/registry.rs
@@ -776,77 +776,6 @@ impl WarmTableRegistry {
             .all(|r| super::rebuild::reader_backing_present(r))
     }
 
-    /// Install the test-only swap rendezvous (see the field doc).
-    #[cfg(test)]
-    pub(crate) fn set_swap_barrier(&self, f: Arc<dyn Fn() + Send + Sync>) {
-        *self
-            .swap_barrier
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner) = Some(f);
-    }
-
-    /// Invoke the swap rendezvous if one is installed (clone the `Arc` out first
-    /// so it is called WITHOUT holding the `swap_barrier` lock).
-    #[cfg(test)]
-    fn run_swap_barrier(&self) {
-        let hook = self
-            .swap_barrier
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .clone();
-        if let Some(f) = hook {
-            f();
-        }
-    }
-
-    /// Install the test-only per-open rendezvous (see the field doc).
-    #[cfg(test)]
-    pub(crate) fn set_open_barrier(&self, f: Arc<dyn Fn() + Send + Sync>) {
-        *self
-            .open_barrier
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner) = Some(f);
-    }
-
-    /// Invoke the per-open rendezvous if one is installed. `pub(super)` for
-    /// [`super::rebuild::WarmTableRegistry::open_added`] (campsite split).
-    #[cfg(test)]
-    pub(super) fn run_open_barrier(&self) {
-        let hook = self
-            .open_barrier
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .clone();
-        if let Some(f) = hook {
-            f();
-        }
-    }
-
-    /// Install the test-only pre-parse rendezvous (see the field doc).
-    #[cfg(test)]
-    pub(crate) fn set_open_parse_barrier(&self, f: Arc<dyn Fn() + Send + Sync>) {
-        *self
-            .open_parse_barrier
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner) = Some(f);
-    }
-
-    /// Invoke the pre-parse rendezvous if one is installed. The `Arc` is cloned
-    /// out first so the hook runs WITHOUT holding the `open_parse_barrier` lock
-    /// (same discipline as [`Self::run_swap_barrier`]). `pub(super)` for
-    /// [`super::rebuild::WarmTableRegistry::open_added`] (campsite split).
-    #[cfg(test)]
-    pub(super) fn run_open_parse_barrier(&self) {
-        let hook = self
-            .open_parse_barrier
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .clone();
-        if let Some(f) = hook {
-            f();
-        }
-    }
-
     /// Test-only: the total accounted footprint (`used_bytes`).
     #[cfg(test)]
     pub(crate) fn debug_used_bytes(&self) -> u64 {
@@ -877,6 +806,14 @@ impl WarmTableRegistry {
 
 // `reader_backing_present` + `open_one_reader` moved to [`super::rebuild`]
 // (issue #2383, campsite split).
+
+// Test-only rendezvous plumbing (swap / per-open / pre-parse barriers), in a
+// separate file (campsite rule, epic #1116) loaded here: `registry.rs` is over
+// the 800-line source threshold, so the hooks live beside the tests that drive
+// them rather than in the middle of the production impl (issue #3940).
+#[cfg(test)]
+#[path = "registry_test_hooks.rs"]
+mod registry_test_hooks;
 
 // Registry integration tests over real in-process SSTables (issue #2310), in a
 // separate file (campsite rule) loaded here.

--- a/cqlite-flight/src/warm/registry.rs
+++ b/cqlite-flight/src/warm/registry.rs
@@ -188,7 +188,7 @@ pub struct WarmTableRegistry {
     #[cfg(test)]
     pub(super) open_barrier: Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
     /// Test-only hook invoked INSIDE the coalesced real-open closure, on the
-    /// leader's own thread, immediately BEFORE `open_one_reader` runs the
+    /// OPENING thread itself, immediately BEFORE `open_one_reader` runs the
     /// Index.db open+parse — i.e. downstream of EVERY flight-side cancel gate
     /// (`rebuild`'s pre-rebuild + pre-open checks, `open_added`'s per-iteration
     /// check, and the coalescer's follower-wait poll), so a cancellation tripped

--- a/cqlite-flight/src/warm/registry_test_hooks.rs
+++ b/cqlite-flight/src/warm/registry_test_hooks.rs
@@ -1,0 +1,73 @@
+//! Test-only rendezvous plumbing for [`WarmTableRegistry`] (campsite split,
+//! epic #1116 / issue #3940).
+//!
+//! Three `#[cfg(test)]` hooks, each a `Mutex<Option<Arc<dyn Fn()>>>` field on
+//! the registry (declared there, with the doc that says what each one is FOR):
+//!
+//! | hook | fires |
+//! |---|---|
+//! | `swap_barrier` | in `rebuild`, past the probe + open, before the swap lock |
+//! | `open_barrier` | at the top of each `open_added` iteration, BEFORE its cancel check |
+//! | `open_parse_barrier` | inside the coalesced real-open closure, immediately before the Index.db open+parse |
+//!
+//! One discipline applies to all three `run_*`: clone the `Arc` OUT of the lock
+//! and invoke the hook WITHOUT holding it, so a hook that re-enters the registry
+//! (or blocks on another thread that does) cannot self-deadlock on the hook slot.
+//! `None` is a no-op, and none of this exists in a non-test build.
+
+use std::sync::{Arc, PoisonError};
+
+use super::WarmTableRegistry;
+
+impl WarmTableRegistry {
+    /// Install the test-only swap rendezvous (see the field doc).
+    pub(crate) fn set_swap_barrier(&self, f: Arc<dyn Fn() + Send + Sync>) {
+        *self
+            .swap_barrier
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner) = Some(f);
+    }
+
+    /// Invoke the swap rendezvous if one is installed.
+    pub(super) fn run_swap_barrier(&self) {
+        Self::run_hook(&self.swap_barrier);
+    }
+
+    /// Install the test-only per-open rendezvous (see the field doc).
+    pub(crate) fn set_open_barrier(&self, f: Arc<dyn Fn() + Send + Sync>) {
+        *self
+            .open_barrier
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner) = Some(f);
+    }
+
+    /// Invoke the per-open rendezvous if one is installed. Visible to
+    /// [`super::super::rebuild`]'s `open_added` (campsite split).
+    pub(in crate::warm) fn run_open_barrier(&self) {
+        Self::run_hook(&self.open_barrier);
+    }
+
+    /// Install the test-only pre-parse rendezvous (see the field doc).
+    pub(crate) fn set_open_parse_barrier(&self, f: Arc<dyn Fn() + Send + Sync>) {
+        *self
+            .open_parse_barrier
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner) = Some(f);
+    }
+
+    /// Invoke the pre-parse rendezvous if one is installed. Visible to
+    /// [`super::super::rebuild`]'s `open_added` (campsite split).
+    pub(in crate::warm) fn run_open_parse_barrier(&self) {
+        Self::run_hook(&self.open_parse_barrier);
+    }
+
+    /// Clone the installed hook OUT of `slot` and invoke it with the slot lock
+    /// RELEASED (see the module doc). A poisoned slot is recovered rather than
+    /// panicked on, matching the registry's `lock_inner` discipline.
+    fn run_hook(slot: &std::sync::Mutex<Option<Arc<dyn Fn() + Send + Sync>>>) {
+        let hook = slot.lock().unwrap_or_else(PoisonError::into_inner).clone();
+        if let Some(f) = hook {
+            f();
+        }
+    }
+}

--- a/cqlite-flight/src/warm/spin_tests_2383.rs
+++ b/cqlite-flight/src/warm/spin_tests_2383.rs
@@ -421,10 +421,24 @@ fn cancel_during_large_index_parse_aborts_promptly() {
     // cancel strictly BETWEEN two parsed entries is not reachable from this crate
     // without a clock (the loop lives in cqlite-core and exposes no progress
     // signal), so that stride's own coverage belongs to a cqlite-core-local test
-    // beside the loop, not here. Trading a probabilistic in-loop landing for a
+    // beside the loop, not here. That test EXISTS and was MEASURED to hold the
+    // stride, so this narrowing is not a net coverage loss for the repository:
+    // `cqlite_core::storage::sstable::index_reader::lazy::tests::
+    // ensure_materialized_cancel_mid_parse_aborts_promptly` (400k entries, several
+    // CANCEL_POLL_INTERVAL windows) goes RED with ONLY the in-loop stride poll
+    // disabled and the coarse pre-parse check intact — the exact configuration
+    // that leaves THIS test green. Trading a probabilistic in-loop landing for a
     // deterministic pre-parse one is the deliberate choice of #3940: the old test
     // did not reliably land in the loop either, it merely failed loudly when it
     // missed.
+    //
+    // NOT FIXED HERE, and filed rather than left implicit: that core sibling still
+    // uses the `baseline / 20` calibrated margin this issue removes — its doc
+    // comment cites this test as the shared convention — so it carries the same
+    // two-scheduling-window defect one crate over, in a longer-running gate
+    // component. It is out of scope for #3940 (different crate, and a
+    // deterministic fix there needs a hook INSIDE the core parse loop, whose
+    // mid-loop landing is precisely that test's value) and is tracked separately.
     assert!(
         matches!(res, Err(WarmError::Cancelled)),
         "a cancel tripped on the opening thread immediately before a large \

--- a/cqlite-flight/src/warm/spin_tests_2383.rs
+++ b/cqlite-flight/src/warm/spin_tests_2383.rs
@@ -438,7 +438,7 @@ fn cancel_during_large_index_parse_aborts_promptly() {
     // two-scheduling-window defect one crate over, in a longer-running gate
     // component. It is out of scope for #3940 (different crate, and a
     // deterministic fix there needs a hook INSIDE the core parse loop, whose
-    // mid-loop landing is precisely that test's value) and is tracked separately.
+    // mid-loop landing is precisely that test's value) and is tracked as issue #3982.
     assert!(
         matches!(res, Err(WarmError::Cancelled)),
         "a cancel tripped on the opening thread immediately before a large \

--- a/cqlite-flight/src/warm/spin_tests_2383.rs
+++ b/cqlite-flight/src/warm/spin_tests_2383.rs
@@ -422,6 +422,25 @@ fn cancel_at_large_index_parse_entry_aborts_promptly() {
     // retain. Verified by positive control: with fix C's parse-side cancel polling
     // removed, this assertion FAILS with `res == Ok`.
     //
+    // WHAT "PROMPTLY" MEANS HERE, because it is narrower than the word suggests
+    // (roborev job 90): the cancel is observed by `parse_index_data_cancellable`'s
+    // coarse pre-parse `cancel.check()?`, which runs AFTER `Index.db` has been
+    // opened and read into memory — the parse operates on an in-memory `&[u8]`.
+    // So this does NOT assert that the file read was avoided. It asserts that the
+    // O(entries) ENTRY LOOP is skipped in its entirety, which is exactly the cost
+    // #2383 fix C exists to avoid (a 1.58M-entry parse continuing after a client
+    // disconnect); the read is bounded by file size, not by entry count. That
+    // placement is fix C's, is unchanged by #3940, and was equally true of the
+    // calibrated-margin predecessor — whose cancel also landed after the read.
+    //
+    // WHY THIS IS NOT STRENGTHENED WITH THE PARSE COUNTER, so the idea is not
+    // re-proposed: `cqlite.sstable.index_parses_total` would prove the full parse
+    // did not complete, but reading it needs the OTel capture harness, which
+    // installs a PROCESS-GLOBAL meter provider and therefore must not share
+    // cqlite-flight's parallel `--lib` unit-test binary (roborev #2163 precedent;
+    // the #3382 `OnceLock` poisoning class). This test is a `--lib` unit test, so
+    // that counter is unavailable to it by construction, not by omission.
+    //
     // WHAT IT DOES NOT DISCRIMINATE, stated because a silent narrowing is
     // indistinguishable from coverage: a cancel positioned at the open boundary is
     // caught by fix C's coarse PRE-PARSE check, which is behaviourally identical

--- a/cqlite-flight/src/warm/spin_tests_2383.rs
+++ b/cqlite-flight/src/warm/spin_tests_2383.rs
@@ -25,7 +25,6 @@
 //! crate-internal test hooks (`set_open_barrier`, `debug_*`, `metrics`).
 
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::Duration;
@@ -326,24 +325,22 @@ fn concurrent_misses_single_flight_one_parse_per_generation() {
 
 /// **Fix C — cancel granularity inside the parse.** Cancelling DURING a large
 /// `Index.db` parse must abort promptly with `WarmError::Cancelled`, not run the
-/// whole O(entries) parse to completion. A single big generation (150k partitions)
-/// makes the parse dominate wall time; the canceller waits until the open has
-/// begun (the open barrier fired), then — after a margin that guarantees the
-/// registry's coarse pre-open cancel check has already passed — trips the flag
-/// mid-parse.
+/// whole O(entries) parse to completion. A single big generation (150k
+/// partitions) keeps that parse the dominant cost of the open being aborted.
 ///
-/// The margin is CALIBRATED against this host's own just-measured cost of fully
-/// opening+parsing this exact fixture (issue #2383 roborev-1653 NIT 5 — "no
-/// wall-clock races in tests"), not a fixed constant: a hardcoded sleep flakes on
-/// a fast host once the full parse completes faster than the constant, and
-/// raising the entry count to force a structural floor was measured to scale
-/// FAR worse than linearly in `SSTableReader::open` (150k → 1.8s, 2M → 5+min;
-/// not this issue's fix surface), so it is not a viable alternative here. A
-/// small, conservative FRACTION of a just-measured baseline instead scales DOWN
-/// automatically with host speed — comfortably past the microsecond-scale
-/// coarse pre-open check (a same-thread, no-I/O comparison) and comfortably
-/// short of the real run's parse, including under page-cache speedup from the
-/// calibration pass warming the OS cache for the timed run.
+/// Positioning is STRUCTURAL, not calibrated (issue #3940). The cancel is
+/// tripped by the OPENING thread itself, from the pre-parse barrier inside the
+/// coalesced real-open closure — downstream of `rebuild`'s pre-rebuild and
+/// pre-open cancel checks, of `open_added`'s per-iteration check and of the
+/// coalescer's follower poll — so no cancel gate but the parse's own
+/// `ScanCancel` polling can observe it. The predecessor of this test slept
+/// `baseline / 20` on a second thread, where `baseline` was a separately-timed
+/// uncancelled warm of the same fixture; that compares two DIFFERENT scheduling
+/// windows and failed the `flight-tests` gate under concurrent-gate CPU
+/// contention (the sleep outlived the parse, so the open returned `Ok`). There
+/// is now no clock, no sleep, no calibration pass and no canceller thread. The
+/// exact discrimination boundary — including what this positioning does NOT
+/// cover — is stated at the assertion site.
 ///
 /// RED pre-#2383-fix-C: neither `parse_all_partition_keys_with_summary` nor
 /// `SSTableReader::open` polled the cancel flag, so once past the coarse
@@ -369,65 +366,70 @@ fn cancel_during_large_index_parse_aborts_promptly() {
     let schema = simple_schema();
     let (_temp, table_dir) = build_big_single_gen(&schema, 150_000);
 
-    // Calibrate: fully open+parse the SAME fixture, uncancelled, once — this also
-    // warms the OS page cache ahead of the timed run below (biasing that run
-    // FASTER, never slower, than this baseline).
-    let calib_start = std::time::Instant::now();
-    WarmTableRegistry::new()
-        .warm_readers(
-            &key(),
-            ddl(),
-            &schema,
-            None,
-            &table_dir,
-            None,
-            &CancelFlag::new(),
-        )
-        .expect("calibration warm (uncancelled) completes");
-    let baseline = calib_start.elapsed();
-    // 1/20th of the measured baseline: tens of ms on every host we've observed,
-    // dwarfing the coarse check's same-thread gap, and a small enough fraction to
-    // stay comfortably inside the timed run even under real page-cache speedup.
-    let margin = baseline / 20;
-
     let reg = WarmTableRegistry::new();
     let cancel = CancelFlag::new();
 
-    // Signal when the (single) open has started; the open barrier fires at the top
-    // of the open loop, immediately BEFORE the registry's coarse pre-open cancel
-    // check — so the canceller waits for it, then adds the calibrated margin so
-    // that coarse check has certainly passed and we are now inside the parse.
-    let open_started = Arc::new(AtomicBool::new(false));
+    // Position the cancel STRUCTURALLY, not temporally (issue #3940).
+    //
+    // The pre-parse barrier fires on the opening thread INSIDE the coalesced
+    // real-open closure: downstream of `rebuild`'s pre-rebuild and pre-open
+    // cancel checks, downstream of `open_added`'s per-iteration check, and
+    // downstream of the coalescer's follower-wait poll (this call is the LEADER,
+    // whose path has no cancel gate of its own). Tripping the flag from the
+    // barrier therefore puts the cancellation in front of the reader open+parse
+    // with NO other observer left between the two.
     {
-        let flag = Arc::clone(&open_started);
-        reg.set_open_barrier(Arc::new(move || flag.store(true, Ordering::SeqCst)));
+        let cancel = cancel.clone();
+        reg.set_open_parse_barrier(Arc::new(move || cancel.cancel()));
     }
 
-    let canceller = {
-        let cancel = cancel.clone();
-        let open_started = Arc::clone(&open_started);
-        thread::spawn(move || {
-            while !open_started.load(Ordering::SeqCst) {
-                thread::yield_now();
-            }
-            // Margin: let the coarse pre-open cancel check run first, so this trip
-            // lands strictly DURING the parse (never at the coarse boundary, which
-            // the unfixed code already honors).
-            thread::sleep(margin);
-            cancel.cancel();
-        })
-    };
-
     let res = reg.warm_readers(&key(), ddl(), &schema, None, &table_dir, None, &cancel);
-    canceller.join().expect("canceller");
 
-    // RED today: the parse ignores the mid-parse cancel and returns Ok. GREEN once
-    // the parse loop polls the cancel flag (fix C) and returns Cancelled promptly.
+    // WHAT REPLACED THE 1/20th CALIBRATED MARGIN, AND WHY IT IS CONTENTION-IMMUNE
+    // (issue #3940).
+    //
+    // This assertion was always `matches!(res, Err(WarmError::Cancelled))` — never
+    // a timing assert. The wall clock was only ever a POSITIONING DEVICE: a
+    // canceller thread slept `baseline / 20` (a separately-measured uncancelled
+    // warm) so its trip would land past the coarse pre-open check and inside the
+    // parse. That compares TWO scheduling windows — the calibration warm and the
+    // timed warm — and under concurrent-gate CPU contention they see different CPU
+    // availability, so `margin` came out longer than the timed parse and the
+    // cancel arrived AFTER the open had already returned `Ok`. Hence the
+    // `flight-tests` flake.
+    //
+    // Positioning is now structural: the cancel is tripped BY the opening thread
+    // itself, at a fixed point in the call graph, before the parse begins. There
+    // is no clock, no sleep, no calibration run and no second thread — so there
+    // are no two scheduling windows to compare and nothing for CPU contention to
+    // skew. The ordering the old margin tried to buy probabilistically is now an
+    // invariant of the control flow.
+    //
+    // WHAT THIS DISCRIMINATES: the `CancelFlag` -> `ScanCancel` bridge
+    // (`open_added`) and the Index.db open/parse's cancel awareness (#2383 fix C,
+    // `IndexReader::open_with_summary_cancellable` ->
+    // `parse_index_data_cancellable`) surfacing `Error::Cancelled` BY VARIANT, and
+    // `rebuild` mapping it to `WarmError::Cancelled` instead of a fail-closed
+    // retain. Verified by positive control: with fix C's parse-side cancel polling
+    // removed, this assertion FAILS with `res == Ok`.
+    //
+    // WHAT IT DOES NOT DISCRIMINATE, stated because a silent narrowing is
+    // indistinguishable from coverage: a cancel positioned at the open boundary is
+    // caught by fix C's coarse PRE-PARSE check, which is behaviourally identical
+    // to the entry-loop's own poll at entry 0 — so removing ONLY the in-loop
+    // `entry_index % CANCEL_POLL_INTERVAL` poll leaves this test GREEN. Landing a
+    // cancel strictly BETWEEN two parsed entries is not reachable from this crate
+    // without a clock (the loop lives in cqlite-core and exposes no progress
+    // signal), so that stride's own coverage belongs to a cqlite-core-local test
+    // beside the loop, not here. Trading a probabilistic in-loop landing for a
+    // deterministic pre-parse one is the deliberate choice of #3940: the old test
+    // did not reliably land in the loop either, it merely failed loudly when it
+    // missed.
     assert!(
         matches!(res, Err(WarmError::Cancelled)),
-        "a cancel tripped DURING a large Index.db parse must abort promptly with \
-         Cancelled (calibrated margin {margin:?} from baseline {baseline:?}), got \
-         {:?} (issue #2383 fix C)",
+        "a cancel tripped on the opening thread immediately before a large \
+         Index.db open+parse must abort with Cancelled, got {:?} (issue #2383 \
+         fix C; positioning per issue #3940)",
         res.map(|w| (w.outcome, w.readers.len()))
     );
 }

--- a/cqlite-flight/src/warm/spin_tests_2383.rs
+++ b/cqlite-flight/src/warm/spin_tests_2383.rs
@@ -323,10 +323,19 @@ fn concurrent_misses_single_flight_one_parse_per_generation() {
     drop(temp);
 }
 
-/// **Fix C — cancel granularity inside the parse.** Cancelling DURING a large
-/// `Index.db` parse must abort promptly with `WarmError::Cancelled`, not run the
-/// whole O(entries) parse to completion. A single big generation (150k
-/// partitions) keeps that parse the dominant cost of the open being aborted.
+/// **Fix C — cancel granularity at the parse.** A cancel that becomes visible AT
+/// THE ENTRY to a large `Index.db` open+parse must abort promptly with
+/// `WarmError::Cancelled`, not run the whole O(entries) parse to completion. A
+/// single big generation (150k partitions) keeps that parse the dominant cost of
+/// the open being aborted.
+///
+/// The name says `at_entry`, not `during`, and that is deliberate (issue #3940):
+/// the cancel lands immediately BEFORE the entry loop, so what this test
+/// discriminates is the parse's cancel AWARENESS, not its poll STRIDE. A name is
+/// a claim about behaviour (the #3641 ruling), and the predecessor's name —
+/// `cancel_during_large_index_parse_aborts_promptly` — would now overstate it.
+/// The stride's own coverage lives beside the loop in cqlite-core and is named
+/// at the assertion site.
 ///
 /// Positioning is STRUCTURAL, not calibrated (issue #3940). The cancel is
 /// tripped by the OPENING thread itself, from the pre-parse barrier inside the
@@ -362,7 +371,7 @@ fn concurrent_misses_single_flight_one_parse_per_generation() {
 /// `ensure_materialized_cancel_mid_parse_aborts_promptly`
 /// (`cqlite-core/src/storage/sstable/index_reader/lazy.rs`).
 #[test]
-fn cancel_during_large_index_parse_aborts_promptly() {
+fn cancel_at_large_index_parse_entry_aborts_promptly() {
     let schema = simple_schema();
     let (_temp, table_dir) = build_big_single_gen(&schema, 150_000);
 
@@ -441,9 +450,9 @@ fn cancel_during_large_index_parse_aborts_promptly() {
     // mid-loop landing is precisely that test's value) and is tracked as issue #3982.
     assert!(
         matches!(res, Err(WarmError::Cancelled)),
-        "a cancel tripped on the opening thread immediately before a large \
+        "a cancel tripped on the opening thread AT THE ENTRY to a large \
          Index.db open+parse must abort with Cancelled, got {:?} (issue #2383 \
-         fix C; positioning per issue #3940)",
+         fix C; structural positioning + name per issue #3940)",
         res.map(|w| (w.outcome, w.readers.len()))
     );
 }

--- a/cqlite-flight/tests/issue_2383_resolve_spin_test.rs
+++ b/cqlite-flight/tests/issue_2383_resolve_spin_test.rs
@@ -193,7 +193,7 @@ async fn do_get_drain(svc: &CqliteFlightService, ticket: Vec<u8>) -> usize {
 /// × opens) amplification, seen as 8× re-parses for one logical query).
 ///
 /// Re-anchored (issue #2412, coordinator-flagged regression class — same root
-/// cause as `spin_tests_2383::cancel_during_large_index_parse_aborts_promptly`):
+/// cause as `spin_tests_2383::cancel_at_large_index_parse_entry_aborts_promptly`):
 /// this test originally asserted query 1 (cold) full-parses `Index.db` `>= 2`
 /// (once per generation) via `index_parses_total`. Since #2412 Stage 2, BIG
 /// open defers that parse (`open_lazy`) whenever a usable `Summary.db` is


### PR DESCRIPTION
Closes #3940.

## What was wrong

`cqlite-flight`'s `cancel_during_large_index_parse_aborts_promptly` FAILed the `flight-tests` gate
component under concurrent-gate CPU contention, reddening a gate of record in which **36 of 37
components passed** on a diff containing zero Rust.

**One correction to the issue's framing, because it changes the fix.** The assertion was never a
timing assert — it was `matches!(res, Err(WarmError::Cancelled))`. The wall clock was only a
*positioning device*: a canceller thread slept `margin = baseline / 20` so its trip would land past
the registry's coarse pre-open cancel check (`rebuild.rs:348`) and inside the `Index.db` parse.

That makes the flake **directional**, not symmetric jitter:

1. contention inflates `baseline`, so `margin` is large;
2. the timed run is then *faster* — the calibration pass warmed the OS page cache, as its own
   comment said;
3. the sleep outlives the parse, so the cancel is set after `open_added` already returned `Ok`.

Which is exactly why it was reported 3/3 green in isolation.

## The fix

Positioning is now **structural**, per the issue's suggestion #2. A `#[cfg(test)]`
`open_parse_barrier` fires on the opening thread inside the coalesced real-open closure in
`open_added` — downstream of `rebuild`'s pre-rebuild and pre-open checks, of `open_added`'s
per-iteration check, and of the coalescer's follower poll — and the test's callback trips the cancel
flag there. **No `Instant`, no `sleep`, no calibration pass, no canceller thread**, so there are no
two scheduling windows to compare and nothing for contention to skew.

The barrier fires in `Role::Lead` and `Role::DeadPathFallThrough` — i.e. every thread that performs
a real open — and not in `Role::Hit`/`Role::Follow`, and the `Lead` arm has no cancel gate between
role election and `do_open()`. Verified against the coalescer, because the whole fix rests on that
position.

## Acceptance criteria

- [x] **Does not fail under concurrent-gate CPU contention.** 25/25 pass with 32 spinners on a
      16-core box already carrying nine peer lanes (loadavg 11.8 → 28.5), behind a pre-load sanity
      gate so a broken harness cannot read as a pass. The subagent's earlier runs add 20/20 (32
      spinners) and 30/30 (64 spinners).
- [x] **The replacement is justified at the assertion site**, stating what it measures and why it is
      contention-immune — plus, deliberately, what it does *not* cover.
- [x] **`flight-tests` green on an unloaded host** — `--lite` `scoped-tests` PASS, 403 cqlite-flight
      tests, at every round.

## Evidence: the positive control, which is the only thing that makes this valid

A deterministic reposition is a substitute only if it still **discriminates**. If any cancel gate
between the barrier and the parse's own `ScanCancel` poll returned `Cancelled` by itself, this test
would go green with fix C reverted — a vacuous pass wearing the old test's name, strictly worse than
the flake. Run in a throwaway `git worktree`, not the dirty tree:

| configuration | result |
|---|---|
| both fix-C poll sites disabled (coarse pre-parse + in-loop stride) | **RED** — `got Ok((RebuiltDelta, 1))` |
| only the in-loop stride poll disabled | GREEN (the declared narrowing) |
| only the in-loop stride poll disabled, core sibling | **RED** — so the stride *is* covered |

So discrimination is retained, and the narrowing is **declared and measured** rather than asserted.

## What this deliberately does not cover, and where it went

Landing a cancel strictly *between* two parsed entries is not reachable from this crate without a
clock — the loop is in `cqlite-core` and exposes no progress signal. The repository does not lose
that coverage: `ensure_materialized_cancel_mid_parse_aborts_promptly` (400k entries, several
`CANCEL_POLL_INTERVAL` windows) holds it, measured above.

**#3982 filed** — that sibling carries the *identical* `baseline/20` construction, and its own doc
comment cites this test as the shared convention. Same defect, one crate over, in a longer gate
component. Not folded in here: different crate, and a deterministic fix there needs a hook *inside*
the core parse loop, which is a real design call with its own review surface.

## An honest limitation: this was not reproduced synthetically

The **old** test passed 20/20, 30/30 and 6/6×3 under 32 and 64 spinners and asymmetric spinner
lifetimes. Uniform load slows the calibration and timed windows *equally*, so `margin` scales with
the parse and the ratio survives. The field failure needed contention **heavy during calibration and
relieved during measurement**, which is what two concurrent gates produce as components start and
finish.

So this PR does **not** claim "reproduced, then fixed". It rests on the mechanism (no clock ⇒ no two
windows), the positive control, and the field evidence in the issue (`run-id
/tmp/agent-gate.Xi0zGT`, `commit d41395f`). Recorded in #3982 too, so "spinners don't reproduce it"
is not later triaged as evidence against.

## Review

- `--lite`: **PASS** at `30428cf` (`tree-integrity: PASS`, `dirty: no`).
- roborev jobs 89 and 90, both with every deterministic key PASS and `prompt-content: PASS`
  (4/4 then 5/5 census code paths present).
  - Job 89 (Medium) said the test no longer exercises the entry loop "despite its **name**". The
    coverage half is answered above; **the naming half was a real defect** and this repo's own #3641
    ruling — *a name is a claim about behaviour*. Renamed
    `cancel_during_large_index_parse_aborts_promptly` →
    `cancel_at_large_index_parse_entry_aborts_promptly`, doc header corrected, predecessor's name
    kept so the history is followable.
  - Job 90 observed, correctly, that cancellation is checked only **after** `Index.db` is read into
    memory. True, not a regression (the predecessor's cancel also landed after the read), and it
    does not undercut the property: the O(entries) entry loop is skipped entirely, which is the cost
    fix C exists to avoid. The word "promptly" is now scoped at the assertion site.
  - Its suggested fix — parse-progress instrumentation in `cqlite-core` — **is #3982**.
- `index_parses_total` would prove the full parse did not complete, but it needs the OTel
  process-global meter provider, which must not share the parallel `--lib` binary (#2163 precedent,
  #3382 `OnceLock` class). Unavailable by construction; written down at the site so it is not
  re-proposed each round.

## Residual for the closer

The stride finding is expected to re-report a third time, since the only remaining fix for it is in
another crate. **It is not to be fixed here and not to be merged past silently** — it needs a
lead-granted `roborev-defer: findings` naming #3982 and that round's own base/head/job (#3626).
A worker may request, never grant.

Gate of record has NOT been run yet — that is the closer's single run.