### PR TITLE
test(#3846): the nested-frozen-UDT gap's golden must DECODE the declared UDT, and canon_matches_declared_kinds gets direct coverage

### DIFF
--- a/cqlite-cli/tests/support/golden_value_canon_container.rs
+++ b/cqlite-cli/tests/support/golden_value_canon_container.rs
@@ -834,3 +834,9 @@ fn brief(s: &str) -> String {
 #[cfg(test)]
 #[path = "golden_value_canon_container_tests.rs"]
 mod tests;
+
+// The LEAF question `canon_matches_declared_kinds` answers, in a suite of its own:
+// it had no direct coverage at all and is now a SECOND caller's rule (issue #3846).
+#[cfg(test)]
+#[path = "golden_value_canon_kinds_tests.rs"]
+mod kinds_tests;

--- a/cqlite-cli/tests/support/golden_value_canon_kinds_tests.rs
+++ b/cqlite-cli/tests/support/golden_value_canon_kinds_tests.rs
@@ -1,0 +1,542 @@
+//! Direct unit coverage for [`super::canon_matches_declared_kinds`] — the LEAF
+//! question the gap machinery asks of a canonical value (issue #3846).
+//!
+//! # Why a suite of its own
+//!
+//! That function had no direct test at all. It was reached only through
+//! `compare::gap::Divergence::NestedFrozenValueLeftUndecodedByGolden` — one call
+//! site, one declared type family — so only its `Numeric` and `Boolean` arms were
+//! ever exercised, and then only indirectly, while the arms added since (the
+//! per-type scalar spellings of roborev job 105, the CSV boolean pair of job 72,
+//! `NullHere`'s positional rule from job 60, and every container arm) were covered
+//! by nothing that names them. A rule reached only as a side effect of another
+//! check is a rule whose narrowing or widening is invisible: an arm can be relaxed
+//! without reddening anything as long as the one caller's cases keep their verdicts.
+//!
+//! It is also now a SECOND caller's rule
+//! (`Divergence::NestedFrozenUdtRendersAsBlobHex`, issue #3846), which makes each
+//! arm's behaviour shared rather than incidental to one gap.
+//!
+//! # Where the expectations come from
+//!
+//! Every accepted spelling below is `cassandra-5.0.8`'s, read at the pin, or the
+//! committed DDL's — never CQLite's current output (CLAUDE.md: a CQLite `file:line`
+//! is never format authority). The individual scalar spellings are pinned as
+//! predicates in `golden_value_scalar_spelling_tests.rs`; what these cases pin is
+//! that THIS function consults them, per declared type, and what each container arm
+//! does with its members.
+//!
+//! Every rule is asked from BOTH sides — a `Canon` the declared type implies, and
+//! one it does not — because a one-sided case passes just as well when the arm has
+//! stopped discriminating at all.
+
+use super::super::schema::{CqlType, UdtType};
+use super::super::{Canon, Egress};
+use super::canon_matches_declared_kinds;
+
+// =======================================================================
+// Helpers: the declared types and the canonical values, spelled out
+// =======================================================================
+
+fn text_ty() -> CqlType {
+    CqlType::Text("text".to_string())
+}
+
+fn int_ty() -> CqlType {
+    CqlType::Numeric("int".to_string())
+}
+
+fn num(text: &str) -> Canon {
+    Canon::Num(text.to_string())
+}
+
+fn text(s: &str) -> Canon {
+    Canon::Text(s.to_string())
+}
+
+/// `matches` under BOTH egresses, for the arms whose answer does not depend on one.
+/// Stated as a helper rather than repeated so a case cannot silently cover one
+/// egress only.
+fn matches_both(canon: &Canon, ty: &CqlType) -> (bool, bool) {
+    (
+        canon_matches_declared_kinds(canon, ty, Egress::Json),
+        canon_matches_declared_kinds(canon, ty, Egress::Csv),
+    )
+}
+
+// =======================================================================
+// The entry point: a whole CELL may be null; a MEMBER may not
+// =======================================================================
+
+/// A null CELL is accepted at the entry point for every declared type, and that is
+/// a positional fact rather than a relaxation: the row may simply not have written
+/// the column.
+#[test]
+fn a_null_cell_is_accepted_at_every_declared_type() {
+    for ty in [
+        int_ty(),
+        text_ty(),
+        CqlType::Boolean,
+        CqlType::Blob,
+        CqlType::Timestamp,
+        CqlType::Opaque("uuid".to_string()),
+        CqlType::List(Box::new(int_ty())),
+        CqlType::Set(Box::new(int_ty())),
+        CqlType::Map(Box::new(text_ty()), Box::new(int_ty())),
+        CqlType::Tuple(vec![int_ty()]),
+        CqlType::Udt(UdtType {
+            name: "u".to_string(),
+            fields: vec![("f".to_string(), int_ty())],
+        }),
+    ] {
+        let (json, csv) = matches_both(&Canon::Null, &ty);
+        assert!(
+            json && csv,
+            "a null CELL of declared type `{}` is legal in both egresses",
+            ty.describe()
+        );
+    }
+}
+
+/// CQL does not permit a null INSIDE a collection — a `set<int>` cannot hold one,
+/// and writing a null map value DELETES the entry rather than storing one — so a
+/// null at a collection ELEMENT, a map KEY or a map VALUE is not a decode of that
+/// type (roborev job 60). It DOES permit a null TUPLE SLOT and a null UDT FIELD:
+/// `cassandra-5.0.8 UserType.toJSONString` writes `null` for a field whose buffer
+/// is absent, which is why a dump of a frozen UDT always carries every declared
+/// field.
+#[test]
+fn a_null_member_is_positional_forbidden_in_collections_legal_in_tuples_and_udts() {
+    let forbidden: &[(CqlType, Canon)] = &[
+        (
+            CqlType::List(Box::new(int_ty())),
+            Canon::Seq(vec![Canon::Null]),
+        ),
+        (
+            CqlType::Set(Box::new(int_ty())),
+            Canon::Seq(vec![Canon::Null]),
+        ),
+        (
+            CqlType::Map(Box::new(text_ty()), Box::new(int_ty())),
+            Canon::Entries(vec![(Canon::Null, num("1"))]),
+        ),
+        (
+            CqlType::Map(Box::new(text_ty()), Box::new(int_ty())),
+            Canon::Entries(vec![(text("k"), Canon::Null)]),
+        ),
+    ];
+    for (ty, canon) in forbidden {
+        let (json, csv) = matches_both(canon, ty);
+        assert!(
+            !json && !csv,
+            "a null member of `{}` is not a decode of that type",
+            ty.describe()
+        );
+    }
+
+    let allowed: &[(CqlType, Canon)] = &[
+        (
+            CqlType::Tuple(vec![int_ty(), text_ty()]),
+            Canon::Seq(vec![Canon::Null, text("x")]),
+        ),
+        (
+            CqlType::Udt(UdtType {
+                name: "u".to_string(),
+                fields: vec![("a".to_string(), int_ty()), ("b".to_string(), text_ty())],
+            }),
+            Canon::Fields(vec![
+                ("a".to_string(), Canon::Null),
+                ("b".to_string(), text("x")),
+            ]),
+        ),
+    ];
+    for (ty, canon) in allowed {
+        let (json, csv) = matches_both(canon, ty);
+        assert!(
+            json && csv,
+            "a null tuple slot / UDT field IS what toJSONString writes for `{}`",
+            ty.describe()
+        );
+    }
+}
+
+// =======================================================================
+// The scalar arms, one declared type at a time
+// =======================================================================
+
+/// A NUMERIC declared type takes [`Canon::Num`] and nothing else. This is the arm
+/// the one historical caller exercised, and the reason the function exists:
+/// `canon_typed` canonicalizes a string at a declared `int` as `Canon::Text` ON
+/// PURPOSE, so that the COMPARISON reports the inequality — which is no use at a
+/// position where the other side is undecoded (roborev job 38).
+#[test]
+fn a_numeric_declared_type_takes_a_number_only() {
+    let ty = int_ty();
+    let (json, csv) = matches_both(&num("42"), &ty);
+    assert!(json && csv, "a canonicalized number IS an `int` decode");
+    for wrong in [text("not-an-int"), text("42"), Canon::Bool(true)] {
+        let (json, csv) = matches_both(&wrong, &ty);
+        assert!(
+            !json && !csv,
+            "{wrong:?} is not a decode of `int`: canon_typed emits `Canon::Num` there"
+        );
+    }
+}
+
+/// `text`/`varchar`/`ascii`: EVERY string is a well-formed value, so
+/// [`Canon::Text`] is the whole question and there is deliberately nothing to
+/// narrow — including a string that happens to look like another type's spelling.
+/// A number is still refused: `UTF8Type.toJSONString` quotes its value with
+/// `JsonUtils.quoteAsJsonString`, so a `text` column is a JSON string.
+#[test]
+fn a_text_declared_type_takes_any_string_and_no_other_kind() {
+    for name in ["text", "varchar", "ascii"] {
+        let ty = CqlType::Text(name.to_string());
+        for any in [text(""), text("0xnothex"), text("not-a-uuid"), text("42")] {
+            let (json, csv) = matches_both(&any, &ty);
+            assert!(
+                json && csv,
+                "every string is a well-formed `{name}` value: {any:?}"
+            );
+        }
+        for wrong in [num("42"), Canon::Bool(true)] {
+            let (json, csv) = matches_both(&wrong, &ty);
+            assert!(!json && !csv, "{wrong:?} is not a `{name}` decode");
+        }
+    }
+}
+
+/// BOOLEAN is the one EGRESS-AWARE arm, because the projection differs:
+/// `Canon::for_csv` renders a boolean as its TEXT spelling, so the text form is
+/// legal under [`Egress::Csv`] and not under [`Egress::Json`] — but ONLY the two
+/// spellings that projection can produce. Accepting every `Canon::Text` there let
+/// `"not-a-bool"` qualify as a decoded boolean (roborev job 72). Authority for the
+/// pair: `cassandra-5.0.8 BooleanSerializer.toString` returns `value.toString()`,
+/// i.e. `true`/`false`, and `for_csv` uses Rust's `bool::to_string`, the same two
+/// words.
+#[test]
+fn a_boolean_declared_type_is_egress_aware_and_takes_only_the_two_spellings() {
+    let ty = CqlType::Boolean;
+    for b in [true, false] {
+        let (json, csv) = matches_both(&Canon::Bool(b), &ty);
+        assert!(
+            json && csv,
+            "a `Canon::Bool` is a boolean decode in both egresses"
+        );
+    }
+    for spelling in ["true", "false"] {
+        assert!(
+            canon_matches_declared_kinds(&text(spelling), &ty, Egress::Csv),
+            "`{spelling}` is what `for_csv` renders a boolean as"
+        );
+        assert!(
+            !canon_matches_declared_kinds(&text(spelling), &ty, Egress::Json),
+            "the JSON egress carries the raw JSON boolean, so `\"{spelling}\"` is a \
+             kind divergence there and not a decode"
+        );
+    }
+    for wrong in [text("not-a-bool"), text("TRUE"), text("1"), num("1")] {
+        let (json, csv) = matches_both(&wrong, &ty);
+        assert!(
+            !json && !csv,
+            "{wrong:?} is not a spelling BooleanSerializer.toString or for_csv can produce"
+        );
+    }
+}
+
+/// The three declared types that share [`Canon::Text`] with `text` each get ONE
+/// BOUNDED SPELLING CHECK, so a non-hex blob, a malformed timestamp and arbitrary
+/// text at an opaque position are no longer decodes of those types (roborev job
+/// 105). What is pinned here is that this function CONSULTS the per-type rule; the
+/// spellings themselves are `scalar_spelling`'s, pinned in its own suite.
+#[test]
+fn blob_timestamp_and_opaque_declared_types_each_consult_their_own_spelling() {
+    // (declared type, a spelling that type HAS, a spelling it does NOT).
+    let cases: &[(CqlType, &str, &str)] = &[
+        // `BytesType.toJSONString` = `"0x" + bytesToHex(buffer)`; the refused text is
+        // `BytesSerializer.toString`'s BARE hex, which is the `getString` spelling.
+        (CqlType::Blob, "0xdeadbeef", "deadbeef"),
+        // `TimestampType.toJSONString` writes `TimestampSerializer.toString`'s UTC
+        // form; `canon_timestamp` maps both legitimate spellings onto one canonical
+        // form and passes anything else through verbatim, so an unrecognised spelling
+        // is exactly "the canonicalizer did not see a timestamp here".
+        (
+            CqlType::Timestamp,
+            "2025-10-06T01:12:05.394Z",
+            "not-a-timestamp",
+        ),
+        // `UUIDSerializer.toString` = Java `UUID.toString`.
+        (
+            CqlType::Opaque("uuid".to_string()),
+            "15291a77-d739-4e73-8397-b787442f3a1f",
+            "not-a-uuid",
+        ),
+        (
+            CqlType::Opaque("timeuuid".to_string()),
+            "78f64100-a251-11f0-a18d-d6726a637a4c",
+            "not-a-timeuuid",
+        ),
+        // `SimpleDateSerializer.toString` = `ISO_LOCAL_DATE`.
+        (
+            CqlType::Opaque("date".to_string()),
+            "2025-06-18",
+            "18/06/2025",
+        ),
+        // `TimeSerializer.toString` = fixed-width `HH:MM:SS.nnnnnnnnn`.
+        (
+            CqlType::Opaque("time".to_string()),
+            "01:12:05.394017000",
+            "01:12:05",
+        ),
+        // `Duration.toString` = `<digits><unit>` groups in the fixed order
+        // `y mo d h m s ms us ns`.
+        (
+            CqlType::Opaque("duration".to_string()),
+            "46702000000000ns",
+            "12 hours",
+        ),
+        // `InetAddressSerializer.toString` = `getHostAddress()`, i.e. an address
+        // literal and nothing else.
+        (
+            CqlType::Opaque("inet".to_string()),
+            "154.47.65.214",
+            "not-an-address",
+        ),
+    ];
+    for (ty, spelled, misspelled) in cases {
+        // The CONTROL first, in both egresses: without it the refusal could pass
+        // because the arm had stopped matching this type at all.
+        let (json, csv) = matches_both(&text(spelled), ty);
+        assert!(
+            json && csv,
+            "`{spelled}` IS a spelling a `{}` value has",
+            ty.describe()
+        );
+        let (json, csv) = matches_both(&text(misspelled), ty);
+        assert!(
+            !json && !csv,
+            "`{misspelled}` is not a spelling a `{}` value has, so it is not a decode \
+             of that type",
+            ty.describe()
+        );
+        // And the VARIANT still has to be `Canon::Text`.
+        let (json, csv) = matches_both(&num("1"), ty);
+        assert!(
+            !json && !csv,
+            "a number is not a `{}` decode: canon_typed emits `Canon::Text` there",
+            ty.describe()
+        );
+    }
+}
+
+/// An OPAQUE type this module has read NO authority for is REFUSED rather than
+/// given a guessed rule: `opaque_spelling_matches` answers `None`, and the caller
+/// must treat that as a non-match (`== Some(true)`, never `!= Some(false)`). That
+/// is the fail-closed direction — the gap stops suppressing and an ordinary diff is
+/// reported, which a reader can act on, where accepting arbitrary text cannot be
+/// recovered from.
+///
+/// Constructed directly BECAUSE the schema reader cannot produce this value (an
+/// unknown type name is a hard parse error there), so this pins that arm's own
+/// fail-closed branch.
+#[test]
+fn an_opaque_type_with_no_authority_is_refused_never_given_a_guessed_rule() {
+    let ty = CqlType::Opaque("vector".to_string());
+    for any in [text("anything"), text(""), text("0xdeadbeef")] {
+        let (json, csv) = matches_both(&any, &ty);
+        assert!(
+            !json && !csv,
+            "an opaque type with no spelling rule must be refused: {any:?}"
+        );
+    }
+}
+
+// =======================================================================
+// The container arms: the variant, and every member recursively
+// =======================================================================
+
+/// A LIST and a SET both require [`Canon::Seq`] and hold EVERY element to the
+/// declared element type. One bad element is enough: the question is whether the
+/// value is a decode of the declared type, not whether most of it is.
+#[test]
+fn a_list_or_set_requires_a_seq_and_checks_every_element() {
+    for ty in [
+        CqlType::List(Box::new(int_ty())),
+        CqlType::Set(Box::new(int_ty())),
+    ] {
+        let (json, csv) = matches_both(&Canon::Seq(vec![num("1"), num("2")]), &ty);
+        assert!(
+            json && csv,
+            "a seq of numbers IS a decode of `{}`",
+            ty.describe()
+        );
+        // Empty is a decode too: an empty frozen collection is a legal value.
+        let (json, csv) = matches_both(&Canon::Seq(vec![]), &ty);
+        assert!(
+            json && csv,
+            "an empty seq is a decode of `{}`",
+            ty.describe()
+        );
+        // ONE bad element, in each position, and a wrong VARIANT.
+        for wrong in [
+            Canon::Seq(vec![text("not-an-int"), num("2")]),
+            Canon::Seq(vec![num("1"), text("not-an-int")]),
+            Canon::Entries(vec![(num("1"), num("2"))]),
+            Canon::Fields(vec![("f".to_string(), num("1"))]),
+            num("1"),
+            text("[1, 2]"),
+        ] {
+            let (json, csv) = matches_both(&wrong, &ty);
+            assert!(
+                !json && !csv,
+                "{wrong:?} is not a decode of `{}`",
+                ty.describe()
+            );
+        }
+    }
+}
+
+/// A TUPLE requires [`Canon::Seq`] and checks each slot against its OWN declared
+/// type, positionally. ARITY is deliberately not this function's question —
+/// `canon_container` refuses a tuple of the wrong arity before it can get here, and
+/// duplicating that rule would be a second opinion about it — so a SHORT seq's
+/// declared slots are checked pairwise, which is what `zip` does.
+#[test]
+fn a_tuple_checks_each_slot_against_its_own_declared_type() {
+    let ty = CqlType::Tuple(vec![int_ty(), text_ty()]);
+    let (json, csv) = matches_both(&Canon::Seq(vec![num("1"), text("x")]), &ty);
+    assert!(
+        json && csv,
+        "a number then a string IS a decode of that tuple"
+    );
+    // The slot types are NOT interchangeable: the same two members swapped are a
+    // decode of neither slot.
+    let (json, csv) = matches_both(&Canon::Seq(vec![text("x"), num("1")]), &ty);
+    assert!(!json && !csv, "the slot order is the declared one");
+    for wrong in [
+        Canon::Seq(vec![text("not-an-int"), text("x")]),
+        Canon::Entries(vec![(num("1"), text("x"))]),
+        num("1"),
+    ] {
+        let (json, csv) = matches_both(&wrong, &ty);
+        assert!(!json && !csv, "{wrong:?} is not a decode of that tuple");
+    }
+}
+
+/// A MAP requires [`Canon::Entries`] and checks BOTH halves of every entry against
+/// their own declared types.
+#[test]
+fn a_map_checks_both_halves_of_every_entry() {
+    let ty = CqlType::Map(Box::new(text_ty()), Box::new(int_ty()));
+    let (json, csv) = matches_both(
+        &Canon::Entries(vec![(text("a"), num("1")), (text("b"), num("2"))]),
+        &ty,
+    );
+    assert!(json && csv, "text keys and numeric values ARE a decode");
+    let (json, csv) = matches_both(&Canon::Entries(vec![]), &ty);
+    assert!(json && csv, "an empty map is a decode");
+    for wrong in [
+        // A KEY of the value's type, and a VALUE of the key's.
+        Canon::Entries(vec![(num("1"), num("1"))]),
+        Canon::Entries(vec![(text("a"), text("not-an-int"))]),
+        // One bad entry among good ones.
+        Canon::Entries(vec![(text("a"), num("1")), (text("b"), text("no"))]),
+        Canon::Seq(vec![text("a"), num("1")]),
+        text("{a: 1}"),
+    ] {
+        let (json, csv) = matches_both(&wrong, &ty);
+        assert!(!json && !csv, "{wrong:?} is not a decode of that map");
+    }
+}
+
+/// A UDT requires [`Canon::Fields`] and checks each field against the type the
+/// committed `CREATE TYPE` declares FOR THAT NAME.
+///
+/// A name the DDL does not declare answers FALSE rather than being tolerated: an
+/// undeclared name has no declared type, and a value with no declared type is never
+/// compared permissively. `canon_udt` already refuses such a value — the field SET
+/// and ORDER are its rules, quoting `cassandra-5.0.8 UserType.toJSONString` — so
+/// this arm's own branch is unreachable through `canon_typed`; it is pinned here
+/// because an unreachable-but-PERMISSIVE branch is worse than no branch (roborev
+/// job 305), and this suite is where that can be asked at all.
+#[test]
+fn a_udt_checks_each_field_against_the_type_declared_for_that_name() {
+    let ty = CqlType::Udt(UdtType {
+        name: "geo".to_string(),
+        fields: vec![
+            ("lat".to_string(), int_ty()),
+            ("tag".to_string(), text_ty()),
+        ],
+    });
+    let good = Canon::Fields(vec![
+        ("lat".to_string(), num("42")),
+        ("tag".to_string(), text("x")),
+    ]);
+    let (json, csv) = matches_both(&good, &ty);
+    assert!(json && csv, "the declared kinds per name ARE a decode");
+    for wrong in [
+        // The right names, the WRONG kinds — each field's own type is consulted.
+        Canon::Fields(vec![
+            ("lat".to_string(), text("not-an-int")),
+            ("tag".to_string(), text("x")),
+        ]),
+        Canon::Fields(vec![
+            ("lat".to_string(), num("42")),
+            ("tag".to_string(), num("42")),
+        ]),
+        // A name the CREATE TYPE does not declare.
+        Canon::Fields(vec![
+            ("lat".to_string(), num("42")),
+            ("elevation".to_string(), num("42")),
+        ]),
+        // The wrong VARIANT: a UDT is not a seq or a map, whatever its members are.
+        Canon::Seq(vec![num("42"), text("x")]),
+        Canon::Entries(vec![(text("lat"), num("42"))]),
+    ] {
+        let (json, csv) = matches_both(&wrong, &ty);
+        assert!(!json && !csv, "{wrong:?} is not a decode of `geo`");
+    }
+}
+
+/// The recursion carries the declared type down and the POSITIONAL null rule with
+/// it, so a leaf several levels deep is held to its own declared type and a null
+/// inside a nested collection is still forbidden while a nested UDT field's null is
+/// still legal.
+#[test]
+fn the_recursion_reaches_a_nested_leaf_and_keeps_the_positional_null_rule() {
+    // `list<frozen<tuple<int, frozen<map<text, blob>>>>>`
+    let ty = CqlType::List(Box::new(CqlType::Tuple(vec![
+        int_ty(),
+        CqlType::Map(Box::new(text_ty()), Box::new(CqlType::Blob)),
+    ])));
+    let good = Canon::Seq(vec![Canon::Seq(vec![
+        num("1"),
+        Canon::Entries(vec![(text("k"), text("0xdeadbeef"))]),
+    ])]);
+    let (json, csv) = matches_both(&good, &ty);
+    assert!(
+        json && csv,
+        "the nested decode is well-formed at every leaf"
+    );
+    // The DEEPEST leaf's own spelling rule still applies three levels down.
+    let bad_leaf = Canon::Seq(vec![Canon::Seq(vec![
+        num("1"),
+        Canon::Entries(vec![(text("k"), text("deadbeef"))]),
+    ])]);
+    let (json, csv) = matches_both(&bad_leaf, &ty);
+    assert!(
+        !json && !csv,
+        "bare hex at a nested `blob` is the getString spelling, not toJSONString's"
+    );
+    // A null MAP VALUE stays forbidden at depth…
+    let null_value = Canon::Seq(vec![Canon::Seq(vec![
+        num("1"),
+        Canon::Entries(vec![(text("k"), Canon::Null)]),
+    ])]);
+    let (json, csv) = matches_both(&null_value, &ty);
+    assert!(!json && !csv, "a null map value is not a stored entry");
+    // …while a null TUPLE SLOT stays legal at the same depth.
+    let null_slot = Canon::Seq(vec![Canon::Seq(vec![num("1"), Canon::Null])]);
+    let (json, csv) = matches_both(&null_slot, &ty);
+    assert!(json && csv, "a null tuple slot is legal at any depth");
+}

--- a/cqlite-cli/tests/support/golden_value_canon_kinds_tests.rs
+++ b/cqlite-cli/tests/support/golden_value_canon_kinds_tests.rs
@@ -540,3 +540,75 @@ fn the_recursion_reaches_a_nested_leaf_and_keeps_the_positional_null_rule() {
     let (json, csv) = matches_both(&null_slot, &ty);
     assert!(json && csv, "a null tuple slot is legal at any depth");
 }
+
+// =======================================================================
+// Completeness: a new declared-type variant cannot join this suite silently
+// =======================================================================
+
+/// Which case above asks about this declared type's arm.
+///
+/// The match is EXHAUSTIVE over [`CqlType`], so adding a variant does not compile
+/// until somebody names the case that covers it — the "derive, never curate" rule
+/// applied to a suite whose subject set is a Rust enum, and the reason this suite
+/// exists at all: `canon_matches_declared_kinds` grew four arms (roborev jobs 60,
+/// 72, 105 and this issue's) with no test naming any of them.
+///
+/// Like `scripts/tests/workspace-test-disposition.txt`, it records COMPLETENESS AND
+/// LABELING, not truth: it cannot check that the named case really exercises the
+/// arm, only that a decision was taken for every variant. That is deliberately the
+/// weaker claim, and it is the half a compiler can enforce.
+fn covering_case(ty: &CqlType) -> &'static str {
+    match ty {
+        CqlType::Numeric(_) => "a_numeric_declared_type_takes_a_number_only",
+        CqlType::Text(_) => "a_text_declared_type_takes_any_string_and_no_other_kind",
+        CqlType::Boolean => {
+            "a_boolean_declared_type_is_egress_aware_and_takes_only_the_two_spellings"
+        }
+        CqlType::Blob | CqlType::Timestamp | CqlType::Opaque(_) => {
+            "blob_timestamp_and_opaque_declared_types_each_consult_their_own_spelling"
+        }
+        CqlType::List(_) | CqlType::Set(_) => {
+            "a_list_or_set_requires_a_seq_and_checks_every_element"
+        }
+        CqlType::Tuple(_) => "a_tuple_checks_each_slot_against_its_own_declared_type",
+        CqlType::Map(..) => "a_map_checks_both_halves_of_every_entry",
+        CqlType::Udt(_) => "a_udt_checks_each_field_against_the_type_declared_for_that_name",
+    }
+}
+
+/// Every [`CqlType`] variant has a case, and the census cannot pass VACUOUSLY: the
+/// table below carries one value per variant and the count is FLOORED, so a
+/// shrunken table reports no gap because it asks about nothing (the case-floor
+/// idiom, CLAUDE.md).
+#[test]
+fn every_declared_type_variant_has_a_covering_case() {
+    let one_per_variant: &[CqlType] = &[
+        int_ty(),
+        text_ty(),
+        CqlType::Boolean,
+        CqlType::Blob,
+        CqlType::Timestamp,
+        CqlType::Opaque("uuid".to_string()),
+        CqlType::List(Box::new(int_ty())),
+        CqlType::Set(Box::new(int_ty())),
+        CqlType::Map(Box::new(text_ty()), Box::new(int_ty())),
+        CqlType::Tuple(vec![int_ty()]),
+        CqlType::Udt(UdtType {
+            name: "u".to_string(),
+            fields: vec![("f".to_string(), int_ty())],
+        }),
+    ];
+    assert_eq!(
+        one_per_variant.len(),
+        11,
+        "the per-variant table has shrunk, so this census asks about less than \
+         `CqlType` declares"
+    );
+    for ty in one_per_variant {
+        assert!(
+            !covering_case(ty).is_empty(),
+            "`{}` must name the case that covers its arm",
+            ty.describe()
+        );
+    }
+}

--- a/cqlite-cli/tests/support/golden_value_compare_gap.rs
+++ b/cqlite-cli/tests/support/golden_value_compare_gap.rs
@@ -108,7 +108,15 @@ pub enum Divergence {
     /// number of hex digits, which is CQL's spelling of a byte string.
     ///
     /// NOT COVERED: arbitrary text at that position, a decoded object whose
-    /// content differs, a null, a number. DECLARED RESIDUAL: what the bytes behind
+    /// content differs, a null, a number — and, on the ORACLE side, a golden
+    /// object that is not a DECODE of the declared UDT at all: a field name the
+    /// `CREATE TYPE` does not declare, a declared field left out, another field
+    /// order, or a leaf that is not a value of its declared type. Object-ness
+    /// used to stand in for the premise "the golden decoded it" (issue #3846), so
+    /// a malformed oracle was suppressed alongside the egress's blob hex; the
+    /// matcher now canonicalizes the golden under the declared type, exactly as
+    /// [`Divergence::NestedFrozenValueLeftUndecodedByGolden`] does on its egress
+    /// side. DECLARED RESIDUAL: what the bytes behind
     /// the hex DECODE to is not compared — those bytes are the nested UDT's
     /// serialization, so recovering the content would mean re-implementing
     /// Cassandra's UDT value serializer here, which this gap does not do. The gap
@@ -514,11 +522,64 @@ impl Divergence {
                 }
             }
             Divergence::NestedFrozenUdtRendersAsBlobHex => {
-                // The golden decoded an object at a position the DDL declares a
-                // UDT, and the egress rendered a blob literal there.
-                matches!(golden, Value::Object(_))
-                    && matches!(ty, CqlType::Udt(_))
-                    && matches!(cli, Value::String(text) if is_blob_hex(text))
+                // The DDL declares a UDT here, the golden DECODED it, and the egress
+                // rendered a blob literal instead.
+                if !matches!(ty, CqlType::Udt(_)) {
+                    return false;
+                }
+                // EGRESS: a blob literal and nothing else — `0x` and an EVEN number of
+                // hex digits, CQL's spelling of a byte string. Arbitrary text, a decoded
+                // object, a null or a number here is a DIFFERENT divergence.
+                if !matches!(cli, Value::String(text) if is_blob_hex(text)) {
+                    return false;
+                }
+                // GOLDEN: A DECODE OF THE DECLARED UDT, NOT MERELY AN OBJECT (issue
+                // #3846).
+                //
+                // This was `matches!(golden, Value::Object(_))`, so object-ness stood in
+                // for "the golden decoded the nested frozen UDT" — which is this gap's
+                // whole premise, and the only side that could carry an expectation at a
+                // position where the egress is undecoded (#3042). An object whose field
+                // NAMES, field ORDER or leaf KINDS are not the committed `CREATE TYPE`'s
+                // satisfied it anyway, so a MALFORMED oracle was suppressed alongside the
+                // egress's blob hex — strictly more than the gap says it covers.
+                //
+                // Same weakness, same answer, as the sibling
+                // [`Divergence::NestedFrozenValueLeftUndecodedByGolden`] closed on its
+                // EGRESS side (roborev job 32 for the structure, job 38 for the leaf
+                // kinds, job 105 for the per-type spellings): CANONICALIZE the side whose
+                // decode the premise asserts, under the declared type, and read
+                // `canon_typed`'s OWN OUTPUT back. `canon_udt` IS this lane's structural
+                // authority — every declared field present, no undeclared name, declared
+                // ORDER — quoting `cassandra-5.0.8 UserType.toJSONString`, which walks the
+                // declared field list and writes every field (`null` when its buffer is
+                // absent); `container::canon_matches_declared_kinds` adds the leaf
+                // question and nothing else, because `canon_typed(...).is_ok()` is not a
+                // validity test (it accepts a string where an `int` is declared on
+                // PURPOSE, leaving the inequality to the comparison — and here there is no
+                // other side left to report it).
+                //
+                // NOT the strict type validator #3846 rules out and #3500 abandoned: no
+                // parsing, no calendar or range logic, no arity or field-set logic of its
+                // own. It reads back what the canonicalizer already decided.
+                //
+                // The position's OWN `kinding` is passed rather than a fixed
+                // [`Kinding::Natural`]: at a STRINGIFIED position `sstabledump` spells a
+                // whole frozen UDT as one flat `getString` string, so an object there is
+                // not a rendering that writer produces, and `canon_container` refuses it —
+                // the fail-closed direction, and the same latitude the golden is given
+                // everywhere else in this lane. A UDT FIELD, which is every position a
+                // case has ever declared this gap at, is [`Kinding::Natural`]
+                // (`compare::At::field`).
+                if !matches!(golden, Value::Object(_)) {
+                    return false;
+                }
+                match super::canon_typed(golden, egress, ty, depth, kinding, Side::Golden) {
+                    Ok(canon) => {
+                        super::super::container::canon_matches_declared_kinds(&canon, ty, egress)
+                    }
+                    Err(_) => false,
+                }
             }
             Divergence::NonFiniteFloatRendersAsJsonNull => {
                 egress == Egress::Json

--- a/cqlite-cli/tests/support/golden_value_compare_gap_udt_tests.rs
+++ b/cqlite-cli/tests/support/golden_value_compare_gap_udt_tests.rs
@@ -1,0 +1,187 @@
+//! The GOLDEN half of `Divergence::NestedFrozenUdtRendersAsBlobHex`: a golden that
+//! is really a DECODE of the declared UDT (issue #3846).
+//!
+//! Split out of `golden_value_compare_gap_tests.rs` under the campsite rule
+//! (CLAUDE.md, epic #1135), which had reached the ~1500-line test target. A child
+//! of `golden_value_compare_tests.rs`, so the shared `row`/`schema_of` helpers and
+//! the committed `NESTED_UDT_DDL` are reached through `use super::*` and are stated
+//! once.
+//!
+//! # What these cases are about
+//!
+//! That gap's premise is "the GOLDEN decoded the nested frozen UDT while the egress
+//! rendered raw bytes", so the golden side is where its expectation may come from at
+//! all (#3042). It used to be read as `matches!(golden, Value::Object(_))`: object-ness
+//! stood in for "a decode of the declared UDT", so an object whose FIELD NAMES, field
+//! ORDER or leaf KINDS are not the committed `CREATE TYPE`'s satisfied the premise and
+//! the gap suppressed the position anyway (issue #3846). That is the same weakness the
+//! sibling `NestedFrozenValueLeftUndecodedByGolden` closed on its EGRESS side (roborev
+//! jobs 32/38/105) — one variant over, on the golden side.
+//!
+//! Every expectation below is the committed DDL's or `cassandra-5.0.8`'s, never
+//! CQLite's output: `UserType.toJSONString` walks the DECLARED field list and writes
+//! every declared field (`null` when its buffer is absent), so a decoded golden
+//! carries exactly the declared fields, in declaration order, each spelled as its
+//! declared type's own `toJSONString`.
+//!
+//! Each rule is pinned from BOTH sides — a decode that must still match, and a
+//! non-decode that must be REPORTED — so narrowing the rule back reds a case rather
+//! than quietly restoring the suppression.
+
+use super::super::super::container::MapKeySpelling;
+use super::super::gap::Position;
+use super::super::super::schema::CqlType;
+use super::*;
+use serde_json::json;
+
+/// The blob-hex spelling of the nested UDT's serialized bytes — the EGRESS half of
+/// the gap, held fixed by every case here so each one varies only the golden.
+/// Synthetic since #3631 (the egress decodes that field now); the exact bytes are not
+/// what the gap is keyed on.
+const HOME_AS_BLOB_HEX: &str =
+    "0x0000000a31204e617679205761790000000941726c696e67746f6e000000053232323031";
+
+/// The declared type of a FIELD of a UDT column, read through the REAL schema reader
+/// so every case below is asked about the committed DDL's own type rather than a
+/// hand-built one.
+fn field_ty(ddl: &str, column: &str, field: &str) -> CqlType {
+    let schema = schema_of(ddl, "t");
+    let Some(col) = schema.column(column) else {
+        panic!("the DDL must declare the column `{column}`");
+    };
+    let CqlType::Udt(udt) = &col.ty else {
+        panic!("`{column}` must be declared a UDT");
+    };
+    match udt.fields.iter().find(|(name, _)| name == field) {
+        Some((_, ty)) => ty.clone(),
+        None => panic!("the UDT `{}` must declare the field `{field}`", udt.name),
+    }
+}
+
+/// Is the pair at `e.home` the declared divergence, with the golden varied?
+fn home_gap_matched(golden: &Value) -> bool {
+    let home_ty = field_ty(NESTED_UDT_DDL, "e", "home");
+    Divergence::NestedFrozenUdtRendersAsBlobHex.matched(
+        golden,
+        &json!(HOME_AS_BLOB_HEX),
+        Position {
+            ty: &home_ty,
+            egress: Egress::Json,
+            // A UDT field's own position, as `compare::At::field` builds it.
+            depth: Depth::Inside,
+            kinding: Kinding::Natural,
+            map_key_spelling: MapKeySpelling::ToJsonString,
+        },
+    )
+}
+
+/// The golden's FIELD SET and field ORDER must be the committed `CREATE TYPE`'s.
+///
+/// `cassandra-5.0.8 UserType.toJSONString` iterates `for (int i = 0; i < types.size();
+/// i++)` over the DECLARED field list and writes every declared field, so an object
+/// carrying an undeclared name, missing a declared one, or emitting them in another
+/// order is not a rendering that writer can produce — hence not the decoded golden this
+/// gap's premise asserts, and the position must be REPORTED rather than suppressed.
+#[test]
+fn the_nested_udt_gap_requires_a_golden_that_decodes_the_declared_udt() {
+    // THE CONTROL FIRST: without it every refusal below could pass because the matcher
+    // had stopped matching this position at all.
+    assert!(
+        home_gap_matched(&json!({"street": "1 Navy Way", "city": "Arlington", "zip": "22201"})),
+        "the committed golden's own `e.home` object IS a decode of `address`, so blob \
+         hex against it is the declared gap"
+    );
+
+    // An UNDECLARED field name (`town`), which also leaves `city` unemitted.
+    assert!(
+        !home_gap_matched(&json!({"street": "1 Navy Way", "town": "Arlington", "zip": "22201"})),
+        "`town` is not declared by the committed CREATE TYPE, so this object is not a \
+         decode of `address` and the gap must not suppress the position"
+    );
+    // A DECLARED field left out. `toJSONString` emits every declared field, `null`
+    // included, so an absent field is a missing field and not an agreement.
+    assert!(
+        !home_gap_matched(&json!({"street": "1 Navy Way", "city": "Arlington"})),
+        "an object missing the declared `zip` is not a decode of `address`"
+    );
+    // The DECLARED ORDER is street, city, zip.
+    assert!(
+        !home_gap_matched(&json!({"city": "Arlington", "street": "1 Navy Way", "zip": "22201"})),
+        "`toJSONString` emits a UDT's fields in declaration order, so another order is \
+         not a rendering it can produce"
+    );
+    // And a golden that is not a field→value object at all.
+    for not_a_udt in [
+        json!("1 Navy Way, Arlington"),
+        json!(HOME_AS_BLOB_HEX),
+        json!(null),
+        json!(9),
+        json!(["1 Navy Way", "Arlington", "22201"]),
+    ] {
+        assert!(
+            !home_gap_matched(&not_a_udt),
+            "{not_a_udt} is not the decoded golden object this gap declares"
+        );
+    }
+}
+
+/// A one-off DDL with a NUMERIC and a BLOB nested field, because the committed
+/// `address` is text-only and every string is a well-formed `text` value — so the leaf
+/// KINDS could not be exercised through it.
+const TYPED_NESTED_DDL: &str = "CREATE TYPE geo (lat int, tag blob); \
+     CREATE TYPE place (name text, at frozen<geo>); \
+     CREATE TABLE t (id int PRIMARY KEY, p frozen<place>);";
+
+fn geo_gap_matched(golden: &Value) -> bool {
+    let at_ty = field_ty(TYPED_NESTED_DDL, "p", "at");
+    Divergence::NestedFrozenUdtRendersAsBlobHex.matched(
+        golden,
+        &json!(HOME_AS_BLOB_HEX),
+        Position {
+            ty: &at_ty,
+            egress: Egress::Json,
+            depth: Depth::Inside,
+            kinding: Kinding::Natural,
+            map_key_spelling: MapKeySpelling::ToJsonString,
+        },
+    )
+}
+
+/// The golden's LEAF KINDS must be the ones the declared field types imply.
+///
+/// The field set, the order and the shape can all be the DDL's while a leaf is not a
+/// value of its declared type — `"not-an-int"` at a declared `int`, bare hex at a
+/// declared `blob` — and at this position the golden is the ONLY side that could carry
+/// the expectation, so reading object-ness as validity suppressed a malformed oracle.
+/// Same read-back the sibling gap does on its egress side (roborev jobs 38/105).
+///
+/// Authorities for the two spellings, both `cassandra-5.0.8`: `Int32Type.toJSONString`
+/// writes the value with `writeRawValue`, i.e. a JSON NUMBER; `BytesType.toJSONString`
+/// returns `"\"0x" + ByteBufferUtil.bytesToHex(buffer) + '"'`, i.e. `0x` and an even
+/// number of hex digits (`BytesSerializer.toString`'s BARE hex is the `getString`
+/// spelling, which is not what this position carries).
+#[test]
+fn the_nested_udt_gap_requires_golden_leaves_of_the_declared_kinds() {
+    assert!(
+        geo_gap_matched(&json!({"lat": 42, "tag": "0xdeadbeef"})),
+        "a JSON number at `int` and a `0x` hex literal at `blob` are what \
+         toJSONString writes, so this IS the decoded golden the gap declares"
+    );
+    assert!(
+        !geo_gap_matched(&json!({"lat": "not-an-int", "tag": "0xdeadbeef"})),
+        "text at a declared `int` is not a value toJSONString can write there"
+    );
+    assert!(
+        !geo_gap_matched(&json!({"lat": 42, "tag": "deadbeef"})),
+        "bare hex is BytesSerializer.toString's getString spelling, not the `0x` \
+         literal toJSONString writes at a natural position"
+    );
+    // AND A NULL FIELD IS STILL A DECODE, which is what keeps this from being a
+    // tightening the oracle contradicts: `UserType.toJSONString` writes `null` for a
+    // field whose buffer is absent, so every declared field is present and a null one
+    // is legal at that position.
+    assert!(
+        geo_gap_matched(&json!({"lat": null, "tag": "0x"})),
+        "a null UDT field and the empty blob are both what toJSONString writes"
+    );
+}

--- a/cqlite-cli/tests/support/golden_value_compare_gap_udt_tests.rs
+++ b/cqlite-cli/tests/support/golden_value_compare_gap_udt_tests.rs
@@ -29,8 +29,8 @@
 //! than quietly restoring the suppression.
 
 use super::super::super::container::MapKeySpelling;
-use super::super::gap::Position;
 use super::super::super::schema::CqlType;
+use super::super::gap::Position;
 use super::*;
 use serde_json::json;
 

--- a/cqlite-cli/tests/support/golden_value_compare_tests.rs
+++ b/cqlite-cli/tests/support/golden_value_compare_tests.rs
@@ -1394,5 +1394,8 @@ mod order;
 #[path = "golden_value_compare_gap_tests.rs"]
 mod gaps;
 
+#[path = "golden_value_compare_gap_udt_tests.rs"]
+mod gap_udt;
+
 #[path = "golden_value_compare_refusal_tests.rs"]
 mod refusals;


### PR DESCRIPTION
Closes #3846.

## What this is

The residual of #3846 after PR #3781 merged. **One of the issue's three parts was already
delivered on main** and is NOT re-implemented here — see "Scope correction" below. This PR
delivers the other two.

## Part 2 — the nested-frozen-UDT gap's golden must DECODE the declared UDT

`Divergence::NestedFrozenUdtRendersAsBlobHex` accepted
`matches!(golden, Value::Object(_)) && matches!(ty, CqlType::Udt(_)) && <cli is blob hex>`.
Object-ness stood in for the gap's own premise — "the golden decoded the nested frozen UDT" —
so a golden with an **undeclared field name**, a **missing declared field**, a **different
field order**, or a **leaf of the wrong kind** satisfied it anyway. The gap then SUPPRESSED
that position, at exactly the place where the egress is undecoded and the golden is the only
side that can carry an expectation (#3042).

The matcher now canonicalizes the golden under the declared type and reads `canon_typed`'s own
output back: `canon_udt` for structure (every declared field present, no undeclared name,
declared order — quoting `cassandra-5.0.8 UserType.toJSONString`, which walks the declared
field list and writes every field, `null` when its buffer is absent) plus
`container::canon_matches_declared_kinds` for leaves. `Err(_) => false`, fail-closed.

This is the same answer the sibling `NestedFrozenValueLeftUndecodedByGolden` already uses on
its EGRESS side. **It stays inside the #3500/#3846 boundary**: no parsing, no calendar/range
logic, no arity logic — it composes two functions that were already checked.

## Part 3 — direct unit coverage for `canon_matches_declared_kinds`

That function had **zero** direct tests: one definition, one call site, doc references. Only
its Numeric and Boolean arms were reached, indirectly, through the gap. New suite
`golden_value_canon_kinds_tests.rs` (13 tests) pins the arms as they exist on main today,
including the four PR #3781 added (blob hex, canonical timestamp, per-name opaque with `None`
REFUSING, the CSV boolean pair), plus the positional-null rule and nested recursion.

## Scope correction — part 1 was already delivered by #3781

#3846's part 1 ("leaf-kind validity stops at `Canon::Text`") was fixed on #3781's own branch by
roborev job 105. On main, `kinds_match` already splits `Text` / `Blob(is_blob_hex)` /
`Timestamp(is_canonical_timestamp)` / `Opaque(opaque_spelling_matches, None refuses)`. Nothing
here re-implements it. **The issue title still names part 1 and is now stale.**

## Evidence

**Red verified independently**, not inferred from commit order: in a throwaway worktree at the
pre-fix commit `c968f1078` both new part-2 tests FAIL —
`the_nested_udt_gap_requires_a_golden_that_decodes_the_declared_udt` ("`town` is not declared by
the committed CREATE TYPE") and `the_nested_udt_gap_requires_golden_leaves_of_the_declared_kinds`
("text at a declared `int` is not a value toJSONString can write there"). Both PASS at HEAD;
kinds suite 13/13.

**Coverage note, stated rather than implied:** `--lite`'s `scoped-tests` reports 222 tests, which
is exactly `cqlite-cli --lib` — unchanged before and after adding 15 tests. Lite runs the touched
package's `--lib` plus the diff's NEW `--test` targets, and these are `#[path]` modules inside the
existing `issue_1491_json_csv_golden_parity` target, so **lite did not execute them**. The full
gate does: `cli-tests` derives its set from the `cqlite-cli/tests/*.rs` glob (#2039), this target
is not quarantined and declares no `required-features`, so it runs in Pass 1.

```
==== AGENT-GATE LITE SUMMARY ====
MODE: lite (FAST ITERATION — NOT the gate of record)
commit: 37defbe  dirty: no   tree-integrity: PASS
component-set: ADVISORY-PASS (39/39 names vs origin/main 67f11ae6…)
scoped-tests: PASS (19s) [test cqlite-cli default-features] {verified: 222 tests passed}
RESULT: PASS
```

```
==== ROBOREV REVIEW SUMMARY ====
reviewed-sha: a5b997e435…..37defbe87…   job: 127   model: gpt-5.6-sol
census: 5 files, +877/-6   tokens: input=172143 cached=140160 output=1064
push-assert/census-check/code-free/job-record/sha-assert/review-completed: PASS
prompt-content: PASS (5/5 code census paths present)   vacuity-tier1/tier2: PASS
findings: NONE   roborev-exit: PASS
RESULT: PASS
```

The full `scripts/agent-gate.sh` gate of record has NOT been run yet — that is the closer's ONE run.

## Residual

`rust-reviewer` was spawned on this diff and never returned a report (it went idle twice without
sending one). Its read was substituted by roborev job 127 above — an independent, durable,
merge-gating review with `findings: NONE` — plus a manual check of the four correctness cases I
had flagged for it (a golden that decodes a DIFFERENT UDT; a null field; an empty object; a UDT
nested inside the UDT). All four are handled: canonicalization is against the DECLARED type, the
UDT arm recurses by declared field name with `NullHere::Allowed`, and structure is `canon_udt`'s
job. Recorded here rather than left silent.
