### PR TITLE
feat(#3997): linked jemalloc for the cqlite-flight BINARY behind a non-default feature — mechanism only, measurement handed to a rig lane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1427,6 +1427,7 @@ dependencies = [
  "serial_test",
  "tempfile",
  "thiserror 1.0.69",
+ "tikv-jemallocator",
  "tokio",
  "tokio-util",
  "tonic 0.12.3",
@@ -5870,6 +5871,26 @@ dependencies = [
  "byteorder",
  "integer-encoding",
  "ordered-float",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/cqlite-flight/Cargo.toml
+++ b/cqlite-flight/Cargo.toml
@@ -27,7 +27,13 @@ futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-clap = { workspace = true }
+# `string`: clap's owned-`String` builder APIs. Needed because `--version`'s text
+# is composed AT RUNTIME from the linked allocator name (issue #3997, R2.1) —
+# `Command::long_version` otherwise takes only a `&'static str`, and the allocator
+# is a value threaded in from `main.rs` rather than a literal available here. The
+# feature adds `impl From<String> for clap::builder::Str` and nothing else; it
+# pulls in no new crate.
+clap = { workspace = true, features = ["string"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 

--- a/cqlite-flight/Cargo.toml
+++ b/cqlite-flight/Cargo.toml
@@ -62,6 +62,35 @@ opentelemetry = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
 tracing-opentelemetry = { workspace = true, optional = true }
 
+# jemalloc as the process-wide allocator for the SERVER BINARY ONLY, behind the
+# non-default `jemalloc` feature (issue #3997). LINUX-ONLY BY PLACEMENT: the
+# allocator is a Linux-production concern (the #3551 rig, the Trino/Helm
+# deployment), and jemalloc's C source is compiled from scratch by
+# `tikv-jemalloc-sys`' build script — so keeping the dependency under a target
+# `cfg` means a macOS/Windows developer build never pays for a C toolchain it
+# has no use for. The `#[global_allocator]` use site in `src/main.rs` is
+# ADDITIONALLY cfg-gated on `target_os = "linux"`, so an off-Linux build with
+# `--features jemalloc` is inert rather than broken.
+#
+# Pinned to the `0.6` line deliberately, because the pin has to match the
+# jemalloc version #3551 MEASURED. VERIFIED, not assumed: this resolves
+# `tikv-jemallocator 0.6.1` -> `tikv-jemalloc-sys
+# 0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7`, whose `+` build
+# metadata names the vendored jemalloc release, and the vendored tree confirms
+# it independently (`jemalloc/ChangeLog`'s newest release entry is
+# `5.3.0 (May 6, 2022)`, and `build.rs` passes that same metadata to jemalloc's
+# `configure --with-version`). #3551 measured `LD_PRELOAD` of the rig's distro
+# `libjemalloc.so.2`, which is **5.3.0** — so this is the same major.minor, as
+# task 0.3 requires. The newer `0.7` line bundles 5.3.1; taking it would make
+# the linked build a different allocator release from the one the `LD_PRELOAD`
+# baseline was measured against. Bump this only alongside a re-measurement.
+#
+# NOT in `default` here: the default posture is decided by the linked-build
+# A-vs-E measurement (requirement R3), not by this manifest. The feature exists
+# and is off.
+[target.'cfg(target_os = "linux")'.dependencies]
+tikv-jemallocator = { version = "0.6", optional = true }
+
 [features]
 # Off by default: the Flight server is normally run without an OTLP collector,
 # and enabling OTel pulls in the exporter stack. Turn it on explicitly with
@@ -111,6 +140,18 @@ test-util = []
 # test binary (issue #1494, AD5) so it can observe the Flight producer's total/peak
 # allocation. Never in defaults — it stays confined to that one gated test binary.
 dhat-heap = []
+# Link jemalloc as the process-wide `#[global_allocator]` of the `cqlite-flight`
+# BINARY (issue #3997, requirement R1). Off by default until the arm-A-vs-arm-E
+# measurement on the #3551 rig says otherwise (requirement R3); build with
+# `cargo build -p cqlite-flight --features jemalloc`. The dependency is declared
+# under a `cfg(target_os = "linux")` target section above, and the install site
+# in `src/main.rs` repeats that `cfg`, so this feature is a no-op off Linux —
+# `cqlite-flight --version` then reports `allocator: system`, which is the truth.
+# Confined to the BIN target by construction: `main.rs` is compiled into the
+# binary only, so the library target that `tools/flight-loadgen`, the benches and
+# every integration test link never carries an allocator
+# (`scripts/tests/test_flight_allocator_confinement.sh` pins this structurally).
+jemalloc = ["dep:tikv-jemallocator"]
 
 [dev-dependencies]
 # Enable cqlite-core's SHARED Arrow row-shape corpus (issue #2932) for TESTS

--- a/cqlite-flight/Dockerfile
+++ b/cqlite-flight/Dockerfile
@@ -34,6 +34,18 @@ RUN cargo chef prepare --recipe-path recipe.json
 #     are character-for-character identical to the final build (release profile,
 #     -p cqlite-flight, --features observability); a mismatch would cook artifacts
 #     the final build cannot reuse — a silent no-op that recompiles anyway (D3).
+#
+#     ALLOCATOR (issue #3997): `--features observability` is the whole feature set,
+#     so this image links the SYSTEM allocator (glibc malloc). The non-default
+#     `jemalloc` feature is NOT enabled here and there is nothing to configure at
+#     deploy time — the allocator is a compile-time choice and the running image
+#     reports which one it got, on the startup `info` line as `allocator=` and via
+#     `cqlite-flight --version`. Adding `jemalloc` to BOTH lines below (they must
+#     stay character-for-character identical, see D3 above) is what would change
+#     that; do NOT add it to only one. Whether the default flips at all is decided
+#     by the linked-build A/E measurement on the #3551 rig against the
+#     pre-registered kill criterion in openspec/changes/flight-jemalloc/proposal.md
+#     — not here, and not by inheriting #3551's LD_PRELOAD figure.
 FROM chef AS builder
 COPY --from=planner /src/recipe.json recipe.json
 RUN cargo chef cook --release --locked -p cqlite-flight --features observability --recipe-path recipe.json

--- a/cqlite-flight/README.md
+++ b/cqlite-flight/README.md
@@ -394,12 +394,67 @@ table = reader.read_all()
 print(table.to_pandas())
 ```
 
+## Allocator (`jemalloc` feature, issue #3997)
+
+**The released binary and the published image use the SYSTEM allocator. There is nothing
+to configure, and nothing to configure it with.** `jemalloc` is a non-default Cargo feature
+of this crate; `default = []`, so every ordinary build — including the GHCR image, which
+builds `--features observability` and nothing else — links glibc `malloc` exactly as it
+always has. No `LD_PRELOAD` was ever deployed, so nothing has been removed either.
+
+Which allocator a binary actually installed is reported by the binary itself, in two places,
+both derived from the same `cfg` as the installation so they cannot disagree with what was
+linked:
+
+```bash
+cqlite-flight --version
+# cqlite-flight 0.16.1
+# allocator: system          <- or `jemalloc`
+
+# and on the startup `info` line:
+#   cqlite-flight starting ... allocator=system
+```
+
+To build with it (Linux only — the dependency is declared under a
+`cfg(target_os = "linux")` target section and the install site is cfg-gated to match, so the
+feature is inert, not broken, elsewhere):
+
+```bash
+cargo build --release -p cqlite-flight --features jemalloc
+```
+
+**Why it is off by default, and what would change that.** #3551 measured **+29.21% rows/s**
+on the served path from swapping glibc `malloc` for jemalloc at the pinning the measurement
+rig has always used (`docs/reports/ws0-3551-report.md`, 31 clean within-round pairs, worst
+pair-control 2.41%). That measurement used **`LD_PRELOAD` on one binary**, deliberately — which
+is a different artifact from a linked `#[global_allocator]`, differing in initialization order,
+in static-vs-dynamic symbol resolution, and in what runs before `main`. **That number is
+therefore NOT a claim about this feature.** The linked A-vs-E measurement, with peak and
+steady-state RSS against the <128 MB target, is issue #3997's remaining work and runs on the
+#3551 rig; a pre-registered kill criterion in
+`openspec/changes/flight-jemalloc/proposal.md` decides whether `default` flips, stays opt-in,
+or the feature is removed and the null recorded. Until that verdict lands, do not quote a
+speedup for this flag.
+
+The allocator is confined to **this crate's binary target** and is structurally pinned there
+by `scripts/tests/test_flight_allocator_confinement.sh` (a `tooling-tests` gate component). A
+`#[global_allocator]` is process-global and there can be exactly one, so a library that
+declares one imposes it on every embedder with no way to override — and CQLite is embedded via
+PyO3, napi-rs and (M6) WASM inside host runtimes that own their own allocator. `cqlite-core`,
+`cqlite-cli` and every binding therefore keep the system allocator, and the library target of
+this crate — what `tools/flight-loadgen`, the benches and every integration test link — carries
+no allocator at all.
+
 ## Building & testing
 
 ```bash
 cargo build -p cqlite-flight
 cargo test  -p cqlite-flight
 env RUSTFLAGS="-D warnings" cargo clippy -p cqlite-flight --all-targets
+
+# with the non-default linked allocator (Linux only, see "Allocator" above)
+cargo build -p cqlite-flight --features jemalloc
+bash scripts/tests/test_flight_allocator_link.sh   # asserts both arms discriminate
 ```
 
 Tests build real SSTables in-process via the write engine (no external test data),

--- a/cqlite-flight/README.md
+++ b/cqlite-flight/README.md
@@ -411,8 +411,16 @@ cqlite-flight --version
 # cqlite-flight 0.16.1
 # allocator: system          <- or `jemalloc`
 
-# and on the startup `info` line:
-#   cqlite-flight starting ... allocator=system
+# and on the startup `info` line (tracing renders a string field QUOTED, and
+# `fmt::layer()` colours it even when redirected to a file — so strip ANSI before
+# grepping, or a correct binary looks silent):
+#   cqlite-flight starting ... allocator="system"
+```
+
+```bash
+# Reading it back from a redirected log, ANSI stripped:
+sed -e "s/$(printf '\033')\[[0-9;]*m//g" server.log | grep -o 'allocator=[^ ]*'
+# -> allocator="system"
 ```
 
 To build with it (Linux only — the dependency is declared under a

--- a/cqlite-flight/src/cli.rs
+++ b/cqlite-flight/src/cli.rs
@@ -41,7 +41,11 @@ pub const ARG_MAX_CONCURRENT_SCANS: &str = "max_concurrent_scans";
 #[derive(Parser, Debug)]
 #[command(
     name = "cqlite-flight",
-    about = "Arrow Flight server for compacted CQLite SSTables"
+    about = "Arrow Flight server for compacted CQLite SSTables",
+    // `version` here only makes the FLAG exist; the text it prints is replaced
+    // per-invocation by [`command_with_allocator`], because the linked allocator
+    // is known to the BINARY and not to this library (issue #3997, R2.1).
+    version
 )]
 pub struct Args {
     /// Root directory holding `<keyspace>/<table>[-<uuid>]/` SSTable dirs.
@@ -119,6 +123,35 @@ pub struct Args {
     pub max_inflight_egress_bytes: usize,
 }
 
+/// The clap [`Command`](clap::Command) with `--version`'s long form carrying the
+/// allocator this process linked (issue #3997, requirement R2.1).
+///
+/// R2.1's contract is exact: `cqlite-flight --version` stdout contains **exactly
+/// one** line matching `^allocator: (jemalloc|system)$`. clap prints the version
+/// text verbatim after the `<name> ` prefix on the first line, so the allocator
+/// goes on its OWN line — the second — which satisfies the anchored grammar;
+/// embedding it in the first line would not.
+///
+/// BOTH `version` (`-V`) and `long_version` (`--version`) are set to the same
+/// text, deliberately. clap's default is for `-V` to print the short form and
+/// `--version` the long one, which would make the allocator observable through
+/// one flag and not the other — a distinction an operator has no reason to
+/// expect from a two-line version string. R2.1 names `--version`; this makes
+/// `-V` answer identically rather than merely satisfying the letter.
+///
+/// `allocator` is a parameter rather than a constant read here because a linked
+/// `#[global_allocator]` is a property of the BIN target. This library is also
+/// compiled into every integration-test binary, where the `jemalloc` feature can
+/// be on while no allocator is installed at all, so a value derived here would
+/// be able to disagree with what the running process actually uses. The single
+/// source of truth is `main.rs`'s `ALLOCATOR`, adjacent to the install site.
+pub fn command_with_allocator(allocator: &str) -> clap::Command {
+    let version = format!("{}\nallocator: {allocator}", env!("CARGO_PKG_VERSION"));
+    Args::command()
+        .version(version.clone())
+        .long_version(version)
+}
+
 impl Args {
     /// Parse the process command line, returning the typed arguments **and** the
     /// [`ArgMatches`] they came from.
@@ -128,8 +161,13 @@ impl Args {
     /// [`ArgMatches::value_source`] can say whether a value arrived from the
     /// command line, the environment, or nowhere. Exits with clap's usage
     /// message on a parse error, exactly as [`Parser::parse`] does.
-    pub fn parse_with_matches() -> (Self, ArgMatches) {
-        let matches = Self::command().get_matches();
+    ///
+    /// `allocator` is the caller's linked-allocator name; see
+    /// [`command_with_allocator`] for why it is passed in. `--version` and
+    /// `--help` short-circuit inside clap BEFORE required-argument validation,
+    /// so `cqlite-flight --version` works with no `--data-dir`.
+    pub fn parse_with_matches(allocator: &str) -> (Self, ArgMatches) {
+        let matches = command_with_allocator(allocator).get_matches();
         match Self::from_arg_matches(&matches) {
             Ok(args) => (args, matches),
             Err(e) => e.exit(),
@@ -140,12 +178,18 @@ impl Args {
     /// instead of exiting — the entry point the #3225 precedence tests drive, so
     /// they exercise the REAL parser (including its `env =` attributes) rather
     /// than a hand-built configuration.
-    pub fn try_parse_with_matches_from<I, T>(argv: I) -> Result<(Self, ArgMatches), clap::Error>
+    ///
+    /// Takes the same `allocator` string, so a test can drive the exact
+    /// `Command` the binary builds rather than a differently-configured one.
+    pub fn try_parse_with_matches_from<I, T>(
+        allocator: &str,
+        argv: I,
+    ) -> Result<(Self, ArgMatches), clap::Error>
     where
         I: IntoIterator<Item = T>,
         T: Into<std::ffi::OsString> + Clone,
     {
-        let matches = Self::command().try_get_matches_from(argv)?;
+        let matches = command_with_allocator(allocator).try_get_matches_from(argv)?;
         let args = Self::from_arg_matches(&matches)?;
         Ok((args, matches))
     }
@@ -204,11 +248,16 @@ fn explicit_max_concurrent_scans(
 /// * `available_parallelism` is OMITTED (not logged as a placeholder) when the
 ///   oracle returned no answer; `max_concurrent_scans_source` is then
 ///   `derived-fallback`, so the absence is never ambiguous.
+/// * `allocator` is the linked global allocator (issue #3997, requirement
+///   R2.2) — the SAME string `--version` prints, so a log capture and an
+///   out-of-band `--version` can never disagree. Passed in by `main.rs` for the
+///   reason documented on [`command_with_allocator`].
 pub fn log_startup(
     args: &Args,
     scans: &ResolvedMaxConcurrentScans,
     admission_limit: usize,
     max_concurrent_streams: u32,
+    allocator: &str,
 ) {
     let listen = args.listen;
     tracing::info!(
@@ -221,6 +270,7 @@ pub fn log_startup(
         available_parallelism = scans.available_parallelism,
         admission_wait_timeout_ms = args.admission_wait_timeout_ms,
         max_concurrent_streams,
+        allocator,
         "cqlite-flight starting"
     );
 }

--- a/cqlite-flight/src/main.rs
+++ b/cqlite-flight/src/main.rs
@@ -1,6 +1,46 @@
 //! `cqlite-flight` — Arrow Flight server exposing on-the-fly compacted SSTable
 //! data. Runs co-located with a Cassandra node and reads its local SSTables.
 
+// ---------------------------------------------------------------------------
+// Global allocator (issue #3997, requirement R1)
+// ---------------------------------------------------------------------------
+//
+// A `#[global_allocator]` is PROCESS-WIDE and there can be exactly one per
+// binary, which is why this lives in `main.rs` and nowhere else: rustc compiles
+// `main.rs` into the **bin** target only, so the **library** target that
+// `tools/flight-loadgen`, the benches and every integration test link never
+// carries an allocator. That is also what keeps it from colliding with the
+// memory ratchets, each of which installs its own allocator in its own TEST
+// binary (`issue_1494_producer_mem_budget`'s `dhat::Alloc`, `cqlite-core`'s
+// `cfg(test)` `CountingAllocator`). `scripts/tests/test_flight_allocator_confinement.sh`
+// pins that confinement structurally, so a later "move it to lib.rs for
+// convenience" fails the gate.
+//
+// Off Linux the `jemalloc` feature is deliberately inert: the dependency is
+// declared under a `cfg(target_os = "linux")` target section in `Cargo.toml`, so
+// the crate does not even exist to name off-Linux.
+#[cfg(all(feature = "jemalloc", target_os = "linux"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+/// The allocator this binary actually installed, as reported by `--version` and
+/// by the startup log line (requirement R2).
+///
+/// **Why this const lives in `main.rs` next to the install site rather than in
+/// the library.** It is derived from the SAME `cfg` predicate as the
+/// `#[global_allocator]` above, which is the only way the reported string and
+/// the linked allocator cannot disagree. Deriving it in the library instead
+/// would be a latent lie: the library sees `feature = "jemalloc"` in a TEST
+/// binary too — where `main.rs` is not compiled and therefore NO global
+/// allocator is installed — so a library-side const would report `jemalloc` for
+/// a process running on the system allocator. Keep the two adjacent.
+#[cfg(all(feature = "jemalloc", target_os = "linux"))]
+const ALLOCATOR: &str = "jemalloc";
+/// See the documented sibling above: the negation of the exact same predicate,
+/// so the two arms are total and cannot both (or neither) apply.
+#[cfg(not(all(feature = "jemalloc", target_os = "linux")))]
+const ALLOCATOR: &str = "system";
+
 use arrow_flight::flight_service_server::FlightServiceServer;
 use tonic::transport::server::TcpIncoming;
 use tonic::transport::Server;
@@ -47,7 +87,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Parse WITH the `ArgMatches` (issue #3225): the admission ceiling's
     // provenance — flag vs env vs derived — is a property of the parse, and
     // only `ArgMatches::value_source` can report it.
-    let (args, matches) = Args::parse_with_matches();
+    // `ALLOCATOR` is threaded THROUGH the parse because `--version`'s output is
+    // built by clap from the `Command` this call constructs (issue #3997, R2.1):
+    // the binary is the only place that knows which allocator was linked, and
+    // `cli` is the only place that owns the clap `Command`.
+    let (args, matches) = Args::parse_with_matches(ALLOCATOR);
     let listen = args.listen;
     // The effective ceiling and where it came from. With nothing configured this
     // is `clamp(2 x available_parallelism, 2, 64)` (issue #3225) rather than the
@@ -81,7 +125,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .saturating_mul(4)
         .max(1024);
 
-    cli::log_startup(&args, &scans, admission_limit, max_concurrent_streams);
+    cli::log_startup(
+        &args,
+        &scans,
+        admission_limit,
+        max_concurrent_streams,
+        ALLOCATOR,
+    );
     // Saturation instrumentation (issue #2419, WS2): spawn the background sampler
     // that drives the `cqlite.proc.*` OS-resource gauges (thread/fd/RSS) on a ~2s
     // cadence. It takes its OWN `shutdown_signal()` future — the same SIGTERM /
@@ -196,6 +246,21 @@ mod tests {
         // Must never panic regardless of feature state, and there's nothing to
         // assert beyond "it returns" — disabled is the common, silent case.
         log_observability_status(false, "http://localhost:4317");
+    }
+
+    /// The reported allocator name must be exactly what THIS build's cfg says,
+    /// and must be one of the two values requirement R2.1's grammar admits. This
+    /// is the in-binary half; the end-to-end half (the built binary's real
+    /// `--version` stdout) is `tests/issue_3997_allocator_surface.rs`, and the
+    /// link-level half is `scripts/tests/test_flight_allocator_link.sh`.
+    #[test]
+    fn allocator_const_matches_the_cfg_that_installs_the_allocator() {
+        let expected = if cfg!(all(feature = "jemalloc", target_os = "linux")) {
+            "jemalloc"
+        } else {
+            "system"
+        };
+        assert_eq!(ALLOCATOR, expected);
     }
 
     #[test]

--- a/cqlite-flight/tests/issue_3225_admission_provenance.rs
+++ b/cqlite-flight/tests/issue_3225_admission_provenance.rs
@@ -30,11 +30,20 @@ use cqlite_flight::admission::{
 use cqlite_flight::cli::{self, Args, ARG_MAX_CONCURRENT_SCANS};
 use serial_test::serial;
 
+/// The allocator name these tests hand the parser (issue #3997). This target is
+/// an INTEGRATION test, so `main.rs` — and therefore the real
+/// `#[global_allocator]` and its `ALLOCATOR` const — is not compiled into it;
+/// nothing here asserts on the allocator, so a fixed placeholder is honest. The
+/// allocator's own end-to-end assertion drives the BUILT BINARY, in
+/// `issue_3997_allocator_surface.rs`.
+const TEST_ALLOCATOR: &str = "system";
+
 /// Parse a command line through the real parser and resolve the ceiling.
 fn resolve(argv: &[&str]) -> admission::ResolvedMaxConcurrentScans {
     let mut full = vec!["cqlite-flight", "--data-dir", "/tmp/cqlite-flight-test"];
     full.extend_from_slice(argv);
-    let (args, matches) = Args::try_parse_with_matches_from(full).expect("argv must parse");
+    let (args, matches) =
+        Args::try_parse_with_matches_from(TEST_ALLOCATOR, full).expect("argv must parse");
     cli::resolve_max_concurrent_scans(&args, &matches)
 }
 
@@ -295,14 +304,15 @@ mod startup_log {
 
         let mut full = vec!["cqlite-flight", "--data-dir", "/tmp/cqlite-flight-test"];
         full.extend_from_slice(argv);
-        let (args, matches) = Args::try_parse_with_matches_from(full).expect("argv must parse");
+        let (args, matches) =
+            Args::try_parse_with_matches_from(TEST_ALLOCATOR, full).expect("argv must parse");
         let scans = scans.unwrap_or_else(|| cli::resolve_max_concurrent_scans(&args, &matches));
         let limit = admission_limit_for(scans.value);
 
         let capture = Capture::default();
         let subscriber = tracing_subscriber::registry().with(capture.clone());
         tracing::subscriber::with_default(subscriber, || {
-            cli::log_startup(&args, &scans, limit, 1024);
+            cli::log_startup(&args, &scans, limit, 1024, TEST_ALLOCATOR);
         });
         let events = capture.0.lock().expect("capture mutex").clone();
         let starting: Vec<_> = events

--- a/cqlite-flight/tests/issue_3997_allocator_surface.rs
+++ b/cqlite-flight/tests/issue_3997_allocator_surface.rs
@@ -1,0 +1,99 @@
+//! Requirement R2.1 (issue #3997): the allocator the `cqlite-flight` BINARY
+//! linked is observable from OUTSIDE the process.
+//!
+//! This drives the BUILT BINARY (`env!("CARGO_BIN_EXE_cqlite-flight")`) rather
+//! than the library, because that is the only artifact that carries a
+//! `#[global_allocator]` at all: `main.rs` — and with it the install site and the
+//! `ALLOCATOR` const — is compiled into the bin target only, never into this test
+//! binary. An in-library assertion could not tell a linked allocator from a
+//! feature flag being on.
+//!
+//! **GATE FACT, so nobody reads a green gate as having run this.** The full
+//! gate's `flight-tests` component runs `cqlite-flight` at `--lib --bins` ONLY,
+//! and prints a run-time census naming the ~42 integration `--test` targets it
+//! does NOT run and why (#3384/#3375). THIS TARGET IS ONE OF THEM: no gate
+//! component executes it. The GATE-ENFORCING surface for R1/R2.1 is
+//! `scripts/tests/test_flight_allocator_link.sh`, which is registered in
+//! `tooling-tests`, builds the binary in BOTH feature states, checks the linked
+//! symbols and re-checks this same `--version` contract. This file is the
+//! cargo-native expression of the contract — valuable when someone runs
+//! `cargo test -p cqlite-flight --test issue_3997_allocator_surface`, and not a
+//! merge gate on its own.
+//!
+//! The single test passes in BOTH feature states by construction: it derives the
+//! expected value from `cfg!(all(feature = "jemalloc", target_os = "linux"))`,
+//! which cargo resolves for THIS build — the same predicate the binary's install
+//! site uses, and cargo builds the bin dependency of an integration test with the
+//! same feature set.
+
+use std::process::Command;
+
+/// The value R2.1 requires for the feature set this test was compiled under.
+///
+/// Derived from the predicate rather than hard-coded, so the one test is correct
+/// with the feature on and off. Note the `target_os` half: `--features jemalloc`
+/// on macOS is deliberately inert (the dependency is declared under a
+/// `cfg(target_os = "linux")` target section), so `system` is the truthful answer
+/// there and this test asserts it.
+fn expected_allocator() -> &'static str {
+    if cfg!(all(feature = "jemalloc", target_os = "linux")) {
+        "jemalloc"
+    } else {
+        "system"
+    }
+}
+
+/// A line satisfies R2.1's grammar iff it is EXACTLY `allocator: jemalloc` or
+/// `allocator: system`.
+///
+/// Written as an exact whole-line match against a closed set rather than a
+/// prefix test: a prefix accepts `allocator: jemalloc-maybe` and a whole-line
+/// regex-free comparison is the honest spelling of `^allocator: (jemalloc|system)$`
+/// for a line that has already been split on `\n`.
+fn matches_grammar(line: &str) -> bool {
+    line == "allocator: jemalloc" || line == "allocator: system"
+}
+
+#[test]
+fn version_reports_exactly_one_allocator_line_naming_this_builds_allocator() {
+    let exe = env!("CARGO_BIN_EXE_cqlite-flight");
+    // NO `--data-dir`, which is a REQUIRED argument: `--version` must
+    // short-circuit before required-argument validation, so a successful run
+    // here also pins that property.
+    let out = Command::new(exe)
+        .arg("--version")
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run {exe} --version: {e}"));
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "`{exe} --version` must exit 0 with no --data-dir supplied \
+         (the flag has to short-circuit required-arg validation); \
+         status={:?} stderr={stderr}",
+        out.status.code()
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let allocator_lines: Vec<&str> = stdout.lines().filter(|l| matches_grammar(l)).collect();
+
+    // EXACTLY one — "at least one" is not the contract. Two lines would mean two
+    // sources of truth, and zero would mean the surface is missing.
+    assert_eq!(
+        allocator_lines.len(),
+        1,
+        "R2.1: `--version` stdout must hold EXACTLY ONE line matching \
+         `^allocator: (jemalloc|system)$`; found {}. Full stdout:\n{stdout}",
+        allocator_lines.len()
+    );
+
+    let expected = format!("allocator: {}", expected_allocator());
+    assert_eq!(
+        allocator_lines[0],
+        expected,
+        "R2.1: the reported allocator must match what THIS build linked. \
+         cfg(all(feature = \"jemalloc\", target_os = \"linux\")) = {}, so the line \
+         must be `{expected}`. Full stdout:\n{stdout}",
+        cfg!(all(feature = "jemalloc", target_os = "linux"))
+    );
+}

--- a/docs/development/dev-cookbook.md
+++ b/docs/development/dev-cookbook.md
@@ -745,7 +745,13 @@ cargo build --release -p cqlite-flight --features jemalloc
 # Which allocator a built binary ACTUALLY installed — reported by the binary, from
 # the same cfg as the installation, so it cannot disagree with what was linked:
 ./target/release/cqlite-flight --version | grep '^allocator: '   # -> jemalloc | system
-# The startup `info` line carries the same value as `allocator=<value>`.
+# The startup `info` line carries the same value, rendered by tracing as a QUOTED
+# string field: `allocator="jemalloc"` / `allocator="system"`. `fmt::layer()` leaves
+# ANSI escapes in even when stdout is a file, so strip them before matching —
+# a raw `grep 'allocator="system"'` finds NOTHING on a perfectly good binary (#3400,
+# in a new place). Both surfaces derive from ONE const, so they cannot disagree, and
+# `scripts/tests/test_flight_allocator_link.sh` asserts that AGREEMENT rather than
+# each surface against a literal.
 
 # The gate-enforcing guard for the above (a `tooling-tests` component). Builds BOTH
 # arms and asserts they DISCRIMINATE — jemalloc symbols present + `allocator: jemalloc`

--- a/docs/development/dev-cookbook.md
+++ b/docs/development/dev-cookbook.md
@@ -734,7 +734,40 @@ cargo build --package cqlite-core --features cli-helpers
 # Build/test core with the embeddable Parquet writer (Epic #682)
 cargo build --package cqlite-core --features parquet
 cargo test --package cqlite-core --features parquet
+
+# Flight server with the LINKED non-glibc allocator (issue #3997) — Linux only,
+# NON-DEFAULT. `default = []`, so every ordinary build (and the GHCR image) links
+# glibc malloc; this feature is the only way to get jemalloc, and it applies to
+# cqlite-flight's BIN target only — the lib target, every binding and cqlite-core
+# keep the system allocator.
+cargo build --release -p cqlite-flight --features jemalloc
+
+# Which allocator a built binary ACTUALLY installed — reported by the binary, from
+# the same cfg as the installation, so it cannot disagree with what was linked:
+./target/release/cqlite-flight --version | grep '^allocator: '   # -> jemalloc | system
+# The startup `info` line carries the same value as `allocator=<value>`.
+
+# The gate-enforcing guard for the above (a `tooling-tests` component). Builds BOTH
+# arms and asserts they DISCRIMINATE — jemalloc symbols present + `allocator: jemalloc`
+# under the feature, `0 JEMALLOC SYMBOLS RECOGNISED` + `allocator: system` without it.
+# SKIPs naming the cause off-Linux or on a host missing cargo/cc/make/nm; a failed
+# build is a FAIL, never a SKIP.
+bash scripts/tests/test_flight_allocator_link.sh
+
+# The structural confinement guard: exactly one non-test production `#[global_allocator]`
+# in the workspace (cqlite-flight/src/main.rs, feature-gated), `tikv-jemallocator` named
+# by no manifest under cqlite-core/, cqlite-cli/ or bindings/, and every cqlite-flight
+# dependent linking the LIBRARY target. Needs no cargo and never SKIPs.
+bash scripts/tests/test_flight_allocator_confinement.sh
 ```
+
+**Do not quote a speedup for `--features jemalloc` yet.** #3551's **+29.21% rows/s** was
+measured by `LD_PRELOAD`ing jemalloc into one binary, which is a different artifact from a
+linked `#[global_allocator]` (initialization order, static-vs-dynamic symbol resolution, what
+runs before `main`). The linked A-vs-E measurement — plus `VmHWM`/`VmRSS` against the <128 MB
+target — is issue #3997's remaining work on the #3551 rig, and a pre-registered kill criterion
+(`openspec/changes/flight-jemalloc/proposal.md`) decides whether `default` flips, the feature
+stays opt-in, or it is removed and the null recorded. A null there is a shippable result.
 
 ## Runtime tuning knobs (env)
 

--- a/openspec/changes/flight-jemalloc/design.md
+++ b/openspec/changes/flight-jemalloc/design.md
@@ -1,0 +1,72 @@
+# Design — flight-jemalloc (issue #3997)
+
+## The one constraint that dominates: bin-target only
+
+A `#[global_allocator]` is process-wide and there can be exactly one per binary. That fact decides
+where the code goes and dissolves two of #3997's five open questions:
+
+- **Where:** `cqlite-flight/src/main.rs`, guarded by
+  `#[cfg(all(feature = "jemalloc", target_os = "linux"))]`. Rust compiles `main.rs` into the **bin**
+  target only. The **lib** target (`src/lib.rs`, what `flight-loadgen`, the integration tests and the
+  benches link) never sees it.
+- **Collision with the ratchets — none, by construction.** `issue_1494_producer_mem_budget` installs
+  `dhat::Alloc` in its own **test** binary; `cqlite-core`'s `CountingAllocator` is `cfg(test)` in
+  core's own test binary. Neither is the Flight **bin** target, so no two `#[global_allocator]`s ever
+  meet. Requirement R4 pins this structurally (a grep-lint that the token appears in exactly one
+  production file) so a later "move it to lib.rs for convenience" fails the gate.
+- **Bindings/embedders — unaffected, by construction.** Python/Node depend on `cqlite-core`, not
+  `cqlite-flight` (verified: no `Cargo.toml` outside `cqlite-flight/`, `tools/flight-loadgen/` names
+  it, and both link the library target). R5 states this as a requirement with a manifest test.
+
+## Dependency
+
+`tikv-jemallocator` (jemalloc 5.3, the version #3551 measured via `LD_PRELOAD`), `optional = true`,
+enabled by feature `jemalloc`. Chosen over mimalloc because mimalloc has **no measurement** on this
+workload and #3551's kill criterion says every multiplier is measured, not modeled. Swapping to a
+different allocator later is a one-line change behind the same feature and needs its own arm.
+
+Default posture is decided by the measurement (proposal §Kill criterion), not by this document:
+`default = ["jemalloc"]` is written into `Cargo.toml` **only** in the task that records a SHIP-as-default
+verdict. Until then the feature exists and is off.
+
+## Observability of the choice
+
+A compile-time allocator is invisible at runtime unless the binary says so. Two surfaces, both
+testable from outside the process:
+
+1. `cqlite-flight --version` prints an extra line `allocator: jemalloc` / `allocator: system`.
+2. The startup `tracing::info!` line that already logs observability status gains `allocator=<name>`.
+
+Both are derived from the same `cfg` the installation uses (one `const ALLOCATOR: &str`), so they
+cannot disagree with what was linked.
+
+## Measurement design (reuses #3551's rig verbatim)
+
+`scripts/perf/ws0-3551-abc.sh` gains arm **E**: same flags as arm A (`--flight-server-cpus 2,10
+--flight-pin-mode siblings --flight-allocator system`) but pointing at a **second binary** built with
+`--features jemalloc`. This is the one place the "one binary across all arms" invariant is
+deliberately broken, and the aggregate must say so: the per-session sha256 of the flight binary
+already recorded by the rig will differ between A and E, and `ws0_abc_aggregate.py`'s cross-arm
+invariant check must be told E is an allowed exception rather than silently loosened for all arms.
+
+Memory: the rig samples `/proc/<pid>/status` `VmHWM` and `VmRSS` of the flight server at scan end for
+every arm (new in this change; it is the same `ws0_flight_arm.py` that already owns the server pid).
+Peak N is measured too: one paired A/E at the admission ceiling (`--max-concurrent-scans` default),
+because a lock-contention win at N=1 can be a fragmentation loss at N=peak.
+
+Reporting contract (inherited, non-negotiable): rows/s per physical core warm, cycles/row, IPC, RSS
+peak; **never** CPU-share-in-malloc — a share drop with flat rows/s is a FAIL (#3096 kill criterion).
+
+## Deployment
+
+The Trino/Helm deployment runs the release binary; no `LD_PRELOAD` was ever deployed, so nothing is
+removed. `[profile.release]` is untouched. The connector needs no change.
+
+## Alternatives rejected
+
+- **Runtime switch (`CQLITE_FLIGHT_ALLOCATOR=…`)** — impossible for a linked global allocator; an
+  `LD_PRELOAD`-based switch was rejected because it is deployment configuration outside the binary
+  and is exactly what #3551 could not certify as the shipped form.
+- **Workspace-wide allocator** — imposes on embedders; violates the scope decision F1 asked for.
+- **Arena-count tuning (`MALLOC_ARENA_MAX`)** — measured worse (arm C0, −22.71%).
+- **Bundling the pin change** — arm B: pin alone is −19.25%; needs its own topology design.

--- a/openspec/changes/flight-jemalloc/proposal.md
+++ b/openspec/changes/flight-jemalloc/proposal.md
@@ -1,0 +1,81 @@
+# flight-jemalloc — issue #3997
+
+**Milestone:** 0.17 (read-perf headline). **Routing:** design-driven (OpenSpec) — it adds a
+dependency and changes the memory-behaviour profile of a shipped binary, which #3217 partC F1 ruled
+is a product decision, not a tuning knob.
+
+## Why
+
+glibc `malloc` is the single largest **measured** cost on the served path, and it is the cheapest
+lever left in the 0.17 program. #3551 (`docs/reports/ws0-3551-report.md`, 31 clean within-round pairs
+across 3 interleaved sets, worst pair-control 2.41%) measured a 2×2 of server **pin** × **allocator**
+on the canonical WS0 corpus, one binary across every arm:
+
+| arm | pin | allocator | Δ rows/s vs A | Δ cycles/row | IPC |
+|---|---|---|--:|--:|--:|
+| A control | `2,10` (1 phys core) | glibc | — | — | 1.46 |
+| **D** | `2,10` | **jemalloc** | **+29.21%** | **−21.71%** | 1.56 |
+| C | `2,3` (2 phys cores) | jemalloc | +61.17% | −42.37% | 2.12 |
+| B | `2,3` | glibc | −19.25% | +17.85% | 1.39 |
+| C0 | `2,3` | glibc + `MALLOC_ARENA_MAX=2` | −22.71% | +22.11% | 1.36 |
+
+Arm D is the deliverable: **+29% rows/s per physical core with no pin change**, at the pinning the
+rig has always used. On that rig it moves the served path from 266k rows/s to ~344k against a bare
+scan of 352k — i.e. it closes almost the whole remaining served-vs-bare gap that is the 0.17
+throughput program's stated goal (#3023: "within ~1.3× of bare scan").
+
+The mechanism is a sign-flipping interaction — the same pin change is −19% under glibc and +25% under
+jemalloc — so glibc's malloc lock is what serialises the second core. That also supplies a mechanism
+for #3248's unexplained +49% allocator term under Flight. The arena-cap alternative (#3228 stage 1)
+was run as arm C0 and falsified in the opposite direction; #3228 is closed on that evidence.
+
+## What changes
+
+`cqlite-flight`'s **binary** links jemalloc as its `#[global_allocator]` (`tikv-jemallocator`),
+behind a Cargo feature `jemalloc` that is **on by default for the binary target on Linux** once the
+linked-build measurement in this change clears its kill criterion. The installation lives in
+`cqlite-flight/src/main.rs` **only** — the library target, every test binary, every example and every
+other workspace crate keep the system allocator. The binary reports the allocator it was built with
+at startup and in `--version`.
+
+Nothing in `cqlite-core`, the CLI, or the Python/Node bindings changes. No pin/topology change is
+made (arm B shows the pin alone is harmful; arm C's extra gain needs a deployment design of its own).
+
+## What this change must establish that #3551 did not
+
+1. **Linked allocator, not `LD_PRELOAD`.** Every #3551 arm preloaded `libjemalloc.so` into the same
+   binary. The shipped form is linked. The A/B is re-run in the linked form, same rig, same method,
+   same pin, before any number is claimed for the shipped binary.
+2. **Memory behaviour.** RSS peak (`VmHWM`) and steady-state RSS per arm, plus the existing Flight
+   producer dhat budget (`issue_1494_producer_mem_budget`), against the <128 MB target. A throughput
+   win that breaks the memory target does not ship.
+3. **Scope of imposition.** The allocator is imposed on the `cqlite-flight` **process**, never on
+   library consumers (`flight-loadgen` and the crate's own tests link `cqlite-flight` as a library).
+
+## Kill criterion (pre-registered)
+
+Linked-build arm **E** (jemalloc linked, pin `2,10`) vs arm A (glibc, same binary minus the feature):
+
+- **SHIP as default** if median paired Δrows/s ≥ **+15%** (≥3 clean pairs, every pair up, worst
+  pair-control < 3%) **and** RSS peak ≤ **1.10×** arm A **and** the dhat producer budget still passes.
+- **SHIP as opt-in (non-default)** if +3% ≤ Δ < +15%, or RSS peak in (1.10×, 1.25×].
+- **Do NOT ship; record the null** if Δ < +3% or RSS peak > 1.25× — the feature is removed, the
+  report is committed, and #3997 closes as an honest negative (#3248 AC6). A null here is a result.
+
+## Non-goals
+
+- Changing server CPU pinning or admission (`--max-concurrent-scans`) — separable, harmful alone.
+- Any allocator change in `cqlite-core`, `cqlite-cli`, `bindings/python`, `bindings/node`, or the
+  library target of `cqlite-flight`. Embedders own their allocator.
+- mimalloc, snmalloc, or any arena/`Value<'arena>` refactor (#3028, #2624 — the 0.18 road).
+- `MALLOC_ARENA_MAX` at 1/4/default — moot once glibc is not the production allocator.
+- Reducing allocation *count* or *bytes/row* (#3028). This change cuts allocator *cost* only.
+- macOS/Windows behaviour: the feature is inert off-Linux; production is Linux.
+
+## Impact statements (openspec rules)
+
+- **No-heuristics mandate:** untouched — no decode path changes.
+- **Public binding surfaces:** untouched by construction (bindings do not depend on `cqlite-flight`).
+- **<128 MB memory budget:** the subject of requirement R3; measured, not assumed.
+- **Gate:** one new structural lint (allocator confined to `main.rs`), one new startup-surface test,
+  the existing `memory-budget` component (`cqlite-flight --features dhat-heap`) must still run.

--- a/openspec/changes/flight-jemalloc/specs/flight-allocator/spec.md
+++ b/openspec/changes/flight-jemalloc/specs/flight-allocator/spec.md
@@ -1,0 +1,71 @@
+# flight-allocator — new capability for flight-jemalloc (issue #3997)
+
+The `cqlite-flight` server binary MAY link a non-glibc global allocator. This spec fixes where it
+lives, what it must not touch, how the choice is observable, and what has to be measured before the
+default changes. All requirements are ADDED.
+
+## Requirement R1 — Linked allocator behind a feature, confined to the binary target
+
+`cqlite-flight` SHALL expose a Cargo feature `jemalloc` that, on `target_os = "linux"`, installs
+`tikv_jemallocator::Jemalloc` as `#[global_allocator]` in `cqlite-flight/src/main.rs` and nowhere
+else. With the feature off, or off-Linux, the binary SHALL use the system allocator.
+
+- **Scenario R1.1** — Given a Linux host, When `cargo build -p cqlite-flight --features jemalloc`
+  is run, Then `nm`/`readelf` on the binary resolves `malloc` to jemalloc's symbol (`je_malloc` or
+  the `_rjem_` prefix) — asserted by `scripts/tests/test_flight_allocator_link.sh`.
+- **Scenario R1.2** — Given the same host, When `cargo build -p cqlite-flight --no-default-features`
+  is run, Then no jemalloc symbol is present in the binary (same test, negative arm).
+- **Scenario R1.3** — Given any host, When `cargo test -p cqlite-flight` and
+  `cargo test -p cqlite-flight --features dhat-heap` run, Then both build and pass — the allocator
+  is not in any test binary (gate components `flight-tests`, `memory-budget`).
+
+## Requirement R2 — The allocator in use is observable from outside the process
+
+- **Scenario R2.1** — When `cqlite-flight --version` runs, Then stdout contains exactly one line
+  matching `^allocator: (jemalloc|system)$`, and the value matches R1's build (integration test
+  `cqlite-flight/tests/issue_3997_allocator_surface.rs`, run under both feature states in the gate).
+- **Scenario R2.2** — When the server starts, Then the first startup `info` log line contains
+  `allocator=<same value>`.
+
+## Requirement R3 — The default is decided by a linked-build measurement, not inferred from #3551
+
+`default = ["jemalloc"]` SHALL be written only after arm E (linked jemalloc, pin `2,10`) is measured
+against arm A on the #3551 rig with #3551's paired interleaved method, and the pre-registered kill
+criterion (proposal) is applied.
+
+- **Scenario R3.1** — Given `scripts/perf/ws0-3551-abc.sh` with arm `E`, When ≥3 clean within-round
+  A/E pairs are collected, Then `docs/reports/ws0-3997-report.md` records median Δrows/s, Δcycles/row,
+  IPC, `VmHWM` and `VmRSS` per arm at N=1 **and** at the admission ceiling, with the byte basis and
+  fixture sha256 named, and states which of SHIP-default / SHIP-opt-in / DO-NOT-SHIP applies.
+- **Scenario R3.2** — Given the report says SHIP-default, Then the `Cargo.toml` default-feature
+  commit cites the report path and the median figure in its message; Given it says otherwise, Then
+  `default` stays `[]` and the report is still committed (a null is a deliverable).
+- **Scenario R3.3** — Given arm E's binary sha256 differs from arm A's, Then the aggregate's
+  cross-arm invariant check names E as the one permitted exception and still FAILs on any other
+  cross-arm binary difference (`scripts/tests/test_ws0_abc_driver_guards.sh` gains this case).
+
+## Requirement R4 — Structural confinement is gate-enforced
+
+- **Scenario R4.1** — When `scripts/tests/test_flight_allocator_confinement.sh` runs (a `tooling-tests`
+  member), Then it asserts that `global_allocator` occurs in exactly one non-test production file in
+  the workspace, `cqlite-flight/src/main.rs`, guarded by the `jemalloc` feature; any `src/lib.rs`
+  or `cqlite-core` occurrence outside `cfg(test)` FAILs.
+
+## Requirement R5 — No library consumer, binding, or other crate inherits the allocator
+
+- **Scenario R5.1** — When the confinement test runs, Then it also asserts no `Cargo.toml` under
+  `bindings/`, `cqlite-core/`, `cqlite-cli/` names `tikv-jemallocator`, and that every dependent of
+  `cqlite-flight` (`tools/flight-loadgen`, the crate's own dev-dependency) links the library target.
+
+## Requirement R6 — Memory budget is preserved
+
+- **Scenario R6.1** — Given arm E, When R3.1's measurement runs, Then `VmHWM` ≤ 1.10× arm A for
+  SHIP-default (≤1.25× for opt-in), at both N=1 and peak N.
+- **Scenario R6.2** — When the gate's `memory-budget` component runs, Then
+  `issue_1494_producer_mem_budget` still executes and passes unchanged.
+
+## Acceptance
+
+Gate PASS (full, one run of record) + C intent audit against this spec + roborev clean, and R3.1's
+report committed with an explicit verdict. Wiring evidence for the user-facing surface is R2.1's
+end-to-end test against the built binary.

--- a/openspec/changes/flight-jemalloc/tasks.md
+++ b/openspec/changes/flight-jemalloc/tasks.md
@@ -1,0 +1,66 @@
+# Tasks — flight-jemalloc (issue #3997)
+
+Ordered. Groups 1–2 are the mechanism (small), 3 is the measurement (the expensive part, on the
+#3551 rig `ip-172-31-7-163`), 4 is the decision, 5 is doctrine/coverage. Commit after every group.
+
+## 0. Premises — re-confirm on the box, STOP if false
+
+- [ ] 0.1 No `#[global_allocator]` in any non-test production file (`git grep global_allocator -- '*.rs'`
+      shows only `cfg(test)` core sites, dhat test binaries, examples). Design rests on this.
+- [ ] 0.2 `bindings/**/Cargo.toml` and `cqlite-core/Cargo.toml` do not depend on `cqlite-flight`.
+- [ ] 0.3 `libjemalloc.so.2` used by #3551 is jemalloc 5.3 (`ldconfig -p`, or the report's recorded
+      version) — the `tikv-jemallocator` pin must match the major measured.
+
+## 1. Mechanism (R1, R2) — surface: `cqlite-flight` binary
+
+- [ ] 1.1 `cqlite-flight/Cargo.toml`: `tikv-jemallocator = { version = "0.6", optional = true }`,
+      feature `jemalloc = ["dep:tikv-jemallocator"]`. **`default` stays `[]` in this group.**
+- [ ] 1.2 `cqlite-flight/src/main.rs`: `#[cfg(all(feature = "jemalloc", target_os = "linux"))]
+      #[global_allocator] static GLOBAL: tikv_jemallocator::Jemalloc = …;` plus one
+      `const ALLOCATOR: &str` derived from the same cfg.
+- [ ] 1.3 `--version` prints `allocator: <ALLOCATOR>`; startup info line gains `allocator=`.
+- [ ] 1.4 Test `cqlite-flight/tests/issue_3997_allocator_surface.rs` (R2.1): runs the built binary
+      with `--version` under the active feature set and asserts the line. Must pass in BOTH states.
+- [ ] 1.5 `scripts/tests/test_flight_allocator_link.sh` (R1.1/R1.2): symbol check on Linux;
+      SKIP-with-reason off-Linux (never a vacuous PASS — print the platform).
+- [ ] 1.6 `--lite` green; commit.
+
+## 2. Confinement (R4, R5) — surface: `tooling-tests`
+
+- [ ] 2.1 `scripts/tests/test_flight_allocator_confinement.sh`: exactly-one-production-site assert
+      + no `tikv-jemallocator` in core/cli/bindings manifests + dependents link the lib target.
+      Register it where `tooling-tests` discovers scripts; confirm it is EXECUTED (census line).
+- [ ] 2.2 `--lite` green; commit; open the PR (draft) so the rig work below has a head to certify.
+
+## 3. Measurement (R3.1, R3.3, R6.1) — rig `ip-172-31-7-163`, #3551 method
+
+- [ ] 3.1 Build two release binaries from the SAME commit: `--no-default-features` (arm A) and
+      `--features jemalloc` (arm E); record both sha256 in the round metadata.
+- [ ] 3.2 `scripts/perf/ws0-3551-abc.sh`: add arm `E` (= arm A flags + `--flight-binary <E>`);
+      `ws0_abc_aggregate.py`: allow E as the single permitted cross-arm binary exception (R3.3 test
+      in `test_ws0_abc_driver_guards.sh`).
+- [ ] 3.3 `ws0_flight_arm.py`: sample `VmHWM`/`VmRSS` of the server pid at scan end; add both to the
+      aggregate tables.
+- [ ] 3.4 Run ≥3 interleaved sets of A/E at N=1 (pin `2,10`, quiescence-gated as #3551) and ≥3 pairs
+      at the admission ceiling. Quiescence + pair-control rules unchanged.
+- [ ] 3.5 `docs/reports/ws0-3997-report.md` + `docs/reports/ws0-3997-artifacts/`: tables, verdict
+      per the pre-registered criterion, byte basis, fixture sha256, binary sha256s. Post the verdict
+      on #3023 (single reporting surface) and #3997.
+
+## 4. Decision (R3.2)
+
+- [ ] 4.1 SHIP-default → `default = ["jemalloc"]` in `cqlite-flight/Cargo.toml`, commit message cites
+      the report path + median Δ. Confirm `flight-loadgen` still builds (it inherits default
+      features of the lib target but installs nothing).
+- [ ] 4.2 SHIP-opt-in or DO-NOT-SHIP → leave `default = []`; for DO-NOT-SHIP remove the feature and
+      keep the report; close #3997 as an honest negative.
+
+## 5. Doctrine + endgame
+
+- [ ] 5.1 `docs/development/dev-cookbook.md`: how to build with/without the allocator; how to read
+      `allocator:` in `--version`. `docs/observability/` if the startup line is documented there.
+- [ ] 5.2 Helm/Trino deployment notes: state that the release binary carries the allocator; nothing
+      to configure.
+- [ ] 5.3 Full gate ONCE (`AGENT_GATE_SUMMARY_FILE` redirect) → C intent audit vs this spec →
+      roborev (`scripts/flow/roborev-review.sh --agent … --model …`) clean → `premerge-assert` →
+      `gh pr merge --auto --squash --delete-branch` → flow-finalize (telemetry via PR-in-worktree).

--- a/openspec/changes/flight-jemalloc/tasks.md
+++ b/openspec/changes/flight-jemalloc/tasks.md
@@ -5,41 +5,41 @@ Ordered. Groups 1–2 are the mechanism (small), 3 is the measurement (the expen
 
 ## 0. Premises — re-confirm on the box, STOP if false
 
-- [ ] 0.1 No `#[global_allocator]` in any non-test production file (`git grep global_allocator -- '*.rs'`
+- [x] 0.1 No `#[global_allocator]` in any non-test production file (`git grep global_allocator -- '*.rs'`
       shows only `cfg(test)` core sites, dhat test binaries, examples). Design rests on this.
-- [ ] 0.2 `bindings/**/Cargo.toml` and `cqlite-core/Cargo.toml` do not depend on `cqlite-flight`.
-- [ ] 0.3 `libjemalloc.so.2` used by #3551 is jemalloc 5.3 (`ldconfig -p`, or the report's recorded
+- [x] 0.2 `bindings/**/Cargo.toml` and `cqlite-core/Cargo.toml` do not depend on `cqlite-flight`.
+- [x] 0.3 `libjemalloc.so.2` used by #3551 is jemalloc 5.3 (`ldconfig -p`, or the report's recorded
       version) — the `tikv-jemallocator` pin must match the major measured.
 
 ## 1. Mechanism (R1, R2) — surface: `cqlite-flight` binary
 
-- [ ] 1.1 `cqlite-flight/Cargo.toml`: `tikv-jemallocator = { version = "0.6", optional = true }`,
+- [x] 1.1 `cqlite-flight/Cargo.toml`: `tikv-jemallocator = { version = "0.6", optional = true }`,
       feature `jemalloc = ["dep:tikv-jemallocator"]`. **`default` stays `[]` in this group.**
-- [ ] 1.2 `cqlite-flight/src/main.rs`: `#[cfg(all(feature = "jemalloc", target_os = "linux"))]
+- [x] 1.2 `cqlite-flight/src/main.rs`: `#[cfg(all(feature = "jemalloc", target_os = "linux"))]
       #[global_allocator] static GLOBAL: tikv_jemallocator::Jemalloc = …;` plus one
       `const ALLOCATOR: &str` derived from the same cfg.
-- [ ] 1.3 `--version` prints `allocator: <ALLOCATOR>`; startup info line gains `allocator=`.
-- [ ] 1.4 Test `cqlite-flight/tests/issue_3997_allocator_surface.rs` (R2.1): runs the built binary
+- [x] 1.3 `--version` prints `allocator: <ALLOCATOR>`; startup info line gains `allocator=`.
+- [x] 1.4 Test `cqlite-flight/tests/issue_3997_allocator_surface.rs` (R2.1): runs the built binary
       with `--version` under the active feature set and asserts the line. Must pass in BOTH states.
-- [ ] 1.5 `scripts/tests/test_flight_allocator_link.sh` (R1.1/R1.2): symbol check on Linux;
+- [x] 1.5 `scripts/tests/test_flight_allocator_link.sh` (R1.1/R1.2): symbol check on Linux;
       SKIP-with-reason off-Linux (never a vacuous PASS — print the platform).
-- [ ] 1.6 `--lite` green; commit.
+- [x] 1.6 `--lite` green; commit.
 
 ## 2. Confinement (R4, R5) — surface: `tooling-tests`
 
-- [ ] 2.1 `scripts/tests/test_flight_allocator_confinement.sh`: exactly-one-production-site assert
+- [x] 2.1 `scripts/tests/test_flight_allocator_confinement.sh`: exactly-one-production-site assert
       + no `tikv-jemallocator` in core/cli/bindings manifests + dependents link the lib target.
       Register it where `tooling-tests` discovers scripts; confirm it is EXECUTED (census line).
-- [ ] 2.2 `--lite` green; commit; open the PR (draft) so the rig work below has a head to certify.
+- [x] 2.2 `--lite` green; commit; open the PR (draft) so the rig work below has a head to certify.
 
 ## 3. Measurement (R3.1, R3.3, R6.1) — rig `ip-172-31-7-163`, #3551 method
 
 - [ ] 3.1 Build two release binaries from the SAME commit: `--no-default-features` (arm A) and
       `--features jemalloc` (arm E); record both sha256 in the round metadata.
-- [ ] 3.2 `scripts/perf/ws0-3551-abc.sh`: add arm `E` (= arm A flags + `--flight-binary <E>`);
+- [x] 3.2 `scripts/perf/ws0-3551-abc.sh`: add arm `E` (= arm A flags + `--flight-binary <E>`);
       `ws0_abc_aggregate.py`: allow E as the single permitted cross-arm binary exception (R3.3 test
       in `test_ws0_abc_driver_guards.sh`).
-- [ ] 3.3 `ws0_flight_arm.py`: sample `VmHWM`/`VmRSS` of the server pid at scan end; add both to the
+- [x] 3.3 `ws0_flight_arm.py`: sample `VmHWM`/`VmRSS` of the server pid at scan end; add both to the
       aggregate tables.
 - [ ] 3.4 Run ≥3 interleaved sets of A/E at N=1 (pin `2,10`, quiescence-gated as #3551) and ≥3 pairs
       at the admission ceiling. Quiescence + pair-control rules unchanged.
@@ -57,10 +57,45 @@ Ordered. Groups 1–2 are the mechanism (small), 3 is the measurement (the expen
 
 ## 5. Doctrine + endgame
 
-- [ ] 5.1 `docs/development/dev-cookbook.md`: how to build with/without the allocator; how to read
+- [x] 5.1 `docs/development/dev-cookbook.md`: how to build with/without the allocator; how to read
       `allocator:` in `--version`. `docs/observability/` if the startup line is documented there.
-- [ ] 5.2 Helm/Trino deployment notes: state that the release binary carries the allocator; nothing
+- [x] 5.2 Helm/Trino deployment notes: state that the release binary carries the allocator; nothing
       to configure.
 - [ ] 5.3 Full gate ONCE (`AGENT_GATE_SUMMARY_FILE` redirect) → C intent audit vs this spec →
       roborev (`scripts/flow/roborev-review.sh --agent … --model …`) clean → `premerge-assert` →
       `gh pr merge --auto --squash --delete-branch` → flow-finalize (telemetry via PR-in-worktree).
+
+---
+
+## Lane status (worker lane `ip-172-31-5-53`, worktree `/data/lanes/lane-3997`)
+
+**Done here:** groups 0, 1, 2, 5, and tasks **3.2/3.3** (the driver arm + the RSS sampling,
+including the sampler's CALL SITE in `scripts/perf/lib-measure.sh` — it landed as a collector
+with nothing calling it, which left R6.1 undecidable).
+
+**NOT done, and NOT doable here — `3.1`, `3.4`, `3.5` and group `4`.** They require the #3551
+rig `ip-172-31-7-163`; this lane is on `ip-172-31-5-53` and the rig is unreachable from it
+(`ssh` → `Permission denied (publickey)`). So **R3.1, R3.2 and R6.1 are UNMET in this change**
+and a `spec-auditor` (C) run against this spec must report them so. `default` stays `[]`, so
+nothing ships the allocator to anyone: the feature is opt-in and inert until the rig verdict.
+
+**Deviation from 3.2 as written, recorded deliberately.** The driver flag is `--bin-dir-e DIR`,
+not `--flight-binary <E>`. No `--flight-binary` exists anywhere in the rig, and the digest the
+aggregate reads for its cross-arm invariant is derived from `--bin-dir`
+(`ws0_binaries.record_binary_provenance` off `$BIN`) — so a per-binary override would launch one
+program and record another's digest, granting R3.3's exception against the wrong bytes. R3.3
+names no flag, so this deviates from the task wording only, not from the requirement.
+
+**Rig recipe for whoever picks up 3.1/3.4/3.5:** build `bins-A/` (all three binaries,
+`--no-default-features`), then `bins-E/` = the `--features jemalloc` `cqlite-flight` plus
+hardlinks/copies of `bins-A`'s `ws0-scan-bench` and `flight-loadgen`; the driver refuses the set
+otherwise (that two-sided precondition is what earns arm E its exception). With `--bin-dir-e` the
+set is **6 arms/round** (A,B,C0,C,D,E), not A/E only — there is no `--arms` selector on the
+driver; the aggregate is then run `--arms A,E --baseline A`, and the driver prints that command.
+
+**Rig-only confirmations nobody has made yet** (reasoned, not measured — do not treat as done):
+a `tikv-jemallocator`-linked binary leaves **no** `libjemalloc` mapping, which is what lets arm E
+run under `--flight-allocator system` and still pass `verify_flight_server_allocator`'s per-rep
+`/proc/<pid>/{environ,maps}` check; real `VmHWM`/`VmRSS` magnitudes under load; the digest
+precondition against real cargo output; and that `refuse_binaries_older_than_head` accepts two
+separately-built bin dirs.

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -21894,6 +21894,63 @@ run_tooling_tests() {
     return 0
   fi
 
+  # cqlite-flight allocator CONFINEMENT guard + its positive control (#3997, R4.1/R5.1).
+  # ABOVE the python3 gate on purpose: both need nothing beyond bash + git + grep, and
+  # folding a never-SKIPping suite into a SKIP-aware block would be a coverage hole
+  # wearing a SKIP's clothes (#3522's ruling). Static source/manifest scan, ~0.3s + ~2s.
+  # What it pins: a `#[global_allocator]` is PROCESS-WIDE, and the whole design of #3997
+  # rests on the one install site living in cqlite-flight/src/main.rs, which rustc compiles
+  # into the BIN target alone — that is what keeps jemalloc out of the library every
+  # embedder, binding and integration test links, and out of the memory ratchets that
+  # install their OWN allocator in their OWN test binaries. Nothing about that is enforced
+  # by the compiler: a later "move it to lib.rs for convenience" would build fine and
+  # silently impose an allocator on every consumer. It also asserts no manifest outside
+  # cqlite-flight names tikv-jemallocator, and that every cqlite-flight dependent links the
+  # LIBRARY target (`artifact`/`bin` refused). Every occurrence is CLASSIFIED, and an
+  # unrecognised shape is a named FAIL rather than a skipped line. The selftest is the
+  # positive control — 21 cases over scratch git trees, 2 green controls so a
+  # refuse-everything guard cannot satisfy the 17 reds, each red required to NAME its
+  # planted defect. A failure FAILs the component, mirroring the guards above.
+  echo ">>> [$name] bash scripts/tests/test_flight_allocator_confinement.sh; bash scripts/tests/test_flight_allocator_confinement_selftest.sh"
+  if ! bash "$REPO_ROOT/scripts/tests/test_flight_allocator_confinement.sh" >>"$log" 2>&1 ||
+     ! bash "$REPO_ROOT/scripts/tests/test_flight_allocator_confinement_selftest.sh" >>"$log" 2>&1; then
+    status=FAIL
+    echo "--- [$name] FAILED (flight allocator confinement #3997); last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $RECORDED_STATUS ($((end - start))s)"
+    return 0
+  fi
+
+  # cqlite-flight LINKED-allocator guard (#3997, R1.1/R1.2/R2.1). THE gate-enforcing
+  # surface for the jemalloc mechanism, and it is here because nothing else runs it: the
+  # cargo-native test expressing the same contract
+  # (cqlite-flight/tests/issue_3997_allocator_surface.rs) is executed by NO component —
+  # `flight-tests` runs cqlite-flight at `--lib --bins` only and censuses the ~42
+  # integration `--test` targets it does not run (#3384). This guard also covers a property
+  # no cargo test can reach: what is actually LINKED INTO the binary. Two DEBUG builds
+  # (`--features jemalloc`, then default features, which is the feature set other components
+  # already built, so it is warm) and per arm: the symbol table must / must not carry
+  # jemalloc symbols, and `--version` must report the matching `allocator:` line. The arms
+  # are each other's control — a matcher that matches everything satisfies the positive arm
+  # alone, one that matches nothing satisfies the negative arm alone. Internally SKIP-aware
+  # and always NAMING the cause (off-Linux printing the actual `uname -s`; no cargo/cc/make/
+  # symbol tool/bounded `timeout`; unparseable symbol output), while a FAILING cargo build is
+  # a FAIL, not a skip. Measured 5.3s warm on a fleet box. A failure FAILs the component.
+  echo ">>> [$name] bash scripts/tests/test_flight_allocator_link.sh"
+  if ! bash "$REPO_ROOT/scripts/tests/test_flight_allocator_link.sh" >>"$log" 2>&1; then
+    status=FAIL
+    echo "--- [$name] FAILED (flight linked-allocator guard #3997); last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $RECORDED_STATUS ($((end - start))s)"
+    return 0
+  fi
+
   if ! command -v python3 >/dev/null 2>&1; then
     status=SKIP
     echo ">>> [$name] SKIP (no python3 on PATH; selftest truncation reader needs it)"

--- a/scripts/perf/lib-measure.sh
+++ b/scripts/perf/lib-measure.sh
@@ -338,6 +338,30 @@ measure_flight() {
     > "$OUT_DIR/$tag.log" 2>&1 \
     || { stop_server; echo "FATAL: flight rep $tag failed — see $OUT_DIR/$tag.log" >&2; exit 1; }
 
+  # THE FLIGHT SERVER'S SCAN-END RESIDENT SET (issue #3997, R6.1). Sampled HERE and
+  # nowhere else, because this is the last instant at which there is anything to
+  # sample: the counted window has closed, so the read perturbs no measurement, and
+  # `stop_server` on the next line destroys the process whose `/proc` entry is the
+  # only source of these two numbers. Ordering, not preference — moving it below
+  # `stop_server` would sample a pid that no longer exists, and the collector would
+  # correctly record every arm as UNMEASURED.
+  #
+  # `VmHWM` is a HIGH-WATER MARK, so reading it after the load is over is exactly
+  # right: it reports the peak the process ever reached, which is what R6.1's
+  # `≤ 1.10x` ceiling is about. `VmRSS` is ONE INSTANTANEOUS SAMPLE and is recorded
+  # as such — never as a mean over the rep.
+  #
+  # NOT `|| true`, and not `|| :`. A non-zero exit here means the sampler could not
+  # WRITE ITS RECORD AT ALL (an unwritable `$OUT_DIR`), which is a broken rig, not a
+  # missing measurement — an unobservable RSS is reported by the sampler as an
+  # explicit `UNMEASURED — <cause>` record and exits 0. Swallowing the write failure
+  # would turn a broken output directory into a silently RSS-less round.
+  #
+  # Deliberately ONE LINE: a `\`-continuation makes the next token a bare
+  # `"$OUT_DIR/..."`, which `lib-perf-lint.sh`'s `is_var_command` reads as a variable
+  # command and flags.
+  python3 "$WS0_MEASURE_LIB_DIR/ws0_flight_arm.py" sample-server-rss "$SERVER_PID" "$OUT_DIR/$tag.server-rss.json" > /dev/null
+
   stop_server
   echo "  $tag done"
 }

--- a/scripts/perf/ws0-3551-abc.sh
+++ b/scripts/perf/ws0-3551-abc.sh
@@ -276,7 +276,7 @@ require_reported_allocator() {
     exit 2
   fi
   if [[ $rc -ne 0 ]]; then
-    echo "FATAL: \`$bin --version\` exited $rc, so its allocator is UNMEASURED." >&2
+    echo "FATAL: $label — \`$bin --version\` exited $rc, so its allocator is UNMEASURED." >&2
     echo "       R2.1 requires --version to short-circuit before argument validation and exit 0." >&2
     _echo_version_streams "$out" "$err"
     exit 2
@@ -284,7 +284,8 @@ require_reported_allocator() {
   mapfile -t matched < <(printf '%s\n' "$out" | grep -E "$ALLOCATOR_SURFACE_RE") || true
   n=${#matched[@]}
   if [[ $n -ne 1 ]]; then
-    echo "FATAL: \`$bin --version\` printed $n line(s) matching '$ALLOCATOR_SURFACE_RE';" >&2
+    echo "FATAL: $label — \`$bin --version\` printed $n line(s) matching" >&2
+    echo "       '$ALLOCATOR_SURFACE_RE' on STDOUT;" >&2
     echo "       R2.1's contract is EXACTLY ONE. Neither 0 nor 2+ is read as either allocator:" >&2
     echo "       an unrecognised or absent line is UNMEASURED, and defaulting either way is how" >&2
     echo "       a glibc build would be measured as the jemalloc arm. NOTE the count is taken" >&2

--- a/scripts/perf/ws0-3551-abc.sh
+++ b/scripts/perf/ws0-3551-abc.sh
@@ -31,6 +31,10 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 CORPUS=""
 BIN_DIR=""
+# ARM E's OWN BINARY SET (#3997). Empty = arm E is not part of this set, and the arm list below
+# does not carry it. See `arm_bin_dir` for why arm E is a second --bin-dir rather than a
+# per-binary override, and for the invariant this driver enforces on it up front.
+BIN_DIR_E=""
 OUT=""
 ROUNDS=3
 STEP_DURATION="45s"
@@ -52,6 +56,18 @@ PIN_B="2,3"
 # would buy nothing but a second failure mode.
 MEASURED_BINARIES=(ws0-scan-bench cqlite-flight flight-loadgen)
 
+# ARM E (#3997) — THE ONE ARM THAT MEASURES DIFFERENT BYTES, AND THE ONE THAT IS OPT-IN.
+#
+# Its id and its differing binary are named ONCE here because three places must agree on them:
+# this driver (which arm gets which --bin-dir), `ws0_abc_aggregate.py` (whose cross-arm binary
+# invariant grants this arm — and only this arm, on this binary — a NAMED exception), and
+# `scripts/tests/test_ws0_abc_driver_guards.sh` (which asserts BOTH directions of that
+# exception). The aggregator states the same pair in its own constants; the guard suite reads
+# both and refuses a disagreement, because two sides of one exception silently naming different
+# arms is how a narrow exception becomes a disabled check.
+ARM_E="E"
+ARM_E_BINARY="cqlite-flight"
+
 usage() {
   cat <<EOF
 ws0-3551-abc.sh — issue #3551 interleaved SMT-unpin + allocator trial
@@ -60,7 +76,15 @@ ws0-3551-abc.sh — issue #3551 interleaved SMT-unpin + allocator trial
   --bin-dir DIR      ONE frozen binary set measured by EVERY arm. REQUIRED, and required to be
                      one directory: the arms must not differ in their binaries (#3248 withdrew a
                      machine-code claim for exactly that reason), so this is deliberately not
-                     per-arm.
+                     per-arm. ARM E is the ONE exception, and it is opt-in — see --bin-dir-e.
+  --bin-dir-e DIR    OPTIONAL, and giving it is what ADDS ARM E to this set (#3997). A SECOND
+                     frozen binary set whose $ARM_E_BINARY is a DIFFERENT build — the linked
+                     jemalloc #[global_allocator] — and whose other measured binaries are the
+                     SAME BYTES as --bin-dir's. Both halves are CHECKED from the digests before
+                     anything is measured: an identical $ARM_E_BINARY would publish two labels
+                     for one treatment, and a differing ws0-scan-bench or flight-loadgen would
+                     move the drift control or the client apparatus, which is a second treatment.
+                     Omit it and the set is A/B/C0/C/D exactly as before.
   --out DIR          Where the r<N>-<arm>/ session dirs go. REQUIRED. A (round, arm) that
                      already holds a results.json is SKIPPED, so an interrupted set resumes
                      instead of starting over — which matters on a shared box. The resume is
@@ -84,6 +108,17 @@ what is attributable; arm C differs from arm A in BOTH axes and on its own is no
   1 phys core $PIN_A     A            D
   2 phys cores $PIN_B    B            C
   C0 = B + MALLOC_ARENA_MAX=$ARENA_MAX (#3217 partC F1-AC2's pre-registered arena experiment)
+  E  = arm A's FLAGS EXACTLY, measured against --bin-dir-e's binary set (#3997, R3.1/R3.3).
+       Present only when --bin-dir-e is given. Arms A/B/C0/C/D vary the allocator by
+       LD_PRELOAD into one binary, which is what let #3551 hold every arm's bytes identical;
+       arm E is the SHIPPED form — jemalloc LINKED as the binary's #[global_allocator] — so it
+       is the first arm that legitimately runs different bytes from arm A. Its flags say
+       --flight-allocator system because nothing is preloaded: the per-rep check then asserts
+       an EMPTY LD_PRELOAD and no jemalloc *mapping*, both of which a statically linked
+       allocator satisfies. So the allocator column of the aggregate's configuration table
+       reads 'system' for arm E too, and the allocator difference is visible ONLY as the
+       binary digest — which is why the aggregate prints those digests per arm rather than
+       leaving arm E's treatment to be inferred from a flag that cannot show it.
 
 \$OUT/abc-run.json is this set's RUN FINGERPRINT: the corpus path AND its recorded Data.db
 sha256 + row count, the --bin-dir path AND a digest of every measured binary in it, the arm set
@@ -101,6 +136,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --corpus) CORPUS="${2:-}"; shift 2 ;;
     --bin-dir) BIN_DIR="${2:-}"; shift 2 ;;
+    --bin-dir-e) BIN_DIR_E="${2:-}"; shift 2 ;;
     --out) OUT="${2:-}"; shift 2 ;;
     --rounds) ROUNDS="${2:-}"; shift 2 ;;
     --step-duration) STEP_DURATION="${2:-}"; shift 2 ;;
@@ -124,6 +160,14 @@ done
 mkdir -p "$OUT"
 
 ARMS=(A B C0 C D)
+
+# Arm E joins the set only when its binary set is supplied — see --bin-dir-e in the usage text
+# and `arm_bin_dir` below. Omitted, this driver's arm set and every fingerprint field it writes
+# are byte-identical to the pre-#3997 ones.
+if [[ -n "$BIN_DIR_E" ]]; then
+  [[ -d "$BIN_DIR_E" ]] || { echo "FATAL: --bin-dir-e '$BIN_DIR_E' is not a directory" >&2; exit 2; }
+  ARMS+=("$ARM_E")
+fi
 
 arm_flags() {
   # The one place an arm's identity is defined. Printed into the run record below AND read back
@@ -151,7 +195,45 @@ arm_flags() {
     # and (C-D)-(B-A) is the interaction — which is the quantity the SMT hypothesis is actually
     # about. Measuring only A/B/C leaves the headline attributable to either variable.
     D)  printf '%s\n' --flight-server-cpus "$PIN_A" --flight-pin-mode siblings --flight-allocator jemalloc ;;
+    # ARM E IS ARM A'S FLAG LIST, CHARACTER FOR CHARACTER, and that is the whole design (#3997).
+    # The treatment is carried entirely by `arm_bin_dir` below: arm E measures a binary that
+    # LINKS jemalloc as its `#[global_allocator]`, so there is nothing to preload and no knob to
+    # turn — `--flight-allocator jemalloc` here would set LD_PRELOAD and make arm E a
+    # preload-AND-link arm, i.e. two changes at once, which is the confound arm D was added to
+    # break. `system` is therefore the correct and honest value: it is what the SERVER'S
+    # ENVIRONMENT will hold, it is what `lib-flight-arm.sh` verifies per rep from
+    # /proc/<pid>/{environ,maps}, and a statically linked jemalloc leaves no `libjemalloc`
+    # MAPPING for that check to trip on.
+    #
+    # Consequence, stated because it is the reason R3.3 exists: arms A and E record an IDENTICAL
+    # treatment, so NOTHING in the recorded flags distinguishes them. The distinguishing fact is
+    # the `cqlite-flight` digest in each session's own `binary_provenance`, which is why the
+    # aggregator prints it per arm.
+    E)  printf '%s\n' --flight-server-cpus "$PIN_A" --flight-pin-mode siblings --flight-allocator system ;;
     *)  echo "FATAL: unknown arm '$1'" >&2; return 2 ;;
+  esac
+}
+
+# arm_bin_dir <arm> — WHICH FROZEN BINARY SET THIS ARM MEASURES (#3997).
+#
+# The one place that answer is given, mirroring `arm_flags` deliberately rather than being
+# folded into it: `arm_flags` output is FINGERPRINTED as an arm's flag list and read back out of
+# each session's recorded pinning, while the binary set is fingerprinted as digests and read
+# back out of each session's `binary_provenance`. Two different records, two different refusals.
+#
+# WHY A SECOND --bin-dir AND NOT A PER-BINARY OVERRIDE. `ws0-baseline.sh` derives the session's
+# whole `binary_provenance` block from `--bin-dir` (`ws0_binaries.py`), and that block is the
+# ONLY thing the aggregator can read the measured bytes out of. A `--flight-binary <path>`
+# override — the shape #3997's task list sketched — would launch one binary while the session
+# recorded the digest of another, so R3.3's exception would be granted against a digest that
+# named the wrong program: exactly the unobserved-treatment defect the rest of this file is
+# built to refuse. A second `--bin-dir` needs no new plumbing anywhere and keeps every digest
+# truthful. Build it as: the jemalloc `cqlite-flight` plus HARDLINKS (or copies) of --bin-dir's
+# own `ws0-scan-bench` and `flight-loadgen`, whose sameness is checked below.
+arm_bin_dir() {
+  case "$1" in
+    E) printf '%s\n' "$BIN_DIR_E" ;;
+    *) printf '%s\n' "$BIN_DIR" ;;
   esac
 }
 
@@ -301,6 +383,56 @@ for b in "${MEASURED_BINARIES[@]}"; do
   digest="$(sha256_of "$BIN_DIR/$b")" || exit 2
   fp+=("binary_sha256.$b=$digest")
 done
+# ARM E'S BINARY SET, AND THE TWO-SIDED PRECONDITION THAT EARNS ITS EXCEPTION (#3997, R3.3).
+#
+# `ws0_abc_aggregate.py` grants arm E a NAMED exception to the cross-arm "every arm ran the same
+# bytes" invariant. An exception is only narrow if BOTH of its edges are checked, so both are
+# checked HERE, from the digests, before a single rep runs:
+#
+#   * $ARM_E_BINARY MUST DIFFER. Identical bytes would make arm E a second label for arm A's
+#     treatment, and the aggregate would publish a "linked jemalloc" row measured from the
+#     glibc binary — a permitted exception used to hide the absence of the thing under test.
+#   * EVERY OTHER MEASURED BINARY MUST BE THE SAME BYTES. `ws0-scan-bench` IS the drift control
+#     and `flight-loadgen` is the client apparatus; moving either makes arm E differ from arm A
+#     in two properties, which is the confound arm D exists to break. The aggregate refuses
+#     these on its own too — that is the "still FAILs on any other cross-arm binary difference"
+#     half of R3.3 — but a refusal AFTER a multi-hour set has run is a refusal that costs the
+#     rig its window, so the same facts are established up front from the same digests.
+#
+# These fields are recorded ONLY when arm E is in the set, so a set started before #3997 (or
+# without --bin-dir-e) resumes against a byte-identical fingerprint. Switching arm E on or off
+# over one --out is caught by the `arms` field, which changes with it.
+if [[ -n "$BIN_DIR_E" ]]; then
+  fp+=("bin_dir_e=$BIN_DIR_E")
+  for b in "${MEASURED_BINARIES[@]}"; do
+    digest="$(sha256_of "$BIN_DIR/$b")" || exit 2
+    digest_e="$(sha256_of "$BIN_DIR_E/$b")" || exit 2
+    fp+=("binary_sha256_e.$b=$digest_e")
+    if [[ "$b" == "$ARM_E_BINARY" ]]; then
+      if [[ "$digest" == "$digest_e" ]]; then
+        echo "FATAL: --bin-dir-e '$BIN_DIR_E/$b' is the SAME BYTES as --bin-dir '$BIN_DIR/$b'" >&2
+        echo "       (sha256 $digest). Arm $ARM_E exists to measure a DIFFERENT $ARM_E_BINARY —" >&2
+        echo "       the build that LINKS jemalloc as its #[global_allocator]. Identical bytes" >&2
+        echo "       make arm $ARM_E a second LABEL for arm A's treatment, and the aggregate" >&2
+        echo "       would then publish a linked-allocator row measured from the control binary." >&2
+        echo "       Remedy: build --bin-dir-e's $ARM_E_BINARY with the jemalloc feature, or drop" >&2
+        echo "       --bin-dir-e and run the A/B/C0/C/D set." >&2
+        exit 2
+      fi
+    elif [[ "$digest" != "$digest_e" ]]; then
+      echo "FATAL: --bin-dir-e '$BIN_DIR_E/$b' differs from --bin-dir '$BIN_DIR/$b'" >&2
+      echo "         --bin-dir   $digest" >&2
+      echo "         --bin-dir-e $digest_e" >&2
+      echo "       Only $ARM_E_BINARY may differ between arm $ARM_E and the other arms." >&2
+      echo "       ws0-scan-bench IS the drift control and flight-loadgen is the client" >&2
+      echo "       apparatus, so a differing one makes arm $ARM_E differ from arm A in TWO" >&2
+      echo "       properties and its delta attributable to neither." >&2
+      echo "       Remedy: hardlink or copy --bin-dir's $b into --bin-dir-e rather than" >&2
+      echo "       rebuilding it, so the bytes are the same bytes by construction." >&2
+      exit 2
+    fi
+  done
+fi
 for arm in "${ARMS[@]}"; do
   mapfile -t af < <(arm_flags "$arm")
   fp+=("arm_flags.$arm=${af[*]}")
@@ -580,7 +712,12 @@ for ((r = 1; r <= ROUNDS; r++)); do
     # the line `perf-lint-allow` would have silenced a lint that was reasoning correctly; the
     # array makes the leading word the literal `bash` instead. Second, an empty optional value
     # cannot become an empty positional argument this way.
-    local_args=(--corpus "$CORPUS" --bin-dir "$BIN_DIR" --out "$dir"
+    # THE BINARY SET IS PER-ARM, and for every arm but E it is the one `--bin-dir` names — see
+    # `arm_bin_dir`. Resolved through the function rather than branched here so there is exactly
+    # one place that answers "which bytes did this arm measure", the same way `arm_flags`
+    # answers "under which flags".
+    arm_bins="$(arm_bin_dir "$arm")"
+    local_args=(--corpus "$CORPUS" --bin-dir "$arm_bins" --out "$dir"
                 --reps 1 --temp warm --arm bypass
                 --step-duration "$STEP_DURATION" --port "$PORT")
     if [[ -n "$QUIESCENCE_TS" ]]; then
@@ -626,3 +763,13 @@ echo
 _arms_csv=$(IFS=,; echo "${ARMS[*]}")
 echo "all rounds complete. aggregate with:"
 echo "  python3 $HERE/ws0_abc_aggregate.py --root $OUT --arms $_arms_csv --baseline ${ARMS[0]}"
+# ...and, when arm E is in the set, the TWO-ARM aggregate #3997's kill criterion is read from.
+# Printed as a SECOND command rather than replacing the one above: the whole-set table is still
+# what makes each arm's delta readable against the others, and R3.1 asks for the A/E pair
+# specifically (median Δrows/s, Δcycles/row, IPC, VmHWM and VmRSS per arm). Derived from the
+# arm ids, never a literal — the line above was a literal once and arm D's arrival silently
+# made it wrong (roborev, #3551 round 2).
+if [[ -n "$BIN_DIR_E" ]]; then
+  echo "and, for #3997's pre-registered A/$ARM_E kill criterion, the two-arm table:"
+  echo "  python3 $HERE/ws0_abc_aggregate.py --root $OUT --arms ${ARMS[0]},$ARM_E --baseline ${ARMS[0]}"
+fi

--- a/scripts/perf/ws0-3551-abc.sh
+++ b/scripts/perf/ws0-3551-abc.sh
@@ -527,6 +527,20 @@ if [[ -n "$BIN_DIR_E" ]]; then
     digest_e="$(sha256_of "$BIN_DIR_E/$b")" || exit 2
     fp+=("binary_sha256_e.$b=$digest_e")
     if [[ "$b" == "$ARM_E_BINARY" ]]; then
+      # SHADOWED, AND KEPT ON PURPOSE — DO NOT DELETE THIS BRANCH AS DEAD (#3997, roborev round
+      # 2). `require_reported_allocator` runs EARLIER, with the argument checks, and asks both
+      # binaries for R2.1's `allocator:` line; identical bytes cannot report two different
+      # allocators, so an identical $ARM_E_BINARY is refused up there — naming which binary
+      # reported what — and this refusal cannot fire in the driver today. It is retained as
+      # DEFENCE IN DEPTH against a reordering (the allocator pair sits before the first side
+      # effect precisely so a false premise costs no output directory, and a future edit that
+      # moved it would silently take this property with it), NOT because it is reachable.
+      #
+      # NO TEST ASSERTS THIS TEXT, and that is deliberate rather than an omission: an assertion
+      # that cannot fire is the vacuous pass. The digest-identity refusal's REACHABLE, TESTED
+      # home is `ws0_abc_aggregate.py` — `test_ws0_abc_driver_guards.sh` case 5l — which runs
+      # STANDALONE over a session directory, executes no binaries and therefore has no allocator
+      # oracle available to it at all. The property is enforced at the layer that can enforce it.
       if [[ "$digest" == "$digest_e" ]]; then
         echo "FATAL: --bin-dir-e '$BIN_DIR_E/$b' is the SAME BYTES as --bin-dir '$BIN_DIR/$b'" >&2
         echo "       (sha256 $digest). Arm $ARM_E exists to measure a DIFFERENT $ARM_E_BINARY —" >&2

--- a/scripts/perf/ws0-3551-abc.sh
+++ b/scripts/perf/ws0-3551-abc.sh
@@ -233,6 +233,13 @@ arm_flags() {
 # built to refuse. A second `--bin-dir` needs no new plumbing anywhere and keeps every digest
 # truthful. Build it as: the jemalloc `cqlite-flight` plus HARDLINKS (or copies) of --bin-dir's
 # own `ws0-scan-bench` and `flight-loadgen`, whose sameness is checked below.
+#
+# THE `*)` BRANCH IS TOTAL, NOT A PERMISSIVE DEFAULT. The question this function answers has
+# exactly two answers by construction — arm E measures --bin-dir-e's set, every other arm
+# measures --bin-dir's — so there is no unknown-arm case for it to swallow: `$BIN_DIR` is the
+# CORRECT answer for any arm id that is not E, including one that should never have been asked
+# for. Enumerating the arms here instead would duplicate `arm_flags`'s table for no gain, and
+# `arm_flags` already refuses an unknown arm by name.
 arm_bin_dir() {
   case "$1" in
     E) printf '%s\n' "$BIN_DIR_E" ;;

--- a/scripts/perf/ws0-3551-abc.sh
+++ b/scripts/perf/ws0-3551-abc.sh
@@ -84,6 +84,12 @@ ws0-3551-abc.sh — issue #3551 interleaved SMT-unpin + allocator trial
                      anything is measured: an identical $ARM_E_BINARY would publish two labels
                      for one treatment, and a differing ws0-scan-bench or flight-loadgen would
                      move the drift control or the client apparatus, which is a second treatment.
+                     AND THE ALLOCATOR IS ASKED OF BOTH BINARIES, not inferred from the digests:
+                     \`$ARM_E_BINARY --version\` must report 'allocator: system' in --bin-dir and
+                     'allocator: jemalloc' in --bin-dir-e (R2.1), before anything runs. A digest
+                     difference proves DIFFERENT BYTES and never 'jemalloc' — any unrelated
+                     rebuild satisfies it — and /proc/<pid>/maps cannot see a statically linked
+                     allocator, so this surface is the only thing that can tell them apart.
                      Omit it and the set is A/B/C0/C/D exactly as before.
   --out DIR          Where the r<N>-<arm>/ session dirs go. REQUIRED. A (round, arm) that
                      already holds a results.json is SKIPPED, so an interrupted set resumes
@@ -160,6 +166,108 @@ done
 # file's standing reason: refusing an impossible configuration AFTER acting on it is the defect.
 [[ -z "$BIN_DIR_E" || -d "$BIN_DIR_E" ]] \
   || { echo "FATAL: --bin-dir-e '$BIN_DIR_E' is not a directory" >&2; exit 2; }
+
+# ARM E'S TREATMENT IS ASKED OF THE BINARY, NEVER INFERRED FROM ITS BYTES (#3997, R2.1;
+# roborev round 2, job 132).
+#
+# The digest precondition below establishes that arm E's $ARM_E_BINARY is a DIFFERENT build from
+# the control's. "Different" is not "jemalloc": a rebuild with another feature set, a stale
+# binary from another branch, or any unrelated rebuild satisfies it while still linking glibc
+# malloc — and NOTHING downstream catches that. Arm E runs under `--flight-allocator system` by
+# construction (nothing is preloaded), and `verify_flight_server_allocator`'s
+# `/proc/<pid>/maps` check CANNOT see a statically linked jemalloc — that blindness is exactly
+# what lets arm E carry the `system` label. So the mapping check is structurally silent here,
+# the digest check is satisfied, and the aggregate would then label a glibc-vs-glibc pair a
+# linked-allocator comparison and attribute run-to-run noise to jemalloc.
+#
+# So the allocator is READ OFF THE BINARY'S OWN `--version` SURFACE, which is R2's whole
+# purpose: the reported string is derived from the SAME `cfg` that installs the
+# `#[global_allocator]`, so it cannot disagree with what was linked. This retires the rig-only
+# residual "a tikv-jemallocator-linked binary leaves no libjemalloc mapping" — reasoned, never
+# measured — by removing the need to infer anything.
+#
+# BOTH SIDES ARE ASKED, because either alone is insufficient: E reporting `jemalloc` while the
+# CONTROL also links jemalloc makes the A-vs-E delta not an allocator delta at all.
+#
+# SCOPE, stated because it is a decision: this fires only when `--bin-dir-e` is given, i.e. when
+# arm E is in the set and the linked-allocator claim is being made. A set without arm E is
+# byte-identical in behaviour to the pre-#3997 driver (an opt-in that changes the default is not
+# opt-in), so its control binary is NOT asked — a linked-jemalloc `--bin-dir` would make arms
+# A/B/C0/C/D silently jemalloc arms, which this check does not cover and which nothing else
+# does either. NAMED, not closed.
+#
+# NO SYMBOL READER IS INVOLVED, deliberately. `nm`/`readelf` would be a second oracle for one
+# fact, would need its own three-valued unmeasurable handling, and would make a binutils
+# installation a hard prerequisite of a measurement rig that does not otherwise need one.
+# `--version` decides it, from the same cfg — `scripts/tests/test_flight_allocator_link.sh`
+# owns the symbol-level assertion, at build time, where the toolchain is present by definition.
+ALLOCATOR_SURFACE_RE='^allocator: (jemalloc|system)$'
+
+# require_reported_allocator <label> <binary> <expected> — fail CLOSED on every unmeasurable
+# state, each naming its own cause, because "the binary did not say" and "the binary said the
+# other thing" are different operator actions (rebuild vs. point --bin-dir-e somewhere else).
+require_reported_allocator() {
+  local label="$1" bin="$2" expect="$3" rc=0 out n
+  local -a matched
+  if [[ ! -f "$bin" ]]; then
+    echo "FATAL: $label '$bin' is not a file, so its allocator could not be READ." >&2
+    echo "       Arm $ARM_E's treatment is the LINKED allocator, and R2.1's --version surface is" >&2
+    echo "       the only thing that can state which one was linked." >&2
+    exit 2
+  fi
+  if [[ ! -x "$bin" ]]; then
+    echo "FATAL: $label '$bin' is not EXECUTABLE, so its reported allocator is UNMEASURED." >&2
+    echo "       Refused rather than skipped: a digest difference proves DIFFERENT BYTES and" >&2
+    echo "       never 'jemalloc', so nothing else in this rig can establish arm $ARM_E's" >&2
+    echo "       treatment. Remedy: chmod +x, or point --bin-dir-e at a real build directory." >&2
+    exit 2
+  fi
+  if command -v timeout >/dev/null 2>&1; then
+    out="$(timeout -k 5 60 "$bin" --version 2>&1)" || rc=$?
+  else
+    # A missing bound must not inherit the permissive branch, and an unbounded `--version` on a
+    # wrong or wedged binary would hang the whole set with no verdict — which blocks the
+    # measurement anyway, so refusing now with a named remedy strictly dominates hanging later.
+    echo "FATAL: no timeout(1) on this host, so \`$label --version\` cannot be BOUNDED." >&2
+    echo "       Refused rather than run unbounded: a wedged binary would hang the set with no" >&2
+    echo "       verdict. Remedy: install coreutils' timeout." >&2
+    exit 2
+  fi
+  if [[ $rc -ne 0 ]]; then
+    echo "FATAL: \`$bin --version\` exited $rc, so its allocator is UNMEASURED." >&2
+    echo "       R2.1 requires --version to short-circuit before argument validation and exit 0." >&2
+    echo "       Its output follows:" >&2
+    printf '%s\n' "$out" | sed 's/^/         | /' >&2
+    exit 2
+  fi
+  mapfile -t matched < <(printf '%s\n' "$out" | grep -E "$ALLOCATOR_SURFACE_RE") || true
+  n=${#matched[@]}
+  if [[ $n -ne 1 ]]; then
+    echo "FATAL: \`$bin --version\` printed $n line(s) matching '$ALLOCATOR_SURFACE_RE';" >&2
+    echo "       R2.1's contract is EXACTLY ONE. Neither 0 nor 2+ is read as either allocator:" >&2
+    echo "       an unrecognised or absent line is UNMEASURED, and defaulting either way is how" >&2
+    echo "       a glibc build would be measured as the jemalloc arm. Its output follows:" >&2
+    printf '%s\n' "$out" | sed 's/^/         | /' >&2
+    exit 2
+  fi
+  if [[ "${matched[0]}" != "allocator: $expect" ]]; then
+    echo "FATAL: $label '$bin' reports '${matched[0]}', expected 'allocator: $expect'." >&2
+    echo "       Arm $ARM_E is the LINKED-jemalloc treatment and every other arm selects its" >&2
+    echo "       allocator by LD_PRELOAD into the control binary, so the pair must read" >&2
+    echo "       --bin-dir=system and --bin-dir-e=jemalloc. A digest DIFFERENCE proves only" >&2
+    echo "       different bytes — any unrelated rebuild satisfies it — and /proc/<pid>/maps" >&2
+    echo "       cannot see a statically linked allocator, so this surface is the only thing" >&2
+    echo "       that can tell the two apart. Remedy: build --bin-dir-e's $ARM_E_BINARY with" >&2
+    echo "       --features jemalloc (and --bin-dir's without it), or drop --bin-dir-e." >&2
+    exit 2
+  fi
+  echo "arm $ARM_E precondition: $label '$bin' reports '${matched[0]}' (R2.1)"
+}
+
+if [[ -n "$BIN_DIR_E" ]]; then
+  require_reported_allocator "--bin-dir $ARM_E_BINARY" "$BIN_DIR/$ARM_E_BINARY" system
+  require_reported_allocator "--bin-dir-e $ARM_E_BINARY" "$BIN_DIR_E/$ARM_E_BINARY" jemalloc
+fi
 
 mkdir -p "$OUT"
 

--- a/scripts/perf/ws0-3551-abc.sh
+++ b/scripts/perf/ws0-3551-abc.sh
@@ -156,6 +156,10 @@ done
 [[ "$ARENA_MAX" =~ ^[1-9][0-9]*$ ]] || { echo "FATAL: --arena-max must be a positive integer, got '$ARENA_MAX'" >&2; exit 2; }
 [[ -d "$CORPUS" ]]  || { echo "FATAL: --corpus '$CORPUS' is not a directory" >&2; exit 2; }
 [[ -d "$BIN_DIR" ]] || { echo "FATAL: --bin-dir '$BIN_DIR' is not a directory" >&2; exit 2; }
+# Checked HERE, with the other argument checks and BEFORE the first side effect below, for this
+# file's standing reason: refusing an impossible configuration AFTER acting on it is the defect.
+[[ -z "$BIN_DIR_E" || -d "$BIN_DIR_E" ]] \
+  || { echo "FATAL: --bin-dir-e '$BIN_DIR_E' is not a directory" >&2; exit 2; }
 
 mkdir -p "$OUT"
 
@@ -165,7 +169,6 @@ ARMS=(A B C0 C D)
 # and `arm_bin_dir` below. Omitted, this driver's arm set and every fingerprint field it writes
 # are byte-identical to the pre-#3997 ones.
 if [[ -n "$BIN_DIR_E" ]]; then
-  [[ -d "$BIN_DIR_E" ]] || { echo "FATAL: --bin-dir-e '$BIN_DIR_E' is not a directory" >&2; exit 2; }
   ARMS+=("$ARM_E")
 fi
 

--- a/scripts/perf/ws0-3551-abc.sh
+++ b/scripts/perf/ws0-3551-abc.sh
@@ -206,8 +206,30 @@ ALLOCATOR_SURFACE_RE='^allocator: (jemalloc|system)$'
 # require_reported_allocator <label> <binary> <expected> — fail CLOSED on every unmeasurable
 # state, each naming its own cause, because "the binary did not say" and "the binary said the
 # other thing" are different operator actions (rebuild vs. point --bin-dir-e somewhere else).
+# _echo_version_streams <stdout> <stderr> — reprint what the binary said, WITH THE STREAM NAMED.
+# Every refusal shows both, because stderr is where a binary that cannot start explains itself;
+# they are LABELLED because an unlabelled dump is the merge this round removed, one layer up in
+# the reader's head — a reader who cannot tell which stream carried the `allocator:` line cannot
+# check the diagnosis. An EMPTY stream says so affirmatively rather than printing nothing, since
+# "printed nothing on stdout" is the whole finding in the stderr-only case.
+_echo_version_streams() {
+  local o="$1" e="$2"
+  if [[ -n "$o" ]]; then
+    echo "       stdout (the ONLY stream R2.1's line may come from):" >&2
+    printf '%s\n' "$o" | sed 's/^/         stdout | /' >&2
+  else
+    echo "       stdout: EMPTY — nothing was printed on the only stream that can satisfy R2.1." >&2
+  fi
+  if [[ -n "$e" ]]; then
+    echo "       stderr (DIAGNOSTIC ONLY — it can satisfy nothing):" >&2
+    printf '%s\n' "$e" | sed 's/^/         stderr | /' >&2
+  else
+    echo "       stderr: EMPTY." >&2
+  fi
+}
+
 require_reported_allocator() {
-  local label="$1" bin="$2" expect="$3" rc=0 out n
+  local label="$1" bin="$2" expect="$3" rc=0 out err n stream_dir
   local -a matched
   if [[ ! -f "$bin" ]]; then
     echo "FATAL: $label '$bin' is not a file, so its allocator could not be READ." >&2
@@ -223,7 +245,27 @@ require_reported_allocator() {
     exit 2
   fi
   if command -v timeout >/dev/null 2>&1; then
-    out="$(timeout -k 5 60 "$bin" --version 2>&1)" || rc=$?
+    # THE TWO STREAMS ARE CAPTURED SEPARATELY, AND ONLY STDOUT IS MATCHED (#3997, roborev round
+    # 3, job 133). This function is the oracle of LAST RESORT for arm E's premise — it exists
+    # because a digest difference and an empty `/proc/<pid>/maps` can both be satisfied by
+    # something that is not jemalloc — so an oracle that accepts a CONTRACT VIOLATION is not a
+    # weaker oracle, it is a differently-shaped hole in the same place. R2.1 puts the
+    # `allocator:` line on STDOUT; a `2>&1` merge accepted a binary that printed it only on
+    # stderr, i.e. exactly the malformed build this precondition exists to reject.
+    #
+    # stderr is still CAPTURED and REPRINTED in every refusal below — a binary that cannot start
+    # explains itself there and that is the operator's next action — but it is LABELLED as
+    # stderr and it can satisfy nothing.
+    if ! stream_dir="$(mktemp -d)"; then
+      echo "FATAL: could not create a temporary directory, so \`$label --version\` could not be" >&2
+      echo "       run with its streams SEPARATED — and merging them would let a stderr-only" >&2
+      echo "       allocator line satisfy R2.1's stdout contract. UNMEASURED, refused." >&2
+      exit 2
+    fi
+    timeout -k 5 60 "$bin" --version >"$stream_dir/out" 2>"$stream_dir/err" || rc=$?
+    out="$(cat "$stream_dir/out")"
+    err="$(cat "$stream_dir/err")"
+    rm -rf "$stream_dir"
   else
     # A missing bound must not inherit the permissive branch, and an unbounded `--version` on a
     # wrong or wedged binary would hang the whole set with no verdict — which blocks the
@@ -236,8 +278,7 @@ require_reported_allocator() {
   if [[ $rc -ne 0 ]]; then
     echo "FATAL: \`$bin --version\` exited $rc, so its allocator is UNMEASURED." >&2
     echo "       R2.1 requires --version to short-circuit before argument validation and exit 0." >&2
-    echo "       Its output follows:" >&2
-    printf '%s\n' "$out" | sed 's/^/         | /' >&2
+    _echo_version_streams "$out" "$err"
     exit 2
   fi
   mapfile -t matched < <(printf '%s\n' "$out" | grep -E "$ALLOCATOR_SURFACE_RE") || true
@@ -246,8 +287,10 @@ require_reported_allocator() {
     echo "FATAL: \`$bin --version\` printed $n line(s) matching '$ALLOCATOR_SURFACE_RE';" >&2
     echo "       R2.1's contract is EXACTLY ONE. Neither 0 nor 2+ is read as either allocator:" >&2
     echo "       an unrecognised or absent line is UNMEASURED, and defaulting either way is how" >&2
-    echo "       a glibc build would be measured as the jemalloc arm. Its output follows:" >&2
-    printf '%s\n' "$out" | sed 's/^/         | /' >&2
+    echo "       a glibc build would be measured as the jemalloc arm. NOTE the count is taken" >&2
+    echo "       from STDOUT ALONE: a line on stderr is not one of R2.1's lines, so it neither" >&2
+    echo "       satisfies the grammar nor raises this count." >&2
+    _echo_version_streams "$out" "$err"
     exit 2
   fi
   if [[ "${matched[0]}" != "allocator: $expect" ]]; then
@@ -259,6 +302,7 @@ require_reported_allocator() {
     echo "       cannot see a statically linked allocator, so this surface is the only thing" >&2
     echo "       that can tell the two apart. Remedy: build --bin-dir-e's $ARM_E_BINARY with" >&2
     echo "       --features jemalloc (and --bin-dir's without it), or drop --bin-dir-e." >&2
+    _echo_version_streams "$out" "$err"
     exit 2
   fi
   echo "arm $ARM_E precondition: $label '$bin' reports '${matched[0]}' (R2.1)"

--- a/scripts/perf/ws0_abc_aggregate.py
+++ b/scripts/perf/ws0_abc_aggregate.py
@@ -730,7 +730,7 @@ def rss_table(sessions, complete, arms, baseline) -> list[str]:
         " beside it because the shape of peak-vs-end is what separates \"the allocator retains"
         " more\" from \"the allocator peaked higher once\"; do not read it as an average.",
         "",
-        f"The pre-registered thresholds, for reference and NOT applied here: VmHWM <= 1.10x arm"
+        "The pre-registered thresholds, for reference and NOT applied here: VmHWM <= 1.10x arm"
         f" {baseline} for SHIP-default, <= 1.25x for SHIP-opt-in, above that DO-NOT-SHIP. The"
         " criterion is JOINT with throughput and with the dhat producer budget, neither of which"
         " this tool can see, so it prints the ratio and states no verdict.",

--- a/scripts/perf/ws0_abc_aggregate.py
+++ b/scripts/perf/ws0_abc_aggregate.py
@@ -116,6 +116,30 @@ BINARY_EXCEPTION_FIELD = f"binary_sha256.{BINARY_EXCEPTION_BINARY}"
 RSS_FIELDS = ("server_vm_hwm_kb", "server_vm_rss_kb")
 RSS_UNMEASURED_PREFIX = "UNMEASURED"
 
+# THE MARKER IS A GRAMMAR, NOT A PREFIX (#3997, roborev round 4), and this side stays
+# INDEPENDENT of the collector's. `startswith(RSS_UNMEASURED_PREFIX)` accepted a bare
+# "UNMEASURED", an "UNMEASUREDgarbage" and an empty-cause marker as legitimate absences, so a
+# CORRUPT session read as one that merely did not measure. The prefix stays RESTATED rather than
+# imported for the reason above — and the two implementations are now pinned in BOTH directions
+# (accept AND reject) by `test_ws0_abc_driver_guards.sh` case 5h, which drives them by import
+# rather than comparing source text. One strict reader and one loose one is the state that would
+# be indefensible; two strict independent ones, pinned against each other, is not.
+RSS_UNMEASURED_MARKER = f"{RSS_UNMEASURED_PREFIX} \u2014 "
+
+
+def is_unmeasured_marker(value) -> bool:
+    """True for a WELL-FORMED `UNMEASURED — <cause>` marker, and for nothing else.
+
+    The exact prefix — em dash and trailing space, as `ws0_flight_arm.rss_unmeasured` writes it
+    — plus a cause that is not empty or whitespace-only. The cause is the whole value of a
+    marker: it decides the operator's next action (a vanished pid is a rep to re-run, an
+    unreadable `/proc` is a box to fix), so a marker without one is a corrupt record and not an
+    honest absence.
+    """
+    if not isinstance(value, str) or not value.startswith(RSS_UNMEASURED_MARKER):
+        return False
+    return bool(value[len(RSS_UNMEASURED_MARKER):].strip())
+
 # The corpus's identity, as the session recorded it. The PATH is deliberately not compared here:
 # the driver's run fingerprint pins the path, and this tool's subject is the bytes that were
 # measured -- two sessions reading the same corpus through different mount paths are comparable,
@@ -202,14 +226,28 @@ def read_rss_fields(raw: dict, flight_arm: str, p: pathlib.Path) -> dict:
             block, field, f"{p}: warm measurement {flight_arm!r}",
             "R6.1 compares arm E's PEAK RSS against arm A's, so an unrecorded one is a"
             " comparison that cannot be made — and ws0_flight_arm writes an explicit"
-            f" '{RSS_UNMEASURED_PREFIX} - <cause>' marker rather than omitting the key, so an"
+            f" '{RSS_UNMEASURED_MARKER}<cause>' marker rather than omitting the key, so an"
             " absent key is a session this tool does not model",
         )
         if isinstance(value, str):
-            if not value.startswith(RSS_UNMEASURED_PREFIX):
+            if not is_unmeasured_marker(value):
+                # TWO CAUSES, TWO MESSAGES. A value CARRYING the marker word without its form is
+                # a CORRUPT record — something wrote a marker and lost its cause — while an
+                # arbitrary string is a session this tool does not model. Both are refusals, and
+                # the remedies differ, so they are not folded into one sentence.
+                if value.startswith(RSS_UNMEASURED_PREFIX):
+                    raise Unreadable(
+                        f"{p}: warm {flight_arm} records {field}={value!r}, which carries the"
+                        f" {RSS_UNMEASURED_PREFIX!r} word but is NOT the"
+                        f" '{RSS_UNMEASURED_MARKER}<cause>' form (exact prefix, then a non-empty"
+                        " CAUSE). A causeless or mangled marker is a CORRUPT record, not an"
+                        " honest absence: the cause is the whole value of a marker, because it"
+                        " is what decides the operator's next action. Refused rather than"
+                        " counted as an unmeasured figure."
+                    )
                 raise Unreadable(
                     f"{p}: warm {flight_arm} records {field}={value!r}, a string that is not an"
-                    f" '{RSS_UNMEASURED_PREFIX} - <cause>' marker. Refused rather than"
+                    f" '{RSS_UNMEASURED_MARKER}<cause>' marker. Refused rather than"
                     " classified as either an observation or an absence."
                 )
             out[field] = value

--- a/scripts/perf/ws0_abc_aggregate.py
+++ b/scripts/perf/ws0_abc_aggregate.py
@@ -447,6 +447,40 @@ def validate_configuration(sessions, complete, arms) -> list[str]:
             f"The exception permits arm {BINARY_EXCEPTION_ARM} to differ from the OTHER ARMS,"
             " not from ITSELF: a treatment that changed mid-set is not one arm.",
         )
+        # DIRECTION 3 — ARM E's BINARY MUST ACTUALLY DIFFER FROM THE SHARED ONE. Directions 1
+        # and 2 establish that the non-E arms share one digest and that arm E's own is stable;
+        # NEITHER establishes that the two are DIFFERENT, and the exception's whole premise is
+        # that they are. Without this, `bins-E/` built by copying the control `cqlite-flight`
+        # instead of the `--features jemalloc` one passes every check above, arm E is silently a
+        # duplicate of arm A, and the report announces a linked-allocator comparison while
+        # attributing pure run-to-run noise to the allocator — the #3248 defect class, whose
+        # machine-code sub-claim was WITHDRAWN for exactly this.
+        #
+        # The driver has a two-sided precondition that refuses identical bytes at dispatch time.
+        # That is not a substitute: this tool is run STANDALONE over a session directory some
+        # other invocation produced, so the property has to be established from the sessions
+        # themselves.
+        others = [a for a in arms if a != BINARY_EXCEPTION_ARM]
+        if others:
+            e_digest = sessions[(complete[0], BINARY_EXCEPTION_ARM)][
+                "invariants"][BINARY_EXCEPTION_FIELD]
+            shared_digest = sessions[(complete[0], others[0])][
+                "invariants"][BINARY_EXCEPTION_FIELD]
+            if e_digest == shared_digest:
+                raise Unreadable(
+                    f"arm {BINARY_EXCEPTION_ARM}'s {BINARY_EXCEPTION_BINARY} is the SAME BYTES"
+                    f" as every other arm's: arm {BINARY_EXCEPTION_ARM} recorded"
+                    f" {e_digest!r} and arm {others[0]} recorded {shared_digest!r}."
+                    f" Arm {BINARY_EXCEPTION_ARM} exists to measure the build that LINKS its"
+                    " allocator, so an IDENTICAL digest means it measured the CONTROL"
+                    f" program — arm {BINARY_EXCEPTION_ARM} is then a second LABEL for arm"
+                    f" {others[0]}, not a second treatment, and every figure attributed to the"
+                    " linked allocator below would be run-to-run noise. Most likely cause:"
+                    " `--bin-dir-e` was populated by copying the control"
+                    f" `{BINARY_EXCEPTION_BINARY}` rather than the `--features jemalloc` build."
+                    " REFUSED rather than reported: #3248 WITHDREW a machine-code sub-claim for"
+                    " exactly an arm that did not run what its label said."
+                )
     _refuse_unless_identical(
         "the set's ADMISSION TRIPLE is not identical across arms",
         [(tag, s["admission"]) for tag, s in every],
@@ -487,6 +521,11 @@ def validate_configuration(sessions, complete, arms) -> list[str]:
             str(sessions[(r, a)]["invariants"][BINARY_EXCEPTION_FIELD])
             for r in complete for a in arms if a != BINARY_EXCEPTION_ARM
         })
+        # The peer arm NAMED in the differ-assertion below. An arm-E-only set has no peer, and
+        # the assertion is skipped there rather than compared against nothing, so this sentence
+        # must not index an empty list to say so.
+        peer_arms = [a for a in arms if a != BINARY_EXCEPTION_ARM]
+        peer_label = peer_arms[0] if peer_arms else "any other arm (there is none in this set)"
         lines += [
             f"* **ARM {BINARY_EXCEPTION_ARM} RAN A DIFFERENT `{BINARY_EXCEPTION_BINARY}` BINARY"
             " — the ONE permitted exception to the identical-bytes invariant (#3997 R3.3).**"
@@ -502,6 +541,11 @@ def validate_configuration(sessions, complete, arms) -> list[str]:
             " generator — is identical in EVERY session, arm"
             f" {BINARY_EXCEPTION_ARM} included. Any other cross-arm binary difference is still a"
             " REFUSAL.",
+            "    * AND ENFORCED IN THE OTHER DIRECTION: the two digests above are asserted to"
+            f" DIFFER. Equal digests would mean arm {BINARY_EXCEPTION_ARM} measured the SAME"
+            f" program as every other arm — a second LABEL for arm"
+            f" {peer_label}, not a second treatment —"
+            " so that set is REFUSED rather than reported as a linked-allocator comparison.",
             f"    * NOT COVERED BY IT: arm {BINARY_EXCEPTION_ARM}'s recorded `flight_allocator`"
             " reads `system` — nothing is preloaded, because the allocator is linked — so the"
             " configuration table CANNOT show the allocator difference and the binary digest is"

--- a/scripts/perf/ws0_abc_aggregate.py
+++ b/scripts/perf/ws0_abc_aggregate.py
@@ -79,6 +79,43 @@ ADMISSION_FIELDS = (
     "available_parallelism",
 )
 
+# THE ONE PERMITTED CROSS-ARM BINARY DIFFERENCE, AND THE ONLY ONE (issue #3997, R3.3).
+#
+# Every arm of #3551 varied the allocator by LD_PRELOAD into ONE binary, deliberately: that is
+# what let the "every arm ran identical bytes" invariant above hold, and #3248's machine-code
+# sub-claim was WITHDRAWN for violating it. #3997 ships the allocator LINKED as the binary's
+# `#[global_allocator]`, which is a different program, so arm E is the first arm that
+# legitimately measures different bytes from arm A.
+#
+# The exception is NAMED and NARROW, and every word of that is load-bearing:
+#
+#   * it applies to arm `E` and to NO other arm id;
+#   * it applies to `cqlite-flight` and to NO other measured binary — `ws0-scan-bench` IS the
+#     drift control and `flight-loadgen` is the client apparatus, so a difference in either
+#     still REFUSES, for arm E as for every other arm;
+#   * arm E's own digest must still be IDENTICAL IN EVERY ROUND of arm E. That check is added
+#     with the exception, not implied by it: removing the field from the cross-arm comparison
+#     would otherwise leave arm E free to change binaries mid-set, unexamined;
+#   * and it is SAID OUT LOUD in the report — the validation block names it and
+#     `binary_table` prints every arm's digest — because a permitted exception that is
+#     invisible in the output is indistinguishable, to a reader, from an invariant that held.
+#
+# With arm E absent from `--arms` this file behaves exactly as it did before: the exception
+# costs an untouched set nothing.
+BINARY_EXCEPTION_ARM = "E"
+BINARY_EXCEPTION_BINARY = "cqlite-flight"
+BINARY_EXCEPTION_FIELD = f"binary_sha256.{BINARY_EXCEPTION_BINARY}"
+
+# THE SERVER-RSS FIELDS `ws0_flight_arm.collect_flight` PUBLISHES PER ARM (issue #3997, R6.1),
+# and the marker prefix it uses for a field that was NOT OBSERVED. The prefix is restated here
+# rather than imported — this tool imports no sibling module, and pulling in the collector would
+# drag the whole reporting path in for one string — so `test_ws0_abc_driver_guards.sh` PINS the
+# two spellings against each other. A silently diverged prefix would make every unmeasured
+# marker land in the "not a number" refusal below instead of the UNMEASURED column, which is a
+# loud failure rather than a quiet one, but it would still be the wrong failure.
+RSS_FIELDS = ("server_vm_hwm_kb", "server_vm_rss_kb")
+RSS_UNMEASURED_PREFIX = "UNMEASURED"
+
 # The corpus's identity, as the session recorded it. The PATH is deliberately not compared here:
 # the driver's run fingerprint pins the path, and this tool's subject is the bytes that were
 # measured -- two sessions reading the same corpus through different mount paths are comparable,
@@ -133,6 +170,58 @@ def _require(mapping, key, where, why):
     return mapping[key]
 
 
+def read_rss_fields(raw: dict, flight_arm: str, p: pathlib.Path) -> dict:
+    """The Flight arm's two scan-end RSS figures, each THREE-VALUED (#3997, R6.1).
+
+    * a positive finite number -> a real kB observation, usable in R6.1's ratio;
+    * an `UNMEASURED - <cause>` marker string -> the sampler could not observe it (a vanished
+      pid, an unreadable `/proc/<pid>/status`, an absent field, or a driver that never sampled).
+      CARRIED THROUGH, not dropped: the tables print it, and no ratio is computed from it;
+    * an ABSENT key, or a value that is neither -> `Unreadable`, with the field named.
+
+    The absent key is a REFUSAL for the reason every other absent field here is:
+    `ws0_flight_arm.collect_flight` writes both keys UNCONDITIONALLY — an unobserved figure is
+    the marker, never a missing key — so a session lacking them was produced by something this
+    tool does not model, and a skipped comparison is exactly how the divergence this validation
+    exists to catch would pass unexamined. A ZERO is refused for the sharper reason: R6.1 is a
+    RATIO CEILING, and zero is the one value that satisfies every ceiling there is.
+    """
+    measurements = raw.get("measurements") or []
+    block = None
+    for m in measurements:
+        if m.get("temperature") == "warm" and m.get("arm") == flight_arm:
+            block = m
+            break
+    if block is None:
+        raise Unreadable(
+            f"{p}: the warm {flight_arm} measurement could not be re-read for its RSS fields"
+        )
+    out = {}
+    for field in RSS_FIELDS:
+        value = _require(
+            block, field, f"{p}: warm measurement {flight_arm!r}",
+            "R6.1 compares arm E's PEAK RSS against arm A's, so an unrecorded one is a"
+            " comparison that cannot be made — and ws0_flight_arm writes an explicit"
+            f" '{RSS_UNMEASURED_PREFIX} - <cause>' marker rather than omitting the key, so an"
+            " absent key is a session this tool does not model",
+        )
+        if isinstance(value, str):
+            if not value.startswith(RSS_UNMEASURED_PREFIX):
+                raise Unreadable(
+                    f"{p}: warm {flight_arm} records {field}={value!r}, a string that is not an"
+                    f" '{RSS_UNMEASURED_PREFIX} - <cause>' marker. Refused rather than"
+                    " classified as either an observation or an absence."
+                )
+            out[field] = value
+            continue
+        out[field] = _positive(
+            value, f"{p}: warm {flight_arm} {field}",
+            "it is a resident-set size in kB and the numerator or denominator of R6.1's peak-RSS"
+            " ratio; a zero or non-finite one would satisfy any ceiling it were compared with",
+        )
+    return out
+
+
 def load_session(d: pathlib.Path) -> dict:
     """One `ws0-baseline.sh` results.json, reduced to the fields this report prints.
 
@@ -169,6 +258,10 @@ def load_session(d: pathlib.Path) -> dict:
     if len(flight) != 1:
         raise Unreadable(f"{p}: expected exactly one warm flight arm, found {flight!r}")
     out["flight_arm"] = flight[0]
+    # THE FLIGHT SERVER'S SCAN-END RSS, read from the FLIGHT leg only (#3997, R6.1). The
+    # bare-scan leg starts no server, so the fields exist on the Flight measurement and nowhere
+    # else — asking for them on the control would be asking a question with no subject.
+    out["warm"][out["flight_arm"]].update(read_rss_fields(raw, out["flight_arm"], p))
     # THE RECORDED CONFIGURATION, every field REQUIRED. Note what is deliberately gone: this
     # used to read `pin.get("flight_server_cpus", pin.get("server_cpus"))`, a FALLBACK that
     # silently substituted the bare-scan pin for a session that never recorded a flight pin --
@@ -297,14 +390,63 @@ def validate_configuration(sessions, complete, arms) -> list[str]:
             " one arm's deltas.",
         )
     every = [(_tag(r, a, sessions[(r, a)]), sessions[(r, a)]) for r in complete for a in arms]
+    # ARM E'S `cqlite-flight` DIGEST IS HELD OUT OF THE CROSS-ARM COMPARISON — AND ONLY IT, AND
+    # ONLY WHEN ARM E IS IN THE SET (#3997, R3.3). Held out of EVERY arm's mapping rather than
+    # deleted from arm E's: `_refuse_unless_identical` refuses a field one record carries and
+    # another does not, so a one-sided removal would red as "NOT RECORDED" and the exception
+    # would be unusable. The held-out field is then checked TWICE below, once per direction.
+    exception_active = BINARY_EXCEPTION_ARM in arms
+    if exception_active:
+        cross_arm = [
+            (tag, {k: v for k, v in s["invariants"].items() if k != BINARY_EXCEPTION_FIELD})
+            for tag, s in every
+        ]
+    else:
+        cross_arm = [(tag, s["invariants"]) for tag, s in every]
     _refuse_unless_identical(
         "the set's CROSS-ARM INVARIANTS are not identical",
-        [(tag, s["invariants"]) for tag, s in every],
+        cross_arm,
         "If the bare-scan pin or the client pin differs between arms the DRIFT CONTROL IS GONE —"
         " the bare scan becomes a second treatment and there is nothing left to read the first"
         " one against; if the corpus identity or a binary digest differs, the arms did not"
         " measure the same thing at all.",
     )
+    if exception_active:
+        # DIRECTION 1 — EVERY OTHER ARM still shares one `cqlite-flight`. This is the half that
+        # keeps the exception NARROW: without it, holding the field out of the comparison above
+        # would have disabled the check for the whole set rather than for one arm.
+        _refuse_unless_identical(
+            f"the set's {BINARY_EXCEPTION_BINARY} digest DIFFERS between arms other than"
+            f" {BINARY_EXCEPTION_ARM}",
+            [(_tag(r, a, sessions[(r, a)]),
+              {BINARY_EXCEPTION_FIELD: _require(
+                  sessions[(r, a)]["invariants"], BINARY_EXCEPTION_FIELD,
+                  f"{_tag(r, a, sessions[(r, a)])}: `invariants`",
+                  "the arms must measure IDENTICAL BYTES; arm"
+                  f" {BINARY_EXCEPTION_ARM} is the ONE named exception (#3997 R3.3) and this"
+                  " session is not it")})
+             for r in complete for a in arms if a != BINARY_EXCEPTION_ARM],
+            f"Arm {BINARY_EXCEPTION_ARM} is the ONE permitted exception to the identical-bytes"
+            " invariant (#3997 R3.3) and it is not this pair. #3248 WITHDREW a machine-code"
+            " sub-claim for exactly this: two arms running different bytes are not one"
+            " comparison.",
+        )
+        # DIRECTION 2 — ARM E's OWN binary did not change mid-set. Its digest is out of the
+        # cross-arm comparison, so nothing else would notice a rebuild between rounds, and a
+        # per-round delta computed across two of arm E's binaries is not one arm's delta.
+        _refuse_unless_identical(
+            f"arm {BINARY_EXCEPTION_ARM}'s {BINARY_EXCEPTION_BINARY} changed within the set",
+            [(_tag(r, BINARY_EXCEPTION_ARM, sessions[(r, BINARY_EXCEPTION_ARM)]),
+              {BINARY_EXCEPTION_FIELD: _require(
+                  sessions[(r, BINARY_EXCEPTION_ARM)]["invariants"], BINARY_EXCEPTION_FIELD,
+                  f"{_tag(r, BINARY_EXCEPTION_ARM, sessions[(r, BINARY_EXCEPTION_ARM)])}:"
+                  " `invariants`",
+                  "it is the ONE digest this set permits to differ from the other arms, so it"
+                  " is the one digest nothing else would notice changing")})
+             for r in complete],
+            f"The exception permits arm {BINARY_EXCEPTION_ARM} to differ from the OTHER ARMS,"
+            " not from ITSELF: a treatment that changed mid-set is not one arm.",
+        )
     _refuse_unless_identical(
         "the set's ADMISSION TRIPLE is not identical across arms",
         [(tag, s["admission"]) for tag, s in every],
@@ -314,20 +456,65 @@ def validate_configuration(sessions, complete, arms) -> list[str]:
         " with the flight pin and a moved ceiling is a second treatment.",
     )
     inv = sessions[(complete[0], arms[0])]
-    return [
+    # THE COUNT IS THE NUMBER ACTUALLY COMPARED ACROSS ARMS, taken from the mapping that was
+    # compared — not from the session's full invariant set. With arm E in the set one field is
+    # held out by the exception, and a line claiming all 7 while 6 were compared would be the
+    # census overstating its own subject.
+    compared = len(cross_arm[0][1]) if cross_arm else len(inv["invariants"])
+    lines = [
         "Configuration VALIDATED over every aggregated (round, arm):"
         f" {len(every)} session(s) = {len(complete)} pairable round(s) x {len(arms)} arm(s).",
         "",
         f"* per-arm TREATMENT stability, all of {', '.join(TREATMENT_FIELDS)}: identical in"
         " every round of each arm.",
-        f"* CROSS-ARM invariants, all {len(inv['invariants'])} of them"
+        f"* CROSS-ARM invariants, all {compared} of them"
         f" ({', '.join(PIN_INVARIANT_FIELDS)}, the corpus identity and every measured binary's"
         " sha256): identical in every session.",
         f"* the ADMISSION TRIPLE ({', '.join(ADMISSION_FIELDS)}): identical in every session.",
         "* SCOPE: the aggregated sessions only. A round dropped as incomplete contributes to no"
         " figure below and is not examined.",
-        "",
     ]
+    # THE EXCEPTION IS DECLARED WHERE THE INVARIANT IS DECLARED, in both states. Saying nothing
+    # when arm E is absent would leave a reader unable to tell "the exception did not apply" from
+    # "this build has no exception", and the whole risk of a permitted exception is that it is
+    # read as an invariant that held.
+    if exception_active:
+        digests = sorted({
+            str(sessions[(r, BINARY_EXCEPTION_ARM)]["invariants"][BINARY_EXCEPTION_FIELD])
+            for r in complete
+        })
+        others = sorted({
+            str(sessions[(r, a)]["invariants"][BINARY_EXCEPTION_FIELD])
+            for r in complete for a in arms if a != BINARY_EXCEPTION_ARM
+        })
+        lines += [
+            f"* **ARM {BINARY_EXCEPTION_ARM} RAN A DIFFERENT `{BINARY_EXCEPTION_BINARY}` BINARY"
+            " — the ONE permitted exception to the identical-bytes invariant (#3997 R3.3).**"
+            f" Arm {BINARY_EXCEPTION_ARM} measures the build that LINKS its allocator, which is"
+            " a different program by construction; every other arm's flags select an allocator"
+            " by LD_PRELOAD into ONE binary. Both digests, in full:",
+            f"    * arm {BINARY_EXCEPTION_ARM}: `{'`, `'.join(digests)}`",
+            f"    * every other arm ({', '.join(a for a in arms if a != BINARY_EXCEPTION_ARM)}):"
+            f" `{'`, `'.join(others)}`",
+            "    * STILL ENFORCED: that digest is identical in every round of arm"
+            f" {BINARY_EXCEPTION_ARM}; it is identical across all the OTHER arms; and every"
+            " other measured binary — the bare-scan bench (the drift control) and the load"
+            " generator — is identical in EVERY session, arm"
+            f" {BINARY_EXCEPTION_ARM} included. Any other cross-arm binary difference is still a"
+            " REFUSAL.",
+            f"    * NOT COVERED BY IT: arm {BINARY_EXCEPTION_ARM}'s recorded `flight_allocator`"
+            " reads `system` — nothing is preloaded, because the allocator is linked — so the"
+            " configuration table CANNOT show the allocator difference and the binary digest is"
+            " the only place it appears. Read the digest table, not the allocator column.",
+        ]
+    else:
+        lines.append(
+            f"* the cross-arm binary exception for arm {BINARY_EXCEPTION_ARM} (#3997 R3.3) is"
+            f" NOT IN PLAY: arm {BINARY_EXCEPTION_ARM} is not in this set, so EVERY arm was"
+            " required to have measured identical bytes and did."
+        )
+    lines.append("")
+    return lines
 
 
 def control_table(sessions, complete, arms) -> list[str]:
@@ -491,6 +678,162 @@ def layer2(sessions, complete, arms, baseline) -> list[str]:
     return lines
 
 
+def _rss_series(sessions, complete, arm, field):
+    """One arm's RSS series over the pairable rounds: (measured values, unmeasured causes).
+
+    A marker goes to the SECOND list carrying its round, never into the first as a zero and
+    never dropped silently. The caller publishes a figure only when the second list is EMPTY —
+    see `rss_table` for why a partial series is refused rather than medianed.
+    """
+    values, unmeasured = [], []
+    for r in complete:
+        s = sessions[(r, arm)]
+        value = s["warm"][s["flight_arm"]][field]
+        if isinstance(value, str):
+            unmeasured.append(f"r{r}: {value}")
+        else:
+            values.append(value)
+    return values, unmeasured
+
+
+def _rss_cell(values, unmeasured, complete):
+    """A published median, or an UNMEASURED cell NAMING how many rounds are missing.
+
+    A MEDIAN OVER A SUBSET OF THE ROUNDS IS NOT PUBLISHED, and that is a decision rather than
+    strictness for its own sake: the whole table is PAIRED BY ROUND, so an arm figure taken over
+    rounds 1 and 3 sitting beside a baseline figure taken over 1, 2 and 3 is not a paired
+    comparison, and R6.1's ceiling would then be applied to two different experiments. The
+    partial state is therefore reported as unmeasured WITH ITS COUNT, so a reader can see the
+    difference between "no sample at all" and "two of three rounds".
+    """
+    if unmeasured:
+        return f"UNMEASURED ({len(values)} of {len(complete)} round(s) observed)"
+    return f"{statistics.median(values):,.0f}"
+
+
+def rss_table(sessions, complete, arms, baseline) -> list[str]:
+    """The server's scan-end RSS per arm — R6.1's input, and only its input (#3997).
+
+    NO VERDICT IS COMPUTED HERE. The pre-registered criterion (proposal.md) is a JOINT one
+    over throughput AND memory, its thresholds differ per outcome (<=1.10x for SHIP-default,
+    <=1.25x for SHIP-opt-in) and the dhat producer budget is a third term this tool never sees.
+    So the thresholds are STATED in the caption and the measured ratio is printed beside them;
+    turning that into a PASS would be this tool asserting a product decision it cannot see two
+    thirds of.
+    """
+    lines = [
+        "## Server RSS at scan end (#3997 R6.1 — the memory half of the kill criterion)",
+        "",
+        "`VmHWM` is the kernel's PEAK-RSS high-water mark for the Flight server process, so a"
+        " scan-end read is the rep's PEAK and the criterion's subject. `VmRSS` is ONE"
+        " INSTANTANEOUS SAMPLE at scan end — not a mean, not a steady-state estimate — printed"
+        " beside it because the shape of peak-vs-end is what separates \"the allocator retains"
+        " more\" from \"the allocator peaked higher once\"; do not read it as an average.",
+        "",
+        f"The pre-registered thresholds, for reference and NOT applied here: VmHWM <= 1.10x arm"
+        f" {baseline} for SHIP-default, <= 1.25x for SHIP-opt-in, above that DO-NOT-SHIP. The"
+        " criterion is JOINT with throughput and with the dhat producer budget, neither of which"
+        " this tool can see, so it prints the ratio and states no verdict.",
+        "",
+    ]
+    rows = []
+    for a in arms:
+        hwm, hwm_absent = _rss_series(sessions, complete, a, "server_vm_hwm_kb")
+        rss, rss_absent = _rss_series(sessions, complete, a, "server_vm_rss_kb")
+        base_hwm, base_absent = _rss_series(sessions, complete, baseline,
+                                            "server_vm_hwm_kb")
+        if a == baseline:
+            ratio = "baseline"
+        elif hwm_absent or base_absent:
+            # NOT MEASURABLE, NAMED — never a ratio computed from the rounds that happen to
+            # have both, which would be a paired figure over an unstated pairing.
+            ratio = (
+                f"NOT MEASURABLE ({len(hwm_absent)} round(s) of {a},"
+                f" {len(base_absent)} of {baseline} unobserved)"
+            )
+        else:
+            # PAIRED PER ROUND, then medianed — the same shape as every other delta in this
+            # report, and for the same reason: the pairing is the control for drift.
+            paired = []
+            for r, arm_value, base_value in zip(complete, hwm, base_hwm):
+                divisor = _positive(
+                    base_value,
+                    f"the baseline arm {baseline}'s VmHWM in round {r}",
+                    "it is the divisor of every paired peak-RSS ratio in this table")
+                paired.append(arm_value / divisor)
+            ratio = f"{statistics.median(paired):.4f}x"
+        rows.append([
+            a,
+            _rss_cell(hwm, hwm_absent, complete),
+            fmt_spread(hwm) if not hwm_absent else "n/a (unmeasured)",
+            _rss_cell(rss, rss_absent, complete),
+            fmt_spread(rss) if not rss_absent else "n/a (unmeasured)",
+            ratio,
+        ])
+    lines.append(table(rows, ["arm", "VmHWM kB (median)", "VmHWM spread",
+                              "VmRSS kB (median, ONE sample per rep)", "VmRSS spread",
+                              f"paired VmHWM vs {baseline}"]))
+    lines.append("")
+    # THE CAUSES, IN FULL, WHEN THERE ARE ANY. A cell reading UNMEASURED tells a reader the
+    # figure is absent and nothing about what to do next, and the remedy is entirely determined
+    # by the cause — a vanished pid is a rep to re-run, an unsampled session is a driver that
+    # never called the sampler.
+    causes = []
+    for a in arms:
+        for field in RSS_FIELDS:
+            _, absent = _rss_series(sessions, complete, a, field)
+            causes += [f"* arm {a} `{field}` {c}" for c in absent]
+    if causes:
+        lines.append("Every UNMEASURED figure above, with the cause the sampler recorded:")
+        lines.append("")
+        lines += causes
+        lines.append("")
+    else:
+        lines.append(f"All {len(arms) * len(complete)} session(s) yielded BOTH RSS figures:"
+                     " 0 UNMEASURED RECOGNISED.")
+        lines.append("")
+    return lines
+
+
+def binary_table(sessions, complete, arms) -> list[str]:
+    """Which `cqlite-flight` each arm measured, printed rather than left to the invariant.
+
+    This table exists because of #3997 R3.3: arm E is a NAMED exception to the identical-bytes
+    invariant, and an exception a reader cannot see is one they will assume did not apply. It is
+    printed for EVERY set, arm E present or not — a table that appears only in the exceptional
+    case teaches nobody what the normal case looks like, and the normal case ("one digest, every
+    arm") is the invariant itself, stated as data.
+    """
+    lines = [
+        f"## The measured `{BINARY_EXCEPTION_BINARY}` binary, per arm (#3997 R3.3)",
+        "",
+        "Read back from each session's own `binary_provenance`, never from the driver's"
+        " intention. Every arm shares ONE digest unless arm"
+        f" {BINARY_EXCEPTION_ARM} is present, which is the single permitted exception — its"
+        " allocator is LINKED, so it is a different program and its `flight_allocator` column"
+        " still reads `system`. Any OTHER cross-arm difference, in this binary or in the"
+        " bare-scan bench or the load generator, is a REFUSAL and this report was not produced.",
+        "",
+    ]
+    rows = []
+    reference = None
+    for a in arms:
+        digests = sorted({
+            str(sessions[(r, a)]["invariants"][BINARY_EXCEPTION_FIELD]) for r in complete
+        })
+        if a != BINARY_EXCEPTION_ARM and reference is None:
+            reference = digests[0]
+        rows.append([
+            a,
+            ", ".join(digests),
+            "PERMITTED EXCEPTION (#3997 R3.3) — linked allocator, a DIFFERENT binary"
+            if a == BINARY_EXCEPTION_ARM
+            else ("the shared binary" if digests[0] == reference else "DIFFERS"),
+        ])
+    lines.append(table(rows, ["arm", "sha256", "relation to the other arms"]))
+    lines.append("")
+    return lines
+
 def config_table(sessions, complete, arms) -> list[str]:
     """What each arm actually WAS, read back from its own artifacts.
 
@@ -575,6 +918,8 @@ def main(argv=None) -> int:
     lines += control_table(sessions, complete, arms)
     lines += layer1(sessions, complete, arms, args.baseline)
     lines += layer2(sessions, complete, arms, args.baseline)
+    lines += rss_table(sessions, complete, arms, args.baseline)
+    lines += binary_table(sessions, complete, arms)
     lines += config_table(sessions, complete, arms)
 
     text = "\n".join(lines)

--- a/scripts/perf/ws0_abc_aggregate.py
+++ b/scripts/perf/ws0_abc_aggregate.py
@@ -460,21 +460,28 @@ def validate_configuration(sessions, complete, arms) -> list[str]:
         # That is not a substitute: this tool is run STANDALONE over a session directory some
         # other invocation produced, so the property has to be established from the sessions
         # themselves.
-        others = [a for a in arms if a != BINARY_EXCEPTION_ARM]
-        if others:
+        # ONE ROUND IS ENOUGH, and only because directions 1 and 2 ran FIRST: they establish
+        # that arm E's digest is identical in every round and that the other arms share one in
+        # every session, so round `complete[0]` is representative of both sides. Read this as
+        # ordered, not as three independent checks. (`peer_arms` rather than `others`: the
+        # declaration block below binds that name to a set of DIGESTS, and two meanings for one
+        # name in one function is how a later edit picks the wrong one.)
+        peer_arms = [a for a in arms if a != BINARY_EXCEPTION_ARM]
+        if peer_arms:
             e_digest = sessions[(complete[0], BINARY_EXCEPTION_ARM)][
                 "invariants"][BINARY_EXCEPTION_FIELD]
-            shared_digest = sessions[(complete[0], others[0])][
+            shared_digest = sessions[(complete[0], peer_arms[0])][
                 "invariants"][BINARY_EXCEPTION_FIELD]
             if e_digest == shared_digest:
                 raise Unreadable(
                     f"arm {BINARY_EXCEPTION_ARM}'s {BINARY_EXCEPTION_BINARY} is the SAME BYTES"
                     f" as every other arm's: arm {BINARY_EXCEPTION_ARM} recorded"
-                    f" {e_digest!r} and arm {others[0]} recorded {shared_digest!r}."
+                    f" {e_digest!r} and arm {peer_arms[0]} recorded {shared_digest!r}."
                     f" Arm {BINARY_EXCEPTION_ARM} exists to measure the build that LINKS its"
                     " allocator, so an IDENTICAL digest means it measured the CONTROL"
                     f" program — arm {BINARY_EXCEPTION_ARM} is then a second LABEL for arm"
-                    f" {others[0]}, not a second treatment, and every figure attributed to the"
+                    f" {peer_arms[0]}, not a second treatment, and every figure attributed to"
+                    " the"
                     " linked allocator below would be run-to-run noise. Most likely cause:"
                     " `--bin-dir-e` was populated by copying the control"
                     f" `{BINARY_EXCEPTION_BINARY}` rather than the `--features jemalloc` build."
@@ -521,11 +528,28 @@ def validate_configuration(sessions, complete, arms) -> list[str]:
             str(sessions[(r, a)]["invariants"][BINARY_EXCEPTION_FIELD])
             for r in complete for a in arms if a != BINARY_EXCEPTION_ARM
         })
-        # The peer arm NAMED in the differ-assertion below. An arm-E-only set has no peer, and
-        # the assertion is skipped there rather than compared against nothing, so this sentence
-        # must not index an empty list to say so.
-        peer_arms = [a for a in arms if a != BINARY_EXCEPTION_ARM]
-        peer_label = peer_arms[0] if peer_arms else "any other arm (there is none in this set)"
+        # THE DIFFER-ASSERTION IS REPORTED FROM WHETHER IT RAN, not from the fact that the
+        # exception is active — it is skipped for an arm-E-only set, which has no peer digest to
+        # differ from, and a sentence claiming it held there would assert a check that did not
+        # happen. Derived from the SAME `peer_arms` the assertion used, so the sentence cannot
+        # name an arm the check did not compare.
+        if peer_arms:
+            differ_line = (
+                "    * AND ENFORCED IN THE OTHER DIRECTION: the two digests above are asserted"
+                f" to DIFFER. Equal digests would mean arm {BINARY_EXCEPTION_ARM} measured the"
+                " SAME program as every other arm — a second LABEL for arm"
+                f" {peer_arms[0]}, not a second treatment — so that set is REFUSED rather than"
+                " reported as a linked-allocator comparison."
+            )
+        else:
+            differ_line = (
+                "    * NOT ASSERTED HERE: arm"
+                f" {BINARY_EXCEPTION_ARM} is the ONLY arm in this set, so there is no shared"
+                " digest for its own to be compared against and the differ-assertion was"
+                " SKIPPED. Nothing below rests on arm"
+                f" {BINARY_EXCEPTION_ARM} having measured a different program from any other"
+                " arm, because no other arm was measured."
+            )
         lines += [
             f"* **ARM {BINARY_EXCEPTION_ARM} RAN A DIFFERENT `{BINARY_EXCEPTION_BINARY}` BINARY"
             " — the ONE permitted exception to the identical-bytes invariant (#3997 R3.3).**"
@@ -541,11 +565,7 @@ def validate_configuration(sessions, complete, arms) -> list[str]:
             " generator — is identical in EVERY session, arm"
             f" {BINARY_EXCEPTION_ARM} included. Any other cross-arm binary difference is still a"
             " REFUSAL.",
-            "    * AND ENFORCED IN THE OTHER DIRECTION: the two digests above are asserted to"
-            f" DIFFER. Equal digests would mean arm {BINARY_EXCEPTION_ARM} measured the SAME"
-            f" program as every other arm — a second LABEL for arm"
-            f" {peer_label}, not a second treatment —"
-            " so that set is REFUSED rather than reported as a linked-allocator comparison.",
+            differ_line,
             f"    * NOT COVERED BY IT: arm {BINARY_EXCEPTION_ARM}'s recorded `flight_allocator`"
             " reads `system` — nothing is preloaded, because the allocator is linked — so the"
             " configuration table CANNOT show the allocator difference and the binary digest is"

--- a/scripts/perf/ws0_flight_arm.py
+++ b/scripts/perf/ws0_flight_arm.py
@@ -136,6 +136,15 @@ MERGE_PATH_OBSERVABILITY_NOTE = (
 # a number — the same shape `CONTENT_VOLUME_NO_ORACLE` uses one module over.
 RSS_UNMEASURED = "UNMEASURED"
 
+# THE MARKER'S FULL FORM, and it is a GRAMMAR rather than a prefix (#3997, roborev round 4).
+# `startswith(RSS_UNMEASURED)` accepted a bare "UNMEASURED", an "UNMEASUREDgarbage", and a
+# marker whose cause was empty or whitespace-only — so a CORRUPT artifact read as an ordinary
+# missing measurement. Neither reader ever turns a marker into a number (it is carried through
+# and printed, never medianed or ratioed), so this could not satisfy R6.1's ceiling; what it
+# destroyed is the distinction between "refuse this artifact" and "we did not measure this",
+# and the cause IS the value here because the operator's next action is determined by it.
+RSS_UNMEASURED_MARKER = f"{RSS_UNMEASURED} \u2014 "
+
 # The AFFIRMATIVE status, spelled once. The sampler writes it and `read_server_rss` requires
 # exactly it or a marker — a status it cannot classify is a refusal, because "the record says
 # something else" and "the record says it could not measure" are different states.
@@ -162,8 +171,19 @@ def rss_unmeasured(cause: str) -> str:
     the operator's next action is entirely determined by the why — a vanished pid is a rep to
     re-run, a `/proc` that could not be read is a box to fix, an absent `VmHWM` is a kernel
     that does not export it. So the cause is part of the value.
+
+    A causeless marker cannot be MINTED either: `rss_unmeasured("")` would build a value this
+    module's own reader refuses, which is a producer and a consumer disagreeing about one
+    contract. Refused at the source instead, where the caller that lost its cause is named.
     """
-    return f"{RSS_UNMEASURED} — {cause}"
+    text = cause.strip() if isinstance(cause, str) else ""
+    if not text:
+        raise ValueError(
+            "rss_unmeasured() requires a non-empty CAUSE: the marker's whole value is why the"
+            f" figure is absent, and {RSS_UNMEASURED_MARKER!r} with nothing after it is the"
+            " corrupt form this module's reader refuses."
+        )
+    return f"{RSS_UNMEASURED_MARKER}{cause}"
 
 
 def rss_is_measured(value: object) -> bool:
@@ -178,8 +198,18 @@ def rss_is_measured(value: object) -> bool:
 
 
 def _rss_marker(value: object) -> bool:
-    """True for an explicit `rss_unmeasured(...)` marker, and for nothing else."""
-    return isinstance(value, str) and value.startswith(RSS_UNMEASURED)
+    """True for a WELL-FORMED `rss_unmeasured(...)` marker, and for nothing else.
+
+    The exact `RSS_UNMEASURED_MARKER` prefix — em dash and trailing space, as the producer
+    writes it — plus a cause that is not empty or whitespace-only. Deliberately NOT
+    `startswith(RSS_UNMEASURED)`, which accepted a bare word and an arbitrary suffix and so
+    classified a corrupt value as an honest absence. A malformed marker now reaches
+    `read_server_rss`'s "a value this reader cannot classify" refusal, which is the correct
+    answer for it: that record was written by something this module does not model.
+    """
+    if not isinstance(value, str) or not value.startswith(RSS_UNMEASURED_MARKER):
+        return False
+    return bool(value[len(RSS_UNMEASURED_MARKER):].strip())
 
 
 def parse_proc_status_rss(text: str, where: str) -> dict:

--- a/scripts/perf/ws0_flight_arm.py
+++ b/scripts/perf/ws0_flight_arm.py
@@ -381,31 +381,67 @@ def read_server_rss(d: pathlib.Path, tag: str) -> dict:
     return record
 
 
+# THE PUBLISHED ARM-LEVEL RSS FIELD PER /proc FIELD, and the per-field census key beside it.
+# Spelled as ONE table because the two must not drift: a published figure whose census counts a
+# DIFFERENT field is a completeness claim about something other than the number it sits next to,
+# which is half of this issue's own defect. The census keys deliberately do NOT begin
+# `server_vm` — `test_ws0_abc_driver_guards.sh` case 5h derives the PUBLISHED field set by that
+# prefix and pins it against the aggregator's `RSS_FIELDS`, so a census key sharing the prefix
+# would join a set it is not a member of.
+RSS_PUBLISHED_FIELDS = (
+    # (published field, per-rep record key, /proc field, per-field census key)
+    ("server_vm_hwm_kb", "vm_hwm_kb", "VmHWM", "server_rss_reps_measured_vm_hwm_kb"),
+    ("server_vm_rss_kb", "vm_rss_kb", "VmRSS", "server_rss_reps_measured_vm_rss_kb"),
+)
+
+
 def server_rss_block(samples: list[dict], temp: str, arm: str) -> dict:
-    """The arm-level RSS the aggregate reads, plus the census that keeps it honest.
+    """The arm-level RSS the aggregate reads, plus the per-field census that keeps it honest.
 
-    The two published figures are MEDIANS OVER THE REPS THAT WERE MEASURED, and the number of
-    reps behind each one is published beside it — a median over 1 of 3 reps and a median over
-    3 of 3 are different claims, and the abc driver runs `--reps 1`, so this is routinely a
-    single observation and must not read as more.
+    A FIGURE IS PUBLISHED ONLY WHEN EVERY REP SUPPLIED THAT FIELD. Anything less is the
+    `UNMEASURED — <cause>` marker, with the counts in the cause. This used to publish a median
+    over whichever reps happened to be measured, so 1 of 3 reps yielded a number
+    indistinguishable from a complete measurement, and nothing downstream could tell: the
+    aggregator refuses a partial series ACROSS ROUNDS but reads this one value PER ROUND, so a
+    rep-level hole arrived as a clean observation and R6.1's ceiling — a RATIO ceiling, which an
+    unrepresentative low median silently satisfies — was applied to a series that was never
+    measured. Doctrine, and the reason this is a refusal rather than a caveat: an unmeasured
+    quantity and a cleanly measured one must never read alike, and no partial series may be
+    averaged or ratioed as if it were complete.
 
-    If NO rep of this arm was measured, the figure is the MARKER, never a median of an empty
-    list and never a 0. `statistics.median([])` raises, which would abort the whole report for
-    a quantity that is merely absent; and a 0 would satisfy R6.1's ceiling outright.
+    Note the counts stay MEANINGFUL rather than merely absent — a median over 1 of 3 reps and no
+    sample at all are different remedies (a rep to re-run vs a driver that never sampled), so the
+    cause names how many of how many, and the per-rep `server_rss.status` carries the why.
+
+    THE CENSUS IS PER FIELD, NEVER ONE SHARED COUNT. `VmHWM` and `VmRSS` are read from the same
+    `/proc/<pid>/status` but fail independently (a kernel that exports one and not the other, a
+    parse that recognised one line), and a single count derived from `VmHWM` alone was affirming
+    a completeness that did not hold for `VmRSS`. The old shared `server_rss_reps_measured` key
+    is GONE rather than kept beside the per-field ones: two sources of truth for one fact is the
+    thing being removed, not a compatibility surface (nothing read it).
+
+    With NO rep at all the figure is the MARKER too, never a median of an empty list — an empty
+    `all(...)` is vacuously true, so the total is tested explicitly; `statistics.median([])`
+    raises, which would abort the whole report for a quantity that is merely absent, and a 0
+    would satisfy R6.1's ceiling outright.
     """
-    hwm = [s["vm_hwm_kb"] for s in samples if rss_is_measured(s["vm_hwm_kb"])]
-    rss = [s["vm_rss_kb"] for s in samples if rss_is_measured(s["vm_rss_kb"])]
-    absent = rss_unmeasured(
-        f"no rep of {arm} ({temp}) yielded a scan-end sample; see each rep's own"
-        " `server_rss.status` for the cause"
-    )
-    return {
-        "server_vm_hwm_kb": statistics.median(hwm) if hwm else absent,
-        "server_vm_rss_kb": statistics.median(rss) if rss else absent,
-        "server_rss_reps_measured": len(hwm),
-        "server_rss_reps_total": len(samples),
-        "server_rss_sample_timing": RSS_SAMPLE_TIMING_NOTE,
-    }
+    total = len(samples)
+    out = {"server_rss_reps_total": total}
+    for field, key, proc_field, census_key in RSS_PUBLISHED_FIELDS:
+        observed = [s[key] for s in samples if rss_is_measured(s[key])]
+        out[census_key] = len(observed)
+        if total and len(observed) == total:
+            out[field] = statistics.median(observed)
+        else:
+            out[field] = rss_unmeasured(
+                f"{len(observed)} of {total} rep(s) of {arm} ({temp}) yielded a scan-end"
+                f" {proc_field}; a median over a SUBSET of the reps is not this arm's figure —"
+                " R6.1 is a RATIO CEILING, which an unrepresentative median can satisfy without"
+                " ever having been measured. See each rep's own `server_rss.status` for the"
+                " cause of the missing one(s)."
+            )
+    out["server_rss_sample_timing"] = RSS_SAMPLE_TIMING_NOTE
+    return out
 
 
 def _cli_sample_server_rss(argv: list[str]) -> int:

--- a/scripts/perf/ws0_flight_arm.py
+++ b/scripts/perf/ws0_flight_arm.py
@@ -423,7 +423,10 @@ def server_rss_block(samples: list[dict], temp: str, arm: str) -> dict:
     With NO rep at all the figure is the MARKER too, never a median of an empty list — an empty
     `all(...)` is vacuously true, so the total is tested explicitly; `statistics.median([])`
     raises, which would abort the whole report for a quantity that is merely absent, and a 0
-    would satisfy R6.1's ceiling outright.
+    would satisfy R6.1's ceiling outright. That state has TWO causes with DIFFERENT remedies —
+    reps ran and none supplied the field (the box or the kernel) versus no rep was recorded at
+    all (the driver never sampled) — so they get different sentences rather than one that
+    describes a subset median over reps that do not exist.
     """
     total = len(samples)
     out = {"server_rss_reps_total": total}
@@ -432,13 +435,30 @@ def server_rss_block(samples: list[dict], temp: str, arm: str) -> dict:
         out[census_key] = len(observed)
         if total and len(observed) == total:
             out[field] = statistics.median(observed)
-        else:
+        elif observed:
             out[field] = rss_unmeasured(
                 f"{len(observed)} of {total} rep(s) of {arm} ({temp}) yielded a scan-end"
                 f" {proc_field}; a median over a SUBSET of the reps is not this arm's figure —"
                 " R6.1 is a RATIO CEILING, which an unrepresentative median can satisfy without"
                 " ever having been measured. See each rep's own `server_rss.status` for the"
                 " cause of the missing one(s)."
+            )
+        elif total:
+            # EVERY rep ran and none supplied this field — a different remedy from the partial
+            # case (the box or the kernel, not one rep to re-run), so it is a different sentence
+            # rather than the subset-median wording, which would describe a subset that does not
+            # exist. A cause that misdescribes its own state is what stops the next person
+            # looking.
+            out[field] = rss_unmeasured(
+                f"0 of {total} rep(s) of {arm} ({temp}) yielded a scan-end {proc_field}; there"
+                " is nothing to median, and a 0 would satisfy R6.1's ratio ceiling outright."
+                " See each rep's own `server_rss.status` for the cause."
+            )
+        else:
+            out[field] = rss_unmeasured(
+                f"0 of 0 rep(s) of {arm} ({temp}) yielded a scan-end {proc_field}: this arm"
+                " recorded NO rep at all, so nothing was sampled — the driver did not run the"
+                " arm, or ran it without the scan-end sampler."
             )
     out["server_rss_sample_timing"] = RSS_SAMPLE_TIMING_NOTE
     return out

--- a/scripts/perf/ws0_flight_arm.py
+++ b/scripts/perf/ws0_flight_arm.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 
 import json
 import pathlib
+import statistics
+import sys
 
 from ws0_collect import prewarm_block, read_prewarm, spread, REQUIRED_EVENTS
 from ws0_content_volume import (
@@ -113,6 +115,335 @@ MERGE_PATH_OBSERVABILITY_NOTE = (
     " selected BypassReason per request and REFUSE any rep whose executed arm differs from the"
     " requested one."
 )
+
+
+# ===========================================================================
+# THE SERVER PROCESS'S RSS — R6.1 of the flight-allocator spec (issue #3997)
+# ===========================================================================
+# Two fields of `/proc/<server-pid>/status`, sampled ONCE per rep at scan end. What each one is,
+# and what the scan-end timing does and does not buy, is stated at the field definition below
+# (`RSS_SAMPLE_TIMING_NOTE`) rather than here, so the caveat travels with the value into
+# `results.json` instead of living only in this file.
+#
+# WHY R6.1 EXISTS AT ALL: jemalloc's dirty-page decay is time-based, so a linked jemalloc can
+# win on throughput while holding more resident. #3997's pre-registered criterion is therefore
+# a JOINT one, and a peak-RSS figure that was not observed cannot satisfy half of it.
+#
+# EVERY UNMEASURED STATE IS AN EXPLICIT MARKER NAMING ITS CAUSE, NEVER A ZERO AND NEVER AN
+# ABSENT KEY. A 0 kB resident set and an unreadable `/proc/<pid>/status` must not read alike:
+# the first would satisfy any ratio ceiling and the second is a comparison that was not made.
+# The marker is a STRING, so a downstream reader that averages it raises rather than publishing
+# a number — the same shape `CONTENT_VOLUME_NO_ORACLE` uses one module over.
+RSS_UNMEASURED = "UNMEASURED"
+
+# The AFFIRMATIVE status, spelled once. The sampler writes it and `read_server_rss` requires
+# exactly it or a marker — a status it cannot classify is a refusal, because "the record says
+# something else" and "the record says it could not measure" are different states.
+RSS_MEASURED = "measured"
+
+RSS_STATUS_FIELDS = ("VmHWM", "VmRSS")
+
+RSS_SAMPLE_TIMING_NOTE = (
+    "Sampled ONCE per rep at SCAN END — after the perf window closed, before the server was"
+    " stopped — from /proc/<server-pid>/status. `VmHWM` is a kernel-maintained HIGH-WATER MARK,"
+    " so a scan-end read yields the PEAK over the whole rep and needs no sampling loop (which"
+    " would perturb a pinned measurement). `VmRSS` is NOT a high-water mark: it is ONE"
+    " INSTANTANEOUS SAMPLE at that moment, NOT a mean, NOT a time-weighted average and NOT a"
+    " steady-state estimate. Do not average it across reps or arms and call the result an"
+    " average RSS; nothing here computes one. An unmeasured field carries an explicit"
+    f" '{RSS_UNMEASURED} — <cause>' marker, never a 0 and never an absent key."
+)
+
+
+def rss_unmeasured(cause: str) -> str:
+    """The one spelling of an unmeasured RSS field: the marker, then the CAUSE.
+
+    A bare sentinel would tell a reader that the number is absent and nothing about why, and
+    the operator's next action is entirely determined by the why — a vanished pid is a rep to
+    re-run, a `/proc` that could not be read is a box to fix, an absent `VmHWM` is a kernel
+    that does not export it. So the cause is part of the value.
+    """
+    return f"{RSS_UNMEASURED} — {cause}"
+
+
+def rss_is_measured(value: object) -> bool:
+    """True only for a value that is a REAL observation of a resident-set size in kB.
+
+    Keyed on the value being a non-bool integer, never on "it is not the marker string": a
+    future third state would otherwise inherit the measured branch, which is the permissive
+    default this rig refuses everywhere else. `bool` is excluded explicitly because
+    `isinstance(True, int)` is true in Python and `True` is not a kilobyte count.
+    """
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
+def _rss_marker(value: object) -> bool:
+    """True for an explicit `rss_unmeasured(...)` marker, and for nothing else."""
+    return isinstance(value, str) and value.startswith(RSS_UNMEASURED)
+
+
+def parse_proc_status_rss(text: str, where: str) -> dict:
+    """`VmHWM`/`VmRSS` in kB out of a `/proc/<pid>/status` body, each three-valued.
+
+    Returns a dict keyed by the two field names, each value either a positive int (kB) or an
+    `rss_unmeasured(...)` marker naming why that field could not be read. Never raises: the
+    caller is the measurement driver at scan end, and aborting a rep whose throughput was
+    already measured would discard a good observation to report a missing one.
+
+    Refused rather than guessed, field by field:
+
+    * a field ABSENT from the body — some kernels/processes export no `Vm*` lines at all;
+    * a UNIT other than `kB`. `/proc/<pid>/status` has always used kB, so a different unit is a
+      body this parser does not model, and silently treating it as kB would publish a figure
+      1024x wrong against a 1.10x ceiling;
+    * a value that is not a non-negative integer, or is zero — a running server with a zero
+      resident set is not a measurement, and zero is precisely the value that would satisfy any
+      ratio ceiling.
+    """
+    out: dict[str, object] = {}
+    seen: dict[str, str] = {}
+    for line in text.splitlines():
+        name, sep, rest = line.partition(":")
+        if sep and name in RSS_STATUS_FIELDS:
+            seen[name] = rest.strip()
+    for field in RSS_STATUS_FIELDS:
+        if field not in seen:
+            out[field] = rss_unmeasured(
+                f"{where} carries no '{field}:' line, so that field was NOT OBSERVED"
+            )
+            continue
+        parts = seen[field].split()
+        if len(parts) != 2 or parts[1] != "kB":
+            out[field] = rss_unmeasured(
+                f"{where} records '{field}: {seen[field]}', which is not the"
+                " '<integer> kB' shape this parser models — a unit it does not recognise is"
+                " refused rather than read as kB"
+            )
+            continue
+        try:
+            value = int(parts[0])
+        except ValueError:
+            out[field] = rss_unmeasured(
+                f"{where} records '{field}: {seen[field]}', whose value is not an integer"
+            )
+            continue
+        if value <= 0:
+            out[field] = rss_unmeasured(
+                f"{where} records '{field}: {value} kB'; a live server process with a"
+                " non-positive resident set is not an observation, and zero is the one value"
+                " that satisfies every ratio ceiling"
+            )
+            continue
+        out[field] = value
+    return out
+
+
+def sample_server_rss(pid: object, status_path: object = None) -> dict:
+    """ONE rep's scan-end RSS record for the Flight server process.
+
+    `status_path` exists for the tests and for a caller that has already resolved the path; it
+    defaults to `/proc/<pid>/status`. The record ALWAYS carries both fields and a `status`, so a
+    consumer never has to distinguish "absent key" from "unmeasured" — see RSS_UNMEASURED.
+    """
+    record: dict[str, object] = {
+        "pid": pid,
+        "source": None,
+        "sampled_at": "scan-end (perf window closed, server not yet stopped)",
+        "sample_timing": RSS_SAMPLE_TIMING_NOTE,
+    }
+    if isinstance(pid, bool) or not isinstance(pid, int) or pid <= 0:
+        cause = (
+            f"the driver supplied {pid!r} as the server pid, which is not a positive integer,"
+            " so no process could be read"
+        )
+        record["source"] = RSS_UNMEASURED
+        record["vm_hwm_kb"] = rss_unmeasured(cause)
+        record["vm_rss_kb"] = rss_unmeasured(cause)
+        record["status"] = rss_unmeasured(cause)
+        return record
+    path = pathlib.Path(status_path) if status_path is not None else pathlib.Path(
+        f"/proc/{pid}/status"
+    )
+    record["source"] = str(path)
+    try:
+        text = path.read_text()
+    except OSError as exc:
+        # A VANISHED PID AND AN UNREADABLE /proc ARE ONE STATE HERE, and the errno text names
+        # which: `FileNotFoundError` is the server having already exited (the rep's peak went
+        # with it), anything else is a box that could not be read. Either way the field was not
+        # observed, and the cause is carried rather than collapsed to "unavailable".
+        cause = f"{path} could not be READ ({exc}) — the field was NOT OBSERVED"
+        record["vm_hwm_kb"] = rss_unmeasured(cause)
+        record["vm_rss_kb"] = rss_unmeasured(cause)
+        record["status"] = rss_unmeasured(cause)
+        return record
+    fields = parse_proc_status_rss(text, str(path))
+    record["vm_hwm_kb"] = fields["VmHWM"]
+    record["vm_rss_kb"] = fields["VmRSS"]
+    if rss_is_measured(record["vm_hwm_kb"]) and rss_is_measured(record["vm_rss_kb"]):
+        record["status"] = RSS_MEASURED
+    else:
+        unread = [
+            name for name, key in (("VmHWM", "vm_hwm_kb"), ("VmRSS", "vm_rss_kb"))
+            if not rss_is_measured(record[key])
+        ]
+        record["status"] = rss_unmeasured(
+            f"{', '.join(unread)} not observed from {path} — see the field(s) for the cause"
+        )
+    return record
+
+
+def read_server_rss(d: pathlib.Path, tag: str) -> dict:
+    """Rep `tag`'s scan-end RSS record, or a marker record naming why there is none.
+
+    THREE-VALUED, and the third value is a REFUSAL rather than a marker:
+
+    * the artifact is present and well-formed -> its record, as written at scan end;
+    * the artifact is ABSENT -> a marker record. That is the `read_prewarm` case: the driver
+      predates the sampling, or the rep died before it. R6.1 is then UNMEASURED for that rep,
+      which is reported rather than assumed satisfied;
+    * the artifact is present and MALFORMED -> `Invalid`. An unreadable JSON body, or a field
+      that is neither a positive integer nor an `UNMEASURED — ...` marker, is a CORRUPT
+      artifact, and a corrupt artifact is not an honest absence: something wrote a value this
+      reader cannot classify, and classifying it as absent would hide that.
+    """
+    p = d / f"{tag}.server-rss.json"
+    if not p.exists():
+        cause = (
+            f"no {p.name} beside this rep's artifacts — the server's RSS was not sampled for"
+            " it (a driver that predates R6.1, or a rep that died before scan end)"
+        )
+        return {
+            "pid": RSS_UNMEASURED,
+            "source": RSS_UNMEASURED,
+            "sampled_at": RSS_UNMEASURED,
+            "sample_timing": RSS_SAMPLE_TIMING_NOTE,
+            "vm_hwm_kb": rss_unmeasured(cause),
+            "vm_rss_kb": rss_unmeasured(cause),
+            "status": rss_unmeasured(cause),
+        }
+    try:
+        record = json.loads(p.read_text())
+    except (OSError, ValueError) as exc:
+        raise Invalid(
+            f"flight rep {tag}: {p} exists but could not be read as JSON ({exc}). Refused"
+            " rather than treated as an absent sample: something wrote that file, and calling a"
+            " corrupt record an honest absence would hide it."
+        ) from None
+    if not isinstance(record, dict):
+        raise Invalid(
+            f"flight rep {tag}: {p} must hold a JSON object, got {type(record).__name__}."
+        )
+    for key in ("vm_hwm_kb", "vm_rss_kb", "status"):
+        if key not in record:
+            raise Invalid(
+                f"flight rep {tag}: {p} carries no {key!r}. The sampler writes all three"
+                " unconditionally — an unmeasured field carries an"
+                f" '{RSS_UNMEASURED} — <cause>' marker — so an absent key is a record this"
+                " reader does not model, not an unmeasured sample."
+            )
+    marked = _rss_marker(record["status"])
+    if record["status"] != RSS_MEASURED and not marked:
+        raise Invalid(
+            f"flight rep {tag}: {p} records status={record['status']!r}, which is neither"
+            f" {RSS_MEASURED!r} nor an '{RSS_UNMEASURED} — <cause>' marker. A verdict this"
+            " reader cannot classify is refused rather than assumed to be either one."
+        )
+    for key in ("vm_hwm_kb", "vm_rss_kb"):
+        value = record[key]
+        if rss_is_measured(value) or _rss_marker(value):
+            continue
+        raise Invalid(
+            f"flight rep {tag}: {p} records {key}={value!r}, which is neither a positive"
+            f" integer of kB nor an '{RSS_UNMEASURED} — <cause>' marker. A value this reader"
+            " cannot classify is refused: the one thing it must never become is a number in"
+            " R6.1's peak-RSS ratio."
+        )
+    # ...AND THE STATUS MUST AGREE WITH THE FIELDS IT SUMMARISES. A record claiming
+    # `measured` beside a marker value is not a partially-measured sample: it is a record whose
+    # own verdict contradicts its own data, and the verdict is the field a hurried reader
+    # believes. Both directions, because either alone leaves the other reachable.
+    both = rss_is_measured(record["vm_hwm_kb"]) and rss_is_measured(record["vm_rss_kb"])
+    if record["status"] == RSS_MEASURED and not both:
+        raise Invalid(
+            f"flight rep {tag}: {p} records status={RSS_MEASURED!r} while at least one of"
+            f" vm_hwm_kb/vm_rss_kb carries an {RSS_UNMEASURED} marker. The verdict contradicts"
+            " the data it summarises, so neither is trusted."
+        )
+    if marked and both:
+        raise Invalid(
+            f"flight rep {tag}: {p} records an {RSS_UNMEASURED} status"
+            f" ({record['status']!r}) while BOTH vm_hwm_kb and vm_rss_kb hold real"
+            " observations. The verdict contradicts the data it summarises, so neither is"
+            " trusted."
+        )
+    record.setdefault("sample_timing", RSS_SAMPLE_TIMING_NOTE)
+    return record
+
+
+def server_rss_block(samples: list[dict], temp: str, arm: str) -> dict:
+    """The arm-level RSS the aggregate reads, plus the census that keeps it honest.
+
+    The two published figures are MEDIANS OVER THE REPS THAT WERE MEASURED, and the number of
+    reps behind each one is published beside it — a median over 1 of 3 reps and a median over
+    3 of 3 are different claims, and the abc driver runs `--reps 1`, so this is routinely a
+    single observation and must not read as more.
+
+    If NO rep of this arm was measured, the figure is the MARKER, never a median of an empty
+    list and never a 0. `statistics.median([])` raises, which would abort the whole report for
+    a quantity that is merely absent; and a 0 would satisfy R6.1's ceiling outright.
+    """
+    hwm = [s["vm_hwm_kb"] for s in samples if rss_is_measured(s["vm_hwm_kb"])]
+    rss = [s["vm_rss_kb"] for s in samples if rss_is_measured(s["vm_rss_kb"])]
+    absent = rss_unmeasured(
+        f"no rep of {arm} ({temp}) yielded a scan-end sample; see each rep's own"
+        " `server_rss.status` for the cause"
+    )
+    return {
+        "server_vm_hwm_kb": statistics.median(hwm) if hwm else absent,
+        "server_vm_rss_kb": statistics.median(rss) if rss else absent,
+        "server_rss_reps_measured": len(hwm),
+        "server_rss_reps_total": len(samples),
+        "server_rss_sample_timing": RSS_SAMPLE_TIMING_NOTE,
+    }
+
+
+def _cli_sample_server_rss(argv: list[str]) -> int:
+    """`ws0_flight_arm.py sample-server-rss <pid> <out.json>` — the scan-end sampler.
+
+    Called by the measurement driver at scan end, between the perf window closing and
+    `stop_server`. It ALWAYS writes a record — a measured one or a marker one naming the cause —
+    and exits 0 for both, deliberately: the throughput measurement for that rep is already
+    complete and correct, and aborting it because a peak-RSS read failed would discard a good
+    observation in order to report a missing one. The MISSING half is then reported honestly,
+    by the marker, all the way into the aggregate's table.
+
+    exit 2 is reserved for the one state that is not an unmeasured sample: the record could not
+    be WRITTEN at all. Nothing downstream would then be able to tell this rep from one the
+    driver never sampled, so it is a refusal the caller can see.
+    """
+    if len(argv) != 2:
+        sys.stderr.write(
+            "usage: ws0_flight_arm.py sample-server-rss <server-pid> <out.json>\n"
+        )
+        return 2
+    raw_pid, out = argv
+    try:
+        pid: object = int(raw_pid)
+    except ValueError:
+        pid = raw_pid
+    record = sample_server_rss(pid)
+    try:
+        pathlib.Path(out).write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")
+    except OSError as exc:
+        sys.stderr.write(
+            f"FATAL: the scan-end RSS record could not be WRITTEN to {out} ({exc}). This is the"
+            " one RSS failure that is refused rather than marked: with no record at all, this"
+            " rep is indistinguishable downstream from one that was never sampled.\n"
+        )
+        return 2
+    print(record["status"])
+    return 0
 
 
 def expected_requests(temp: str) -> str:
@@ -290,6 +621,7 @@ def collect_flight(
     per_rep = []
     missing: list[str] = []
     prewarm: list[dict] = []
+    rss_samples: list[dict] = []
     round_meta: dict[int, dict[str, int]] = {}
     for rep in range(1, reps + 1):
         tag = flight_rep_tag(arm, temp, rep)
@@ -445,6 +777,11 @@ def collect_flight(
         )
         # The prewarm outcome for THIS rep, recorded by ws0-baseline.sh.
         prewarm.append({"rep": rep, "status": read_prewarm(d, tag)})
+        # ...and the SERVER PROCESS'S SCAN-END RSS for this rep (#3997, R6.1). Read the same
+        # way the prewarm status is — an absent artifact is an UNMEASURED marker naming its
+        # cause, never a 0 — and carried into the rep below rather than summarised away, so a
+        # reader can see which reps the arm-level median rests on.
+        rss_samples.append(read_server_rss(d, tag))
         # ...and its OBSERVED round + position within that round (#3272 R3).
         meta = collect_round_meta(d, tag, rep)
         round_meta[rep] = meta
@@ -583,6 +920,10 @@ def collect_flight(
                     }
                 ),
                 "prewarm": prewarm[-1]["status"],
+                # THE SERVER'S SCAN-END RSS, or the NAMED reason it was not observed (#3997,
+                # R6.1). Never absent and never 0: R6.1's criterion is a RATIO against arm A's
+                # peak, and a 0 would satisfy every ceiling it could be compared with.
+                "server_rss": rss_samples[-1],
             }
         )
     require_complete(f"flight do_get {arm} ({temp})", per_rep, reps, missing)
@@ -621,5 +962,23 @@ def collect_flight(
         # Every rep's outcome is recorded here, and `prewarm_all_ok` is the single
         # field a reader can check.
         **prewarm_block(prewarm, temp),
+        # THE ARM-LEVEL RSS FIGURES R6.1 IS READ FROM, with the rep census beside them (#3997).
+        # `ws0_abc_aggregate.py` reads `server_vm_hwm_kb`/`server_vm_rss_kb` per session and
+        # medians them across rounds; either may be an UNMEASURED marker, which that tool
+        # prints as such instead of computing a ratio from it.
+        **server_rss_block(rss_samples, temp, f"flight_do_get_{arm}"),
         "reps": per_rep,
     }
+
+
+if __name__ == "__main__":
+    # ONE subcommand, and an unrecognised one is a usage refusal rather than a default: this
+    # module is a COLLECTOR that `ws0_report.py` imports, and its only executable surface is the
+    # scan-end sampler the driver calls per rep (#3997, R6.1).
+    if len(sys.argv) >= 2 and sys.argv[1] == "sample-server-rss":
+        sys.exit(_cli_sample_server_rss(sys.argv[2:]))
+    sys.stderr.write(
+        "ws0_flight_arm.py is the Flight arm COLLECTOR, imported by ws0_report.py. Its only"
+        " subcommand is:\n    ws0_flight_arm.py sample-server-rss <server-pid> <out.json>\n"
+    )
+    sys.exit(2)

--- a/scripts/tests/test_flight_allocator_confinement.sh
+++ b/scripts/tests/test_flight_allocator_confinement.sh
@@ -1,0 +1,369 @@
+#!/usr/bin/env bash
+# Allocator confinement guard (issue #3997, requirements R4.1 and R5.1).
+#
+# A STATIC assertion over committed source and manifests. No cargo, no build, no
+# network, no datasets, no python3 — shell, `git` and `grep` only — so it ALWAYS
+# runs and NEVER SKIPs. It is the structural half of the mechanism: its sibling
+# `test_flight_allocator_link.sh` proves the right thing IS linked into the
+# binary; this one proves nothing else ever gets it.
+#
+# THREE PROPERTIES:
+#
+#   1. (R4.1) `#[global_allocator]` occurs in EXACTLY ONE non-test production
+#      file in the workspace — `cqlite-flight/src/main.rs` — and that occurrence
+#      is guarded by the `jemalloc` feature. Every other occurrence in any `*.rs`
+#      file must fall into a RECOGNISED legitimate class. A `src/lib.rs` or
+#      `cqlite-core` occurrence outside `cfg(test)` FAILs.
+#   2. (R5.1) No `Cargo.toml` outside cqlite-flight (and the workspace root, whose
+#      `[workspace.dependencies]` declarations are inert until a member opts in)
+#      names `tikv-jemallocator`. R5.1 names `bindings/`, `cqlite-core/` and
+#      `cqlite-cli/`; this is deliberately stricter and covers all three.
+#   3. (R5.1) Every dependent of `cqlite-flight` links its LIBRARY target, and the
+#      set of dependents is exactly the RECORDED one. An ordinary Cargo dependency
+#      always links the library target; the only way to depend on a BIN target is
+#      the `artifact = "bin"` (bindeps) syntax, so that is what is refused.
+#
+# WHY IT MATTERS. A `#[global_allocator]` is process-wide, and the whole design of
+# #3997 rests on `main.rs` being compiled into the BIN target only: that is what
+# keeps the allocator out of the library every embedder, binding and integration
+# test links, and out of the memory ratchets that install their OWN allocator in
+# their OWN test binaries. Nothing about that is enforced by the compiler — a
+# later "move it to lib.rs for convenience" would build fine and silently impose
+# jemalloc on every consumer of the library. This guard is that enforcement.
+#
+# REFUSE, NEVER GUESS. Every occurrence must be classified into a named class; an
+# unrecognised shape is a NAMED FAIL, never a skipped line. Same for the manifest
+# scan: a dependency declaration in a shape this guard does not recognise FAILs
+# with an instruction to extend the guard, because "the scan found nothing it
+# understood" must never read the same as "the tree is clean".
+#
+# AFFIRMATIVE CENSUS. Every count is reported as `N ... RECOGNISED`, never a bare
+# number, and each check refuses to pass on an EMPTY subject: a scan that measured
+# nothing is not a clean scan.
+#
+# Every line is prefixed `FLIGHT-ALLOC-CONF: ` so this output cannot be mistaken
+# for, or grepped as, a gate SUMMARY.
+#
+# Positive control (a guard nobody has watched fail is a guard nobody knows works):
+# scripts/tests/test_flight_allocator_confinement_selftest.sh, which substitutes
+# this artifact into scratch trees carrying each incident class.
+set -uo pipefail
+
+P='FLIGHT-ALLOC-CONF: '
+say()  { printf '%s%s\n' "$P" "$*"; }
+ok()   { say "ok $*"; }
+pass() { say "verdict PASS — $*"; exit 0; }
+fail() { say "verdict FAIL — $*"; exit 1; }
+
+usage() {
+  cat <<'EOF'
+Usage: test_flight_allocator_confinement.sh [--help]
+
+Allocator confinement guard (issue #3997, R4.1/R5.1). A static assertion over
+committed source and manifests:
+
+  * `#[global_allocator]` occurs in exactly one non-test production file,
+    cqlite-flight/src/main.rs, guarded by the `jemalloc` feature;
+  * no Cargo.toml outside cqlite-flight (and the workspace root) names
+    tikv-jemallocator;
+  * every dependent of cqlite-flight links its LIBRARY target, and the dependent
+    set is the recorded one.
+
+No options. Needs only a shell, git and grep — it never SKIPs. Exit 0 = PASS,
+1 = FAIL, 2 = usage error.
+EOF
+}
+
+case "${1-}" in
+  --help|-h) usage; exit 0 ;;
+  '') : ;;
+  *) usage >&2; printf '%s\n' "${P}verdict FAIL — unrecognised argument: $1" >&2; exit 2 ;;
+esac
+[ "$#" -le 1 ] || { usage >&2; printf '%s\n' "${P}verdict FAIL — too many arguments ($#)" >&2; exit 2; }
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+# Resolved from this script's OWN location, with no env override: an override is
+# settable by the party the guard constrains (CLAUDE.md #3312 — "the constrained
+# party must not choose its own enforcer"). A self-test needing a different tree
+# COPIES this script into that tree.
+ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
+
+command -v git  >/dev/null 2>&1 || fail "no \`git\` on PATH — this guard enumerates TRACKED files only (an untracked scratch file or a target/ artifact must not be able to satisfy or break it), so git is a hard prerequisite, not an optional accelerator"
+command -v grep >/dev/null 2>&1 || fail "no \`grep\` on PATH"
+git -C "$ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+  || fail "$ROOT is not a git work tree — cannot enumerate tracked files; refusing to fall back to a filesystem walk, which would read target/ artifacts and untracked scratch files as if they were committed source"
+
+# The RECORDED site of the one production allocator. Hard-coded on purpose: one
+# visible location, inside the diff a reviewer already reads. Moving it is a
+# deliberate, reviewable act — and per the design (`openspec/changes/flight-jemalloc/design.md`)
+# it may not move at all, because only `main.rs` is bin-target-exclusive.
+PRODUCTION_SITE='cqlite-flight/src/main.rs'
+# The feature the one production site must be guarded by.
+PRODUCTION_FEATURE='feature = "jemalloc"'
+# Manifests permitted to name the allocator crate. cqlite-flight is the owner; the
+# workspace root is allowed because a `[workspace.dependencies]` entry declares
+# nothing for any member until that member writes `workspace = true` — refusing it
+# would red a legitimate future refactor, and a guard that reds on correct input is
+# the guard agents learn to waive (CLAUDE.md).
+ALLOCATOR_CRATE='tikv-jemallocator'
+ALLOCATOR_MANIFESTS='Cargo.toml
+cqlite-flight/Cargo.toml'
+# Every manifest permitted to declare a dependency on cqlite-flight.
+#   tools/flight-loadgen  the load generator, which drives the Flight client.
+#   cqlite-flight itself  the self-referential DEV-dependency that turns on
+#                         `test-util` for the examples/ and tests/ targets.
+# Both link the LIBRARY target, which is exactly the point: neither can inherit a
+# bin-target allocator.
+FLIGHT_DEPENDENTS='cqlite-flight/Cargo.toml
+tools/flight-loadgen/Cargo.toml'
+
+# `grep -c` exits 1 for a count of ZERO while still PRINTING "0", so its status is
+# deliberately not used as a signal — the printed count is the datum, and the
+# non-emptiness floors below are what reject a vacuous scan. This guards only the
+# thing that would otherwise slip through: a value that is not a number at all,
+# which would reach `[ "$n" -gt 0 ]` as a bash syntax error rather than a named
+# cause. Returns non-zero rather than calling fail(), because fail() ends in
+# `exit`, and an `exit` inside a command substitution leaves only the SUBSHELL.
+count_lines() {
+  local n
+  n=$(printf '%s\n' "$1" | grep -c .)
+  case "$n" in ''|*[!0-9]*) return 1 ;; esac
+  printf '%s\n' "$n"
+}
+
+# Strip a line's comment tail and surrounding whitespace, for the cfg scan below.
+# A `//`-comment can legitimately CONTAIN the text `#[cfg(` (this repo's own
+# allocator sites are documented in prose directly above them), so counting cfg
+# attributes without stripping comments would read documentation as code.
+strip_code() {
+  printf '%s\n' "$1" | sed -e 's://.*::' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
+}
+
+# =============================================================================
+# 1. (R4.1) every `global_allocator` occurrence is classified
+# =============================================================================
+#
+# Two tiers, because the token appears both as an ATTRIBUTE and inside prose:
+#
+#   * a line whose code (comment tail stripped) STARTS with `#[global_allocator]`
+#     is an INSTALL SITE and is classified by location and cfg guard;
+#   * a line where the token survives only inside a comment is a MENTION and
+#     installs nothing.
+#
+# Anything else — the token in code, not at the start of an attribute — is a
+# NAMED FAIL. It is not a shape this workspace uses, and guessing at it is
+# exactly what this guard exists not to do.
+occurrences=$(git -C "$ROOT" grep -n 'global_allocator' -- '*.rs')
+rc=$?
+# rc 1 means "no match", which for THIS token means the subject is missing: the
+# one production site and ~25 test-binary sites are committed source. Never a pass.
+[ "$rc" -eq 0 ] || fail "\`git grep global_allocator -- '*.rs'\` exited $rc; expected matches (the production site plus the memory-ratchet test binaries are committed source). An empty or failed scan is not a clean scan."
+n_occ=$(count_lines "$occurrences") || fail "cannot count the occurrence census — unmeasurable is not a pass"
+[ "$n_occ" -gt 0 ] || fail "zero \`global_allocator\` occurrences found — refusing to pass vacuously over an empty subject"
+
+n_attr=0; n_mention=0; n_testdir=0; n_cfgtest=0; n_production=0
+production_sites=''
+
+# Classify ONE install site's cfg guard. Walks UP from the attribute, collecting
+# attribute lines and skipping pure comment/blank lines, and stops at anything
+# else. Prints the joined attribute text.
+#
+# A multi-line `#[cfg(all(\n ... \n))]` stops the walk early and yields no cfg
+# text, so the caller FAILs — with a cause that says the shape was not recognised
+# rather than claiming the site is unguarded. Both outcomes are non-passing, so
+# the distinction is only in the diagnostic; it exists because "extend the guard"
+# and "you left an allocator ungated" send a reader to different places.
+collect_attrs() {
+  local file="$1" line="$2" i=0 n code out=''
+  n=$((line - 1))
+  while [ "$n" -ge 1 ] && [ "$i" -lt 30 ]; do
+    code=$(strip_code "$(sed -n "${n}p" "$file")")
+    if [ -z "$code" ]; then n=$((n - 1)); i=$((i + 1)); continue; fi
+    case "$code" in
+      '#['*|'#!['*) out="$code $out"; n=$((n - 1)); i=$((i + 1)) ;;
+      *) break ;;
+    esac
+  done
+  printf '%s\n' "$out"
+}
+
+while IFS= read -r occ; do
+  [ -n "$occ" ] || continue
+  file=${occ%%:*}
+  rest=${occ#*:}
+  lineno=${rest%%:*}
+  text=${rest#*:}
+  case "$lineno" in ''|*[!0-9]*) fail "cannot parse a line number out of the census entry '$occ' — refusing to classify a location this guard cannot read" ;; esac
+
+  code=$(strip_code "$text")
+  case "$code" in
+    '#[global_allocator]'*)
+      n_attr=$((n_attr + 1))
+      # --- class A: a test-binary or example install site. `tests/` and
+      # --- `examples/` are cargo's own target directories: nothing there is
+      # --- compiled into a library or a production binary, so an allocator in one
+      # --- is confined by construction.
+      case "$file" in
+        */tests/*|tests/*|*/examples/*|examples/*)
+          n_testdir=$((n_testdir + 1)); continue ;;
+      esac
+
+      attrs=$(collect_attrs "$ROOT/$file" "$lineno")
+      n_cfg=$(printf '%s\n' "$attrs" | grep -o '#\[cfg(' | grep -c .)
+      case "$n_cfg" in ''|*[!0-9]*) fail "$file:$lineno — cannot count the cfg attributes guarding this \`#[global_allocator]\`; unmeasurable is not a pass" ;; esac
+      if [ "$n_cfg" -ne 1 ]; then
+        fail "$file:$lineno — this \`#[global_allocator]\` is guarded by $n_cfg recognised \`#[cfg(...)]\` attribute(s); exactly 1 is required (issue #3997, R4.1). Either it is UNGATED (a process-wide allocator imposed on every build), or it is preceded by a shape this scan does not recognise — most likely a MULTI-LINE cfg attribute, which the walk stops at. If the latter, extend collect_attrs() in $(basename "$0"). Collected attribute text: '${attrs}'"
+      fi
+
+      # --- class B: `cfg(test)` in a crate's own sources. Compiled into that
+      # --- crate's unit-test binary only, never into the library an embedder
+      # --- links. This is what cqlite-core's CountingAllocator (#1883) and its
+      # --- dhat-heap sibling (#1668) are.
+      #
+      # The `test` token is matched with word boundaries so `feature = "test-util"`
+      # or an identifier ending in `test` cannot satisfy it.
+      if printf '%s\n' "$attrs" | grep -qE '(^|[^A-Za-z0-9_])test([^A-Za-z0-9_]|$)'; then
+        n_cfgtest=$((n_cfgtest + 1)); continue
+      fi
+
+      # --- class C: THE one production install site. Must be at the recorded
+      # --- path AND guarded by the jemalloc feature. A production allocator
+      # --- anywhere else — or here but ungated by the feature — is the incident
+      # --- this guard exists for.
+      if [ "$file" = "$PRODUCTION_SITE" ]; then
+        printf '%s\n' "$attrs" | grep -qF "$PRODUCTION_FEATURE" \
+          || fail "$file:$lineno — the production \`#[global_allocator]\` is NOT guarded by \`$PRODUCTION_FEATURE\` (issue #3997, R4.1). \`default = []\`, so an unguarded site would put jemalloc in every build, including one whose operator never asked for it. Collected attribute text: '${attrs}'"
+        n_production=$((n_production + 1))
+        production_sites="$production_sites$file:$lineno
+"
+        continue
+      fi
+
+      fail "$file:$lineno — a \`#[global_allocator]\` in PRODUCTION sources outside \`$PRODUCTION_SITE\`, and not under \`cfg(test)\` (issue #3997, R4.1). A global allocator is PROCESS-WIDE: in a library's sources it is imposed on every binary that links that library, including the Python/Node bindings and every embedder. The only sanctioned production site is $PRODUCTION_SITE, which rustc compiles into the cqlite-flight BIN target alone. Collected attribute text: '${attrs}'"
+      ;;
+    *'global_allocator'*)
+      # The token survives comment-stripping, so it is in CODE but is not the head
+      # of an attribute. Not a shape this workspace uses; refuse rather than guess.
+      fail "$file:$lineno — \`global_allocator\` appears in CODE in a shape this guard does not recognise (it is not the start of a \`#[global_allocator]\` attribute). Refusing to guess whether it installs an allocator. Stripped code: '${code}'"
+      ;;
+    *)
+      # Stripped to nothing / the token lived only in a comment: a MENTION. It
+      # installs nothing. This repo's allocator sites are documented in prose
+      # directly above them, so mentions are the majority of the census.
+      n_mention=$((n_mention + 1))
+      ;;
+  esac
+done <<EOF
+$occurrences
+EOF
+
+# Affirmative floors. Without these, a census that classified nothing — or one
+# whose subject vanished — would still reach PASS.
+[ "$n_attr" -gt 0 ]     || fail "0 \`#[global_allocator]\` ATTRIBUTE sites recognised out of $n_occ occurrence(s) — every occurrence was read as prose, so the classifier verified nothing; refusing to pass vacuously"
+[ "$n_testdir" -gt 0 ]  || fail "0 test/example allocator sites recognised — the memory-ratchet test binaries are committed source, so their absence means this scan is not seeing the tree it thinks it is"
+[ "$n_production" -eq 1 ] || fail "$n_production production \`#[global_allocator]\` site(s) recognised; exactly 1 is required, at $PRODUCTION_SITE, guarded by \`$PRODUCTION_FEATURE\` (issue #3997, R4.1). Found: ${production_sites:-<none>}"
+ok "$n_occ global_allocator occurrence(s) RECOGNISED: $n_attr install site(s) + $n_mention prose mention(s)"
+ok "install sites RECOGNISED: 1 production ($PRODUCTION_SITE, guarded by \`$PRODUCTION_FEATURE\`) + $n_cfgtest cfg(test) + $n_testdir under tests/ or examples/"
+
+# =============================================================================
+# 2. (R5.1) no manifest outside the allowed set names the allocator crate
+# =============================================================================
+alloc_manifests=$(git -C "$ROOT" grep -l -F "$ALLOCATOR_CRATE" -- '*Cargo.toml')
+rc=$?
+# rc 1 = no manifest names it. That is NOT clean: cqlite-flight's manifest must,
+# or the feature does not exist and this guard's whole subject is gone.
+[ "$rc" -eq 0 ] || fail "no Cargo.toml names \`$ALLOCATOR_CRATE\` (git grep exited $rc) — the jemalloc feature's dependency has gone missing, so this check has no subject; refusing to pass vacuously"
+n_alloc=$(count_lines "$alloc_manifests") || fail "cannot count the allocator-manifest census — unmeasurable is not a pass"
+printf '%s\n' "$alloc_manifests" | grep -qxF 'cqlite-flight/Cargo.toml' \
+  || fail "cqlite-flight/Cargo.toml does NOT name \`$ALLOCATOR_CRATE\`, but some other manifest does ($(printf '%s ' $alloc_manifests)) — the allocator has moved out of the crate that owns it"
+while IFS= read -r m; do
+  [ -n "$m" ] || continue
+  printf '%s\n' "$ALLOCATOR_MANIFESTS" | grep -qxF "$m" \
+    || fail "$m names \`$ALLOCATOR_CRATE\` (issue #3997, R5.1). Only cqlite-flight may depend on the allocator crate, and only the workspace root may DECLARE it in [workspace.dependencies] (inert until a member opts in). A library crate, a binding or the CLI naming it would impose a process-wide allocator on every embedder that links it."
+done <<EOF
+$alloc_manifests
+EOF
+ok "$n_alloc manifest(s) naming \`$ALLOCATOR_CRATE\` RECOGNISED, all inside the permitted set: $(printf '%s ' $alloc_manifests)"
+
+# =============================================================================
+# 3. (R5.1) every dependent of cqlite-flight links the LIBRARY target
+# =============================================================================
+#
+# Manifest-static on purpose: no cargo, so this stays in the fast, always-runs
+# tier. The TOML grammar bounds the scan — a dependency can only be declared by a
+# KEY (`cqlite-flight = ...` / `cqlite-flight.<x> = ...`) or by a dependency TABLE
+# HEADER (`[<...>dependencies.cqlite-flight]`). A mention inside a string value or
+# a comment declares nothing, which is why those are not dependency shapes rather
+# than being "assumed harmless".
+flight_lines=$(git -C "$ROOT" grep -n -- 'cqlite-flight' -- '*Cargo.toml')
+rc=$?
+[ "$rc" -eq 0 ] || fail "\`git grep cqlite-flight -- '*Cargo.toml'\` exited $rc; expected matches (the crate declares its own name) — an empty or failed scan is not a clean scan"
+n_dep_entries=0
+seen_dependents=''
+while IFS= read -r entry; do
+  [ -n "$entry" ] || continue
+  file=${entry%%:*}
+  rest=${entry#*:}
+  lineno=${rest%%:*}
+  text=${rest#*:}
+  # Trim only. A TOML comment is `#`-introduced and is rejected below by SHAPE;
+  # no comment-tail stripping here, because a `#` inside a string value is not a
+  # comment and stripping from it would mangle a real dependency line.
+  code=$(printf '%s\n' "$text" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+  # A TOML comment declares nothing. Tested FIRST so a comment mentioning a
+  # dependency line cannot be read as one.
+  case "$code" in '#'*) continue ;; esac
+
+  is_dep=no
+  case "$code" in
+    'cqlite-flight'[[:space:]]*'='*|'cqlite-flight='*|'cqlite-flight.'*|'"cqlite-flight"'*'='*) is_dep=yes ;;
+  esac
+  case "$code" in
+    '['*'dependencies.cqlite-flight]'|'['*'dependencies.cqlite-flight'[[:space:]]*']')
+      fail "$file:$lineno declares the cqlite-flight dependency as a TABLE HEADER, a shape this guard does not parse (its body, where an \`artifact\` key would live, is on other lines). Refusing to certify it. Extend $(basename "$0") to walk the table body, or express the dependency inline." ;;
+  esac
+  # An inline `[dependencies]` table (legal TOML: `dependencies = { cqlite-flight
+  # = { ... } }`) would put the key mid-line. Refuse rather than miss it.
+  if [ "$is_dep" = no ]; then
+    case "$code" in
+      *'cqlite-flight'[[:space:]]*'='*|*'cqlite-flight='*)
+        fail "$file:$lineno mentions cqlite-flight followed by \`=\` in a position this guard does not recognise as a top-level dependency key (an inline dependencies table?). Refusing to guess whether it declares a dependency. Line: '${code}'" ;;
+    esac
+    continue
+  fi
+
+  # A dependency KEY. Two things to assert.
+  #   * `name = "cqlite-flight"` is the PACKAGE declaration, not a dependency —
+  #     but it has key `name`, so it never reaches here.
+  #   * `artifact`/`bin` on the entry is cargo's (unstable) way to depend on a
+  #     BINARY target, which is the only route by which a dependent could inherit
+  #     the bin's global allocator.
+  case "$code" in
+    *artifact*|*'bin ='*|*'bin='*)
+      fail "$file:$lineno depends on cqlite-flight with an \`artifact\`/\`bin\` key (issue #3997, R5.1). That is a dependency on the BINARY target, which is where the jemalloc \`#[global_allocator]\` lives — the dependent would inherit a process-wide allocator. Depend on the LIBRARY target instead. Line: '${code}'" ;;
+  esac
+  n_dep_entries=$((n_dep_entries + 1))
+  seen_dependents="$seen_dependents$file
+"
+  printf '%s\n' "$FLIGHT_DEPENDENTS" | grep -qxF "$file" \
+    || fail "$file:$lineno declares a NEW dependency on cqlite-flight that is not in this guard's recorded dependent set (issue #3997, R5.1). Every dependent widens the blast radius of anything in that crate, so the set is reviewed rather than inferred: if this is intended, add $file to FLIGHT_DEPENDENTS in $(basename "$0") and state in the diff that it links the LIBRARY target."
+done <<EOF
+$flight_lines
+EOF
+
+n_expected=$(count_lines "$FLIGHT_DEPENDENTS") || fail "cannot count the recorded dependent set — unmeasurable is not a pass"
+[ "$n_dep_entries" -gt 0 ] || fail "0 cqlite-flight dependency entries RECOGNISED, but the recorded set names $n_expected — the scan found none of them, so it verified nothing; refusing to pass vacuously"
+# Every RECORDED dependent must still exist and still declare the dependency.
+# Without this, deleting a dependent while leaving it recorded would keep the
+# count satisfiable, and the set would decay into fiction.
+while IFS= read -r m; do
+  [ -n "$m" ] || continue
+  [ -f "$ROOT/$m" ] || fail "$m is in this guard's recorded dependent set but does not exist on disk — remove it from FLIGHT_DEPENDENTS in $(basename "$0")"
+  printf '%s\n' "$seen_dependents" | grep -qxF "$m" \
+    || fail "$m is in this guard's recorded dependent set but declares no cqlite-flight dependency any more — remove it from FLIGHT_DEPENDENTS in $(basename "$0") so the recorded set stays a fact rather than a leftover"
+done <<EOF
+$FLIGHT_DEPENDENTS
+EOF
+ok "$n_dep_entries cqlite-flight dependency entr(y|ies) RECOGNISED across the $n_expected recorded dependent(s), 0 ARTIFACT/BIN DEPENDENCIES RECOGNISED — every dependent links the LIBRARY target"
+
+pass "allocator confinement holds: one feature-gated production install site at $PRODUCTION_SITE, $n_cfgtest cfg(test) + $n_testdir test/example sites, \`$ALLOCATOR_CRATE\` named by no manifest outside the permitted set, and every cqlite-flight dependent on the library target (issue #3997, R4.1/R5.1)"

--- a/scripts/tests/test_flight_allocator_confinement_selftest.sh
+++ b/scripts/tests/test_flight_allocator_confinement_selftest.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+# Self-test / positive control for scripts/tests/test_flight_allocator_confinement.sh
+# (issue #3997, R4.1/R5.1).
+#
+# A guard is only worth its green if it is capable of red, and for a guard whose
+# whole job is to red on a future refactor nobody has made yet, that is the ONLY
+# way to know it works. Every case builds a scratch workspace that reproduces the
+# real tree's shape in miniature, copies the guard into it at the same relative
+# path, and asserts the verdict — and every red case must NAME the planted defect,
+# because a bare non-zero exit is produced just as well by an unrelated abort.
+#
+# THE GUARD RESOLVES ITS ROOT FROM ITS OWN LOCATION, so there is deliberately no
+# path or env seam to aim at a fixture (CLAUDE.md #3312: a case needing a different
+# subject SUBSTITUTES THE ARTIFACT in its own scratch copy of the tree). A
+# test-only seam would be one more thing a real invoker can set.
+#
+# TWO GREEN CONTROLS. Without them a guard hard-wired to refuse everything would
+# satisfy every red case below and look fully tested.
+#
+# NO CARGO ANYWHERE, and no network: the guard is source-and-manifest static, so
+# this suite is too — deterministic, offline, toolchain-independent. The scratch
+# trees live OUTSIDE the repository (under mktemp) and are `git init`-ed, because
+# the guard enumerates TRACKED files: a tree inside the repo would resolve to the
+# repo's own git dir and the fixture would silently measure the real workspace.
+set -uo pipefail
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+GUARD="$SCRIPT_DIR/test_flight_allocator_confinement.sh"
+GUARD_BASE=$(basename "$GUARD")
+[ -f "$GUARD" ] || { echo "FAIL: guard under test not found at $GUARD" >&2; exit 1; }
+command -v git >/dev/null 2>&1 || { echo "FAIL: this suite needs git (the guard enumerates tracked files)" >&2; exit 1; }
+
+TMPROOT=$(mktemp -d "${TMPDIR:-/tmp}/flightallocconf.XXXXXX") || exit 1
+trap 'rm -rf "$TMPROOT"' EXIT
+
+fails=0
+cases=0
+pass_case() { echo "ok: $*"; cases=$((cases + 1)); }
+fail_case() { echo "FAIL: $*" >&2; fails=$((fails + 1)); cases=$((cases + 1)); }
+
+# make_tree <case> — lay down a MINIMAL but COMPLETE tree that the guard passes,
+# so each case below can mutate exactly one thing. Echoes the tree root.
+#
+# The shape mirrors the real workspace in every respect the guard reads: the one
+# feature-gated production install site, two `cfg(test)` sites in a library's own
+# sources, a `tests/` site, the allocator crate named only by permitted manifests,
+# and both recorded dependents declaring a plain (library) dependency.
+make_tree() {
+  # SEPARATE statements, deliberately: `local a="$1" b="$TMPROOT/$a"` expands ALL
+  # of `local`'s arguments BEFORE the builtin assigns any of them, so the second
+  # would read an unset `a` and die under `set -u`.
+  local case_name="$1"
+  local ws="$TMPROOT/$case_name"
+  mkdir -p "$ws/scripts/tests" "$ws/cqlite-flight/src" "$ws/cqlite-flight/tests" \
+           "$ws/cqlite-core/src" "$ws/tools/flight-loadgen/src" "$ws/bindings/python"
+
+  cp "$GUARD" "$ws/scripts/tests/$GUARD_BASE"
+  chmod +x "$ws/scripts/tests/$GUARD_BASE"
+
+  printf '[workspace]\nmembers = [\n    "cqlite-flight",\n    "cqlite-core",\n]\n' > "$ws/Cargo.toml"
+
+  # The one production install site, feature-gated, with prose ABOVE it that
+  # itself contains the token — the real tree documents its allocator sites, and
+  # a classifier that read documentation as code would mis-count here.
+  cat > "$ws/cqlite-flight/src/main.rs" <<'RS'
+//! A `#[global_allocator]` is process-wide; this prose must count as a MENTION.
+#[cfg(all(feature = "jemalloc", target_os = "linux"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+fn main() {}
+RS
+  printf '[package]\nname = "cqlite-flight"\n\n[dependencies]\ntikv-jemallocator = { version = "0.6", optional = true }\n\n[features]\ndefault = []\njemalloc = ["dep:tikv-jemallocator"]\n\n[dev-dependencies]\ncqlite-flight = { path = ".", features = ["test-util"] }\n' \
+    > "$ws/cqlite-flight/Cargo.toml"
+
+  # A test-binary install site (the memory-ratchet shape).
+  printf '#[global_allocator]\nstatic A: dhat::Alloc = dhat::Alloc;\n' > "$ws/cqlite-flight/tests/mem_budget.rs"
+
+  # Two cfg(test) sites in a library's own sources.
+  cat > "$ws/cqlite-core/src/lib.rs" <<'RS'
+// only one `#[global_allocator]` per binary — a MENTION.
+#[cfg(all(test, feature = "state_machine", not(feature = "dhat-heap")))]
+#[global_allocator]
+static TEST_ALLOC: Counting = Counting;
+
+#[cfg(all(test, feature = "dhat-heap"))]
+#[global_allocator]
+static DHAT_TEST_ALLOC: dhat::Alloc = dhat::Alloc;
+RS
+  printf '[package]\nname = "cqlite-core"\n' > "$ws/cqlite-core/Cargo.toml"
+
+  printf '[package]\nname = "flight-loadgen"\ndescription = "load generator for cqlite-flight"\n\n[dependencies]\ncqlite-flight = { path = "../../cqlite-flight", features = ["test-util"] }\n' \
+    > "$ws/tools/flight-loadgen/Cargo.toml"
+  printf 'fn main() {}\n' > "$ws/tools/flight-loadgen/src/main.rs"
+  printf '[package]\nname = "cqlite-py"\n' > "$ws/bindings/python/Cargo.toml"
+
+  git -C "$ws" init -q >/dev/null 2>&1
+  git -C "$ws" add -A >/dev/null 2>&1
+  printf '%s\n' "$ws"
+}
+
+# run_case <label> <tree> <expect: pass|fail> [needle...]
+#   A red case must NAME the planted defect: `needle` is grepped (fixed-string)
+#   against the guard's output, so an unrelated abort cannot satisfy it.
+run_case() {
+  local label="$1" ws="$2" expect="$3"; shift 3
+  local out rc needle
+  out=$(bash "$ws/scripts/tests/$GUARD_BASE" 2>&1); rc=$?
+  case "$expect" in
+    pass)
+      if [ "$rc" -ne 0 ]; then
+        fail_case "$label: expected PASS, guard exited $rc. Output:
+$out"
+        return
+      fi
+      printf '%s\n' "$out" | grep -q '^FLIGHT-ALLOC-CONF: verdict PASS' \
+        || { fail_case "$label: exited 0 but printed no PASS verdict line. Output:
+$out"; return; }
+      ;;
+    fail)
+      if [ "$rc" -eq 0 ]; then
+        fail_case "$label: expected FAIL, guard exited 0 (a FALSE PASS on a planted defect). Output:
+$out"
+        return
+      fi
+      printf '%s\n' "$out" | grep -q '^FLIGHT-ALLOC-CONF: verdict FAIL' \
+        || { fail_case "$label: exited $rc but printed no FAIL verdict line. Output:
+$out"; return; }
+      ;;
+    *) fail_case "$label: internal — unknown expectation '$expect'"; return ;;
+  esac
+  for needle in "$@"; do
+    printf '%s\n' "$out" | grep -qF -- "$needle" \
+      || { fail_case "$label: verdict was $expect but the output does not NAME '$needle' — a verdict that does not identify its subject is not evidence. Output:
+$out"; return; }
+  done
+  pass_case "$label"
+}
+
+# ---------------------------------------------------------------- green controls
+ws=$(make_tree g1_pristine)
+run_case "G1 pristine tree passes" "$ws" pass \
+  'cqlite-flight/src/main.rs' '2 cfg(test)'
+
+# A tree where the workspace ROOT manifest also declares the allocator crate in
+# [workspace.dependencies]. That is inert until a member opts in, so it must PASS —
+# the second green control, and the one that pins the guard does not simply refuse
+# every mention of the crate.
+ws=$(make_tree g2_workspace_dep)
+printf '\n[workspace.dependencies]\ntikv-jemallocator = { version = "0.6" }\n' >> "$ws/Cargo.toml"
+git -C "$ws" add -A >/dev/null 2>&1
+run_case "G2 [workspace.dependencies] declaration is inert and passes" "$ws" pass \
+  '2 manifest(s) naming `tikv-jemallocator` RECOGNISED'
+
+# ------------------------------------------------------------------- red: R4.1
+# THE incident class: someone moves the allocator into a library's sources "for
+# convenience". It builds fine and imposes jemalloc on every embedder.
+ws=$(make_tree r1_allocator_in_lib)
+cat >> "$ws/cqlite-core/src/lib.rs" <<'RS'
+
+#[cfg(feature = "jemalloc")]
+#[global_allocator]
+static ESCAPED: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+RS
+git -C "$ws" add -A >/dev/null 2>&1
+run_case "R1 a feature-gated allocator in cqlite-core/src/lib.rs is rejected" "$ws" fail \
+  'cqlite-core/src/lib.rs' 'PRODUCTION sources outside'
+
+# An UNGATED allocator in a library's sources — the same class with no cfg at all,
+# which must not be excused by the cfg-count branch.
+ws=$(make_tree r2_ungated_in_lib)
+printf '\n#[global_allocator]\nstatic ESCAPED: Sys = Sys;\n' >> "$ws/cqlite-core/src/lib.rs"
+git -C "$ws" add -A >/dev/null 2>&1
+run_case "R2 an UNGATED allocator in a library's sources is rejected" "$ws" fail \
+  'cqlite-core/src/lib.rs' 'guarded by 0 recognised'
+
+# The production site loses its feature gate: `default = []`, so this would put
+# jemalloc in every build including one nobody asked for.
+ws=$(make_tree r3_production_ungated)
+cat > "$ws/cqlite-flight/src/main.rs" <<'RS'
+#[cfg(target_os = "linux")]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+fn main() {}
+RS
+git -C "$ws" add -A >/dev/null 2>&1
+run_case "R3 the production site without the jemalloc feature gate is rejected" "$ws" fail \
+  'cqlite-flight/src/main.rs' 'NOT guarded by'
+
+# A SECOND production install site at the recorded path's crate but another file.
+ws=$(make_tree r4_second_production_site)
+mkdir -p "$ws/cqlite-flight/src"
+cat > "$ws/cqlite-flight/src/other.rs" <<'RS'
+#[cfg(feature = "jemalloc")]
+#[global_allocator]
+static SECOND: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+RS
+git -C "$ws" add -A >/dev/null 2>&1
+run_case "R4 a second production install site in the same crate is rejected" "$ws" fail \
+  'cqlite-flight/src/other.rs'
+
+# The production site DISAPPEARS. The guard must red on an absent subject too,
+# not merely on an extra one — otherwise deleting the mechanism would pass.
+ws=$(make_tree r5_no_production_site)
+printf 'fn main() {}\n' > "$ws/cqlite-flight/src/main.rs"
+git -C "$ws" add -A >/dev/null 2>&1
+run_case "R5 an ABSENT production install site is rejected" "$ws" fail \
+  '0 production'
+
+# A multi-line cfg attribute: the walk stops at it, so the guard must refuse with
+# the "extend the guard" cause rather than claim the site is unguarded.
+ws=$(make_tree r6_multiline_cfg)
+cat > "$ws/cqlite-flight/src/main.rs" <<'RS'
+#[cfg(all(
+    feature = "jemalloc",
+    target_os = "linux"
+))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+fn main() {}
+RS
+git -C "$ws" add -A >/dev/null 2>&1
+run_case "R6 a MULTI-LINE cfg attribute is refused, not guessed at" "$ws" fail \
+  'MULTI-LINE cfg attribute'
+
+# `global_allocator` in code in a shape the classifier does not recognise.
+ws=$(make_tree r7_unrecognised_code)
+printf 'const X: &str = "global_allocator";\n' > "$ws/cqlite-core/src/odd.rs"
+git -C "$ws" add -A >/dev/null 2>&1
+run_case "R7 the token in CODE in an unrecognised shape is refused" "$ws" fail \
+  'does not recognise'
+
+# NO occurrences at all: an empty subject must never read as clean.
+ws=$(make_tree r8_empty_subject)
+printf 'fn main() {}\n' > "$ws/cqlite-flight/src/main.rs"
+rm -f "$ws/cqlite-flight/tests/mem_budget.rs"
+printf '// nothing here\n' > "$ws/cqlite-core/src/lib.rs"
+git -C "$ws" add -A >/dev/null 2>&1
+run_case "R8 a tree with ZERO occurrences is rejected, not passed vacuously" "$ws" fail \
+  'not a clean scan'
+
+# The test/example floor: install sites exist but NONE under tests/ or examples/,
+# which means the scan is not seeing the tree it thinks it is.
+ws=$(make_tree r9_no_test_sites)
+rm -f "$ws/cqlite-flight/tests/mem_budget.rs"
+git -C "$ws" add -A >/dev/null 2>&1
+run_case "R9 zero test/example install sites is rejected" "$ws" fail \
+  '0 test/example allocator sites recognised'
+
+# ------------------------------------------------------------------- red: R5.1
+# A binding names the allocator crate — the leak R5 exists to prevent.
+ws=$(make_tree r10_binding_names_allocator)
+printf '[package]\nname = "cqlite-py"\n\n[dependencies]\ntikv-jemallocator = "0.6"\n' \
+  > "$ws/bindings/python/Cargo.toml"
+git -C "$ws" add -A >/dev/null 2>&1
+run_case "R10 a binding manifest naming tikv-jemallocator is rejected" "$ws" fail \
+  'bindings/python/Cargo.toml' 'R5.1'
+
+# cqlite-core names it.
+ws=$(make_tree r11_core_names_allocator)
+printf '[package]\nname = "cqlite-core"\n\n[dependencies]\ntikv-jemallocator = "0.6"\n' \
+  > "$ws/cqlite-core/Cargo.toml"
+git -C "$ws" add -A >/dev/null 2>&1
+run_case "R11 cqlite-core naming tikv-jemallocator is rejected" "$ws" fail \
+  'cqlite-core/Cargo.toml'
+
+# The allocator crate leaves cqlite-flight entirely: an absent subject again.
+ws=$(make_tree r12_allocator_crate_gone)
+printf '[package]\nname = "cqlite-flight"\n\n[features]\ndefault = []\n\n[dev-dependencies]\ncqlite-flight = { path = "." }\n' \
+  > "$ws/cqlite-flight/Cargo.toml"
+git -C "$ws" add -A >/dev/null 2>&1
+run_case "R12 the allocator dependency vanishing from cqlite-flight is rejected" "$ws" fail \
+  'gone missing'
+
+# A dependent asking for the BIN target — the one route by which a dependent could
+# inherit the binary's global allocator.
+ws=$(make_tree r13_artifact_bin_dep)
+printf '[package]\nname = "flight-loadgen"\n\n[dependencies]\ncqlite-flight = { path = "../../cqlite-flight", artifact = "bin" }\n' \
+  > "$ws/tools/flight-loadgen/Cargo.toml"
+git -C "$ws" add -A >/dev/null 2>&1
+run_case "R13 an artifact=\"bin\" dependency on cqlite-flight is rejected" "$ws" fail \
+  'BINARY target'
+
+# A NEW, unrecorded dependent.
+ws=$(make_tree r14_new_dependent)
+mkdir -p "$ws/tools/newthing"
+printf '[package]\nname = "newthing"\n\n[dependencies]\ncqlite-flight = { path = "../../cqlite-flight" }\n' \
+  > "$ws/tools/newthing/Cargo.toml"
+git -C "$ws" add -A >/dev/null 2>&1
+run_case "R14 a NEW unrecorded dependent of cqlite-flight is rejected" "$ws" fail \
+  'tools/newthing/Cargo.toml' 'recorded dependent set'
+
+# A RECORDED dependent that stops declaring the dependency: the recorded set must
+# stay a fact rather than decay into a leftover.
+ws=$(make_tree r15_recorded_dependent_stale)
+printf '[package]\nname = "flight-loadgen"\n' > "$ws/tools/flight-loadgen/Cargo.toml"
+git -C "$ws" add -A >/dev/null 2>&1
+run_case "R15 a recorded dependent that no longer declares the dependency is rejected" "$ws" fail \
+  'tools/flight-loadgen/Cargo.toml'
+
+# A dependency declared as a TABLE HEADER: a shape the guard does not parse, so it
+# must refuse rather than certify a body it never read.
+ws=$(make_tree r16_table_header_dep)
+printf '[package]\nname = "flight-loadgen"\n\n[dependencies.cqlite-flight]\npath = "../../cqlite-flight"\n' \
+  > "$ws/tools/flight-loadgen/Cargo.toml"
+git -C "$ws" add -A >/dev/null 2>&1
+run_case "R16 a TABLE-HEADER dependency declaration is refused, not certified" "$ws" fail \
+  'TABLE HEADER'
+
+# ------------------------------------------------------------- red: prerequisites
+# Not a git work tree: the guard must refuse rather than fall back to a filesystem
+# walk, which would read target/ artifacts and untracked files as committed source.
+ws=$(make_tree r17_not_a_git_tree)
+rm -rf "$ws/.git"
+run_case "R17 a non-git tree is refused, never walked as a filesystem" "$ws" fail \
+  'not a git work tree'
+
+# ------------------------------------------------------------------------ usage
+out=$(bash "$GUARD" --help 2>&1); rc=$?
+if [ "$rc" -eq 0 ] && printf '%s\n' "$out" | grep -q 'Usage: test_flight_allocator_confinement.sh'; then
+  pass_case "U1 --help exits 0 and prints usage"
+else
+  fail_case "U1 --help: rc=$rc output:
+$out"
+fi
+out=$(bash "$GUARD" --nope 2>&1); rc=$?
+if [ "$rc" -eq 2 ]; then
+  pass_case "U2 an unrecognised argument exits 2"
+else
+  fail_case "U2 unrecognised argument: expected exit 2, got $rc. Output:
+$out"
+fi
+
+# CASE FLOOR (#3544's lesson): a span-replacing edit can silently delete cases and
+# leave a green tally over a shrunken suite. 21 cases: 2 green, 17 red, 2 usage.
+FLOOR=21
+[ "$cases" -ge "$FLOOR" ] || { echo "FAIL: only $cases case(s) ran; the suite declares a floor of $FLOOR — cases were deleted" >&2; fails=$((fails + 1)); }
+
+echo "----"
+if [ "$fails" -eq 0 ]; then
+  echo "PASS: allocator confinement guard self-test — $cases case(s), 0 failure(s) (#3997)"
+  exit 0
+fi
+echo "FAIL: allocator confinement guard self-test — $cases case(s), $fails failure(s) (#3997)" >&2
+exit 1

--- a/scripts/tests/test_flight_allocator_link.sh
+++ b/scripts/tests/test_flight_allocator_link.sh
@@ -25,6 +25,33 @@
 # the feature being wired to a `#[global_allocator]` that is never installed, or
 # `--version` reporting a string that disagrees with what was linked.
 #
+# EACH ARM ASSERTS ON A PRIVATE SNAPSHOT OF THE BINARY IT ITSELF BUILT, NEVER ON
+# THE WELL-KNOWN PATH. This is the ordering hazard the guard is most likely to
+# have, so it is closed by mechanism rather than by argument: the positive and the
+# negative arm both uplift to the SAME `target/debug/cqlite-flight`, so an
+# assertion made against that path is an assertion about whatever last wrote it.
+# Instead each arm builds with `--message-format=json`, finds the
+# `compiler-artifact` message for the `cqlite-flight` BIN target, and takes TWO
+# things from it:
+#
+#   * `"features":[...]` — cargo's OWN statement of the feature set the artifact
+#     was built with. The arm asserts its identity against that, so "this is the
+#     jemalloc build" is attested by cargo rather than inferred from the flags we
+#     passed. A mismatch is a FAIL, not a skip.
+#   * `"executable"` — the artifact path, which is then COPIED to a per-arm
+#     private file, with the source's device+inode+size checked either side of the
+#     copy. Every symbol and `--version` assertion runs against that private copy.
+#
+# Two measurements this rests on, both taken on this tree rather than assumed:
+# cargo emits the artifact message even for a FULLY FRESH build (the warm case the
+# gate hits), and a no-op `cargo build` RE-UPLIFTS — a jemalloc-bearing binary
+# planted at `target/debug/cqlite-flight` was replaced by the correct
+# default-features one by a build that recompiled nothing (`Finished` in 0.17s,
+# inode changed). So the well-known path is refreshed by each arm; the residual
+# exposure it leaves is a CONCURRENT build in the same target directory
+# overwriting it between our build and our read, and the private copy plus the
+# inode check is what closes that.
+#
 # WHY DEBUG, NOT RELEASE. Two reasons, both load-bearing. (1) Cost: the gate's
 # other components already build this crate in debug, so the negative arm is warm
 # and free, and the positive arm adds one cqlite-flight recompile plus jemalloc's
@@ -94,6 +121,13 @@ case "${1-}" in
 esac
 [ "$#" -le 1 ] || { usage >&2; printf '%s\n' "${P}verdict FAIL — too many arguments ($#)" >&2; exit 2; }
 
+# Per-run scratch, for the private per-arm artifact snapshots. Created before any
+# arm runs and removed on EXIT (`|| true`, because a failing command in a bash
+# EXIT trap under `set -e` would replace the exit status; this script does not set
+# -e, but the habit is cheap and the trap must never change a verdict).
+SCRATCH=$(mktemp -d "${TMPDIR:-/tmp}/flightalloclink.XXXXXX") || { printf '%s\n' "${P}verdict SKIP — cannot create a scratch directory for the per-arm artifact snapshots; nothing was measured" >&2; exit 0; }
+trap 'rm -rf "$SCRATCH" || true' EXIT
+
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 # Resolved from this script's OWN location, with no env override: an override is
 # settable by the party the guard constrains (CLAUDE.md #3312).
@@ -150,8 +184,7 @@ rc=$?
 [ "$rc" -eq 0 ] || fail "\`cargo metadata\` exited $rc — the workspace manifests do not read, which is a broken tree rather than an unmeasurable host. Remedy: fix the manifest, then re-run."
 TARGET_DIR=$(printf '%s' "$metadata" | tr ',' '\n' | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p' | head -1)
 [ -n "$TARGET_DIR" ] || skip "could not read \`target_directory\` out of \`cargo metadata\`'s output — the reader did not recognise it, so nothing was measured (a cargo JSON shape change, or a target path holding an escaped character)"
-BIN="$TARGET_DIR/debug/cqlite-flight"
-say "target-dir $TARGET_DIR"
+say "target-dir $TARGET_DIR (reported for diagnosis only — NO arm asserts on \$TARGET_DIR/debug/cqlite-flight; see the header)"
 
 # Count jemalloc symbols and TOTAL symbols in one read, so a zero jemalloc count
 # is always accompanied by the evidence that the tool produced a symbol table at
@@ -205,43 +238,122 @@ check_version_line() {
   return 0
 }
 
+# Resolve the artifact THIS arm's build produced, from that build's own JSON.
+# Echoes `<executable-path>\t<comma-separated features>`; returns non-zero when
+# the message stream holds no single recognisable bin artifact.
+#
+# The filter requires ALL of: a compiler-artifact message, the `cqlite-flight`
+# name, `"crate_types":["bin"]`, and a non-null `executable`. EXACTLY ONE such
+# message must be present — zero means we cannot say what we built, and more than
+# one means the stream is not the shape this parser was written against; either
+# way, refusing beats picking.
+resolve_arm_artifact() {
+  local json="$1" lines n exe feats
+  lines=$(grep '"reason":"compiler-artifact"' "$json" 2>/dev/null \
+          | grep '"name":"cqlite-flight"' \
+          | grep '"crate_types":\["bin"\]' \
+          | grep -o '{.*"executable":"[^"]*".*}')
+  n=$(printf '%s\n' "$lines" | grep -c .)
+  case "$n" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$n" -eq 1 ] || return 1
+  exe=$(printf '%s\n' "$lines" | sed -n 's/.*"executable":"\([^"]*\)".*/\1/p')
+  feats=$(printf '%s\n' "$lines" | sed -n 's/.*"features":\[\([^]]*\)\].*/\1/p' | tr -d '"')
+  [ -n "$exe" ] || return 1
+  printf '%s\t%s\n' "$exe" "$feats"
+}
+
+# The identity of a file, as a value that changes when the file is REPLACED.
+# `%d:%i` (device:inode) plus size: cargo uplifts by hardlink, so a re-uplift or a
+# peer's overwrite lands on a NEW inode. Prints nothing on failure.
+file_identity() {
+  stat -c '%d:%i:%s' -- "$1" 2>/dev/null
+}
+
+# Snapshot `$1` into the per-arm private file `$2`, refusing if the source was
+# replaced across the copy. Returns 0 = snapshot taken, 1 = could not, 2 = the
+# source changed under us.
+snapshot_artifact() {
+  local src="$1" dst="$2" id_before id_after
+  id_before=$(file_identity "$src")
+  [ -n "$id_before" ] || return 1
+  cp -- "$src" "$dst" 2>/dev/null || return 1
+  id_after=$(file_identity "$src")
+  [ -n "$id_after" ] || return 1
+  [ "$id_before" = "$id_after" ] || return 2
+  [ -s "$dst" ] || return 1
+  chmod u+x -- "$dst" 2>/dev/null || return 1
+  return 0
+}
+
 # One arm. `$1` = arm label, `$2` = extra cargo args (may be empty), `$3` =
 # `present` | `absent`, `$4` = the expected `--version` allocator value.
 run_arm() {
-  local label="$1" extra="$2" expect_syms="$3" expect_alloc="$4" rc_local counts jem total
+  local label="$1" extra="$2" expect_syms="$3" expect_alloc="$4"
+  local rc_local counts jem total resolved exe feats bin
+  local json="$SCRATCH/$label.json" err="$SCRATCH/$label.err"
   say "arm $label: cargo build -p cqlite-flight ${extra:-<default features>}"
   # 25 min with a 30s SIGKILL escalation: the positive arm compiles jemalloc's
   # vendored C source cold, and the negative arm is the feature set the gate's other
   # components already built, so it is warm.
+  # JSON on stdout (the artifact record this arm asserts against), human-readable
+  # progress and diagnostics on stderr (kept for the failure message).
   # shellcheck disable=SC2086  # $extra is a deliberate word-split of our own literal flags
-  timeout -k 30 1500 cargo build -p cqlite-flight $extra >/dev/null 2>&1
+  timeout -k 30 1500 cargo build -p cqlite-flight $extra --message-format=json >"$json" 2>"$err"
   rc_local=$?
-  [ "$rc_local" -eq 0 ] || fail "arm $label: \`cargo build -p cqlite-flight ${extra:-(default features)}\` exited $rc_local. This is a BROKEN BUILD, not an unmeasurable host. Remedy: run that exact command by hand and fix what it reports."
-  [ -f "$BIN" ] || fail "arm $label: the build reported success but $BIN does not exist — refusing to assert anything about a binary that is not there"
+  [ "$rc_local" -eq 0 ] || fail "arm $label: \`cargo build -p cqlite-flight ${extra:-(default features)}\` exited $rc_local. This is a BROKEN BUILD, not an unmeasurable host. Remedy: run that exact command by hand and fix what it reports. Last lines of its stderr: $(tail -5 "$err" 2>/dev/null | tr '\n' '|')"
 
-  counts=$(read_symbols "$BIN")
+  # --- resolve the artifact from THIS build, never from the well-known path.
+  resolved=$(resolve_arm_artifact "$json")
   rc_local=$?
-  [ "$rc_local" -eq 0 ] || skip "arm $label: \`$SYMTOOL\` could not be read for $BIN (non-zero exit, timeout, or output this script cannot parse) — nothing was measured"
+  [ "$rc_local" -eq 0 ] || skip "arm $label: the build succeeded but its \`--message-format=json\` stream holds no single recognisable \`cqlite-flight\` bin artifact record, so this arm cannot say WHICH binary it produced — nothing was measured (a cargo JSON shape change). Refusing to fall back to \$TARGET_DIR/debug/cqlite-flight: both arms uplift to that path, so an assertion against it is an assertion about whatever last wrote it."
+  exe=${resolved%%	*}
+  feats=${resolved##*	}
+
+  # --- the arm's IDENTITY, attested by cargo rather than inferred from our flags.
+  case "$expect_syms" in
+    present)
+      printf '%s\n' "$feats" | tr ',' '\n' | grep -qx 'jemalloc' \
+        || fail "arm $label: cargo reports this artifact was built with features [$feats], which does NOT include \`jemalloc\` — the positive arm did not build the binary it thinks it did, so any symbol verdict from it would be meaningless" ;;
+    absent)
+      printf '%s\n' "$feats" | tr ',' '\n' | grep -qx 'jemalloc' \
+        && fail "arm $label: cargo reports this artifact was built with features [$feats], which DOES include \`jemalloc\` — the negative arm is not measuring a default-features build. \`default = []\`, so the allocator feature must not be reachable from a plain \`cargo build -p cqlite-flight\`" ;;
+  esac
+  say "arm $label: cargo attests features [${feats:-<none>}] for $exe"
+
+  # --- private snapshot. Every assertion below runs on this copy, so a concurrent
+  # --- build overwriting the uplifted path cannot change what we measured.
+  bin="$SCRATCH/$label.bin"
+  snapshot_artifact "$exe" "$bin"
+  rc_local=$?
+  case "$rc_local" in
+    0) : ;;
+    2) fail "arm $label: $exe was REPLACED while being snapshotted (its device:inode:size changed across the copy) — another build in this target directory is racing this one, so nothing measured here would be attributable to this arm's build. Re-run when no concurrent cargo build shares \$TARGET_DIR." ;;
+    *) skip "arm $label: cannot snapshot the built artifact $exe into this run's scratch directory — nothing was measured" ;;
+  esac
+
+  counts=$(read_symbols "$bin")
+  rc_local=$?
+  [ "$rc_local" -eq 0 ] || skip "arm $label: \`$SYMTOOL\` could not be read for the snapshot of $exe (non-zero exit, timeout, or output this script cannot parse) — nothing was measured"
   jem=${counts%% *}
   total=${counts##* }
   # AFFIRMATIVE MEASUREMENT: a zero jemalloc count is only meaningful if the tool
   # produced a symbol table. Zero total symbols means the read told us nothing —
   # a stripped binary or a silently-empty tool — which must never read as clean.
-  [ "$total" -gt 0 ] || skip "arm $label: \`$SYMTOOL\` produced ZERO symbol lines for $BIN, so a zero jemalloc count would be UNMEASURED rather than clean (a stripped binary, or a symbol reader that emitted nothing)"
+  [ "$total" -gt 0 ] || skip "arm $label: \`$SYMTOOL\` produced ZERO symbol lines for the snapshot of $exe, so a zero jemalloc count would be UNMEASURED rather than clean (a stripped binary, or a symbol reader that emitted nothing)"
 
   case "$expect_syms" in
     present)
-      [ "$jem" -gt 0 ] || fail "arm $label (R1.1): expected jemalloc symbols in $BIN and found 0 JEMALLOC SYMBOLS RECOGNISED out of $total symbol lines read. The \`jemalloc\` feature is declared but nothing was linked — check that src/main.rs's #[global_allocator] cfg matches the feature name and that the dependency is not cfg'd out on this target."
+      [ "$jem" -gt 0 ] || fail "arm $label (R1.1): expected jemalloc symbols in the artifact cargo built at $exe and found 0 JEMALLOC SYMBOLS RECOGNISED out of $total symbol lines read. The \`jemalloc\` feature is declared but nothing was linked — check that src/main.rs's #[global_allocator] cfg matches the feature name and that the dependency is not cfg'd out on this target."
       say "arm $label: $jem JEMALLOC SYMBOLS RECOGNISED (of $total symbol lines read)"
       ;;
     absent)
-      [ "$jem" -eq 0 ] || fail "arm $label (R1.2): expected NO jemalloc symbols in the default-features binary and found $jem of $total symbol lines read. The allocator has escaped its feature gate — the default build must use the system allocator."
+      [ "$jem" -eq 0 ] || fail "arm $label (R1.2): expected NO jemalloc symbols in the default-features artifact cargo built at $exe and found $jem of $total symbol lines read. The allocator has escaped its feature gate — the default build must use the system allocator."
       say "arm $label: 0 JEMALLOC SYMBOLS RECOGNISED (of $total symbol lines read — the reader produced a symbol table, so this zero is MEASURED)"
       ;;
     *) fail "internal: unknown symbol expectation '$expect_syms'" ;;
   esac
 
-  check_version_line "$BIN" "$expect_alloc" \
+  check_version_line "$bin" "$expect_alloc" \
     || fail "arm $label (R2.1): \`cqlite-flight --version\` did not report 'allocator: $expect_alloc' as its single allocator line (detail above)"
   say "arm $label: --version reports 'allocator: $expect_alloc'"
   say "arm $label VERDICT PASS"

--- a/scripts/tests/test_flight_allocator_link.sh
+++ b/scripts/tests/test_flight_allocator_link.sh
@@ -50,7 +50,17 @@
 # inode changed). So the well-known path is refreshed by each arm; the residual
 # exposure it leaves is a CONCURRENT build in the same target directory
 # overwriting it between our build and our read, and the private copy plus the
-# inode check is what closes that.
+# inode check NARROWS that — it does not eliminate it, because a read and a copy
+# are two operations.
+#
+# THAT RESIDUAL CAN ONLY PRODUCE A FALSE RED, NEVER A FALSE PASS, and the reason
+# is structural rather than hopeful. The positive arm passes only on a binary with
+# jemalloc symbols AND `allocator: jemalloc`; the negative arm only on one with
+# neither. Since `ALLOCATOR` is derived from the SAME cfg that installs the
+# allocator, a binary satisfying either arm IS a binary of that arm's
+# configuration. So a cross-arm mix-up — the negative arm reading the positive
+# arm's binary, or the reverse — makes the arm find the WRONG symbol state and
+# FAIL. There is no substitution that passes while measuring nothing.
 #
 # WHY DEBUG, NOT RELEASE. Two reasons, both load-bearing. (1) Cost: the gate's
 # other components already build this crate in debug, so the negative arm is warm

--- a/scripts/tests/test_flight_allocator_link.sh
+++ b/scripts/tests/test_flight_allocator_link.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# cqlite-flight linked-allocator guard (issue #3997, requirements R1.1, R1.2, R2.1).
+# cqlite-flight linked-allocator guard (issue #3997, requirements R1.1, R1.2, R1.3,
+# R2.1, R2.2).
 #
 # THE GATE-ENFORCING SURFACE for the jemalloc mechanism. It exists because the
 # cargo-native test that expresses the same contract
@@ -13,11 +14,31 @@
 # TWO ARMS, WHICH ARE EACH OTHER'S CONTROL. That is the whole design:
 #
 #   positive  `cargo build -p cqlite-flight --features jemalloc`
-#             -> the binary MUST carry jemalloc symbols, and `--version` MUST say
-#                `allocator: jemalloc`.
+#             -> the binary MUST carry jemalloc symbols, `--version` MUST say
+#                `allocator: jemalloc`, and the STARTUP LOG LINE must say
+#                `allocator=jemalloc` in AGREEMENT with that `--version`.
 #   negative  `cargo build -p cqlite-flight` (default features; `default = []`)
-#             -> the binary MUST carry NONE, and `--version` MUST say
-#                `allocator: system`.
+#             -> the binary MUST carry NONE, and both surfaces MUST say
+#                `system`, again in agreement.
+#
+# THREE ASSERTIONS PER ARM, AND THE THIRD IS AN AGREEMENT RATHER THAN A THIRD
+# LITERAL (R2.2). `design.md:41` claims the two externally observable surfaces
+# cannot disagree, because both are threaded from one `ALLOCATOR` const; the log
+# assertion is therefore made against the value `--version` was just proved to
+# print. Asserting each against its own literal would pass with one of them
+# hard-coded. R2.2 had NO exercising test from any surface before this: its only
+# other coverage would be a `cqlite-flight` integration target, which under #3384
+# no gate component executes, and the one target that captures the event
+# (`issue_3225_admission_provenance.rs`) passes a PLACEHOLDER allocator and says
+# in its own doc comment that it asserts nothing about it — while
+# `cqlite-flight/README.md` shows the line to operators.
+#
+# PLUS ONE WHOLE-SUITE ASSERTION AFTER THE ARMS (R1.3): `cargo test -p
+# cqlite-flight --features jemalloc --lib --bins`. "The allocator is not in any
+# test binary" was true by rustc's compilation model and MEASURED BY NOTHING — no
+# gate invocation enabled `jemalloc` for a `cargo test` — so it was a design
+# argument. Two `#[global_allocator]`s is a compile error, so if the allocator
+# ever escaped the bin target this invocation stops building.
 #
 # A single arm proves nothing: a symbol matcher that matches everything satisfies
 # the positive arm, and one that matches nothing satisfies the negative arm. Only
@@ -248,6 +269,110 @@ check_version_line() {
   return 0
 }
 
+# ANSI, STRIPPED AT THE PARSE SITE (CLAUDE.md #3400). MEASURED on this tree, not assumed:
+# `tracing_subscriber`'s `fmt::layer()` has ANSI on by DEFAULT and the escapes SURVIVE
+# REDIRECTION TO A FILE — a captured startup line reads
+# `…allocator<ESC>[2m=<ESC>[0m"system"`, so a `grep 'allocator="system"'` on the raw capture
+# matches NOTHING while the binary is behaving perfectly. Neither `NO_COLOR` nor a tty check is
+# relied on: the strip is at the point of the read, which is the only place that cannot be
+# bypassed by how the caller is invoked. ESC is built with `printf` rather than written as a
+# `\x1b` escape, which is a GNU-sed extension.
+ESC=$(printf '\033')
+strip_ansi() { sed "s/${ESC}\[[0-9;]*[a-zA-Z]//g"; }
+
+# R2.2 — THE STARTUP `info` LINE CARRIES `allocator=<value>`, AND IT AGREES WITH `--version`.
+#
+# `$1` = the snapshotted binary, `$2` = arm label, `$3` = the allocator value this arm's
+# `--version` reported (NOT a literal: see below).
+#
+# WHY THIS IS HERE AND NOT IN A CARGO TEST. R2.2's only other coverage would be a
+# `cqlite-flight` integration target, and under #3384 NO gate component executes those — the
+# same reason this whole guard exists. `issue_3225_admission_provenance.rs` captures this very
+# event and passes a PLACEHOLDER allocator, asserting nothing about it, so the field was
+# claimed to operators by `cqlite-flight/README.md` with no assertion anywhere behind it.
+#
+# WHAT IS ASSERTED IS THE AGREEMENT, not two separate values. `design.md:41` claims the two
+# surfaces cannot disagree because both derive from one `ALLOCATOR` const; the caller passes in
+# the value `--version` ACTUALLY printed, and this function requires the log field to equal it.
+# Asserting each against its own literal would pass even if one of them were hard-coded.
+#
+# KEYED ON THE NAMED EVENT, NOT ON "THE FIRST LINE". R2.2's wording says the first `info` line,
+# and under default configuration `cqlite-flight starting` genuinely is first — but
+# `main.rs:85` calls `log_observability_status` BEFORE `log_startup`, and that emits an `info`
+# line when `CQLITE_OTEL_ENABLED` is set. Keying on `cqlite-flight starting` makes the
+# assertion independent of an env var rather than hostage to one; it is not a defect in the code.
+#
+# `--listen 127.0.0.1:0` so the kernel picks a free port: this runs inside a gate component on a
+# box with up to four peer lanes and a real server, and a fixed port would make the guard fail
+# on contention rather than on the property. `RUST_LOG=info` is set EXPLICITLY because the
+# subscriber's filter is `EnvFilter::try_from_default_env()` — an inherited `RUST_LOG=warn`
+# would suppress the line and make a correct binary look silent.
+#
+# THE CHILD IS ALWAYS REAPED, on every path including the refusals: this function never calls
+# `fail` (which would `exit` with a server still holding a port). It reaps, then returns
+# non-zero after printing `verdict-detail`, exactly as `check_version_line` does.
+check_startup_allocator_line() {
+  local path="$1" label="$2" expect="$3"
+  local dir="$SCRATCH/$label.startup" pid rc_local waited=0 line n logged
+  mkdir -p "$dir/data" 2>/dev/null || {
+    say "verdict-detail arm $label (R2.2): cannot create a scratch --data-dir; nothing was measured"
+    return 1
+  }
+  # Streams captured SEPARATELY (the round-3 lesson one file over): the line is on STDOUT,
+  # measured, and a merged capture would let a future stderr-only regression pass unnoticed.
+  RUST_LOG=info "$path" --data-dir "$dir/data" --listen 127.0.0.1:0 \
+    >"$dir/out" 2>"$dir/err" &
+  pid=$!
+  # BOUNDED POLL, never a spin: 60 x 0.25s = 15s for a process whose only job before this line
+  # is parsing argv. Each pass also checks the child is still ALIVE, so a binary that dies of a
+  # bind failure or a panic is diagnosed as that rather than waited out to the full bound.
+  while [ "$waited" -lt 60 ]; do
+    if grep -q 'cqlite-flight starting' "$dir/out" 2>/dev/null; then
+      break
+    fi
+    if ! kill -0 "$pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.25
+    waited=$((waited + 1))
+  done
+  kill "$pid" 2>/dev/null
+  wait "$pid" 2>/dev/null
+  rc_local=$?
+  logged=$(strip_ansi < "$dir/out" 2>/dev/null)
+  n=$(printf '%s\n' "$logged" | grep -c 'cqlite-flight starting')
+  case "$n" in ''|*[!0-9]*) n=0 ;; esac
+  if [ "$n" -eq 0 ]; then
+    say "verdict-detail arm $label (R2.2): the binary printed NO \`cqlite-flight starting\` line on stdout within the bound (child exited $rc_local). The startup line is the surface \`cqlite-flight/README.md\` shows to operators, so its absence is a FAIL and not an unmeasurable host. stdout and stderr follow, ANSI-stripped:"
+    printf '%s\n' "$logged" | sed "s/^/${P}    stdout | /"
+    strip_ansi < "$dir/err" 2>/dev/null | sed "s/^/${P}    stderr | /"
+    return 1
+  fi
+  if [ "$n" -ne 1 ]; then
+    say "verdict-detail arm $label (R2.2): $n \`cqlite-flight starting\` lines on stdout; R2.2 describes ONE startup line, and a second would mean two configurations were logged in one process — neither can be read as the configuration this arm measured."
+    printf '%s\n' "$logged" | sed "s/^/${P}    stdout | /"
+    return 1
+  fi
+  line=$(printf '%s\n' "$logged" | grep 'cqlite-flight starting' | head -1)
+  # BOTH RENDERINGS of the field are accepted — `allocator="system"` (tracing's own quoting for
+  # a `&str` field, which is what it emits today, measured) and a bare `allocator=system` (what
+  # a `%allocator` Display field would print, and what the README shows). Quoting is a
+  # rendering choice of the subscriber; the VALUE is the contract, and it is compared exactly.
+  local got
+  got=$(printf '%s\n' "$line" | sed -n 's/.*[[:space:]]allocator="\([^"]*\)".*/\1/p' | head -1)
+  [ -n "$got" ] || got=$(printf '%s\n' "$line" | sed -n 's/.*[[:space:]]allocator=\([^ 	"]*\).*/\1/p' | head -1)
+  if [ -z "$got" ]; then
+    say "verdict-detail arm $label (R2.2): the \`cqlite-flight starting\` line carries NO \`allocator=\` field, so the value the README shows operators is not being logged at all. Line as read (ANSI-stripped): $line"
+    return 1
+  fi
+  if [ "$got" != "$expect" ]; then
+    say "verdict-detail arm $label (R2.2): the startup line reports allocator='$got' while this arm's own \`--version\` reported '$expect'. The two surfaces are threaded from ONE \`ALLOCATOR\` const (design.md:41), so a disagreement means one of them is no longer derived from what was linked — which is the failure the pair of surfaces exists to make impossible. Line as read: $line"
+    return 1
+  fi
+  say "arm $label: startup log line reports allocator='$got', AGREEING with its own --version (R2.2, read from stdout)"
+  return 0
+}
+
 # Resolve the artifact THIS arm's build produced, from that build's own JSON.
 # Echoes `<executable-path>\t<comma-separated features>`; returns non-zero when
 # the message stream holds no single recognisable bin artifact.
@@ -366,6 +491,11 @@ run_arm() {
   check_version_line "$bin" "$expect_alloc" \
     || fail "arm $label (R2.1): \`cqlite-flight --version\` did not report 'allocator: $expect_alloc' as its single allocator line (detail above)"
   say "arm $label: --version reports 'allocator: $expect_alloc'"
+  # R2.2 — the OTHER externally observable surface, asserted to AGREE with the one above. The
+  # value passed in is the one `--version` was just proved to report, so this is the agreement
+  # `design.md:41` claims and not two independent literals.
+  check_startup_allocator_line "$bin" "$label" "$expect_alloc" \
+    || fail "arm $label (R2.2): the startup \`cqlite-flight starting\` info line did not report \`allocator=$expect_alloc\` in agreement with its own \`--version\` (detail above). This is the surface cqlite-flight/README.md shows operators."
   say "arm $label VERDICT PASS"
 }
 
@@ -374,4 +504,19 @@ run_arm() {
 run_arm positive '--features jemalloc' present jemalloc
 run_arm negative ''                    absent  system
 
-pass "both arms discriminated: --features jemalloc links jemalloc and reports it, the default build links none and reports 'system' (issue #3997, R1.1/R1.2/R2.1)"
+# --- R1.3, MEASURED RATHER THAN ARGUED. "The allocator is not in any test binary" was true by
+# --- rustc's compilation model — a `#[global_allocator]` in `main.rs` is not linked into a
+# --- `--lib`/`--test` target — but NO gate invocation ever enabled `jemalloc` for a
+# --- `cargo test`, so the claim rested on a design argument and nothing executed it. One
+# --- invocation converts that from `partial` to `satisfied`: if the allocator ever escaped the
+# --- bin target, this is where it would collide (two `#[global_allocator]`s is a compile
+# --- error), and the unit suite would fail to build rather than silently link two.
+say "R1.3: cargo test -p cqlite-flight --features jemalloc --lib --bins"
+r13_err="$SCRATCH/r13.err"
+timeout -k 30 1500 cargo test -p cqlite-flight --features jemalloc --lib --bins \
+  >"$SCRATCH/r13.out" 2>"$r13_err"
+rc=$?
+[ "$rc" -eq 0 ] || fail "R1.3: \`cargo test -p cqlite-flight --features jemalloc --lib --bins\` exited $rc. The feature must not reach any test binary: a second \`#[global_allocator]\` is a COMPILE error, and a runtime failure here is the allocator perturbing the crate's own unit suite. Either way this is a broken tree, not an unmeasurable host. Remedy: run that exact command by hand. Last lines of its stderr: $(tail -5 "$r13_err" 2>/dev/null | tr '\n' '|')"
+say "R1.3: the unit suite BUILDS AND PASSES with the jemalloc feature on — the allocator does not reach a test binary (MEASURED, not inferred from rustc's model)"
+
+pass "both arms discriminated: --features jemalloc links jemalloc and reports it on BOTH surfaces (--version and the startup log line, in agreement), the default build links none and reports 'system' on both, and the unit suite builds and passes with the feature on (issue #3997, R1.1/R1.2/R1.3/R2.1/R2.2)"

--- a/scripts/tests/test_flight_allocator_link.sh
+++ b/scripts/tests/test_flight_allocator_link.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# cqlite-flight linked-allocator guard (issue #3997, requirements R1.1, R1.2, R2.1).
+#
+# THE GATE-ENFORCING SURFACE for the jemalloc mechanism. It exists because the
+# cargo-native test that expresses the same contract
+# (`cqlite-flight/tests/issue_3997_allocator_surface.rs`) is executed by NO gate
+# component: `flight-tests` runs cqlite-flight at `--lib --bins` only and prints a
+# run-time census naming the ~42 integration `--test` targets it does not run
+# (#3384). This script is registered in `tooling-tests`, so it does run — and it
+# covers a property no cargo test can reach at all: what is actually LINKED INTO
+# the binary.
+#
+# TWO ARMS, WHICH ARE EACH OTHER'S CONTROL. That is the whole design:
+#
+#   positive  `cargo build -p cqlite-flight --features jemalloc`
+#             -> the binary MUST carry jemalloc symbols, and `--version` MUST say
+#                `allocator: jemalloc`.
+#   negative  `cargo build -p cqlite-flight` (default features; `default = []`)
+#             -> the binary MUST carry NONE, and `--version` MUST say
+#                `allocator: system`.
+#
+# A single arm proves nothing: a symbol matcher that matches everything satisfies
+# the positive arm, and one that matches nothing satisfies the negative arm. Only
+# the pair discriminates, and only the pair can catch the failure that matters —
+# the feature being wired to a `#[global_allocator]` that is never installed, or
+# `--version` reporting a string that disagrees with what was linked.
+#
+# WHY DEBUG, NOT RELEASE. Two reasons, both load-bearing. (1) Cost: the gate's
+# other components already build this crate in debug, so the negative arm is warm
+# and free, and the positive arm adds one cqlite-flight recompile plus jemalloc's
+# vendored C source. (2) Correctness of the measurement: jemalloc is STATICALLY
+# linked and its symbols are NOT dynamic (measured: `nm -D` reports 0 while plain
+# `nm` reports the `_rjem_*` table), so the check must read the ordinary symbol
+# table — which a stripped release binary would not have. Never "optimize" this to
+# `--release`.
+#
+# FAIL-CLOSED, AND NON-VACUOUS:
+#   * Off Linux           -> SKIP printing the ACTUAL platform. The dependency is
+#                            declared under a `cfg(target_os = "linux")` target
+#                            section, so there is nothing to link and nothing to
+#                            assert; never a silent or vacuous PASS.
+#   * Unmeasurable        -> SKIP **naming the cause**: no cargo, no symbol tool,
+#                            no `cc`/`make` (jemalloc compiles C from source), no
+#                            `timeout` accepting `-k` with which to BOUND the
+#                            builds, or a symbol tool whose output this script
+#                            cannot parse. An unmeasured check and a clean one must
+#                            never read alike.
+#   * A cargo build that FAILS -> FAIL naming the arm and the remedy. That is a
+#                            broken tree, not an unmeasurable host.
+#   * Affirmative zero    -> the negative arm reports
+#                            `0 JEMALLOC SYMBOLS RECOGNISED`, never a bare `0`,
+#                            and it is accepted ONLY when the symbol tool
+#                            demonstrably produced a non-empty symbol table. A
+#                            tool that printed nothing at all is UNMEASURED, not
+#                            clean.
+#
+# Every line is prefixed `FLIGHT-ALLOC-LINK: ` so this output cannot be mistaken
+# for, or grepped as, a gate SUMMARY. One verdict line per arm plus one terminal
+# verdict line.
+#
+# Needs: cargo, a C toolchain, and `nm` or `readelf`. NO datasets, NO network
+# beyond whatever cargo already has vendored/locked, NO Docker, NO python3.
+set -uo pipefail
+
+P='FLIGHT-ALLOC-LINK: '
+say()  { printf '%s%s\n' "$P" "$*"; }
+# Exit statuses: 0 = PASS or SKIP (an unmeasurable host must not red the gate),
+# 1 = FAIL, 2 = usage. SKIP exits 0 deliberately and says so LOUDLY; the component
+# treats a non-zero exit as FAIL.
+pass() { say "verdict PASS — $*"; exit 0; }
+skip() { say "verdict SKIP — $*"; say "verdict-detail NOTHING WAS MEASURED; this is not a clean result"; exit 0; }
+fail() { say "verdict FAIL — $*"; exit 1; }
+
+usage() {
+  cat <<'EOF'
+Usage: test_flight_allocator_link.sh [--help]
+
+cqlite-flight linked-allocator guard (issue #3997, R1.1/R1.2/R2.1).
+
+Builds `cqlite-flight` in DEBUG twice — once with `--features jemalloc`, once
+with default features — and asserts that jemalloc symbols are present in the
+first binary and absent from the second, and that each binary's `--version`
+reports the matching `allocator:` line.
+
+No options. Exit 0 = PASS or SKIP (SKIP always names its cause), 1 = FAIL,
+2 = usage error. Off Linux it SKIPs, printing the platform it found.
+EOF
+}
+
+case "${1-}" in
+  --help|-h) usage; exit 0 ;;
+  '') : ;;
+  *) usage >&2; printf '%s\n' "${P}verdict FAIL — unrecognised argument: $1" >&2; exit 2 ;;
+esac
+[ "$#" -le 1 ] || { usage >&2; printf '%s\n' "${P}verdict FAIL — too many arguments ($#)" >&2; exit 2; }
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+# Resolved from this script's OWN location, with no env override: an override is
+# settable by the party the guard constrains (CLAUDE.md #3312).
+ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
+
+# --- 0. platform. The `jemalloc` feature is inert off Linux BY CONSTRUCTION (the
+# --- dependency lives under `[target.'cfg(target_os = "linux")'.dependencies]`),
+# --- so there is no linked allocator to find and asserting its absence would
+# --- prove nothing about the mechanism. Print what we actually found.
+platform=$(uname -s 2>/dev/null)
+[ -n "$platform" ] || skip "cannot read the platform (\`uname -s\` produced nothing) — refusing to guess"
+if [ "$platform" != "Linux" ]; then
+  skip "this guard is Linux-only and this host reports \`uname -s\` = '$platform'; the \`jemalloc\` feature is inert off Linux by construction (the dependency is declared under [target.'cfg(target_os = \"linux\")'.dependencies])"
+fi
+say "platform Linux ($(uname -m 2>/dev/null || echo 'unknown machine'))"
+
+# --- 1. capabilities. Each absence is its own NAMED skip: "no cargo" and "no C
+# --- compiler" send an operator to different remedies.
+command -v cargo >/dev/null 2>&1 || skip "no \`cargo\` on PATH — cannot build either arm"
+# jemalloc is built from vendored C source by `tikv-jemalloc-sys`' build script, so
+# a working C toolchain is a hard prerequisite of the POSITIVE arm specifically.
+command -v cc   >/dev/null 2>&1 || skip "no \`cc\` on PATH — tikv-jemalloc-sys compiles jemalloc's vendored C source and cannot build without a C compiler"
+command -v make >/dev/null 2>&1 || skip "no \`make\` on PATH — tikv-jemalloc-sys drives jemalloc's own autotools/make build"
+
+# The BOUND. An unbounded `cargo build` can hang the gate on a stalled registry
+# fetch or a wedged linker, and a missing bounding capability must NOT inherit the
+# permissive branch (CLAUDE.md): probe it by RUNNING it, because presence on PATH
+# is not support for `-k` (a SIGTERM-only bound does not bound a child that ignores
+# SIGTERM).
+command -v timeout >/dev/null 2>&1 || skip "no \`timeout\` on PATH — refusing to run an UNBOUNDED cargo build inside a gate component"
+timeout -k 1 5 true >/dev/null 2>&1 || skip "this host's \`timeout\` does not accept \`-k\` (probed by running it) — refusing to run a cargo build under a bound that cannot escalate to SIGKILL"
+
+# The symbol reader. `nm` first, `readelf --syms` as the fallback; BOTH are read
+# for the ORDINARY symbol table, never `-D`/`--dyn-syms`: measured, jemalloc's
+# statically linked symbols do not appear in the dynamic table at all (`nm -D`
+# reports 0 on a binary whose plain `nm` shows the whole `_rjem_*` table), so a
+# dynamic-only reader would report a clean negative arm for BOTH builds — a false
+# PASS in the exact direction this guard exists to prevent.
+SYMTOOL=''
+if command -v nm >/dev/null 2>&1; then
+  SYMTOOL=nm
+elif command -v readelf >/dev/null 2>&1; then
+  SYMTOOL=readelf
+fi
+[ -n "$SYMTOOL" ] || skip "neither \`nm\` nor \`readelf\` is on PATH — cannot read the binary's symbol table"
+say "capabilities cargo, cc, make, bounded-timeout, symbol-reader=$SYMTOOL"
+
+# --- 2. where cargo puts the binary. Asked of CARGO, not assumed to be
+# --- `$ROOT/target`: the answer honours CARGO_TARGET_DIR and any
+# --- `build.target-dir` in a config file, and guessing would make this guard
+# --- silently measure a stale artifact from a previous layout.
+metadata=$(timeout -k 30 300 cargo metadata --format-version 1 --no-deps --manifest-path "$ROOT/Cargo.toml" 2>/dev/null)
+rc=$?
+[ "$rc" -eq 0 ] || fail "\`cargo metadata\` exited $rc — the workspace manifests do not read, which is a broken tree rather than an unmeasurable host. Remedy: fix the manifest, then re-run."
+TARGET_DIR=$(printf '%s' "$metadata" | tr ',' '\n' | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p' | head -1)
+[ -n "$TARGET_DIR" ] || skip "could not read \`target_directory\` out of \`cargo metadata\`'s output — the reader did not recognise it, so nothing was measured (a cargo JSON shape change, or a target path holding an escaped character)"
+BIN="$TARGET_DIR/debug/cqlite-flight"
+say "target-dir $TARGET_DIR"
+
+# Count jemalloc symbols and TOTAL symbols in one read, so a zero jemalloc count
+# is always accompanied by the evidence that the tool produced a symbol table at
+# all. Emits `<jemalloc-count> <total-count>` on stdout; returns non-zero when the
+# read itself failed.
+#
+# Both accepted prefixes are asserted: `_rjem_` is what the Rust-vendored build
+# produces (measured on this tree), `je_` is upstream jemalloc's own prefix, which
+# a differently-configured build would emit. R1.1 names both.
+read_symbols() {
+  local path="$1" out rc_local jem total
+  case "$SYMTOOL" in
+    nm)      out=$(timeout -k 5 120 nm      -- "$path" 2>/dev/null); rc_local=$? ;;
+    readelf) out=$(timeout -k 5 120 readelf --syms -W -- "$path" 2>/dev/null); rc_local=$? ;;
+    *)       return 1 ;;
+  esac
+  [ "$rc_local" -eq 0 ] || return 1
+  # `grep -c` exits 1 on a count of ZERO while still printing "0", so its status is
+  # deliberately not used as a signal — the printed count is the datum.
+  total=$(printf '%s\n' "$out" | grep -c .)
+  jem=$(printf '%s\n' "$out" | grep -cE '(_rjem_|[^A-Za-z0-9_]je_|^je_)')
+  case "$total$jem" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  printf '%s %s\n' "$jem" "$total"
+}
+
+# `--version` under R2.1's grammar: EXACTLY one line equal to
+# `allocator: jemalloc` or `allocator: system`, and its value as expected. Counted,
+# because "at least one" is not the contract.
+check_version_line() {
+  local path="$1" expect="$2" out rc_local lines n
+  out=$(timeout -k 5 60 "$path" --version 2>/dev/null)
+  rc_local=$?
+  [ "$rc_local" -eq 0 ] || {
+    say "verdict-detail \`$path --version\` exited $rc_local (expected 0; the flag must short-circuit before required-argument validation, with no --data-dir supplied)"
+    return 1
+  }
+  lines=$(printf '%s\n' "$out" | grep -E '^allocator: (jemalloc|system)$')
+  n=$(printf '%s\n' "$lines" | grep -c .)
+  case "$n" in ''|*[!0-9]*) say "verdict-detail cannot count the allocator lines in \`--version\` output"; return 1 ;; esac
+  [ "$n" -eq 1 ] || {
+    say "verdict-detail R2.1 requires EXACTLY ONE line matching '^allocator: (jemalloc|system)\$'; found $n. Full --version output follows."
+    printf '%s\n' "$out" | sed "s/^/${P}    | /"
+    return 1
+  }
+  [ "$lines" = "allocator: $expect" ] || {
+    say "verdict-detail R2.1: expected 'allocator: $expect', got '$lines'"
+    return 1
+  }
+  return 0
+}
+
+# One arm. `$1` = arm label, `$2` = extra cargo args (may be empty), `$3` =
+# `present` | `absent`, `$4` = the expected `--version` allocator value.
+run_arm() {
+  local label="$1" extra="$2" expect_syms="$3" expect_alloc="$4" rc_local counts jem total
+  say "arm $label: cargo build -p cqlite-flight ${extra:-<default features>}"
+  # 25 min with a 30s SIGKILL escalation: the positive arm compiles jemalloc's
+  # vendored C source cold, and the negative arm is the feature set the gate's other
+  # components already built, so it is warm.
+  # shellcheck disable=SC2086  # $extra is a deliberate word-split of our own literal flags
+  timeout -k 30 1500 cargo build -p cqlite-flight $extra >/dev/null 2>&1
+  rc_local=$?
+  [ "$rc_local" -eq 0 ] || fail "arm $label: \`cargo build -p cqlite-flight ${extra:-(default features)}\` exited $rc_local. This is a BROKEN BUILD, not an unmeasurable host. Remedy: run that exact command by hand and fix what it reports."
+  [ -f "$BIN" ] || fail "arm $label: the build reported success but $BIN does not exist — refusing to assert anything about a binary that is not there"
+
+  counts=$(read_symbols "$BIN")
+  rc_local=$?
+  [ "$rc_local" -eq 0 ] || skip "arm $label: \`$SYMTOOL\` could not be read for $BIN (non-zero exit, timeout, or output this script cannot parse) — nothing was measured"
+  jem=${counts%% *}
+  total=${counts##* }
+  # AFFIRMATIVE MEASUREMENT: a zero jemalloc count is only meaningful if the tool
+  # produced a symbol table. Zero total symbols means the read told us nothing —
+  # a stripped binary or a silently-empty tool — which must never read as clean.
+  [ "$total" -gt 0 ] || skip "arm $label: \`$SYMTOOL\` produced ZERO symbol lines for $BIN, so a zero jemalloc count would be UNMEASURED rather than clean (a stripped binary, or a symbol reader that emitted nothing)"
+
+  case "$expect_syms" in
+    present)
+      [ "$jem" -gt 0 ] || fail "arm $label (R1.1): expected jemalloc symbols in $BIN and found 0 JEMALLOC SYMBOLS RECOGNISED out of $total symbol lines read. The \`jemalloc\` feature is declared but nothing was linked — check that src/main.rs's #[global_allocator] cfg matches the feature name and that the dependency is not cfg'd out on this target."
+      say "arm $label: $jem JEMALLOC SYMBOLS RECOGNISED (of $total symbol lines read)"
+      ;;
+    absent)
+      [ "$jem" -eq 0 ] || fail "arm $label (R1.2): expected NO jemalloc symbols in the default-features binary and found $jem of $total symbol lines read. The allocator has escaped its feature gate — the default build must use the system allocator."
+      say "arm $label: 0 JEMALLOC SYMBOLS RECOGNISED (of $total symbol lines read — the reader produced a symbol table, so this zero is MEASURED)"
+      ;;
+    *) fail "internal: unknown symbol expectation '$expect_syms'" ;;
+  esac
+
+  check_version_line "$BIN" "$expect_alloc" \
+    || fail "arm $label (R2.1): \`cqlite-flight --version\` did not report 'allocator: $expect_alloc' as its single allocator line (detail above)"
+  say "arm $label: --version reports 'allocator: $expect_alloc'"
+  say "arm $label VERDICT PASS"
+}
+
+# Positive arm FIRST, negative arm SECOND, so the tree is left holding the
+# default-features build every other gate component expects.
+run_arm positive '--features jemalloc' present jemalloc
+run_arm negative ''                    absent  system
+
+pass "both arms discriminated: --features jemalloc links jemalloc and reports it, the default build links none and reports 'system' (issue #3997, R1.1/R1.2/R2.1)"

--- a/scripts/tests/test_ws0_abc_driver_guards.sh
+++ b/scripts/tests/test_ws0_abc_driver_guards.sh
@@ -1447,6 +1447,44 @@ else
   fail "5k. an arm-E-less set must not record arm-E fingerprint fields (have: $(tr -d '\n' < "$OUT/abc-run.json"))"
 fi
 
+# --- 5l. AND THE EXCEPTION'S OWN PREMISE: ARM E'S BINARY MUST ACTUALLY DIFFER. Cases 5a–5f
+# establish that the non-E arms share one digest and that arm E's own is stable between rounds;
+# NEITHER establishes that the two are DIFFERENT, which is the one fact the exception is granted
+# for. `bins-E/` populated by copying the control `cqlite-flight` instead of the
+# `--features jemalloc` build satisfies every check above, makes arm E a silent duplicate of arm
+# A, and the report then attributes pure run-to-run noise to the allocator — #3248's own defect
+# class. The driver's dispatch-time precondition (case 5j) is NOT this check: this tool is run
+# STANDALONE over a session directory some other invocation produced, so the property has to be
+# established from the sessions themselves.
+SAMESET="$TMP/set-E-same-binary"
+mkset "$SAMESET" 3 A,E 400000 250000 20000 25000
+mut_all_rounds "$SAMESET" E binary_provenance.binaries.cqlite-flight "{\"sha256\":\"$B_SHA\"}"
+agg_refuses_naming_arms "5l. arm E whose cqlite-flight is the SAME BYTES as every other arm's is REFUSED — the exception grants a DIFFERENT binary, and an identical one is arm A under a second label" \
+  "$SAMESET" A,E A "SAME BYTES" "second LABEL for arm A" "$B_SHA" \
+  "would be run-to-run noise" "--bin-dir-e"
+# THE ACCEPT DIRECTION IS THE UNTOUCHED A/E SET (case 5a), asserted here AGAIN against the SAME
+# tokens this refusal is matched on, so this case cannot be passing because the aggregator refuses
+# every A/E set: the control differs from the RED arm in exactly one property, arm E's digest.
+out=$(python3 "$AGG" --root "$ESET" --arms A,E --baseline A 2>&1); rc=$?
+if [ "$rc" -eq 0 ] && ! grep -qF "SAME BYTES" <<<"$out"; then
+  pass "5l. ...while a GENUINELY DIFFERING arm-E digest is still ACCEPTED and says nothing about identical bytes — the check is the equality, not the comparison"
+else
+  fail "5l. the differing-digest control must still be accepted (rc=$rc, out: $(tail -3 <<<"$out"))"
+fi
+if grep -q "the two digests above are asserted to DIFFER" <<<"$out"; then
+  pass "5l. ...and the declaration SAYS the difference is asserted, so a reader is not left inferring it from two printed strings"
+else
+  fail "5l. the declaration must state that the digests are asserted to differ (out: $(head -16 <<<"$out"))"
+fi
+# AND IT IS KEYED ON THE EXCEPTION ARM, not on "two arms share a digest": arms A and B sharing
+# one is the INVARIANT, and reddening on it would break every set in parts 0-4.
+out=$(python3 "$AGG" --root "$SET" --arms A,B,C0,C --baseline A 2>&1); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "5l. ...and arms that SHARE a digest with no arm E present are still accepted — sharing is the invariant, and only arm E's sharing is the defect"
+else
+  fail "5l. an arm-E-less set of shared digests must still aggregate (rc=$rc, out: $(tail -3 <<<"$out"))"
+fi
+
 # ===========================================================================
 # PART 6 — THE SERVER'S SCAN-END RSS: R6.1's INPUT (#3997)
 # ===========================================================================

--- a/scripts/tests/test_ws0_abc_driver_guards.sh
+++ b/scripts/tests/test_ws0_abc_driver_guards.sh
@@ -32,7 +32,18 @@
 #   * PART 6 (R6.1) the Flight server's scan-end `VmHWM`/`VmRSS`, per arm, and the property that
 #     an UNMEASURED figure and a genuinely small one do not read alike — a marker naming its
 #     cause, a ratio that reads NOT MEASURABLE, and a refusal for a zero, an absent key or a
-#     string that is not a marker.
+#     string that is not a marker. Cases 6j-6n carry the same property one level down, at the
+#     REP: a field only SOME reps supplied is a marker and not a median over the survivors, and
+#     each field's observation count is its OWN — asserted in both directions of the asymmetry,
+#     because one shared count cannot report 2 for one field and 3 for the other.
+#
+# Two roborev blockers on #3997 added case 5l and cases 6j-6n. Both were the same failure mode:
+# a rig that can publish a measurement it did not make. 5l — the exception checked that arm E's
+# digest was STABLE and that the others were SHARED, never that the two DIFFER, so a `bins-E/`
+# copied from the control passed every check and the report attributed run-to-run noise to the
+# allocator. 6j-6n — a partially sampled arm published a median over whichever reps survived,
+# and R6.1 is a RATIO CEILING, which an unrepresentative low median satisfies without having
+# been measured.
 #
 # # The bar, per #3249 (a hardcoded `_PERF_STATE="ok"` survived 118/118 tests)
 #
@@ -231,7 +242,11 @@ for rnd in range(1, rounds + 1):
                  # R6.1's two figures, on the FLIGHT leg only — the bare scan starts no server.
                  "server_vm_hwm_kb": RSS[arm][0],
                  "server_vm_rss_kb": RSS[arm][1],
-                 "server_rss_reps_measured": 1, "server_rss_reps_total": 1},
+                 # THE CENSUS IS PER FIELD (#3997 roborev): one shared count derived from
+                 # VmHWM alone affirmed a completeness that need not hold for VmRSS.
+                 "server_rss_reps_measured_vm_hwm_kb": 1,
+                 "server_rss_reps_measured_vm_rss_kb": 1,
+                 "server_rss_reps_total": 1},
             ],
             "pinning": {
                 "server_cpus": "2,10", "client_cpus": "4,12",
@@ -1626,6 +1641,185 @@ mut "$SSET/r2-A/results.json" measurements.1.server_vm_hwm_kb "n/a"
 agg_refuses_naming_arms "6h. a VmHWM string that is not an UNMEASURED marker is REFUSED — classified as neither an observation nor an absence" \
   "$SSET" A,E A "server_vm_hwm_kb" "'n/a'" "is not an"
 
+# --- 6j–6n. THE REP LEVEL, WHICH IS A DIFFERENT HOLE FROM THE ROUND LEVEL. Cases 6d–6e are
+# about a ROUND whose figure is a marker; these are about the ARM figure that becomes that
+# value. `server_rss_block` used to median whichever REPS happened to be measured, so 1 of 3
+# reps published a number the aggregator could not tell from a complete measurement — and R6.1
+# is a RATIO CEILING, which an unrepresentative low median satisfies without ever having been
+# measured. The subject is the COLLECTOR, driven BY IMPORT rather than through a fabricated
+# results.json, because the property is a property of that function and a fixture would only
+# restate whatever it returned.
+cat > "$TMP/rssblock.py" <<'RSSPY'
+import json
+import pathlib
+import sys
+
+# The collector is imported from the SHIPPED path, so no case below can pass against a copy.
+sys.path.insert(0, str(pathlib.Path(sys.argv[1])))
+import ws0_flight_arm as arm  # noqa: E402
+
+
+def value(token):
+    """One rep's field: an integer of kB, or `X` for a field that rep did not supply.
+
+    The unmeasured token is built with the collector's OWN `rss_unmeasured`, never a hand-typed
+    string — a marker this suite spelled itself would keep matching after the real spelling
+    moved.
+    """
+    if token == "X":
+        return arm.rss_unmeasured("planted: this rep supplied no sample")
+    return int(token)
+
+
+hwm = sys.argv[2].split(",") if sys.argv[2] else []
+rss = sys.argv[3].split(",") if sys.argv[3] else []
+if len(hwm) != len(rss):
+    sys.stderr.write("the two specs must name the same number of reps\n")
+    raise SystemExit(3)
+samples = [{"vm_hwm_kb": value(h), "vm_rss_kb": value(r)} for h, r in zip(hwm, rss)]
+block = arm.server_rss_block(samples, "warm", "flight_do_get_E")
+if len(sys.argv) > 4 and sys.argv[4] != "__ALL__":
+    key = sys.argv[4]
+    # AN ABSENT KEY IS REPORTED AFFIRMATIVELY, never as an empty line: case 6k asserts that the
+    # old shared census key is GONE, and "" would be indistinguishable from a key holding "".
+    print(block[key] if key in block else "__ABSENT__")
+    raise SystemExit(0)
+print(json.dumps(block, sort_keys=True))
+RSSPY
+rssblock() { python3 "$TMP/rssblock.py" "$REPO_ROOT/scripts/perf" "$@"; }
+
+# --- 6j. THE ACCEPT DIRECTION. Every rep supplied both fields, so both are published as
+# NUMBERS — the median over the reps — and the per-field census says 3 of 3. Without this
+# control a collector that markered everything would pass every case below.
+got=$(rssblock "100,200,300" "80,90,100" server_vm_hwm_kb)
+if [ "$got" = "200" ]; then
+  pass "6j. every rep supplying VmHWM publishes the MEDIAN over the reps (200 of 100/200/300)"
+else
+  fail "6j. a complete VmHWM series must publish its median (got '$got')"
+fi
+got=$(rssblock "100,200,300" "80,90,100" server_vm_rss_kb)
+if [ "$got" = "90" ]; then
+  pass "6j. ...and VmRSS its own median (90), taken from its own reps rather than VmHWM's"
+else
+  fail "6j. a complete VmRSS series must publish its median (got '$got')"
+fi
+got=$(rssblock "100,200,300" "80,90,100" __ALL__)
+if grep -q '"server_rss_reps_measured_vm_hwm_kb": 3' <<<"$got" \
+   && grep -q '"server_rss_reps_measured_vm_rss_kb": 3' <<<"$got" \
+   && grep -q '"server_rss_reps_total": 3' <<<"$got"; then
+  pass "6j. ...and the census reports 3 of 3 reps PER FIELD, so each figure carries its own completeness"
+else
+  fail "6j. the per-field census must report 3 of 3 for both fields (got '$got')"
+fi
+
+# --- 6k. THE REFUSAL DIRECTION, AND THE PER-FIELD ASYMMETRY. One rep's VmHWM is missing while
+# every rep's VmRSS is present: the VmHWM figure must become a MARKER while VmRSS stays a
+# NUMBER. A single shared observation count cannot express that state, which is the second half
+# of the finding — the census affirmed a completeness that held for one field only.
+got=$(rssblock "100,200,X" "80,90,100" server_vm_hwm_kb)
+case "$got" in
+  UNMEASURED*"2 of 3 rep(s)"*VmHWM*)
+    pass "6k. a VmHWM missing on 1 of 3 reps publishes an UNMEASURED marker naming the COUNT and the /proc field, not a median over the 2 survivors" ;;
+  *) fail "6k. a partial VmHWM must be an UNMEASURED marker with its counts (got '$got')" ;;
+esac
+case "$got" in
+  ''|*[!0-9.]*) pass "6k. ...and it is NOT a number, so a partial series and a complete one cannot read alike" ;;
+  *) fail "6k. the partial VmHWM rendered as a NUMBER ('$got')" ;;
+esac
+if grep -qF "RATIO CEILING" <<<"$got"; then
+  pass "6k. ...and the cause says WHY a subset median is refused — R6.1's ceiling is satisfiable by an unrepresentative one"
+else
+  fail "6k. the cause must state why a subset median is refused (got '$got')"
+fi
+got=$(rssblock "100,200,X" "80,90,100" server_vm_rss_kb)
+if [ "$got" = "90" ]; then
+  pass "6k. ...while VmRSS, which EVERY rep supplied, is still published (90) — the refusal is per FIELD, not per arm"
+else
+  fail "6k. a complete VmRSS must survive an incomplete VmHWM (got '$got')"
+fi
+got=$(rssblock "100,200,X" "80,90,100" __ALL__)
+if grep -q '"server_rss_reps_measured_vm_hwm_kb": 2' <<<"$got" \
+   && grep -q '"server_rss_reps_measured_vm_rss_kb": 3' <<<"$got"; then
+  pass "6k. ...and the census records 2 for VmHWM and 3 for VmRSS — two counts, because the two fields fail independently"
+else
+  fail "6k. the census must differ per field (got '$got')"
+fi
+got=$(rssblock "100,200,X" "80,90,100" server_rss_reps_measured)
+if [ "$got" = "__ABSENT__" ]; then
+  pass "6k. ...and the old SHARED server_rss_reps_measured key is GONE, not kept beside them — one fact, one source"
+else
+  fail "6k. the shared census key must be removed (got '$got')"
+fi
+
+# --- 6l. THE OTHER DIRECTION OF THE SAME ASYMMETRY, as an EXACT MIRROR of 6k — same rep count,
+# same values, the hole moved to the other field. The pair is what shows the two counts are not
+# two spellings of one number: a single shared count cannot be 2 and 3 at once, so whichever
+# field it was derived from, one of these two cases had to fail before this change.
+got=$(rssblock "100,200,300" "80,90,X" server_vm_hwm_kb)
+if [ "$got" = "200" ]; then
+  pass "6l. a VmRSS missing on 1 of 3 reps leaves VmHWM published (200) — the fields are read independently"
+else
+  fail "6l. a complete VmHWM must survive an incomplete VmRSS (got '$got')"
+fi
+got=$(rssblock "100,200,300" "80,90,X" server_vm_rss_kb)
+case "$got" in
+  UNMEASURED*"2 of 3 rep(s)"*VmRSS*)
+    pass "6l. ...and VmRSS is the marker, naming VmRSS and 2 of 3 — the marker says WHICH field went unmeasured" ;;
+  *) fail "6l. a partial VmRSS must be an UNMEASURED marker naming its own field (got '$got')" ;;
+esac
+got=$(rssblock "100,200,300" "80,90,X" __ALL__)
+if grep -q '"server_rss_reps_measured_vm_hwm_kb": 3' <<<"$got" \
+   && grep -q '"server_rss_reps_measured_vm_rss_kb": 2' <<<"$got"; then
+  pass "6l. ...and the census inverts with it (3 VmHWM, 2 VmRSS) — the exact inverse of 6k's 2/3, which one shared count could not report"
+else
+  fail "6l. the census must invert with the asymmetry (got '$got')"
+fi
+
+# --- 6m. NO REP AT ALL. `all(...)` over an empty sequence is vacuously TRUE, so the total is
+# tested explicitly: a zero-rep arm must reach the marker and not `statistics.median([])`, which
+# raises and would abort the whole report for a quantity that is merely absent.
+got=$(rssblock "" "" server_vm_hwm_kb); rc=$?
+case "$got" in
+  UNMEASURED*"0 of 0 rep(s)"*)
+    pass "6m. a ZERO-rep arm publishes the marker naming 0 of 0 — never a crash, and never a 0 kB that would satisfy R6.1's ceiling" ;;
+  *) fail "6m. a zero-rep arm must publish the marker (rc=$rc, got '$got')" ;;
+esac
+
+# --- 6n. THE TWO SIDES, END TO END. The marker in case 6d is one this suite typed; this one is
+# the string the COLLECTOR actually produced for a partial rep set, planted into a session and
+# read by the AGGREGATOR. That is what pins the contract: a producer marker the consumer
+# classified as "a string that is not a marker" would REFUSE (6h) instead of reporting
+# UNMEASURED, and one it classified as a number would publish a ratio over a rep set nobody
+# measured.
+REAL_MARKER=$(rssblock "100,200,X" "80,90,100" server_vm_hwm_kb)
+PSET="$TMP/set-E-partial-reps"
+mkset "$PSET" 3 A,E 400000 250000 20000 25000
+mut "$PSET/r2-E/results.json" measurements.1.server_vm_hwm_kb "$REAL_MARKER"
+PREPORT="$TMP/report-E-partial-reps.md"
+out=$(python3 "$AGG" --root "$PSET" --arms A,E --baseline A --out "$PREPORT" 2>&1); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "6n. the collector's OWN partial-rep marker is accepted by the aggregator as an absence — not refused as an unclassifiable string"
+else
+  fail "6n. the real marker must be classified as an absence (rc=$rc, out: $(tail -3 <<<"$out"))"
+fi
+got=$(cell "$PREPORT" "Server RSS" E "VmHWM kB (median)")
+if [ "$got" = "UNMEASURED (2 of 3 round(s) observed)" ]; then
+  pass "6n. ...and arm E's VmHWM cell reads UNMEASURED with its round count, so a REP-level hole is visible at the ARM level"
+else
+  fail "6n. the partial-rep round must render UNMEASURED (got '$got')"
+fi
+got=$(cell "$PREPORT" "Server RSS" E "paired VmHWM vs A")
+if [ "$got" = "NOT MEASURABLE (1 round(s) of E, 0 of A unobserved)" ]; then
+  pass "6n. ...and R6.1's ratio reads NOT MEASURABLE — the ceiling is not applied to a series a rep never supplied"
+else
+  fail "6n. R6.1's ratio must be NOT MEASURABLE for a partial-rep arm (got '$got')"
+fi
+if grep -qF "$REAL_MARKER" "$PREPORT"; then
+  pass "6n. ...and the collector's cause is reprinted IN FULL, counts included — the remedy is a rep to re-run, and only the cause says so"
+else
+  fail "6n. the collector's cause must reach the report (RSS section: $(sed -n '/## Server RSS/,/^## /p' "$PREPORT" | tail -5 | tr '\n' ' '))"
+fi
+
 # --- 6i. THE CLEAN A/E SET ONCE MORE, so no case above passed by leaving a fixture broken.
 out=$(python3 "$AGG" --root "$ESET" --arms A,E --baseline A); rc=$?
 if [ "$rc" -eq 0 ] && grep -q "0 UNMEASURED RECOGNISED" <<<"$out"; then
@@ -1645,8 +1839,10 @@ fi
 # floor by 29 elsewhere in this repo's history.
 # MEASURED: 98 (fingerprint + provenance + configuration + ratio), 105 (+ the F1
 # fingerprint-absent cases), 162 (+ #3997's parts 5 and 6 — arm E's cross-arm binary exception in
-# BOTH directions, and the scan-end server RSS R6.1 is read from).
-MIN_CHECKS=150
+# BOTH directions, and the scan-end server RSS R6.1 is read from), 183 (+ the two #3997 roborev
+# blockers: case 5l, arm E's binary must actually DIFFER from the shared one, and cases 6j-6n,
+# the REP-level completeness of each RSS field with its own per-field census).
+MIN_CHECKS=170
 if [ "$checks" -lt "$MIN_CHECKS" ]; then
   echo
   echo "FAIL - only $checks check(s) ran; this suite has at least $MIN_CHECKS."

--- a/scripts/tests/test_ws0_abc_driver_guards.sh
+++ b/scripts/tests/test_ws0_abc_driver_guards.sh
@@ -1315,8 +1315,32 @@ fi
 # narrow exception becomes a disabled check, and neither file can detect it alone.
 drv_arm=$(grep -oE '^ARM_E="[^"]*"' "$ABC_DRIVER" | head -1 | cut -d'"' -f2)
 drv_bin=$(grep -oE '^ARM_E_BINARY="[^"]*"' "$ABC_DRIVER" | head -1 | cut -d'"' -f2)
-agg_arm=$(grep -oE '^BINARY_EXCEPTION_ARM = "[^"]*"' "$AGG" | head -1 | cut -d'"' -f2)
-agg_bin=$(grep -oE '^BINARY_EXCEPTION_BINARY = "[^"]*"' "$AGG" | head -1 | cut -d'"' -f2)
+# THE PYTHON SIDES ARE DERIVED BY IMPORT, not by grepping their source: the producer's field
+# names come from the dict `server_rss_block` actually RETURNS and the consumer's from the tuple
+# it actually READS, so a rename that a source-text scan would miss (a computed key, a moved
+# constant) still moves these values. The driver is shell and has no such surface, so its two
+# constants are read from source — the one place here where that is the only option.
+_py=$(cd "$REPO_ROOT/scripts/perf" && python3 -c '
+import ws0_abc_aggregate as agg
+import ws0_flight_arm as arm
+print(agg.BINARY_EXCEPTION_ARM)
+print(agg.BINARY_EXCEPTION_BINARY)
+print(arm.RSS_UNMEASURED)
+print(agg.RSS_UNMEASURED_PREFIX)
+print(" ".join(sorted(k for k in arm.server_rss_block([], "warm", "x") if k.startswith("server_vm"))))
+print(" ".join(sorted(agg.RSS_FIELDS)))
+') || _py=""
+if [ -n "$_py" ]; then
+  pass "5h. (setup) both python sides IMPORT cleanly, so the constants below are the ones the code uses"
+else
+  fail "5h. (setup) the aggregator and the flight-arm collector must import — the derivations below are vacuous otherwise"
+fi
+agg_arm=$(sed -n 1p <<<"$_py")
+agg_bin=$(sed -n 2p <<<"$_py")
+arm_mod_marker=$(sed -n 3p <<<"$_py")
+agg_marker=$(sed -n 4p <<<"$_py")
+prod_fields=$(sed -n 5p <<<"$_py")
+agg_fields=$(sed -n 6p <<<"$_py")
 if [ -n "$drv_arm" ] && [ "$drv_arm" = "$agg_arm" ]; then
   pass "5h. the driver's ARM_E ('$drv_arm') and the aggregator's BINARY_EXCEPTION_ARM name the SAME arm"
 else
@@ -1327,12 +1351,23 @@ if [ -n "$drv_bin" ] && [ "$drv_bin" = "$agg_bin" ]; then
 else
   fail "5h. driver ARM_E_BINARY='$drv_bin' vs aggregator BINARY_EXCEPTION_BINARY='$agg_bin'"
 fi
-arm_mod_marker=$(grep -oE '^RSS_UNMEASURED = "[^"]*"' "$FLIGHT_ARM" | head -1 | cut -d'"' -f2)
-agg_marker=$(grep -oE '^RSS_UNMEASURED_PREFIX = "[^"]*"' "$AGG" | head -1 | cut -d'"' -f2)
 if [ -n "$arm_mod_marker" ] && [ "$arm_mod_marker" = "$agg_marker" ]; then
   pass "5h. ...and the UNMEASURED marker prefix is the same string in the producer and the consumer ('$agg_marker')"
 else
   fail "5h. ws0_flight_arm RSS_UNMEASURED='$arm_mod_marker' vs aggregator RSS_UNMEASURED_PREFIX='$agg_marker' — an unmeasured RSS would land in the wrong branch"
+fi
+# ...AND THE FIELD NAMES, from the dict the producer RETURNS and the tuple the consumer READS. A
+# rename on one side alone makes every session refuse with `NOT RECORDED` — loud, but the wrong
+# failure, and one nobody would attribute to a rename.
+if [ -n "$prod_fields" ] && [ "$prod_fields" = "$agg_fields" ]; then
+  pass "5h. ...and the RSS field NAMES agree between producer and consumer ('$agg_fields'), derived from the objects themselves"
+else
+  fail "5h. ws0_flight_arm publishes '$prod_fields' while the aggregator reads '$agg_fields'"
+fi
+if [ "$prod_fields" = "server_vm_hwm_kb server_vm_rss_kb" ]; then
+  pass "5h. ...and they are the two /proc fields R6.1 names — VmHWM (the peak) and VmRSS (the scan-end sample)"
+else
+  fail "5h. the published RSS fields must be server_vm_hwm_kb + server_vm_rss_kb, got '$prod_fields'"
 fi
 
 # --- 5i. THE DRIVER SIDE. Arm E is OPT-IN, dispatched against its OWN --bin-dir, and its binary
@@ -1571,7 +1606,7 @@ fi
 # counting the source — the loops and helpers multiply, and a source estimate understated a
 # floor by 29 elsewhere in this repo's history.
 # MEASURED: 98 (fingerprint + provenance + configuration + ratio), 105 (+ the F1
-# fingerprint-absent cases), 159 (+ #3997's parts 5 and 6 — arm E's cross-arm binary exception in
+# fingerprint-absent cases), 162 (+ #3997's parts 5 and 6 — arm E's cross-arm binary exception in
 # BOTH directions, and the scan-end server RSS R6.1 is read from).
 MIN_CHECKS=150
 if [ "$checks" -lt "$MIN_CHECKS" ]; then

--- a/scripts/tests/test_ws0_abc_driver_guards.sh
+++ b/scripts/tests/test_ws0_abc_driver_guards.sh
@@ -1784,6 +1784,15 @@ case "$got" in
     pass "6m. a ZERO-rep arm publishes the marker naming 0 of 0 — never a crash, and never a 0 kB that would satisfy R6.1's ceiling" ;;
   *) fail "6m. a zero-rep arm must publish the marker (rc=$rc, got '$got')" ;;
 esac
+# ...AND THE OTHER ZERO STATE, which has a different remedy: every rep RAN and none supplied
+# the field (the box or the kernel) is not "the driver never sampled", so the two must not share
+# one sentence. Both are markers; only the cause differs, and the cause is the whole value.
+got=$(rssblock "X,X" "X,X" server_vm_hwm_kb)
+case "$got" in
+  UNMEASURED*"0 of 2 rep(s)"*VmHWM*)
+    pass "6m. ...and an arm whose 2 reps ALL failed reads '0 of 2', distinct from '0 of 0' — reps that ran and failed are a different remedy from reps that never ran" ;;
+  *) fail "6m. an all-failed arm must publish a marker naming 0 of 2 (got '$got')" ;;
+esac
 
 # --- 6n. THE TWO SIDES, END TO END. The marker in case 6d is one this suite typed; this one is
 # the string the COLLECTOR actually produced for a partial rep set, planted into a session and
@@ -1841,7 +1850,8 @@ fi
 # fingerprint-absent cases), 162 (+ #3997's parts 5 and 6 — arm E's cross-arm binary exception in
 # BOTH directions, and the scan-end server RSS R6.1 is read from), 183 (+ the two #3997 roborev
 # blockers: case 5l, arm E's binary must actually DIFFER from the shared one, and cases 6j-6n,
-# the REP-level completeness of each RSS field with its own per-field census).
+# the REP-level completeness of each RSS field with its own per-field census), 184 (+ the
+# all-reps-failed cause, distinct from the no-rep-recorded one).
 MIN_CHECKS=170
 if [ "$checks" -lt "$MIN_CHECKS" ]; then
   echo

--- a/scripts/tests/test_ws0_abc_driver_guards.sh
+++ b/scripts/tests/test_ws0_abc_driver_guards.sh
@@ -1865,7 +1865,8 @@ fi
 # BOTH directions, and the scan-end server RSS R6.1 is read from), 183 (+ the two #3997 roborev
 # blockers: case 5l, arm E's binary must actually DIFFER from the shared one, and cases 6j-6n,
 # the REP-level completeness of each RSS field with its own per-field census), 184 (+ the
-# all-reps-failed cause and the arm-E-only declaration), 185.
+# all-reps-failed cause, distinct from the no-rep-recorded one), 185 (+ the arm-E-only set's
+# declaration that the differ-assertion was SKIPPED).
 MIN_CHECKS=170
 if [ "$checks" -lt "$MIN_CHECKS" ]; then
   echo

--- a/scripts/tests/test_ws0_abc_driver_guards.sh
+++ b/scripts/tests/test_ws0_abc_driver_guards.sh
@@ -154,6 +154,29 @@ TREATMENT = {
     "B": ("2,3", "distinct-cores", "system", None),
     "C0": ("2,3", "distinct-cores", "system", 2),
     "C": ("2,3", "distinct-cores", "jemalloc", None),
+    "D": ("2,10", "siblings", "jemalloc", None),
+    # ARM E RECORDS ARM A'S TREATMENT, CHARACTER FOR CHARACTER (#3997). That is not a fixture
+    # shortcut — it is the property R3.3 exists for: arm E's allocator is LINKED, so nothing is
+    # preloaded, `--flight-allocator system` is what the driver passes and `system` is what the
+    # session records. NOTHING in the recorded treatment distinguishes arm E from arm A, and the
+    # binary digest below is the only place the difference appears.
+    "E": ("2,10", "siblings", "system", None),
+}
+
+# THE `cqlite-flight` DIGEST PER ARM. Arm E's DIFFERS by construction, which is the whole
+# subject of R3.3; every other arm shares one. A case that needs the other shape mutates it.
+FLIGHT_SHA = {"E": "e" * 64}
+
+# THE SCAN-END RSS PER ARM (#3997, R6.1), distinct per arm so a swapped column or a
+# median-of-the-wrong-arm is detectable, and chosen so arm E's VmHWM is EXACTLY 1.10x arm A's —
+# the SHIP-default threshold, i.e. the one ratio a reader of this table has to get right.
+RSS = {
+    "A": (100000, 80000),
+    "B": (101000, 81000),
+    "C0": (102000, 82000),
+    "C": (103000, 83000),
+    "D": (104000, 84000),
+    "E": (110000, 88000),
 }
 for rnd in range(1, rounds + 1):
     for arm in arms:
@@ -169,7 +192,11 @@ for rnd in range(1, rounds + 1):
                 {"temperature": "warm", "arm": "flight_bypass", "reps": [{}],
                  "rows_per_sec": {"median": flight_rps, "spread_pct_of_median": 2.0, "n": 1},
                  "cycles_per_row": {"median": flight_cpr}, "ipc": {"median": 1.36},
-                 "row_denominator_total": 2000},
+                 "row_denominator_total": 2000,
+                 # R6.1's two figures, on the FLIGHT leg only — the bare scan starts no server.
+                 "server_vm_hwm_kb": RSS[arm][0],
+                 "server_vm_rss_kb": RSS[arm][1],
+                 "server_rss_reps_measured": 1, "server_rss_reps_total": 1},
             ],
             "pinning": {
                 "server_cpus": "2,10", "client_cpus": "4,12",
@@ -181,7 +208,7 @@ for rnd in range(1, rounds + 1):
             "corpus_identity": {"data_db_sha256": "abc123", "rows": 1000},
             "binary_provenance": {"binaries": {
                 "ws0-scan-bench": {"sha256": "a" * 64},
-                "cqlite-flight": {"sha256": "b" * 64},
+                "cqlite-flight": {"sha256": FLIGHT_SHA.get(arm, "b" * 64)},
                 "flight-loadgen": {"sha256": "c" * 64}}},
             "flight_admission": {"max_concurrent_scans": 4,
                                  "max_concurrent_scans_source": "derived",
@@ -300,6 +327,17 @@ make_bins() {
   for b in ws0-scan-bench cqlite-flight flight-loadgen; do
     printf 'ELF-ish %s %s\n' "$b" "$tag" > "$dir/$b"
   done
+}
+# make_bins_e <dir> <src-dir> <tag> — arm E's binary set: the SAME BYTES as <src-dir> for every
+# measured binary EXCEPT cqlite-flight, which is a different build. The shape the driver's
+# two-sided precondition ACCEPTS, so the RED arms below can each break exactly one half of it.
+make_bins_e() {
+  local dir="$1" src="$2" tag="$3" b
+  mkdir -p "$dir"
+  for b in ws0-scan-bench cqlite-flight flight-loadgen; do
+    cp "$src/$b" "$dir/$b"
+  done
+  printf 'ELF-ish cqlite-flight LINKED-JEMALLOC %s\n' "$tag" > "$dir/cqlite-flight"
 }
 # Mark a (round, arm) session dir MEASURED: a results.json plus the window record the driver
 # writes. Both, because either alone is one of the states this suite refuses.
@@ -752,6 +790,29 @@ agg_refuses_naming() {
   local -a expect=("$@")
   local out rc missing="" token
   out=$(python3 "$AGG" --root "$root" --arms A,B,C0,C --baseline A 2>&1); rc=$?
+  if [ "$rc" -eq 0 ]; then
+    fail "$label: must REFUSE, exited 0"
+    return
+  fi
+  for token in "${expect[@]}"; do
+    grep -qF -- "$token" <<<"$out" || missing="$missing [$token]"
+  done
+  if [ -n "$missing" ]; then
+    fail "$label: refused but did not NAME$missing (out: $(tail -3 <<<"$out"))"
+    return
+  fi
+  pass "$label"
+}
+
+# agg_refuses_naming_arms <label> <root> <arms-csv> <baseline> <token>… — `agg_refuses_naming`
+# for a set whose arm list is not the default four. Added by #3997 because R3.3's cases are
+# ABOUT the arm list: whether arm E is present is what switches the exception on, so a helper
+# that hardcodes `A,B,C0,C` cannot express either direction of it.
+agg_refuses_naming_arms() {
+  local label="$1" root="$2" arms_csv="$3" base="$4"; shift 4
+  local -a expect=("$@")
+  local out rc missing="" token
+  out=$(python3 "$AGG" --root "$root" --arms "$arms_csv" --baseline "$base" 2>&1); rc=$?
   if [ "$rc" -eq 0 ]; then
     fail "$label: must REFUSE, exited 0"
     return

--- a/scripts/tests/test_ws0_abc_driver_guards.sh
+++ b/scripts/tests/test_ws0_abc_driver_guards.sh
@@ -1394,6 +1394,47 @@ print(arm.RSS_UNMEASURED)
 print(agg.RSS_UNMEASURED_PREFIX)
 print(" ".join(sorted(k for k in arm.server_rss_block([], "warm", "x") if k.startswith("server_vm"))))
 print(" ".join(sorted(agg.RSS_FIELDS)))
+# THE FULL MARKER FORM FROM EACH SIDE, and then the two PREDICATES driven over one table of
+# values (#3997 roborev round 4). The two readers are INDEPENDENT by design — the aggregator
+# imports no sibling module — so what has to be pinned is not one implementation but their
+# AGREEMENT, in BOTH directions: one strict reader and one loose one is the state that would let
+# a corrupt session through whichever tool happened to read it. Driven by IMPORT, never by
+# comparing source text: a predicate can be rewritten without its spelling changing.
+print(arm.RSS_UNMEASURED_MARKER)
+print(agg.RSS_UNMEASURED_MARKER)
+CASES = [
+    ("bare-word", arm.RSS_UNMEASURED, False),
+    ("word-plus-garbage", arm.RSS_UNMEASURED + "garbage", False),
+    ("prefix-no-space-no-cause", arm.RSS_UNMEASURED + " —", False),
+    ("prefix-empty-cause", arm.RSS_UNMEASURED_MARKER, False),
+    ("prefix-whitespace-cause", arm.RSS_UNMEASURED_MARKER + "   ", False),
+    ("hyphen-not-em-dash", arm.RSS_UNMEASURED + " - a cause", False),
+    ("not-a-marker", "n/a", False),
+    ("well-formed", arm.rss_unmeasured("the pid was gone before the sample"), True),
+]
+def verdict_word(flag, yes, no):
+    return yes if flag else no
+
+
+verdicts = []
+for name, value, expect in CASES:
+    a_says = arm._rss_marker(value)
+    g_says = agg.is_unmeasured_marker(value)
+    verdicts.append(
+        name
+        + ":" + verdict_word(a_says, "ACCEPT", "REJECT")
+        + "/" + verdict_word(g_says, "ACCEPT", "REJECT")
+        + "/" + verdict_word(a_says == g_says, "AGREE", "DISAGREE")
+        + "/" + verdict_word(a_says == expect and g_says == expect, "AS-SPECIFIED", "WRONG")
+    )
+print(" ".join(verdicts))
+# AND THE PRODUCER CANNOT MINT WHAT ITS READER REFUSES: a causeless cause is refused at the
+# source, so the two sides cannot disagree by way of a value one of them created.
+try:
+    arm.rss_unmeasured("   ")
+    print("MINT-ACCEPTED-EMPTY-CAUSE")
+except ValueError:
+    print("MINT-REFUSES-EMPTY-CAUSE")
 ') || _py=""
 if [ -n "$_py" ]; then
   pass "5h. (setup) both python sides IMPORT cleanly, so the constants below are the ones the code uses"
@@ -1406,6 +1447,10 @@ arm_mod_marker=$(sed -n 3p <<<"$_py")
 agg_marker=$(sed -n 4p <<<"$_py")
 prod_fields=$(sed -n 5p <<<"$_py")
 agg_fields=$(sed -n 6p <<<"$_py")
+arm_marker_form=$(sed -n 7p <<<"$_py")
+agg_marker_form=$(sed -n 8p <<<"$_py")
+marker_verdicts=$(sed -n 9p <<<"$_py")
+mint_verdict=$(sed -n 10p <<<"$_py")
 if [ -n "$drv_arm" ] && [ "$drv_arm" = "$agg_arm" ]; then
   pass "5h. the driver's ARM_E ('$drv_arm') and the aggregator's BINARY_EXCEPTION_ARM name the SAME arm"
 else
@@ -1433,6 +1478,48 @@ if [ "$prod_fields" = "server_vm_hwm_kb server_vm_rss_kb" ]; then
   pass "5h. ...and they are the two /proc fields R6.1 names — VmHWM (the peak) and VmRSS (the scan-end sample)"
 else
   fail "5h. the published RSS fields must be server_vm_hwm_kb + server_vm_rss_kb, got '$prod_fields'"
+fi
+
+# ...AND THE MARKER'S FULL FORM, plus the two PREDICATES' agreement in BOTH DIRECTIONS (#3997
+# roborev round 4). `startswith("UNMEASURED")` accepted a bare word, an arbitrary suffix and an
+# EMPTY CAUSE as legitimate absences, so a corrupt session read as one that merely did not
+# measure. The two readers stay independent by design, so what is pinned here is their
+# AGREEMENT: a strict reader beside a loose one would let a corrupt session through whichever
+# tool happened to read it.
+if [ -n "$arm_marker_form" ] && [ "$arm_marker_form" = "$agg_marker_form" ]; then
+  pass "5h. ...and the FULL marker form is the same string on both sides ('$agg_marker_form') — em dash AND trailing space, not just the word"
+else
+  fail "5h. marker form differs: collector '$arm_marker_form' vs aggregator '$agg_marker_form'"
+fi
+case "$arm_marker_form" in
+  "UNMEASURED "*) pass "5h. ...and it is the word followed by a SEPARATOR AND A SPACE, so a bare 'UNMEASURED' cannot match it" ;;
+  *) fail "5h. the marker form must extend the word with a separator, got '$arm_marker_form'" ;;
+esac
+# EVERY CASE, BOTH READERS, AND THE EXPECTED VERDICT — one table, so a reader can see that the
+# accept direction is in it. A tightened check that refused legitimate markers would turn every
+# genuinely-unmeasured arm into a hard refusal, i.e. break the rig on exactly the runs it exists
+# to describe, so `well-formed:ACCEPT/ACCEPT` matters as much as the seven rejections.
+for _case in $marker_verdicts; do
+  _name=${_case%%:*}
+  _verdict=${_case#*:}
+  case "$_verdict" in
+    */AGREE/AS-SPECIFIED)
+      pass "5h. marker grammar '$_name': both readers answer as specified and AGREE ($_verdict)" ;;
+    *DISAGREE*)
+      fail "5h. marker grammar '$_name': the two readers DISAGREE ($_verdict) — one strict, one loose" ;;
+    *)
+      fail "5h. marker grammar '$_name': answered against the contract ($_verdict)" ;;
+  esac
+done
+if [ "$(printf '%s\n' $marker_verdicts | grep -c .)" -eq 8 ]; then
+  pass "5h. ...and all 8 grammar cases ran — including the ACCEPT case, so the tightening is pinned against over-refusal too"
+else
+  fail "5h. the grammar table must contribute 8 verdicts, got '$marker_verdicts'"
+fi
+if [ "$mint_verdict" = "MINT-REFUSES-EMPTY-CAUSE" ]; then
+  pass "5h. ...and the PRODUCER refuses to MINT a causeless marker, so neither side can be handed a value the other's reader rejects"
+else
+  fail "5h. rss_unmeasured() must refuse an empty cause (got '$mint_verdict')"
 fi
 
 # --- 5i. THE DRIVER SIDE. Arm E is OPT-IN, dispatched against its OWN --bin-dir, and its binary
@@ -2056,6 +2143,52 @@ else
   fail "6n. the collector's cause must reach the report (RSS section: $(sed -n '/## Server RSS/,/^## /p' "$PREPORT" | tail -5 | tr '\n' ' '))"
 fi
 
+# --- 6o. A MALFORMED MARKER IS A CORRUPT ARTIFACT, NOT AN HONEST ABSENCE (#3997 roborev round
+# 4). Case 6h refuses a string that is not a marker at all; these carry the `UNMEASURED` WORD
+# without its FORM — a bare word, an arbitrary suffix, an empty cause — which
+# `startswith("UNMEASURED")` accepted as a legitimate unmeasured figure. No published number was
+# ever at risk (a marker is printed, never medianed), so what this restores is the distinction
+# between "refuse this session" and "this figure was not measured", and the CAUSE is the whole
+# value of a marker because it is what decides the operator's next action. The ACCEPT direction
+# is case 6d, which carries a well-formed marker through to an UNMEASURED cell end to end.
+for _bad in UNMEASURED UNMEASUREDgarbage; do
+  MSET="$TMP/set-E-malformed-$_bad"
+  mkset "$MSET" 3 A,E 400000 250000 20000 25000
+  mut "$MSET/r2-E/results.json" measurements.1.server_vm_hwm_kb "$_bad"
+  agg_refuses_naming_arms "6o. a marker of '$_bad' — the word without its form — is REFUSED as a CORRUPT record, not counted as an unmeasured figure" \
+    "$MSET" A,E A "server_vm_hwm_kb" "but is NOT the" "CORRUPT record" "non-empty" "CAUSE"
+done
+# THE EMPTY-CAUSE FORMS: the exact prefix, then nothing (or only whitespace). These are the
+# closest thing to a legitimate marker that is still not one, and the prefix check alone passed
+# them both.
+ESET_EMPTY="$TMP/set-E-empty-cause"
+mkset "$ESET_EMPTY" 3 A,E 400000 250000 20000 25000
+mut "$ESET_EMPTY/r1-E/results.json" measurements.1.server_vm_rss_kb "UNMEASURED — "
+agg_refuses_naming_arms "6o. the exact prefix with an EMPTY cause is REFUSED — a marker whose cause is missing tells an operator nothing to act on" \
+  "$ESET_EMPTY" A,E A "server_vm_rss_kb" "CORRUPT record" "CAUSE"
+WSET="$TMP/set-E-whitespace-cause"
+mkset "$WSET" 3 A,E 400000 250000 20000 25000
+mut "$WSET/r3-E/results.json" measurements.1.server_vm_hwm_kb "UNMEASURED —    "
+agg_refuses_naming_arms "6o. ...and a WHITESPACE-ONLY cause too, which a non-empty-string test would have accepted" \
+  "$WSET" A,E A "server_vm_hwm_kb" "CORRUPT record"
+# AND A HYPHEN IS NOT AN EM DASH. The producer writes 'UNMEASURED — <cause>'; a value spelled
+# with an ASCII hyphen was written by something else, and the two refusals must not be one
+# message: 'this artifact is corrupt' and 'this session is not one this tool models' are
+# different remedies.
+HSET="$TMP/set-E-hyphen"
+mkset "$HSET" 3 A,E 400000 250000 20000 25000
+mut "$HSET/r2-E/results.json" measurements.1.server_vm_hwm_kb "UNMEASURED - the pid was gone"
+agg_refuses_naming_arms "6o. a HYPHEN in place of the em dash is REFUSED — the marker's separator is part of its form, not a rendering choice" \
+  "$HSET" A,E A "server_vm_hwm_kb" "CORRUPT record"
+# THE TWO REFUSALS ARE DISTINCT, which is the whole point of splitting them: a value that never
+# claimed to be a marker gets the 'not modelled' message and NOT the corrupt-record one.
+out=$(python3 "$AGG" --root "$SSET" --arms A,E --baseline A 2>&1); rc=$?
+if [ "$rc" -ne 0 ] && grep -qF "is not an" <<<"$out" && ! grep -qF "CORRUPT record" <<<"$out"; then
+  pass "6o. ...while 'n/a' — a string that never claimed to be a marker — still gets the OTHER refusal, so the two causes stay distinguishable"
+else
+  fail "6o. a non-marker string must not be reported as a corrupt marker (rc=$rc, out: $(tail -3 <<<"$out"))"
+fi
+
 # --- 6i. THE CLEAN A/E SET ONCE MORE, so no case above passed by leaving a fixture broken.
 out=$(python3 "$AGG" --root "$ESET" --arms A,E --baseline A); rc=$?
 if [ "$rc" -eq 0 ] && grep -q "0 UNMEASURED RECOGNISED" <<<"$out"; then
@@ -2081,8 +2214,12 @@ fi
 # all-reps-failed cause, distinct from the no-rep-recorded one), 185 (+ the arm-E-only set's
 # declaration that the differ-assertion was SKIPPED), 196 (+ case 5m, the reported-allocator
 # precondition: the accept direction printed affirmatively, both wrong-value directions, and the
-# five unmeasurable states).
-MIN_CHECKS=185
+# five unmeasurable states), 201 (+ 5m's STREAM DISCIPLINE: a well-formed allocator line on
+# stderr — stdout empty, stdout noisy, split across the two, and on the control side — plus the
+# stream-labelled diagnostic), 219 (+ the UNMEASURED marker GRAMMAR: case 5h's 8-case
+# accept/reject table driven over BOTH readers by import plus the producer's causeless-mint
+# refusal, and case 6o's malformed markers end to end).
+MIN_CHECKS=205
 if [ "$checks" -lt "$MIN_CHECKS" ]; then
   echo
   echo "FAIL - only $checks check(s) ran; this suite has at least $MIN_CHECKS."

--- a/scripts/tests/test_ws0_abc_driver_guards.sh
+++ b/scripts/tests/test_ws0_abc_driver_guards.sh
@@ -29,6 +29,9 @@
 #     exception is asserted to be ACCEPTED for arm E and STILL REFUSED for another arm id,
 #     another binary, another pair of arms while E is present, and arm E versus itself between
 #     rounds. A one-directional test cannot tell a narrow exception from a deleted check.
+#     Case 5m is the OTHER half of arm E's premise, and it is not a digest question at all: a
+#     digest difference proves DIFFERENT BYTES and never `jemalloc`, so both binaries are ASKED
+#     for R2.1's `allocator:` line and every unmeasurable answer is a named refusal.
 #   * PART 6 (R6.1) the Flight server's scan-end `VmHWM`/`VmRSS`, per arm, and the property that
 #     an UNMEASURED figure and a genuinely small one do not read alike — a marker naming its
 #     cause, a ratio that reads NOT MEASURABLE, and a refusal for a zero, an absent key or a
@@ -37,13 +40,16 @@
 #     each field's observation count is its OWN — asserted in both directions of the asymmetry,
 #     because one shared count cannot report 2 for one field and 3 for the other.
 #
-# Two roborev blockers on #3997 added case 5l and cases 6j-6n. Both were the same failure mode:
-# a rig that can publish a measurement it did not make. 5l — the exception checked that arm E's
-# digest was STABLE and that the others were SHARED, never that the two DIFFER, so a `bins-E/`
-# copied from the control passed every check and the report attributed run-to-run noise to the
-# allocator. 6j-6n — a partially sampled arm published a median over whichever reps survived,
-# and R6.1 is a RATIO CEILING, which an unrepresentative low median satisfies without having
-# been measured.
+# Three roborev blockers on #3997 added cases 5l, 5m and 6j-6n. All three were the same failure
+# mode: a rig that can publish a measurement it did not make. 5l — the exception checked that arm
+# E's digest was STABLE and that the others were SHARED, never that the two DIFFER, so a
+# `bins-E/` copied from the control passed every check and the report attributed run-to-run noise
+# to the allocator. 5m — its complement: ANY unrelated rebuild satisfies "differs", and neither
+# the `system` flag nor the `/proc/<pid>/maps` check can see a statically linked allocator, so a
+# glibc build could be measured as the jemalloc arm; the allocator is now read off each binary's
+# own `--version` surface, which is derived from the same cfg that installs it. 6j-6n — a
+# partially sampled arm published a median over whichever reps survived, and R6.1 is a RATIO
+# CEILING, which an unrepresentative low median satisfies without having been measured.
 #
 # # The bar, per #3249 (a hardcoded `_PERF_STATE="ok"` survived 118/118 tests)
 #
@@ -1557,6 +1563,109 @@ else
   fail "5l. an arm-E-only set must declare the assertion skipped (rc=$rc, out: $(head -16 <<<"$out"))"
 fi
 
+# --- 5m. AND THE ALLOCATOR IS ASKED OF THE BINARY, NOT INFERRED FROM ITS BYTES (#3997 R2.1,
+# roborev round 2 job 132). Case 5j asserts that arm E's binary DIFFERS from the control's; that
+# proves DIFFERENT BYTES and never `jemalloc`. Any unrelated rebuild — another feature set, a
+# stale binary from another branch — satisfies it while still linking glibc malloc, and nothing
+# downstream catches it: arm E runs under `--flight-allocator system` by construction and the
+# per-rep `/proc/<pid>/maps` check CANNOT see a statically linked jemalloc, which is the very
+# property that lets arm E carry the `system` label. So both binaries are asked for R2.1's
+# `allocator:` line before anything runs. Every state below is a REFUSAL naming its own cause,
+# because "the binary said the other thing" and "the binary did not say" are different remedies.
+E_OK="$TMP/bins-e-alloc-ok"
+make_bins_e "$E_OK" "$BINS" ok
+E_ALLOC_OUT="$TMP/out-e-alloc-ok"
+out=$(run_abc "$TMP/d-base" --corpus "$CORPUS" --bin-dir "$BINS" --bin-dir-e "$E_OK" \
+        --out "$E_ALLOC_OUT" --rounds 1); rc=$?
+# THE ACCEPT DIRECTION, AND IT IS AFFIRMATIVE. `rc=0` alone would also be produced by a check
+# that never ran, which is this repo's vacuous pass; the driver PRINTS what each binary reported,
+# so the oracle is the two printed lines and not the absence of a refusal.
+if [ "$rc" -eq 0 ] \
+   && grep -qF "reports 'allocator: system' (R2.1)" <<<"$out" \
+   && grep -qF "reports 'allocator: jemalloc' (R2.1)" <<<"$out"; then
+  pass "5m. the correct pair is ACCEPTED and the driver PRINTS both reported allocators — observed to have ASKED, not merely to have not refused"
+else
+  fail "5m. the correct pair must be accepted with both allocators printed (rc=$rc, out: $(grep -i alloc <<<"$out" | head -4))"
+fi
+if grep -qF -- "--bin-dir cqlite-flight" <<<"$out" && grep -qF -- "--bin-dir-e cqlite-flight" <<<"$out"; then
+  pass "5m. ...and it names WHICH binary each answer came from, so a reader is not left guessing which side was asked"
+else
+  fail "5m. each printed line must name its binary set (out: $(grep -i alloc <<<"$out" | head -4))"
+fi
+
+# THE FINDING'S OWN FAILURE SCENARIO: arm E's binary DIFFERS in bytes (so case 5j's digest
+# precondition is satisfied) and is still a `system` build. This is the input that used to be
+# accepted and measured as the linked-allocator arm.
+E_SYS="$TMP/bins-e-reports-system"
+make_bins_e "$E_SYS" "$BINS" rebuild-only system
+refuses_naming "5m. arm E's binary DIFFERING in bytes but reporting 'allocator: system' is REFUSED — the finding's own scenario: a rebuild that links glibc, measured as the jemalloc arm" \
+  "$TMP/d-base" "--bin-dir-e cqlite-flight" "reports 'allocator: system'" \
+  "expected 'allocator: jemalloc'" "different bytes" -- \
+  --corpus "$CORPUS" --bin-dir "$BINS" --bin-dir-e "$E_SYS" --out "$TMP/out-e-sys" --rounds 1
+# ...AND THE REFUSAL PRECEDES THE FIRST SIDE EFFECT, which is why the check sits with the
+# argument checks: `--out` must not even exist afterwards.
+if [ ! -e "$TMP/out-e-sys" ]; then
+  pass "5m. ...and it refuses BEFORE the first side effect — --out was never created, let alone fingerprinted"
+else
+  fail "5m. the refusal must precede mkdir -p \$OUT (found $(ls -A "$TMP/out-e-sys" | tr '\n' ' '))"
+fi
+
+# THE OTHER SIDE IS ASKED TOO. E reporting jemalloc while the CONTROL also links it is not an
+# allocator delta either — it is one treatment under two labels, the same defect from the other
+# end — so a control that reports `jemalloc` is refused with arm E's binary blameless.
+CTRL_JEM="$TMP/bins-control-jemalloc"
+make_bins "$CTRL_JEM" one jemalloc
+E_FOR_CTRL="$TMP/bins-e-for-ctrl"
+make_bins_e "$E_FOR_CTRL" "$CTRL_JEM" ctrl
+refuses_naming "5m. a CONTROL --bin-dir reporting 'allocator: jemalloc' is REFUSED — both sides are asked, because E-vs-jemalloc-control is not an allocator delta" \
+  "$TMP/d-base" "--bin-dir cqlite-flight" "reports 'allocator: jemalloc'" \
+  "expected 'allocator: system'" -- \
+  --corpus "$CORPUS" --bin-dir "$CTRL_JEM" --bin-dir-e "$E_FOR_CTRL" --out "$TMP/out-ctrl-jem" --rounds 1
+
+# EVERY UNMEASURABLE STATE, EACH NAMING ITS CAUSE. An absent line, an unrecognised value, two
+# lines, a non-zero exit and a non-executable file are all "the allocator is UNMEASURED", and
+# defaulting any of them either way is exactly how a glibc build gets measured as the jemalloc
+# arm.
+E_NOLINE="$TMP/bins-e-no-line"
+make_bins_e "$E_NOLINE" "$BINS" noline __NO_LINE__
+refuses_naming "5m. an arm-E binary whose --version prints NO allocator line is REFUSED as UNMEASURED, not defaulted to either allocator" \
+  "$TMP/d-base" "printed 0 line(s) matching" "EXACTLY ONE" "UNMEASURED" -- \
+  --corpus "$CORPUS" --bin-dir "$BINS" --bin-dir-e "$E_NOLINE" --out "$TMP/out-e-noline" --rounds 1
+E_UNKNOWN="$TMP/bins-e-unknown-alloc"
+make_bins_e "$E_UNKNOWN" "$BINS" unknown tcmalloc
+refuses_naming "5m. an UNRECOGNISED allocator value ('tcmalloc') is REFUSED by the anchored grammar — not read as 'some allocator', and not as jemalloc" \
+  "$TMP/d-base" "printed 0 line(s) matching" "^allocator: (jemalloc|system)\$" -- \
+  --corpus "$CORPUS" --bin-dir "$BINS" --bin-dir-e "$E_UNKNOWN" --out "$TMP/out-e-unknown" --rounds 1
+E_TWO="$TMP/bins-e-two-lines"
+make_bins_e "$E_TWO" "$BINS" two __TWO_LINES__
+refuses_naming "5m. TWO matching lines are REFUSED — R2.1's contract is EXACTLY ONE, and 'at least one' would let a binary claim both allocators" \
+  "$TMP/d-base" "printed 2 line(s) matching" "EXACTLY ONE" -- \
+  --corpus "$CORPUS" --bin-dir "$BINS" --bin-dir-e "$E_TWO" --out "$TMP/out-e-two" --rounds 1
+E_RC="$TMP/bins-e-nonzero"
+make_bins_e "$E_RC" "$BINS" rc __NONZERO__
+refuses_naming "5m. a NON-ZERO --version exit is REFUSED even though the output carried the right line — an answer from a failed invocation is not an answer" \
+  "$TMP/d-base" "exited 3" "UNMEASURED" -- \
+  --corpus "$CORPUS" --bin-dir "$BINS" --bin-dir-e "$E_RC" --out "$TMP/out-e-rc" --rounds 1
+E_NOX="$TMP/bins-e-not-executable"
+make_bins_e "$E_NOX" "$BINS" nox
+chmod -x "$E_NOX/cqlite-flight"
+refuses_naming "5m. a NON-EXECUTABLE arm-E binary is REFUSED naming that cause — a digest can be taken of a file that cannot be asked anything" \
+  "$TMP/d-base" "is not EXECUTABLE" "UNMEASURED" "chmod +x" -- \
+  --corpus "$CORPUS" --bin-dir "$BINS" --bin-dir-e "$E_NOX" --out "$TMP/out-e-nox" --rounds 1
+
+# AND THE CHECK IS PART OF THE OPT-IN, NOT OF THE DEFAULT. Without --bin-dir-e no allocator is
+# asked of anything, so a pre-#3997 A/B/C0/C/D set behaves exactly as it did — the same property
+# case 5k asserts of the fingerprint. This is the scope the driver DECLARES rather than leaves to
+# be discovered: a linked-jemalloc --bin-dir would make arms A/B/C0/C/D silently jemalloc arms,
+# which this check does not cover and nothing else does either.
+out=$(run_abc "$TMP/d-base" --corpus "$CORPUS" --bin-dir "$CTRL_JEM" \
+        --out "$TMP/out-no-e-jem" --rounds 1); rc=$?
+if [ "$rc" -eq 0 ] && ! grep -q "(R2.1)" <<<"$out"; then
+  pass "5m. WITHOUT --bin-dir-e no allocator is asked at all — even of a jemalloc-reporting control, so the pre-#3997 default is unchanged (declared scope, not a closed hole)"
+else
+  fail "5m. an arm-E-less set must not ask any binary its allocator (rc=$rc, out: $(grep -i 'alloc\|R2.1' <<<"$out" | head -3))"
+fi
+
 # ===========================================================================
 # PART 6 — THE SERVER'S SCAN-END RSS: R6.1's INPUT (#3997)
 # ===========================================================================
@@ -1909,8 +2018,10 @@ fi
 # blockers: case 5l, arm E's binary must actually DIFFER from the shared one, and cases 6j-6n,
 # the REP-level completeness of each RSS field with its own per-field census), 184 (+ the
 # all-reps-failed cause, distinct from the no-rep-recorded one), 185 (+ the arm-E-only set's
-# declaration that the differ-assertion was SKIPPED).
-MIN_CHECKS=170
+# declaration that the differ-assertion was SKIPPED), 196 (+ case 5m, the reported-allocator
+# precondition: the accept direction printed affirmatively, both wrong-value directions, and the
+# five unmeasurable states).
+MIN_CHECKS=185
 if [ "$checks" -lt "$MIN_CHECKS" ]; then
   echo
   echo "FAIL - only $checks check(s) ran; this suite has at least $MIN_CHECKS."

--- a/scripts/tests/test_ws0_abc_driver_guards.sh
+++ b/scripts/tests/test_ws0_abc_driver_guards.sh
@@ -1500,6 +1500,20 @@ else
   fail "5l. an arm-E-less set of shared digests must still aggregate (rc=$rc, out: $(tail -3 <<<"$out"))"
 fi
 
+# AND THE DECLARATION IS DERIVED FROM WHETHER THE ASSERTION RAN, not from the exception being
+# active: an arm-E-ONLY set has no shared digest to differ from, so the comparison is SKIPPED —
+# and a sentence claiming it held there would assert a check that did not happen (a label must
+# be derived from the state it renders, never from an assumption about which states reach it).
+EONLY="$TMP/set-E-only"
+mkset "$EONLY" 2 E 400000 250000 20000 25000
+out=$(python3 "$AGG" --root "$EONLY" --arms E --baseline E 2>&1); rc=$?
+if [ "$rc" -eq 0 ] && grep -q "NOT ASSERTED HERE" <<<"$out" \
+   && ! grep -q "the two digests above are asserted to DIFFER" <<<"$out"; then
+  pass "5l. ...and an arm-E-ONLY set says the differ-assertion was SKIPPED rather than claiming it held — there is no other arm to differ from"
+else
+  fail "5l. an arm-E-only set must declare the assertion skipped (rc=$rc, out: $(head -16 <<<"$out"))"
+fi
+
 # ===========================================================================
 # PART 6 — THE SERVER'S SCAN-END RSS: R6.1's INPUT (#3997)
 # ===========================================================================
@@ -1851,7 +1865,7 @@ fi
 # BOTH directions, and the scan-end server RSS R6.1 is read from), 183 (+ the two #3997 roborev
 # blockers: case 5l, arm E's binary must actually DIFFER from the shared one, and cases 6j-6n,
 # the REP-level completeness of each RSS field with its own per-field census), 184 (+ the
-# all-reps-failed cause, distinct from the no-rep-recorded one).
+# all-reps-failed cause and the arm-E-only declaration), 185.
 MIN_CHECKS=170
 if [ "$checks" -lt "$MIN_CHECKS" ]; then
   echo

--- a/scripts/tests/test_ws0_abc_driver_guards.sh
+++ b/scripts/tests/test_ws0_abc_driver_guards.sh
@@ -371,23 +371,54 @@ make_identity() {
   mkdir -p "$dir"
   printf '{"data_db_sha256":"%s","rows":%s,"seed":7}\n' "$sha" "$rows" > "$dir/corpus-identity.json"
 }
+# make_bins <dir> <tag> [reported-allocator] — a frozen binary set. Every file is EXECUTABLE
+# and `cqlite-flight` answers `--version` with R2.1's single `allocator: <value>` line, because
+# since #3997's roborev round 2 the driver ASKS the binary rather than inferring its treatment
+# from a digest difference (a digest proves different BYTES, never `jemalloc`). The default is
+# `system`, which is what a --bin-dir control must report; a case needing the other value, or a
+# broken surface, passes its own.
 make_bins() {
-  local dir="$1" tag="$2" b
+  local dir="$1" tag="$2" alloc="${3:-system}" b
   mkdir -p "$dir"
   for b in ws0-scan-bench cqlite-flight flight-loadgen; do
     printf 'ELF-ish %s %s\n' "$b" "$tag" > "$dir/$b"
   done
+  write_flight_stub "$dir/cqlite-flight" "$tag" "$alloc"
+  chmod +x "$dir"/ws0-scan-bench "$dir"/cqlite-flight "$dir"/flight-loadgen
+}
+# write_flight_stub <path> <tag> <allocator-body> — the `cqlite-flight` stand-in. <tag> is what
+# makes its BYTES differ between binary sets (the digest precondition's subject); the third
+# argument is the `--version` body, so a case can plant a WRONG value, NO allocator line, TWO of
+# them, or a non-zero exit — the states the driver must refuse rather than default.
+write_flight_stub() {
+  local path="$1" tag="$2" alloc="$3"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf '# ELF-ish cqlite-flight %s\n' "$tag"
+    printf 'if [ "${1:-}" = "--version" ]; then\n'
+    case "$alloc" in
+      __NO_LINE__)   printf '  printf "cqlite-flight 0.0.0-fixture\\n"\n' ;;
+      __TWO_LINES__) printf '  printf "allocator: jemalloc\\nallocator: system\\n"\n' ;;
+      __NONZERO__)   printf '  printf "allocator: jemalloc\\n"; exit 3\n' ;;
+      *)             printf '  printf "cqlite-flight 0.0.0-fixture\\nallocator: %s\\n"\n' "$alloc" ;;
+    esac
+    printf '  exit 0\nfi\nexit 0\n'
+  } > "$path"
+  chmod +x "$path"
 }
 # make_bins_e <dir> <src-dir> <tag> — arm E's binary set: the SAME BYTES as <src-dir> for every
 # measured binary EXCEPT cqlite-flight, which is a different build. The shape the driver's
 # two-sided precondition ACCEPTS, so the RED arms below can each break exactly one half of it.
+# The fourth argument is arm E's REPORTED allocator, defaulting to the `jemalloc` the driver
+# requires of it; a case needing a wrong or broken surface passes its own. Its `cqlite-flight`
+# still DIFFERS in bytes from <src-dir>'s, which is the digest half of the precondition.
 make_bins_e() {
-  local dir="$1" src="$2" tag="$3" b
+  local dir="$1" src="$2" tag="$3" alloc="${4:-jemalloc}" b
   mkdir -p "$dir"
   for b in ws0-scan-bench cqlite-flight flight-loadgen; do
     cp "$src/$b" "$dir/$b"
   done
-  printf 'ELF-ish cqlite-flight LINKED-JEMALLOC %s\n' "$tag" > "$dir/cqlite-flight"
+  write_flight_stub "$dir/cqlite-flight" "LINKED-JEMALLOC $tag" "$alloc"
 }
 # Mark a (round, arm) session dir MEASURED: a results.json plus the window record the driver
 # writes. Both, because either alone is one of the states this suite refuses.
@@ -1440,11 +1471,23 @@ done
 # from the same digests. Both edges, because an exception with one edge checked is not narrow.
 SAME_E="$TMP/bins-e-same"
 make_bins "$SAME_E" one   # identical bytes to $BINS: cqlite-flight does NOT differ
-refuses_naming "5j. an arm-E binary set whose cqlite-flight is the SAME BYTES is REFUSED — identical bytes make arm E a second LABEL for arm A" \
-  "$TMP/d-base" "SAME BYTES" "cqlite-flight" "second LABEL" -- \
+# THE PROPERTY IS UNCHANGED — identical bytes are still REFUSED before anything runs — but the
+# MESSAGE moved, and that is worth stating rather than quietly re-matching: since the #3997
+# roborev round-2 fix the driver ASKS both binaries for their allocator, and that check now
+# precedes the digest one. Identical bytes CANNOT report two different allocators, so this input
+# refuses on the allocator pair and the driver's own SAME-BYTES text is shadowed. The refusal is
+# strictly more informative (it names which binary reported what), the digest-identity refusal
+# remains live and reachable in the AGGREGATOR — which executes no binaries and is asserted by
+# case 5l — and the driver keeps its digest check as defence in depth against a reordering.
+refuses_naming "5j. an arm-E binary set whose cqlite-flight is the SAME BYTES is REFUSED — a copy of the control reports the control's allocator, so arm E would be a second LABEL for arm A" \
+  "$TMP/d-base" "--bin-dir-e cqlite-flight" "reports 'allocator: system'" \
+  "expected 'allocator: jemalloc'" -- \
   --corpus "$CORPUS" --bin-dir "$BINS" --bin-dir-e "$SAME_E" --out "$TMP/out-e-same" --rounds 1
 BAD_E="$TMP/bins-e-bad"
-make_bins "$BAD_E" two    # every binary differs, including the drift control's
+# `jemalloc` so this set PASSES the allocator pair and its refusal is therefore attributable to
+# the ONE property it plants: a differing ws0-scan-bench. A fixture that failed two checks at
+# once would pass this case while proving nothing about the digest half.
+make_bins "$BAD_E" two jemalloc   # every binary differs, including the drift control's
 refuses_naming "5j. an arm-E binary set whose ws0-scan-bench ALSO differs is REFUSED — only cqlite-flight may differ" \
   "$TMP/d-base" "ws0-scan-bench' differs from" "Only cqlite-flight may differ" "drift control" -- \
   --corpus "$CORPUS" --bin-dir "$BINS" --bin-dir-e "$BAD_E" --out "$TMP/out-e-bad" --rounds 1

--- a/scripts/tests/test_ws0_abc_driver_guards.sh
+++ b/scripts/tests/test_ws0_abc_driver_guards.sh
@@ -21,6 +21,19 @@
 #     denotes everywhere else in this rig, where it is a ROWS/S ratio (`ws0_report.py`,
 #     `ws0-baseline.sh`'s printed line, `ws0-3248-artifacts/ac0/DELTA-TABLE.md`).
 #
+# # Parts 5 and 6 — issue #3997's two additions to the same two files
+#
+#   * PART 5 (R3.3) arm `E` measures a `cqlite-flight` that LINKS its allocator, so it is the
+#     FIRST arm that legitimately runs different bytes from arm A — the single permitted
+#     exception to the cross-arm identical-bytes invariant. Every case there is paired: the
+#     exception is asserted to be ACCEPTED for arm E and STILL REFUSED for another arm id,
+#     another binary, another pair of arms while E is present, and arm E versus itself between
+#     rounds. A one-directional test cannot tell a narrow exception from a deleted check.
+#   * PART 6 (R6.1) the Flight server's scan-end `VmHWM`/`VmRSS`, per arm, and the property that
+#     an UNMEASURED figure and a genuinely small one do not read alike — a marker naming its
+#     cause, a ratio that reads NOT MEASURABLE, and a refusal for a zero, an absent key or a
+#     string that is not a marker.
+#
 # # The bar, per #3249 (a hardcoded `_PERF_STATE="ok"` survived 118/118 tests)
 #
 # OBSERVED TO FIRE, and observed to fire ON THE PLANTED THING:
@@ -78,6 +91,12 @@ if [ "$NARMS" -lt 2 ]; then
   exit 1
 fi
 AGG="$REPO_ROOT/scripts/perf/ws0_abc_aggregate.py"
+# The COLLECTOR that produces the per-arm RSS fields the aggregator consumes (#3997,
+# R6.1). Read here only to PIN the two sides' UNMEASURED marker prefix against each other
+# — see case 5h. The aggregator imports no sibling module, so the string is restated there
+# and a silent divergence would send every unmeasured figure down the refusal branch
+# instead of the UNMEASURED column.
+FLIGHT_ARM="$REPO_ROOT/scripts/perf/ws0_flight_arm.py"
 
 fails=0
 # `checks` counts what actually RAN (incremented by pass/fail themselves), so the floor at the
@@ -86,7 +105,7 @@ checks=0
 pass() { checks=$((checks + 1)); echo "ok   - $1"; }
 fail() { checks=$((checks + 1)); echo "FAIL - $1"; fails=$((fails + 1)); }
 
-for f in "$ABC_DRIVER" "$AGG"; do
+for f in "$ABC_DRIVER" "$AGG" "$FLIGHT_ARM"; do
   [ -f "$f" ] || { echo "FAIL - missing $f"; exit 1; }
 done
 # python3 is a HARD REQUIREMENT of this rig (`ws0-baseline.sh` refuses to run without it, and
@@ -122,16 +141,32 @@ import sys
 p = pathlib.Path(sys.argv[1])
 doc = json.loads(p.read_text())
 keys = sys.argv[2].split(".")
+
+
+def step(container, key):
+    """One path element, addressing a LIST by index and an OBJECT by name.
+
+    The list arm arrived with #3997: R6.1's two fields live on ONE ELEMENT of `measurements`,
+    so `measurements.1.server_vm_hwm_kb` has to reach into an array. `container["1"]` raises
+    TypeError on a list, which would have made every RSS case fail for a reason unrelated to
+    its subject.
+    """
+    if isinstance(container, list):
+        return int(key)
+    return key
+
+
 cur = doc
 for k in keys[:-1]:
-    cur = cur[k]
+    cur = cur[step(cur, k)]
+last = step(cur, keys[-1])
 if sys.argv[3] == "__DELETE__":
-    del cur[keys[-1]]
+    del cur[last]
 else:
     try:
-        cur[keys[-1]] = json.loads(sys.argv[3])
+        cur[last] = json.loads(sys.argv[3])
     except ValueError:
-        cur[keys[-1]] = sys.argv[3]
+        cur[last] = sys.argv[3]
 p.write_text(json.dumps(doc))
 PY
 
@@ -1121,6 +1156,411 @@ else
   fail "4g. the validation scope must be the pairable rounds only (rc=$rc, out: $(sed -n 3p <<<"$out"))"
 fi
 
+# ===========================================================================
+# PART 5 — ARM E's CROSS-ARM BINARY EXCEPTION, BOTH DIRECTIONS (#3997, R3.3)
+# ===========================================================================
+# THE SUBJECT. Every #3551 arm varied the allocator by LD_PRELOAD into ONE binary, so the
+# aggregator could require every arm to have measured IDENTICAL BYTES — and #3248 WITHDREW a
+# machine-code sub-claim for violating exactly that. #3997 ships the allocator LINKED as the
+# binary's `#[global_allocator]`, so arm E is the first arm that legitimately runs a different
+# `cqlite-flight` from arm A, and R3.3 makes it the SINGLE PERMITTED EXCEPTION.
+#
+# WHY BOTH DIRECTIONS, AND WHY SO MANY REFUSAL ARMS. A one-directional test cannot tell a NARROW
+# exception from a DISABLED CHECK: "arm E's differing binary is accepted" is satisfied just as
+# well by deleting the invariant. So the accept direction is paired with a refusal arm for every
+# way the exception could have been made wider than R3.3 says — another ARM ID, another BINARY,
+# another PAIR of arms while E is present, and arm E differing from ITSELF between rounds.
+ESET="$TMP/set-E"
+mkset "$ESET" 3 A,E 400000 250000 20000 25000
+# `mut_all_rounds <root> <arm> <field> <value>` — the same mutation in EVERY round of one arm,
+# which is what makes a mutation a CROSS-ARM difference rather than a within-arm one. Mutating a
+# single round would trip the per-arm stability check first and the case would pass on the wrong
+# refusal.
+mut_all_rounds() {
+  local root="$1" arm="$2" field="$3" value="$4" r
+  for r in 1 2 3; do mut "$root/r$r-$arm/results.json" "$field" "$value"; done
+}
+E_SHA="eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+B_SHA="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+# --- 5a. THE ACCEPT DIRECTION. Arm E's differing cqlite-flight is ACCEPTED — and the report
+# SAYS SO, naming both digests in full. A permitted exception that is invisible in the output is
+# indistinguishable, to a reader, from an invariant that held.
+EREPORT="$TMP/report-E.md"
+out=$(python3 "$AGG" --root "$ESET" --arms A,E --baseline A --out "$EREPORT"); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "5a. arm E's DIFFERING cqlite-flight is ACCEPTED — the exception exists and the set aggregates"
+else
+  fail "5a. an A/E set must aggregate (rc=$rc, out: $(tail -3 <<<"$out"))"
+fi
+if grep -q "ARM E RAN A DIFFERENT \`cqlite-flight\` BINARY" <<<"$out" \
+   && grep -q "ONE permitted exception" <<<"$out"; then
+  pass "5a. ...and the report DECLARES the exception out loud, naming the arm and the binary"
+else
+  fail "5a. the report must declare arm E's binary exception (out: $(head -14 <<<"$out"))"
+fi
+if grep -qF "$E_SHA" <<<"$out" && grep -qF "$B_SHA" <<<"$out"; then
+  pass "5a. ...and it names BOTH sha256s IN FULL — arm E's and the one every other arm shared"
+else
+  fail "5a. both digests must appear in full (out: $(head -14 <<<"$out"))"
+fi
+if grep -q "STILL ENFORCED" <<<"$out" && grep -q "Any other cross-arm binary difference is still a REFUSAL" <<<"$out"; then
+  pass "5a. ...and it states what the exception does NOT waive, rather than leaving the scope to be inferred"
+else
+  fail "5a. the declaration must state what is still enforced"
+fi
+if grep -q "NOT COVERED BY IT" <<<"$out" && grep -q "Read the digest table, not the allocator column" <<<"$out"; then
+  pass "5a. ...and it warns that arm E's allocator column reads 'system' — the linked allocator leaves no flag to show"
+else
+  fail "5a. the declaration must warn that the allocator column cannot show arm E's treatment"
+fi
+got=$(cell "$EREPORT" "binary, per arm" E "sha256")
+if [ "$got" = "$E_SHA" ]; then
+  pass "5a. the per-arm digest TABLE prints arm E's own sha256, read back from its sessions"
+else
+  fail "5a. the digest table must print arm E's sha256, got '$got'"
+fi
+got=$(cell "$EREPORT" "binary, per arm" A "sha256")
+if [ "$got" = "$B_SHA" ]; then
+  pass "5a. ...and arm A's, so a reader compares two printed digests rather than trusting a sentence"
+else
+  fail "5a. the digest table must print arm A's sha256, got '$got'"
+fi
+got=$(cell "$EREPORT" "binary, per arm" E "relation to the other arms")
+if [ "$got" = "PERMITTED EXCEPTION (#3997 R3.3) — linked allocator, a DIFFERENT binary" ]; then
+  pass "5a. ...and arm E's row is LABELLED a permitted exception, not left as an unexplained difference"
+else
+  fail "5a. arm E's row must be labelled a permitted exception, got '$got'"
+fi
+got=$(cell "$EREPORT" "binary, per arm" A "relation to the other arms")
+if [ "$got" = "the shared binary" ]; then
+  pass "5a. ...and every other arm's row says it is THE SHARED BINARY — the invariant, stated as data"
+else
+  fail "5a. arm A's row must read 'the shared binary', got '$got'"
+fi
+
+# --- 5b. THE REFUSAL DIRECTION, ARM ID. The exception is keyed on the arm `E` and on NO OTHER
+# arm id. The IDENTICAL digest difference, moved to arm D, must still REFUSE — otherwise what
+# was implemented is "one arm may differ", which is not what R3.3 grants.
+DSET="$TMP/set-D-differs"
+mkset "$DSET" 3 A,D 400000 250000 20000 25000
+mut_all_rounds "$DSET" D binary_provenance.binaries.cqlite-flight "{\"sha256\":\"$E_SHA\"}"
+agg_refuses_naming_arms "5b. the SAME differing cqlite-flight on arm D (not E) is still REFUSED — the exception is keyed on the ARM ID" \
+  "$DSET" A,D A "CROSS-ARM INVARIANTS" "binary_sha256.cqlite-flight" "$E_SHA" "$B_SHA"
+
+# --- 5c. THE REFUSAL DIRECTION, BINARY. The exception is keyed on `cqlite-flight`. Arm E's
+# ws0-scan-bench IS the drift control: if it differs there is nothing left to read the treatment
+# against, so arm E gets no more latitude there than any other arm.
+SBSET="$TMP/set-E-scanbench"
+mkset "$SBSET" 3 A,E 400000 250000 20000 25000
+mut_all_rounds "$SBSET" E binary_provenance.binaries.ws0-scan-bench '{"sha256":"9999"}'
+agg_refuses_naming_arms "5c. arm E with a DIFFERING ws0-scan-bench is REFUSED — the exception does not reach the drift control's binary" \
+  "$SBSET" A,E A "CROSS-ARM INVARIANTS" "binary_sha256.ws0-scan-bench" "'9999'" "DRIFT CONTROL IS GONE"
+
+LGSET="$TMP/set-E-loadgen"
+mkset "$LGSET" 3 A,E 400000 250000 20000 25000
+mut_all_rounds "$LGSET" E binary_provenance.binaries.flight-loadgen '{"sha256":"8888"}'
+agg_refuses_naming_arms "5c. arm E with a DIFFERING flight-loadgen is REFUSED — nor does it reach the client apparatus" \
+  "$LGSET" A,E A "CROSS-ARM INVARIANTS" "binary_sha256.flight-loadgen" "'8888'"
+
+# --- 5d. THE REFUSAL DIRECTION WITH THE EXCEPTION ACTIVE. This is the case that separates a
+# NARROW exception from a DISABLED CHECK: arm E is in the set, so the held-out field is held out
+# — and a cqlite-flight difference between two OTHER arms must STILL refuse. Implemented by
+# comparing that field among the non-E arms, which is a check that exists only because the
+# cross-arm one no longer covers it.
+BSET="$TMP/set-E-plus-B"
+mkset "$BSET" 3 A,B,E 400000 250000 20000 25000
+mut_all_rounds "$BSET" B binary_provenance.binaries.cqlite-flight '{"sha256":"7777"}'
+agg_refuses_naming_arms "5d. with arm E PRESENT, a differing cqlite-flight between arms A and B is STILL REFUSED — the exception did not disable the check" \
+  "$BSET" A,B,E A "cqlite-flight digest DIFFERS between arms other than E" "'7777'" \
+  "Arm E is the ONE permitted exception" "#3248 WITHDREW"
+
+# --- 5e. AND ARM E MAY NOT DIFFER FROM ITSELF. Its digest is out of the cross-arm comparison, so
+# nothing else would notice a rebuild between rounds — and a per-round delta computed across two
+# of arm E's binaries is not one arm's delta. The check is added WITH the exception, not implied
+# by it.
+XSET="$TMP/set-E-rebuilt"
+mkset "$XSET" 3 A,E 400000 250000 20000 25000
+mut "$XSET/r2-E/results.json" binary_provenance.binaries.cqlite-flight '{"sha256":"6666"}'
+agg_refuses_naming_arms "5e. arm E's OWN cqlite-flight changing between rounds is REFUSED — the exception permits differing from the other arms, not from itself" \
+  "$XSET" A,E A "arm E's cqlite-flight changed within the set" "'6666'" "$E_SHA" "r2-E"
+
+# --- 5f. AN ABSENT DIGEST IS COULD-NOT-MEASURE, EVEN FOR THE EXCEPTION ARM. The one field the
+# exception holds out is the one field nothing else would notice missing, so it is `_require`d
+# rather than read with a default.
+NSET="$TMP/set-E-nodigest"
+mkset "$NSET" 3 A,E 400000 250000 20000 25000
+mut "$NSET/r1-E/results.json" binary_provenance.binaries.cqlite-flight __DELETE__
+agg_refuses_naming_arms "5f. arm E with NO recorded cqlite-flight digest is REFUSED naming the field — not waved through by the exception" \
+  "$NSET" A,E A "binary_sha256.cqlite-flight" "NOT RECORDED"
+
+# --- 5g. THE OTHER STATE OF THE DECLARATION. With arm E absent the report must SAY the exception
+# is not in play. Silence would leave a reader unable to tell "it did not apply" from "this build
+# has no exception", and the whole risk of a permitted exception is being read as an invariant.
+out=$(python3 "$AGG" --root "$SET" --arms A,B,C0,C --baseline A); rc=$?
+if [ "$rc" -eq 0 ] && grep -q "exception for arm E (#3997 R3.3) is NOT IN PLAY" <<<"$out" \
+   && grep -q "EVERY arm was required to have measured identical bytes and did" <<<"$out"; then
+  pass "5g. with arm E ABSENT the report DECLARES the exception NOT IN PLAY and the full invariant enforced"
+else
+  fail "5g. the exception's absence must be declared (rc=$rc, out: $(head -14 <<<"$out"))"
+fi
+if ! grep -q "ARM E RAN A DIFFERENT" <<<"$out"; then
+  pass "5g. ...and it does NOT claim an exception nothing used"
+else
+  fail "5g. a set without arm E must not declare the exception applied"
+fi
+
+# --- 5h. THE THREE FILES NAME THE SAME ARM AND THE SAME BINARY. The exception is implemented on
+# one side and granted on the other; two sides silently naming different arms is precisely how a
+# narrow exception becomes a disabled check, and neither file can detect it alone.
+drv_arm=$(grep -oE '^ARM_E="[^"]*"' "$ABC_DRIVER" | head -1 | cut -d'"' -f2)
+drv_bin=$(grep -oE '^ARM_E_BINARY="[^"]*"' "$ABC_DRIVER" | head -1 | cut -d'"' -f2)
+agg_arm=$(grep -oE '^BINARY_EXCEPTION_ARM = "[^"]*"' "$AGG" | head -1 | cut -d'"' -f2)
+agg_bin=$(grep -oE '^BINARY_EXCEPTION_BINARY = "[^"]*"' "$AGG" | head -1 | cut -d'"' -f2)
+if [ -n "$drv_arm" ] && [ "$drv_arm" = "$agg_arm" ]; then
+  pass "5h. the driver's ARM_E ('$drv_arm') and the aggregator's BINARY_EXCEPTION_ARM name the SAME arm"
+else
+  fail "5h. driver ARM_E='$drv_arm' vs aggregator BINARY_EXCEPTION_ARM='$agg_arm' — the exception is granted to a different arm than it is built for"
+fi
+if [ -n "$drv_bin" ] && [ "$drv_bin" = "$agg_bin" ]; then
+  pass "5h. ...and the SAME binary ('$drv_bin'), so the driver's precondition and the aggregator's exception are about one program"
+else
+  fail "5h. driver ARM_E_BINARY='$drv_bin' vs aggregator BINARY_EXCEPTION_BINARY='$agg_bin'"
+fi
+arm_mod_marker=$(grep -oE '^RSS_UNMEASURED = "[^"]*"' "$FLIGHT_ARM" | head -1 | cut -d'"' -f2)
+agg_marker=$(grep -oE '^RSS_UNMEASURED_PREFIX = "[^"]*"' "$AGG" | head -1 | cut -d'"' -f2)
+if [ -n "$arm_mod_marker" ] && [ "$arm_mod_marker" = "$agg_marker" ]; then
+  pass "5h. ...and the UNMEASURED marker prefix is the same string in the producer and the consumer ('$agg_marker')"
+else
+  fail "5h. ws0_flight_arm RSS_UNMEASURED='$arm_mod_marker' vs aggregator RSS_UNMEASURED_PREFIX='$agg_marker' — an unmeasured RSS would land in the wrong branch"
+fi
+
+# --- 5i. THE DRIVER SIDE. Arm E is OPT-IN, dispatched against its OWN --bin-dir, and its binary
+# set is CHECKED on both edges before a rep runs. The stub log is the oracle: it records the argv
+# of every session the driver launched, so which --bin-dir each arm received is MEASURED here
+# rather than read off the source.
+BINS_E="$TMP/bins-e"
+make_bins_e "$BINS_E" "$BINS" jem
+E_OUT="$TMP/out-arm-e"
+out=$(run_abc "$TMP/d-base" --corpus "$CORPUS" --bin-dir "$BINS" --bin-dir-e "$BINS_E" \
+        --out "$E_OUT" --rounds 1); rc=$?
+n=$(stub_invocations)
+if [ "$rc" -eq 0 ] && [ "$n" -eq "$((NARMS + 1))" ]; then
+  pass "5i. --bin-dir-e ADDS arm E: round 1 ran $n sessions, one more than the $NARMS arms the driver declares"
+else
+  fail "5i. --bin-dir-e must add exactly one arm (rc=$rc, invocations=$n, out: $(tail -5 <<<"$out"))"
+fi
+if grep -q "r1-E" "$ABC_STUB_LOG"; then
+  pass "5i. ...and the extra session is arm E's (--out .../r1-E)"
+else
+  fail "5i. arm E's session must be launched (log: $(tr '\n' ' ' < "$ABC_STUB_LOG" | cut -c1-200))"
+fi
+if grep 'r1-E' "$ABC_STUB_LOG" | grep -qF -- "--bin-dir $BINS_E"; then
+  pass "5i. ...and arm E was dispatched against --bin-dir-e's OWN binary set, which is the treatment"
+else
+  fail "5i. arm E must receive --bin-dir-e's directory ($(grep 'r1-E' "$ABC_STUB_LOG"))"
+fi
+if grep 'r1-A' "$ABC_STUB_LOG" | grep -qF -- "--bin-dir $BINS" \
+   && ! grep 'r1-A' "$ABC_STUB_LOG" | grep -qF -- "--bin-dir $BINS_E"; then
+  pass "5i. ...while every other arm still measures --bin-dir's set — arm A got $BINS and not the E one"
+else
+  fail "5i. arm A must still receive --bin-dir (log: $(grep 'r1-A' "$ABC_STUB_LOG"))"
+fi
+# ARM E'S FLAGS ARE ARM A'S FLAGS. Not a nit: `--flight-allocator jemalloc` here would ALSO set
+# LD_PRELOAD, making arm E a preload-AND-link arm — two changes at once, which is the confound
+# arm D was added to break.
+a_flags=$(grep 'r1-A' "$ABC_STUB_LOG" | grep -oE -- '--flight-server-cpus.*$')
+e_flags=$(grep 'r1-E' "$ABC_STUB_LOG" | grep -oE -- '--flight-server-cpus.*$')
+if [ -n "$a_flags" ] && [ "$a_flags" = "$e_flags" ]; then
+  pass "5i. ...and arm E's flight FLAGS are arm A's character for character ('$e_flags') — the binary is the only difference"
+else
+  fail "5i. arm E's flags must equal arm A's (A: '$a_flags' vs E: '$e_flags')"
+fi
+for field in bin_dir_e binary_sha256_e.cqlite-flight binary_sha256_e.ws0-scan-bench \
+             binary_sha256_e.flight-loadgen arm_flags.E; do
+  if grep -q "\"$field\"" "$E_OUT/abc-run.json"; then
+    pass "5i. the run fingerprint records $field, so an arm-E set cannot resume as a different one"
+  else
+    fail "5i. the fingerprint must record $field (have: $(tr -d '\n' < "$E_OUT/abc-run.json"))"
+  fi
+done
+
+# --- 5j. THE DRIVER'S TWO-SIDED PRECONDITION. The aggregator refuses a bad arm-E set too, but
+# only AFTER the set has run — hours on a shared box — so the same facts are established up front
+# from the same digests. Both edges, because an exception with one edge checked is not narrow.
+SAME_E="$TMP/bins-e-same"
+make_bins "$SAME_E" one   # identical bytes to $BINS: cqlite-flight does NOT differ
+refuses_naming "5j. an arm-E binary set whose cqlite-flight is the SAME BYTES is REFUSED — identical bytes make arm E a second LABEL for arm A" \
+  "$TMP/d-base" "SAME BYTES" "cqlite-flight" "second LABEL" -- \
+  --corpus "$CORPUS" --bin-dir "$BINS" --bin-dir-e "$SAME_E" --out "$TMP/out-e-same" --rounds 1
+BAD_E="$TMP/bins-e-bad"
+make_bins "$BAD_E" two    # every binary differs, including the drift control's
+refuses_naming "5j. an arm-E binary set whose ws0-scan-bench ALSO differs is REFUSED — only cqlite-flight may differ" \
+  "$TMP/d-base" "ws0-scan-bench' differs from" "Only cqlite-flight may differ" "drift control" -- \
+  --corpus "$CORPUS" --bin-dir "$BINS" --bin-dir-e "$BAD_E" --out "$TMP/out-e-bad" --rounds 1
+refuses_naming "5j. --bin-dir-e pointing at a NON-DIRECTORY is REFUSED before anything runs" \
+  "$TMP/d-base" "--bin-dir-e" "is not a directory" -- \
+  --corpus "$CORPUS" --bin-dir "$BINS" --bin-dir-e "$TMP/no-such-dir" --out "$TMP/out-e-nodir" --rounds 1
+
+# --- 5k. AND THE DEFAULT IS UNCHANGED. Omitting --bin-dir-e must leave the arm set and the
+# fingerprint exactly as they were before #3997 — an opt-in that silently changes the default is
+# not opt-in, and every case in parts 0-4 rests on that.
+if ! grep -q '"bin_dir_e"' "$OUT/abc-run.json" && ! grep -q '"binary_sha256_e' "$OUT/abc-run.json" \
+   && ! grep -q '"arm_flags.E"' "$OUT/abc-run.json"; then
+  pass "5k. WITHOUT --bin-dir-e the fingerprint carries NO arm-E field, so a pre-#3997 set still resumes"
+else
+  fail "5k. an arm-E-less set must not record arm-E fingerprint fields (have: $(tr -d '\n' < "$OUT/abc-run.json"))"
+fi
+
+# ===========================================================================
+# PART 6 — THE SERVER'S SCAN-END RSS: R6.1's INPUT (#3997)
+# ===========================================================================
+# `VmHWM` is the kernel's PEAK-RSS high-water mark, so a scan-end read IS the rep's peak and is
+# what R6.1's `<= 1.10x arm A` ceiling is about. `VmRSS` at scan end is ONE INSTANTANEOUS SAMPLE.
+# The fixture's arm-E VmHWM is EXACTLY 1.10x arm A's, so the printed ratio has one right answer.
+got=$(cell "$EREPORT" "Server RSS" A "VmHWM kB (median)")
+if [ "$got" = "100,000" ]; then
+  pass "6a. the RSS table prints arm A's VmHWM median (100,000 kB), read from the session's own record"
+else
+  fail "6a. arm A's VmHWM must be 100,000, got '$got'"
+fi
+got=$(cell "$EREPORT" "Server RSS" E "VmHWM kB (median)")
+if [ "$got" = "110,000" ]; then
+  pass "6a. ...and arm E's (110,000 kB)"
+else
+  fail "6a. arm E's VmHWM must be 110,000, got '$got'"
+fi
+got=$(cell "$EREPORT" "Server RSS" E "paired VmHWM vs A")
+if [ "$got" = "1.1000x" ]; then
+  pass "6a. ...and the PAIRED VmHWM ratio vs arm A is 1.1000x — R6.1's figure, read straight off the table"
+else
+  fail "6a. the paired VmHWM ratio must be 1.1000x, got '$got'"
+fi
+# THE TWO QUANTITIES ARE NOT THE SAME COLUMN. The fixture separates them (100,000 vs 80,000), so
+# a swapped or duplicated column is detectable rather than invisible.
+got=$(cell "$EREPORT" "Server RSS" A "VmRSS kB (median, ONE sample per rep)")
+if [ "$got" = "80,000" ]; then
+  pass "6b. VmRSS is its OWN quantity (80,000 kB for arm A), not a second printing of VmHWM"
+else
+  fail "6b. arm A's VmRSS must be 80,000, got '$got'"
+fi
+got=$(cell "$EREPORT" "Server RSS" E "VmRSS kB (median, ONE sample per rep)")
+if [ "$got" = "88,000" ]; then
+  pass "6b. ...and 88,000 kB for arm E"
+else
+  fail "6b. arm E's VmRSS must be 88,000, got '$got'"
+fi
+if grep -q "ONE INSTANTANEOUS SAMPLE" "$EREPORT" && grep -q "do not read it as an average" "$EREPORT"; then
+  pass "6b. ...and the table SAYS VmRSS is one instantaneous sample and not an average, where a reader will see it"
+else
+  fail "6b. the RSS table must state that VmRSS is a single sample"
+fi
+if grep -q "0 UNMEASURED RECOGNISED" "$EREPORT"; then
+  pass "6c. a fully measured set reports an AFFIRMATIVE ZERO ('0 UNMEASURED RECOGNISED'), not a bare 0 or silence"
+else
+  fail "6c. the RSS section must affirm zero unmeasured figures"
+fi
+if grep -q "NOT applied here" "$EREPORT" && grep -q "states no verdict" "$EREPORT"; then
+  pass "6c. ...and the section states the thresholds WITHOUT computing a verdict — the criterion is joint with two terms this tool cannot see"
+else
+  fail "6c. the RSS section must state that it applies no verdict"
+fi
+
+# --- 6d. AN UNMEASURED FIGURE IS A NAMED MARKER, NOT A ZERO AND NOT AN OMISSION. This is the
+# case the whole design is for: an unmeasured RSS and a genuinely tiny RSS must not read alike.
+USET="$TMP/set-E-unmeasured"
+mkset "$USET" 3 A,E 400000 250000 20000 25000
+mut "$USET/r2-E/results.json" measurements.1.server_vm_hwm_kb \
+  "UNMEASURED — /proc/4242/status could not be READ ([Errno 2] No such file or directory)"
+UREPORT="$TMP/report-E-unmeasured.md"
+out=$(python3 "$AGG" --root "$USET" --arms A,E --baseline A --out "$UREPORT"); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "6d. one round's UNMEASURED VmHWM does not abort the report — the throughput half of the set is still readable"
+else
+  fail "6d. an unmeasured RSS must not abort the aggregate (rc=$rc, out: $(tail -3 <<<"$out"))"
+fi
+got=$(cell "$UREPORT" "Server RSS" E "VmHWM kB (median)")
+if [ "$got" = "UNMEASURED (2 of 3 round(s) observed)" ]; then
+  pass "6d. arm E's VmHWM cell reads 'UNMEASURED (2 of 3 round(s) observed)' — the count says it is PARTIAL, not merely absent"
+else
+  fail "6d. the partial cell must name its count, got '$got'"
+fi
+case "$got" in
+  ''|*[!0-9,]*) pass "6d. ...and it is NOT a number: no median over the observed subset stands in for a paired figure the set cannot supply" ;;
+  *) fail "6d. the unmeasured cell rendered as a NUMBER ('$got') — an unmeasured RSS and a measured one must not read alike" ;;
+esac
+got=$(cell "$UREPORT" "Server RSS" E "paired VmHWM vs A")
+if [ "$got" = "NOT MEASURABLE (1 round(s) of E, 0 of A unobserved)" ]; then
+  pass "6d. ...and R6.1's ratio reads 'NOT MEASURABLE', naming how many rounds of each arm were unobserved"
+else
+  fail "6d. the ratio must be NOT MEASURABLE with its counts, got '$got'"
+fi
+got=$(cell "$UREPORT" "Server RSS" E "VmHWM spread")
+if [ "$got" = "n/a (unmeasured)" ]; then
+  pass "6d. ...and its spread is 'n/a (unmeasured)', never a measured-looking 0.00% over the rounds that survived"
+else
+  fail "6d. the spread of a partial series must read n/a (unmeasured), got '$got'"
+fi
+if grep -qF "arm E \`server_vm_hwm_kb\` r2: UNMEASURED — /proc/4242/status could not be READ" "$UREPORT"; then
+  pass "6d. ...and the CAUSE the sampler recorded is printed IN FULL, per round — the remedy is entirely determined by it"
+else
+  fail "6d. the recorded cause must be printed (RSS section: $(sed -n '/## Server RSS/,/^## /p' "$UREPORT" | tail -6 | tr '\n' ' '))"
+fi
+if ! grep -q "0 UNMEASURED RECOGNISED" "$UREPORT"; then
+  pass "6d. ...and the affirmative-zero line is GONE — it cannot be printed by a set that has an unmeasured figure"
+else
+  fail "6d. a set with an unmeasured figure must not claim 0 unmeasured"
+fi
+
+# --- 6e. AN UNMEASURED BASELINE POISONS THE RATIO TOO, in the other direction: the ceiling is a
+# ratio, so a missing DENOMINATOR is just as fatal as a missing numerator.
+BSET2="$TMP/set-E-baseline-unmeasured"
+mkset "$BSET2" 3 A,E 400000 250000 20000 25000
+mut "$BSET2/r1-A/results.json" measurements.1.server_vm_hwm_kb \
+  "UNMEASURED — the pid was gone before the sample"
+out=$(python3 "$AGG" --root "$BSET2" --arms A,E --baseline A --out "$TMP/report-bu.md"); rc=$?
+got=$(cell "$TMP/report-bu.md" "Server RSS" E "paired VmHWM vs A")
+if [ "$rc" -eq 0 ] && [ "$got" = "NOT MEASURABLE (0 round(s) of E, 1 of A unobserved)" ]; then
+  pass "6e. an unmeasured BASELINE round makes arm E's ratio NOT MEASURABLE too — a ceiling with no denominator is not a ceiling"
+else
+  fail "6e. an unmeasured baseline must poison the ratio (rc=$rc, got '$got')"
+fi
+
+# --- 6f. A ZERO IS REFUSED, NOT READ AS A TINY RSS. Zero is precisely the value that satisfies
+# every ratio ceiling there is, so it is the one number that must never reach the table.
+ZSET="$TMP/set-E-zero"
+mkset "$ZSET" 3 A,E 400000 250000 20000 25000
+mut "$ZSET/r1-A/results.json" measurements.1.server_vm_hwm_kb 0
+agg_refuses_naming_arms "6f. a ZERO VmHWM is REFUSED naming the field — zero satisfies every ratio ceiling, so it may not be read as a tiny RSS" \
+  "$ZSET" A,E A "server_vm_hwm_kb" "not usable as a divisor" "satisfy any ceiling"
+
+# --- 6g. AN ABSENT KEY IS COULD-NOT-MEASURE AND IS REFUSED WITH THE FIELD NAMED. The collector
+# writes both keys unconditionally — an unobserved figure is the MARKER — so a session lacking
+# them is one this tool does not model, and a skipped comparison is how R6.1 would go unmeasured
+# behind a green report.
+ASET="$TMP/set-E-absent"
+mkset "$ASET" 3 A,E 400000 250000 20000 25000
+mut "$ASET/r3-E/results.json" measurements.1.server_vm_rss_kb __DELETE__
+agg_refuses_naming_arms "6g. an ABSENT server_vm_rss_kb is REFUSED naming the field, not silently skipped" \
+  "$ASET" A,E A "server_vm_rss_kb" "NOT RECORDED" "Refused rather than skipped"
+
+# --- 6h. A STRING THAT IS NOT A MARKER IS REFUSED. "the record says something else" and "the
+# record says it could not measure" are different states, and only one of them may be published
+# as an absence.
+SSET="$TMP/set-E-badstring"
+mkset "$SSET" 3 A,E 400000 250000 20000 25000
+mut "$SSET/r2-A/results.json" measurements.1.server_vm_hwm_kb "n/a"
+agg_refuses_naming_arms "6h. a VmHWM string that is not an UNMEASURED marker is REFUSED — classified as neither an observation nor an absence" \
+  "$SSET" A,E A "server_vm_hwm_kb" "'n/a'" "is not an"
+
+# --- 6i. THE CLEAN A/E SET ONCE MORE, so no case above passed by leaving a fixture broken.
+out=$(python3 "$AGG" --root "$ESET" --arms A,E --baseline A); rc=$?
+if [ "$rc" -eq 0 ] && grep -q "0 UNMEASURED RECOGNISED" <<<"$out"; then
+  pass "6i. the untouched A/E set is still accepted with every RSS figure observed — every RED arm above differed from THIS control"
+else
+  fail "6i. the clean A/E control must still pass (rc=$rc, out: $(tail -3 <<<"$out"))"
+fi
+
 # ==========================================================================
 # A MINIMUM CHECK COUNT — this file has no `set -e`
 # ==========================================================================
@@ -1130,8 +1570,10 @@ fi
 # case cannot red the suite. RE-DERIVE IT BY RUNNING THE SUITE at each addition, never by
 # counting the source — the loops and helpers multiply, and a source estimate understated a
 # floor by 29 elsewhere in this repo's history.
-# MEASURED: 98 (fingerprint + provenance + configuration + ratio), 105 (+ the F1 fingerprint-absent cases).
-MIN_CHECKS=100
+# MEASURED: 98 (fingerprint + provenance + configuration + ratio), 105 (+ the F1
+# fingerprint-absent cases), 159 (+ #3997's parts 5 and 6 — arm E's cross-arm binary exception in
+# BOTH directions, and the scan-end server RSS R6.1 is read from).
+MIN_CHECKS=150
 if [ "$checks" -lt "$MIN_CHECKS" ]; then
   echo
   echo "FAIL - only $checks check(s) ran; this suite has at least $MIN_CHECKS."
@@ -1142,7 +1584,7 @@ fi
 
 echo
 if [ "$fails" -eq 0 ]; then
-  echo "PASS - all $checks WS0 A/B/C (run fingerprint / session provenance / configuration / ratio) checks fired as specified"
+  echo "PASS - all $checks WS0 A/B/C (run fingerprint / session provenance / configuration / ratio / arm-E binary exception / server RSS) checks fired as specified"
   exit 0
 fi
 echo "FAIL - $fails of $checks check(s) failed"

--- a/scripts/tests/test_ws0_abc_driver_guards.sh
+++ b/scripts/tests/test_ws0_abc_driver_guards.sh
@@ -31,7 +31,11 @@
 #     rounds. A one-directional test cannot tell a narrow exception from a deleted check.
 #     Case 5m is the OTHER half of arm E's premise, and it is not a digest question at all: a
 #     digest difference proves DIFFERENT BYTES and never `jemalloc`, so both binaries are ASKED
-#     for R2.1's `allocator:` line and every unmeasurable answer is a named refusal.
+#     for R2.1's `allocator:` line and every unmeasurable answer is a named refusal — INCLUDING
+#     a well-formed line on the WRONG STREAM. R2.1 puts it on stdout; the first version of that
+#     precondition captured `2>&1` and accepted a stderr-only claim, so the stream is now part
+#     of the contract and is pinned with stdout empty, stdout noisy, and the line split across
+#     the two.
 #   * PART 6 (R6.1) the Flight server's scan-end `VmHWM`/`VmRSS`, per arm, and the property that
 #     an UNMEASURED figure and a genuinely small one do not read alike — a marker naming its
 #     cause, a ratio that reads NOT MEASURABLE, and a refusal for a zero, an absent key or a
@@ -406,6 +410,15 @@ write_flight_stub() {
       __NO_LINE__)   printf '  printf "cqlite-flight 0.0.0-fixture\\n"\n' ;;
       __TWO_LINES__) printf '  printf "allocator: jemalloc\\nallocator: system\\n"\n' ;;
       __NONZERO__)   printf '  printf "allocator: jemalloc\\n"; exit 3\n' ;;
+      # THE STREAM-DISCIPLINE PLANTS (#3997 roborev round 3). R2.1 puts the line on STDOUT;
+      # these three put a perfectly well-formed one where it must NOT count. The first two
+      # differ only in whether stdout is EMPTY or merely innocent, because a fix that keyed on
+      # "stdout was empty" rather than on "stdout carried no matching line" would pass one and
+      # fail the other. The third splits the line ACROSS the streams, which is the shape an
+      # anchored grammar over a merged capture would still have accepted.
+      __STDERR_ONLY__)  printf '  printf "allocator: jemalloc\\n" >&2\n' ;;
+      __STDERR_NOISE__) printf '  printf "cqlite-flight 0.0.0-fixture\\nbuild: fixture\\n"\n  printf "allocator: jemalloc\\n" >&2\n' ;;
+      __SPLIT__)        printf '  printf "allocator: "\n  printf "jemalloc\\n" >&2\n' ;;
       *)             printf '  printf "cqlite-flight 0.0.0-fixture\\nallocator: %s\\n"\n' "$alloc" ;;
     esac
     printf '  exit 0\nfi\nexit 0\n'
@@ -1652,6 +1665,54 @@ chmod -x "$E_NOX/cqlite-flight"
 refuses_naming "5m. a NON-EXECUTABLE arm-E binary is REFUSED naming that cause — a digest can be taken of a file that cannot be asked anything" \
   "$TMP/d-base" "is not EXECUTABLE" "UNMEASURED" "chmod +x" -- \
   --corpus "$CORPUS" --bin-dir "$BINS" --bin-dir-e "$E_NOX" --out "$TMP/out-e-nox" --rounds 1
+
+# THE ALLOCATOR LINE MUST COME FROM STDOUT (#3997 roborev round 3, job 133). The precondition
+# captured `--version` with `2>&1`, so a binary printing a perfectly well-formed
+# `allocator: jemalloc` ONLY on stderr was ACCEPTED — R2.1's contract, and the real CLI, put
+# that line on stdout. This function is the oracle of last resort for arm E's premise, so an
+# oracle that accepts a contract violation is not a weaker oracle: it is the same hole in a
+# different shape, and it admits exactly the malformed build the precondition exists to reject.
+E_STDERR="$TMP/bins-e-stderr-only"
+make_bins_e "$E_STDERR" "$BINS" stderronly __STDERR_ONLY__
+refuses_naming "5m. an arm-E binary printing 'allocator: jemalloc' ONLY ON STDERR is REFUSED — stderr can satisfy nothing, whatever it says" \
+  "$TMP/d-base" "printed 0 line(s) matching" "stdout: EMPTY" "DIAGNOSTIC ONLY" -- \
+  --corpus "$CORPUS" --bin-dir "$BINS" --bin-dir-e "$E_STDERR" --out "$TMP/out-e-stderr" --rounds 1
+# ...AND WITH STDOUT NON-EMPTY, which is the case that separates a real fix from one keyed on
+# "stdout was empty": the question is whether stdout carried a MATCHING line, not whether it
+# printed anything.
+E_STDERR2="$TMP/bins-e-stderr-noise"
+make_bins_e "$E_STDERR2" "$BINS" stderrnoise __STDERR_NOISE__
+refuses_naming "5m. ...and still REFUSED when stdout carries unrelated output, so the check is 'no MATCHING line on stdout' and not 'stdout was empty'" \
+  "$TMP/d-base" "printed 0 line(s) matching" "build: fixture" "stderr | allocator: jemalloc" -- \
+  --corpus "$CORPUS" --bin-dir "$BINS" --bin-dir-e "$E_STDERR2" --out "$TMP/out-e-stderr2" --rounds 1
+# ...AND A LINE SPLIT ACROSS THE TWO STREAMS is refused, which is the shape an anchored grammar
+# over a MERGED capture would have accepted: `allocator: ` on stdout, `jemalloc` on stderr.
+E_SPLIT="$TMP/bins-e-split-streams"
+make_bins_e "$E_SPLIT" "$BINS" split __SPLIT__
+refuses_naming "5m. ...and a line SPLIT across stdout and stderr is REFUSED — the two streams are never rejoined, so neither half completes the other" \
+  "$TMP/d-base" "printed 0 line(s) matching" "stdout | allocator: " -- \
+  --corpus "$CORPUS" --bin-dir "$BINS" --bin-dir-e "$E_SPLIT" --out "$TMP/out-e-split" --rounds 1
+# AND THE CONTROL SIDE IS ASKED WITH THE SAME DISCIPLINE — a stderr-only answer from --bin-dir
+# is no more an answer than one from --bin-dir-e. The check is a property of the function, and
+# the function is called twice.
+CTRL_STDERR="$TMP/bins-control-stderr"
+make_bins "$CTRL_STDERR" one __STDERR_ONLY__
+E_FOR_CS="$TMP/bins-e-for-ctrl-stderr"
+make_bins_e "$E_FOR_CS" "$CTRL_STDERR" cs
+refuses_naming "5m. a CONTROL whose allocator line is on STDERR is refused too — stream discipline is a property of the function, which is called for both sides" \
+  "$TMP/d-base" "--bin-dir cqlite-flight" "printed 0 line(s) matching" "stdout: EMPTY" -- \
+  --corpus "$CORPUS" --bin-dir "$CTRL_STDERR" --bin-dir-e "$E_FOR_CS" --out "$TMP/out-ctrl-stderr" --rounds 1
+# AND THE DIAGNOSTIC NAMES THE STREAM, which is what makes the refusal actionable: a reader who
+# cannot tell which stream carried the line cannot check the diagnosis, and an unlabelled dump
+# is the `2>&1` merge again, one layer up.
+out=$(run_abc "$TMP/d-base" --corpus "$CORPUS" --bin-dir "$BINS" --bin-dir-e "$E_STDERR" \
+        --out "$TMP/out-e-stderr-lbl" --rounds 1); rc=$?
+if [ "$rc" -ne 0 ] && grep -qE '^ +stderr \| allocator: jemalloc$' <<<"$out" \
+   && ! grep -qE '^ +stdout \| allocator: jemalloc$' <<<"$out"; then
+  pass "5m. ...and the refusal REPRINTS the stderr line LABELLED as stderr, never as stdout — the operator can see where the claim came from"
+else
+  fail "5m. the diagnostic must label the stream (rc=$rc, out: $(grep -E 'stdout|stderr' <<<"$out" | head -4))"
+fi
 
 # AND THE CHECK IS PART OF THE OPT-IN, NOT OF THE DEFAULT. Without --bin-dir-e no allocator is
 # asked of anything, so a pre-#3997 A/B/C0/C/D set behaves exactly as it did — the same property


### PR DESCRIPTION
> **MERGE POSTURE — mechanism-only slice, by lead ruling on `req-3997-01` Q1 (2026-09-06).**
> R3.1, R3.2 and R6.1 are **unmet in this PR and that is authorized**: they are **justified-partial by lead ruling**, deferred to the measurement slice **#4120**. A `spec-auditor` (C) run against the sealed spec is *expected* to report those three `unmet` — that is the correct result, not a defect. `default = []`, so the feature reaches nobody until #4120 decides it. #3997 stays OPEN until the measurement lands; telemetry is stamped `--slice` with `closed_at: null`.
>
> Follow-ups filed from this lane: **#4120** (the measurement + the default decision) · **#4121** (perf-rig: ask the control binary its allocator on every run) · **#4122** (revisit CPU pinning, design-driven) · **#4123** (infra: the `github-coord-worker` skill is missing on this box).

**Part of #3997 — deliberately NOT a closing reference.** No closing keyword appears anywhere in this body, because #3997 MUST stay open: the linked-build measurement and the default-flip decision are not here and cannot be taken in this lane. (GitHub honours a closing keyword regardless of any qualifier next to it — "closes #N partially" still closes #N — so the safe form is the only form used here.)

OpenSpec change: `openspec/changes/flight-jemalloc/` (proposal · design · `specs/flight-allocator/spec.md` · tasks), Seam 1 approved by the owner 2026-09-05, `resume-dont-ask` sealed.

## What this does

`cqlite-flight`'s **server binary** may now link jemalloc as its `#[global_allocator]`, behind a **non-default** `jemalloc` Cargo feature. `default = []` — so this PR ships the allocator to **nobody**. The feature exists, is opt-in, and is inert until a measurement says otherwise.

| Requirement | State |
|---|---|
| **R1** — linked allocator behind a feature, confined to the bin target | ✅ met |
| **R2** — the allocator in use is observable from outside the process | ✅ met |
| **R3.3** — arm E is the ONE permitted cross-arm binary exception | ✅ met |
| **R4** — structural confinement is gate-enforced | ✅ met |
| **R5** — no library consumer, binding or other crate inherits it | ✅ met |
| **R3.1 / R3.2** — the linked-build A/E measurement, and the default decided by it | ❌ **UNMET — rig only** |
| **R6.1** — `VmHWM` ≤ 1.10× arm A at N=1 and peak N | ❌ **UNMET — rig only** |
| **R6.2** — the `memory-budget` dhat ratchet still runs unchanged | ✅ met (untouched; no test binary carries the allocator) |

### The mechanism

`tikv-jemallocator` **0.6.1**, `optional`, declared under `[target.'cfg(target_os = "linux")'.dependencies]`, enabled by feature `jemalloc`. Installed in `cqlite-flight/src/main.rs` and nowhere else, so the **library** target — what `tools/flight-loadgen`, the benches and every integration test link — carries no allocator, and neither does `cqlite-core`, the CLI, or any binding.

**The version pin was verified, not inferred from the crate version.** `tikv-jemallocator 0.6.1` → `tikv-jemalloc-sys 0.6.1+5.3.0-1-ge13ca993…`, whose `+` build metadata names the vendored jemalloc release, corroborated independently by the vendored `jemalloc/ChangeLog` (newest entry `5.3.0 (May 6, 2022)`) and by `build.rs` passing that metadata to jemalloc's `configure --with-version`. #3551 `LD_PRELOAD`ed the rig's distro `libjemalloc.so.2`, which is **5.3.0** — same release, as task 0.3 requires. The newer `0.7` line bundles **5.3.1**; taking it would have made the linked build a different allocator release from the one the baseline was measured against.

### Observability (R2)

`cqlite-flight` had **no `--version` flag at all** before this change, so R2.1 meant adding the flag, not adding a line to one.

```
$ cqlite-flight --version
cqlite-flight 0.16.1
allocator: jemalloc      # or `system`
```

plus `allocator=<same value>` on the startup `info` line. Both derive from **one `const ALLOCATOR`**, and that const deliberately lives in `main.rs` next to the install site rather than in the library — because the library sees `feature = "jemalloc"` even in a **test** binary, where `main.rs` is not compiled and no allocator is installed, so a library-side const would report `jemalloc` for a process running on the system allocator.

## Enforcement — and a gate fact that shaped it

**The gate runs `cqlite-flight` at `--lib --bins` only** and prints a census of the ~42 integration `--test` targets it does not run (#3384). So the spec-named `cqlite-flight/tests/issue_3997_allocator_surface.rs` **does not execute in the gate**; it lands because the spec names it and because a developer and the rig lane run it, and its module header says so in as many words. The merge-gating surface is two shell guards registered in `run_tooling_tests` (`scripts/agent-gate.sh:19673`, `:19701`):

- **`test_flight_allocator_link.sh`** (R1.1/R1.2/R2.1, both feature states) — builds each arm and asserts on **the artifact that arm's own build produced**, resolved from `cargo build --message-format=json`'s own attestation, never the well-known `target/debug/cqlite-flight` path that the other arm also writes. Measured here:
  - positive: `cargo attests features [default,jemalloc]` → **824 JEMALLOC SYMBOLS RECOGNISED** of 213867 symbol lines, `allocator: jemalloc`
  - negative: `cargo attests features [default]` → **0 JEMALLOC SYMBOLS RECOGNISED** of 197030, `allocator: system`
  - SKIPs naming the cause off-Linux or on a host lacking cargo/`cc`/`make`/`nm`/a `-k`-capable `timeout`; a **failed build is a FAIL, never a SKIP**; a zero symbol count is only accepted when the reader produced a non-empty symbol table, so an unmeasured read cannot read as clean.
- **`test_flight_allocator_confinement.sh`** (R4.1/R5.1) — static, needs no cargo, never SKIPs: `verdict PASS — 37 global_allocator occurrence(s) RECOGNISED: 25 install site(s) + 12 prose mention(s)`; **1 production site** (`cqlite-flight/src/main.rs`, feature-gated) + 2 `cfg(test)` + 22 under `tests/`/`examples/`; `tikv-jemallocator` named by no manifest outside the permitted set; every `cqlite-flight` dependent on the **library** target. It **refuses rather than guesses** on an unclassifiable shape, and it carries a **positive control** (`..._selftest.sh`, 21 cases) because a guard nobody has watched fail is a guard nobody knows works.

## What this PR does NOT establish — read this before reading any number

**#3551's +29.21% is NOT a claim about this feature and is not quoted as one anywhere in the diff.** Every #3551 arm was an **`LD_PRELOAD` into one binary** — deliberately, since that is what let the "identical bytes across arms" invariant hold. A linked `#[global_allocator]` is a different artifact: different initialization order, static-vs-dynamic symbol resolution, and different work before `main`. The linked A-vs-E measurement is the whole point of R3, and **it has not been run.**

**This lane cannot run it.** The measurement needs the #3551 rig `ip-172-31-7-163`; this lane is on `ip-172-31-5-53` and the rig is unreachable from it (`ssh` → `Permission denied (publickey)`). Per the lead's 2026-09-05 instruction, groups 0–2 land and the measurement is handed off in-thread. Consequently **a `spec-auditor` (C) run against this spec must report R3.1, R3.2 and R6.1 as unmet** — that is correct and expected, not a defect to be argued away. `default = []` is what makes it safe to land ahead of them.

### Rig-ready, so the handoff is "run it", not "build it"

Tasks 3.2/3.3 are done here because they are deterministic code whose guards run off-rig:

- arm **E** in `scripts/perf/ws0-3551-abc.sh`, opt-in via a second frozen binary set;
- the **ONE named cross-arm binary exception** in `ws0_abc_aggregate.py` — keyed to arm `E` **and** to `cqlite-flight` specifically, still refusing a differing `ws0-scan-bench`/`flight-loadgen`, still refusing any other arm pair differing, still refusing arm E's own binary changing between rounds, **and now refusing arm E's binary being IDENTICAL to the shared one** (a roborev finding: otherwise `bins-E/` built from the control binary passes every check while the report claims a jemalloc arm — the #3248 defect class);
- `VmHWM`/`VmRSS` sampling in `ws0_flight_arm.py`, three-valued (measured / `UNMEASURED — <cause>` / refusal), never a `0` — R6.1 is a ratio ceiling and zero satisfies every ceiling there is;
- **the sampler's call site** in `scripts/perf/lib-measure.sh`. It arrived as a collector with nothing calling it, which left R6.1 undecidable; the position is forced rather than chosen — after `perf_stat_c` closes the counted window, before `stop_server` destroys the `/proc` entry that is the only source of both numbers.

**Deviation from tasks.md 3.2, recorded deliberately:** the flag is `--bin-dir-e DIR`, not `--flight-binary <E>`. No `--flight-binary` exists in the rig, and the digest the aggregate reads is derived from `--bin-dir` — so a per-binary override would launch one program and record another's digest, granting R3.3's exception against the wrong bytes. R3.3 names no flag, so this deviates from the task wording only.

**Rig recipe:** build `bins-A/` (all three binaries, `--no-default-features`), then `bins-E/` = the `--features jemalloc` `cqlite-flight` plus hardlinks/copies of `bins-A`'s `ws0-scan-bench` and `flight-loadgen`; the driver refuses the set otherwise. With `--bin-dir-e` the set is **6 arms/round** (A,B,C0,C,D,E) — there is no `--arms` selector — and the aggregate is then run `--arms A,E --baseline A` (the driver prints that command).

**Rig-only confirmations nobody has made yet — reasoned, not measured:** that a `tikv-jemallocator`-linked binary leaves **no** `libjemalloc` mapping, which is what lets arm E run under `--flight-allocator system` and still pass `verify_flight_server_allocator`'s per-rep `/proc/<pid>/{environ,maps}` check; real `VmHWM`/`VmRSS` magnitudes under load; the digest precondition against real cargo output; and that `refuse_binaries_older_than_head` accepts two separately-built bin dirs.

## Scope decisions inherited from the lead's ruling, not re-litigated here

- **Allocator only. The pin change is OUT.** #3551 arm B: the pin alone is **−19.25%**, so bundling it would ship a change whose sign depends on the other half landing correctly; pinning is a deployment/topology concern needing its own design. Arm C's extra gain motivates a separate issue against epic #2817.
- **Binary, never the library.** A `#[global_allocator]` is process-global with exactly one per process, so a library declaring one imposes it on every embedder with no override — and CQLite is embedded via PyO3, napi-rs and (M6) WASM inside host runtimes that own their own allocator.
- **jemalloc, not mimalloc** — mimalloc has no measurement on this workload, and the kill criterion says every multiplier is measured, not modelled.

## Gate + review

- `--lite` **PASS** at `79b37cfb` (`tree-integrity: PASS`, `dirty: no`, 422 tests) — full gate of record runs once in the endgame, per the implement loop.
- roborev review-first round: job **131**, 2 findings, both triaged **blocker** and both fixed (the arm-E identical-digest hole above, and a partially-sampled arm publishing a measured-looking median with a `VmHWM`-only census standing in for `VmRSS`). Re-reviewed after the fix — a fix changes bytes, so the earlier round is void.
- **The ONE thing still blocking this PR is `prompt-content: FAIL`, and it needs a lead/owner waiver that I am deliberately not self-granting.** On job 135 the code is clean (`findings: NONE`, `roborev-exit: PASS`) and the terminal `RESULT: FAIL` is caused by nothing else.
  - Round 1 was `1/16` absent — only **`Cargo.lock`**, dropped by roborev's compiled-in lockfile deny-list.
  - Rounds 2-5 are **`16/16`** absent, which is the documented **#3252** signature: the diff outgrew inline delivery and is handed over by snapshot pointer. First suspect ruled out — the root checkout's `.roborev.toml` `exclude_patterns` is a prose/artifact deny-list (`*.md` plus `docs/**/*-artifacts` binaries) and cannot account for 16 code paths.
  - The reviews are genuine on the evidence the tool itself says a human should weigh — token accounting across the rounds: `396k/316k`, `610k/533k`, `607k/542k`, `469k/396k`, `468k/399k` input/cached, against a vacuous baseline of `~18.7k input / 0 cached`; `review-completed`, `vacuity-tier1` and `vacuity-tier2` PASS in every round; and rounds 1-4 each returned substantive, reproducible findings, which a review that received nothing cannot do.
  - A waiver must anchor **job 135 / head `8d8575fc4`** (base `043cc16d98f19af21`). It must NOT be written against an earlier head: every prior round was voided by the fix that followed it.

## Declared residuals

Named here rather than left to be found, because each is a place a reader could over-trust the output.

1. **A published RSS number carries no evidence of its own completeness.** The completeness rule is enforced at the **producer** — an arm-level figure is a median iff there is at least one rep *and* every rep supplied a measured value for *that field*; otherwise it is the `UNMEASURED — <cause>` marker with the counts in the cause. The per-field census (`server_rss_reps_measured_vm_hwm_kb` / `_vm_rss_kb`, replacing the old single `VmHWM`-derived count) is **diagnostic only: the aggregator does not read it.** `read_rss_fields` catches an absent key and a non-marker string, but it cannot catch a number whose census contradicts it — so a *different* producer writing a subset median with an incomplete census would be believed. That is a deliberate trade: one enforcement point in one file, versus a second cross-file contract on the same value that could drift from the figure beside it. No arm-E artifact exists yet (the arm has never run), so nothing is in that state today.
2. **The per-field asymmetry is by design, not a gap.** `VmHWM` complete + `VmRSS` partial ⇒ the `VmHWM` median and R6.1's ratio are published while the `VmRSS` cell reads `UNMEASURED`; the reverse ⇒ the `VmHWM` cell reads `UNMEASURED`, the ratio reads `NOT MEASURABLE`, and the `VmRSS` median is published. Each figure is complete for its own field, and **R6.1's ceiling is `VmHWM`-only**, so a `VmRSS` hole cannot contaminate it. Both directions are pinned (cases 6k/6l).
3. **A labelling tension in the printed table, pre-existing and not introduced here.** A *complete* `VmRSS` series is medianed across reps and rounds, while `RSS_SAMPLE_TIMING_NOTE` says not to average `VmRSS` and call the result an average RSS. The column is labelled `VmRSS kB (median, ONE sample per rep)` and **R6.1 does not read it**, so this is a naming tension in a diagnostic column rather than a defect in a decision input.

At the abc driver's `--reps 1`, completeness is 1-of-1, so the new rule bites as a whole-arm marker; the partial case appears only at `--reps > 1`.

4. **A linked-jemalloc `--bin-dir` would make arms A/B/C0/C/D silently jemalloc arms.** The reported-allocator precondition fires **only** when `--bin-dir-e` is given, so a non-E set is behaviourally identical to the pre-#3997 driver. This is **named in the code** (`scripts/perf/ws0-3551-abc.sh:195-196`) and covered by nothing. It is deliberately NOT closed here: closing it means asking the control's allocator unconditionally, which changes behaviour for every non-E run, and that is #3551'"'"'s rig contract rather than this issue'"'"'s scope. Proposed as a follow-up. (It looks sound — every #3551 arm took its allocator from `LD_PRELOAD`, so every arm'"'"'s *binary* should report `allocator: system`, making an unconditional control check compatible with the existing arms rather than a break.)
5. **One deliberately unreachable branch.** The driver'"'"'s same-bytes digest refusal is now **shadowed** by the allocator precondition upstream (identical bytes cannot report two different allocators). It is retained as defence in depth against a reordering, annotated `DO NOT DELETE THIS BRANCH AS DEAD`, and **no test asserts its text** — deliberately, since an assertion that cannot fire is the vacuous-pass shape. The digest-identity refusal'"'"'s reachable, tested home is the aggregator (case 5l), which runs standalone over a session directory and executes no binaries, so it has no allocator oracle available at all. **Ordering ruling:** the allocator pair stays before `mkdir -p "$OUT"`; measured against the pre-fix driver, that ordering is what prevents a multi-hour set running on a false premise, and making an error message reachable is not worth trading it.

## Review coverage — stated exactly, including what did not happen

- **roborev, two review-first rounds, three blockers, all fixed and pinned.** Each round is voided by the fix that follows it (a fix changes bytes), so only the last round's verdict can certify; the final round runs again in the endgame after the gate of record.
  - **job 131** at `79b37cfb` — 2 findings. (a) `ws0_abc_aggregate.py` never checked that arm E's `cqlite-flight` digest actually DIFFERS from the shared one, so `bins-E/` built from the control binary passed every check while the report claimed a jemalloc arm. (b) `ws0_flight_arm.py` published a median whenever *any* rep was sampled, so a partially-sampled arm read as complete, with a `VmHWM`-only census standing in for `VmRSS`.
  - **job 132** at `197ed207a` — 1 finding, and the sharpest of the lane: **arm E was accepted as the linked-jemalloc treatment on a digest DIFFERENCE alone**, which proves "different bytes" and not "jemalloc". Any unrelated rebuild passed, and nothing downstream caught it — the arm runs under `--flight-allocator system`, and `verify_flight_server_allocator`'s `/proc/<pid>/maps` check is **structurally blind to a statically linked allocator** (that blindness is the very property letting arm E carry the `system` label). The measurement deciding this feature'"'"'s default could have attributed run-to-run noise to the allocator. Fixed by asking each binary: the driver now requires the control to report `allocator: system` and arm E to report `allocator: jemalloc`, using R2.1'"'"'s anchored **exactly-one-line** grammar, bounded, and refusing **before the first side effect**. That is what requirement R2 is for — and it retires the residual "a linked binary leaves no `libjemalloc` mapping", which was reasoned and never measured, by removing the need to infer anything.
  - **job 133** at `03c09efc4` — 1 finding. `require_reported_allocator` merged stderr into stdout (`2>&1`), so a binary emitting the allocator line **only on stderr** satisfied a contract that is stdout-only, and the line count was taken from the merged text too. Fixed by capturing the streams separately and matching and counting **stdout alone**; stderr is still reprinted in refusals through one helper that labels each stream and states affirmatively when one is empty. A failed `mktemp -d` is its own refusal rather than a merge fallback — a fallback would restore the defect on exactly the host where nobody looks. A further shape was found while fixing it: with no trailing newline after `allocator: ` on stdout, the *merged* stream read as a valid line, so split-across-streams had been accepted too.
  - **job 134** at `fbabb12df` — 1 finding, **Low**: unmeasured markers were validated by `startswith("UNMEASURED")`, so a bare word, `UNMEASUREDgarbage` and an empty cause all passed against the documented `UNMEASURED — <cause>` contract, misclassifying a corrupt artifact as an ordinary absence. Fixed as a **grammar** (exact prefix + non-empty cause) in **both** readers, kept independent rather than coupled by an import — their *agreement* is pinned by import in the test, in both directions, over an 8-case accept/reject table. The aggregate now also splits the refusal in two, because the remedies differ (a value carrying the word without its form is a **corrupt record**; an arbitrary string is a session the tool does not model), and the producer refuses to *mint* a causeless marker.
  - **job 135** at `8d8575fc4` — **`findings: NONE`, `roborev-exit: PASS`.** The code is roborev-clean.
  - roborev rated rounds 1-3 **Medium** and round 4 **Low**. The lane triaged the first four as **blocker** — the first three because each let the rig publish a measurement it never made (the #3248 defect class, whose machine-code sub-claim was withdrawn for exactly that), and the fourth for a mechanical reason rather than a severity one: one open finding of any severity drives roborev's terminal `RESULT: FAIL`, which is a blocked merge, so batching a nit into a follow-up would only move the triage onto the closer after a full gate had been spent.
  - **The four findings were one class, narrowing each round:** something weaker accepted as evidence of jemalloc — identical bytes as a distinct arm, then different-but-unrelated bytes as jemalloc, then a stderr line as a stdout contract, then a malformed marker as a legitimate absence. Round 5 finding-free is what convergence looks like; the Rust surface drew no finding in any round.
  - **RED controls measured, not assumed.** Against the pre-fix driver, 11 of the 12 new allocator-precondition checks fail, and one reproduces the actual harm: the whole set running with a glibc arm E. The twelfth is the opt-in no-change control, which correctly passes in both states. Guard suite grew **162 → 219** checks over the four rounds (`test_ws0_abc_driver_guards.sh`, floor **205**), every count re-verified by the lane against the repo rather than taken from a report — which mattered: one intermediate commit was reported as moving the floor to 196 and in fact shipped it at 185 (a dropped hunk in the author's own edit script). The suite was green throughout and no verified figure was wrong, but the floor was looser than advertised for two commits. Both entries are restored and the author now reads the file back and asserts content after writing.
- **`rust-reviewer` did NOT deliver.** The agent went idle three times without returning a report (it ended its turns with plain text rather than sending a message). Rather than record a coverage claim nobody earned: the Rust was reviewed by the lane directly — the two `ALLOCATOR` cfg arms are exact negations, so no target gets both or neither; no `unwrap`/`expect` in library code; the surface test asserts **exactly one** matching line rather than "at least one"; and `-V`/`--version` were verified empirically to agree and to exit 0 with no `--data-dir`. Backing that: two independent roborev rounds over the same diff, neither of which found anything in the Rust. **A dedicated Rust review would have swept more broadly than the lane did** — that is a known, named gap, not an equivalence.
- Every figure quoted in this PR body was measured by the lane against this repo, not taken from a subagent's report.

## Platform honesty

Linux gets the allocator; every other target falls back to system malloc. The dependency is declared under a `cfg(target_os = "linux")` target section **and** the install site is cfg-gated to match, so an off-Linux `--features jemalloc` build is **inert, not broken** — and no correctness anywhere is gated on the allocator being present. The two `ALLOCATOR` cfg arms are exact negations of one another, so no target can get both or neither.

## Bindings

Unaffected by construction — no `Cargo.toml` under `bindings/` names `tikv-jemallocator` and none depends on `cqlite-flight`, both asserted by the confinement guard rather than assumed.

