### PR TITLE
fix(#4206,#4220,#4221): macOS gate-of-record fixes — roborev guard self-test, wc padding, EILSEQ skips, $TMPDIR normalization

### DIFF
--- a/cqlite-cli/tests/issue_1490_parquet_golden_admission.rs
+++ b/cqlite-cli/tests/issue_1490_parquet_golden_admission.rs
@@ -1444,7 +1444,20 @@ fn a_directory_entry_the_harness_cannot_read_refuses_the_fixture() {
         let unreadable = tmp.path().join(std::ffi::OsStr::from_bytes(
             std::mem::take(&mut raw).as_slice(),
         ));
-        std::fs::write(&unreadable, b"").expect("write non-UTF-8 named entry");
+        // APFS (macOS's default filesystem) refuses a non-UTF-8 path component outright — the
+        // fixture this case needs cannot exist there at all, which is a filesystem property, not
+        // a platform one (a non-APFS volume mounted on a macOS host can still create it). Detect
+        // exactly that error (EILSEQ, "Illegal byte sequence") and skip loudly rather than
+        // #[ignore] or cfg(target_os), which would hide the case on hosts that CAN run it.
+        if let Err(e) = std::fs::write(&unreadable, b"") {
+            if e.raw_os_error() == Some(libc::EILSEQ) {
+                println!(
+                    "SKIP: this filesystem refuses non-UTF-8 path components (EILSEQ) — assertion needs a Linux/ext4 host"
+                );
+                return;
+            }
+            panic!("write non-UTF-8 named entry: {e}");
+        }
 
         let err =
             parquet_parity::fixture_root::fixture_in_table_dir("ks.t", tmp.path().to_path_buf())

--- a/cqlite-cli/tests/issue_1490_parquet_golden_admission.rs
+++ b/cqlite-cli/tests/issue_1490_parquet_golden_admission.rs
@@ -1431,8 +1431,13 @@ fn a_field_the_structure_description_does_not_cover_is_refused() {
 fn a_directory_entry_the_harness_cannot_read_refuses_the_fixture() {
     // A non-UTF-8 entry name: the deterministic instance of "cannot read this
     // entry". It used to be dropped by a `filter_map(|e| e.file_name().to_str())`.
+    // A LABELED block, not a bare one: this function has a SECOND, independent #[cfg(unix)]
+    // block below (the unlistable-directory case), which runs fine on APFS. A bare `return`
+    // from the EILSEQ skip below would exit the whole function and silently discard that
+    // second block's coverage too — `break 'non_utf8` exits only this block instead (roborev
+    // job 3406, Medium).
     #[cfg(unix)]
-    {
+    'non_utf8: {
         use std::os::unix::ffi::OsStrExt;
 
         let tmp = tempfile::TempDir::new().expect("tempdir");
@@ -1454,7 +1459,7 @@ fn a_directory_entry_the_harness_cannot_read_refuses_the_fixture() {
                 println!(
                     "SKIP: this filesystem refuses non-UTF-8 path components (EILSEQ) — assertion needs a Linux/ext4 host"
                 );
-                return;
+                break 'non_utf8;
             }
             panic!("write non-UTF-8 named entry: {e}");
         }

--- a/cqlite-cli/tests/support/golden_fixture_staging.rs
+++ b/cqlite-cli/tests/support/golden_fixture_staging.rs
@@ -225,6 +225,38 @@ mod tests {
         std::fs::write(path, bytes).expect("write");
     }
 
+    /// APFS (macOS's default filesystem) refuses a path component that is not valid
+    /// UTF-8 outright, with EILSEQ ("Illegal byte sequence"), so the fixtures the
+    /// non-UTF-8 cases below need cannot exist there at all. That is a property of the
+    /// FILESYSTEM, not of the platform — a non-APFS volume mounted on a macOS host can
+    /// still hold such a name — which is why it is detected from the ERROR and skipped
+    /// LOUDLY, rather than hidden behind `#[ignore]` or `cfg(target_os)`, either of
+    /// which would also hide the case on the hosts that CAN run it (issue #4221).
+    fn is_non_utf8_name_refusal(e: &std::io::Error) -> bool {
+        e.raw_os_error() == Some(libc::EILSEQ)
+    }
+
+    /// The one line a skipping case prints, so a reader of a green log can tell a case
+    /// that RAN from one this filesystem refused to host.
+    fn skip_non_utf8_unsupported(what: &str) {
+        println!(
+            "SKIP: this filesystem refuses non-UTF-8 path components (EILSEQ) — {what} needs a host whose filesystem accepts them (e.g. Linux/ext4)"
+        );
+    }
+
+    /// `touch` for a name that may not be valid UTF-8. `false` means the filesystem
+    /// refused the NAME itself (EILSEQ); any other write failure is still a panic, so
+    /// this can never turn a real defect into a skip.
+    #[must_use]
+    fn touch_non_utf8(path: &Path, bytes: &[u8]) -> bool {
+        std::fs::create_dir_all(path.parent().expect("has a parent")).expect("mkdir");
+        match std::fs::write(path, bytes) {
+            Ok(()) => true,
+            Err(e) if is_non_utf8_name_refusal(&e) => false,
+            Err(e) => panic!("write: {e}"),
+        }
+    }
+
     /// The discriminating case for the "lexicographically first golden" pick: a
     /// directory holding an EARLIER golden for a generation that is not the one
     /// present. Taking the first sorted golden compared the CLI's reading of
@@ -324,13 +356,24 @@ mod tests {
         // it, because the CLI reading the staged directory certainly will.
         let odd = std::ffi::OsStr::from_bytes(b"nb-2-\xff-big-Data.db");
         assert!(odd.to_str().is_none(), "the staged name is not valid UTF-8");
-        std::fs::write(fixture.join(odd), b"y").expect("write");
-        let why = golden_path(&fixture).expect_err("two SSTables, one golden");
-        assert!(
-            why.contains("holds 2 *-Data.db files") && why.contains("exactly one SSTable per case"),
-            "a name it cannot read is still a second SSTable: {why}"
-        );
-        std::fs::remove_file(fixture.join(odd)).expect("unlink");
+        // Only this HALF of the case needs a filesystem that accepts the name; the
+        // symlink half below runs anywhere. So skip the half, not the case — skipping
+        // the whole test would silently drop the unreadable-ENTRY coverage too.
+        match std::fs::write(fixture.join(odd), b"y") {
+            Ok(()) => {
+                let why = golden_path(&fixture).expect_err("two SSTables, one golden");
+                assert!(
+                    why.contains("holds 2 *-Data.db files")
+                        && why.contains("exactly one SSTable per case"),
+                    "a name it cannot read is still a second SSTable: {why}"
+                );
+                std::fs::remove_file(fixture.join(odd)).expect("unlink");
+            }
+            Err(e) if is_non_utf8_name_refusal(&e) => {
+                skip_non_utf8_unsupported("the non-UTF-8 second-SSTable half of this case");
+            }
+            Err(e) => panic!("write: {e}"),
+        }
 
         // An entry the filesystem cannot DESCRIBE, in the fixture directory and in
         // the keyspace directory beside it.
@@ -376,8 +419,14 @@ mod tests {
             data_db.to_str().is_none() && golden.to_str().is_none(),
             "both staged names are not valid UTF-8, which is the whole subject"
         );
-        touch(&fixture.join(data_db), b"x");
-        touch(&fixture.join(golden), b"{}");
+        if !touch_non_utf8(&fixture.join(data_db), b"x") {
+            skip_non_utf8_unsupported("the non-UTF-8 golden-pairing assertion");
+            return;
+        }
+        assert!(
+            touch_non_utf8(&fixture.join(golden), b"{}"),
+            "the filesystem accepted the SSTable's non-UTF-8 name but refused its golden's"
+        );
         assert_eq!(
             golden_path(&fixture).expect("the golden is right there beside its SSTable"),
             fixture.join(golden),
@@ -387,10 +436,16 @@ mod tests {
         // And the pairing is still by NAME, not "any golden in the directory": a
         // differently-named golden does not satisfy this SSTable.
         let other = tmp.path().join("t-def");
-        touch(&other.join(data_db), b"x");
-        touch(
-            &other.join(std::ffi::OsStr::from_bytes(b"nb-2-\xff-big-Data.db.jsonl")),
-            b"{}",
+        assert!(
+            touch_non_utf8(&other.join(data_db), b"x"),
+            "this filesystem accepted the same non-UTF-8 name moments ago"
+        );
+        assert!(
+            touch_non_utf8(
+                &other.join(std::ffi::OsStr::from_bytes(b"nb-2-\xff-big-Data.db.jsonl")),
+                b"{}",
+            ),
+            "this filesystem accepted the same non-UTF-8 name moments ago"
         );
         golden_path(&other).expect_err("a golden for another generation does not pair");
     }

--- a/cqlite-core/tests/issue_3148_fixture_roots_contract.rs
+++ b/cqlite-core/tests/issue_3148_fixture_roots_contract.rs
@@ -459,7 +459,20 @@ fn non_utf8_override_is_rejected_fail_closed() {
     let mut bytes = tmp.path().as_os_str().to_os_string().into_vec();
     bytes.extend_from_slice(b"/bad\xff\xfedir");
     let raw = std::ffi::OsString::from_vec(bytes);
-    std::fs::create_dir(&raw).expect("create a non-UTF-8 directory");
+    // APFS (macOS's default filesystem) refuses a non-UTF-8 path component outright — the
+    // fixture this case needs cannot exist there at all, which is a filesystem property, not
+    // a platform one (a non-APFS volume mounted on a macOS host can still create it). Detect
+    // exactly that error (EILSEQ, "Illegal byte sequence") and skip loudly rather than
+    // #[ignore] or cfg(target_os), which would hide the case on hosts that CAN run it.
+    if let Err(e) = std::fs::create_dir(&raw) {
+        if e.raw_os_error() == Some(libc::EILSEQ) {
+            println!(
+                "SKIP: this filesystem refuses non-UTF-8 path components (EILSEQ) — assertion needs a Linux/ext4 host"
+            );
+            return;
+        }
+        panic!("create a non-UTF-8 directory: {e}");
+    }
     assert!(
         raw.to_str().is_none(),
         "the fixture value must actually be invalid UTF-8"

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -4041,6 +4041,11 @@ _component_set_bounded() {
   # branch for a measurement that did not happen.
   local _cap_n
   _cap_n=$(head -c "$((_CS_CAP_MAX_BYTES + 1))" "$_CS_CAP_OUT" 2>/dev/null | wc -c 2>/dev/null)
+  # BSD `wc -c` (macOS) right-pads its count with leading spaces; GNU `wc -c` does not. Strip all
+  # whitespace before the numeric refusal check below so a macOS host's padded-but-valid count is
+  # not mistaken for the unmeasurable case — the `''|*[!0-9]*` refusal itself is unchanged and still
+  # fires closed on anything that isn't a bare digit string after stripping (#4220).
+  _cap_n=${_cap_n//[[:space:]]/}
   case "$_cap_n" in
     ''|*[!0-9]*)
       _component_set_replay_err
@@ -5805,8 +5810,13 @@ _component_set_probe_inner() {
   local _cs_complete=no _cs_obj_total="" _cs_obj_absent=""
   if _component_set_bounded "$_CS_BOUND_SECS" env -i "${_CS_GIT_ENV[@]}" ${_CS_READ_ENV[@]+"${_CS_READ_ENV[@]}"} git --no-replace-objects -C "$_CS_READ_DIR" cat-file -e "$remote_sha^{commit}" >/dev/null 2>&1 \
      && _component_set_bounded "$_CS_BOUND_SECS" env -i "${_CS_GIT_ENV[@]}" ${_CS_READ_ENV[@]+"${_CS_READ_ENV[@]}"} git --no-replace-objects -C "$_CS_READ_DIR" rev-list --objects --missing=print --no-walk "$remote_sha" >"$csdir/objcensus" 2>/dev/null; then
+    # BSD `wc -c` (macOS) right-pads its count with leading spaces, which would otherwise always
+    # trip the `*[!0-9]*` case below and silently force the slow (correct but expensive) path on
+    # every macOS run. Strip whitespace before the numeric case-match (#4220).
     _cs_obj_total=$(wc -c <"$csdir/objcensus" 2>/dev/null)
+    _cs_obj_total=${_cs_obj_total//[[:space:]]/}
     _cs_obj_absent=$(sed -n '/^?/p' "$csdir/objcensus" 2>/dev/null | wc -c 2>/dev/null)
+    _cs_obj_absent=${_cs_obj_absent//[[:space:]]/}
     case "$_cs_obj_total" in ''|*[!0-9]*) _cs_obj_total=0 ;; esac
     case "$_cs_obj_absent" in ''|*[!0-9]*) _cs_obj_absent=1 ;; esac
     if [ "$_cs_obj_total" -gt 0 ] && [ "$_cs_obj_absent" -eq 0 ]; then _cs_complete=yes; fi

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -15821,6 +15821,13 @@ run_component() { # run_component <name> <cmd...>
 # records SKIP (loudly, never silently PASS) so a missing toolchain can't mask a
 # real Python regression the way it did pre-#865. Anything else (venv/build/test
 # failure) is a hard FAIL.
+# The soft open-file limit run_python_bindings requires before it will run pytest
+# (issue #4221). 4096 is not a measured requirement of the suite — it is comfortably
+# above anything a CORRECT reader needs, chosen so this guard removes the harness's
+# contribution to the EMFILE class without quietly becoming the reason a leaky reader
+# passes. See the block in run_python_bindings for the full mechanism.
+_PB_NOFILE_MIN=4096
+
 run_python_bindings() {
   local name=python-bindings
   if [ -n "$ONLY" ] && ! grep -qw "$name" <<<"${ONLY//,/ }"; then
@@ -15858,6 +15865,7 @@ run_python_bindings() {
   # cargo ran when nothing had. Captured here and mapped by the SHARED _fm_note_maturin_rc,
   # the same helper the --lite python tier uses.
   local pbv_rc=0
+  local nofile_eff=""
   # The reach marker travels by ENV because the verifier runs as a CHILD process; _pbv_build
   # touches it immediately before invoking maturin, so the reach is MEASURED rather than
   # inferred from this aggregate rc (roborev job 285).
@@ -15867,14 +15875,72 @@ run_python_bindings() {
   _fm_note_maturin_rc "$name" "$pbv_rc" "$pbv_reach"
   if [ "$pbv_rc" -eq 0 ]; then
     active_venv=$(cat "$active_venv_file" 2>/dev/null); [ -n "$active_venv" ] || active_venv="$venv"
-    if RUN_SLOW_TESTS="${RUN_SLOW_TESTS:-0}" bash -c '
+    # OPEN-FILE LIMIT — a HARNESS defect, fixed here so it cannot false-FAIL the gate of
+    # record (issue #4221). macOS has no `systemd-run --user`, so a detached gate is
+    # launched with `launchctl submit` — and a launchd job inherits launchd's SOFT
+    # `maxfiles` of 256, NOT the interactive shell's (measured on this host: 1048576
+    # interactive vs 256 under launchd; hard limit `unlimited` in both, which is why
+    # raising it here is permitted). The python parity suite accumulates a handle per
+    # SSTable component across a Database session, so under 256 the descriptor table is
+    # exhausted mid-suite and the reader yields ZERO ROWS instead of raising: ten
+    # test_parity.py cases FAIL as `got 0, expected N` with no EMFILE anywhere in the
+    # log, and the SAME ten pass at the interactive limit. Bisected by running the
+    # identical gate-built module under `ulimit -n 256` (the ten failures, byte for
+    # byte) and unrestricted (10/10 green).
+    #
+    # This does NOT fix the reader. `EMFILE` swallowed into a silent empty result, and
+    # the handle accumulation that reaches the limit at all, are a real product defect
+    # tracked on its own issue; the limit is deliberately set well above what a correct
+    # reader would ever need, so this guard cannot become the reason a leaky reader
+    # looks green.
+    #
+    # FAIL-CLOSED: if the limit cannot be brought to $_PB_NOFILE_MIN, the component FAILs
+    # naming the observed value rather than running — continuing would re-enter exactly
+    # the silently-wrong state this guard exists to prevent, and a component that reports
+    # `got 0, expected N` for an environmental reason is the worst of both outcomes.
+    # `-S` on EVERY ulimit call below is load-bearing, not decoration: bash's `ulimit -n N`
+    # with neither -S nor -H sets the SOFT **and HARD** limits together, so the bare form
+    # would permanently lower launchd's `unlimited` hard limit to $_PB_NOFILE_MIN for this
+    # process tree — a one-way door, since a hard limit can never be raised back by an
+    # unprivileged process. (Observed while verifying this guard: a probe that lowered the
+    # soft limit with the bare form could not raise it again — `cannot modify limit:
+    # Operation not permitted` — which is the same trap one step earlier.) Reading with
+    # `-S` likewise asks the question this guard actually cares about.
+    local nofile_out
+    nofile_out=$(mktemp "${TMPDIR:-/tmp}/agent-gate-nofile.XXXXXX")
+    if RUN_SLOW_TESTS="${RUN_SLOW_TESTS:-0}" _PB_NOFILE_MIN="$_PB_NOFILE_MIN" \
+       _PB_NOFILE_OUT="$nofile_out" bash -c '
         set -euo pipefail
+        want="$_PB_NOFILE_MIN"
+        cur=$(ulimit -S -n 2>/dev/null || printf "")
+        if [ "$cur" != unlimited ]; then
+          case "$cur" in
+            ""|*[!0-9]*) : ;;
+            *) if [ "$cur" -lt "$want" ]; then ulimit -S -n "$want" 2>/dev/null || : ; fi ;;
+          esac
+        fi
+        eff=$(ulimit -S -n 2>/dev/null || printf "")
+        printf "%s" "$eff" >"$_PB_NOFILE_OUT"
+        if [ "$eff" != unlimited ]; then
+          case "$eff" in
+            ""|*[!0-9]*)
+              printf "agent-gate: open-file limit UNMEASURABLE (got %s) — refusing to run pytest (#4221)\n" "${eff:-<no value>}"
+              exit 97 ;;
+            *)
+              if [ "$eff" -lt "$want" ]; then
+                printf "agent-gate: open-file limit %s is below the required %s and could not be raised — refusing to run pytest, because under a low limit this suite fails as '\''got 0, expected N'\'' rather than erroring (#4221). A gate launched via launchctl/launchd inherits a soft maxfiles of 256; relaunch with a higher soft limit.\n" "$eff" "$want"
+                exit 97
+              fi ;;
+          esac
+        fi
         . "'"$active_venv"'/bin/activate"
         pytest bindings/python/tests -q' >>"$log" 2>&1; then
       status=PASS
     else
       status=FAIL
     fi
+    nofile_eff=$(cat "$nofile_out" 2>/dev/null)
+    rm -f "$nofile_out"
   else
     status=FAIL
     active_venv=$(cat "$active_venv_file" 2>/dev/null); [ -n "$active_venv" ] || active_venv="$venv"
@@ -15890,7 +15956,12 @@ run_python_bindings() {
   fi
   end=$(date +%s)
   record_result "$name" "$status" "$((end - start))"
-  echo ">>> [$name] $RECORDED_STATUS ($((end - start))s)"
+  # Report the EFFECTIVE open-file limit pytest actually ran under (#4221), so a future
+  # reader of a green log can tell a run that had headroom from one that merely happened
+  # not to hit the ceiling — the failure mode this guards is SILENT (`got 0, expected N`),
+  # so the limit must be visible even on a PASS. Empty only when pytest was never reached
+  # (the maturin build failed), in which case there is no limit to report.
+  echo ">>> [$name] $RECORDED_STATUS ($((end - start))s)${nofile_eff:+ [open-files: $nofile_eff, required >= $_PB_NOFILE_MIN]}"
 }
 
 # _node_bindings_corpus_present: does CQLITE_DATASETS_ROOT hold a corpus the node jest

--- a/scripts/tests/test_agent_gate_component_set.sh
+++ b/scripts/tests/test_agent_gate_component_set.sh
@@ -1929,13 +1929,13 @@ fi
 # not itself host-dependent, and stays meaningful on a GNU-`wc` CI runner too): a small, legitimate
 # capture must still return RC 0 with its bytes intact once the numeric check strips whitespace
 # before matching.
-padwc_bin="$tmp/padwc-bin"
-mkdir -p "$padwc_bin"
-for _t in bash sh sed awk grep cut tr mktemp date basename dirname cat head tail sort \
-          uniq rm mkdir cp mv ln uname nproc env find touch stat comm od xargs sleep kill \
-          ps df readlink id iconv timeout nice chmod git; do
-  _src=$(command -v "$_t" 2>/dev/null) && [ -n "$_src" ] && ln -sf "$_src" "$padwc_bin/$_t"
-done
+# Single-sourced from `mkbin` (roborev job 3406, Medium) rather than a second, hand-rolled
+# tool list: a curated PATH missing a tool the gate legitimately needs (the first draft here
+# omitted `gtimeout`, `mkbin`'s own documented macOS bound-mechanism fallback) makes the
+# invocation fail for a reason unrelated to the padded-wc property this case measures — and
+# the `PATH="$padwc_bin"` prefix below governs the lookup of the outer `timeout` itself, not
+# just what the gate calls. `mkbin padwc wc` omits only `wc`, which is replaced below.
+padwc_bin=$(mkbin padwc wc)
 padwc_real=$(command -v wc)
 cat >"$padwc_bin/wc" <<EOF
 #!/usr/bin/env bash

--- a/scripts/tests/test_agent_gate_component_set.sh
+++ b/scripts/tests/test_agent_gate_component_set.sh
@@ -1920,6 +1920,40 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# THE CAP CHECK TOLERATES A BSD-STYLE PADDED `wc -c` (issue #4220). macOS ships BSD `wc`, which
+# right-pads its byte count with leading spaces (`wc -c` -> "     42" rather than GNU's "42"). The
+# cap-refusal check is a TEXTUAL case-match ('' | *[!0-9]*), so an unstripped padded count always
+# matched the `*[!0-9]*` arm and refused every capture through this path — not only oversized ones
+# — turning every bounded call into an RC-198 replay-refusal on any BSD-`wc` host. Reproduced here
+# with a `wc` SHIM that pads deterministically regardless of the host's own `wc` (so this case is
+# not itself host-dependent, and stays meaningful on a GNU-`wc` CI runner too): a small, legitimate
+# capture must still return RC 0 with its bytes intact once the numeric check strips whitespace
+# before matching.
+padwc_bin="$tmp/padwc-bin"
+mkdir -p "$padwc_bin"
+for _t in bash sh sed awk grep cut tr mktemp date basename dirname cat head tail sort \
+          uniq rm mkdir cp mv ln uname nproc env find touch stat comm od xargs sleep kill \
+          ps df readlink id iconv timeout nice chmod git; do
+  _src=$(command -v "$_t" 2>/dev/null) && [ -n "$_src" ] && ln -sf "$_src" "$padwc_bin/$_t"
+done
+padwc_real=$(command -v wc)
+cat >"$padwc_bin/wc" <<EOF
+#!/usr/bin/env bash
+out=\$("$padwc_real" "\$@")
+printf '   %s\n' "\$out"
+EOF
+chmod +x "$padwc_bin/wc"
+padwc_out="$tmp/padwc.out"; padwc_rc=""
+PATH="$padwc_bin" timeout 30 bash "$GATE" --component-set-bounded-run 10 "$osz_small" >"$padwc_out" 2>/dev/null; padwc_rc=$?
+padwc_line=$(sed -n 's/^RC: //p' "$padwc_out" 2>/dev/null)
+if [ "$padwc_rc" != 124 ] && [ "$padwc_line" = 0 ] && grep -q 'component-set-small' "$padwc_out" 2>/dev/null; then
+  ok "4220-padded-wc-cap: a BSD-style padded 'wc -c' count (leading spaces) is stripped before the numeric refusal check, so a legitimate small capture still returns RC 0 with its bytes replayed rather than being misread as unmeasurable"
+else
+  bad "4220-padded-wc-cap: expected RC=0 with 'component-set-small' replayed under a padded-wc PATH (got rc='$padwc_rc' line='$padwc_line')"
+  printf '%s\n' "$padwc_out"
+fi
+
+# ---------------------------------------------------------------------------
 # THE STDERR REPLAY IS BOUNDED TOO, AND IT TRUNCATES WHERE STDOUT REFUSES (roborev job 299, Medium).
 # The stdout cap above left stderr as a bare `cat`, which is the SAME defect on the other stream: a
 # descendant that outlives a SUCCESSFUL child keeps the stderr fd it inherited, and `cat` on a

--- a/scripts/tests/test_agent_gate_logdir_cleanup.sh
+++ b/scripts/tests/test_agent_gate_logdir_cleanup.sh
@@ -146,6 +146,23 @@ if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
   printf 'FAIL - could not create a scratch dir under %s — refusing to run\n' "${TMPDIR:-/tmp}"
   exit 1
 fi
+# NORMALIZE ONCE, HERE, RATHER THAN AT EVERY COMPARISON (issue #4221 item 3). macOS's
+# default `$TMPDIR` ends in a trailing slash, so the template above yields a `tmp` whose
+# path carries a literal "//" (e.g. ".../T//agent-gate-logdir.XXXXXX"). Every path this
+# suite builds by STRING CONCATENATION off `$tmp` (`$tmp/fakeroot`, `$tmp/td-...`, the
+# `find "$tmp" ...` scan) keeps that "//" verbatim — but a path the GATE ITSELF reports
+# does not: it reaches its own absolute paths through a real `cd`+`pwd`, and a shell's
+# `cd` collapses consecutive slashes as part of ordinary pathname resolution (verified:
+# `cd a//b && pwd` prints `a/b`) even without `-P`. So a suite built on `$tmp` and a gate
+# report built on a real `cd` disagreed on FORM for the exact same directory — not a
+# leak, a textual double-vs-single-slash mismatch. Collapsing `$tmp` to its canonical
+# form immediately, before anything is derived from it, makes every downstream
+# concatenation agree with what the gate's own `cd`+`pwd` would produce.
+tmp=$(cd "$tmp" && pwd) || tmp=""
+if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
+  printf 'FAIL - could not normalize the scratch dir path — refusing to run\n'
+  exit 1
+fi
 trap 'rm -rf "$tmp"' EXIT INT TERM
 
 # Fixture git must be ISOLATED from the invoker's environment, not merely given an
@@ -4303,11 +4320,28 @@ fi
 # before AC27/AC28/AC29 raised it by 34, 200 before AC25/AC26 raised it by 26); the floor is
 # what notices a DELETED CASE — every
 # case in this file contributes at least 5 verdicts — rather than a drifting count.
+#
+# TWO FLOORS, KEYED ON THE SAME AFFIRMATIVE CAPABILITY PROBE EVERY DEGRADED BRANCH ABOVE
+# ALREADY USES (issue #4221 item 3) — a single flat 259 was never actually reachable on a
+# degraded host: measured STABLY at 247 across 8 back-to-back runs on a macOS host with
+# OWNER_MARKER_CAPABLE=0 (this file's own declared Linux-only dependency), 27 short of the
+# full 274, not the 15-verdict margin the flat floor assumed. Guessing a wider flat margin
+# would only re-hide the exact defect this floor exists to catch (#3544's lesson) on the
+# capable branch, so each branch gets ITS OWN calibrated floor instead of one shared guess:
+# 259 where the capability is present (unchanged — every Linux-measured total above stays
+# covered), 243 where it is absent (4 below the measured-stable 247, so a genuinely deleted
+# case — minimum 5 verdicts — still drops the total below it, while ordinary run-to-run
+# noise does not).
 _total_verdicts=$((PASS + FAIL))
-if [ "$_total_verdicts" -ge 259 ]; then
-  ok "suite floor: $_total_verdicts verdicts reported (floor 259) — no case was silently dropped"
+if [ "$OWNER_MARKER_CAPABLE" = 1 ]; then
+  _floor=259
 else
-  bad "suite floor: only $_total_verdicts verdicts reported (floor 259) — at least one case was deleted or died before its assertions"
+  _floor=243
+fi
+if [ "$_total_verdicts" -ge "$_floor" ]; then
+  ok "suite floor: $_total_verdicts verdicts reported (floor $_floor) — no case was silently dropped"
+else
+  bad "suite floor: only $_total_verdicts verdicts reported (floor $_floor) — at least one case was deleted or died before its assertions"
 fi
 
 printf '\n%s\n' "scripts/tests/test_agent_gate_logdir_cleanup.sh   passed: $PASS  failed: $FAIL"

--- a/scripts/tests/test_agent_gate_logdir_cleanup.sh
+++ b/scripts/tests/test_agent_gate_logdir_cleanup.sh
@@ -4323,20 +4323,25 @@ fi
 #
 # TWO FLOORS, KEYED ON THE SAME AFFIRMATIVE CAPABILITY PROBE EVERY DEGRADED BRANCH ABOVE
 # ALREADY USES (issue #4221 item 3) — a single flat 259 was never actually reachable on a
-# degraded host: measured STABLY at 247 across 8 back-to-back runs on a macOS host with
+# degraded host: measured STABLY at 247 across 10 back-to-back runs on a macOS host with
 # OWNER_MARKER_CAPABLE=0 (this file's own declared Linux-only dependency), 27 short of the
 # full 274, not the 15-verdict margin the flat floor assumed. Guessing a wider flat margin
 # would only re-hide the exact defect this floor exists to catch (#3544's lesson) on the
 # capable branch, so each branch gets ITS OWN calibrated floor instead of one shared guess:
 # 259 where the capability is present (unchanged — every Linux-measured total above stays
-# covered), 243 where it is absent (4 below the measured-stable 247, so a genuinely deleted
-# case — minimum 5 verdicts — still drops the total below it, while ordinary run-to-run
-# noise does not).
+# covered).
+#
+# NO SLACK on the degraded branch (roborev job 3406, Medium): several cases collapse to
+# exactly ONE verdict when OWNER_MARKER_CAPABLE=0 — AC15 (~line 1501), AC16 (~line 1688),
+# AC17 (~line 1976) and AC20 (~line 2832) each emit a single `ok` on that branch — so a
+# 4-verdict margin (243) is blind to precisely the cases that are branch-specific to the
+# path this floor exists to protect: deleting any ONE of them (247 -> 246) would still
+# clear 243. The measured-stable total IS the floor here: 247, exactly.
 _total_verdicts=$((PASS + FAIL))
 if [ "$OWNER_MARKER_CAPABLE" = 1 ]; then
   _floor=259
 else
-  _floor=243
+  _floor=247
 fi
 if [ "$_total_verdicts" -ge "$_floor" ]; then
   ok "suite floor: $_total_verdicts verdicts reported (floor $_floor) — no case was silently dropped"

--- a/scripts/tests/test_agent_gate_logdir_cleanup.sh
+++ b/scripts/tests/test_agent_gate_logdir_cleanup.sh
@@ -1199,6 +1199,37 @@ wait_for_logdir() {
   return 1
 }
 
+# Wait for the STUB's OWN readiness marker, not merely for its log directory.
+#
+# THE RACE THIS CLOSES (issue #4221). `wait_for_logdir` above returns as soon as the log
+# DIRECTORY exists, and the gate creates that during early start-up — BEFORE the #1825 slot is
+# granted (the same ordering that leaves a still-QUEUED run carrying the `RESULT: INCOMPLETE`
+# sentinel). The stub then calls `acquire_gate_slot`, which self-exempts for --lite/--delta/--only
+# but NOT for a full run (scripts/agent-gate.sh:26541-26543), so it can sit there for as long as
+# something else holds the cap. A `kill -TERM` delivered in that window kills a run that is still
+# starting up or still queued: it exits 1 during start-up instead of dying of the signal, and its
+# disposition then reads "early exit status 1 with diagnostic content" rather than the
+# signalled-with-evidence wording this case exists to assert. Measured at the commit that added
+# this helper, 10 consecutive runs on macOS: 1 passed, 9 failed on exactly that string. The odds
+# are WORSE inside a real gate, because the parent gate is itself holding a slot against a
+# default cap of 2 — which is why this reddened the gate of record rather than staying a
+# developer-shell curiosity.
+#
+# The stub already publishes readiness; this case simply never waited for it. It drops
+# "$CQLITE_GATE_STUB_RUNDIR/holding.$PID" (scripts/agent-gate.sh:26682) immediately AFTER
+# acquire_gate_slot returns and immediately BEFORE its sleep. Waiting for THAT file is a POSITIVE
+# signal that the run is past start-up and past the slot. A `sleep` long enough to "usually" cover
+# both would only re-introduce the same race at a different duration — which is the whole lesson.
+wait_for_stub_holding() {
+  local rundir="$1" tries="${2:-600}" i   # 600 * 0.05s = 30s bound
+  for ((i = 0; i < tries; i++)); do
+    set -- "$rundir"/holding.*
+    [ -e "$1" ] && return 0
+    sleep 0.05
+  done
+  return 1
+}
+
 # (a) THE SUMMARY WRITE FAILS. An unwritable caller-known path (a missing parent
 #     directory — the same class as a full disk) makes emit_summary's authoritative
 #     write fail AFTER the block, and its declared disposition, are already composed.
@@ -1249,25 +1280,37 @@ env -u AGENT_GATE_PARENT_RUN_ID \
 sig_pid=$!
 if d11b=$(wait_for_logdir "$td11b"); then
   ok "AC11b: precondition — the signalled run created its bundle ($d11b)"
-  : >"$d11b/planted-component.result"
-  kill -TERM "$sig_pid" 2>/dev/null
-  wait "$sig_pid"; sig_rc=$?
-  if [ "$sig_rc" -ge 128 ]; then
-    ok "AC11b: precondition — the run really died of the signal (exit $sig_rc)"
+  # The bundle existing is NOT readiness — see wait_for_stub_holding. Signal only a run that
+  # has demonstrably passed start-up AND the #1825 slot, or this case measures the start-up
+  # race instead of the behaviour it names.
+  if wait_for_stub_holding "$td11b/rundir"; then
+    ok "AC11b: precondition — the stub is past start-up and holds its slot (readiness marker present)"
+    : >"$d11b/planted-component.result"
+    kill -TERM "$sig_pid" 2>/dev/null
+    wait "$sig_pid"; sig_rc=$?
+    if [ "$sig_rc" -ge 128 ]; then
+      ok "AC11b: precondition — the run really died of the signal (exit $sig_rc)"
+    else
+      bad "AC11b: precondition failed — the run exited $sig_rc, not of a signal; the case measured something else"
+    fi
+    if [ -d "$d11b" ]; then
+      ok "AC11b: a SIGTERMed run with evidence in its bundle KEPT it"
+    else
+      bad "AC11b: a SIGTERMed run's bundle was DELETED — the post-mortem case par excellence, removed by the cleanup"
+    fi
+    disp11b=$(artifact_field "$d11b" logdir-disposition)
+    case "$disp11b" in
+      RETAINED*evidence*) ok "AC11b: the signalled bundle NAMES its retention ($disp11b)" ;;
+      '') bad "AC11b: the signalled bundle published no disposition artifact" ;;
+      *) bad "AC11b: the signalled bundle named an unexpected reason ('$disp11b')" ;;
+    esac
   else
-    bad "AC11b: precondition failed — the run exited $sig_rc, not of a signal; the case measured something else"
+    # A TIMEOUT here is a REAL failure, not a skip: either the stub never got its slot within
+    # 30s or it died during start-up. Say which is being claimed, and do not TERM-and-assert
+    # anyway, because those assertions would be about a run in an unknown state.
+    bad "AC11b: precondition FAILED — no readiness marker under $td11b/rundir within 30s; the stub is still queued for an #1825 slot or died during start-up, so TERMing now would measure the start-up race rather than the signalled-bundle behaviour"
+    kill -TERM "$sig_pid" 2>/dev/null; wait "$sig_pid" 2>/dev/null || :
   fi
-  if [ -d "$d11b" ]; then
-    ok "AC11b: a SIGTERMed run with evidence in its bundle KEPT it"
-  else
-    bad "AC11b: a SIGTERMed run's bundle was DELETED — the post-mortem case par excellence, removed by the cleanup"
-  fi
-  disp11b=$(artifact_field "$d11b" logdir-disposition)
-  case "$disp11b" in
-    RETAINED*evidence*) ok "AC11b: the signalled bundle NAMES its retention ($disp11b)" ;;
-    '') bad "AC11b: the signalled bundle published no disposition artifact" ;;
-    *) bad "AC11b: the signalled bundle named an unexpected reason ('$disp11b')" ;;
-  esac
 else
   bad "AC11b: the signalled run never created a bundle — cannot measure"
   kill -TERM "$sig_pid" 2>/dev/null; wait "$sig_pid" 2>/dev/null

--- a/scripts/tests/test_agent_gate_schemas_preflight.sh
+++ b/scripts/tests/test_agent_gate_schemas_preflight.sh
@@ -53,6 +53,26 @@ if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
   echo "FATAL: mktemp -d produced no usable directory ('$tmp'); refusing to run (paths would resolve under /)" >&2
   exit 1
 fi
+# NORMALIZE ONCE, HERE, rather than at every comparison (issue #4221, same defect family as
+# the `$TMPDIR//` normalization already applied to test_agent_gate_logdir_cleanup.sh). TWO
+# macOS-only discrepancies made five #3131 cases compare a path against ITSELF and disagree:
+#   1. `$TMPDIR` ends in a trailing slash there, so the template above yields a literal "//"
+#      (".../T//agent-gate-schemas.XXXXXX"), which every path built by STRING CONCATENATION
+#      off `$tmp` carries verbatim;
+#   2. `$TMPDIR` lives under the `/var` -> `/private/var` symlink, and the subject of these
+#      cases — test-data/scripts/fetch-datasets.sh — resolves the root it REPORTS with
+#      `cd ... && pwd -P` (fetch-datasets.sh:149,156,333,338,1154), i.e. physically.
+# So the script printed "/private/var/.../T/x" while the case expected "/var/.../T//x" —
+# the same directory, three textual differences, and the cases that compare the two
+# (3131-export-line, 3131-export-quoting, 3131-warm-cache, 3131-warm-cache-note,
+# 3131-remedy-quoting) FAILed on every macOS host for a reason unrelated to what they test.
+# `pwd -P` (not the plain `pwd` the logdir suite needed) because it must match the SUBJECT's
+# own resolution: collapsing the "//" alone would still leave /var vs /private/var.
+tmp=$(cd "$tmp" && pwd -P) || tmp=""
+if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
+  echo "FATAL: could not normalize the scratch root to its physical path; refusing to run" >&2
+  exit 1
+fi
 trap 'rm -rf "$tmp"' EXIT
 
 # CHILD PROBE MODE. The scratch-root-guard case below re-invokes THIS script with a failing

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -1214,20 +1214,19 @@ run_wrapper() { # run_wrapper [--wrapper <path>] <work-dir> [extra wrapper args.
   OUT="$tmp/out-$CASE_N.txt"
   INVOKED="$tmp/invoked-$CASE_N.txt"
   # The observer writes beside the transcript, so the stub is told which record to wait on (FIX 4).
+  # PLAIN ASSIGNMENT, not an `--log`-arg scan (roborev job 61, issue #4206 round 2). The scan
+  # this replaced (`for _rw_i in $(seq 1 $#)` -> `${!_rw_i}`) existed to let a caller override
+  # WRAPPER_LOG_PATH by passing `--log <path>` in "$@". It never could: NONE of this file's 264
+  # `run_wrapper` call sites pass `--log` (verified: `grep -c` over every call site), and the
+  # invocation below hardcodes its OWN `--log "$tmp/transcript-$CASE_N.txt"` immediately before
+  # "$@", so a case that did pass one would hand the wrapper two `--log` flags rather than
+  # override it — the scan was dead code with no reachable caller. Dead code is also where the
+  # bug lived: the GNU/BSD `seq` divergence this round fixed was in a loop nothing ever drove
+  # past zero elements, and the scan's OWN indirect expansion had a second, sibling out-of-bounds
+  # read (`${!_rw_next}` past `$#` when `--log` was the last arg) that a first fix pass missed
+  # for the same reason — nothing exercises this loop's body. Removing the scan removes both
+  # defects at the root instead of patching the second one in code nothing calls.
   WRAPPER_LOG_PATH="$tmp/transcript-$CASE_N.txt"
-  # Bash arithmetic, not `seq 1 $#` (issue #4206): with zero extra args ($#=0),
-  # BSD seq (`seq 1 0`) emits "1\n0" while GNU seq emits nothing, so on macOS the
-  # loop ran with _rw_i=1 and indirect-expanded `${!_rw_i}` past the bound — a
-  # $1 that does not exist under `set -u` — an `unbound variable` failure on
-  # every invocation, including a zero-arg one. `for ((...))` loops zero times
-  # for $#=0 on both platforms, matching intent exactly.
-  local _rw_n=$#
-  for ((_rw_i = 1; _rw_i <= _rw_n; _rw_i++)); do
-    if [ "${!_rw_i}" = "--log" ]; then
-      _rw_next=$((_rw_i + 1))
-      WRAPPER_LOG_PATH="${!_rw_next}"
-    fi
-  done
   : >"$INVOKED"
   # The sanctioned invocation reviews the RANGE <base>..HEAD, so the job record's
   # git_ref is "<base40>..<head40>". Default the stub to the correct range unless the
@@ -6989,10 +6988,15 @@ assert_says 'case (jd1) --help records the measurement behind it' "'job=265' on 
 # THE PRESCRIBED COMMANDS MUST BE ONES THAT WORK. `show <id> --json` NESTS the fields under `.job`,
 # so a top-level jq over that payload prints nulls — a check whose output cannot show what it claims.
 # The `|` pipes are ESCAPED (issue #4206): an unescaped `|` is ERE alternation, and the pattern's
-# trailing `|` left an EMPTY alternative — GNU grep tolerates that permissively, but BSD grep
-# (macOS's `/usr/bin/grep`) refuses it outright with `empty (sub)expression`, so this assertion
-# could never pass on macOS. `assert_says` was previously unreachable here on this platform: the
-# earlier BSD-`seq` crash in `run_wrapper` (same issue) aborted the suite before case (jd1) ever ran.
+# trailing `|` left an EMPTY alternative — one broken regex, two symptoms. An empty alternative
+# matches the EMPTY STRING, so under GNU grep (every hosted CI lane is Linux) this assertion
+# matched every line of $OUT unconditionally: a VACUOUS PASS, the exact failure class this suite
+# exists to catch, and it has been silently passing this way for as long as the pattern has
+# existed. Under BSD grep (macOS's `/usr/bin/grep`) the same malformed regex is refused outright
+# with `empty (sub)expression`, so the assertion could never even RUN there. `assert_says` was
+# additionally unreachable on macOS for an unrelated reason: the earlier BSD-`seq` crash in
+# `run_wrapper` (same issue) aborted the suite before case (jd1) ever ran, so the vacuous pass
+# was never locally observable on this platform either.
 assert_says 'case (jd1) --help prescribes the NESTED .job projection' \
   "roborev show <id> --json \| jq '\.job \|"
 assert_says 'case (jd1) --help names the nesting trap' "NESTS git_ref/status/token_usage"

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -1215,7 +1215,14 @@ run_wrapper() { # run_wrapper [--wrapper <path>] <work-dir> [extra wrapper args.
   INVOKED="$tmp/invoked-$CASE_N.txt"
   # The observer writes beside the transcript, so the stub is told which record to wait on (FIX 4).
   WRAPPER_LOG_PATH="$tmp/transcript-$CASE_N.txt"
-  for _rw_i in $(seq 1 $#); do
+  # Bash arithmetic, not `seq 1 $#` (issue #4206): with zero extra args ($#=0),
+  # BSD seq (`seq 1 0`) emits "1\n0" while GNU seq emits nothing, so on macOS the
+  # loop ran with _rw_i=1 and indirect-expanded `${!_rw_i}` past the bound — a
+  # $1 that does not exist under `set -u` — an `unbound variable` failure on
+  # every invocation, including a zero-arg one. `for ((...))` loops zero times
+  # for $#=0 on both platforms, matching intent exactly.
+  local _rw_n=$#
+  for ((_rw_i = 1; _rw_i <= _rw_n; _rw_i++)); do
     if [ "${!_rw_i}" = "--log" ]; then
       _rw_next=$((_rw_i + 1))
       WRAPPER_LOG_PATH="${!_rw_next}"
@@ -6981,8 +6988,13 @@ assert_says 'case (jd1) --help says to verify git_ref, never the id alone' "VERI
 assert_says 'case (jd1) --help records the measurement behind it' "'job=265' on two lanes"
 # THE PRESCRIBED COMMANDS MUST BE ONES THAT WORK. `show <id> --json` NESTS the fields under `.job`,
 # so a top-level jq over that payload prints nulls — a check whose output cannot show what it claims.
+# The `|` pipes are ESCAPED (issue #4206): an unescaped `|` is ERE alternation, and the pattern's
+# trailing `|` left an EMPTY alternative — GNU grep tolerates that permissively, but BSD grep
+# (macOS's `/usr/bin/grep`) refuses it outright with `empty (sub)expression`, so this assertion
+# could never pass on macOS. `assert_says` was previously unreachable here on this platform: the
+# earlier BSD-`seq` crash in `run_wrapper` (same issue) aborted the suite before case (jd1) ever ran.
 assert_says 'case (jd1) --help prescribes the NESTED .job projection' \
-  "roborev show <id> --json | jq '\.job |"
+  "roborev show <id> --json \| jq '\.job \|"
 assert_says 'case (jd1) --help names the nesting trap' "NESTS git_ref/status/token_usage"
 # THE TOP-LEVEL id IS THE REVIEW ROW'S OWN SEQUENCE, measured over ten records: asking for 9
 # returns id=8 with job_id=9. A human reading it manufactures the very doubt the check removes.


### PR DESCRIPTION
## Summary

`scripts/tests/test_roborev_review_guard.sh` crashed with `unbound variable` at line 1219 on every invocation on macOS (`run_wrapper`'s arg-scan used `for _rw_i in $(seq 1 $#)`; BSD `seq 1 0` emits `1\n0` while GNU emits nothing, so with zero extra args — the overwhelming majority of the file's 264 `run_wrapper` call sites — the loop ran with `_rw_i=1` and `${!_rw_i}` indirect-expanded past `$#` under `set -u`). Since this self-test runs inside the `roborev-lints` gate component (both `--lite` and full gate), this made the gate of record unrunnable to completion on this box.

Replaced the `seq`-driven scan with a bash arithmetic `for ((...))` loop, which correctly iterates zero times for `$#=0` on both platforms.

Fixing that crash exposed a second, previously-unreachable macOS-only failure in the same file: case (jd1)'s `assert_says` pattern `roborev show <id> --json | jq '\.job |` has an unescaped trailing `|`, an ERE with an empty alternative. Under GNU grep (every hosted CI lane) this matched every line unconditionally — a **vacuous pass** — while BSD grep (macOS) refuses it outright with `empty (sub)expression`. Escaped both pipes to the intended literal text.

A second commit addressed two of the four Low findings from the first roborev pass on this fix (job 3363): removed a now-dead `--log`-arg scan in `run_wrapper` (no call site among the file's 264 ever passes `--log`; the invocation hardcodes its own `--log` flag immediately before `"$@"`, so the scan was unreachable — and it had a second, sibling out-of-bounds indirect-expansion bug the first pass missed for the same reason nothing exercises it) and corrected the case (jd1) comment to name the vacuous-pass consequence precisely rather than describing it as GNU grep merely "tolerating" the pattern.

No other script under `scripts/tests/` or `scripts/flow/` has the same live `seq 1 $var` pattern (one match in `test_ws0_round_metadata.sh:121` is inside a historical doc comment describing a pre-fix loop, not live code).

## Follow-up

A second roborev pass (job 3365) on the fix-of-the-fix surfaced three further findings (2 Medium, 1 Low) in the same test file's `assert_says`/`assert_lacks` helpers — real, but out of scope for this issue's 2-round script cap (owner ruling #3893) and not blocking #4206's acceptance (self-test passes on macOS and Linux, no behaviour change to the guard it tests). Filed as #4214 (unmilestoned tooling debt, not board-tracked): `assert_lacks` (and to a lesser extent `assert_says`) treats `grep`'s exit status 2 (invalid regex) the same as "pattern not found," so a malformed regex — the exact defect class this issue is about — can still silently pass on both platforms; and the file has no guard preventing reintroduction of an empty-string-matching pattern anywhere across its 48 `grep -qE` assertion sites.

## Daemon infra note (not a code issue)

Two earlier roborev attempts with `--agent codex` (jobs 3357, 3358) failed on a daemon/CLI infra defect, not a code finding: `agent: codex requires --full-auto for stdin input; upgrade codex or use --agentic`. `roborev status` showed the daemon otherwise healthy, and the identical error had also hit an unrelated job (3353) ~3h earlier — a standing `codex`-agent integration issue on this box (`codex-cli 0.144.5`), unrelated to this diff. Certification proceeded with `--agent claude-code --model claude-opus-5` per lead authorization; the codex/daemon issue should be tracked separately by whoever owns that box's roborev config.

## LITE gate (`scripts/agent-gate.sh --lite`)

```
==== AGENT-GATE LITE SUMMARY ====
run-id: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T/agent-gate.Cu7DzH
MODE: lite (FAST ITERATION — NOT the gate of record; full agent-gate.sh must PASS once before merge)
commit: 68b71d2 branch: issue-4206-roborev-guard-macos dirty: yes
lite-scope: file-size fmt clippy roborev-lints scoped-tests (full gate NOT run — run it once before merge)
tree-start: 68b71d27704f dirty: yes digest: 3e8efdadccdd
tree-end: 68b71d27704f dirty: yes digest: 3e8efdadccdd
tree-integrity: PASS
file-size:         PASS (0s)  [no-cargo]
fmt:               PASS (6s)  [fmt workspace features=n/a]
clippy:            PASS (4s)  [clippy workspace(excl 5) --all-features | clippy cqlite-core --features 25:all-compression,arrow,bench-internals,+22 more | clippy cqlite-cli --features 8:benchmarks,cli-helpers,delta-export,+5 more | clippy cqlite-flight+cqlite-py+cqlite-node --features cqlite-node/write-support]
roborev-lints:     PASS (370s)  [no-cargo]
scoped-tests:      PASS (22s)  [test cqlite-core --features cli-helpers]  {verified: 4054 tests passed and 0 test binaries built/verified}
disk-exhaustion: 0 RECOGNISED (#3800) -- no non-PASS component to scan (5/5 PASS)
logdir-disposition: REMOVED at exit on PASS
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```

(Run against the working tree that became commit 6443355, captured just before that commit — hence `dirty: yes` / `tree-start` naming the prior commit. `roborev-lints` includes a full run of `scripts/tests/test_roborev_review_guard.sh` itself: `passed: 1596 failed: 0` on this macOS box, versus an unconditional crash before this fix.)

## ROBOREV review (round 2, `--agent claude-code --model claude-opus-5`, job 3365)

```
==== ROBOREV REVIEW SUMMARY ====
repo: /Users/patrickmcfadin/local_projects/cqlite/.claude/worktrees/issue-4206-roborev-guard-macos
branch: issue-4206-roborev-guard-macos
base: origin/main
head-sha: 64433558256506fda8cc408e5b786b585381ed24
reviewed-sha: 316f9f711b2a146de8dc3c2e1f9d179e53307633..64433558256506fda8cc408e5b786b585381ed24
assert-base: 316f9f711b2a146de8dc3c2e1f9d179e53307633 (merge-base of origin/main and HEAD; origin/main tip 316f9f711b2a146de8dc3c2e1f9d179e53307633)
job: 3365
model: claude-opus-5
census: 1 file, +23/-7
push-assert: PASS
census-check: PASS
code-free: PASS
job-record: PASS (no token accounting in the record)
sha-assert: PASS
review-completed: PASS
prompt-content: PASS (1/1 code census paths present)
vacuity-tier1: PASS
findings: PRESENT (3)
roborev-exit: FINDINGS (exit 1)
RESULT: FAIL
==== END ROBOREV REVIEW SUMMARY ====
```

RESULT is FAIL on findings, not infra — see **Follow-up** above (filed as #4214) and **owner ruling** below for why this PR proceeds anyway.

**Owner ruling**: 2-round script cap (#3893) reached; #4206's acceptance criteria (self-test passes on macOS and Linux, no behaviour change to the guard it tests) is independently satisfied. Round-2 findings deferred to #4214 rather than fixed here.

https://claude.ai/code/session_01861dD62mokTbz2ThZj3FRF


## Bundled: #4220 + #4221 (owner ruling 2026-09-11)

Per owner ruling, bundling the remaining macOS gate-of-record defects into this PR so a macOS
host can produce a `RESULT: PASS` full gate. Three additional commits:

### #4220 — BSD `wc` padding broke agent-gate.sh's numeric refusal checks

BSD `wc -c`/`-l`/`-w` (macOS) right-pads its output with leading spaces; GNU `wc` does not. Two
sites in `scripts/agent-gate.sh` case-matched a `wc` capture as a bare digit string
(`''|*[!0-9]*`) — a textual check that always matched the non-digit arm on a padded count:

- `_component_set_bounded`'s stdout cap check (~line 4043): **every** bounded capture on a
  BSD-`wc` host was refused (RC 198), not just oversized ones — this made the bounded-run
  primitive fail-closed on essentially every call on macOS.
- The upstream-identity object census (~line 5813-5814): `_cs_obj_total`/`_cs_obj_absent` were
  reset to their fail-closed defaults on every run, permanently forcing the slow verification
  path instead of the fast object-reuse path.

Fixed by stripping `[[:space:]]` before the case-match in both spots; the refusal itself is
unchanged.

**wc-site audit** (`scripts/agent-gate.sh`, `scripts/flow/*.sh`, `scripts/ci/*.sh`):

| Site | Verdict |
|---|---|
| `agent-gate.sh:4043` (stdout cap check) | **Fixed** |
| `agent-gate.sh:5813-5814` (object census) | **Fixed** |
| `agent-gate.sh:2520,12064,16344,20338,23636,23644,23867,24523,24730-24731,26845,27224` | Safe — already piped through `tr -d ' '`/`tr -d '[:space:]'` |
| `flow/roborev-review-oracles.sh:2311` | Safe — consumed only inside `$(( ... + 1))`, an arithmetic context that tolerates whitespace (verified empirically) |
| `ci/ensure_real_dataset.sh:110-111` | Safe — consumed only inside `[[ $N -gt 0 ]]`, likewise arithmetic |
| `flow/drive-issue-state.sh:1701-1702`, `flow/lane-lock.sh:1066`, `flow/roborev-review-checks.sh:179`, `ci/check-pub-surface.sh:985,987,1363-1364` | Safe — already stripped |
| Every other `scripts/flow/*.sh` / `scripts/ci/*.sh` | No `wc -c`/`-l`/`-w` sites at all |

Added a TDD regression case (`4220-padded-wc-cap`) to
`scripts/tests/test_agent_gate_component_set.sh` that shims `wc` to pad deterministically
(host-independent) and asserts a legitimate small bounded capture still returns RC 0 with its
bytes replayed. Verified RED (RC 198) against the pre-fix script, GREEN against the fix.

**Follow-up, deliberately NOT in this PR**: a launchd fallback for `scripts/flow/gate-detached.sh`
(unrelated capability, would expand scope) — tracked as a follow-up issue to file separately.

### #4221 items 1-2 — SKIP loudly on APFS's EILSEQ instead of panicking

`cqlite-core/tests/issue_3148_fixture_roots_contract.rs::non_utf8_override_is_rejected_fail_closed`
and
`cqlite-cli/tests/issue_1490_parquet_golden_admission.rs::a_directory_entry_the_harness_cannot_read_refuses_the_fixture`
each need a real non-UTF-8-named filesystem entry. APFS refuses to create one at all (EILSEQ, os
error 92), so the fixture-creating call panicked before either assertion ran.

Fixed by detecting exactly that error (`raw_os_error() == Some(libc::EILSEQ)`) at the
fixture-creating call, printing an affirmative `SKIP: ...` line, and returning; any other error
still panics, and a host that CAN create the fixture (e.g. a non-APFS volume on macOS) still runs
the assertion unchanged — decided by the observed error, not `cfg(target_os)`/`#[ignore]`.

### #4221 item 3 — `test_agent_gate_logdir_cleanup.sh` hermetic-accounting + floor

macOS's `$TMPDIR` ends in a trailing slash, so the suite's own `$tmp=$(mktemp -d
"${TMPDIR:-/tmp}/...")` carried a literal `//`; every path built by string concatenation off
`$tmp` kept it, while a path the gate itself reports goes through a real `cd`+`pwd` (which
collapses consecutive slashes) — so the suite's hermeticity enumeration and the gate's own
self-reported paths disagreed on FORM for the same directory, reading as an unexplained leak.
Fixed by normalizing `$tmp` once, immediately after creation (`tmp=$(cd "$tmp" && pwd)`) — the
same "normalise once, at the creation site" principle `scripts/agent-gate.sh:8180-8207` already
applies to its own `$TMPDIR`-derived `GATE_LOGDIR_PARENT` (confirmed: the shipped gate strips
trailing slashes there already, so this defect was test-only, never in the gate itself).

A second, independent defect surfaced by the same run: the suite's flat verdict floor (259)
assumed the macOS owner-marker-capability degradation cost ~15 verdicts relative to Linux's 274;
measured stably at 247 across 10 consecutive runs on this host — 27 short, not 15 — so 259 was
never reachable here regardless of the double-slash fix. Fixed by keying the floor on the same
`OWNER_MARKER_CAPABLE` probe the file's degraded branches already use: 259 unchanged where
present, 243 (4 below the measured-stable 247) where absent.

Audited every other `"$TMPDIR/..."` textual path comparison in `scripts/tests/*.sh` for the same
shape (an expected-vs-discovered path *set* compared across two different derivation mechanisms):
no other file has it. `test_agent_gate_disk_exhaustion.sh`, `test_base_staleness.sh` and
`test_claude_auth_capability.sh` each use `comm -13`/`comm -23`, but over verdict-token lists or
before/after snapshots taken through the *same* mechanism at both ends, not a raw-`$TMPDIR` string
against a subprocess-normalized one.

**Pre-existing, unrelated flake observed (not fixed here, out of scope for item 3)**: `AC11b`
intermittently (~50% of runs on this host, reproduced on the pre-fix script too) reads a
SIGTERMed run's disposition as `RETAINED: early exit status 1 with diagnostic content
(post-mortem)` instead of the evidence-based reason — a signal-timing race. Worth a follow-up
issue if it recurs.

## LITE gate, round 2 (`scripts/agent-gate.sh --lite`)

```
==== AGENT-GATE LITE SUMMARY ====
run-id: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T/agent-gate.Kg23a2
MODE: lite (FAST ITERATION — NOT the gate of record; full agent-gate.sh must PASS once before merge)
commit: debb002 branch: issue-4206-roborev-guard-macos dirty: no
lite-scope: file-size fmt clippy roborev-lints scoped-tests (full gate NOT run — run it once before merge)
tree-start: debb0029d32c dirty: no digest: 06a46eb9fdcd
tree-end: debb0029d32c dirty: no digest: 06a46eb9fdcd
tree-integrity: PASS
file-size:         OPT-OUT (0s)  [no-cargo] — CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced); 1 over-threshold file(s) grown — see file-size.log under logs:
fmt:               PASS (6s)  [fmt workspace features=n/a]
clippy:            PASS (6s)  [clippy workspace(excl 5) --all-features | clippy cqlite-core --features 25:all-compression,arrow,bench-internals,+22 more | clippy cqlite-cli --features 8:benchmarks,cli-helpers,delta-export,+5 more | clippy cqlite-flight+cqlite-py+cqlite-node --features cqlite-node/write-support]
roborev-lints:     PASS (192s)  [no-cargo]
scoped-tests:      PASS (26s)  [test cqlite-cli default-features | test cqlite-core --features cli-helpers]  {verified: 4308 tests passed and 0 test binaries built/verified}
disk-exhaustion: 0 RECOGNISED (#3800)
logdir-disposition: RETAINED: file-size OPT-OUT disclosure #3402
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```

**`file-size` OPT-OUT disclosure**: `cqlite-cli/tests/issue_1490_parquet_golden_admission.rs`
grew from 1497 to 1510 lines (limit 1500) from the item-2 EILSEQ fix. Trimmed the added comment as
far as reasonable without hurting clarity; the file was already 3 lines from the ceiling before
this change and a full split is out of scope for a bug-fix PR (epic #1135, test-file splitting).
Re-ran with `CQLITE_ALLOW_FILE_GROWTH=1` per CLAUDE.md's documented escape hatch.

Also ran the three directly-affected tests by name:
- `cargo test -p cqlite-core --test issue_3148_fixture_roots_contract non_utf8_override_is_rejected_fail_closed` — PASS (prints the SKIP line)
- `cargo test -p cqlite-cli --test issue_1490_parquet_golden_admission a_directory_entry_the_harness_cannot_read_refuses_the_fixture` — PASS (prints the SKIP line)
- `bash scripts/tests/test_agent_gate_logdir_cleanup.sh` — floor met (247 ≥ 243), no hermetic mismatch (AC11b pre-existing flake aside)

Closes #4206. Closes #4220. Closes #4221.


## ROBOREV review (round, `--agent claude-code --model claude-opus-5`, job 3406)

Reviewed the #4220/#4221 bundle (this diff on top of #4206's already-merged-round fix).

```
==== ROBOREV REVIEW SUMMARY ====
job: 3406
model: claude-opus-5
census: 6 files, +132/-12
push-assert: PASS
census-check: PASS
code-free: PASS
sha-assert: PASS
review-completed: PASS
prompt-content: PASS (6/6 code census paths present)
vacuity-tier1: PASS
findings: PRESENT (7)
roborev-exit: FINDINGS (exit 1)
RESULT: FAIL
==== END ROBOREV REVIEW SUMMARY ====
```

7 findings (3 Medium, 4 Low). Per the roborev-severity rubric and owner ruling #3893 (scripts
capped at 2 rounds; this PR's rounds are already used), fixed the 3 Medium findings in a follow-up
commit and batched the 4 Low findings into a single comment on #4221 rather than running a third
round:

- **Medium** — the `#4221` item-2 EILSEQ skip's `return` exited the whole
  `a_directory_entry_the_harness_cannot_read_refuses_the_fixture` test function, silently
  discarding its second, independent `#[cfg(unix)]` block (the unlistable-directory case, which
  runs fine on APFS). Fixed: labeled block + `break 'non_utf8` scopes the skip to just the guarded
  block.
- **Medium** — the `#4221` item-3 degraded-branch floor (243) had a blind spot: several
  degraded-branch cases (AC15/AC16/AC17/AC20) each emit exactly one verdict, so deleting any one of
  them (247 -> 246) still cleared 243. Fixed: tightened to 247 (measured-stable, no slack).
- **Medium** — the `#4220` regression case's PATH shim hand-duplicated `mkbin`'s tool list and had
  already drifted (missing `gtimeout`, the gate's own macOS bound-mechanism fallback). Fixed:
  single-sourced via `padwc_bin=$(mkbin padwc wc)`.
- 4 **Low** findings (a diagnostic printing a path instead of file content; a dead variable left
  over from #4206's fix; `println!`-based skips invisible without `--nocapture`; a doc comment
  misattributing the double-slash cause) — batched into
  https://github.com/pmcfadin/cqlite/issues/4221#issuecomment-5636597450, not fixed here.

Re-ran `--lite` after the Medium fixes:

```
==== AGENT-GATE LITE SUMMARY ====
run-id: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T/agent-gate.<r3>
commit: 3263c08 branch: issue-4206-roborev-guard-macos dirty: no
tree-integrity: PASS
file-size:         OPT-OUT (0s)  [no-cargo] — CQLITE_ALLOW_FILE_GROWTH=1 (ratchet NOT enforced); 1 over-threshold file(s) grown
fmt:               PASS (5s)
clippy:            PASS (5s)
roborev-lints:     PASS (179s)
scoped-tests:      PASS (27s)  {verified: 4308 tests passed and 0 test binaries built/verified}
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```

Per owner instruction, this PR's script rounds are now exhausted (2 total) — the next gate to run
against this branch is the ONE full `scripts/agent-gate.sh` (gate of record) inside `flow-closer`,
never another `--lite`/roborev round for a scripts change.


---

## Closer addendum — three further macOS host defects found BY the gate of record (#4221)

The first full gate of record on this macOS host (run-id `agent-gate.xC6aX3`, commit `1775c8e`)
completed all 39 components: 36 PASS, `file-size` OPT-OUT (as designed, see above), and **3 FAIL**.
All three were the same class this PR exists to close — the host defeats the harness, not the
product — so they are fixed here rather than deferred.

### F1 — `cli-tests`: two more APFS EILSEQ sites (commit `d3c0dfd`)

`cqlite-cli/tests/support/golden_fixture_staging.rs:225,:327` panicked with
`write: Os { code: 92, ... "Illegal byte sequence" }`. #4221 had applied the loud-SKIP guard to
`issue_3148_fixture_roots_contract.rs` and `issue_1490_parquet_golden_admission.rs` but not to this
third file, so the class was only partly closed. Same guard, unchanged in principle: detect the
FILESYSTEM's refusal from the ERROR, never `#[ignore]`/`cfg(target_os)`. Any non-EILSEQ write error
still panics, so it cannot convert a real defect into a skip.

The second case is skipped **by half, not whole**: only its non-UTF-8 block needs a filesystem that
accepts the name, while the unreadable-ENTRY (symlink) block below it runs anywhere. Skipping the
whole case would have silently dropped that coverage on every macOS run.

| target | before | after |
|---|---|---|
| `cqlite-cli --test issue_1491_json_csv_golden_parity` | 307 passed, **2 failed** | **309 passed, 0 failed** |

### F2 — `python-bindings`: launchd's 256 open-file limit (commit `8a82c0a`)

Ten `test_parity.py` cases failed as `got 0, expected N` — 9 tables returning **zero rows** (all 6
`test_oa`, `test_collections.empty_collections_table`, `test_timeseries.stock_prices`,
`time_bucketed_counters`) plus `TestE2ESummary`.

Root cause is the **launch method**, not the reader and not the corpus. macOS has no
`systemd-run --user`, so a detached gate is launched with `launchctl submit` — and a launchd job
inherits launchd's soft `maxfiles`. Measured on this host:

```
$ launchctl limit maxfiles
	maxfiles    256            unlimited
$ ulimit -S -n          # interactive shell, same host
1048576
```

The corpus was independently ruled out: `fetch-datasets.sh --verify-only` VERIFIES that exact root
(915/915 git-tracked fixtures present, 159 `*-Data.db`), and failing and passing tables are alike
compressed.

**Verification** (the gate-built module, three ways — this is the one-line verification the guard
has in place of a self-test, since the gate self-tests do not cover `run_python_bindings` cheaply):

```
# A. the defect, reproduced
$ bash -c 'ulimit -S -n 256; . target/agent-gate-venv/bin/activate; pytest bindings/python/tests/test_parity.py -q'
10 failed, 36 passed, 1 skipped, 1 xfailed

# B. the guard's raise (soft 256 -> 4096)
$ bash -c 'ulimit -S -n 256; ulimit -S -n 4096; . target/agent-gate-venv/bin/activate; pytest bindings/python/tests/test_parity.py -q'
47 passed, 1 xfailed

# C. fail-closed, when the ceiling makes 4096 unreachable (soft=hard=512)
agent-gate: open-file limit 512 is below the required 4096 and could not be raised — refusing to run pytest (#4221)
exit=97          # pytest never runs
```

Fail-closed is deliberate: the failure being guarded is **silent** (`got 0, expected N`, with no
EMFILE anywhere in the log), and a component reporting a data-parity mismatch for an environmental
reason is worse than one that refuses. The effective limit is printed on the component's line so a
reader of a **green** log can see the headroom it ran with.

`-S` on every `ulimit` call is load-bearing: bash's bare `ulimit -n N` sets the soft **and hard**
limits together, which would permanently lower launchd's `unlimited` hard limit to 4096 for the
gate's process tree — a one-way door. Caught while verifying this guard, when a probe using the bare
form could not raise its own limit back (`cannot modify limit: Operation not permitted`).

**This does not fix the reader.** EMFILE swallowed into a silent empty result, and the handle
accumulation that reaches the limit at all, are a real product defect tracked on its own issue; 4096
is deliberately far above what a correct reader needs, so this guard cannot become the reason a
leaky reader looks green.

### F3 — `tooling-tests`: `$TMPDIR` trailing slash + the `/var` -> `/private/var` symlink (commit `1090a15`)

36 passed / 5 failed, all five in `scripts/tests/test_agent_gate_schemas_preflight.sh`
(`3131-export-line`, `3131-export-quoting`, `3131-warm-cache`, `3131-warm-cache-note`,
`3131-remedy-quoting`). None of this PR's three already-fixed self-tests failed.

Same family as the `$TMPDIR//` normalization this PR already applied to
`test_agent_gate_logdir_cleanup.sh`, with a second discrepancy stacked on it. The cases compare a
path built by string concatenation off `$tmp` against the path the SUBJECT reports, and on macOS
those two spellings of the same directory differ twice: `$TMPDIR` ends in a trailing slash (so the
`mktemp -d` template yields a literal `//`), and `$TMPDIR` lives under the `/var` -> `/private/var`
symlink while `test-data/scripts/fetch-datasets.sh` resolves what it prints with `cd ... && pwd -P`
(`fetch-datasets.sh:149,156,333,338,1154`). So the script printed `/private/var/.../T/x` where the
case expected `/var/.../T//x`.

`pwd -P`, not the plain `pwd` the logdir suite needed — collapsing the `//` alone would still leave
`/var` vs `/private/var`. Normalized once at creation, so no comparison site has to remember.

| self-test | before | after |
|---|---|---|
| `test_agent_gate_schemas_preflight.sh` | 36 passed, **5 failed** | **41 passed, 0 failed** |

Identical (41/0) with a trailing-slash `TMPDIR` and without one — the gate's launchd environment
supplies the latter, which is why only the `/private` half was visible in the gate log.

### Note for anyone running the self-tests by hand

`test_agent_gate_component_set.sh` (144/4) and `test_agent_gate_logdir_cleanup.sh` (247/1) FAIL when
run standalone from an interactive shell, but PASS inside the gate (160/0 and 248/0). The
discriminator is the same trailing-slash `$TMPDIR`: an interactive shell has one, the gate's launchd
environment does not. Pre-existing and environment-dependent, not introduced here and not
gate-blocking — recorded so nobody concludes this PR broke them.
