### PR TITLE
docs(#3723): the AC2 prose had decayed into being false — correct it, and pin the counts so it cannot happen a sixth time

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_value/fixed_width.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_value/fixed_width.rs
@@ -65,11 +65,14 @@
 //!
 //! A UDT field's length header decides whether a field is absent (`-1`), present
 //! and empty (`0`) or present with bytes. Five sites route the `0`:
-//! `parse_udt_value` and `raw_type_value.rs`'s UDT arm through
-//! `create_empty_value_for_type`, and `parse_nested_udt_from_registry`,
-//! `parse_inline_udt_value` and `raw_type_value.rs`'s registry arm by calling a
-//! field decoder with an explicit `&[]`. Before #3847 the first two answered
-//! "empty BLOB" and the other three answered `Err`; all five now answer `null`.
+//! `parse_udt_value`, `parse_nested_udt_from_registry`, `parse_inline_udt_value`
+//! and `raw_type_value.rs`'s two UDT arms (marshal/inline and registry-resolved).
+//! All five hand it to the SAME delegate today,
+//! `typed_value.rs::parse_simple_udt_field_value_at`, with an explicit `&[]`, and
+//! all five answer `null`. They did not always: before #3847 `parse_udt_value` and
+//! `raw_type_value.rs`'s marshal/inline arm routed through
+//! `create_empty_value_for_type` — a function since DELETED (#3631/PR#3820) — and
+//! answered "empty BLOB", while the other three answered `Err`.
 //! An `Err` there was the worse of the two, because `row_data.rs` `break`s its
 //! column loop on a failing column, so the failing column AND every later one
 //! silently became null.

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_value/issue_3847_empty_fixed_width_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_value/issue_3847_empty_fixed_width_tests.rs
@@ -239,14 +239,14 @@ fn an_empty_duration_is_still_refused_declared_residual_of_3847() {
 // `typed_value.rs::parse_simple_udt_field_value_at`, with an explicit `&[]`; what
 // differs is the dispatch that reaches it, so a loop widened in one arm and not the
 // other is exactly how rounds 1 and 2 of this review found real defects.
+// Kept end-to-end rather than helper-level on the wiring-evidence rule: green
+// helper-only unit tests are not sufficient.
 //
 // (An earlier revision of this note named `create_empty_value_for_type` as the
 // marshal arm's route. No such function exists any more — #3631/PR#3820 replaced it,
 // and the per-type rule it used to carry now lives once, in
 // `typed_value/scalar_rules.rs::empty_is_a_value`. The two-route reasoning above is
 // unchanged; only the name was stale.)
-// Kept end-to-end rather than helper-level on the wiring-evidence rule: green
-// helper-only unit tests are not sufficient.
 // ---------------------------------------------------------------------------
 
 /// `pair(a int, b int)` in MARSHAL form. Field names are hex: `70616972` =

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_value/issue_3847_empty_fixed_width_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_value/issue_3847_empty_fixed_width_tests.rs
@@ -11,17 +11,22 @@
 //! `smallint`, `tinyint`, `date` and `time` — gates writes, not reads, and is not
 //! this path's oracle. See `raw_value/fixed_width.rs` for the full statement.
 //!
-//! # What these cases pin, and why the THREE widths are one test each
+//! # What these cases pin, and why each width that matters is its own test
 //!
 //! Before #3847 the composed accepted set of this path was exactly `{n}`: the
 //! width guard refused `len < n` and the arm's reported consumption `n` made the
 //! caller's fully-consumed assert refuse `len > n`. It is now `{n, 0}`, and the
 //! `0` half only works because the arm reports `0` CONSUMED — report `n` there
 //! and the fully-consumed assert refuses the value the width guard just admitted.
-//! So each type is driven at all four widths that matter: `0` (⇒ `Null`), the
+//! So each type is driven at every width that matters — `0` (⇒ `Null`), the
 //! under-widths `1..n` (still refused), exactly `n` (⇒ the value), and `n + 1`
-//! (still refused, by consumption). Widening one half without the other is a
-//! defect that a `0`-only case cannot see.
+//! (still refused, by consumption) — one test per width, each named for the
+//! width it drives: `an_empty_buffer_decodes_to_null_for_every_fixed_width_scalar`,
+//! `a_partial_buffer_is_still_refused`,
+//! `an_exactly_n_byte_buffer_still_decodes_to_a_value` and
+//! `an_over_width_buffer_is_still_refused_by_the_consumption_assert`. The names are
+//! spelled rather than counted, so this paragraph cannot decay against the file.
+//! Widening one half without the other is a defect that a `0`-only case cannot see.
 //!
 //! Driven through `parse_value_from_raw_bytes` — the bounded entry point that
 //! CARRIES the fully-consumed assert — never through the reporting twin, because
@@ -194,8 +199,10 @@ fn an_empty_component_of_a_tuple_decodes_to_null() {
 /// DECLARED RESIDUAL — `duration` is NOT in #3847's scope and is NOT widened
 /// here, and this case pins that so the gap is measured rather than assumed.
 ///
-/// `duration` is variable-width (three signed VInts), so it is not one of the 11
-/// fixed-width arms. Cassandra splits on it: `DurationSerializer.validate` is
+/// `duration` is variable-width (three signed VInts), so it is not a fixed-width
+/// arm at all — it appears nowhere in the `FIXED_WIDTH` table above, whose extent
+/// is pinned by `the_fixed_width_table_covers_every_arm` rather than restated in
+/// prose here. Cassandra splits on it: `DurationSerializer.validate` is
 /// `< 3` and REJECTS empty, while `DurationSerializer.deserialize:61-63` returns
 /// `null` for empty like every other type. By this path's own oracle
 /// (`deserialize`, not `validate`) an empty `duration` should therefore decode to
@@ -226,25 +233,33 @@ fn an_empty_duration_is_still_refused_declared_residual_of_3847() {
 // deleted, because the REASON these two cases exist is unchanged.
 //
 // `raw_type_value.rs` has two zero-length branches reachable only THROUGH
-// `parse_value_from_raw_bytes`, and they use DIFFERENT routing helpers — the
-// marshal/inline arm calls `create_empty_value_for_type` while the registry arm
-// calls a field decoder with an explicit `&[]`. Two helpers, so two ways to
-// diverge, which is exactly how rounds 1 and 2 of this review found real defects.
+// `parse_value_from_raw_bytes` — the marshal/inline UDT arm and the
+// registry-resolved arm — and each one carries its OWN separately-written
+// field-header loop. Both hand the zero-length field to the SAME delegate today,
+// `typed_value.rs::parse_simple_udt_field_value_at`, with an explicit `&[]`; what
+// differs is the dispatch that reaches it, so a loop widened in one arm and not the
+// other is exactly how rounds 1 and 2 of this review found real defects.
+//
+// (An earlier revision of this note named `create_empty_value_for_type` as the
+// marshal arm's route. No such function exists any more — #3631/PR#3820 replaced it,
+// and the per-type rule it used to carry now lives once, in
+// `typed_value/scalar_rules.rs::empty_is_a_value`. The two-route reasoning above is
+// unchanged; only the name was stale.)
 // Kept end-to-end rather than helper-level on the wiring-evidence rule: green
 // helper-only unit tests are not sufficient.
 // ---------------------------------------------------------------------------
 
 /// `pair(a int, b int)` in MARSHAL form. Field names are hex: `70616972` =
 /// "pair", `61` = "a", `62` = "b". Reaches `raw_type_value.rs`'s marshal/inline
-/// UDT arm, whose zero-length branch routes through
-/// `create_empty_value_for_type`.
+/// UDT arm, whose zero-length branch delegates to
+/// `parse_simple_udt_field_value_at` with an explicit `&[]`.
 const MARSHAL_PAIR: &str = "org.apache.cassandra.db.marshal.UserType(issue_3847_ks,70616972,\
 61:org.apache.cassandra.db.marshal.Int32Type,\
 62:org.apache.cassandra.db.marshal.Int32Type)";
 
 /// A parser whose registry resolves the BARE name `pair` — the route to
-/// `raw_type_value.rs`'s registry arm, whose zero-length branch calls
-/// `parse_simple_udt_field_value` with an explicit `&[]`.
+/// `raw_type_value.rs`'s registry arm, whose own field-header loop calls that same
+/// `parse_simple_udt_field_value_at` with an explicit `&[]`.
 fn parser_with_pair_registry() -> V5CompressedLegacyParser {
     let mut reg = crate::schema::UdtRegistry::new();
     reg.register_udt(
@@ -291,7 +306,8 @@ fn a_zero_length_field_of_a_marshal_form_udt_decodes_to_null() {
 }
 
 /// FIFTH site: the registry-resolved arm, end to end. Distinct from the fourth
-/// because it routes through a DIFFERENT helper.
+/// because it reaches the shared delegate through a DIFFERENT dispatch arm, with its
+/// own field-header loop.
 #[test]
 fn a_zero_length_field_of_a_registry_resolved_udt_decodes_to_null() {
     let value = parser_with_pair_registry()

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_value/issue_3847_empty_fixed_width_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_value/issue_3847_empty_fixed_width_tests.rs
@@ -5,7 +5,7 @@
 //!
 //! `docs/round-artifacts/issue-3847-cassandra-oracle.md`, read at the pinned
 //! `cassandra-5.0.8` tag: `TypeSerializer.deserialize` maps an empty buffer to
-//! `null` for all twelve fixed-width scalars, with no per-type exceptions, and
+//! `null` for every fixed-width scalar, with no per-type exceptions, and
 //! `BooleanSerializer.serialize(null)` emits `EMPTY_BYTE_BUFFER`, so empty is the
 //! on-the-wire spelling of null. `validate()` — which DOES reject empty for
 //! `smallint`, `tinyint`, `date` and `time` — gates writes, not reads, and is not
@@ -64,16 +64,19 @@ const FIXED_WIDTH: &[(&str, usize)] = &[
     ("time", 8),
 ];
 
-/// The table above must cover all ELEVEN `require_fixed_width` call sites named
-/// in #3847 — a case floor, so a span-replacing edit that silently drops rows
-/// reds instead of reporting a green tally over a shrunken table (#3544's
-/// lesson). 15 spellings over 11 arms.
+/// The table above must cover EVERY `require_fixed_width` call site in
+/// `raw_value/reporting.rs`, the arm set #3847 names — a case floor, so a
+/// span-replacing edit that silently drops rows reds instead of reporting a green
+/// tally over a shrunken table (#3544's lesson). The arm count is deliberately
+/// not restated in prose: a hand-maintained census decays (it did, twice, in the
+/// sibling `nested_fixed_width_length_tests.rs`). The one number below is
+/// admissible because the assertion PINS it — it cannot drift silently.
 #[test]
 fn the_fixed_width_table_covers_every_arm() {
     assert_eq!(
         FIXED_WIDTH.len(),
         15,
-        "the table must carry all 15 spellings of the 11 fixed-width arms"
+        "the table must carry all 15 spellings the fixed-width arms accept"
     );
     let widths: Vec<usize> = FIXED_WIDTH.iter().map(|(_, n)| *n).collect();
     for n in [1usize, 2, 4, 8, 16] {

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_value/nested_fixed_width_length_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_value/nested_fixed_width_length_tests.rs
@@ -99,9 +99,10 @@
 //! the WRITE rule and non-uniform; this is a READ path, whose oracle is
 //! `deserialize()` — uniform across every serializer in that table, where an EMPTY
 //! buffer IS the wire spelling of `null`
-//! (`docs/round-artifacts/issue-3847-cassandra-oracle.md`, read at the pinned tag). **#3847 (`a5171a5ba`) made this path match it**, the four
-//! `validate()`-strict types included, so the accepted set at the VALUE positions is
-//! `{n, 0}`, pinned by
+//! (`docs/round-artifacts/issue-3847-cassandra-oracle.md`, read at the pinned
+//! tag). **#3847 (`a5171a5ba`) made this path match it**, the four
+//! `validate()`-strict types included, so the accepted set at the VALUE positions
+//! is `{n, 0}`, pinned by
 //! `zero_length_fixed_width_element_decodes_to_null_at_the_three_value_positions`.
 //! What remains is not a width difference: a KEY-LIKE member (map key, set member)
 //! accepts `0` too, but can never answer `Null` — Cassandra has no null map key — so

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_value/nested_fixed_width_length_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_value/nested_fixed_width_length_tests.rs
@@ -834,12 +834,15 @@ fn one_field_udt(ft: CqlType) -> Vec<(String, CqlType)> {
 /// `zero_length_fixed_width_element_decodes_to_null_at_the_three_value_positions`.
 /// Those are two of THREE INDEPENDENT answers to the empty-fixed-width question,
 /// and nothing enforces that they keep agreeing: this bounded path's uniform
-/// `{n, 0}` RULE (`raw_value/fixed_width.rs`'s `admissible_at_least` — one rule for
-/// every type, not a per-type table), the typed/UDT path's `empty_is_a_value` table
-/// (`row_decoder/typed_value/scalar_rules.rs`), and the cell-path KEY's own
-/// `validate()`-oracle table (`row_decoder/complex_column/cell_path_key.rs`), which
-/// stays `{n}` for the four strict types. The SCOPE note in
-/// `raw_value/fixed_width.rs` states that coupling.
+/// `{n, 0}` RULE (`raw_value/fixed_width.rs`'s `admissible_at_least`, which admits the
+/// same two widths for every type), the typed/UDT path's `empty_is_a_value`
+/// (`row_decoder/typed_value/scalar_rules.rs` — also uniform, a `matches!` over the
+/// spellings for which an empty buffer is a real value rather than null), and the
+/// cell-path KEY's `validate()`-oracle table
+/// (`row_decoder/complex_column/cell_path_key.rs::cql_short_allowed_widths` — the one
+/// that genuinely IS per-type), which stays `{n}` for the four strict types. The SCOPE
+/// note in `raw_value/fixed_width.rs` names two of those answers; the third is stated
+/// separately, in that same file's `THE CELL-PATH KEY` section.
 ///
 /// The case fails in BOTH directions: if any of the five stops refusing a
 /// non-zero wrong width, and if a correct width stops decoding to its declared

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_value/nested_fixed_width_length_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_value/nested_fixed_width_length_tests.rs
@@ -41,10 +41,16 @@
 //! Issue **#3811** landed first and made that guard unnecessary: every bounded
 //! caller reaches `parse_value_from_raw_bytes`, a thin wrapper over
 //! `raw_value::reporting`'s consumption-reporting twin plus
-//! `require_fully_consumed`. Composed with each arm's own
-//! `require_fixed_width` (`data.len() < n`), the ACCEPTED SET IS EXACTLY `{n}`:
-//! `len == 0` and `len < n` are refused under-width, while `len > n` leaves
-//! `len - n` bytes unconsumed and is refused by the caller's assert. The property
+//! `require_fully_consumed`. **UNTIL #3847** each arm's own `require_fixed_width`
+//! guard was `data.len() < n`, and the composed accepted set WAS exactly `{n}`:
+//! `len == 0` and `len < n` were both refused under-width. **THAT IS NO LONGER
+//! TRUE OF EITHER HALF.** #3847 replaced the guard with `admissible_at_least`
+//! (`raw_value/fixed_width.rs`), which maps an EMPTY slice to
+//! `FixedWidthCell::Null` and reports `0` consumed, so the composed accepted set
+//! is now `{n, 0}` — see the ZERO-LENGTH note at the end of this header for the
+//! oracle and the key-like exception. What is unchanged: `len` in `1..n` is
+//! refused under-width, and `len > n` leaves `len - n` bytes unconsumed and is
+//! refused by the caller's assert. The property
 //! AC1 and AC3 assert is therefore enforced on THAT PATH by #3811's mechanism,
 //! and these cases pin it for every fixed-width type at the five nesting
 //! positions [`nesting_positions`] enumerates — coverage #3811's own tests
@@ -90,12 +96,13 @@
 //!
 //! The ZERO-length case is NO LONGER a narrowing. The table above is `validate()`,
 //! the WRITE rule and non-uniform; this is a READ path, whose oracle is
-//! `deserialize()` — uniform across all twelve, where an EMPTY buffer IS the wire
+//! `deserialize()` — uniform across every serializer in that table, where an
+//! EMPTY buffer IS the wire
 //! spelling of `null` (`docs/round-artifacts/issue-3847-cassandra-oracle.md`, read
 //! at the pinned tag). **#3847 (`a5171a5ba`) made this path match it**, the four
 //! `validate()`-strict types included, so the accepted set at the VALUE positions is
 //! `{n, 0}`, pinned by
-//! `zero_length_fixed_width_element_decodes_to_null_at_the_four_value_positions`.
+//! `zero_length_fixed_width_element_decodes_to_null_at_the_three_value_positions`.
 //! What remains is not a width difference: a KEY-LIKE member (map key, set member)
 //! accepts `0` too, but can never answer `Null` — Cassandra has no null map key — so
 //! it is kept OPAQUELY as an empty blob (#3747), pinned by
@@ -317,16 +324,16 @@ fn wrong_declared_length_is_refused_at_every_nesting_position() {
     }
 }
 
-/// AC2, POST-#3847: a ZERO-length fixed-width element DECODES TO NULL at the four
-/// VALUE positions — it is no longer refused.
+/// AC2, POST-#3847: a ZERO-length fixed-width element DECODES TO NULL at the
+/// THREE non-key-like positions — it is no longer refused.
 ///
 /// **This replaces a characterisation test #3723 deliberately did not endorse.**
 /// Its own comment read: *"The 'or 0' family is refused because
 /// `require_fixed_width` is `data.len() < n` — a PRE-EXISTING divergence from
 /// Cassandra, tracked as #3847; this case characterises it, it does not endorse
 /// it."* #3847 closed that divergence, so the expectation FLIPS here rather than
-/// the test being deleted: #3723's coverage (all fifteen types x every nesting
-/// position) is kept and only the asserted answer moves. The old name asserted a
+/// the test being deleted: #3723's coverage (every type in [`FIXED_WIDTH_TYPES`] x
+/// every nesting position) is kept and only the asserted answer moves. The old name asserted a
 /// refusal, so it could not survive the flip — a name is a claim about behaviour.
 ///
 /// Oracle: `deserialize()`, uniformly, at the pinned `cassandra-5.0.8` tag — every
@@ -335,11 +342,18 @@ fn wrong_declared_length_is_refused_at_every_nesting_position() {
 /// `date`, `time` reject empty there); that asymmetry is why the cell-path KEY
 /// table stays strict while this VALUE path does not.
 ///
-/// The MAP KEY position is excluded and has its own case below.
+/// TWO of the positions [`nesting_positions`] enumerates are excluded, not one:
+/// the MAP KEY **and the SET MEMBER**, because Cassandra stores a set member in the
+/// CELL PATH exactly as it stores a map key. Both have their own case below. That
+/// leaves the three the name states — the list element, the map VALUE and the tuple
+/// field — and those three are PINNED BY NAME at the end of the loop rather than
+/// counted in prose, so this count cannot decay (it did: the name said "four" while
+/// the predicate skipped two, roborev job 134).
 #[test]
-fn zero_length_fixed_width_element_decodes_to_null_at_the_four_value_positions() {
+fn zero_length_fixed_width_element_decodes_to_null_at_the_three_value_positions() {
     let p = parser();
     for (t, _width) in FIXED_WIDTH_TYPES {
+        let mut ran: Vec<String> = Vec::new();
         for (label, type_str, build) in nesting_positions(t) {
             if label.contains("key") || label.contains("set<") {
                 continue; // KEY-LIKE positions (map key, set member) are the sibling case
@@ -351,7 +365,10 @@ fn zero_length_fixed_width_element_decodes_to_null_at_the_four_value_positions()
                     panic!("{t} at {label}: #3847 admits a 0-byte element; got {e:?}")
                 });
             let element = match &decoded {
-                Value::List(xs) | Value::Set(xs) | Value::Tuple(xs) => xs
+                // No `Value::Set` arm: the SET position is key-like and excluded
+                // above, so it is unreachable here — the `other` arm below panics
+                // if that ever changes.
+                Value::List(xs) | Value::Tuple(xs) => xs
                     .first()
                     .unwrap_or_else(|| panic!("{t} at {label}: container empty"))
                     .clone(),
@@ -367,7 +384,22 @@ fn zero_length_fixed_width_element_decodes_to_null_at_the_four_value_positions()
                 Value::Null,
                 "{t} at {label}: an empty fixed-width element is NULL, not a refusal"
             );
+            ran.push(label);
         }
+        // I1: the enumeration is PINNED BY NAME, not merely counted. Without this
+        // the label predicate above (or a label string in `nesting_positions`)
+        // could drift, the loop skip EVERY position, and the case still pass green
+        // having compared nothing — the "assert per case" rule one level in.
+        // MEASURED, not assumed: three positions run, the two KEY-LIKE ones do not.
+        assert_eq!(
+            ran,
+            vec![
+                format!("frozen<list<{t}>>"),
+                format!("frozen<map<text,{t}>> value"),
+                format!("tuple<{t},text>"),
+            ],
+            "{t}: exactly the three NON-key-like positions must run, in order"
+        );
     }
 }
 
@@ -387,6 +419,7 @@ fn zero_length_fixed_width_element_decodes_to_null_at_the_four_value_positions()
 fn zero_length_fixed_width_key_like_member_is_opaque_never_null() {
     let p = parser();
     for (t, _width) in FIXED_WIDTH_TYPES {
+        let mut ran: Vec<String> = Vec::new();
         for (label, type_str, build) in nesting_positions(t) {
             if !(label.contains("key") || label.contains("set<")) {
                 continue;
@@ -418,7 +451,21 @@ fn zero_length_fixed_width_key_like_member_is_opaque_never_null() {
                 Value::blob(Vec::new()),
                 "{t} at {label}: preserved opaquely, as the cell-path key is"
             );
+            ran.push(label);
         }
+        // I1, as in the value case: pinned BY NAME so the predicate cannot drift
+        // into skipping everything. These two sets PARTITION the positions
+        // [`nesting_positions`] enumerates, so a position added there, removed, or
+        // relabelled fails one of the two cases — which is what keeps the "five"
+        // in that helper's doc from decaying into a stale hand-maintained count.
+        assert_eq!(
+            ran,
+            vec![
+                format!("frozen<set<{t}>>"),
+                format!("frozen<map<{t},text>> key"),
+            ],
+            "{t}: exactly the two KEY-LIKE positions must run, in order"
+        );
     }
 }
 
@@ -781,9 +828,15 @@ fn one_field_udt(ft: CqlType) -> Vec<(String, CqlType)> {
 /// reads as null via `accessor.isEmpty(value) ? null : …`. It is the same
 /// disposition `empty_is_a_value` encodes, and since #3847 (`a5171a5ba`) the
 /// bounded `raw_value` path AGREES with it rather than diverging — see
-/// `zero_length_fixed_width_element_decodes_to_null_at_the_four_value_positions`.
-/// The two answers still come from two INDEPENDENT tables (the SCOPE note in
-/// `raw_value/fixed_width.rs`); nothing enforces that they keep agreeing.
+/// `zero_length_fixed_width_element_decodes_to_null_at_the_three_value_positions`.
+/// Those are two of THREE INDEPENDENT answers to the empty-fixed-width question,
+/// and nothing enforces that they keep agreeing: this bounded path's uniform
+/// `{n, 0}` RULE (`raw_value/fixed_width.rs`'s `admissible_at_least` — one rule for
+/// every type, not a per-type table), the typed/UDT path's `empty_is_a_value` table
+/// (`row_decoder/typed_value/scalar_rules.rs`), and the cell-path KEY's own
+/// `validate()`-oracle table (`row_decoder/complex_column/cell_path_key.rs`), which
+/// stays `{n}` for the four strict types. The SCOPE note in
+/// `raw_value/fixed_width.rs` states that coupling.
 ///
 /// The case fails in BOTH directions: if any of the five stops refusing a
 /// non-zero wrong width, and if a correct width stops decoding to its declared

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_value/nested_fixed_width_length_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_value/nested_fixed_width_length_tests.rs
@@ -88,12 +88,18 @@
 //! typed decoder, whose `empty_is_a_value` reads Cassandra's
 //! `accessor.isEmpty(value) ? null : …` guard. The same case characterises it.
 //!
-//! CQLite is therefore NARROWER than Cassandra for every `… or 0` row of the table above,
-//! whose `validate` admits an EMPTY buffer (`Int32Serializer.java`
-//! `size(value) != 4 && !isEmpty(value)`, deserializing to Java `null`). That
-//! divergence PREDATES both issues, is deliberate, and is tracked as **#3847**;
-//! `zero_length_fixed_width_element_is_refused_at_every_nesting_position` below
-//! characterises it rather than endorsing it.
+//! The ZERO-length case is NO LONGER a narrowing. The table above is `validate()`,
+//! the WRITE rule and non-uniform; this is a READ path, whose oracle is
+//! `deserialize()` — uniform across all twelve, where an EMPTY buffer IS the wire
+//! spelling of `null` (`docs/round-artifacts/issue-3847-cassandra-oracle.md`, read
+//! at the pinned tag). **#3847 (`a5171a5ba`) made this path match it**, the four
+//! `validate()`-strict types included, so the accepted set at the VALUE positions is
+//! `{n, 0}`, pinned by
+//! `zero_length_fixed_width_element_decodes_to_null_at_the_four_value_positions`.
+//! What remains is not a width difference: a KEY-LIKE member (map key, set member)
+//! accepts `0` too, but can never answer `Null` — Cassandra has no null map key — so
+//! it is kept OPAQUELY as an empty blob (#3747), pinned by
+//! `zero_length_fixed_width_key_like_member_is_opaque_never_null`.
 
 use super::*;
 
@@ -772,10 +778,11 @@ fn one_field_udt(ft: CqlType) -> Vec<(String, CqlType)> {
 /// that is not part of what #3631 closed: an empty field carries
 /// `ByteBufferUtil.EMPTY_BYTE_BUFFER`, which every one of those serializers
 /// reads as null via `accessor.isEmpty(value) ? null : …`. It is the same
-/// disposition `empty_is_a_value` encodes, and it is the OPPOSITE of the
-/// bounded-path treatment `zero_length_fixed_width_element_is_refused_at_every_nesting_position`
-/// characterises under #3847 — the asymmetry is real and is asserted here so it
-/// cannot change unnoticed.
+/// disposition `empty_is_a_value` encodes, and since #3847 (`a5171a5ba`) the
+/// bounded `raw_value` path AGREES with it rather than diverging — see
+/// `zero_length_fixed_width_element_decodes_to_null_at_the_four_value_positions`.
+/// The two answers still come from two INDEPENDENT tables (the SCOPE note in
+/// `raw_value/fixed_width.rs`); nothing enforces that they keep agreeing.
 ///
 /// The case fails in BOTH directions: if any of the five stops refusing a
 /// non-zero wrong width, and if a correct width stops decoding to its declared

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_value/nested_fixed_width_length_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_value/nested_fixed_width_length_tests.rs
@@ -225,7 +225,8 @@ fn nesting_positions(t: &str) -> Vec<NestingPosition> {
 
 /// Did `err` come from one of the TWO halves of #3811's composed width rule?
 ///
-/// * UNDER-width (including zero): `reporting::require_fixed_width` —
+/// * UNDER-width — a length in `1..n`, since #3847 admits `0` as null:
+///   `reporting::require_fixed_width` —
 ///   `"Frozen element '<col>': need <n> byte(s) for <what>, got <len>"`.
 /// * OVER-width: `require_fully_consumed` —
 ///   `"Bounded value '<col>' of type '<t>' decoded only <n> of <len> byte(s)"`.

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_value/nested_fixed_width_length_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_value/nested_fixed_width_length_tests.rs
@@ -42,15 +42,16 @@
 //! caller reaches `parse_value_from_raw_bytes`, a thin wrapper over
 //! `raw_value::reporting`'s consumption-reporting twin plus
 //! `require_fully_consumed`. **UNTIL #3847** each arm's own `require_fixed_width`
-//! guard was `data.len() < n`, and the composed accepted set WAS exactly `{n}`:
-//! `len == 0` and `len < n` were both refused under-width. **THAT IS NO LONGER
-//! TRUE OF EITHER HALF.** #3847 replaced the guard with `admissible_at_least`
+//! guard was `data.len() < n`, and composed with the consumption assert the
+//! accepted set WAS exactly `{n}` — `len == 0` and `len < n` alike refused
+//! under-width. **NEITHER of those two statements holds today**, and the guard
+//! is the reason: #3847 replaced it with `admissible_at_least`
 //! (`raw_value/fixed_width.rs`), which maps an EMPTY slice to
-//! `FixedWidthCell::Null` and reports `0` consumed, so the composed accepted set
-//! is now `{n, 0}` — see the ZERO-LENGTH note at the end of this header for the
-//! oracle and the key-like exception. What is unchanged: `len` in `1..n` is
-//! refused under-width, and `len > n` leaves `len - n` bytes unconsumed and is
-//! refused by the caller's assert. The property
+//! `FixedWidthCell::Null` and reports `0` consumed, so **the composed accepted
+//! set is now `{n, 0}`** — see the ZERO-LENGTH note at the end of this header for
+//! the oracle and the key-like exception. What is unchanged: `len` in `1..n` is
+//! still refused under-width, and `len > n` still leaves `len - n` bytes
+//! unconsumed and is refused by the caller's assert. The property
 //! AC1 and AC3 assert is therefore enforced on THAT PATH by #3811's mechanism,
 //! and these cases pin it for every fixed-width type at the five nesting
 //! positions [`nesting_positions`] enumerates — coverage #3811's own tests
@@ -96,10 +97,9 @@
 //!
 //! The ZERO-length case is NO LONGER a narrowing. The table above is `validate()`,
 //! the WRITE rule and non-uniform; this is a READ path, whose oracle is
-//! `deserialize()` — uniform across every serializer in that table, where an
-//! EMPTY buffer IS the wire
-//! spelling of `null` (`docs/round-artifacts/issue-3847-cassandra-oracle.md`, read
-//! at the pinned tag). **#3847 (`a5171a5ba`) made this path match it**, the four
+//! `deserialize()` — uniform across every serializer in that table, where an EMPTY
+//! buffer IS the wire spelling of `null`
+//! (`docs/round-artifacts/issue-3847-cassandra-oracle.md`, read at the pinned tag). **#3847 (`a5171a5ba`) made this path match it**, the four
 //! `validate()`-strict types included, so the accepted set at the VALUE positions is
 //! `{n, 0}`, pinned by
 //! `zero_length_fixed_width_element_decodes_to_null_at_the_three_value_positions`.
@@ -333,8 +333,10 @@ fn wrong_declared_length_is_refused_at_every_nesting_position() {
 /// Cassandra, tracked as #3847; this case characterises it, it does not endorse
 /// it."* #3847 closed that divergence, so the expectation FLIPS here rather than
 /// the test being deleted: #3723's coverage (every type in [`FIXED_WIDTH_TYPES`] x
-/// every nesting position) is kept and only the asserted answer moves. The old name asserted a
-/// refusal, so it could not survive the flip — a name is a claim about behaviour.
+/// every nesting position) is kept and only the asserted answer moves. The old
+/// name asserted a refusal, so it could not survive the flip — a name is a claim
+/// about behaviour, which is also why this one had to be renamed again when its
+/// position count turned out to be wrong (roborev job 134).
 ///
 /// Oracle: `deserialize()`, uniformly, at the pinned `cassandra-5.0.8` tag — every
 /// fixed-width `TypeSerializer` maps an EMPTY buffer to null, the wire spelling of


### PR DESCRIPTION
## What this is

Issue #3723's **AC2 documentation half** — the last item of its own scope. The mechanism shipped long ago (#3811, and #3847 for the zero-length disposition); what remained was that this issue's own prose had decayed into being **false**, and was citing a test that does not exist.

**This PR deliberately declares NO closing reference for #3723.** Whether that P1 closes is a lead call, and the `inet` gap below needs a tracker first (see "Not closing" at the bottom).

## The defect

`raw_value/nested_fixed_width_length_tests.rs` — shipped by #3723 itself — asserted in the present tense that CQLite is **"NARROWER than Cassandra"** on the zero-length case and that the divergence is **"tracked as #3847"**. **#3847 merged** (`a5171a5ba`, PR #4017) and removed that fact: the accepted set at the bounded surface is now `{n, 0}`, not `{n}`. A second passage asserted a bounded-vs-UDT-field **asymmetry** that the same change removed. Both cited `zero_length_fixed_width_element_is_refused_at_every_nesting_position` — **a test that exists nowhere in the tree.**

The root cause is worth stating, because it is the fifth instance on this issue: **the claim was true when written and false by the time it shipped.** #3847 landed underneath it. Same mechanism as the `break` claim the C intent audit caught, where the falsifying merge was this branch's own.

## What changed — prose and pinning assertions only

**No production source. No existing assertion's meaning changed.** 3 files, +138/-49.

1. **The false claims corrected** — the zero-length note now states the current rule (`{n, 0}` at the value positions), credits #3847/`a5171a5ba` in the past tense, and cites only tests that exist. The `validate()`-vs-`deserialize()` distinction is the load-bearing argument: the table is the WRITE rule and non-uniform, this is a READ path whose oracle is `deserialize()`, uniform 12-of-12 per `docs/round-artifacts/issue-3847-cassandra-oracle.md` at the pinned tag.
2. **A count that was off by one, found in review** — `..._at_the_four_value_positions` runs **three** positions: its loop skips both `key` and `set<`. The first draft of this fix *propagated that bad count into the header*. Renamed to `..._three_value_positions` after **measuring** it with an instrumented counter rather than trusting the review.
3. **The counts are now pinned, not hand-maintained** — both zero-length cases `assert_eq!` their exact position set **by name**, and the two sets **partition** `nesting_positions` (3 + 2 = 5). So the "five" that used to be prose is now a test that breaks. The assertions were verified **discriminating** by failing them against an empty expectation; previously either loop could have skipped every position and passed green.
4. **Four hand-maintained censuses deleted, not corrected** (12 rows / 13 names / 15 spellings / 11 arms). They had already decayed twice (r10, r20/job 113). Per #3229 — *remove the mechanism rather than carve it a fourth time* — they are replaced with universals, pointers, or spelled names, following the pattern this module already demonstrated: **"The names are spelled rather than counted."** The one surviving number is admissible only because an assertion pins it.
5. **A dead function name in three files** — `create_empty_value_for_type` was cited in the **present tense** and exists nowhere. The role is performed today by `parse_simple_udt_field_value_at` (`typed_value.rs:159`), called with an explicit `&[]` by all five UDT framing sites. A branch whose whole purpose is deleting a citation to a nonexistent test must not ship a citation to a nonexistent function.

## Verification

| stage | result |
|---|---|
| `--lite` (final, `f937cd339`) | **`RESULT: PASS`** — `tree-integrity: PASS`, `dirty: no`, 5/5 components, `scoped-tests` verified **3900 tests / 171 binaries** |
| rust-reviewer r1 (`9bf2383b8`) | 2 blockers, 2 important, 1 nit — **all fixed** |
| roborev **job 134** (`9bf2383b8`) | `RESULT: FAIL`, `findings: PRESENT (1)` — **independently the same blocker** as the reviewer's B2. Fixed |
| rust-reviewer r2 (`5f15071c6`) | all five prior items **FIXED**, counts re-derived from source, **no blockers**; 2 important + 3 nits — all fixed |
| roborev **job 135** (`5f15071c6`) | `RESULT: PASS`, **`findings: NONE`**, `code-free: PASS`, `sha-assert: PASS`, vacuity tier1+tier2 PASS, `prompt-content: PASS (2/2)`, input 80102 tokens (genuine band, not the ~18.7k vacuous baseline) |

**Job 135 does NOT certify this merge** — three commits postdate it. The binding roborev round runs **last**, after the gate of record, per #3752.

Three round-2 confirmations worth recording, each a way this fix could have been quietly wrong: `len in 1..n` at `n == 1` (`tinyint`/`boolean`) is **vacuously true, not false**; the over-width refusal is correctly attributed to the caller's `require_fully_consumed` rather than to `require_fixed_width`, since `admissible_at_least` returns `Bytes` for any `len >= n`; and **no fourth answer exists** — the offset-advancing decoders cannot express an empty fixed-width value, so "three independent answers" is exhaustive rather than merely where someone stopped counting.

`--delta` is **ineligible** here and was not re-probed: a `#[cfg(test)] mod` inside the lib classifies `[PRODUCTION]`, which this issue measured on its previous slice. A full gate is the only route.

## AC7 re-verified against a moving base

`origin/main` advanced three times during this work. `66e9957cc` (#3805 slice 1, PR #4033) touched **`complex_column/cell_path_key.rs` — AC7's own evidence file**. Re-checked: AC7 **still holds**. #4033 added only an empty-buffer (`len == 0`) admission returning `Value::Empty(tag)` ahead of the decode; it changed no consumption or trailing-byte rule, and composites and `duration` resolve `for_cql_type == None` so they keep their outcome. All 14 tests that paragraph names are grepped-present.

## Not closing, and one gap that needs an owner

- **Site 6** (a shadow/TTL-dropped element is `continue`d before decode) is **not** #3723 scope. It is carried by open **#3778**, and the shipped tests say so in their own identifiers (`..._known_gap_3778`). Correction to #3778's closing census: it locates Site 6 at `complex_column/element_decode.rs`, **which does not exist on `origin/main`** — the sites are `complex_column.rs:542/:620/:769/:901`.
- **The `inet` width/empty divergence** (Cassandra 5.0.8 admits `4|16`; this decoder admits any length) is declared and characterised but **tracked by no issue at all**. It goes dark the day #3723 closes. Proposed as a follow-up in `COORD-REQ:3723-11`; filing at finalize.

Refs #3723. Refs #3847, #3811, #3778, #4038.
