### PR TITLE
docs(#4100): CLAUDE.md quotes no completion grammar — clears the tooling-tests 15.11 red on main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,10 +108,12 @@ never idle-waits into a watchdog kill. A queued gate ≠ a hung gate.
 The merge-blocking rules — each one FAILs closed, and the full mechanism for every one of them is in
 `docs/development/gate-ops.md`:
 
-- **Completion and verdict are two assertions.** Probe completion with
-  `grep -qE 'RESULT: (PASS|FAIL)'`; `INCOMPLETE` is a liveness placeholder written at launch, not a
-  verdict. And read a **component's OWN line**, never the terminal token — `PARTIAL` says the *run*
-  was partial, not that your component failed.
+- **Completion and verdict are two assertions.** Probe completion with the terminal-token grammar
+  for the mode you ran — full, `--lite`/`--only`, and `--delta` each have their own, published ONLY
+  in `docs/development/gate-ops.md` (this file deliberately quotes none of them, so it cannot teach
+  a partial set). `INCOMPLETE` is a liveness placeholder written at launch, not a verdict. And read
+  a **component's OWN line**, never the terminal token — `PARTIAL` says the *run* was partial, not
+  that your component failed.
 - **A gate script behind `origin/main` cannot certify.** Rebase before the gate of record.
 - **A worktree that mutates mid-run cannot certify.** Verify `tree-integrity:` and `dirty: no`
   alongside `RESULT:`, and verify the `run-id:` matches the run you launched — a foreign `run-id`


### PR DESCRIPTION
Closes #4100.

**main is RED** on `tooling-tests` guard 15.11 (`the --delta grammar is published at every site that publishes the other two — missing: CLAUDE.md`), reproduced on clean `origin/main` `ad178afca` and independently by three lanes. It blocks every lane's gate of record (local-gate component; CI `required` stays green, so nothing else catches it).

**Fix — remedy (b) from #4100:** the one residual line at `CLAUDE.md:112` quoted the record grammar alone. It now states the rule and points at `docs/development/gate-ops.md` (which carries all three grammars at 429/434/443) and quotes none, so CLAUDE.md falls out of the guard's derived site set. Consistent with the #4092 trim's intent and with 15.11's rationale ("a site that teaches ANY of the three must teach the third" — a pointer teaches none).

**Verification in this tree**
```
bash scripts/tests/test_gate_component_verdict.sh
==== test_gate_component_verdict.sh: passed=126 failed=0 ====     (origin/main: passed=125 failed=1)
git diff --name-only origin/main...HEAD | bash scripts/ci/classify-docs-only.sh
docs-only  (rc=0)
```

**Certification posture, stated honestly:** this is a one-file prose diff (classifier-verified). A docs-only diff cannot be roborev-certified (CLAUDE.md doctrine), and the full gate of record on a tree that includes this fix is what every blocked lane is about to run — the first of those PASSing is the demonstration. Merging on CI `required` green as a main-red hotfix, the same posture as #3977/#4029.

https://claude.ai/code/session_0125yfcchVUfMYtH7arzaD2f