### PR TITLE
docs(#4128): the 27 hours are after the code is written — SDLC audit, intent, and slice 1 spec

### DIFF
--- a/docs/development/ai-native-sdlc-redesign.md
+++ b/docs/development/ai-native-sdlc-redesign.md
@@ -1,0 +1,177 @@
+# AI-Native SDLC Redesign for CQLite
+
+Date: 2026-09-04
+Method: nine parallel read-only audits of the whole SDLC surface, measured against the AI-native SDLC playbook (https://claude.com/blog/the-ai-native-sdlc-playbook).
+
+## The finding in one paragraph
+
+CQLite has already solved the build problem.  The median time from issue to open pull request is about 4 hours.  The median time from open to merge is 34.2 hours.  So review and certification take 27 of those 34 hours.  The repo pays for that delay with 362,265 lines of process machinery, and the machinery does not earn it: the gate of record passes 98.5% of the time, so it almost never catches anything, while 71.4% of pull requests still need rework.  The rework comes from the review layer, not the gate.
+
+## Measured surface
+
+| Area | Size | Source |
+|---|---|---|
+| CI workflow YAML | 13,160 lines, 42 files | `.github/workflows/` |
+| `.github/` non-workflow | 5,168 lines | `.github/` |
+| Shell and Python scripts | 249,178 lines, 249 files | `scripts/` |
+| `scripts/agent-gate.sh` alone | 23,837 lines, 39 components | `scripts/agent-gate.sh:6264` |
+| `scripts/tests/` | 149,644 lines, 135 files | `scripts/tests/` |
+| `.claude/` config | 14,830 lines, 27 skills | `.claude/` |
+| OpenSpec artifacts | 79,929 lines, 108 specs | `openspec/` |
+| `CLAUDE.md` | 687 lines | `CLAUDE.md` |
+| Happy-path agent instructions | 2,333 lines | `CLAUDE.md` + `worker.md` + `flow-*` + `flow-lead`/`flow-closer` |
+| ALL-CAPS imperatives in those files | 146 | `rg` over the same set |
+
+## Measured delivery, from 590 records
+
+Source: `docs/reports/delivery-telemetry.jsonl`.
+
+| Measure | Value |
+|---|---|
+| Median cycle time, open to merge | 34.2 hours |
+| Median issue to pull request | ~4 hours |
+| Median time in review | ~27 hours |
+| Pull requests needing rework | 71.4% (421 of 590) |
+| Mean rework rounds per pull request | 3.32 |
+| Mean roborev findings per pull request | 6.92 |
+| Gate pass rate | 98.5% (581 pass, 8 fail) |
+| Telemetry share of last 200 commits | 44% (88 commits) |
+
+## Diagnosis
+
+### The gate is the constraint, and it is serialized at one
+
+`bootstrap-agent-machine.sh` persists `CQLITE_GATE_MAX_CONCURRENCY=1` (`docs/development/pm-operating-loop.md:146`).  The lite gate runs 1.4 minutes warm on a narrow diff, 20 minutes median on a `cqlite-core/src/` change, and up to 104 minutes under load.  The full gate runs 45 to 120 minutes.  One box therefore certifies two to five changes an hour at best, no matter how many agents run.  19 worktrees exist; a single author drives them.  The worktrees queue, they do not run in parallel.
+
+### Merge authority sits on a laptop, not in CI
+
+24 workflows fire on a pull request.  One is registered as merge-gating (the `flight` tier).  The other 23 are declared exempt in `.github/ci-gating-tiers.yml:156-518`, each deferring its "merge-gating half" to a component of the local `agent-gate.sh`.  GitHub has thousands of parallel runner-minutes available and the design declines them.  Meanwhile CI reruns the same work advisorily: `clippy` in 7 workflows, `cargo fmt` in 4, `cqlite-core` tests in 9.
+
+### There is no fast inner loop
+
+`make dev-check` is the advertised fast path.  It runs `cargo clippy --all-features --all-targets` undiffed plus `llvm-cov`.  Nothing in the Makefile reliably finishes in under five minutes.  The playbook's Test stage depends on the agent verifying its own work between edits; without a sub-two-minute check, every verification is a batch job, and the agent either waits or guesses.
+
+### Prose does the work that hooks should do
+
+The orchestration layer carries 146 ALL-CAPS imperatives across 2,333 lines of happy-path instruction.  It mandates exact return formats (`==== LITE SUMMARY ====`, at most 5 lines), a summary-file redirect so the agent never reads raw stdout, park-and-exit at every checkpoint, and re-verification after every change.  Each of these was written to stop a weaker model from drifting, inventing a verdict, or idling in a poll loop.  The playbook's rule applies: a skill or a prose rule is advisory, and a policy that must always hold needs a hook behind it.  The deterministic parts here are genuinely good and should stay: `scripts/flow/claim.sh` takes a server-side ref lock, and `premerge-assert.sh` fails closed.  The prose repetition around them is dead weight.
+
+### The one hook that exists cannot fail
+
+`.claude/settings.json:59-71` registers a `TaskCompleted` hook that runs `agent-gate.sh --lite` with a 600-second timeout and fails open.  Its own comments record it as "defused for #2671."  So the only hook in the repo is advisory, and the real control is a 12-to-104-minute batch job at the end.
+
+### Bookkeeping outweighs product change
+
+44% of the last 200 commits are `chore(#NNNN): delivery telemetry record for PR #NNNN`, each landing as its own pull request.  The ledger is read by exactly one consumer, `scripts/delivery-telemetry.py retro`, which files a `flow-meta` issue for the top recurring failure.  That consumer does not need one commit per delivery.
+
+### Dead and duplicated machinery
+
+| Item | Lines | Status |
+|---|---|---|
+| `.github/issue-monitoring/` | 2,321 | No CI job invokes it; README claims a 6-hour schedule |
+| `.github/test-quality-gates.sh` | 593 | Manual only |
+| `.github/hooks/pre-commit` | 755 | Opt-in, duplicates CI |
+| 5 orphan `e2e_*` scripts | 1,887 | Zero callers |
+| `tarpaulin.toml` | 33 | Two conflicting floors (35.0 and 80.0); nothing reads it |
+| `make coverage` | n/a | Calls `scripts/coverage.sh`, which does not exist |
+| `start-epic`, `pm-status` skills | 35 | Marked deprecated |
+| `.agents/skills/` (8), `.codex/skills/` (5) | n/a | Duplicate `.claude/skills/` with no declared source of truth |
+| `#[ignore]` tests | 149 attributes | Nothing runs them |
+
+`.pre-commit-config.yaml` runs `cargo test --all-features --workspace` on every commit, and declares `fmt` and `clippy` twice: once as local hooks, again through `doublify/pre-commit-rust`.
+
+### One governance note in the other direction
+
+Merge requires zero human approvals and one status check (`.github/branch-protection.json:5,10`).  The playbook holds that the agent which wrote the code must have no route to approve it.  Today it does.  That is a risk decision, not a productivity problem, and it belongs to the owner.  Do not fix it by adding latency everywhere else; fix it with one code-owner approval informed by review findings.
+
+---
+
+## Prescriptions, in order
+
+Each entry names the change, the constraint it removes, and how to tell it worked.
+
+### 1. Build a diff-scoped `make check` that finishes in under two minutes
+
+Add one target that formats, runs `clippy` on the changed packages only, and runs the unit tests reachable from the changed files.  Exit non-zero on failure.  Record it in `CLAUDE.md` under Commands with an example of healthy output, per the playbook's Test stage.
+
+Removes: the absence of any inner loop.  This is the prerequisite for everything else, because an agent that can verify in 90 seconds does not need the 20-minute lite gate between edits.
+
+Verify: `time make check` on a one-file change in `cqlite-core/src/`.
+
+### 2. Move the gate of record into CI and run its 39 components in parallel
+
+Register the `agent-gate.sh` components as gating tiers in `.github/ci-gating-tiers.yml` instead of exempting 23 workflows that defer to a local script.  Each component becomes a job.  GitHub runs them concurrently.  Delete `CQLITE_GATE_MAX_CONCURRENCY=1` because it stops mattering.
+
+Removes: the one-gate-per-box serialization and the 45-to-120-minute wall-clock full gate.  Wall clock becomes the slowest single component, not the sum.
+
+Verify: elapsed time on the `required` aggregator for a `cqlite-core` change, before and after.
+
+### 3. Cap and parallelize the review loop
+
+Write `REVIEW.md` at the repo root with the playbook's structure: named passes (bugs, security, spec compliance against `openspec/` artifacts), an explicit Important-versus-nit definition, a cap of five nits per review with the remainder reported as a count, and an instruction to skip generated paths and anything CI already enforces.  Run `rust-reviewer` and `roborev` concurrently rather than in sequence (`flow-implement/SKILL.md:145-172`).
+
+Removes: the 27-hour review phase.  6.92 findings times 3.32 rework rounds is where the time goes, and an uncapped nit stream is what makes each round expensive.
+
+Verify: mean `roborev_findings` and mean `rework` per record in `delivery-telemetry.jsonl`, sampled monthly.  Both should fall.
+
+### 4. Feed repeat findings into CLAUDE.md, then cut CLAUDE.md to about 150 lines
+
+Adopt the rule directly: when a mistake appears a second time, the correction goes into `CLAUDE.md` as part of that review.  Then delete the 250 lines of process ceremony that already exist elsewhere.  Specifically: lines 87-130 duplicate `docs/development/gate-ops.md`; lines 541-609 and 627-688 duplicate `docs/development/pm-operating-loop.md`; lines 52-86 list skills that the harness already lists.  Move lines 300-415 (the five testing blind spots) into `docs/development/testing-oracle-guide.md` and link to it.
+
+Keep: project status, the Commands block from step 1, workspace structure, development standards, format authority, and the blind-spot link.
+
+Removes: context spent on instructions the agent does not need at session start.  Stale or duplicated content in `CLAUDE.md` costs context for no return.
+
+Verify: `wc -l CLAUDE.md` under 200, and no product change to the delivery numbers.
+
+### 5. Replace prose enforcement with hooks, and let one hook actually block
+
+Convert the rules that must always hold into `PreToolUse` hooks in `.claude/settings.json`: block edits to test files during a fix task, block edits to protected paths, block a commit whose diff has no accompanying test.  Make the `TaskCompleted` hook run the new `make check` from step 1 and fail closed, because a 90-second check can afford to block where a 600-second one cannot.
+
+Then delete the compensating prose: the mandatory return-format contracts, the summary-file redirect instructions, the repeated ALL-CAPS imperatives, and the park-and-exit choreography.  Keep `claim.sh` and `premerge-assert.sh`; those are real controls.
+
+Removes: roughly 1,500 of the 2,333 happy-path instruction lines, and the drift they were written to prevent.
+
+Verify: the hook blocks a deliberate test-file edit during a fix, and the flow still completes an issue end to end.
+
+### 6. Delete the dead machinery
+
+In one pull request, remove: `.github/issue-monitoring/` (2,321), `.github/test-quality-gates.sh` (593), `.github/hooks/pre-commit` and `.github/setup-quality-gates.sh` (901), the five orphan `e2e_*` scripts (1,887), `tarpaulin.toml`, the broken `make coverage` target, and the `start-epic` and `pm-status` skills.  That is about 5,800 lines.
+
+Separately, declare one source of truth for skills.  `.claude/skills/` holds 27, `.agents/skills/` holds 8, and `.codex/skills/` holds 5 copies of the OpenSpec family.  Pick one directory and make the others symlinks, or delete them.
+
+Then rule on `scripts/tests/`: 149,644 lines of bash that test bash, roughly 80 of which run inside the `tooling-tests` gate component (`scripts/agent-gate.sh:6650`).  Either move that component to nightly, or accept that it is a first-class part of the merge path and budget for it.  Do not leave it implicit.
+
+Removes: maintenance surface, and gate minutes in the `tooling-tests` case.
+
+Verify: `agent-gate.sh` still passes, and the deleted paths appear nowhere in `rg` output.
+
+### 7. Stop committing one telemetry record per delivery
+
+`delivery-telemetry.py retro` is the only consumer.  Append the record inside the merge commit, or batch the day's records into one nightly commit.
+
+Removes: 44% of commit volume and one pull request per delivery.
+
+Verify: `git log --oneline -200 | rg -c 'delivery telemetry'` trends toward zero while `retro` still files its `flow-meta` issue.
+
+### 8. Resolve the 149 ignored tests and the coverage story
+
+Each `#[ignore]` is either a real gap or dead code.  Add a nightly lane that runs `cargo test -- --ignored` and reports, so the count becomes visible instead of invisible.  Pick one coverage tool (the gate already uses `llvm-cov`), commit a baseline, and enforce a floor in CI.  Delete `tarpaulin.toml`.
+
+Removes: an unmeasured hole under a coverage number that nothing enforces.
+
+Verify: the nightly lane reports a count, and the floor fails a deliberate coverage drop.
+
+---
+
+## Sequencing
+
+Steps 1 and 6 depend on nothing; start there in parallel.  Step 2 depends on step 1 only for confidence.  Steps 3 and 4 are the largest win on cycle time and should follow immediately.  Step 5 depends on step 1, because a blocking hook needs a fast check behind it.  Steps 7 and 8 are cleanup and can land any time.
+
+## What is already right, and should not be touched
+
+- Server-side ref locking for issue claims (`scripts/flow/claim.sh`).  Atomic arbitration, not optimism.
+- `premerge-assert.sh` failing closed on stale base and `HOLD:` markers.
+- The permission allowlist.  51 global and 71 local rules pre-approve cargo, git, gh, and jq, so an agent does not stall on prompts.
+- Worktree isolation, one per issue.
+- The committed artifact chain.  `openspec/changes/<name>/` already holds proposal, design, specs, and tasks in git, which is the playbook's central mechanism, built before the playbook named it.
+- Fresh-context verification.  `spec-auditor`, `rust-reviewer`, and `coverage-reviewer` are read-only reviewers in their own context windows.  That is the pattern the playbook recommends.

--- a/openspec/changes/lite-clippy-scoped-to-blast-radius/design.md
+++ b/openspec/changes/lite-clippy-scoped-to-blast-radius/design.md
@@ -1,0 +1,124 @@
+# Design: scoped clippy for `--lite`
+
+## Decision 0 — the scope is `blast_radius ∪ FLOOR`, and `FLOOR` exists because of #1893
+
+A pure blast-radius scope is unsound here, and the reason is written in the source rather than
+inferable from the design.  `scripts/agent-gate.sh:11214` records invariant **#1893**: `--lite`'s
+python tier classifies a venv/pip/maturin toolchain failure as **SKIP** rather than FAIL, and it is
+safe to do so *only because* `run_clippy` still COMPILES `cqlite-py` in the same lite run.  Drop
+`cqlite-py` from the lint set on a diff that does not touch it, and a broken `bindings/python/src`
+sails through a lite run that reports SKIP for the tier that would have caught it.
+
+So the scope is a union with a declared floor, `FLOOR` is defined in exactly one place, and every
+entry carries the issue that put it there.  `cqlite-py` is the founding entry.
+
+**This is a constraint on the cost win, and it is stated rather than hidden.**  `FLOOR` is linted on
+every lite run regardless of diff, so its cost is unavoidable and belongs in the baseline measurement
+as its own row.  A floor that grows without discipline reconstructs the whole-workspace matrix one
+justified entry at a time.  Hence the rule: an entry needs a named reason at the definition site, or
+it does not go on the list.
+
+## Decision 1 — reuse the `scoped-tests` package set rather than derive a second one
+
+`--lite` already computes a package set from the diff for `scoped-tests`.  Deriving a second set for
+clippy would create two answers to "what does this diff affect," and they would drift.
+
+The set is taken from the existing derivation verbatim, including the #2658 direct-dependent fan-out
+for a `cqlite-core/src/` path.  Clippy lints that set.  If the two ever need to differ, that is a
+separate decision with its own rationale, not a silent divergence.
+
+**Rationale for including the fan-out set in clippy scope:** a `cqlite-core` change can introduce a
+lint failure in a dependent without touching that dependent's files.  Dropping the fan-out would make
+scoped lite miss exactly the class the fan-out was added for.  The cost is that a core-src diff is
+barely narrowed, which figure 2 of the proposal's measurement reports honestly.
+
+## Decision 2 — the feature flags come from the existing four-stage matrix, per package
+
+The scoped run must not quietly lint a package at a different feature set than the whole-workspace
+matrix would.  A package linted at narrower features can pass where the gate of record fails, which
+converts a cost fix into a false green.
+
+`run_clippy` at `scripts/agent-gate.sh:11193` is four stages, and stages 2 and 3 carry **explicit
+per-package feature strings** for `cqlite-core` and `cqlite-cli` (both excluding the OpenTelemetry
+stack, whose drift guard is the nightly `CQLITE_CLIPPY_FULL=1` pass, #2662).  Stage 1 is the workspace
+minus five packages at `--all-features`; stage 4 is `cqlite-flight` plus the bindings at defaults.
+
+So scoping selects **which** stages run and **which** packages within stage 1, and changes nothing
+about the feature strings.  This is a filter over an existing matrix, not a new invocation.  A
+consequence worth stating: stage 1 excludes `cqlite-core`, `cqlite-cli`, `cqlite-flight`,
+`cqlite-py`, and `cqlite-node` precisely so `--all-features` never activates their duckdb or otel
+features, so the filter must preserve that exclusion set rather than re-deriving it from the scope.
+
+## Decision 3 — the disclosure line carries counts and a log pointer, never file or package names
+
+`#3402` and `#3401` settled this for `file-size`, and the reasoning transfers.  Rendering repository
+content inline produced three review findings in three rounds, one per attempt at mangling a name.
+The ruling from #3229 applies: remove the mechanism rather than carve it a fourth time.
+
+So the SUMMARY line carries gate-authored text plus computed integers, and the package names live in
+`clippy.log`.  The `_status_detail` boundary already strips `[:cntrl:]` under `LC_ALL=C` and
+withholds any value carrying the completion probe's `RESULT:` token; the scoped line goes through it
+unchanged.
+
+## Decision 4 — a failed derivation SKIPs, and the SKIP names the cause
+
+Three states must be distinguishable in the summary:
+
+| State | Line |
+|---|---|
+| Scoped run, clean | `clippy: PASS [scoped] — N of M packages CHECKED; K NOT CHECKED` |
+| Scoped run, clean, nothing excluded | `clippy: PASS [scoped] — M of M packages CHECKED; 0 NOT-CHECKED RECOGNISED` |
+| Derivation unmeasurable | `clippy: SKIP — blast-radius derivation failed (<named cause>); scope unknown` |
+
+The third must never be a `PASS`.  A permissive branch on an unmeasurable scope is how a check that
+ran against zero packages reports success.  `cargo metadata` failing, a path resolving to no
+workspace member, or a base ref that does not resolve are each a named cause.
+
+## Decision 5 — the regression test is mutation-checked, and the mutations are named
+
+Wired into `tooling-tests`.  Four mutations, each of which the test must red on:
+
+1. Scoped set replaced by the empty set.  Catches the vacuous branch.
+2. Disclosure line removed from the summary.  Catches a silent narrowing.
+3. Fan-out set dropped from the scope for a `cqlite-core/src/` path.  Catches the dependent-breakage
+   regression that Decision 1 exists to prevent.
+4. **`cqlite-py` removed from `FLOOR`.**  Catches the #1893 regression, which is the one mutation a
+   reviewer reading only the diff would not think to look for, because the invariant it breaks lives
+   in a different component's SKIP logic.
+
+A test that passes against the broken implementation pins nothing.  Each mutation is applied and
+reverted in the test's own scratch copy, never in the checkout, so the run cannot perturb the tree
+and trip #2926's mid-run mutation check.
+
+## Decision 6 — `CLAUDE.md` is corrected in the same diff
+
+The Lite row currently documents "clippy is NOT diff-scoped" and gives the bands that follow from it.
+On merge that text describes the old behaviour.  Doctrine that contradicts the code is worse than
+absent doctrine, because an agent reads it and plans around a cost that no longer exists.
+
+The corrected row states the scoped default, keeps the `CQLITE_CLIPPY_FULL=1` escape, and cites the
+new measurement artifact for the bands rather than restating them.
+
+## What is not designed here
+
+The `--all-targets --no-run` fan-out (slice 2) shares Decision 1's package set and will reopen the
+question of whether compile-checking dependents belongs in a fast loop at all.  That question is
+deliberately not answered here.  Slice 1 changes what clippy lints; it changes nothing about what
+gets compiled.
+
+## Cited authorities
+
+All line numbers below were verified against `scripts/agent-gate.sh` at the time of writing.
+`CLAUDE.md`'s Lite row cites `:17233`, `:18220`, and `:9357` for the same facts; those have drifted
+and are corrected by this change.
+
+- `run_clippy` definition, four-stage whole-workspace matrix: `scripts/agent-gate.sh:11193`.
+- `CQLITE_CLIPPY_FULL=1` whole-workspace escape: `:11194`.
+- Nightly `clippy-full` backstop that justifies the existing feature narrowing: `:11186-11192`, #2662.
+- The #1893 `cqlite-py` compile-backstop invariant: `:11214`.
+- `run_lite` and its call to the shared `run_clippy`: `:20532` and `:20546`.
+- `LITE_COMPONENTS`: `:6315`.
+- Core-src direct-dependent fan-out: #2658.
+- Summary-detail trust boundary and the remove-rather-than-carve ruling: #3402, #3401, #3229, #3312.
+- Mid-run tree mutation invalidates a run: #2926.
+- Mutation-checked regression precedent: #3465.

--- a/openspec/changes/lite-clippy-scoped-to-blast-radius/proposal.md
+++ b/openspec/changes/lite-clippy-scoped-to-blast-radius/proposal.md
@@ -1,0 +1,151 @@
+# Proposal: `--lite` pays clippy IN FULL whatever the diff — scope it to the blast radius it already computes
+
+**Milestone:** maintenance / delivery-pipeline cost · **Priority:** P1 · **Routing:** **design-driven** —
+there is no external oracle for *"what must a fast pre-review check cover"*.  The deliverable is a
+contract plus a measurement.  One half of it does have an oracle and it is used below: does a scoped
+clippy still red on the defect class it exists to catch?  · **Intent:** `openspec/intent/active/ai-native-sdlc.md`
+(slice 1 of 7) · **Refs:** #1821 (lite mode), #1844 (per-package scoped-workspace clippy), #2658
+(core-src fan-out), #3763/#3764 (lite admission and disk), #3499 (deferred lint mechanization)
+
+## Why
+
+`--lite` runs on **every fix round**.  Its stated purpose is a cost that is a function of the diff.
+One of its two cost drivers is not.
+
+`run_clippy` is defined once, at `scripts/agent-gate.sh:11193`, and `run_lite` calls that same
+function (`run_component clippy run_clippy`, `scripts/agent-gate.sh:20546`).  It is a four-stage
+**whole-workspace** matrix and **it never reads the diff**.  `LITE_COMPONENTS` at `:6315` lists
+`clippy` unconditionally.  Measured over 188 completed lite runs, per `CLAUDE.md`: a no-op warm,
+**2-7 minutes part-warm**, **16-24 minutes cold**.
+
+**Correction to doctrine, recorded rather than quietly fixed.**  `CLAUDE.md`'s Lite row cites
+`:17233` for the lite dispatch and `:18220` for the full one, framed as two sites.  Both line numbers
+have drifted and the framing is wrong: there is one definition and one shared call.  The substance of
+the claim survives verification; the citations do not.  `CLAUDE.md` is corrected in this change.
+
+`run_lite`'s own text disagrees with itself and is corrected too: the function comment at `:20529`
+says "FULL-workspace clippy" while the banner it echoes at `:20539` says "scoped workspace clippy."
+
+### The precedent this change extends
+
+`run_clippy` is **already** a narrowing, and its justification is already the one used below.  Its
+header at `:11186-11192` records that the historical `--workspace --all-targets --all-features` pass
+runs nightly in a dedicated parallel `clippy-full` job in `gate.yml` (#2662), so the per-package
+matrix in the gate of record is a deliberate reduction backed by a within-24h backstop.  Scoping
+`--lite` by blast radius is the same argument one step further, with the **gate of record** as the
+backstop rather than a nightly lane.  This is not a new kind of concession.
+
+The other driver, `scoped-tests`, *is* diff-scoped.  So `--lite` already derives a package set from
+the diff: the touched package by longest-prefix path match over `cargo metadata` from
+`merge-base(HEAD, <base>)...HEAD` plus `git diff HEAD` over tracked files, defaulting to
+`cqlite-core --lib` when no Rust package is in the diff, and for a `cqlite-core/src/` path also every
+workspace member that directly declares a dependency on `cqlite-core` and owns a `--test` target
+(#2658).
+
+That set exists, is computed on every lite run, and clippy ignores it.
+
+### What the cost buys, and what it does not
+
+A round is not one lite run.  Delivery telemetry over 590 records: **71.4%** of PRs needed rework at
+a mean of **3.32 rounds**.  So the part-warm-to-cold clippy leg is paid roughly three times per
+change on top of the round that first reached lite-green.
+
+The full gate is unaffected by this change and remains the gate of record (#719).  Whatever a scoped
+lite does not check, the full gate checks once, before merge, at the unscoped matrix.  That is the
+property that makes narrowing lite defensible at all, and it is why this change does not touch
+`:18220`.
+
+### The measurement that constrains the design
+
+**To be recorded at `docs/round-artifacts/lite-clippy-scope-measurements.md` before the spec is
+claimed satisfied.**  Three figures, each on this repo at a named `origin/main` sha:
+
+1. For a narrow diff (one file, one non-core package): elapsed clippy seconds unscoped versus scoped,
+   cold and part-warm, and the package count in each.
+2. For a `cqlite-core/src/` diff: the same, where the scoped set includes the #2658 fan-out and is
+   therefore expected to be most of the workspace.  **If scoping saves nothing on this class, the
+   proposal says so rather than claiming a win it does not have.**
+3. The discriminating case: a clippy violation planted in a package **outside** the blast radius.
+   Scoped lite must not FAIL on it, must NAME it as unchecked, and the full gate must still FAIL.
+
+Figure 2 is the one that can falsify the value of this change for the class that hurts most.  It is
+measured and reported either way.
+
+## What Changes
+
+1. **`run_clippy` gains a scoped mode, taken only by the `--lite` call site.**  It takes the package
+   set `scoped-tests` already derives, unions it with a declared floor (item 2), and lints exactly
+   that union at the same feature flags the existing four-stage matrix uses for each package.  The
+   full gate's call to `run_clippy` is untouched and keeps the whole-workspace matrix.
+
+2. **A declared floor of always-linted packages, because one of them is load-bearing for a SKIP.**
+   `scripts/agent-gate.sh:11214` records invariant **#1893**: `cqlite-py` must stay in the linted set
+   because `--lite`'s python tier classifies a venv/pip/maturin toolchain failure as **SKIP** rather
+   than FAIL, and this clippy pass is the compile backstop that makes that SKIP safe.  A blast-radius
+   scope alone would drop `cqlite-py` from most diffs and convert a safe SKIP into a silent hole.
+
+   So the scoped set is `blast_radius ∪ FLOOR`, `FLOOR` is a named list in one place, and `cqlite-py`
+   is on it with #1893 cited at the definition.  A future floor entry needs the same treatment: a
+   named reason, or it does not go on the list.
+
+3. **The narrowing is disclosed in the LITE SUMMARY, and it is not a bare number.**  The component
+   line names how many packages were checked, how many were not, and where the names are:
+
+   ```
+   clippy: PASS (0s) [scoped] — 3 of 14 packages CHECKED; 11 NOT CHECKED (named in <logdir>/clippy.log)
+   ```
+
+   `0 NOT CHECKED` is written `0 NOT-CHECKED RECOGNISED`, never a bare `0`, per the affirmative-zero
+   doctrine.  A reader must not be able to confuse a full-coverage lite run with a narrowed one.
+
+4. **An empty or unmeasurable package set is not a permissive branch.**  If the blast-radius
+   derivation fails for any reason, scoped clippy **SKIPs naming the cause** and does not fall back
+   to lint-nothing.  Because `FLOOR` is non-empty by construction, a set that comes back empty is
+   itself evidence the derivation is broken, and it is treated as such rather than obeyed.
+
+5. **`--delta` and `--only` are unchanged.**  `--delta` builds nothing by construction and `--only`
+   is a diagnostic that is lenient by design.  `--only clippy` therefore keeps the whole-workspace
+   matrix, which is what a diagnostic should do.
+
+6. **A discriminating regression test in `scripts/tests/test_agent_gate_lite_clippy_scope.sh`,
+   wired to `tooling-tests`.**  Four mutations, each of which must red it, named in `design.md`.
+   Mutation-checked per #3465's precedent: a test that passes against both the fixed and the broken
+   implementation pins nothing.
+
+## Non-goals
+
+- **Scoping the FULL gate's clippy.**  The gate of record keeps the whole-workspace matrix.  That is
+  the whole reason lite may narrow.
+- **Re-deciding the #1893 python SKIP.**  This change preserves that invariant via `FLOOR`.  Whether
+  a toolchain failure should SKIP at all is a separate question and is not reopened here.
+- **Removing the four-stage feature narrowing inside `run_clippy`.**  That reduction is #2662's, is
+  backed by the nightly `clippy-full` job, and is orthogonal to package scoping.
+- **A dependency-closure blast radius.**  A commit changing an item the diff *calls*, in a package
+  neither touched nor a direct dependent, is not in the set.  Declared on every run.  The sound route
+  is rustc dep-info, which is #3366.
+- **An admission check or slot cap for `--lite`.**  #3763 owns that gap.  This change reduces what a
+  lite run costs; it does not arbitrate who runs one.
+- **The `cqlite-core/src/` `--all-targets --no-run` fan-out leg.**  That is the reported +18 GB in a
+  single round and it is slice 2, filed separately.  Conflating them would make figure 2 above
+  unreadable, because two changes would be moving the same number.
+- **Removing the `CQLITE_CLIPPY_FULL=1` path.**  It stays as the explicit whole-workspace escape and
+  is not the scoped default's fallback.
+- **A bypass flag for scoped clippy.**  Deliberately absent.  There is no legitimate reason to want a
+  lite run that lints nothing and says PASS.
+
+## Impact
+
+- **No-heuristics mandate:** untouched.  No decode path.  The honesty rule is the same doctrine one
+  level up — the scope comes from `cargo metadata`, which is authoritative, never from a textual
+  guess at which packages a diff affects.
+- **Public binding surfaces (Python/Node/CLI):** none.  Delivery tooling only.
+- **<128 MB memory budget:** unaffected.  No library code changes.
+- **Gate cost:** this is the change's subject.  The full gate's cost is unchanged by construction;
+  lite's cost is the measurement above.
+- **Self-certification:** `agent-gate.sh` is read from the checkout, so this change **can** exercise
+  itself on its own PR, and must.  Its own lite run should print the scoped disclosure line.  Stated
+  because the neighbouring class (a `required`-registry change, a `.roborev.toml` change) cannot, and
+  three lanes have been caught by assuming otherwise.
+- **Doctrine text:** `CLAUDE.md`'s Lite row currently states that clippy is not diff-scoped and gives
+  the bands for that behaviour.  That text becomes wrong on merge and is updated in the same change,
+  not left for a follow-up.

--- a/openspec/changes/lite-clippy-scoped-to-blast-radius/specs/inner-loop-cost/spec.md
+++ b/openspec/changes/lite-clippy-scoped-to-blast-radius/specs/inner-loop-cost/spec.md
@@ -1,0 +1,162 @@
+# inner-loop-cost Specification
+
+## Purpose
+
+The cost of a `--lite` run SHALL be a function of the diff it certifies.  A narrowing SHALL be
+disclosed, and an unmeasurable scope SHALL never read as a clean one.
+
+## Requirements
+
+### Requirement: `--lite` clippy SHALL lint the diff's blast radius unioned with a declared floor
+
+The `clippy` component under `--lite` SHALL lint exactly `blast_radius ∪ FLOOR`, where
+`blast_radius` is the package set `--lite` already derives for `scoped-tests` (including the #2658
+direct-dependent fan-out when a changed path is under `cqlite-core/src/`) and `FLOOR` is a declared
+list of packages linted on every lite run regardless of diff.  Each selected package SHALL be invoked
+at the identical feature flags the existing four-stage matrix at `scripts/agent-gate.sh:11193` uses
+for that package, preserving stage 1's exclusion set so `--all-features` never activates the duckdb
+or OpenTelemetry features.  The full gate's call to `run_clippy` SHALL be unchanged and SHALL continue
+to lint the whole workspace.
+
+#### Scenario: FLOOR is linted on a diff that does not touch it
+- **WHEN** `--lite` runs on a diff touching only `cqlite-core/src/`
+- **THEN** every package in `FLOOR` is linted
+- **AND** `cqlite-py` is among them
+
+#### Scenario: A scoped run cannot lint a package at narrower features than the gate of record
+- **WHEN** a package in the scope is linted
+- **THEN** its feature string is the one the four-stage matrix uses for that package
+- **AND** stage 1's exclusion of `cqlite-core`, `cqlite-cli`, `cqlite-flight`, `cqlite-py` and `cqlite-node` is preserved
+
+#### Scenario: A narrow diff lints only its own package set
+- **WHEN** `--lite` runs on a diff touching one file in one non-`cqlite-core` package
+- **THEN** the `clippy` component lints that package's set and not the whole workspace
+- **AND** the elapsed clippy time is recorded in the measurement artifact against the unscoped baseline
+
+#### Scenario: A core-src diff retains the dependent fan-out
+- **WHEN** `--lite` runs on a diff touching a path under `cqlite-core/src/`
+- **THEN** the scoped set includes every workspace member that directly declares a dependency on `cqlite-core` and owns a `--test` target
+- **AND** a clippy violation introduced in such a dependent by the core change FAILs the scoped run
+
+#### Scenario: Per-package flags match the unscoped matrix
+- **WHEN** a package is linted under the scoped run
+- **THEN** its feature and target flags are the same ones the #1844 matrix uses for that package
+- **AND** no package is linted at a narrower feature set than the gate of record would use
+
+#### Scenario: The full gate is unaffected
+- **WHEN** the full `scripts/agent-gate.sh` runs
+- **THEN** its `clippy` component lints the unscoped per-package matrix
+- **AND** its `AGENT-GATE SUMMARY` carries no scoped disclosure
+
+### Requirement: A scoped run SHALL disclose what it did not check, with an affirmative zero
+
+The `AGENT-GATE LITE SUMMARY` line for `clippy` SHALL name the count of packages CHECKED, the count
+NOT CHECKED, and where the excluded names are recorded.  A run that excluded nothing SHALL print
+`0 NOT-CHECKED RECOGNISED` rather than a bare `0`, so a full-coverage lite run is textually
+distinguishable from a narrowed one.  The line SHALL carry counts and gate-authored text only; the
+package names SHALL live in the component log, and the value SHALL pass through the existing
+`_status_detail` boundary that strips control characters and withholds any value carrying the
+completion probe's `RESULT:` token.
+
+#### Scenario: A narrowed run names its exclusions by count and log
+- **WHEN** a scoped clippy run excludes at least one package
+- **THEN** the summary line states N of M packages CHECKED and K NOT CHECKED
+- **AND** it points at the component log where the excluded package names are written
+- **AND** it contains no package name inline
+
+#### Scenario: A full-coverage scoped run is not mistakable for an unmeasured one
+- **WHEN** the blast radius happens to include every workspace package
+- **THEN** the line reads `0 NOT-CHECKED RECOGNISED`
+- **AND** it does not read as a bare `0`
+
+#### Scenario: A package name cannot break the summary grammar
+- **WHEN** a workspace package path contains a control character or the substring `RESULT:`
+- **THEN** the disclosure line is emitted with that value withheld or sanitized rather than rewritten
+- **AND** the completion probe `grep -qE 'RESULT: (PASS|FAIL)'` still reads the run's own verdict correctly
+
+### Requirement: An unmeasurable scope SHALL SKIP naming the cause and SHALL NOT lint nothing
+
+If the blast-radius derivation cannot be completed, the `clippy` component under `--lite` SHALL
+report `SKIP` with the cause named, and SHALL NOT proceed with an empty package set.  A run that
+linted zero packages SHALL NOT be able to report `PASS`.  Because `FLOOR` is non-empty by
+construction, a computed scope that is empty SHALL be treated as evidence the derivation is broken
+rather than as an instruction to lint nothing.  `cargo metadata` failing or unavailable, a changed
+path resolving to no workspace member, and a base ref that does not resolve are each a named cause.
+
+#### Scenario: A failed derivation skips rather than passes
+- **WHEN** `cargo metadata` fails during blast-radius derivation under `--lite`
+- **THEN** the `clippy` component reports `SKIP` naming that cause
+- **AND** it does not report `PASS`
+- **AND** it does not lint an empty package set
+
+#### Scenario: An empty package set is unreachable as a PASS
+- **WHEN** the derived package set is empty for any reason
+- **THEN** the component does not emit a `PASS` verdict
+- **AND** the summary states that the scope is unknown
+
+### Requirement: FLOOR SHALL preserve the #1893 python compile backstop
+
+`FLOOR` SHALL contain `cqlite-py`, and its definition SHALL cite #1893 at the definition site.
+`--lite`'s python tier classifies a venv, pip or maturin toolchain failure as `SKIP` rather than
+`FAIL`, and that SKIP is safe only because the clippy pass still compiles `cqlite-py` in the same run.
+Every `FLOOR` entry SHALL carry a named reason at the definition site.
+
+#### Scenario: A broken python binding source cannot pass a lite run via the SKIP route
+- **WHEN** `bindings/python/src` does not compile
+- **AND** `--lite` runs on a diff that touches no python path, so the python tier reports `SKIP`
+- **THEN** the `clippy` component FAILs, because `cqlite-py` is in `FLOOR`
+- **AND** the lite run does not report `OVERALL=PASS`
+
+#### Scenario: Removing cqlite-py from FLOOR is caught
+- **WHEN** `cqlite-py` is removed from `FLOOR`
+- **THEN** `scripts/tests/test_agent_gate_lite_clippy_scope.sh` fails
+
+### Requirement: A discriminating regression test SHALL pin the behaviour inside tooling-tests
+
+`scripts/tests/test_agent_gate_lite_clippy_scope.sh` SHALL be wired to the `tooling-tests` component
+and SHALL red under each of four named mutations: the scoped set replaced by the empty set, the
+disclosure line removed from the summary, the #2658 fan-out set dropped for a `cqlite-core/src/`
+path, and `cqlite-py` removed from `FLOOR`.  Each mutation SHALL be applied within the test's own
+scratch copy and never in the checkout, so the test cannot perturb the tree and trip the #2926
+mid-run mutation check.
+
+#### Scenario: The empty-set mutation reds the test
+- **WHEN** the scoped derivation is mutated to return an empty package set
+- **THEN** `test_agent_gate_lite_clippy_scope.sh` fails
+
+#### Scenario: The removed-disclosure mutation reds the test
+- **WHEN** the scoped disclosure line is removed from the lite summary
+- **THEN** `test_agent_gate_lite_clippy_scope.sh` fails
+
+#### Scenario: The dropped-fan-out mutation reds the test
+- **WHEN** the direct-dependent fan-out is dropped from the scope for a `cqlite-core/src/` path
+- **THEN** `test_agent_gate_lite_clippy_scope.sh` fails
+
+#### Scenario: The dropped-FLOOR-entry mutation reds the test
+- **WHEN** `cqlite-py` is removed from `FLOOR`
+- **THEN** `test_agent_gate_lite_clippy_scope.sh` fails
+
+#### Scenario: The test does not perturb the checkout
+- **WHEN** the test runs inside `tooling-tests` during a gate run
+- **THEN** the gate's `tree-integrity:` check reports no mutation and `dirty: no`
+
+### Requirement: Doctrine SHALL state the scoped default and cite the measurement
+
+`CLAUDE.md`'s Lite row SHALL state that `--lite` clippy is scoped to `blast_radius ∪ FLOOR` by
+default, SHALL retain `CQLITE_CLIPPY_FULL=1` as the explicit whole-workspace escape, and SHALL cite
+the committed measurement artifact for the cost bands rather than restating superseded numbers.  Its
+stale citations SHALL be corrected: `run_clippy` is one definition called by both modes, not the
+`:17233` / `:18220` pair the row currently names.  `run_lite`'s internal disagreement SHALL be
+resolved, where its function comment says "FULL-workspace clippy" and the banner it prints says
+"scoped workspace clippy."  Every correction SHALL land in the same change as the behaviour.
+
+#### Scenario: Doctrine matches the code on merge
+- **WHEN** `CLAUDE.md` is read after this change merges
+- **THEN** its Lite row states the scoped clippy default, names `FLOOR`, and names the escape flag
+- **AND** it no longer states that lite clippy is not diff-scoped
+- **AND** it no longer cites `:17233` or `:18220` as two dispatch sites
+- **AND** it cites `docs/round-artifacts/lite-clippy-scope-measurements.md` for the bands
+
+#### Scenario: The gate script no longer contradicts itself
+- **WHEN** `run_lite`'s comment and its printed banner are read after this change
+- **THEN** both describe the same clippy scope

--- a/openspec/changes/lite-clippy-scoped-to-blast-radius/tasks.md
+++ b/openspec/changes/lite-clippy-scoped-to-blast-radius/tasks.md
@@ -1,0 +1,114 @@
+# Tasks: `--lite` clippy scoped to the blast radius
+
+Each task names the surface or test it exercises.  Tasks are ordered so the measurement that could
+falsify the change runs before the change is built out.
+
+## 1. Baseline measurement, before any behaviour change
+
+- [ ] 1.1 Record the unscoped baseline at a named `origin/main` sha.  Surface: `scripts/agent-gate.sh --lite`.
+      Three populations, cold and part-warm each: a narrow non-core diff, a `cqlite-core/src/` diff, and
+      a docs-only diff.  Capture elapsed clippy seconds and the package count linted.
+- [ ] 1.1b Measure `FLOOR` alone as its own row, since its cost is paid on every lite run regardless
+      of diff and therefore bounds the best case.  If `FLOOR` alone approaches the unscoped time, this
+      change cannot deliver a sub-two-minute inner loop and the artifact says so.
+- [ ] 1.2 Write `docs/round-artifacts/lite-clippy-scope-measurements.md` with the baseline table and
+      the exact commands, so every later figure is re-derivable from the repo.
+- [ ] 1.3 **Decision point.** If the `cqlite-core/src/` population shows the scoped set would include
+      substantially the whole workspace, record that in the artifact and say so in the proposal's Why.
+      Do not proceed as though the change helps that class when the measurement says it does not.
+
+## 2. Expose the existing blast-radius derivation as a reusable scope
+
+- [ ] 2.1 Extract the `scoped-tests` package-set derivation into a named function with no side
+      effects, returning the set plus a measurable success or a named failure cause.  Surface:
+      `scripts/agent-gate.sh`.
+- [ ] 2.2 Assert the extraction is behaviour-preserving for `scoped-tests`.  Test:
+      existing `scripts/tests/test_agent_gate_component_set.sh` stays green, plus a new case pinning
+      the derived set for a fixed synthetic diff.
+- [ ] 2.3 Confirm no second definition of the derivation exists.  `scripts/agent-gate.sh:6459`
+      records that a duplicated `_tree*` function previously FAILed `tooling-tests` through a
+      uniqueness assert; the same trap applies here.
+
+## 3. Declare FLOOR
+
+- [ ] 3.1 Define `FLOOR` in exactly one place, with `cqlite-py` as its founding entry and #1893 cited
+      at the definition site.  Surface: `scripts/agent-gate.sh`, adjacent to `run_clippy` at `:11193`.
+- [ ] 3.2 Write the rule into the definition's comment: an entry needs a named reason or it does not
+      go on the list.  A floor that grows undisciplined rebuilds the whole-workspace matrix.
+
+## 4. Scoped clippy at the `--lite` call site only
+
+- [ ] 4.1 Add the scoped mode to `run_clippy`, filtering the four-stage matrix by
+      `blast_radius ∪ FLOOR` and preserving each package's own feature string.  Surface:
+      `scripts/agent-gate.sh:11193`, reached from `run_lite`'s call at `:20546`.
+- [ ] 4.2 Preserve stage 1's exclusion of `cqlite-core`, `cqlite-cli`, `cqlite-flight`, `cqlite-py`
+      and `cqlite-node`, so `--all-features` still never activates a duckdb or otel feature.  Do not
+      re-derive that exclusion set from the scope.
+- [ ] 4.3 Leave the full gate's call to `run_clippy` on the whole-workspace path.  Test: a full-gate
+      summary carries no scoped disclosure.
+- [ ] 4.4 Make an unmeasurable derivation a `SKIP` naming the cause, never a `PASS` and never an
+      empty-set lint.  A computed empty scope is evidence of breakage, since `FLOOR` is non-empty.
+- [ ] 4.5 Leave `--delta` and `--only` unchanged.  `--only clippy` keeps the whole-workspace matrix.
+      Test: their summaries are unchanged in shape for a fixed input.
+- [ ] 4.6 Confirm `CQLITE_CLIPPY_FULL=1` at `:11194` still short-circuits to the historical
+      `--workspace --all-targets --all-features` pass and is not reached via the scoped path.
+
+## 5. Disclosure in the LITE SUMMARY
+
+- [ ] 5.1 Emit the CHECKED / NOT CHECKED counts and the log pointer through the existing
+      `_status_detail` boundary.  Surface: the `AGENT-GATE LITE SUMMARY` block.
+- [ ] 5.2 Write `0 NOT-CHECKED RECOGNISED` for a full-coverage scoped run.  Test: a synthetic diff
+      whose blast radius is the whole workspace.
+- [ ] 5.3 Write the excluded package names to `<logdir>/clippy.log` and to nowhere else.
+- [ ] 5.4 Verify a package path carrying a control character or `RESULT:` cannot break the summary
+      grammar or the completion probe.  Test: a synthetic package path fixture.
+
+## 6. Discriminating regression test
+
+- [ ] 6.1 Write `scripts/tests/test_agent_gate_lite_clippy_scope.sh` and wire it to `tooling-tests`.
+- [ ] 6.2 Pin mutation 1: scoped set replaced by the empty set must red the test.
+- [ ] 6.3 Pin mutation 2: disclosure line removed must red the test.
+- [ ] 6.4 Pin mutation 3: #2658 fan-out dropped for a `cqlite-core/src/` path must red the test.
+- [ ] 6.5 Pin mutation 4: `cqlite-py` removed from `FLOOR` must red the test.  Assert via the #1893
+      route — an uncompilable `bindings/python/src` plus a non-python diff must not reach
+      `OVERALL=PASS`.
+- [ ] 6.6 Apply every mutation in the test's own scratch copy.  Verify the gate reports
+      `tree-integrity:` clean and `dirty: no` on a run that includes this test.
+- [ ] 6.7 Register the new test in the component manifest so
+      `scripts/tests/test_agent_gate_component_set.sh`'s staleness guard stays green.
+
+## 7. Post-change measurement
+
+- [ ] 7.1 Re-run the populations from task 1 against the scoped implementation.  Append the scoped
+      column to `docs/round-artifacts/lite-clippy-scope-measurements.md`.
+- [ ] 7.2 Record the discriminating case: a clippy violation planted outside `blast_radius ∪ FLOOR`.
+      Scoped lite must not FAIL, must name it unchecked, and the full gate must FAIL.
+- [ ] 7.3 State the residual in the artifact: a violation in a package that is neither touched, nor a
+      direct dependent, nor on `FLOOR` is caught by the gate of record, not by lite.
+
+## 8. Doctrine
+
+- [ ] 8.1 Correct `CLAUDE.md`'s Lite row: `blast_radius ∪ FLOOR` default, `CQLITE_CLIPPY_FULL=1`
+      escape retained, bands cited from the measurement artifact rather than restated.
+- [ ] 8.2 Remove the stale `:17233` / `:18220` two-site framing from that row.  There is one
+      `run_clippy` definition, at `:11193`, called by both modes.
+- [ ] 8.3 Resolve `run_lite`'s self-contradiction: its comment at `:20529` says "FULL-workspace
+      clippy" while its printed banner at `:20539` says "scoped workspace clippy."
+- [ ] 8.4 Check `docs/development/gate-ops.md` for text the change makes wrong and correct it here.
+
+## 9. Certification
+
+- [ ] 8.1 `rust-reviewer` + `scripts/flow/roborev-review.sh --agent <a> --model <m>` on the lite-green
+      diff, before the first full gate (review-first, #2086).
+- [ ] 8.2 Run `scripts/agent-gate.sh` — the full gate of record, once, via the summary-file redirect:
+      `AGENT_GATE_SUMMARY_FILE=/tmp/gate-summary.txt bash scripts/agent-gate.sh > gate.log 2>&1 < /dev/null`.
+      Paste the `AGENT-GATE SUMMARY` block verbatim.
+- [ ] 8.3 **Self-certification check:** confirm this change's own `--lite` run printed the scoped
+      disclosure line.  `agent-gate.sh` is read from the checkout, so this PR can and must exercise
+      itself.
+- [ ] 8.4 `spec-auditor` (C) against `openspec/changes/lite-clippy-scoped-to-blast-radius/specs/**`,
+      after the gate is green.  Every requirement `satisfied` with a named test as evidence.
+- [ ] 8.5 Final `roborev` round, last, after C.  Any non-PASS terminal `RESULT` blocks the merge.
+- [ ] 8.6 `scripts/flow/premerge-assert.sh <pr> <certified-sha>`, re-read comments for a fresh
+      `HOLD:`, then arm `gh pr merge --auto --squash --delete-branch`.
+- [ ] 8.7 `flow-finalize`: archive the change, stamp the delivery-telemetry record, close the issue.

--- a/openspec/intent/active/ai-native-sdlc.md
+++ b/openspec/intent/active/ai-native-sdlc.md
@@ -1,0 +1,102 @@
+---
+slug: ai-native-sdlc
+areas: [scripts, .github, .claude, docs]
+stream: delivery
+priority: P1
+status: active
+after: v0.17
+---
+
+# Intent: the delivery loop costs more than the work it certifies
+
+## What I cannot do today
+
+I cannot land a small, correct change in less than a day.  Measured over 590 completed deliveries in
+`docs/reports/delivery-telemetry.jsonl`: median cycle time from PR open to merge is **34.2 hours**.
+Median time from issue to PR open is about **4 hours**.  So roughly **27 hours per change** is spent
+after the code is written.
+
+The certification that consumes those hours almost never rejects anything.  The gate passed 581 of
+590 deliveries (**98.5%**).  Over the same population **71.4%** of PRs needed rework, at a mean of
+**3.32 rounds** and **6.92 roborev findings** each.  The rework comes from the review loop, not from
+the gate.
+
+Each rework round pays the inner loop again, and the inner loop is not scoped to the change.
+`CLAUDE.md` records the mechanism plainly: `--lite` dispatches the identical `run_clippy` the full
+gate does (`scripts/agent-gate.sh:17233` versus `:18220`), and `run_clippy` never reads the diff.
+The repo's own measured bands, over 188 completed lite runs: a no-op warm, **2-7 minutes part-warm**,
+and **16-24 minutes cold**.  A `cqlite-core/src/` diff measures **median 20 minutes, range 3.8-43**
+(n=20), with **~104 minutes under peer load** reported in #3764.
+
+Two further costs compound it.  `--lite` is exempt from the #1825 gate-slot cap, so on a shared box
+its build competes with a peer's gate of record with nothing arbitrating (#3763 owns that gap).  And
+a rebase voids the roborev round by doctrine, while `main` moved 12 times in 4 hours on the night
+#3650 was filed.  So a change can be forced to re-review work that did not change.
+
+## Who is affected
+
+Every lane.  19 worktrees exist and `CQLITE_GATE_MAX_CONCURRENCY=1` is persisted by
+`bootstrap-agent-machine.sh`, so full gates serialize per box regardless of how many agents run.  The
+throughput ceiling is set by certification cost, not by how much work is ready.
+
+## What better looks like
+
+A fix round costs a time proportional to the diff.  A narrow diff certifies in under two minutes,
+cold or warm.  Recurring review findings are mechanized as lints rather than found by a reviewer for
+the seventh time.  Nothing that certifies is silently narrowed: a scoped check names what it did not
+check, per the affirmative-zero doctrine.
+
+## Constraints, taken as given
+
+- **The full gate stays the gate of record.**  `scripts/agent-gate.sh` and its `AGENT-GATE SUMMARY`
+  remain the only verdict that counts (#719).  No slice weakens that.
+- **The full gate stays out of the required per-PR check set.**  `openspec/specs/gate-ci-coverage/spec.md:22`
+  makes that a deliberate requirement so it does not duplicate the light always-running
+  `pr-gate.yml` from epic #1360.  This intent does not reverse it.
+- **No component may pass vacuously.**  Every narrowing must be visible in the SUMMARY and must
+  distinguish *checked and clean* from *not checked*.
+- **No new bypass flags.**  A cost fix that can be switched off buys a vacuous green.
+
+## Slices
+
+Each slice is its own OpenSpec change, filed separately, and each stands alone.  Ordered by measured
+value over cost.
+
+| # | Slice | Removes | Status |
+|---|---|---|---|
+| 1 | `--lite` clippy scoped to the diff's blast radius | The 16-24 min cold clippy leg on every fix round | **this intent's first change** |
+| 2 | Bound the `cqlite-core/src/` fan-out leg | The `--all-targets --no-run` compile of every dependent, reported at +18 GB in #3763/#3764 | filed after slice 1 |
+| 3 | A nit cap and named passes in a root `REVIEW.md` | Uncapped findings driving 3.32 rework rounds | filed after slice 1 |
+| 4 | Mechanize the remaining recurring roborev classes as `roborev-lints` | Findings a reviewer still catches by hand | #3499 owns one of these already |
+| 5 | Trim `CLAUDE.md` to its rules-and-pointers charter | Context spent on mechanism that `gate-ops.md` and `pm-operating-loop.md` already hold | partly done by #4092 |
+| 6 | Batch the delivery-telemetry stamp | 44% of the last 200 commits being one telemetry PR per delivery | independent |
+| 7 | Delete verified-dead delivery machinery | ~5,800 lines nothing invokes | independent |
+
+## Non-goals for the whole intent
+
+- **Relocating the gate of record into CI.**  Ruled out above by an existing requirement.
+- **Raising `CQLITE_GATE_MAX_CONCURRENCY`.**  #1825 capped it for measured reasons; slices 1 and 2
+  reduce what a slot costs instead of contending for more slots.
+- **Changing the endgame order.**  Rebase → gate → C → roborev → premerge-assert → arm is the
+  #2084/#2086/#2087 design and is not re-litigated here.
+- **Changing Seam 1.**  Owner approval of spec and design stays the standing human gate.
+- **A dependency-closure blast radius.**  Slice 1 uses the package set `scoped-tests` already
+  derives.  A true closure needs rustc dep-info, which is #3366's route.
+
+## Open questions for the owner
+
+1. Slice 3 sets a nit cap.  What number, and does a capped nit become one linked follow-up issue at
+   merge, as the current severity triage already says?
+2. Slice 7 deletes `.github/issue-monitoring/` (2,321 lines, no CI job invokes it).  Delete, or wire
+   it?
+3. Slice 6 changes when telemetry lands.  Is a nightly batch commit acceptable, given
+   `delivery-telemetry.py retro` is the only consumer?
+
+## Evidence
+
+- Delivery numbers: `docs/reports/delivery-telemetry.jsonl`, 590 records.
+- Lite cost bands and the clippy scoping defect: `CLAUDE.md`, the Agent Gate section, which cites its
+  own measured populations (n=43 narrow-warm, n=20 core-src, n=188 lite runs).
+- Gate slot cap: `docs/development/pm-operating-loop.md:146`.
+- Base churn rate: `openspec/changes/certified-tree-vs-merged-tree/proposal.md`.
+- Full audit behind this intent: `docs/development/ai-native-sdlc-redesign.md`.


### PR DESCRIPTION
Closes #4128

## Summary

Artifacts only. **No behaviour change**, no code, no workflow edits. `scripts/ci/classify-docs-only.sh` returns `docs-only`.

Measured over 590 deliveries in `docs/reports/delivery-telemetry.jsonl`:

| Measure | Value |
|---|---|
| Median cycle time, open to merge | 34.2 h |
| Median issue to PR open | ~4 h |
| Median time in review | ~27 h |
| PRs needing rework | 71.4% (421/590) |
| Mean rework rounds | 3.32 |
| Mean roborev findings | 6.92 |
| Gate pass rate | 98.5% |

The gate rarely rejects anything. The review loop is where the time goes, and each round pays an inner loop that is not scoped to the change.

## What lands

1. **`docs/development/ai-native-sdlc-redesign.md`** — the audit: nine read-only sweeps over 362,265 lines of delivery machinery, measured against the AI-native SDLC playbook.
2. **`openspec/intent/active/ai-native-sdlc.md`** — the intent, 7 slices named, with the constraints it accepts as given.
3. **`openspec/changes/lite-clippy-scoped-to-blast-radius/`** — slice 1 specified: proposal, design, tasks, and a delta spec for a new `inner-loop-cost` capability with 6 requirements, every one carrying Given/When/Then scenarios per `openspec/config.yaml`.

## Primary-source verification

A code-free diff cannot be roborev-certified, so per doctrine the substitute is primary-source verification, recorded here. Every claim below was checked against `scripts/agent-gate.sh`, not against `CLAUDE.md`.

- **`run_clippy` is ONE definition** at `scripts/agent-gate.sh:11193` — a four-stage whole-workspace matrix that never reads the diff. `run_lite` calls that same function at `:20546`. `CLAUDE.md`'s Lite row cites `:17233` and `:18220` as two dispatch sites; **both have drifted and the two-site framing is wrong.** The substance of its claim survives; the citations do not. Slice 1 corrects the row rather than inheriting the error.
- **`run_lite` contradicts itself**: comment at `:20529` says "FULL-workspace clippy", the banner it prints at `:20539` says "scoped workspace clippy". Recorded for correction in slice 1.
- **Invariant #1893 at `:11214` would have been broken** by the obvious design. `cqlite-py` must stay in the linted set because `--lite`'s python tier reports SKIP on a venv/pip/maturin failure, and this clippy pass is the compile backstop that makes that SKIP safe. A pure blast-radius scope drops `cqlite-py` from most diffs and turns a safe SKIP into a silent hole. The spec therefore scopes to `blast_radius ∪ FLOOR`, and pins the invariant with its own requirement and its own mutation test.
- **`run_clippy` is already a narrowing**, justified the same way: its header at `:11186-11192` records that the historical `--all-features` pass runs nightly in a dedicated `clippy-full` job (#2662). Scoping `--lite` by blast radius extends an existing argument rather than introducing a new concession.

## Explicit non-goal, recorded rather than quietly reversed

**Relocating the gate of record into CI.** An earlier draft of the audit proposed it. `openspec/specs/gate-ci-coverage/spec.md:22` already requires that the full gate is *not* a required per-PR check, deliberately, so it does not duplicate the light always-running `pr-gate.yml` from epic #1360. That decision stands, and the intent lists the reversal as out of scope.

## Slice 1 is falsifiable on purpose

Task 1.3 is a decision point *before* any behaviour change. If the baseline shows a `cqlite-core/src/` diff's blast radius is substantially the whole workspace, scoping saves nothing on the class that hurts most, and the measurement artifact must say so. Task 1.1b measures `FLOOR` alone, since its cost is paid on every lite run and therefore bounds the best case.

## Open questions for the owner

Three sit at the end of the intent, all needed before slice 3 or slice 7 starts:

1. Slice 3 sets a review nit cap. What number?
2. Slice 7 deletes `.github/issue-monitoring/` (2,321 lines, no CI job invokes it). Delete, or wire it?
3. Slice 6 batches the telemetry stamp. Is a nightly batch commit acceptable, given `delivery-telemetry.py retro` is the only consumer?

## Wiring evidence

Not applicable. No public surface changes; these are specification and documentation artifacts. The behaviour they specify lands in a separate issue after 0.17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)