### PR TITLE
release: bump versions to 0.17.0 + release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [v0.17.0] - 2026-09-08
+
 ### Changed
 
 - **BREAKING (public API, source-level): `cqlite-core`'s `Value` enum gains a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "cqlite"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "clap",
  "cqlite-core",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "cqlite-cli"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "arrow 53.4.1",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "cqlite-core"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "cqlite-examples"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "cqlite-core",
  "env_logger",
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "cqlite-ffi-common"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "cqlite-core",
  "num-bigint",
@@ -1407,7 +1407,7 @@ dependencies = [
 
 [[package]]
 name = "cqlite-flight"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "arrow 53.4.1",
  "arrow-flight",
@@ -1438,7 +1438,7 @@ dependencies = [
 
 [[package]]
 name = "cqlite-integration-tests"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "cqlite-node"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "cqlite-py"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "cqlite-core",
  "cqlite-ffi-common",
@@ -2463,7 +2463,7 @@ dependencies = [
 
 [[package]]
 name = "flight-loadgen"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "arrow 53.4.1",
  "arrow-flight",
@@ -3603,7 +3603,7 @@ dependencies = [
 
 [[package]]
 name = "memory-safety-runner"
-version = "0.16.1"
+version = "0.17.0"
 
 [[package]]
 name = "mime"
@@ -6979,7 +6979,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws0-corpus-gen"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "clap",
  "cqlite-core",
@@ -7011,7 +7011,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ resolver = "2"
 # belongs to an unrelated project; the CLI publishes as `cqlite-cli` (binary
 # `cqlite`). See issue #782.
 name = "cqlite"
-version = "0.16.1"
+version = "0.17.0"
 edition = "2021"
 publish = false
 
@@ -64,7 +64,7 @@ crc32fast = { workspace = true }
 cqlite-integration-tests = { path = "tests" }
 
 [workspace.package]
-version = "0.16.1"
+version = "0.17.0"
 edition = "2021"
 authors = ["CQLite Team"]
 license = "Apache-2.0"

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cqlite/node",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cqlite/node",
-      "version": "0.16.1",
+      "version": "0.17.0",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.5.1",

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cqlite/node",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "Node.js bindings for CQLite - read Apache Cassandra 5.0 SSTables without cluster dependencies",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cqlite-py"
-version = "0.16.1"
+version = "0.17.0"
 description = "Python bindings for CQLite - read Cassandra 5.0 SSTables locally without a cluster"
 readme = "README.md"
 # Issue #1459: this floor is now TESTED, not merely advertised — the

--- a/cqlite-cli/Cargo.toml
+++ b/cqlite-cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 # version is required (alongside path) so the dep resolves when published to
 # crates.io. Keep this literal in sync with [workspace.package].version on every
 # release (see release checklist).
-cqlite-core = { path = "../cqlite-core", version = "0.16.1" }
+cqlite-core = { path = "../cqlite-core", version = "0.17.0" }
 
 # CLI framework
 clap = { workspace = true }

--- a/docs/releases/RELEASE_NOTES_v0.17.0.md
+++ b/docs/releases/RELEASE_NOTES_v0.17.0.md
@@ -1,0 +1,163 @@
+# CQLite v0.17.0 — read correctness and read-path performance against stock Cassandra 5
+
+Released: 2026-09-08
+
+v0.17.0 is the largest CQLite release to date: 97 issues closed across a read-correctness
+campaign against Cassandra-written bytes, a measured read-path performance program on the Arrow
+Flight server, a unified value/error contract across the Python, Node and CLI surfaces, and the
+platform-hygiene epics (config honesty, observability, dead code). It targets **stock Cassandra 5.0**
+— no server-side changes — and every parity fix in it is pinned against a Cassandra-written fixture or
+the pinned `cassandra-5.0.8` source, never against CQLite's own prior output.
+
+This note is factual and cites the issues/PRs that shipped. The granular list, including every
+breaking change with before/after examples and consumer guidance, is the `[v0.17.0]` section of
+[`CHANGELOG.md`](../../CHANGELOG.md). Release binaries and the auto-generated GitHub release body are
+produced by `release.yml` on the `v0.17.0` tag.
+
+## Headline 1 — read correctness: refuse or decode, never invent
+
+A campaign over the row/cell decoder found and closed a family of silent-wrong-answer defects. The
+common shape was a decode error swallowed into a truncated or empty result; the common fix is a
+loud, typed error and a fixture-pinned oracle.
+
+- **Silently truncated rows are gone** — row assembly no longer swallows a complex-column decode
+  error into a row missing that column and every later one
+  ([#3721](https://github.com/pmcfadin/cqlite/issues/3721)); partition-header decode errors are no
+  longer hidden behind a byte-resync ([#3928](https://github.com/pmcfadin/cqlite/issues/3928)); the
+  index-random-read path keeps the fatal error kind instead of degrading to a sequential fallback
+  ([#3782](https://github.com/pmcfadin/cqlite/issues/3782)).
+- **P0: misaligned cell offset on point reads and multi-chunk seeks**, hidden behind the swallow
+  above on committed fixtures ([#3890](https://github.com/pmcfadin/cqlite/issues/3890)).
+- **BTI `Rows.db` row-index root base** was 2 bytes low against Cassandra's `writeWithShortLength`
+  framing, masked by a compensating encoder defect; both fixed, pinned against the real Cassandra 5.0
+  `da` fixture ([#3002](https://github.com/pmcfadin/cqlite/issues/3002)).
+- **Collections and nested types**: an empty `''` map key no longer drops its whole entry
+  ([#3747](https://github.com/pmcfadin/cqlite/issues/3747)); an empty fixed-width set member is
+  decoded as the EMPTY element instead of dropped ([#4106](https://github.com/pmcfadin/cqlite/issues/4106));
+  nested fixed-width elements must have exactly Cassandra's length, not at-least
+  ([#3723](https://github.com/pmcfadin/cqlite/issues/3723)); nested tuple/UDT/collection/duration
+  consumption is bounds-checked below the first level ([#3778](https://github.com/pmcfadin/cqlite/issues/3778),
+  [#3809](https://github.com/pmcfadin/cqlite/issues/3809), [#3811](https://github.com/pmcfadin/cqlite/issues/3811));
+  composite (frozen tuple/UDT) collection keys decode through the full value deserializer
+  ([#2339](https://github.com/pmcfadin/cqlite/issues/2339)); UDT field values of many types no longer
+  decode as opaque `Blob` ([#3722](https://github.com/pmcfadin/cqlite/issues/3722)); the legal
+  zero-length buffer is accepted for fixed-width scalars ([#3847](https://github.com/pmcfadin/cqlite/issues/3847))
+  and a `blob_len` overflow in the frozen preamble is guarded ([#3848](https://github.com/pmcfadin/cqlite/issues/3848)).
+- **Ordering parity**: `inet` and `time` compare as Cassandra's byte order, not as formatted strings
+  ([#3790](https://github.com/pmcfadin/cqlite/issues/3790)); the whole-collection writer orders
+  `set<time>`/`map<time,…>` elements as Cassandra's `TimeType` does
+  ([#3935](https://github.com/pmcfadin/cqlite/issues/3935)).
+- **Declaration validity**: `frozen<scalar>` is not declarable CQL and is now refused at both metadata
+  entry points instead of decoded by guess ([#4104](https://github.com/pmcfadin/cqlite/issues/4104)),
+  which exposed and fixed a **write-path** defect — the `Statistics.db` serialization header now
+  carries Cassandra's real `FrozenType(UserType(…))` spelling for a `frozen<UDT>` column instead of
+  `BytesType` ([#4158](https://github.com/pmcfadin/cqlite/issues/4158)), verified against a
+  Cassandra-written header.
+- **CLI JSON parity**: `float` is no longer widened to `f64` ([#3777](https://github.com/pmcfadin/cqlite/issues/3777));
+  `decimal`/`varint` render as unquoted JSON numbers as `sstabledump` does
+  ([#3644](https://github.com/pmcfadin/cqlite/issues/3644)); a UDT renders its declared fields only,
+  with no injected `_type` key ([#3629](https://github.com/pmcfadin/cqlite/issues/3629)).
+- **Two new parity lanes** back these: Parquet round-trip value parity
+  ([#1490](https://github.com/pmcfadin/cqlite/issues/1490)) and JSON/CSV value parity against the
+  `sstabledump` JSONL goldens ([#1491](https://github.com/pmcfadin/cqlite/issues/1491)).
+
+## Headline 2 — read-path performance, measured
+
+The 0.17 throughput program ([#2817](https://github.com/pmcfadin/cqlite/issues/2817)) measured before
+it optimised, and every figure below is in a committed report under `docs/reports/`.
+
+- **Flight `do_get` single-SSTable merge bypass** — a scan over one SSTable no longer pays the k-way
+  merge/reconciliation it does not need: **3.06× more rows/s per core** on the reference corpus
+  ([#3058](https://github.com/pmcfadin/cqlite/issues/3058)). Head-to-head on one physical core against
+  stock Cassandra reading the same SSTable: CQLite's bare read path is **1.25×** Cassandra's `count(*)`
+  and Flight shipping every row is **1.12×** Cassandra's `SELECT *`
+  (`docs/reports/ws0-3100-report.md`), up from 0.29× on the served path in July.
+- **Admission default derived from available parallelism** — `--max-concurrent-scans` follows core
+  count instead of a constant 64, which cost 7–22% of throughput and 3–42× per-scan p50
+  ([#3225](https://github.com/pmcfadin/cqlite/issues/3225)).
+- **Byte-bounded Arrow batches and a wired per-stream result budget**
+  ([#2825](https://github.com/pmcfadin/cqlite/issues/2825), [#2821](https://github.com/pmcfadin/cqlite/issues/2821)),
+  the row-size estimate folded into the build pass ([#3552](https://github.com/pmcfadin/cqlite/issues/3552)),
+  and scan-lifetime `madvise` plumbing ([#2824](https://github.com/pmcfadin/cqlite/issues/2824),
+  [#3853](https://github.com/pmcfadin/cqlite/issues/3853)).
+- **Box ceiling established**: bare scan 2.73M rows/s on 6 physical cores at 93.5% marginal
+  efficiency ([#3299](https://github.com/pmcfadin/cqlite/issues/3299)); the served-path target was
+  re-baselined to what the priced levers can reach ([#3553](https://github.com/pmcfadin/cqlite/issues/3553)).
+- **Allocator**: the glibc malloc lock was measured serialising the second core; jemalloc measured
+  +29% at a fixed pin and +61% with a second physical core under `LD_PRELOAD`
+  ([#3551](https://github.com/pmcfadin/cqlite/issues/3551)). `cqlite-flight` now builds with a
+  linked jemalloc behind the `jemalloc` feature, **off by default**; the shipping default is decided
+  by the linked re-measurement in [#4120](https://github.com/pmcfadin/cqlite/issues/4120).
+- **Field run on a 3-node Cassandra 5.0.9 cluster** (`docs/2024-09-meetup/REPORT.md`): a full-table
+  analytic through CQLite raised the OLTP client's p99 2.21× vs 5.61× for the same query through
+  Cassandra's own CQL path; the same Trino SQL over a 22M-row key-value table ran 1.66× faster through
+  the `cqlite` catalog than the stock `cassandra` connector; 1.72M rows/s sustained from a single
+  Flight pod. Single-pod results — see the known issues below.
+
+## Headline 3 — one value and error contract across bindings
+
+The bindings/FFI audit epics ([#1434](https://github.com/pmcfadin/cqlite/issues/1434),
+[#1435](https://github.com/pmcfadin/cqlite/issues/1435), [#1436](https://github.com/pmcfadin/cqlite/issues/1436)):
+
+- **Shared authoritative error table** — Python and Node map the same core error to the same identity
+  ([#1451](https://github.com/pmcfadin/cqlite/issues/1451)), with the shared byte-math extracted to
+  `cqlite-ffi-common` ([#1452](https://github.com/pmcfadin/cqlite/issues/1452)).
+- **3-way golden parity** — the same `SELECT` through Python, Node and the CLI must yield equal
+  canonical values, enforced in CI ([#1455](https://github.com/pmcfadin/cqlite/issues/1455)).
+- UDT type identity carried out of band (breaking, see below); CQL `decimal` has one rendering in
+  Python (breaking); dataset guards fail on present-but-empty roots
+  ([#1458](https://github.com/pmcfadin/cqlite/issues/1458)); CI tests the claimed Python ≥3.9 / Node ≥18
+  floors ([#1459](https://github.com/pmcfadin/cqlite/issues/1459)); stub-fidelity and exception-path
+  leak tests ([#1456](https://github.com/pmcfadin/cqlite/issues/1456), [#1465](https://github.com/pmcfadin/cqlite/issues/1465)).
+
+## Also in this release — platform hygiene epics
+
+- **Correctness/safety landmines** (Epic AG, [#1684](https://github.com/pmcfadin/cqlite/issues/1684)):
+  parser abort, unbounded channel, `block_on`, shutdown and data-in-logs classes closed.
+- **Config honesty** (Epic AH, partial): ~40 decorative knobs deleted and `Config::validate()` made
+  honest ([#1696](https://github.com/pmcfadin/cqlite/issues/1696)); one public `Config`
+  ([#1697](https://github.com/pmcfadin/cqlite/issues/1697)); `query.max_execution_time` enforced
+  ([#1695](https://github.com/pmcfadin/cqlite/issues/1695)); feature-matrix gate lanes
+  ([#1699](https://github.com/pmcfadin/cqlite/issues/1699)). The epic's remainder rolls to 0.18.
+- **Observability honesty** (Epic AI, [#1686](https://github.com/pmcfadin/cqlite/issues/1686)): the
+  four dead read metrics wired ([#1701](https://github.com/pmcfadin/cqlite/issues/1701)), scan-path
+  errors counted, a loud warning when OTel is enabled on a build without it, read-side phase timings.
+- **Schema subsystem** (Epic AJ, [#1687](https://github.com/pmcfadin/cqlite/issues/1687)), **dead code +
+  public-surface hygiene** (Epic AK, [#1688](https://github.com/pmcfadin/cqlite/issues/1688): `pub mod
+  benchmarks` un-exported, never-compiled tests and the orphan schema JSON exporter deleted), and
+  **CLI/TUI polish** (Epic AL, [#1689](https://github.com/pmcfadin/cqlite/issues/1689)).
+
+## Breaking changes
+
+Each entry in `CHANGELOG.md` `[v0.17.0]` carries before/after output and consumer guidance.
+
+- `cqlite-core`: `Value` gains `Value::Empty(EmptyValueType)` (exhaustive matches need an arm, #3805);
+  `Config.storage` is the single storage config and decorative knobs are deleted (#1696/#1697);
+  `ffi_error_contract` moved to `cqlite-ffi-common` (#1451/#1452); the schema JSON exporter and
+  `pub mod benchmarks` are gone (#1715/#1712); streaming-scan and single-partition-merger builder
+  signatures changed (#2765/#2820 lineage); `ErrorCategory` renames (#1705).
+- CLI `--format json`: `decimal`/`varint` unquoted (#3644), no UDT `_type` key (#3629), `float` not
+  widened (#3777), `EMPTY` cell-path keys render `""` (#3805).
+- Bindings: UDT type identity out of band (#1434 family), Python `decimal` single rendering, Node
+  malformed-`inet` is a typed `PARSE` error.
+- `cqlite-flight`: `--max-concurrent-scans` default now derives from available parallelism (#3225).
+
+## Known issues and scope notes
+
+- **Trino connector `cqlite-trino:0.17.0`** is content-identical to 0.16.1 (`git log v0.16.1..main --
+  trino-connector/` is empty) — a tag-derived version realign, as 0.15.0 was.
+- **A scan over an unreadable SSTable still returns `Ok(empty)` rather than an error**
+  ([#4159](https://github.com/pmcfadin/cqlite/issues/4159), pre-existing in every prior release,
+  fix in flight for 0.18). #4104's refusal surfaces the offending type at `StatisticsReader::open`;
+  the scan-level propagation lands with #4159.
+- Field-found on the 3-node run, all under investigation for 0.18: an unbounded `SELECT count(*)`
+  through the Trino `cqlite` catalog can stall ([#4170](https://github.com/pmcfadin/cqlite/issues/4170));
+  scans are served by the `sidecar-uri` host's Flight pod only, so multi-node fan-out is unmeasured
+  ([#4175](https://github.com/pmcfadin/cqlite/issues/4175)); `timeuuid` maps to `varchar` where the
+  stock connector maps `uuid` ([#4173](https://github.com/pmcfadin/cqlite/issues/4173)).
+- **Parity claim scope**: the `required_parity` lane is green on the release commit; the weekly
+  `exhaustive_regeneration` lane is red on corpus-inventory drift (new 0.17 fixtures without a
+  regeneration recipe, [#3357](https://github.com/pmcfadin/cqlite/issues/3357)), not on a byte
+  divergence. No unqualified "same tests as Cassandra" claim is made.
+- Memory-allocator default and the served-path measurement program continue in 0.18
+  ([#4120](https://github.com/pmcfadin/cqlite/issues/4120), [#2817](https://github.com/pmcfadin/cqlite/issues/2817)).

--- a/website/src/content/docs/releases/index.md
+++ b/website/src/content/docs/releases/index.md
@@ -14,6 +14,7 @@ For the complete, granular change list, see the
 
 | Version | Date | Highlights |
 |---------|------|-----------|
+| [v0.17.0](/cqlite/releases/v0-17-0/) | 2026-09-08 | Read correctness + read-path performance vs stock Cassandra 5 — 97 issues · 3.06× Flight single-SSTable fast path · one value/error contract across Python/Node/CLI · breaking JSON + config changes |
 | [v0.16.1](/cqlite/releases/v0-16-1/) | 2026-07-23 | Reads a second Cassandra on-disk format — CommitLog segment files — via a library API and a `read-commitlog` CLI |
 | [v0.16.0](/cqlite/releases/v0-16-0/) | 2026-07-22 | Trino connector completeness — typed collection columns (array/row/map) · weight-balanced split fan-out · `LIMIT`-cancellation hang fixed |
 | [v0.15.0](/cqlite/releases/v0-15-0/) | 2026-07-17 | Trino latency/throughput/ops — ~15× warm throughput · admission control · saturation gauges · P0 silent-row-loss fix |

--- a/website/src/content/docs/releases/v0-17-0.md
+++ b/website/src/content/docs/releases/v0-17-0.md
@@ -1,0 +1,78 @@
+---
+title: CQLite v0.17.0
+description: Read correctness and read-path performance against stock Cassandra 5 — 97 issues, a 3.06× Flight scan fast path, one value/error contract across Python, Node and CLI.
+sidebar:
+  label: v0.17.0
+  order: 0.5
+---
+
+# CQLite v0.17.0 — read correctness and read-path performance
+
+The largest CQLite release so far: **97 issues** across a read-correctness campaign against
+Cassandra-written bytes, a measured read-path performance program on the Arrow Flight server, a
+unified value and error contract across Python, Node and the CLI, and the platform-hygiene epics.
+It targets **stock Cassandra 5.0** with no server-side changes. Full detail with every breaking
+change: [release notes](https://github.com/pmcfadin/cqlite/blob/main/docs/releases/RELEASE_NOTES_v0.17.0.md)
+and the [CHANGELOG](https://github.com/pmcfadin/cqlite/blob/main/CHANGELOG.md).
+
+## 🔍 Read correctness: refuse or decode, never invent
+
+A family of silent-wrong-answer defects is closed. Row assembly no longer swallows a decode error
+into a truncated row (#3721); a P0 misaligned cell offset on point reads is fixed (#3890); the BTI
+`Rows.db` row-index root base matches Cassandra's framing (#3002); empty map keys and empty set
+members are kept, not dropped (#3747, #4106); nested types are bounds-checked at every level
+(#3723, #3778, #3809, #3811); `inet`/`time` order as Cassandra orders them (#3790, #3935); and
+`frozen<scalar>` — not declarable CQL — is refused instead of guessed (#4104), which exposed and
+fixed a writer defect in the `Statistics.db` header type for `frozen<UDT>` (#4158). Two new parity
+lanes pin JSON/CSV and Parquet output against the `sstabledump` goldens (#1490, #1491).
+
+## ⚡ Read-path performance, measured before optimised
+
+- **3.06× per core** on Flight `do_get` over a single SSTable — the k-way merge is bypassed when
+  there is nothing to merge (#3058). Head-to-head on one core against stock Cassandra reading the
+  same SSTable: **1.25×** its `count(*)` on the bare read path, **1.12×** its `SELECT *` when
+  shipping every row.
+- Admission default follows core count instead of a fixed 64 (#3225); byte-bounded Arrow batches
+  and a wired per-stream budget (#2825, #2821).
+- Box ceiling established at **2.73M rows/s on 6 physical cores** (#3299); jemalloc measured +29%
+  to +61% (#3551) and ships as an opt-in `cqlite-flight` feature, default pending #4120.
+- On a 3-node Cassandra 5.0.9 cluster, a full-table analytic through CQLite cost the OLTP client
+  **2.21×** baseline p99 vs **5.61×** through Cassandra's own CQL path; the same Trino SQL ran
+  **1.66× faster** through the `cqlite` catalog than the stock connector. Single-pod results — see
+  known issues.
+
+## 🧩 One value and error contract across bindings
+
+A shared authoritative error table (#1451), a 3-way golden parity harness where the same `SELECT`
+through Python, Node and the CLI must agree (#1455), UDT identity carried out of band, and CI that
+tests the claimed Python 3.9 and Node 18 floors (#1459).
+
+## 🧹 Platform hygiene
+
+Correctness landmines closed (Epic AG), ~40 decorative config knobs deleted and `Config::validate()`
+made honest (#1696, #1697), the four dead read metrics wired (#1701), `pub mod benchmarks`
+un-exported and never-compiled code removed (Epic AK).
+
+## ⚠️ Breaking changes
+
+`Value::Empty` added to `cqlite-core`'s `Value` enum; `Config.storage` is the single storage config;
+CLI JSON renders `decimal`/`varint` unquoted, drops the injected UDT `_type` key and no longer
+widens `float`; bindings carry UDT identity out of band and Python `decimal` has one rendering;
+`--max-concurrent-scans` default derives from parallelism. Consumer guidance for each is in the
+CHANGELOG.
+
+## Known issues
+
+A scan over an unreadable SSTable still returns empty rather than an error (#4159, pre-existing,
+fixed in 0.18). Field-found: an unbounded `count(*)` through the Trino `cqlite` catalog can stall
+(#4170); scans are served by one Flight pod, so multi-node fan-out is unmeasured (#4175);
+`timeuuid` maps to `varchar` (#4173). The Trino connector `0.17.0` is content-identical to 0.16.1.
+
+## Get it
+
+```bash
+brew install pmcfadin/cqlite/cqlite      # CLI (macOS + Linux)
+cargo add cqlite-core                     # Rust library
+pip install cqlite-py                     # Python
+npm install @cqlite/node                  # Node.js
+```


### PR DESCRIPTION
Closes #4183.

Version bump 0.16.1 → 0.17.0 across every publish manifest (`scripts/bump-version.sh set 0.17.0` — `check v0.17.0` passes — plus the `cqlite-cli` core dep pin, `bindings/node/package-lock.json`, and `Cargo.lock` workspace members via `cargo update --workspace`), the CHANGELOG roll (`[Unreleased]` → `[v0.17.0] - 2026-09-08`), `docs/releases/RELEASE_NOTES_v0.17.0.md`, and the website release page + index row.

Headline: read correctness against Cassandra-written bytes (#3721/#3890/#3002 family), measured read-path performance (#3058 3.06× Flight fast path, #3225, #3299), one value/error contract across bindings (#1434/#1435/#1436), platform-hygiene epics. 97 issues.

**Certification**, same as #2840/#2635 (oracle-driven release chore): the only compiled-input change is version strings, so the PR's `required` check (pr-gate-core + registered tiers) is the certification; `release-preflight.yml` re-asserts tag == every manifest on the tag. Two standing nightlies are RED and disclosed in the release issue and notes, not blocking: `gate.yml` deep-check (#2911) and `exhaustive-regeneration` corpus-inventory drift (#3357) — parity wording in the notes is scoped to the green `required_parity` lane accordingly.

**After merge (owner go required — every registry on the train is immutable):** tag `v0.17.0` on the merge commit → tag push auto-triggers the whole release train (release.yml, python-release, node-release, flight-image, trino-publish, api-docs; never manually dispatch alongside); then cut `release/0.17` at the tag (#2410 convention).

https://claude.ai/code/session_0125yfcchVUfMYtH7arzaD2f
