### PR TITLE
docs: storage-engine PRD (Cassandra-compatible storage execution) + SE1–SE6 roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Full documentation is at **[https://pmcfadin.github.io/cqlite/](https://pmcfadin
 
 ## Vision
 
-CQLite aims to become the standard tool for Cassandra SSTable manipulation outside of the main Apache Cassandra project, enabling new workflows for data analytics, migration, testing, and edge computing.
+CQLite aims to provide a Cassandra-compatible storage engine that shares reconciliation and materialization across analytics, bulk ingestion, and compaction, with incremental integration into Cassandra. The CLI, bindings, and query interfaces remain the accessible product surfaces. See the [Product Requirements](docs/development/PRD.md) for scope, guarantees, and qualification milestones.
 
 ## Project Leadership
 
@@ -339,17 +339,24 @@ See the [**Roadmap**](#roadmap) section below for in-flight epics and milestones
 
 ## Roadmap
 
-CQLite is at **v0.13.0** and production-ready for the use cases above. The path to
-**v1.0** is tracked in the open. Full detail, with milestones, lives at
-[pmcfadin.github.io/cqlite → Roadmap](https://pmcfadin.github.io/cqlite/user-docs/roadmap/).
+The [PRD](docs/development/PRD.md#7-milestones-and-dependency-gates) defines the
+storage-engine qualification program. M1–M5 remain historical delivery milestones;
+the new milestones measure supported workflows and operator outcomes.
 
-| Workstream | Epic |
-|------------|------|
-| Wire storage-layer capabilities (bloom/index/BTI seeks) into the CQL query path + regression guards | [#951](https://github.com/pmcfadin/cqlite/issues/951) |
-| Read-path performance & I/O backend (parallel single-reader scans, io_uring spike) | [#906](https://github.com/pmcfadin/cqlite/issues/906) |
-| CLI & bindings polish (DX & cleanup) | [#907](https://github.com/pmcfadin/cqlite/issues/907) |
-| Compaction byte-parity follow-ups (range tombstones e2e + edge cases) | [#938](https://github.com/pmcfadin/cqlite/issues/938) |
-| M6 — WASM bindings · M7 — performance validation + **v1.0** | _planned_ |
+| Milestone | Outcome |
+|-----------|---------|
+| SE1 — Engine contract | Explicit scope, authority, capabilities, and workload acceptance criteria |
+| SE2 — Shared offline execution | Safe compaction and reusable analytics materialization |
+| SE3 — Analytics offload value | Measured benefit within Cassandra foreground-service and freshness budgets |
+| SE4 — Bulk writing and policy tools | Qualified native ingestion plus compaction planning/simulation |
+| SE5 — Qualified freshness | Proven memtable-tail behavior for opted-in analytical reads |
+| SE6 — Bounded Cassandra integration | One reversible native/offload pilot |
+| SE7 — Native lifecycle qualification | Supported integrated behavior backed by operational evidence |
+
+Qualification is pending; existing implementation and research contribute evidence
+but do not automatically complete these milestones. External-engine **1.0 requires
+SE1–SE4** and the PRD's release gates. WASM and native lifecycle integration are
+separate tracks. See the [user roadmap](https://pmcfadin.github.io/cqlite/user-docs/roadmap/).
 
 The roadmap follows real-world use. Want something prioritized?
 [Open or 👍 an issue](https://github.com/pmcfadin/cqlite/issues) — and
@@ -433,7 +440,7 @@ env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test --package cqlite-cor
 - 33/33 test tables passing (100% validation)
 - All 21 CQL primitive types + collections + UDTs + frozen types
 - All compression algorithms working
-- Tiered test coverage targets (see [PRD Section 5.1](docs/development/PRD.md#51--tiered-coverage-targets))
+- Tiered test coverage targets (see [historical PRD Section 5.1](docs/development/PRD-toolkit-v0.2.md#51--tiered-coverage-targets))
 
 ### ✅ M2 Complete (Jan 2026)
 - CLI with one-shot and REPL modes
@@ -479,7 +486,7 @@ See [docs/development/PRD.md](docs/development/PRD.md) for milestone details.
 ### Language Bindings
 - **Python**: Production-ready sync API (see [Python README](bindings/python/README.md))
 - **Node.js**: Production-ready Promise API (see [Node.js README](bindings/node/README.md))
-- **WASM**: Planned (M6+)
+- **WASM**: Deferred optional surface; not a prerequisite for external-engine 1.0
 
 ## Resources
 
@@ -512,4 +519,4 @@ Special thanks to the Apache Cassandra community and the many contributors who m
 
 ---
 
-**Note**: M1 through M5 milestones are complete and the project is at **v0.13.0**. Core SSTable reading, CLI, output writers (including Parquet), Python and Node.js bindings, and write support with STCS compaction and **byte-for-byte compaction parity vs Apache Cassandra** are production-ready, alongside read-path performance wins, byte-bounded result budgets, an Arrow Flight + Trino connector, canonical BTI (`da`) write/read, and CDC-style delta export. Next: M6 (WASM bindings) and M7 (performance validation + v1.0).
+**Planning note**: M1–M5 record the toolkit and execution foundation. The [current PRD](docs/development/PRD.md) replaces the remaining M6/M7 sequence with SE1–SE7 qualification milestones. Release-specific support and parity claims must follow the [parity release checklist](docs/development/parity-release-checklist.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -88,7 +88,8 @@ Welcome to the CQLite documentation hub. This directory holds technical document
 - **Milestones Complete**: M1 (Core Reading), M2 (CLI), M3 (Output Writers), M4 (Python & Node.js Bindings), M5 (Write Support + Compaction)
 - **v0.13.0**: Read-path constant-factor speedups (Epic E, C2) · Node bindings throughput · byte-bounded result budgets · explicit `Database.refresh()` · no-heuristics correctness fixes
 - **v0.12.0**: Byte-for-byte compaction parity vs Apache Cassandra · Arrow Flight + Trino connector · canonical BTI write/read · CDC delta-export · `WRITETIME()`/`TTL()` in `SELECT`
-- **Next**: M6 (WebAssembly Bindings), M7 (Performance validation + v1.0)
+- **Product direction**: shared storage execution for analytics, materialization, bulk writing, and compaction — see the [current PRD](development/PRD.md)
+- **Next**: SE1–SE4 qualify the external engine for 1.0; SE5–SE7 cover freshness and Cassandra integration. WASM is optional. The [toolkit PRD](development/PRD-toolkit-v0.2.md) preserves historical M1–M7 planning
 - **Test Pass Rate**: 100% (33/33 tables vs sstabledump, see `test-data/validation-matrix.md`)
 
 ---
@@ -96,7 +97,7 @@ Welcome to the CQLite documentation hub. This directory holds technical document
 ## 🔄 Document Maintenance
 
 ### Last Updated
-- Documentation hub: 2026-06-10
+- Documentation hub roadmap: 2026-09-06
 - Performance & profiling docs: 2026-06-10
 - Architecture docs: 2026-01-27
 - User guides: 2026-01-27

--- a/docs/development/PRD-toolkit-v0.2.md
+++ b/docs/development/PRD-toolkit-v0.2.md
@@ -1,0 +1,386 @@
+# CQLite – Concise Product Requirements Document (v0.2)
+
+## 1 · Mission & Vision
+
+* **Mission**  Lower friction to Cassandra data by providing a fast, safe Rust library for local SSTable operations—fully aligned with Apache community values.
+* **Vision**  Become the de‑facto community standard for reading Cassandra 5+ SSTables, usable from CLI, Python, Node.js, and WASM.
+
+---
+
+## 2 · Functional Scope (Must‑Have for v1.0)
+
+| Area                    | Requirements                                                                                                                                                                                                                                     |     |                                                                    |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --- | ------------------------------------------------------------------ |
+| **Core Reading**        | • 100 % Cassandra 5 SSTable format support (data, TOC, index, stats)<br>• All CQL types incl. collections & UDTs<br>• Compression: LZ4, Snappy, Deflate<br>• Zero‑copy deserialization into **provided schema** (schema passed in, not inferred) |     |                                                                    |
+| **CLI (`cqlite`)**      | • **One‑shot mode**: `--schema`, `--data-dir`, optional `--query` & \`--out {json                                                                                                                                                                | csv | parquet}\`<br>• **REPL mode**: interactive attach / query / export |
+| **Output Formats**      | JSON, CSV, Parquet (pluggable writers)                                                                                                                                                                                                           |     |                                                                    |
+| **Language Bindings**   | Typed APIs for Python (sync), Node.js (TS defs); WASM deferred to M6                                                                                                                                                                               |     |                                                                    |
+| **Writing**             | Generate Cassandra 5 SSTables (M5)                                                                                                                                                                                                                     |     |                                                                    |
+| **Performance Targets** | Set after functional parity; goal: *faster than native Cassandra bulk tools*                                                                                                                                                                     |     |                                                                    |
+
+---
+
+## 3 · Architecture & Separation of Concerns
+
+```
+cqlite-core/        # Pure Rust crate
+├── sstable_rw/     # read/write, compression, checksums
+├── schema/         # type system, validation
+└── query/          # minimal SQL parser & executor (optional)
+
+cli/                # REPL + one-shot wrapper (uses core)
+bindings/
+  ├── python/
+  ├── node/
+  └── wasm/
+tests/              # shared fixtures (Cassandra 5 SSTables)
+```
+
+* **Rule**: Core never depends on CLI or bindings.
+* **Async‑first**, **type‑safe**, zero‑copy IO.
+
+---
+
+## 4 · Milestones
+
+| #      | Deliverable                | Key Exit Criteria                                                                         |
+| ------ | -------------------------- | ----------------------------------------------------------------------------------------- |
+| **M1** | **Core Reading Library**   | Reads any Cassandra 5 SSTable; all CQL/UDT types; compression OK; tiered coverage (see Section 5.1) |
+| **M2** | **CLI (REPL + one‑shot)**  | Human can query & verify data from disk; basic `SELECT … WHERE …`                         |
+| **M3** | **Output Writers**         | JSON, CSV, Parquet export work end‑to‑end via CLI                                         |
+| **M4** | **Python & Node.js Bindings** | `pip install cqlite-py`, `npm i @cqlite/node`; CI wheels & native modules                 |
+| **M5** | **Write Support** ✅ **(v0.9.0)** | Generate valid Cassandra 5 SSTables; write API in core and bindings                       |
+| **M6** | **WASM Bindings** *(deferred)*   | `npm i @cqlite/wasm`; IndexedDB support; browser compatibility                            |
+| **M7** | **Perf & Size Validation** *(deferred)* | Benchmarks > native bulk tools; WASM < 2 MB; publish v1.0 release                |
+
+> **Revision Note (Jan 2026)**: M1 coverage revised to tiered targets per Issue #204. M4 now Python & Node.js only (sync Python first). Write Support restored as M5. WASM moved to M6. v1.0 release moved to M7.
+
+> **Revision Note (May 2026)**: M5 complete, v0.9.0 cut. WAL + memtable + STCS compaction + write APIs in Python, Node.js, and CLI ship in this release. M6 (WASM) and M7 (perf + v1.0) are the remaining milestones. See CHANGELOG.md for the full M5 change list.
+
+> **Revision Note (May 2026, v0.9.1)**: Reader-correctness patch. Set-element tombstone skipping (#493), schema-aware tuple decoding for arbitrary arity (#501), and `frozen<udt>` field decoding via the UDT registry (#502) all landed — these are removed from §4.2 Known Issues. Reviving the orphan integration tests (#514) and fixing the aarch64-apple-darwin CI/release runner (#512) also shipped. New reader bugs surfaced by the revived tests are tracked in the v0.9.2 milestone (#516, #517, #518). M6/M7 remain the path to v1.0.
+
+### 4.1 · M5 Write Support Architecture
+
+**Design Principle**: The write API is **mutation-based**, not CQL-dependent. CQL statement support is a convenience layer built on top of the core mutation API.
+
+#### API Layers
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  CLI / Bindings                                         │
+│  • --execute "INSERT INTO..." (optional, needs parser)  │
+│  • --mutation '{...}' (direct, no parser needed)        │
+└─────────────────────────┬───────────────────────────────┘
+                          │
+┌─────────────────────────▼───────────────────────────────┐
+│  WriteEngine (Core API)                                 │
+│  • write(mutation) ← Primary interface                  │
+│  • execute(cql) ← Convenience, depends on CQL parser    │
+│  • flush() / close()                                    │
+│  • export_sstable()                                     │
+└─────────────────────────────────────────────────────────┘
+```
+
+#### Mutation API (Primary)
+
+The `Mutation` struct is the canonical write interface:
+
+```rust
+let mutation = Mutation::new(
+    TableId::new("keyspace", "table"),
+    PartitionKey::single("id", Value::Integer(1)),
+    None,  // Optional clustering key
+    vec![CellOperation::Write { column: "name", value: Value::Text("Alice") }],
+    timestamp,
+    None,  // Optional TTL
+);
+engine.write(mutation)?;
+```
+
+**Rationale**: Mutation-based API ensures:
+- Core write path has no parser dependency
+- Bindings can construct mutations directly (Python dict → Mutation)
+- Bulk import tools bypass CQL overhead
+- Testing doesn't require CQL parser
+
+#### CQL Statement Support (Optional Layer)
+
+CQL INSERT/UPDATE/DELETE parsing is built on top:
+
+```rust
+// Internally converts to Mutation
+engine.execute("INSERT INTO ks.users (id, name) VALUES (1, 'Alice')")?;
+```
+
+This layer depends on the CQL parser (`cqlite-core/src/cql/`) and is **optional** for write functionality.
+
+#### CLI Write Modes
+
+| Mode | Input | Parser Required | Use Case |
+|------|-------|-----------------|----------|
+| `--mutation '{...}'` | JSON | No | Programmatic, bulk import |
+| `--mutations-file` | JSONL file | No | Batch processing |
+| `--execute "INSERT..."` | CQL | Yes | Interactive, familiar syntax |
+
+#### E2E Validation Workflow
+
+The product contract for M5 write support is:
+
+- `WriteEngine` flushes portable Cassandra SSTable components directly into the write directory.
+- Those flushed files are the primary artifact users should be able to copy into a Cassandra table data directory and have Cassandra read without any CQLite-side conversion step.
+- Loader-based workflows such as `sstableloader` may exist as convenience tooling, but they are not the acceptance path for M5 portability.
+
+The end-to-end validation therefore must prove direct Cassandra consumption of flushed files:
+
+```bash
+# 1. Write data via CQLite
+cqlite --writable --schema schema.cql --write-dir ./data \
+  --mutation '{"table":"users","pk":{"id":1},"ops":[...]}'
+
+# 2. Flush to portable Cassandra SSTables
+cqlite --writable --schema schema.cql --write-dir ./data --flush
+
+# 3. Copy the flushed SSTables into the target Cassandra table directory
+cp ./data/nb-*-big-* /var/lib/cassandra/data/keyspace/table-uuid/
+
+# 4. Tell Cassandra to discover the copied SSTables
+nodetool refresh keyspace table
+
+# 5. Verify via cqlsh
+cqlsh -e "SELECT * FROM keyspace.table"
+```
+
+**Exit Criteria**:
+- After flush, CQLite has produced Cassandra-readable SSTables without any additional conversion or repackaging step.
+- Copying those SSTables into a Cassandra 5.0 table directory and invoking Cassandra's native refresh/import mechanism makes the data queryable without errors.
+- `sstableloader` compatibility is a useful secondary workflow, but passing `sstableloader` alone does not satisfy M5.
+
+> **Revision Note (March 2026)**: M5 write support treats flushed SSTables as the primary portable artifact. The milestone acceptance path is now explicitly direct Cassandra readability after copy plus native refresh/import; loader workflows remain secondary convenience tooling. See Issues #392, #393, #396, #397.
+
+---
+
+## 4.2 · Known Issues (post-v0.9.1)
+
+The following are tracked follow-ups, not release blockers. All are open GitHub issues.
+The v0.9.0 reader follow-ups (#493 set-element tombstones, #501 tuple decoding,
+#502 frozen<udt> decoding) were **resolved in v0.9.1**. The v0.9.2 reader and
+compaction correctness fixes (#516 `scan()` token ordering, #517 `get()`/`scan()`
+consistency, #518 `stats().block_count`, #505 compaction row tombstones, #498
+equal-timestamp Delete-vs-Live reconcile, #533 per-cell compaction reconcile,
+#492 streaming `Data.db` writer, and #552 multi-partition Index.db reader) were
+**resolved in v0.9.2** and removed from this list.
+
+| Issue | Milestone | Description | Workaround |
+|-------|-----------|-------------|------------|
+| #311 | — | Python concurrent-query race in schema metadata access | Run one warm-up query before spawning parallel threads on the same handle |
+| #553 | — | Index.db point lookup falls back to a full scan (hash digest vs raw-key mismatch); reads correct, not O(1) | None needed; correctness unaffected |
+
+See [docs/write-support-limitations.md](../write-support-limitations.md) for the full limitations reference.
+
+---
+
+## 5 · Testing Strategy
+
+| Layer       | Tests                                              | Tooling                            |
+| ----------- | -------------------------------------------------- | ---------------------------------- |
+| Core        | Unit + property‑based for type/format edge cases   | Rust `cargo test`, `proptest`      |
+| CLI         | Integration & snapshot tests for commands/output   | `assert_cmd`, `insta`              |
+| Bindings    | Language‑specific unit + FFI smoke tests           | `pytest`, `jest`, web‑worker tests |
+| Integration | End‑to‑end: write/flush portable SSTables → optional cluster import → query verification | GitHub Actions matrix |
+| CI/CD       | PR lint, fmt, unit, integration; codecov gate 75 % | GitHub Actions                     |
+
+### 5.1 · Tiered Coverage Targets
+
+Coverage targets are tiered by module criticality rather than flat percentages:
+
+| Tier | Line Coverage | Branch Coverage | Modules |
+|------|---------------|-----------------|---------|
+| **Critical** | 90%+ | 80%+ | `parser/`, `storage/sstable/reader/`, `storage/sstable/reader/parsing/` |
+| **Important** | 80%+ | 70%+ | `query/`, `schema/`, `types/`, `cql/`, `discovery/` |
+| **Supporting** | 70%+ | 60%+ | `memory/`, `platform/`, `storage/sstable/directory/`, `storage/sstable/bti/` |
+| **Utilities** | 50%+ | 40%+ | `benchmarks/`, `testing/` |
+
+**Aggregate Target**: 75% overall (weighted by module size), enforced via codecov gate.
+
+**Rationale**: Tiered coverage focuses testing effort on critical code paths (parser, storage) where bugs cause data corruption, while allowing pragmatic coverage for utilities and platform abstractions.
+
+---
+
+## 6 · Release & Distribution
+
+* **CI**: GitHub Actions builds artifacts per tag.
+* **Packages**:
+
+  * Cargo crate (`cqlite-core`)
+  * PyPI wheels (`cqlite`) for macOS/Linux/Win
+  * npm (`@cqlite/node`) native pre-builds; WASM (`@cqlite/wasm`) in M6
+  * Homebrew & Linuxbrew taps for CLI
+* **Versioning**: SemVer; v0.x during feature development, v1.0 at M6 completion.
+
+### 6.1 · Python Release Process
+
+**Workflows**:
+- `.github/workflows/python-ci.yml` - Build and test on push/PR
+- `.github/workflows/python-release.yml` - Publish to PyPI on tags
+
+**Triggering a Release**:
+1. Update version in `bindings/python/pyproject.toml`
+2. Create and push a version tag:
+   - **Stable release**: `git tag v0.3.0 && git push origin v0.3.0` → Publishes to PyPI
+   - **Pre-release**: `git tag v0.3.0-rc1 && git push origin v0.3.0-rc1` → Publishes to TestPyPI
+
+**Tag Format**:
+| Pattern | Example | Destination |
+|---------|---------|-------------|
+| `v*` (no suffix) | `v0.3.0`, `v1.0.0` | PyPI (production) |
+| `v*-rc*` | `v0.3.0-rc1` | TestPyPI |
+| `v*-alpha*` | `v0.3.0-alpha1` | TestPyPI |
+| `v*-beta*` | `v0.3.0-beta1` | TestPyPI |
+
+**Authentication**: Uses PyPI Trusted Publishing (OIDC) - no API tokens stored in secrets.
+
+**Platform Matrix** (5 wheels built):
+- Linux x86_64 (manylinux_2_28)
+- Linux ARM64 (manylinux_2_28)
+- macOS x86_64
+- macOS ARM64 (Apple Silicon)
+- Windows x64
+
+**PyPI Setup** (one-time, by repo owner):
+1. Create PyPI project at https://pypi.org/manage/projects/
+2. Add trusted publisher at Settings → Publishing:
+   - Owner: `pmcfadin`
+   - Repository: `cqlite`
+   - Workflow: `python-release.yml`
+3. Repeat for TestPyPI at https://test.pypi.org/
+
+---
+
+## 6.2 · Python API Reference
+
+The Python bindings provide a synchronous API for reading Cassandra 5.0 SSTables.
+
+### Installation
+
+```bash
+pip install cqlite-py
+```
+
+### Quick Start
+
+```python
+import cqlite  # Note: package name is cqlite-py, but import is cqlite
+
+# Open database with schema
+with cqlite.open("path/to/sstables", schema="schema.cql") as db:
+    # Execute query
+    result = db.execute("SELECT * FROM keyspace.table LIMIT 10")
+
+    # Iterate over rows
+    for row in result:
+        print(row["column_name"])
+```
+
+### Core Classes
+
+| Class | Description |
+|-------|-------------|
+| `Database` | Main entry point for querying SSTables |
+| `QueryResult` | Contains all rows from a query execution |
+| `Row` | Dict-like access to column values |
+| `StreamingIterator` | Memory-efficient iteration for large datasets |
+| `PreparedStatement` | Query plan analysis |
+| `DatabaseStats` | Storage, memory, and query metrics |
+| `StreamingConfig` | Configuration for streaming queries |
+
+### Exception Hierarchy
+
+| Exception | When Raised |
+|-----------|-------------|
+| `CqliteError` | Base for all CQLite errors |
+| `SchemaError` | Schema parsing or validation fails |
+| `QueryError` | Query execution fails |
+| `ParseError` | CQL syntax error |
+
+### CQL Type Mappings
+
+| CQL Type | Python Type | Notes |
+|----------|-------------|-------|
+| `boolean` | `bool` | |
+| `int`, `bigint`, `varint` | `int` | Arbitrary precision |
+| `float`, `double` | `float` | |
+| `decimal` | `decimal.Decimal` | Precision preserved |
+| `text`, `ascii` | `str` | |
+| `blob` | `bytes` | |
+| `timestamp` | `datetime.datetime` | UTC timezone-aware |
+| `date` | `datetime.date` | |
+| `time` | `datetime.time` | Microsecond precision |
+| `duration` | `datetime.timedelta` | Month ≈ 30 days |
+| `uuid`, `timeuuid` | `uuid.UUID` | |
+| `inet` | `ipaddress.IPv4Address` / `IPv6Address` | |
+| `list<T>` | `list` | |
+| `set<T>` | `frozenset` | Hashable |
+| `map<K,V>` | `dict` | |
+| `tuple` | `tuple` | |
+| UDT | `dict` | With `_type`, `_keyspace` fields |
+
+> **Note:** the `time`/`duration` rows above are the pre-0.13 mapping and were superseded in v0.13 — see the [v0.13 Migration Guide](./v0.13-migration-guide.md): `time`→`int` (ns since midnight), `duration`→`cqlite.Duration(months, days, nanos)`.
+
+### Type Checking
+
+CQLite ships with PEP 561 type stubs for full mypy/pyright support:
+
+```python
+# mypy will validate these types
+import cqlite
+
+db: cqlite.Database = cqlite.open("data")
+result: cqlite.QueryResult = db.execute("SELECT * FROM ks.tbl")
+row: cqlite.Row = result.rows[0]
+value: str = row["name"]  # Type narrowing works
+```
+
+### Streaming for Large Datasets
+
+```python
+# Memory-efficient streaming (< 128 MB for any size)
+config = cqlite.StreamingConfig(buffer_size=512, chunk_size=5000)
+for row in db.execute_streaming("SELECT * FROM big_table", config=config):
+    process(row)
+```
+
+### Thread Safety
+
+- Database handle is thread-safe via `Arc<Database>`
+- `close()` is idempotent and safe from any thread
+- Each thread should use its own `StreamingIterator`
+- Known: Concurrent queries may need warm-up query first (Issue #311)
+
+---
+
+## 7 · Community & Governance (Snapshot)
+
+* Apache 2.0 license from day 1; CLA + DCO required.
+* Public GitHub project board, weekly community call.
+* Donation path: engage Cassandra PMC by M4, IP clearance by M6.
+
+---
+
+## 8 · Risks & Mitigations (Top 3)
+
+| Risk                   | Impact                       | Mitigation                                            |
+| ---------------------- | ---------------------------- | ----------------------------------------------------- |
+| Cassandra format churn | Read/write breakage          | Modular format adapters + test corpus per release     |
+| WASM memory limits     | Feature gaps in browser env. | IndexedDB chunked IO + streaming deserialization      |
+| External PR quality    | Project instability          | Strict CI gates, contributor guide, mandatory reviews |
+
+---
+
+## 9 · Acceptance / “Definition of Done”
+
+1. **Functional parity** – read SSTables for all Cassandra 5+ formats, CLI & bindings pass all tests.
+2. **Performance** – demonstrably faster bulk reads than Cassandra native tools.
+3. **Coverage quality** – tiered targets met (Critical: 90%+, Important: 80%+, Supporting: 70%+).
+4. **Size** – WASM bundle ≤ 2 MB compressed.
+5. **Community** – ≥ 10 active contributors, docs & governance ready for ASF.
+6. **Release** – v1.0 tagged, packages in Cargo, PyPI, npm; announcement blog post.

--- a/docs/development/PRD.md
+++ b/docs/development/PRD.md
@@ -1,386 +1,174 @@
-# CQLite – Concise Product Requirements Document (v0.2)
-
-## 1 · Mission & Vision
-
-* **Mission**  Lower friction to Cassandra data by providing a fast, safe Rust library for local SSTable operations—fully aligned with Apache community values.
-* **Vision**  Become the de‑facto community standard for reading Cassandra 5+ SSTables, usable from CLI, Python, Node.js, and WASM.
-
----
-
-## 2 · Functional Scope (Must‑Have for v1.0)
-
-| Area                    | Requirements                                                                                                                                                                                                                                     |     |                                                                    |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --- | ------------------------------------------------------------------ |
-| **Core Reading**        | • 100 % Cassandra 5 SSTable format support (data, TOC, index, stats)<br>• All CQL types incl. collections & UDTs<br>• Compression: LZ4, Snappy, Deflate<br>• Zero‑copy deserialization into **provided schema** (schema passed in, not inferred) |     |                                                                    |
-| **CLI (`cqlite`)**      | • **One‑shot mode**: `--schema`, `--data-dir`, optional `--query` & \`--out {json                                                                                                                                                                | csv | parquet}\`<br>• **REPL mode**: interactive attach / query / export |
-| **Output Formats**      | JSON, CSV, Parquet (pluggable writers)                                                                                                                                                                                                           |     |                                                                    |
-| **Language Bindings**   | Typed APIs for Python (sync), Node.js (TS defs); WASM deferred to M6                                                                                                                                                                               |     |                                                                    |
-| **Writing**             | Generate Cassandra 5 SSTables (M5)                                                                                                                                                                                                                     |     |                                                                    |
-| **Performance Targets** | Set after functional parity; goal: *faster than native Cassandra bulk tools*                                                                                                                                                                     |     |                                                                    |
+# CQLite Product Requirements: Cassandra-Compatible Storage Execution
 
----
-
-## 3 · Architecture & Separation of Concerns
-
-```
-cqlite-core/        # Pure Rust crate
-├── sstable_rw/     # read/write, compression, checksums
-├── schema/         # type system, validation
-└── query/          # minimal SQL parser & executor (optional)
+**Revision:** 2026-09-06 — storage-engine direction. This is a product-document revision, not a software release version.
 
-cli/                # REPL + one-shot wrapper (uses core)
-bindings/
-  ├── python/
-  ├── node/
-  └── wasm/
-tests/              # shared fixtures (Cassandra 5 SSTables)
-```
+**Product owner:** Patrick McFadin. **Status:** current product direction and qualification requirements; open architecture choices are identified below. No milestone is complete merely because its design or implementation exists.
 
-* **Rule**: Core never depends on CLI or bindings.
-* **Async‑first**, **type‑safe**, zero‑copy IO.
+This PRD replaces the toolkit-focused milestone sequence for future planning. The [original PRD v0.2](PRD-toolkit-v0.2.md) is preserved unchanged as a historical record. The [research assessment and decision ledger](../reports/2026-09-06-storage-engine-vision-assessment.md) explains the evidence and changes in direction. GitHub tracks execution status; the [changelog](../../CHANGELOG.md) records shipped behavior; release-specific compatibility evidence governs support claims.
 
----
+## 1. Mission and product thesis
 
-## 4 · Milestones
+**Mission:** Make expensive Cassandra data work independently executable, reusable, and measurable while preserving Cassandra's storage semantics and operational safety.
 
-| #      | Deliverable                | Key Exit Criteria                                                                         |
-| ------ | -------------------------- | ----------------------------------------------------------------------------------------- |
-| **M1** | **Core Reading Library**   | Reads any Cassandra 5 SSTable; all CQL/UDT types; compression OK; tiered coverage (see Section 5.1) |
-| **M2** | **CLI (REPL + one‑shot)**  | Human can query & verify data from disk; basic `SELECT … WHERE …`                         |
-| **M3** | **Output Writers**         | JSON, CSV, Parquet export work end‑to‑end via CLI                                         |
-| **M4** | **Python & Node.js Bindings** | `pip install cqlite-py`, `npm i @cqlite/node`; CI wheels & native modules                 |
-| **M5** | **Write Support** ✅ **(v0.9.0)** | Generate valid Cassandra 5 SSTables; write API in core and bindings                       |
-| **M6** | **WASM Bindings** *(deferred)*   | `npm i @cqlite/wasm`; IndexedDB support; browser compatibility                            |
-| **M7** | **Perf & Size Validation** *(deferred)* | Benchmarks > native bulk tools; WASM < 2 MB; publish v1.0 release                |
+**Vision:** A Cassandra-compatible storage engine that shares reconciliation and materialization across analytics, bulk ingestion, and compaction, with incremental integration into Cassandra.
 
-> **Revision Note (Jan 2026)**: M1 coverage revised to tiered targets per Issue #204. M4 now Python & Node.js only (sync Python first). Write Support restored as M5. WASM moved to M6. v1.0 release moved to M7.
+The engine should let an operator prepare data once and reuse that work where the workload warrants it. Analytical queries can scan a protected SSTable set directly or read a reusable materialization. Bulk writers prepare Cassandra-readable files outside the database. Offline compaction reconciles existing files. Later, Cassandra may delegate selected live storage work through a qualified integration boundary.
 
-> **Revision Note (May 2026)**: M5 complete, v0.9.0 cut. WAL + memtable + STCS compaction + write APIs in Python, Node.js, and CLI ship in this release. M6 (WASM) and M7 (perf + v1.0) are the remaining milestones. See CHANGELOG.md for the full M5 change list.
+The product succeeds when those workflows reduce total cost or improve useful capacity within stated correctness, freshness, resource, and foreground-service budgets. Component count, implementation language, isolated throughput, and a second physical representation are not success criteria by themselves.
 
-> **Revision Note (May 2026, v0.9.1)**: Reader-correctness patch. Set-element tombstone skipping (#493), schema-aware tuple decoding for arbitrary arity (#501), and `frozen<udt>` field decoding via the UDT registry (#502) all landed — these are removed from §4.2 Known Issues. Reviving the orphan integration tests (#514) and fixing the aarch64-apple-darwin CI/release runner (#512) also shipped. New reader bugs surfaced by the revived tests are tracked in the v0.9.2 milestone (#516, #517, #518). M6/M7 remain the path to v1.0.
+## 2. Users and primary outcomes
 
-### 4.1 · M5 Write Support Architecture
+| User | Job to accomplish | Required outcome |
+|---|---|---|
+| Cassandra operator | Run analytics without unacceptable interference with operational traffic | Measured foreground latency, CPU/I/O, snapshot retention, and freshness within an agreed workload budget |
+| Analytics engineer | Query Cassandra data repeatedly through familiar analytical tools | Correct results under an explicit source/consistency contract; reusable materializations when they improve economics |
+| Data pipeline engineer | Prepare and ingest bulk data | Bounded-resource generation of portable SSTables; verified Cassandra consumption and end-to-end cost |
+| Storage operator | Compact backups, snapshots, or engine-owned files; evaluate compaction policy | Safe offline transformation, understandable plans, and measured space/read/write amplification |
+| Engine integrator | Reuse storage execution from a library or service | Stable supported interfaces, explicit capabilities, cancellation, diagnostics, and reproducible validation |
 
-**Design Principle**: The write API is **mutation-based**, not CQL-dependent. CQL statement support is a convenience layer built on top of the core mutation API.
+Local inspection, CLI use, Python, Node.js, and export remain supported product surfaces and practical ways to diagnose and exercise the engine. Their historical delivery does not by itself qualify distributed analytics or live compaction offload.
 
-#### API Layers
+## 3. Product and ownership boundaries
 
-```
-┌─────────────────────────────────────────────────────────┐
-│  CLI / Bindings                                         │
-│  • --execute "INSERT INTO..." (optional, needs parser)  │
-│  • --mutation '{...}' (direct, no parser needed)        │
-└─────────────────────────┬───────────────────────────────┘
-                          │
-┌─────────────────────────▼───────────────────────────────┐
-│  WriteEngine (Core API)                                 │
-│  • write(mutation) ← Primary interface                  │
-│  • execute(cql) ← Convenience, depends on CQL parser    │
-│  • flush() / close()                                    │
-│  • export_sstable()                                     │
-└─────────────────────────────────────────────────────────┘
-```
+| Layer | Responsibility | Boundary |
+|---|---|---|
+| CQLite product | CLI, bindings, embedded access, Flight, connectors, conversion, and diagnostics | Preserve supported public behavior while engine internals evolve; no mandatory repository split |
+| Shared storage execution | Schema-aware decoding, mutation semantics, reconciliation, writing, compaction execution, and reusable materialization | Independent of CLI/binding/connector implementation details; share semantics and lifecycle where output contracts match |
+| Analytical host | Distributed query planning and the host engine's scheduling | Trino retains its MPP responsibilities; a DataFusion experiment must establish its role and benefit without duplicating them |
+| Cassandra | Live-write durability, replication, consistency coordination, repair, and authoritative live-file lifecycle | External tools cannot independently replace Cassandra's live file set; native integration requires a separate qualified contract |
 
-#### Mutation API (Primary)
+The [Mustang proposal](../research/mustang-multi-representation-storage-architecture.md) is the architectural candidate for neutral logical segments, optional representations, publication, and routing. Its name, exact package structure, production columnar format, and native integration are not implicitly ratified by this PRD. New shared storage interfaces must avoid dependencies on product-specific surfaces; extraction should follow actual consumers and preserve compatibility.
 
-The `Mutation` struct is the canonical write interface:
+**Initial authority:** Cassandra-readable SSTables remain authoritative. New analytical representations are derived and rebuildable. Changing durability authority, commit-log retirement, or native live-file ownership is outside the initial external-engine release.
 
-```rust
-let mutation = Mutation::new(
-    TableId::new("keyspace", "table"),
-    PartitionKey::single("id", Value::Integer(1)),
-    None,  // Optional clustering key
-    vec![CellOperation::Write { column: "name", value: Value::Text("Alice") }],
-    timestamp,
-    None,  // Optional TTL
-);
-engine.write(mutation)?;
-```
+## 4. Scope and baseline
 
-**Rationale**: Mutation-based API ensures:
-- Core write path has no parser dependency
-- Bindings can construct mutations directly (Python dict → Mutation)
-- Bulk import tools bypass CQL overhead
-- Testing doesn't require CQL parser
+**Baseline at this revision:** the workspace identifies version 0.16.1 and contains unreleased work. Reading, CLI, exports, Python/Node bindings, writes, reconciliation, offline compaction, Flight, and Trino are implemented. The [parity report](../reports/cassandra-test-parity.md) and [claim manifest](../../test-data/cassandra-parity-manifest.yml) qualify the evidence; broad historical “production-ready” wording is not a substitute for them.
 
-#### CQL Statement Support (Optional Layer)
+| Workload | Near-term scope | Separate qualification |
+|---|---|---|
+| Analytics | Protected SSTable reads and reusable current-row analytics epochs | Foreground coexistence, distributed source contract, and end-to-end benefit |
+| Materialization / offline compaction | Shared reconciliation of explicit input sets into supported outputs | Publication/recovery, safe purging, compression, and amortized cost |
+| Bulk writing | Schema-aware mutation ingestion and external-sort/file-generation workflows | Native Cassandra consumption, resource bounds, and complete generation-to-import economics |
+| Compaction policy | Pure metadata planning, explanation, and UCS simulation | Policy invariants and predicted-versus-observed amplification; exact randomized job selection is not required |
+| Fresh analytical reads | Selected CEP-11 memtable export spike | Tail lifecycle, pre-/post-flush equivalence, export latency, and write-path impact |
+| Live storage offload | Bounded integration research | Cassandra-owned reservation and installation, repair-state handling, and fault-tested recovery |
 
-CQL INSERT/UPDATE/DELETE parsing is built on top:
+Target Cassandra 5.0 formats and explicitly qualified version combinations. BIG and BTI capabilities must be reported separately by operation and release; “Cassandra 5+” must not imply support for every future format. Compression reading and production compression writing are separate capabilities. Production SSTable output is currently uncompressed; qualifying compressed output is a requirement of the new offload program, not an existing support claim.
 
-```rust
-// Internally converts to Mutation
-engine.execute("INSERT INTO ks.users (id, name) VALUES (1, 'Alice')")?;
-```
+## 5. Product requirements
 
-This layer depends on the CQL parser (`cqlite-core/src/cql/`) and is **optional** for write functionality.
+The following requirements apply to each advertised workload. A capability matrix must identify exclusions and the evidence supporting each promise.
 
-#### CLI Write Modes
+| ID | Requirement | Acceptance evidence |
+|---|---|---|
+| R1 | **Explicit input and capability contract.** Bind a job/query to source identities, table incarnation, schema, format/version, token coverage, and the time/repair metadata its operation requires. Reject unsupported inputs or expose an explicitly documented partial/export mode; never silently discard data | Supported and unsupported cases through public interfaces; schema/version mismatch and incomplete-input tests |
+| R2 | **One reconciliation foundation.** Preserve per-cell timestamps, equal-timestamp rules, TTL, static rows, schema evolution, and supported cell/row/range/partition deletions. Query and compaction policies must be explicit | Independent Cassandra logical oracles; point/full-scan differential checks; appropriate byte oracles. Self-written/read-back fixtures alone do not qualify semantics |
+| R3 | **Different output contracts remain distinct.** Mutation-preserving SSTables or per-generation caches retain metadata required for future merges. Current-row epochs describe a fixed source set and TTL reference time | Future-merge tests for SSTable/cache output; fixed-epoch logical tests for current rows; no substitution between these representations without a semantic conversion |
+| R4 | **Portable native output.** Bulk and compaction outputs must be consumable by the qualified Cassandra version without CQLite conversion or repackaging | Direct native refresh/import plus query verification on real Cassandra. `sstableloader` is a useful secondary path, not the sole portability proof |
+| R5 | **Safe publication and recovery.** Readers see a complete published result or an explicit failure. Preserve required authoritative inputs until replacement is committed. Define durability/acknowledgment and retry behavior for writable jobs | Crash/disk-full/corruption/cancellation tests around publication and retirement; orphan cleanup; retry tests. Use existing offline publication machinery where sufficient |
+| R6 | **Bounded resources and terminal failures.** Enforce stated memory, temporary-disk, queue, concurrency, and cancellation budgets, including wide partitions and slow consumers. Producer loss must never appear as successful EOF | Resource measurements across input sizes and fan-in; overload and producer-failure tests through shipped paths; explicit errors when budgets cannot be met |
+| R7 | **Visible freshness and consistency.** Expose source/epoch identity and reference time. Preserve the documented single-selected-replica v1 scope; do not imply quorum reads or a global consistent cut. Stale results require an explicit allowed policy | Divergent-replica, snapshot, retry, and TTL-boundary tests; freshness metadata. Maximum event timestamp alone cannot certify complete source coverage |
+| R8 | **Useful compaction and materialization economics.** Measure overlap, purge safety, compressed output, transfer, retained inputs, and rebuild cost. One implementation should serve the common “merge once, serve many” work | Offline correctness suite plus repeated-query break-even measurements; compression/import validation; planner prediction versus executed workload |
+| R9 | **Bulk ingestion independent of CQL parsing.** Preserve mutation-based input as the primary engine path; CQL is a convenience interface. Support bounded ingestion/sorting, explicit completion, and documented failure/retry semantics | Large unsorted input through public ingestion surfaces, interruption/recovery, duplicate/retry behavior, and native Cassandra consumption |
+| R10 | **Safe deployable interfaces.** Published services constrain accessible data and document authentication/authorization and transport requirements. Record per-job progress, failures, resource use, input/output identities, and cleanup state | Deployment tests and operator runbook for the supported topology; enforce access boundaries; verify metrics reflect actual work and failures |
 
-| Mode | Input | Parser Required | Use Case |
-|------|-------|-----------------|----------|
-| `--mutation '{...}'` | JSON | No | Programmatic, bulk import |
-| `--mutations-file` | JSONL file | No | Batch processing |
-| `--execute "INSERT..."` | CQL | Yes | Interactive, familiar syntax |
+Tombstone purging must satisfy the declared retention/repair policy and protect data in excluded overlapping inputs. If required coverage or safety metadata is unavailable, retain tombstones. Acceptance includes partial-compaction resurrection and GC-boundary tests; this requirement applies to offline compaction as well as native integration.
 
-#### E2E Validation Workflow
+Counter support must be declared per operation: generating increments and compacting existing counter contexts are different capabilities. Exclude unsupported counter tables from offload and freshness claims until those semantics are independently qualified.
 
-The product contract for M5 write support is:
+Identical bytes are required only where a specific format/component contract or declared byte oracle requires them. Product-level compaction acceptance requires native readability, logical equivalence, and preservation of merge-affecting metadata. This resolves the conflicting blanket byte-identity wording identified in the research; it does not remove existing byte-level regression gates or broaden parity claims.
 
-- `WriteEngine` flushes portable Cassandra SSTable components directly into the write directory.
-- Those flushed files are the primary artifact users should be able to copy into a Cassandra table data directory and have Cassandra read without any CQLite-side conversion step.
-- Loader-based workflows such as `sstableloader` may exist as convenience tooling, but they are not the acceptance path for M5 portability.
+## 6. Success metrics and qualification protocol
 
-The end-to-end validation therefore must prove direct Cassandra consumption of flushed files:
+Before a qualifying run, the product owner and operator must record a **workload acceptance sheet**: source/version/schema, operation and output contract, data shape and overlap, deployment topology, freshness requirement, baseline, resource budget, minimum useful benefit, foreground latency limit, and failure criteria. Thresholds must be numeric and fixed before the run; a milestone cannot pass with those fields unspecified or adjusted after seeing the result.
 
-```bash
-# 1. Write data via CQLite
-cqlite --writable --schema schema.cql --write-dir ./data \
-  --mutation '{"table":"users","pk":{"id":1},"ops":[...]}'
+| Dimension | Required measurement |
+|---|---|
+| Useful capacity | Completed logical work and box-level aggregate throughput; time to first result and total job/query duration |
+| Foreground protection | Cassandra p95/p99 read/write latency, errors, flush/compaction behavior, CPU, and I/O with Cassandra running |
+| Total cost | Conversion, reconciliation, compression, transfer, validation/import, retries, extra compute, temporary storage, retained snapshots, and derived storage |
+| Reuse | Materialization build/rebuild cost and repeated-query break-even within the declared freshness interval |
+| Freshness / correctness | Source coverage, epoch age, export latency, TTL reference time, exact logical result checks, and unsupported-case behavior |
+| Capacity under overload | Memory/disk high-water marks, queue time, admission shedding, tail latency, cancellation, and cleanup |
 
-# 2. Flush to portable Cassandra SSTables
-cqlite --writable --schema schema.cql --write-dir ./data --flush
+Qualification must cover append-only and overwrite-heavy inputs, realistic overlap and compression, and the formats/types promised for that workload. Declare hardware, physical versus logical cores, cache state, byte basis, repetitions, uncertainty, and applicable fast-path eligibility. Compare equivalent results on the same input; report both equal-hardware and complete-cost implications where offload uses additional resources.
 
-# 3. Copy the flushed SSTables into the target Cassandra table directory
-cp ./data/nb-*-big-* /var/lib/cassandra/data/keyspace/table-uuid/
+Use the existing [throughput mission](../architecture/0.17-throughput-mission.md) and its measurement → gated change → box-level verification → through-Trino checkpoint. Pre-hardening benchmark caveats require a fresh qualifying baseline. The old 600k/core target and an unqualified “faster than Cassandra” are not acceptance bars. Every relative target must state its equation and denominator; per-core attribution cannot substitute for fleet/deployment capacity.
 
-# 4. Tell Cassandra to discover the copied SSTables
-nodetool refresh keyspace table
+An isolated microbenchmark can justify a change, but cannot alone qualify operational offload. At least one independent operator pilot must reproduce each advertised production workload's acceptance result before its 1.0 qualification.
 
-# 5. Verify via cqlsh
-cqlsh -e "SELECT * FROM keyspace.table"
-```
+## 7. Milestones and dependency gates
 
-**Exit Criteria**:
-- After flush, CQLite has produced Cassandra-readable SSTables without any additional conversion or repackaging step.
-- Copying those SSTables into a Cassandra 5.0 table directory and invoking Cassandra's native refresh/import mechanism makes the data queryable without errors.
-- `sstableloader` compatibility is a useful secondary workflow, but passing `sstableloader` alone does not satisfy M5.
+The new **SE** identifiers avoid reusing M1–M7 and existing research workstream numbers. Their status at this revision is **qualification pending**; evidence links, not issue counts, determine completion.
 
-> **Revision Note (March 2026)**: M5 write support treats flushed SSTables as the primary portable artifact. The milestone acceptance path is now explicitly direct Cassandra readability after copy plus native refresh/import; loader workflows remain secondary convenience tooling. See Issues #392, #393, #396, #397.
+| Milestone | User/operator outcome | Exit criteria | Dependencies |
+|---|---|---|---|
+| **SE1 — Engine contract** | Integrators and operators know exactly what the engine owns and guarantees | Supported workload/capability matrix, authority and output contracts, acceptance sheets, interface ownership, and documented exclusions; unresolved choices have an owner and decision trigger | Starts now; uses existing code and research |
+| **SE2 — Shared offline execution** | Safely compact supported inputs and publish reusable analytics output | R1–R6/R8 pass for protected offline inputs; preserve future-merge metadata; at least one qualified production compression codec; fault-tested publication and cleanup; shared reconciliation/materialization across compaction and analytics | SE1 contracts; incremental API extraction only as needed |
+| **SE3 — Analytics offload value** | Analytics delivers a measured benefit within a foreground-service and freshness budget | Preregistered workload passes on hardened measurements with Cassandra running; compare live merge and reusable materialization; include overwrite-heavy data, full build/storage costs, and a through-Trino operator pilot | SE1; SE2 for the reusable-output arm. Existing live-path measurement proceeds in parallel |
+| **SE4 — Bulk writing and policy tools** | Prepare bulk data efficiently and evaluate compaction plans | **Writer gate:** bounded generation → transfer → native import, supported mutation/type parity, retries, compressed output, and operator cost target. **Planner gate:** pure explain/simulate interfaces, tested UCS density/overlap/shard invariants, and predicted-versus-observed amplification | Writer shares SE2 output qualification. Metadata-only planner research/prototyping can start alongside SE1; neither waits for live installation |
+| **SE5 — Qualified freshness** | Opted-in analytical reads include the memtable tail at a stated cost | Selected no-CDC spike passes pre-/post-flush parity, dirty-check/min-interval behavior, write-path/pool safety, concurrent flush/snapshot tests, export latency, and stale-tail retirement | SE1 and qualified read semantics; required only for the stronger tail-freshness promise |
+| **SE6 — Bounded Cassandra integration** | Demonstrate one reversible native/offload boundary | Choose one CEP-17 adapter or coordinated-compaction pilot; prove reservation/installation ownership, repair-state constraints, native-boundary cost, failure/retry recovery, mixed-format behavior, and rollback | Qualified underlying SE2/SE4 functionality and an explicit integration design; do not assume a general engine SPI |
+| **SE7 — Native lifecycle qualification** | Operators can depend on the claimed Cassandra-integrated scope | Upgrade/restart/repair/streaming/snapshot/bootstrap coverage as applicable; sustained pilot, support matrix and runbooks; necessary host contracts accepted upstream or explicitly maintained as experimental fork scope | SE6; community acceptance is required only for claims of upstream-supported new contracts |
 
----
+SE1–SE4 define the initial external-engine program. Existing component maturity may discharge parts of those gates, but prior M1–M5 completion does not discharge them automatically. SE5–SE7 can advance selectively after their prerequisite experiments; they are not mandatory dependencies for useful snapshot analytics or offline bulk/compaction work.
 
-## 4.2 · Known Issues (post-v0.9.1)
+**Initial flagship demonstration:** one overwrite-heavy repeated-analytics workload over a protected input set, served through both live reconciliation and reusable materialization. Demonstrate equivalent results, explicit freshness, amortized cost, space overhead, and Cassandra foreground impact. Qualify compressed bulk output and the pure UCS planner alongside this work.
 
-The following are tracked follow-ups, not release blockers. All are open GitHub issues.
-The v0.9.0 reader follow-ups (#493 set-element tombstones, #501 tuple decoding,
-#502 frozen<udt> decoding) were **resolved in v0.9.1**. The v0.9.2 reader and
-compaction correctness fixes (#516 `scan()` token ordering, #517 `get()`/`scan()`
-consistency, #518 `stats().block_count`, #505 compaction row tombstones, #498
-equal-timestamp Delete-vs-Live reconcile, #533 per-cell compaction reconcile,
-#492 streaming `Data.db` writer, and #552 multi-partition Index.db reader) were
-**resolved in v0.9.2** and removed from this list.
+## 8. Release and support contract
 
-| Issue | Milestone | Description | Workaround |
-|-------|-----------|-------------|------------|
-| #311 | — | Python concurrent-query race in schema metadata access | Run one warm-up query before spawning parallel threads on the same handle |
-| #553 | — | Index.db point lookup falls back to a full scan (hash digest vs raw-key mismatch); reads correct, not O(1) | None needed; correctness unaffected |
+External-engine **1.0 requires SE1–SE4**, the independent operator evidence above, stable public error/type/cancellation contracts, installation/upgrade documentation, and green release gates on the exact release commit. A first materialization output may use a qualified existing format; 1.0 does not require Vortex, a continuous Iceberg daemon, or a native Cassandra adapter.
 
-See [docs/write-support-limitations.md](../write-support-limitations.md) for the full limitations reference.
+Keep tail-freshness and native integration labeled experimental until their applicable SE5–SE7 gates pass. WASM size or availability and acceptance of a native lifecycle CEP do not gate external-engine 1.0. Release numbers alone must not imply all interfaces and operations have equal maturity.
 
----
+Maintain a release-specific matrix of Cassandra versions, read/write formats, codecs, types, operations, interfaces, and deployment modes. Link limitations and required rewrite/migration steps to affected versions. Preserve supported CLI, Rust, Python, Node, Flight, and Trino contracts or ship explicit migration guidance.
 
-## 5 · Testing Strategy
+The [release procedure](RELEASING.md), [parity release checklist](parity-release-checklist.md), [parity tier contracts](parity-ci-tiers.md), and [manifest rules](cassandra-parity-manifest.md) remain the execution authority for checks. This PRD does not waive tests, Clippy, coverage policy, nightly/exhaustive evidence, or review requirements. Byte claims remain scenario-scoped; file parity does not imply Cassandra node-lifecycle parity.
 
-| Layer       | Tests                                              | Tooling                            |
-| ----------- | -------------------------------------------------- | ---------------------------------- |
-| Core        | Unit + property‑based for type/format edge cases   | Rust `cargo test`, `proptest`      |
-| CLI         | Integration & snapshot tests for commands/output   | `assert_cmd`, `insta`              |
-| Bindings    | Language‑specific unit + FFI smoke tests           | `pytest`, `jest`, web‑worker tests |
-| Integration | End‑to‑end: write/flush portable SSTables → optional cluster import → query verification | GitHub Actions matrix |
-| CI/CD       | PR lint, fmt, unit, integration; codecov gate 75 % | GitHub Actions                     |
+Retain Apache 2.0 licensing and community-oriented development. Pursue upstream collaboration through measured, bounded proposals; neither a donation date nor an Apache design acceptance is promised by this PRD.
 
-### 5.1 · Tiered Coverage Targets
+## 9. Recorded decisions, experiments, and non-goals
 
-Coverage targets are tiered by module criticality rather than flat percentages:
+| Topic | Standing decision or requirement | Unresolved / promotion trigger |
+|---|---|---|
+| Freshness | Owner-selected no-CDC, on-demand dirty-checked CEP-11 export of real tail SSTables | Spike remains unqualified. Live FFI/streaming alternative reconsidered only if measured export behavior cannot meet the chosen requirement |
+| DataFusion | July 16 spike-first, promote-on-data decision; Design A is its recorded basis | Role, version alignment, and promotion require the experiment; do not treat a competing remote-fetch draft as the accepted plan |
+| Materialization | Unify shared “merge once, serve many” work. Preserve the existing initial Iceberg design's bounded envelope-input scope | Continuous watching, cluster-wide lineage/dedup, repaired gating, REST catalogs, and maintenance are separate increments; initial Iceberg scope excludes tail exports |
+| Mustang / Vortex | Leading architectural proposal; SSTable authority and rebuildable derived output are initial requirements | Final branding, package/repository split, Vortex production adoption, and synchronous dual-output policy require explicit decisions and workload evidence |
+| Native integration | Preserve Cassandra's authoritative lifecycle until the chosen adapter is qualified | Native routing, atomic multi-representation groups, and coordinated multi-output compaction need additional contracts; no claim that existing plugin APIs provide the complete engine |
 
-| Tier | Line Coverage | Branch Coverage | Modules |
-|------|---------------|-----------------|---------|
-| **Critical** | 90%+ | 80%+ | `parser/`, `storage/sstable/reader/`, `storage/sstable/reader/parsing/` |
-| **Important** | 80%+ | 70%+ | `query/`, `schema/`, `types/`, `cql/`, `discovery/` |
-| **Supporting** | 70%+ | 60%+ | `memory/`, `platform/`, `storage/sstable/directory/`, `storage/sstable/bti/` |
-| **Utilities** | 50%+ | 40%+ | `benchmarks/`, `testing/` |
+Initial non-goals: replacing Cassandra's distributed coordination or commit log; a general drop-in `StorageEngine` SPI; independently authoritative columnar/object-store data; quorum or global-snapshot guarantees for the single-replica analytical path; universal byte identity; an all-purpose SQL engine or a second distributed scheduler inside Trino; every connector/runtime; and browser/WASM delivery as a prerequisite to the engine.
 
-**Aggregate Target**: 75% overall (weighted by module size), enforced via codecov gate.
+## 10. Risks and decision ownership
 
-**Rationale**: Tiered coverage focuses testing effort on critical code paths (parser, storage) where bugs cause data corruption, while allowing pragmatic coverage for utilities and platform abstractions.
+| Risk / open decision | Owner | Required resolution |
+|---|---|---|
+| Semantic divergence between row and derived output | Storage execution maintainers | R2/R3 oracles before routing/representation promotion; scope counter behavior per operation |
+| Extra representations cost more than they save | Product owner and pilot operator | Preregistered break-even and foreground budgets; allow one representation when duplication has no benefit |
+| Native lifecycle or FFI scope exceeds available seams | Cassandra integration lead and product owner | One bounded SE6 design; pinned-version verification, crash-domain cost, and explicit upstream/fork boundary |
+| Product split or naming blocks useful work | Product owner | Resolve interface ownership in SE1; keep repository separation and published names off the experiment's critical path |
+| Unsupported watermark/completeness assumptions | Materialization lead | Distinguish source coverage from event-time maxima; prove late/out-of-order input handling before incremental claims |
+| Research and shipping status diverge | Release lead | Maintain release evidence and decision lineage; supersede stale recommendations rather than treat old audits as current bug lists |
 
----
+Detailed design belongs in linked architecture/OpenSpec records. Open choices must not be presented as shipped features or quietly become milestone dependencies. Missing operator thresholds are qualification blockers, not an invitation to invent favorable thresholds after measurement.
 
-## 6 · Release & Distribution
+## 11. Historical baseline and research map
 
-* **CI**: GitHub Actions builds artifacts per tag.
-* **Packages**:
+| Legacy milestone | Historical deliverable | Treatment in this PRD |
+|---|---|---|
+| M1 | Core reading | Existing foundation; operation-specific evidence still governs support |
+| M2 | CLI | Supported interface and engine diagnostic surface |
+| M3 | Output writers | Existing export foundation for materialization |
+| M4 | Python and Node.js | Supported embedding and workflow surfaces |
+| M5 | Writing and STCS compaction | Existing execution foundation; additional offload qualification in SE2/SE4 |
+| M6 | WASM | Deferred optional surface; removed from the 1.0 critical path |
+| M7 | Performance, size, and 1.0 | Replaced by workload qualification in SE1–SE4 and the release contract above |
 
-  * Cargo crate (`cqlite-core`)
-  * PyPI wheels (`cqlite`) for macOS/Linux/Win
-  * npm (`@cqlite/node`) native pre-builds; WASM (`@cqlite/wasm`) in M6
-  * Homebrew & Linuxbrew taps for CLI
-* **Versioning**: SemVer; v0.x during feature development, v1.0 at M6 completion.
+Start with the [assessment and coverage ledger](../reports/2026-09-06-storage-engine-vision-assessment.md). Supporting records:
 
-### 6.1 · Python Release Process
-
-**Workflows**:
-- `.github/workflows/python-ci.yml` - Build and test on push/PR
-- `.github/workflows/python-release.yml` - Publish to PyPI on tags
-
-**Triggering a Release**:
-1. Update version in `bindings/python/pyproject.toml`
-2. Create and push a version tag:
-   - **Stable release**: `git tag v0.3.0 && git push origin v0.3.0` → Publishes to PyPI
-   - **Pre-release**: `git tag v0.3.0-rc1 && git push origin v0.3.0-rc1` → Publishes to TestPyPI
-
-**Tag Format**:
-| Pattern | Example | Destination |
-|---------|---------|-------------|
-| `v*` (no suffix) | `v0.3.0`, `v1.0.0` | PyPI (production) |
-| `v*-rc*` | `v0.3.0-rc1` | TestPyPI |
-| `v*-alpha*` | `v0.3.0-alpha1` | TestPyPI |
-| `v*-beta*` | `v0.3.0-beta1` | TestPyPI |
-
-**Authentication**: Uses PyPI Trusted Publishing (OIDC) - no API tokens stored in secrets.
-
-**Platform Matrix** (5 wheels built):
-- Linux x86_64 (manylinux_2_28)
-- Linux ARM64 (manylinux_2_28)
-- macOS x86_64
-- macOS ARM64 (Apple Silicon)
-- Windows x64
-
-**PyPI Setup** (one-time, by repo owner):
-1. Create PyPI project at https://pypi.org/manage/projects/
-2. Add trusted publisher at Settings → Publishing:
-   - Owner: `pmcfadin`
-   - Repository: `cqlite`
-   - Workflow: `python-release.yml`
-3. Repeat for TestPyPI at https://test.pypi.org/
-
----
-
-## 6.2 · Python API Reference
-
-The Python bindings provide a synchronous API for reading Cassandra 5.0 SSTables.
-
-### Installation
-
-```bash
-pip install cqlite-py
-```
-
-### Quick Start
-
-```python
-import cqlite  # Note: package name is cqlite-py, but import is cqlite
-
-# Open database with schema
-with cqlite.open("path/to/sstables", schema="schema.cql") as db:
-    # Execute query
-    result = db.execute("SELECT * FROM keyspace.table LIMIT 10")
-
-    # Iterate over rows
-    for row in result:
-        print(row["column_name"])
-```
-
-### Core Classes
-
-| Class | Description |
-|-------|-------------|
-| `Database` | Main entry point for querying SSTables |
-| `QueryResult` | Contains all rows from a query execution |
-| `Row` | Dict-like access to column values |
-| `StreamingIterator` | Memory-efficient iteration for large datasets |
-| `PreparedStatement` | Query plan analysis |
-| `DatabaseStats` | Storage, memory, and query metrics |
-| `StreamingConfig` | Configuration for streaming queries |
-
-### Exception Hierarchy
-
-| Exception | When Raised |
-|-----------|-------------|
-| `CqliteError` | Base for all CQLite errors |
-| `SchemaError` | Schema parsing or validation fails |
-| `QueryError` | Query execution fails |
-| `ParseError` | CQL syntax error |
-
-### CQL Type Mappings
-
-| CQL Type | Python Type | Notes |
-|----------|-------------|-------|
-| `boolean` | `bool` | |
-| `int`, `bigint`, `varint` | `int` | Arbitrary precision |
-| `float`, `double` | `float` | |
-| `decimal` | `decimal.Decimal` | Precision preserved |
-| `text`, `ascii` | `str` | |
-| `blob` | `bytes` | |
-| `timestamp` | `datetime.datetime` | UTC timezone-aware |
-| `date` | `datetime.date` | |
-| `time` | `datetime.time` | Microsecond precision |
-| `duration` | `datetime.timedelta` | Month ≈ 30 days |
-| `uuid`, `timeuuid` | `uuid.UUID` | |
-| `inet` | `ipaddress.IPv4Address` / `IPv6Address` | |
-| `list<T>` | `list` | |
-| `set<T>` | `frozenset` | Hashable |
-| `map<K,V>` | `dict` | |
-| `tuple` | `tuple` | |
-| UDT | `dict` | With `_type`, `_keyspace` fields |
-
-> **Note:** the `time`/`duration` rows above are the pre-0.13 mapping and were superseded in v0.13 — see the [v0.13 Migration Guide](./v0.13-migration-guide.md): `time`→`int` (ns since midnight), `duration`→`cqlite.Duration(months, days, nanos)`.
-
-### Type Checking
-
-CQLite ships with PEP 561 type stubs for full mypy/pyright support:
-
-```python
-# mypy will validate these types
-import cqlite
-
-db: cqlite.Database = cqlite.open("data")
-result: cqlite.QueryResult = db.execute("SELECT * FROM ks.tbl")
-row: cqlite.Row = result.rows[0]
-value: str = row["name"]  # Type narrowing works
-```
-
-### Streaming for Large Datasets
-
-```python
-# Memory-efficient streaming (< 128 MB for any size)
-config = cqlite.StreamingConfig(buffer_size=512, chunk_size=5000)
-for row in db.execute_streaming("SELECT * FROM big_table", config=config):
-    process(row)
-```
-
-### Thread Safety
-
-- Database handle is thread-safe via `Arc<Database>`
-- `close()` is idempotent and safe from any thread
-- Each thread should use its own `StreamingIterator`
-- Known: Concurrent queries may need warm-up query first (Issue #311)
-
----
-
-## 7 · Community & Governance (Snapshot)
-
-* Apache 2.0 license from day 1; CLA + DCO required.
-* Public GitHub project board, weekly community call.
-* Donation path: engage Cassandra PMC by M4, IP clearance by M6.
-
----
-
-## 8 · Risks & Mitigations (Top 3)
-
-| Risk                   | Impact                       | Mitigation                                            |
-| ---------------------- | ---------------------------- | ----------------------------------------------------- |
-| Cassandra format churn | Read/write breakage          | Modular format adapters + test corpus per release     |
-| WASM memory limits     | Feature gaps in browser env. | IndexedDB chunked IO + streaming deserialization      |
-| External PR quality    | Project instability          | Strict CI gates, contributor guide, mandatory reviews |
-
----
-
-## 9 · Acceptance / “Definition of Done”
-
-1. **Functional parity** – read SSTables for all Cassandra 5+ formats, CLI & bindings pass all tests.
-2. **Performance** – demonstrably faster bulk reads than Cassandra native tools.
-3. **Coverage quality** – tiered targets met (Critical: 90%+, Important: 80%+, Supporting: 70%+).
-4. **Size** – WASM bundle ≤ 2 MB compressed.
-5. **Community** – ≥ 10 active contributors, docs & governance ready for ASF.
-6. **Release** – v1.0 tagged, packages in Cargo, PyPI, npm; announcement blog post.
+- [Mustang architecture and proposed phases](../research/mustang-multi-representation-storage-architecture.md) and [assembled-engine composition/decisions](../architecture/issue-1934-assembled-engine-research.md).
+- [Compaction-manager synthesis](../architecture/issue-905-compaction-manager-research.md), [M5 writer council](../research/M5-Write-Support-Council-Recommendation.md), and [fidelity decision](../garbage-free-compaction-improvements/compaction-fidelity-bar-decision.md).
+- [DataFusion council](../architecture/issue-941-datafusion-table-provider-council.md), [promotion decision](../architecture/941-datafusion-decision-brief-2026-07.md), and [Spark/consistency decisions](../architecture/issue-1045-spark-connector-research.md).
+- [Memtable design](<../storage engine/memtable-plugin-design.md>), [Iceberg proposal](<../storage engine/proposal.md>), and [Iceberg decisions](<../storage engine/design.md>). The initial Iceberg type/statics/exclusion behavior remains governed by that scoped design, not by an implied general row-image/CDC contract.
+- [Overlap measurement](../research/issue-2043-reconcile-overlap-multiplier.md), [throughput mission](../architecture/0.17-throughput-mission.md), and [August performance synthesis](../research/throughput-2026-08-research-synthesis.md).

--- a/docs/development/RELEASING.md
+++ b/docs/development/RELEASING.md
@@ -335,5 +335,5 @@ Both paths create a GitHub Release with all artifacts attached.
 - **Release workflow**: `.github/workflows/python-release.yml`
 - **CI workflow**: `.github/workflows/python-ci.yml`
 - **Package config**: `bindings/python/pyproject.toml`
-- **Strategic context**: `docs/development/PRD.md` Section 6.1
+- **Product release criteria**: [PRD release and support contract](PRD.md#8-release-and-support-contract)
 - **Technical details**: `docs/development/M4_spec.md` Section 6

--- a/docs/reports/2026-09-06-storage-engine-vision-assessment.md
+++ b/docs/reports/2026-09-06-storage-engine-vision-assessment.md
@@ -1,0 +1,116 @@
+# CQLite / Mustang: storage-engine vision and milestone assessment
+
+Research assessment, 2026-09-06. This memo recommends a direction; it does not ratify drafts, change existing decisions, or update the project board. Repository baseline: `26399bb06`, workspace version `0.16.1`, including unreleased work.
+
+**Assessment**
+
+The research supports a broader direction than a local Cassandra toolkit: a Cassandra-compatible engine for reconciliation, materialization, analytical reads, bulk generation, and eventually delegated storage work. CQLite supplies a working implementation and its user-facing proving environment. The Mustang paper supplies the proposed architectural model: one logical segment, multiple optional representations, explicit publication and lifecycle, and routing based on semantic capabilities before cost.
+
+This is a credible staged program. It is not evidence that a complete alternative engine can already be installed in Cassandra. The strongest initial authority boundary is the one Mustang proposes: Cassandra-readable SSTables remain authoritative; columnar representations are derived and rebuildable. External value can be proved before changing Cassandra's native storage lifecycle.
+
+My earlier toolkit-first assessment missed the strategic center of the research. My subsequent analytics → bulk writer → compaction sequence also missed an explicit existing conclusion: offline compaction and analytics materialization should share a “merge once, serve many” capability, while a pure compaction planner/simulator can proceed in parallel.
+
+**Method and coverage**
+
+The review used three specialist subagents and a root integration/synthesis pass. The entire `docs/` filesystem tree was inventoried: 3,024 files before this memo, including 412 Markdown files and 1,575 Java files. Those are inventory counts, not reading counts. Broad path/content searches located research beyond the named `docs/research/` directory.
+
+| Review lane | Coverage | Limits |
+|---|---|---|
+| Storage strategy | All 36 Markdown files under `docs/storage engine/` inventoried; top-level reports, design, proposal, spec, tasks, epic, Iceberg decision memo, and memtable design substantively reviewed; Mustang, assembled-engine research, broad format/HTAP surveys, memtable spike, and Sidecar projection decisions reviewed | The 27 underlying Cassandra indexes received heading/summary/correction review, not exhaustive verification of every source-anchor table; external postmortems and bibliography were not all re-audited |
+| Performance | 37 primary documents inventoried; mission, throughput program, overlap experiment, August synthesis/surveys, cache decision, WS0/WS3 reports, and important audit conclusions reviewed | Phase-1/Phase-2 packet screened through its conclusions and later adjudication; no benchmark reruns or exhaustive raw-artifact inspection |
+| Compaction/writing | Manager draft and source-verified synthesis, fidelity decisions, parity assessment/audit/report, write audit, release checklist, M5 research, and Java cursor applicability research reviewed | Large upstream cursor journal, generated parity table, FFM material, and API examples read selectively; binary JFR and HTML allocation reports not re-analyzed |
+| Root synthesis | DataFusion council/design alternatives/promotion decision, Spark research, Trino audit, delta reconciliation, Cloudberry feasibility, milestones, release history, compatibility claims, and selected implementation paths | Integration plans/journals read selectively; no live GitHub board audit, whole-code audit, or new runtime qualification |
+
+Two subagents encountered a usage interruption, then returned their completed syntheses after continuation. No results depend on unfinished agent work. Existing research was classified as an owner decision, proposal, measured report, derived estimate, historical audit, or current implementation evidence. Later explicit corrections outrank earlier sketches. A file's recent Git commit alone does not make its draft an accepted decision.
+
+Selected external verification confirmed the narrow extension boundary: [CEP-11](https://cwiki.apache.org/confluence/spaces/CASSANDRA/pages/184617682/CEP-11%2BPluggable%2Bmemtable%2Bimplementations) explicitly excludes full engine replacement, and [CEP-17](https://issues.apache.org/jira/browse/CASSANDRA-17056) delivered the SSTable format API in Cassandra 5.0. This was not a fresh audit of every external source cited by the repository.
+
+**Decision ledger: preserve what has already been learned**
+
+| Record | Authority and finding | Consequence |
+|---|---|---|
+| [Sidecar Parquet projections](../architecture/cassandra-sidecar-parquet-projections.md), lines 317–341 | June boundary excluded first-party Iceberg commits and a daemon | Historical boundary; later Iceberg decisions broaden it |
+| [Storage-engine feasibility report](<../storage engine/report-2-storage-engine-feasibility.md>), lines 13–29, 94–98 | Source-grounded adjacent-engine recommendation; earlier CDC advice and incorrect version statements have later corrections | Retain the missing-general-SPI finding; do not revive superseded CDC advice or repeat the old CEP-11 version error |
+| [Memtable plugin design](<../storage engine/memtable-plugin-design.md>), lines 6–35 | Explicit July 3 owner decision: no CDC; on-demand, dirty-checked exports of real `nb` tail SSTables through CEP-11 | Preserve this as the selected freshness spike; the document is a draft, not shipped-plugin evidence |
+| [Iceberg design](<../storage engine/design.md>), line 99; [tasks](<../storage engine/tasks.md>), line 9 | Product choices resolved; implementation tasks remain unchecked | Materialization is deliberately in scope, but not implemented merely because the design exists; first scope excludes memtable-tail exports |
+| [Compaction-manager research](../architecture/issue-905-compaction-manager-research.md), lines 118–294 | Planner/executor separation; UCS source research; TOC publication sufficient for offline lifecycle; offline compaction and analytics epochs should converge | Use the synthesis instead of the older transaction-log proposal; pure planning can proceed independently |
+| [Assembled-engine research](../architecture/issue-1934-assembled-engine-research.md), lines 605–725, 818–863 | Maps memtable, compaction, OLAP, DataFusion, and engine-boundary work into one program; several owner decisions remain open | Architectural alignment already exists; naming, API ownership, and duplicate materializers are unresolved coordination issues |
+| [Spark research](../architecture/issue-1045-spark-connector-research.md), lines 113–150 | Owner-approved Flight-based DSv2 direction and documented single-replica v1 contract; bulk writing excluded from that connector scope | Do not reopen the consistency choice by implication or confuse read-connector scope with bulk-writer strategy |
+| [DataFusion decision brief](../architecture/941-datafusion-decision-brief-2026-07.md), lines 3–51 | July 16 owner decision: spike first, promote on data; retains Design A | A competing remote-fetch draft is not automatic authority; embedding DataFusion is not itself a performance milestone |
+| [Mustang paper](../research/mustang-multi-representation-storage-architecture.md), lines 6–31, 55–98, 422–476 | July 21 proposal, explicitly not accepted Apache design; neutral storage contracts, SSTable authority, optional derived Vortex, staged integration | Best strategic blueprint; crate extraction, representation choice, and CEP work still require deliberate adoption and proof |
+| [Throughput mission](../architecture/0.17-throughput-mission.md), lines 330–353, 624–632 | Diagnostic-gated levers, box-level capacity, field checkpoint; older results carry newly discovered rig caveats | Reuse the existing measurement program; rebaseline with the hardened rig before making deployment claims |
+
+**What is built, and what remains a hypothesis**
+
+The current repository contains native readers, writers, reconciliation, offline compaction, exports, language bindings, Flight, and Trino. The manager research identifies an arbitrary-directory compaction executor independent of `WriteEngine`. This means the proposed engine has a substantial operational core rather than only component sketches.
+
+Selected current-code checks found the workspace still organized as CQLite crates and bindings, without the proposed Mustang/Vortex/DataFusion crate structure. The compaction lane verified that directory-fsync hardening is implemented; release history records fixes to earlier TTL defects. Those historical audit findings must not be presented as current blockers. Production SSTable writing remains explicitly uncompressed in the parity claim contract.
+
+The generated [parity report](cassandra-test-parity.md), lines 32–47, still classifies important compaction/load-path scenarios as partial or smoke evidence. Its scenario-level findings are stronger evidence than broad README language. This review did not regenerate the report or certify a release.
+
+| Capability | Feasibility assessment | Decisive remaining proof |
+|---|---|---|
+| External analytics on SSTables | Working foundation; nearest operational product | Useful capacity and foreground Cassandra impact on representative, overlapping data |
+| Offline compaction plus reusable analytics epochs | Strong architectural fit with substantial executor reuse | Safe publication, compression, rebuildability, freshness policy, and amortized economics |
+| Bulk SSTable generation | Existing architecture supports it | Complete generation → transfer → import cost and interoperability on supported cases |
+| Memtable freshness | Concrete selected design | Pre-/post-flush equivalence, lifecycle pinning, export latency, and OLTP overhead |
+| Derived Vortex representation | Plausible accelerator, unproven Cassandra-specific benefit | Same-data semantic parity and equal-cost comparison against current SSTable and Parquet paths |
+| Live compaction offload | Valuable but additional integration work | Cassandra-owned reservation/installation, repair-state handling, failure recovery, and coexistence |
+| Full multi-representation native engine | Longer-term research/CEP program | Host lifecycle contracts, native routing, upgrades, repair/streaming, and optional-native packaging |
+
+**Economic evidence and its limits**
+
+The most strategically useful experiment is the [generation-overlap study](../research/issue-2043-reconcile-overlap-multiplier.md), lines 96–145. Holding generation/producer count constant, its synthetic mixed workload costs 3.24 times the disjoint control at five generations and 8.66 times at twenty. Duplicate versions, not file count alone, drive the additional work. This supports pre-reconciliation for repeated analytics. It does not measure the cost of writing, transferring, validating, or installing compacted outputs; purging was disabled, and real field overlap remains unmeasured.
+
+The matched [WS0-3100 report](ws0-3100-report.md) records a 3.06-times eligible Flight fast-path improvement and 1.12-times Cassandra row-serving throughput on one warm, single-SSTable corpus. The later mission explicitly caveats pre-hardening WS0 results: throughput derivation, unread admission counters, and incomplete schema/session identity require remeasurement. Preserve these as historical observations, not an unconditional deployment guarantee.
+
+The later [concurrency study](ws0-3225-report.md), lines 42–145, corrects the censored six-core optimum to 24 scans and shows that excessive admission harms latency and throughput. Cassandra was not running during that test. It informs resource control, not a claim of low OLTP interference.
+
+The [August performance synthesis](../research/throughput-2026-08-research-synthesis.md) favors reducing owned-row intermediates and working-set size over a runtime rewrite. The expected gains are gated projections. Earlier framing/schema-cache optimizations measured zero; the [mission's retired-claim ledger](../architecture/0.17-throughput-mission.md), lines 429–450, explicitly withdraws several prior hypotheses and targets.
+
+The [Arrow OLAP research](../architecture/issue-2037-arrow-olap-research.md), lines 1444–1530, qualifies its cross-scenario latency conclusions because shared constants were inconsistent. The broad Vortex/OpenZL and HTAP surveys establish prior art and possibilities, not measured CQLite speedups.
+
+A useful new acceptance model is workload-specific break-even: over a declared freshness interval, the total cost of materialization plus repeated queries must beat repeated SSTable reconciliation while staying inside storage and foreground-service budgets. This is a proposed evaluation rule, not a result already measured here. It naturally distinguishes high-update, low-query tables from repeatedly scanned, relatively stable tables.
+
+**Recommended milestones**
+
+Retain M1–M5 as historical delivery records. Replace the remaining linear feature sequence with shared foundations, an external-value gate, and a separate Cassandra-integration gate. WASM should not block any of them.
+
+| Milestone | Outcome | Exit evidence |
+|---|---|---|
+| A. Adopt the engine boundary and semantic contract | One accountable engine program, preserving CQLite as a consumer/proving surface | Decide the CQLite/Mustang boundary; define logical input identity, schema, time, repair state, supported operations, and authority. Distinguish mutation-preserving segments from current-row epochs. Curate only the APIs needed by the next consumers; no mandatory repository split |
+| B. Prove shared reconciliation and materialization | One reusable job can compact supported offline SSTables and publish an analytics representation | Equivalent logical results plus preservation of merge-affecting TTL/deletion metadata in SSTable outputs; compressed production output where economics require it; protected input sets; publication and crash tests; TTL/deletion/schema cases; bounded resources; one shared implementation for manager snapshots and analytics epochs |
+| C. Prove useful analytics offload | A declared workload benefits enough to deploy | Hardened-rig baseline; box-level completed work; BIG/BTI and append-only/overwrite-heavy cases; live scan versus reusable epoch comparison; total conversion/storage cost; Cassandra running under foreground load; through-Trino checkpoint |
+| D. Qualify bulk writing and compaction policy in parallel | External data preparation and metadata-only planning become useful products | Bulk generation → transfer → import parity/cost. UCS planner/simulator uses explicit density/topology inputs and tested policy invariants; compare predicted and observed amplification. Neither lane waits for live compaction installation |
+| E. Prove the selected freshness path | Opted-in analytical reads include the memtable tail with a stated cost | Existing no-CDC spike: pre-/post-flush parity, dirty-check behavior, bounded export latency, pool accounting, concurrent flush/snapshot stress, stale-tail retirement. Promote live-stream alternatives only if measured requirements force reconsideration |
+| F. Pilot one Cassandra integration boundary | Native integration becomes measurable and reversible | Choose one bounded CEP-17 adapter or coordinated compaction pilot. Prove Cassandra-owned lifecycle, crash/retry safety, repair-state exclusions, native-boundary cost, mixed-format operation, and rollback. Use prototype evidence to specify missing hooks |
+| G. Harden the supported engine; advance lifecycle CEPs selectively | A supported distribution with known authority and compatibility boundaries | Sustained operator pilots, release-specific evidence, upgrade/rollback matrix, recovery/repair/streaming tests for claimed scope. Atomic multi-representation publication and native routing advance only after their required contracts are accepted or explicitly owned in a research fork |
+
+Milestones A and the current throughput program should begin together. The metadata-only UCS work can run alongside B. Bulk qualification shares B's writer work but need not wait for C. E is needed for the stronger freshness promise, not for useful snapshot analytics. F should remain bounded; do not fund both broad native-format adoption and live compaction integration before one proves its boundary and value.
+
+Versioning should follow each supported contract. An external engine release can reach 1.0 after its applicable B–D workflows and operational evidence stabilize; it need not wait for a native Cassandra lifecycle CEP. Native adapters should retain a separate experimental/support designation until their F–G gates pass.
+
+**Improvements to the existing plan**
+
+1. Make one team/module own logical reconciliation and materialization. The research already identifies duplicate “merge once, serve many” proposals. Sharing parsers alone is insufficient; share job input identity, output publication, lifecycle, and validation where their semantics actually match.
+2. Keep representation semantics explicit. A per-generation cache must preserve the Cassandra mutation envelope. A fully reconciled epoch can expose current rows at a fixed reference time. A current-row epoch cannot silently stand in for a mutation source during later reconciliation.
+3. Keep SSTable authority and test fallback. Derived-format absence or corruption should permit a correct SSTable path where the query contract allows it. Commit-log recycling and authoritative input retirement must not depend on an unproven derived representation.
+4. Treat compression as shared infrastructure for compaction and bulk writing. An uncompressed replacement can increase disk and network costs relative to compressed inputs. Writer validity alone does not settle offload economics.
+5. Treat Vortex as the named candidate, with a measured selection gate. Preserve the neutral representation contract; benchmark against the existing Parquet/Arrow path on the same data. Avoid making every table pay for a second format before its workload warrants it.
+6. Preserve local versus distributed consistency boundaries. One selected replica and a fixed file set do not establish a global consistent cut. The documented v1 single-replica choice is an accepted scope, not an implementation defect to obscure or silently strengthen.
+7. Use source-coverage watermarks. A maximum mutation timestamp does not, by itself, prove receipt of a complete prefix when timestamps arrive out of order. Track consumed source identities/coverage separately from event-time maxima. This is an assessment inference requiring validation of the materializer contract.
+8. Keep policy choice separate from execution safety. The pure UCS planner is an early deliverable; exact randomized Cassandra job selection is not the right correctness bar. Output readability, logical equivalence, safe purging, and lifecycle behavior are.
+9. End naming and repository decisions as critical-path blockers. Define ownership and unpublished interfaces now; publish names and split repositories when concrete consumers justify the maintenance cost.
+10. Scope counters per operation. Producing external counter increments and merging existing counter contexts are different capabilities. Exclude unsupported counter tables from delegated compaction until context preservation and merge semantics are qualified explicitly.
+
+**Research conflicts to close before promoting the roadmap**
+
+- The June [fidelity decision](../garbage-free-compaction-improvements/compaction-fidelity-bar-decision.md), line 17, makes Cassandra readability and logical equivalence mandatory and identical bytes a non-goal; [byte-parity rules](../compaction/byte-parity-rules.md), line 3, still make a blanket byte requirement. Ratify one product contract while retaining scenario-specific byte oracles.
+- The [remote-fetch DataFusion draft](../datafusion-table-provider-design.md) rejects per-node Flight, while the council and later owner decision retain Design A. Mark proposal lineage and authority explicitly; avoid interpreting both as the current plan.
+- The [assembled-engine record](../architecture/issue-1934-assembled-engine-research.md), lines 460–479, describes global format selection, while Mustang proposes a single-table canary. The adapter spike must establish how selective adoption works on the pinned Cassandra release.
+- The throughput mission computes a per-core “within 1.3-times bare-scan cost” target using division, but describes a box target with multiplication in places. Specify the acceptance equation and unit before a milestone depends on it.
+- Older support pages and issue lists are historical. Current claims should be generated from release-specific capability/evidence records. Fixed TTL, directory-fsync, streaming, and snapshot defects must not remain roadmap blockers because an old audit still lists them.
+
+**Recommended next commitment**
+
+Adopt the proposed engine boundary, preserve the current measurement gates, and select one overwrite-heavy repeated-analytics workload as the first full demonstration. Show the same protected input set served through the existing live merge and through a reusable, rebuildable materialization; measure correctness, amortized cost, freshness, storage, and Cassandra foreground impact. In parallel, qualify compressed bulk output and the pure UCS planner. That proves the shared engine's value before asking Cassandra to delegate authoritative live storage lifecycle.

--- a/docs/test-infrastructure-architecture.md
+++ b/docs/test-infrastructure-architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Enhanced TestContext Framework is designed to achieve tiered test coverage for CQLite (see [PRD Section 5.1](development/PRD.md#51--tiered-coverage-targets)) by providing:
+The Enhanced TestContext Framework is designed to achieve tiered test coverage for CQLite (see [historical PRD Section 5.1](development/PRD-toolkit-v0.2.md#51--tiered-coverage-targets)) by providing:
 
 1. **Enhanced TestContext**: Schema validation, coverage tracking, quality gates
 2. **Test Categorization**: Systematic organization for comprehensive coverage
@@ -30,7 +30,7 @@ pub enum TestCategory {
 - Property Tests: 1000+ generated test cases
 - End-to-End Tests: Critical user scenarios
 
-See [PRD Section 5.1](development/PRD.md#51--tiered-coverage-targets) for authoritative tier definitions.
+See [historical PRD Section 5.1](development/PRD-toolkit-v0.2.md#51--tiered-coverage-targets) for authoritative tier definitions.
 
 ### 2. Enhanced TestContext
 

--- a/website/src/content/docs/user-docs/roadmap.md
+++ b/website/src/content/docs/user-docs/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Roadmap
-description: Where CQLite is headed — milestones, in-flight epics, and how to influence priorities.
+description: CQLite's storage-engine direction, qualification milestones, and path to 1.0.
 sidebar:
   label: Roadmap
   order: 9
@@ -8,75 +8,63 @@ sidebar:
 
 # Roadmap
 
-CQLite is at **v0.13.0**. The read path, CLI, output writers (including Parquet),
-Python and Node.js bindings, and write support with STCS compaction — now with
-**byte-for-byte compaction parity against Apache Cassandra**, an Arrow Flight + Trino
-connector, canonical BTI (`da`) write/read, and CDC-style delta export — are
-production-ready. This page is what comes next.
+CQLite is developing a Cassandra-compatible storage engine for analytics, reusable
+materialization, bulk ingestion, and compaction. The CLI, language bindings, and
+query interfaces remain supported product surfaces.
 
-The roadmap is community-driven. The fastest way to move something up the list is to
-[**open or +1 an issue**](https://github.com/pmcfadin/cqlite/issues) describing your
-use case — and to [**star the repo**](https://github.com/pmcfadin/cqlite) so the
-project's reach is visible.
+The [Product Requirements](https://github.com/pmcfadin/cqlite/blob/main/docs/development/PRD.md)
+define the scope, guarantees, and exit criteria. The
+[research assessment](https://github.com/pmcfadin/cqlite/blob/main/docs/reports/2026-09-06-storage-engine-vision-assessment.md)
+explains the rationale. GitHub tracks execution; the
+[changelog](https://github.com/pmcfadin/cqlite/blob/main/CHANGELOG.md) records shipped behavior.
 
-_Last reviewed: 2026-07-05 (v0.13.0)._
+_Last reviewed: 2026-09-06._
 
-## Milestones
+## Qualification milestones
 
-| Milestone | Status |
-|-----------|--------|
-| M1 — Core SSTable reading | ✅ Complete |
-| M2 — CLI (one-shot + REPL) | ✅ Complete |
-| M3 — Output writers (CSV, JSON, Parquet, CQL) | ✅ Complete |
-| M4 — Python + Node.js bindings | ✅ Complete |
-| M5 — Write support + STCS compaction | ✅ Complete (v0.9.0) |
-| M6 — WASM bindings for the browser | 📋 Planned |
-| M7 — Performance validation + **v1.0** | 📋 Planned |
+These milestones are **qualification pending**. Existing code and research provide
+a foundation; completion requires the PRD's workload and operational evidence.
 
-## In-flight epics
+| Milestone | Outcome |
+|-----------|---------|
+| SE1 — Engine contract | Explicit capabilities, authority, supported workloads, and measurable acceptance criteria |
+| SE2 — Shared offline execution | Safe compaction and reusable analytics materialization, including qualified compressed output |
+| SE3 — Analytics offload value | Measured analytics benefit within foreground Cassandra latency, resource, and freshness budgets |
+| SE4 — Bulk writing and policy tools | Bounded bulk generation through native Cassandra import, plus compaction planning and simulation |
+| SE5 — Qualified freshness | Proven memtable-tail behavior and cost for opted-in analytical reads |
+| SE6 — Bounded Cassandra integration | One reversible native-format or coordinated-compaction pilot |
+| SE7 — Native lifecycle qualification | Supported integrated behavior backed by recovery, lifecycle, and operator evidence |
 
-These are the active workstreams between v0.13.0 and v1.0. Each links to its GitHub
-epic with the child tasks.
+Compaction planning can proceed alongside the engine contract. Bulk writing shares
+output qualification with offline compaction. Live analytics measurement can
+continue while reusable materialization is developed.
 
-> Query-engine completeness (#756), `WRITETIME()`/`TTL()` in `SELECT` (#689), writer
-> format fidelity (#762), wide-partition performance (#751), BTI (`da`) end-to-end
-> read (#660), and the CDC delta-scan envelope (#696) all **shipped in v0.12.0** —
-> see the [changelog](https://github.com/pmcfadin/cqlite/blob/main/CHANGELOG.md).
+## What 1.0 means
 
-### Wire storage capabilities into the query path ([#951](https://github.com/pmcfadin/cqlite/issues/951))
+External-engine **1.0 requires SE1–SE4**, independent operator evidence, stable public
+contracts, and the release checks specified in the PRD. WASM, Vortex adoption, a
+continuous Iceberg daemon, and native Cassandra integration are not prerequisites.
+Freshness and native integrations retain separate experimental status until their
+applicable gates pass.
 
-CQLite's storage layer already has bloom filters, `Index.db`, the BTI `Partitions.db`
-trie, and a point-lookup path — but parts of the CQL query engine still scan every
-SSTable instead of using them. This epic audits for that pattern, wires the gaps
-(within-SSTable partition seeks, clustering-key pushdown, `IN`/token-range lookups),
-and adds regression guards so single-partition reads scale with candidate SSTables,
-not total count.
+The initial authority remains Cassandra-readable SSTables. New analytical
+representations are derived and rebuildable. The proposed Mustang architecture and
+Vortex representation are candidates to validate, not promises of shipped support.
 
-### Read-path performance & I/O backend ([#906](https://github.com/pmcfadin/cqlite/issues/906))
+## Historical milestones
 
-Parallel reads on a single `SSTableReader` (landed) plus a benchmark-first spike on an
-io_uring read backend for Linux.
+M1–M5 delivered core reading, the CLI, output writers, Python/Node bindings, and
+writing with STCS compaction. Those accomplishments remain the foundation.
 
-### Compaction byte-parity follow-ups ([#938](https://github.com/pmcfadin/cqlite/issues/938))
+The old M6 (WASM) and M7 (performance/size/1.0) sequence is replaced by the
+qualification program above. The
+[original PRD](https://github.com/pmcfadin/cqlite/blob/main/docs/development/PRD-toolkit-v0.2.md)
+preserves that history. Historical completion does not imply universal compatibility
+or qualify every new offload workflow.
 
-Edge cases deferred from the v0.12.0 parity work: range tombstones end-to-end through
-the compaction writer, and a handful of writer/reconciliation refinements.
+## Influencing priorities
 
-### CLI & bindings polish ([#907](https://github.com/pmcfadin/cqlite/issues/907))
-
-Developer-experience cleanup: export progress/statistics, clearer
-unsupported-platform errors in the Node loader, and output-mode tidying.
-
-## Influencing the roadmap
-
-Priorities follow real-world use. If you need something:
-
-1. **Search** [existing issues](https://github.com/pmcfadin/cqlite/issues) and add a
-   👍 or a comment with your use case.
-2. **File** a [new issue](https://github.com/pmcfadin/cqlite/issues/new/choose) if it
-   is not tracked.
-3. **Star** [the repo](https://github.com/pmcfadin/cqlite) — visibility directly
-   affects how much time goes into the project.
-4. **Contribute** — see [CONTRIBUTING](https://github.com/pmcfadin/cqlite/blob/main/CONTRIBUTING.md)
-   and look for `good-first-issue` labels.
-</content>
+[Open an issue](https://github.com/pmcfadin/cqlite/issues/new/choose) describing the
+workload, Cassandra version, data shape, freshness requirement, current cost or
+latency, and the improvement that would make deployment worthwhile. Operator
+workloads and reproducible evidence guide qualification priorities.


### PR DESCRIPTION
Owner-authored PRD rewrite, committed from the root checkout's working tree as-is.

- `docs/development/PRD.md` rewritten: mission/thesis, users, ownership boundaries, requirements, qualification protocol, SE1–SE6 milestones and dependency gates, release/support contract, recorded decisions, risks, historical baseline + research map.
- Previous toolkit PRD preserved verbatim as `docs/development/PRD-toolkit-v0.2.md`; the two inbound links (`docs/README.md`, `docs/test-infrastructure-architecture.md`) repointed to it as "historical".
- `README.md` vision + roadmap sections and `website/src/content/docs/user-docs/roadmap.md` updated to the SE1–SE6 qualification milestones (M1–M5 kept as historical delivery milestones).
- `docs/reports/2026-09-06-storage-engine-vision-assessment.md` added (research assessment memo).
- One-line touch in `docs/development/RELEASING.md`.

**Docs-only**: `scripts/ci/classify-docs-only.sh` → `docs-only`; no compiled input, no roborev certification possible for a code-free diff (doctrine); CI `required` is the merge check.

https://claude.ai/code/session_0125yfcchVUfMYtH7arzaD2f
